### PR TITLE
fix(i18n): resolve Chinese locale crash by mapping zh variants to zh-Hans

### DIFF
--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -27,8 +27,12 @@ export async function loadLanguage(lang: string): Promise<void> {
   const resolved = resolveLanguage(lang);
   if (resolved === "en") return;
   if (i18n.hasResourceBundle(resolved, "translation")) return;
-  const messages = await import(`./locales/${resolved}.json`);
-  i18n.addResourceBundle(resolved, "translation", messages.default);
+  try {
+    const messages = await import(`./locales/${resolved}.json`);
+    i18n.addResourceBundle(resolved, "translation", messages.default);
+  } catch {
+    // Locale file missing — i18next fallbackLng "en" keeps the app usable.
+  }
 }
 
 export default i18n;

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -13,11 +13,22 @@ i18n.use(initReactI18next).init({
   },
 });
 
+const languageAliases: Record<string, string> = {
+  zh: "zh-Hans",
+  "zh-CN": "zh-Hans",
+  "zh-TW": "zh-Hans",
+};
+
+function resolveLanguage(lang: string): string {
+  return languageAliases[lang] ?? lang;
+}
+
 export async function loadLanguage(lang: string): Promise<void> {
-  if (lang === "en") return;
-  if (i18n.hasResourceBundle(lang, "translation")) return;
-  const messages = await import(`./locales/${lang}.json`);
-  i18n.addResourceBundle(lang, "translation", messages.default);
+  const resolved = resolveLanguage(lang);
+  if (resolved === "en") return;
+  if (i18n.hasResourceBundle(resolved, "translation")) return;
+  const messages = await import(`./locales/${resolved}.json`);
+  i18n.addResourceBundle(resolved, "translation", messages.default);
 }
 
 export default i18n;


### PR DESCRIPTION
## Summary

- Add language alias map to resolve `zh`, `zh-CN`, `zh-TW` to the existing `zh-Hans.json` locale file
- Prevents `Unknown variable dynamic import: ./locales/zh.json` error when browser language is Chinese

## Root Cause

`index.tsx` extracts the language code from `navigator.language` via `.split("-")[0]`, which turns `zh-CN` → `zh`. The dynamic import then tries to load `./locales/zh.json`, but the actual file is `zh-Hans.json`. Vite cannot resolve this at build time, causing a runtime crash and black screen.

## Fix

Minimal language alias resolution in `i18n.ts` — maps zh variants to the correct locale file name before the dynamic import:

```ts
const languageAliases: Record<string, string> = {
  zh: "zh-Hans",
  "zh-CN": "zh-Hans",
  "zh-TW": "zh-Hans",
};
```

This is a targeted fix for the immediate crash. The broader i18n overhaul in #12933 addresses the full locale normalization.

Fixes #12923

## Test plan

- [ ] Set browser language to Chinese (zh-CN or zh-TW)
- [ ] Start Langflow: `make run_cli`
- [ ] Access `http://localhost:7860` — frontend loads without black screen
- [ ] UI renders in Chinese (zh-Hans locale)
- [ ] `cd src/frontend && npm test -- --testPathPatterns=i18n` — existing i18n tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced language loading to support language alias resolution, improving handling of language variants and locale initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13138)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->