### PR TITLE
feat(memories): make Auto-capture state explicit with badge + toast

### DIFF
--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -837,5 +837,12 @@
   "nodeToolbar.download": "Download",
   "nodeToolbar.delete": "Delete",
   "nodeToolbar.showMore": "Show More",
-  "noteNode.emptyPlaceholder": "Double-click to start typing or enter Markdown..."
+  "noteNode.emptyPlaceholder": "Double-click to start typing or enter Markdown...",
+  "memories.autoCapture.label": "Auto-capture",
+  "memories.autoCapture.stateOn": "ON",
+  "memories.autoCapture.stateOff": "OFF",
+  "memories.autoCapture.ariaEnable": "Enable auto-capture",
+  "memories.autoCapture.ariaDisable": "Disable auto-capture",
+  "memories.autoCapture.toastEnabled": "Auto-capture enabled",
+  "memories.autoCapture.toastDisabled": "Auto-capture disabled"
 }

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryAutoCaptureToggle.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryAutoCaptureToggle.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from "react-i18next";
+import IconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { NextIsActive } from "../hooks/useAutoCaptureDebouncedToggle";
+
+export interface MemoryAutoCaptureToggleProps {
+  /** Whether auto-capture is currently active (post-debounce, draft-aware). */
+  isActive: boolean;
+  /** Invoked with an updater on click; the parent owns debouncing/state. */
+  onToggle: (next: NextIsActive) => void;
+  /** Optional override for the button data-testid. */
+  testId?: string;
+}
+
+/**
+ * Auto-capture toggle button for the Memory details header.
+ *
+ * Renders the toggle icon, label, and a status pill (Badge primitive)
+ * that signals the current ON/OFF state. The whole control is a single
+ * accessible button: ``aria-pressed`` mirrors the state and the
+ * ``aria-label`` switches between the enable/disable phrasing so screen
+ * readers announce the action being taken, not just the label.
+ *
+ * Presentational by design — debouncing and toast plumbing live in the
+ * parent hook (``useAutoCaptureDebouncedToggle``) so this component
+ * stays trivially testable and reusable anywhere a single memory's
+ * auto-capture state needs a toggle.
+ */
+export function MemoryAutoCaptureToggle({
+  isActive,
+  onToggle,
+  testId = "memory-auto-capture-toggle",
+}: MemoryAutoCaptureToggleProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => onToggle((prev) => !prev)}
+      aria-pressed={isActive}
+      aria-label={
+        isActive
+          ? t("memories.autoCapture.ariaDisable")
+          : t("memories.autoCapture.ariaEnable")
+      }
+      className="gap-2"
+      data-testid={testId}
+    >
+      <IconComponent
+        name={isActive ? "ToggleRight" : "ToggleLeft"}
+        className={
+          isActive
+            ? "h-4 w-4 text-accent-emerald-foreground"
+            : "h-4 w-4 text-muted-foreground"
+        }
+      />
+      <span>{t("memories.autoCapture.label")}</span>
+      <Badge
+        variant={isActive ? "successStatic" : "secondaryStatic"}
+        size="sm"
+        className="uppercase tracking-wide"
+        data-testid={`${testId}-state`}
+      >
+        {isActive
+          ? t("memories.autoCapture.stateOn")
+          : t("memories.autoCapture.stateOff")}
+      </Badge>
+    </Button>
+  );
+}
+
+export default MemoryAutoCaptureToggle;

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetailsHeader.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetailsHeader.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
 import type { MemoryDetailsHeaderProps } from "../types";
+import { MemoryAutoCaptureToggle } from "./MemoryAutoCaptureToggle";
 
 export function MemoryDetailsHeader({
   memory,
@@ -124,36 +125,10 @@ export function MemoryDetailsHeader({
           </DropdownMenu>
         )}
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => handleToggleActive((prevIsActive) => !prevIsActive)}
-          aria-pressed={memory.is_active}
-          aria-label={
-            memory.is_active ? "Disable auto-capture" : "Enable auto-capture"
-          }
-          className="gap-2"
-        >
-          <IconComponent
-            name={memory.is_active ? "ToggleRight" : "ToggleLeft"}
-            className={
-              memory.is_active
-                ? "h-4 w-4 text-emerald-600 dark:text-emerald-400"
-                : "h-4 w-4 text-muted-foreground"
-            }
-          />
-          <span>Auto-capture</span>
-          <span
-            data-testid="memory-auto-capture-state"
-            className={
-              memory.is_active
-                ? "rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300"
-                : "rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400"
-            }
-          >
-            {memory.is_active ? "ON" : "OFF"}
-          </span>
-        </Button>
+        <MemoryAutoCaptureToggle
+          isActive={memory.is_active}
+          onToggle={handleToggleActive}
+        />
 
         <DeleteConfirmationModal
           description={`memory "${memory.name}"`}

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetailsHeader.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetailsHeader.tsx
@@ -125,18 +125,34 @@ export function MemoryDetailsHeader({
         )}
 
         <Button
-          variant={memory.is_active ? "primary" : "outline"}
+          variant="outline"
           size="sm"
           onClick={() => handleToggleActive((prevIsActive) => !prevIsActive)}
           aria-pressed={memory.is_active}
-          aria-label="Toggle auto-capture"
+          aria-label={
+            memory.is_active ? "Disable auto-capture" : "Enable auto-capture"
+          }
           className="gap-2"
         >
           <IconComponent
             name={memory.is_active ? "ToggleRight" : "ToggleLeft"}
-            className="h-4 w-4"
+            className={
+              memory.is_active
+                ? "h-4 w-4 text-emerald-600 dark:text-emerald-400"
+                : "h-4 w-4 text-muted-foreground"
+            }
           />
-          Auto-capture
+          <span>Auto-capture</span>
+          <span
+            data-testid="memory-auto-capture-state"
+            className={
+              memory.is_active
+                ? "rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300"
+                : "rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400"
+            }
+          >
+            {memory.is_active ? "ON" : "OFF"}
+          </span>
         </Button>
 
         <DeleteConfirmationModal

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetailsHeader.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetailsHeader.test.tsx
@@ -93,7 +93,7 @@ describe("MemoryDetailsHeader", () => {
     return { ...base, ...(overrides ?? {}) };
   };
 
-  it("renders memory information with explicit auto-capture state label", () => {
+  it("renders memory information with the ON state badge when active", () => {
     const props = makeProps({
       memory: { ...makeProps().memory, is_active: true },
     });
@@ -104,12 +104,12 @@ describe("MemoryDetailsHeader", () => {
     });
     expect(toggleButton).toHaveTextContent("Auto-capture");
     expect(toggleButton).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByTestId("memory-auto-capture-state")).toHaveTextContent(
-      "ON",
-    );
+    expect(
+      screen.getByTestId("memory-auto-capture-toggle-state"),
+    ).toHaveTextContent("ON");
   });
 
-  it("shows OFF and the enable aria-label when auto-capture is inactive", () => {
+  it("renders the OFF state badge and enable aria-label when inactive", () => {
     const props = makeProps({
       memory: { ...makeProps().memory, is_active: false },
     });
@@ -118,9 +118,9 @@ describe("MemoryDetailsHeader", () => {
       name: "Enable auto-capture",
     });
     expect(toggleButton).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByTestId("memory-auto-capture-state")).toHaveTextContent(
-      "OFF",
-    );
+    expect(
+      screen.getByTestId("memory-auto-capture-toggle-state"),
+    ).toHaveTextContent("OFF");
   });
 
   it("calls mutate handlers for actions", () => {

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetailsHeader.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetailsHeader.test.tsx
@@ -93,15 +93,34 @@ describe("MemoryDetailsHeader", () => {
     return { ...base, ...(overrides ?? {}) };
   };
 
-  it("renders memory information", () => {
+  it("renders memory information with explicit auto-capture state label", () => {
     const props = makeProps({
       memory: { ...makeProps().memory, is_active: true },
     });
     render(<MemoryDetailsHeader {...props} />);
     expect(screen.getByText("Memory One")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Toggle auto-capture" }),
-    ).toHaveTextContent("Auto-capture");
+    const toggleButton = screen.getByRole("button", {
+      name: "Disable auto-capture",
+    });
+    expect(toggleButton).toHaveTextContent("Auto-capture");
+    expect(toggleButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("memory-auto-capture-state")).toHaveTextContent(
+      "ON",
+    );
+  });
+
+  it("shows OFF and the enable aria-label when auto-capture is inactive", () => {
+    const props = makeProps({
+      memory: { ...makeProps().memory, is_active: false },
+    });
+    render(<MemoryDetailsHeader {...props} />);
+    const toggleButton = screen.getByRole("button", {
+      name: "Enable auto-capture",
+    });
+    expect(toggleButton).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("memory-auto-capture-state")).toHaveTextContent(
+      "OFF",
+    );
   });
 
   it("calls mutate handlers for actions", () => {
@@ -115,10 +134,12 @@ describe("MemoryDetailsHeader", () => {
   });
 
   it("toggles auto-capture", () => {
-    const props = makeProps();
+    const props = makeProps({
+      memory: { ...makeProps().memory, is_active: false },
+    });
     render(<MemoryDetailsHeader {...props} />);
     fireEvent.click(
-      screen.getByRole("button", { name: "Toggle auto-capture" }),
+      screen.getByRole("button", { name: "Enable auto-capture" }),
     );
 
     const firstCallArg = (props.handleToggleActive as jest.Mock).mock

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/__tests__/useAutoCaptureDebouncedToggle.test.ts
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/__tests__/useAutoCaptureDebouncedToggle.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from "@testing-library/react";
+import type { MemoryInfo } from "@/controllers/API/queries/memories/types";
+import { useAutoCaptureDebouncedToggle } from "../useAutoCaptureDebouncedToggle";
+
+const baseMemory = (overrides?: Partial<MemoryInfo>): MemoryInfo => ({
+  id: "m1",
+  name: "Memory One",
+  description: "",
+  kb_name: "kb-1",
+  embedding_model: "text-embedding-3-small",
+  embedding_provider: "openai",
+  is_active: true,
+  total_messages_processed: 0,
+  sessions_count: 0,
+  batch_size: 1,
+  preprocessing_enabled: false,
+  pending_messages_count: 0,
+  user_id: "u1",
+  flow_id: "flow-1",
+  ...overrides,
+});
+
+const flushPending = () => {
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+};
+
+describe("useAutoCaptureDebouncedToggle", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("fires the debounced mutation with the requested next value", () => {
+    const mutate = jest.fn();
+    const memory = baseMemory({ is_active: true });
+
+    const { result } = renderHook(() =>
+      useAutoCaptureDebouncedToggle({
+        memory,
+        updateMemoryMutation: { mutate },
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+    });
+    expect(mutate).not.toHaveBeenCalled();
+
+    flushPending();
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0]?.[0]).toEqual({
+      memoryId: "m1",
+      auto_capture: false,
+    });
+  });
+
+  it("collapses an on→off→on flip within the debounce window into a no-op", () => {
+    const mutate = jest.fn();
+    const memory = baseMemory({ is_active: true });
+
+    const { result } = renderHook(() =>
+      useAutoCaptureDebouncedToggle({
+        memory,
+        updateMemoryMutation: { mutate },
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+      result.current.handleToggleActive(true);
+    });
+    flushPending();
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("invokes onToggleSuccess with the committed value when the mutation resolves", () => {
+    const onToggleSuccess = jest.fn();
+    const mutate = jest.fn();
+    const memory = baseMemory({ is_active: true });
+
+    const { result } = renderHook(() =>
+      useAutoCaptureDebouncedToggle({
+        memory,
+        updateMemoryMutation: { mutate },
+        onToggleSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+    });
+    flushPending();
+
+    act(() => {
+      mutate.mock.calls[0]?.[1]?.onSuccess?.();
+    });
+
+    expect(onToggleSuccess).toHaveBeenCalledWith(false);
+  });
+
+  it("invokes onToggleError with the attempted value when the mutation fails", () => {
+    const onToggleError = jest.fn();
+    const mutate = jest.fn();
+    const memory = baseMemory({ is_active: false });
+
+    const { result } = renderHook(() =>
+      useAutoCaptureDebouncedToggle({
+        memory,
+        updateMemoryMutation: { mutate },
+        onToggleError,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(true);
+    });
+    flushPending();
+
+    act(() => {
+      mutate.mock.calls[0]?.[1]?.onError?.();
+    });
+
+    expect(onToggleError).toHaveBeenCalledWith(true);
+  });
+
+  it("clears any pending timer when the memory id changes", () => {
+    const mutate = jest.fn();
+    const memoryA = baseMemory({ id: "a", is_active: true });
+    const memoryB = baseMemory({ id: "b", is_active: true });
+
+    const { result, rerender } = renderHook(
+      ({ memory }) =>
+        useAutoCaptureDebouncedToggle({
+          memory,
+          updateMemoryMutation: { mutate },
+        }),
+      { initialProps: { memory: memoryA } },
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+    });
+
+    rerender({ memory: memoryB });
+    flushPending();
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when no memory is selected", () => {
+    const mutate = jest.fn();
+
+    const { result } = renderHook(() =>
+      useAutoCaptureDebouncedToggle({
+        memory: undefined,
+        updateMemoryMutation: { mutate },
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+    });
+    flushPending();
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/__tests__/useMemoriesData.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/__tests__/useMemoriesData.test.tsx
@@ -363,6 +363,71 @@ describe("useMemoriesData", () => {
     jest.useRealTimers();
   });
 
+  it("surfaces an 'Auto-capture disabled' toast when the toggled-off mutation resolves", () => {
+    jest.useFakeTimers();
+    // Default memoryQueryData has is_active: true → toggling to false hits the mutation.
+    const { result } = renderHook(() =>
+      useMemoriesData({
+        currentFlowId: "flow-1",
+        selectedMemoryId: "m1",
+        onSelectMemory: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(false);
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    const lastCall = updateMemoryMutation.mutate.mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual({ memoryId: "m1", auto_capture: false });
+    act(() => {
+      lastCall?.[1]?.onSuccess?.();
+    });
+
+    expect(mockSetSuccessData).toHaveBeenCalledWith({
+      title: "Auto-capture disabled",
+    });
+    jest.useRealTimers();
+  });
+
+  it("surfaces an 'Auto-capture enabled' toast when the toggled-on mutation resolves", () => {
+    jest.useFakeTimers();
+    memoryQueryData = makeMemoryInfo({
+      id: "m1",
+      name: "First",
+      is_active: false,
+    });
+
+    const { result } = renderHook(() =>
+      useMemoriesData({
+        currentFlowId: "flow-1",
+        selectedMemoryId: "m1",
+        onSelectMemory: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleActive(true);
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    const lastCall = updateMemoryMutation.mutate.mock.calls.at(-1);
+    expect(lastCall?.[0]).toEqual({ memoryId: "m1", auto_capture: true });
+    act(() => {
+      lastCall?.[1]?.onSuccess?.();
+    });
+
+    expect(mockSetSuccessData).toHaveBeenCalledWith({
+      title: "Auto-capture enabled",
+    });
+    jest.useRealTimers();
+  });
+
   it("does not call update when toggled back within debounce", () => {
     jest.useFakeTimers();
     const { result } = renderHook(() =>

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useAutoCaptureDebouncedToggle.ts
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useAutoCaptureDebouncedToggle.ts
@@ -23,10 +23,11 @@ type UseAutoCaptureDebouncedToggleArgs = {
    * debounce window).
    */
   onToggleSuccess?: (nextIsActive: boolean) => void;
+  /** Fires when the resolved mutation fails. */
   onToggleError?: (nextIsActive: boolean) => void;
 };
 
-type NextIsActive = boolean | ((prevIsActive: boolean) => boolean);
+export type NextIsActive = boolean | ((prevIsActive: boolean) => boolean);
 
 export const useAutoCaptureDebouncedToggle = ({
   memory,

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useAutoCaptureDebouncedToggle.ts
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useAutoCaptureDebouncedToggle.ts
@@ -16,6 +16,14 @@ type UseAutoCaptureDebouncedToggleArgs = {
   memory: MemoryInfo | undefined;
   updateMemoryMutation: UpdateMemoryMutation;
   debounceMs?: number;
+  /**
+   * Fires when the debounced auto-capture mutation actually resolves so
+   * the caller can announce the state change (e.g. push a toast). Not
+   * called for collapsed no-op toggles (rapid on→off→on within the
+   * debounce window).
+   */
+  onToggleSuccess?: (nextIsActive: boolean) => void;
+  onToggleError?: (nextIsActive: boolean) => void;
 };
 
 type NextIsActive = boolean | ((prevIsActive: boolean) => boolean);
@@ -24,6 +32,8 @@ export const useAutoCaptureDebouncedToggle = ({
   memory,
   updateMemoryMutation,
   debounceMs = AUTO_CAPTURE_DEBOUNCE_MS,
+  onToggleSuccess,
+  onToggleError,
 }: UseAutoCaptureDebouncedToggleArgs) => {
   const autoCaptureTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -112,9 +122,15 @@ export const useAutoCaptureDebouncedToggle = ({
           auto_capture: nextIsActive,
         },
         {
-          onSuccess: clearDraft,
+          onSuccess: () => {
+            clearDraft();
+            onToggleSuccess?.(nextIsActive);
+          },
           // On failure the draft never resolved — reset so UI reflects server state.
-          onError: clearDraft,
+          onError: () => {
+            clearDraft();
+            onToggleError?.(nextIsActive);
+          },
         },
       );
       autoCaptureTimerRef.current = null;

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useMemoriesData.ts
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useMemoriesData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type {
   MemoryDocumentItem,
   MemoryInfo,
@@ -22,6 +23,7 @@ export function useMemoriesData({
   onSelectMemory,
 }: UseMemoriesDataProps) {
   const { setErrorData, setSuccessData } = useAlertStore();
+  const { t } = useTranslation();
 
   const [memoriesSearch, setMemoriesSearch] = useState("");
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -124,11 +126,10 @@ export function useMemoriesData({
       onToggleSuccess: (nextIsActive) =>
         setSuccessData({
           title: nextIsActive
-            ? "Auto-capture enabled"
-            : "Auto-capture disabled",
+            ? t("memories.autoCapture.toastEnabled")
+            : t("memories.autoCapture.toastDisabled"),
         }),
-      // updateMemoryMutation's own onError already surfaces an error toast;
-      // skip a second one here.
+      // updateMemoryMutation's own onError already surfaces an error toast.
     });
 
   const {

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useMemoriesData.ts
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/hooks/useMemoriesData.ts
@@ -121,6 +121,14 @@ export function useMemoriesData({
     useAutoCaptureDebouncedToggle({
       memory,
       updateMemoryMutation,
+      onToggleSuccess: (nextIsActive) =>
+        setSuccessData({
+          title: nextIsActive
+            ? "Auto-capture enabled"
+            : "Auto-capture disabled",
+        }),
+      // updateMemoryMutation's own onError already surfaces an error toast;
+      // skip a second one here.
     });
 
   const {


### PR DESCRIPTION
## Summary

Make the Auto-capture toggle on the Memory Base details header self-explanatory. Before this PR the only feedback after a toggle was a small green/gray dot in the sidebar — easy to miss, especially for first-time users, and not anywhere near the button they just clicked.

Two complementary signals are now wired up, both built on patterns already in Langflow:

1. **Persistent state badge on the button** — `ON` renders as an emerald pill, `OFF` as a slate pill, using the same rounded / uppercase / `text-[10px]` token shape as the status badges in `IngestionRunsSection` and `IngestionHistoryPanel`. The toggle icon swaps `ToggleRight` ↔ `ToggleLeft` and tints emerald when ON for a second glanceable cue. `aria-pressed` reflects state; `aria-label` switches between **"Enable auto-capture"** and **"Disable auto-capture"** so screen readers announce the action.
2. **Toast on commit** — `useAutoCaptureDebouncedToggle` gains optional `onToggleSuccess(nextIsActive)` and `onToggleError(nextIsActive)` callbacks that fire only when the debounced mutation actually resolves (rapid on → off → on within the debounce window stays silent). `useMemoriesData` wires the success callback to `setSuccessData({ title: "Auto-capture enabled" | "Auto-capture disabled" })`. The existing `updateMemoryMutation.onError` already pushes an error toast, so the new path stays quiet on failure to avoid double-notification.

The button keeps the **outline** variant in both states; the pill carries the status color so the control's footprint stays stable across toggles. No layout jitter on click.


## Files

- `MemoryDetailsHeader.tsx` — outline button with state-aware aria, `ToggleRight/Left` icon w/ emerald-tint when ON, emerald/slate status pill rendered via `data-testid="memory-auto-capture-state"`.
- `useAutoCaptureDebouncedToggle.ts` — new optional `onToggleSuccess` / `onToggleError` callbacks invoked from the mutation's `onSuccess` / `onError`.
- `useMemoriesData.ts` — wires the success callback to `setSuccessData` with the appropriate copy.

## Tests

- `MemoryDetailsHeader.test.tsx` — split into ON / OFF cases; asserts pill text, `aria-pressed`, and the state-aware `aria-label`.
- `useMemoriesData.test.tsx` — two new cases (toggle on, toggle off) drive the debounced mutation, invoke the captured `onSuccess`, and assert the right toast copy is pushed via `setSuccessData`.
- Full `MemoriesMainContent` jest suite: **68 / 68 ✅**
- `make format_frontend` clean.

## Test plan

- [x] Open a flow with at least one memory → click a memory → header button reads **Auto-capture · OFF** with a slate pill and `ToggleLeft` icon.
- [x] Click the button → pill turns emerald, label becomes **ON**, icon swaps to `ToggleRight` tinted emerald. After debounce, a "Auto-capture enabled" success toast appears.
- [x] Click again → flips back to OFF with slate pill, "Auto-capture disabled" toast.
- [x] Rapidly toggle on → off → on within the debounce window — no toast fires (collapsed no-op).
- [x] Sidebar dot still matches the committed state (regression check, no change to that behavior).
- [x] Screen reader: button announces "Enable auto-capture, pressed: false" / "Disable auto-capture, pressed: true".

## Screen shots
**Before**
<img width="1893" height="893" alt="image" src="https://github.com/user-attachments/assets/527b55c4-d505-49b9-be8f-b2248877e36d" />


**After**
<img width="1840" height="825" alt="image" src="https://github.com/user-attachments/assets/4cf81ce3-ddd8-40df-9a15-66ab32b2069e" />

