### PR TITLE
refactor(settings): split monolithic Settings into per-domain group mixins

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -1,24 +1,53 @@
+"""Composed ``Settings`` class for Langflow.
+
+Fields live in per-group mixins under :mod:`lfx.services.settings.groups`.
+This module wires them together, configures env-var loading, and exposes the
+YAML helpers and a few model-level utilities (``update_settings``,
+``voice_mode_available``).
+
+Group order in the inheritance list matters: Pydantic collects fields from the
+rightmost base first, so cross-group validators see their dependencies in
+``info.data``. Specifically:
+
+- :class:`PathSettings` is rightmost so ``config_dir`` is validated before
+  ``database_url``.
+- :class:`ServerSettings` precedes :class:`RuntimeSettings` so ``workers`` is
+  validated before ``event_delivery``.
+"""
+
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import json
-import os
 from pathlib import Path
-from shutil import copy2
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 import orjson
 import yaml
-from pydantic import Field, field_validator
-from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, EnvSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 from typing_extensions import override
 
-from lfx.constants import BASE_COMPONENTS_PATH
-from lfx.log.logger import logger
-from lfx.serialization.constants import MAX_ITEMS_LENGTH, MAX_TEXT_LENGTH
-from lfx.services.settings.constants import AGENTIC_VARIABLES, VARIABLES_TO_GET_FROM_ENVIRONMENT
-from lfx.utils.util_strings import is_valid_database_url, sanitize_database_url
+from lfx.constants import BASE_COMPONENTS_PATH as BASE_COMPONENTS_PATH  # noqa: PLC0414  # re-export for back-compat
+from lfx.services.settings.groups import (
+    CacheSettings,
+    ComponentsSettings,
+    DatabaseSettings,
+    McpSettings,
+    ObservabilitySettings,
+    PathSettings,
+    RuntimeSettings,
+    SecuritySettings,
+    ServerSettings,
+    StorageSettings,
+    TelemetrySettings,
+    UiSettings,
+    VariablesSettings,
+)
+
+if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
 
 
 def is_list_of_any(field: FieldInfo) -> bool:
@@ -57,622 +86,27 @@ class CustomSource(EnvSettingsSource):
         return super().prepare_field_value(field_name, field, value, value_is_complex)
 
 
-class Settings(BaseSettings):
-    # Define the default LANGFLOW_DIR
-    config_dir: str | None = None
-    # Define if langflow db should be saved in config dir or
-    # in the langflow directory
-    save_db_in_config_dir: bool = False
-    """Define if langflow database should be saved in LANGFLOW_CONFIG_DIR or in the langflow directory
-    (i.e. in the package directory)."""
+class Settings(
+    VariablesSettings,
+    UiSettings,
+    ComponentsSettings,
+    SecuritySettings,
+    ObservabilitySettings,
+    TelemetrySettings,
+    StorageSettings,
+    CacheSettings,
+    McpSettings,
+    DatabaseSettings,
+    RuntimeSettings,
+    ServerSettings,
+    PathSettings,
+    BaseSettings,
+):
+    """Top-level Langflow settings.
 
-    knowledge_bases_dir: str | None = "~/.langflow/knowledge_bases"
-    """The directory to store knowledge bases."""
-
-    dev: bool = False
-    """If True, Langflow will run in development mode."""
-    database_url: str | None = None
-    """Database URL for Langflow. If not provided, Langflow will use a SQLite database.
-    The driver shall be an async one like `sqlite+aiosqlite` (`sqlite` and `postgresql`
-    will be automatically converted to the async drivers `sqlite+aiosqlite` and
-    `postgresql+psycopg` respectively)."""
-    database_connection_retry: bool = False
-    """If True, Langflow will retry to connect to the database if it fails."""
-    pool_size: int = 20
-    """The number of connections to keep open in the connection pool.
-    For high load scenarios, this should be increased based on expected concurrent users."""
-    max_overflow: int = 30
-    """The number of connections to allow that can be opened beyond the pool size.
-    Should be 2x the pool_size for optimal performance under load."""
-    db_connect_timeout: int = 30
-    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
-    database."""
-    migration_lock_namespace: str | None = None
-    """Optional namespace identifier for PostgreSQL advisory lock during migrations.
-    If not provided, a hash of the database URL will be used. Useful when multiple Langflow
-    instances share the same database and need coordinated migration locking."""
-
-    root_path: str = ""
-    """ASGI root_path for deployments behind a reverse proxy that strips a URL
-    prefix (e.g. '/langflow').  When set, the MCP SSE transport includes this
-    prefix in the POST-back URL so clients can reach the correct endpoint.
-    Can also be set via the LANGFLOW_ROOT_PATH environment variable."""
-
-    @field_validator("root_path", mode="before")
-    @classmethod
-    def validate_root_path(cls, value: Any) -> str:
-        if value is None:
-            return ""
-        if not isinstance(value, str):
-            msg = "root_path must be a string"
-            raise TypeError(msg)
-
-        value = value.strip()
-        if not value or value == "/":
-            return ""
-
-        if "://" in value or "?" in value or "#" in value:
-            msg = "root_path must be an ASGI path prefix only, without scheme, query string, or fragment"
-            raise ValueError(msg)
-
-        if not value.startswith("/"):
-            value = f"/{value}"
-
-        return value.rstrip("/")
-
-    mcp_base_url: str = ""
-    """External base URL used to build MCP server URLs in the UI configuration JSON
-    (e.g. 'https://langflow.example.com'). When empty, the frontend falls back to
-    the browser's window.location.origin."""
-
-    mcp_server_timeout: int = 20
-    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
-    database."""
-
-    # ---------------------------------------------------------------------
-    # MCP Session-manager tuning
-    # ---------------------------------------------------------------------
-    mcp_max_sessions_per_server: int = 10
-    """Maximum number of MCP sessions to keep per unique server (command/url).
-    Mirrors the default constant MAX_SESSIONS_PER_SERVER in util.py. Adjust to
-    control resource usage or concurrency per server."""
-
-    mcp_session_idle_timeout: int = 400  # seconds
-    """How long (in seconds) an MCP session can stay idle before the background
-    cleanup task disposes of it. Defaults to 5 minutes."""
-
-    mcp_session_cleanup_interval: int = 120  # seconds
-    """Frequency (in seconds) at which the background cleanup task wakes up to
-    reap idle sessions."""
-
-    # sqlite configuration
-    sqlite_pragmas: dict | None = {"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000}
-    """SQLite pragmas to use when connecting to the database."""
-
-    db_driver_connection_settings: dict | None = None
-    """Database driver connection settings."""
-
-    db_connection_settings: dict | None = {
-        "pool_size": 20,  # Match the pool_size above
-        "max_overflow": 30,  # Match the max_overflow above
-        "pool_timeout": 30,  # Seconds to wait for a connection from pool
-        "pool_pre_ping": True,  # Check connection validity before using
-        "pool_recycle": 1800,  # Recycle connections after 30 minutes
-        "echo": False,  # Set to True for debugging only
-    }
-    """Database connection settings optimized for high load scenarios.
-    Note: These settings are most effective with PostgreSQL. For SQLite:
-    - Reduce pool_size and max_overflow if experiencing lock contention
-    - SQLite has limited concurrent write capability even with WAL mode
-    - Best for read-heavy or moderate write workloads
-
-    Settings:
-    - pool_size: Number of connections to maintain (increase for higher concurrency)
-    - max_overflow: Additional connections allowed beyond pool_size
-    - pool_timeout: Seconds to wait for an available connection
-    - pool_pre_ping: Validates connections before use to prevent stale connections
-    - pool_recycle: Seconds before connections are recycled (prevents timeouts)
-    - echo: Enable SQL query logging (development only)
+    Composed from per-group mixins. See module docstring for the inheritance
+    order rationale.
     """
-
-    use_noop_database: bool = False
-    """If True, disables all database operations and uses a no-op session.
-    Controlled by LANGFLOW_USE_NOOP_DATABASE env variable."""
-
-    # cache configuration
-    cache_type: Literal["async", "redis", "memory", "disk"] = "async"
-    """The cache type can be 'async' or 'redis'."""
-    cache_expire: int = 3600
-    """The cache expire in seconds."""
-    variable_store: str = "db"
-    """The store can be 'db' or 'kubernetes'."""
-
-    prometheus_enabled: bool = False
-    """If set to True, Langflow will expose Prometheus metrics."""
-    prometheus_port: int = 9090
-    """The port on which Langflow will expose Prometheus metrics. 9090 is the default port."""
-
-    disable_track_apikey_usage: bool = False
-    remove_api_keys: bool = False
-    components_path: list[str] = []
-    """List of paths to custom components.
-
-    Security: This setting defines an allow-list of custom components
-    permitted to execute, even when LANGFLOW_ALLOW_CUSTOM_COMPONENTS is False.
-    """
-    components_index_path: str | None = None
-    """Path or URL to a prebuilt component index JSON file.
-
-    If None, uses the built-in index at lfx/_assets/component_index.json.
-    Set to a file path (e.g., '/path/to/index.json') or URL (e.g., 'https://example.com/index.json')
-    to use a custom index.
-    """
-    langchain_cache: str = "InMemoryCache"
-    load_flows_path: str | None = None
-    bundle_urls: list[str] = []
-
-    # Redis
-    redis_host: str = "localhost"
-    redis_port: int = 6379
-    redis_db: int = 0
-    redis_url: str | None = None
-    redis_cache_expire: int = 3600
-
-    # Sentry
-    sentry_dsn: str | None = None
-    sentry_traces_sample_rate: float | None = 1.0
-    sentry_profiles_sample_rate: float | None = 1.0
-
-    store: bool | None = True
-    store_url: str | None = "https://api.langflow.store"
-    download_webhook_url: str | None = "https://api.langflow.store/flows/trigger/ec611a61-8460-4438-b187-a4f65e5559d4"
-    like_webhook_url: str | None = "https://api.langflow.store/flows/trigger/64275852-ec00-45c1-984e-3bff814732da"
-
-    storage_type: str = "local"
-    """Storage type for file storage. Defaults to 'local'. Supports 'local' and 's3'."""
-    object_storage_bucket_name: str | None = "langflow-bucket"
-    """Object storage bucket name for file storage. Defaults to 'langflow-bucket'."""
-    object_storage_prefix: str | None = "files"
-    """Object storage prefix for file storage. Defaults to 'files'."""
-    object_storage_tags: dict[str, str] | None = None
-    """Object storage tags for file storage."""
-
-    celery_enabled: bool = False
-
-    fallback_to_env_var: bool = True
-    """If set to True, Global Variables set in the UI will fallback to a environment variable
-    with the same name in case Langflow fails to retrieve the variable value."""
-
-    store_environment_variables: bool = True
-    """Whether to store environment variables as Global Variables in the database."""
-    variables_to_get_from_environment: list[str] = VARIABLES_TO_GET_FROM_ENVIRONMENT
-    """List of environment variables to get from the environment and store in the database."""
-    worker_timeout: int = 300
-    """Timeout for the API calls in seconds."""
-    frontend_timeout: int = 0
-    """Timeout for the frontend API calls in seconds."""
-    user_agent: str = "langflow"
-    """User agent for the API calls."""
-    backend_only: bool = False
-    """If set to True, Langflow will not serve the frontend."""
-
-    # CORS Settings
-    cors_origins: list[str] | str = "*"
-    """Allowed origins for CORS. Can be a list of origins or '*' for all origins.
-    Default is '*' for backward compatibility. In production, specify exact origins."""
-    cors_allow_credentials: bool = True
-    """Whether to allow credentials in CORS requests.
-    Default is True for backward compatibility. In v2.0, this will be changed to False when using wildcard origins."""
-    cors_allow_methods: list[str] | str = "*"
-    """Allowed HTTP methods for CORS requests."""
-    cors_allow_headers: list[str] | str = "*"
-    """Allowed headers for CORS requests."""
-
-    # Telemetry
-    do_not_track: bool = False
-    """If set to True, Langflow will not track telemetry."""
-    telemetry_base_url: str = "https://langflow.gateway.scarf.sh"
-    transactions_storage_enabled: bool = True
-    """If set to True, Langflow will track transactions between flows."""
-    vertex_builds_storage_enabled: bool = True
-    """If set to True, Langflow will keep track of each vertex builds (outputs) in the UI for any flow."""
-
-    # Config
-    host: str = "localhost"
-    """The host on which Langflow will run."""
-    port: int = 7860
-    """The port on which Langflow will run."""
-    runtime_port: int | None = Field(default=None, exclude=True)
-    """TEMPORARY: The port detected at runtime after checking for conflicts.
-    This field is system-managed only and will be removed in future versions
-    when strict port enforcement is implemented (errors will be raised if port unavailable)."""
-    workers: int = 1
-    """The number of workers to run."""
-    log_level: str = "critical"
-    """The log level for Langflow."""
-    log_file: str | None = "logs/langflow.log"
-    """The path to log file for Langflow."""
-    alembic_log_file: str = "alembic/alembic.log"
-    """The path to log file for Alembic for SQLAlchemy."""
-    alembic_log_to_stdout: bool = False
-    """If set to True, the log file will be ignored and Alembic will log to stdout."""
-    frontend_path: str | None = None
-    """The path to the frontend directory containing build files. This is for development purposes only.."""
-    open_browser: bool = False
-    """If set to True, Langflow will open the browser on startup."""
-    auto_saving: bool = True
-    """If set to True, Langflow will auto save flows."""
-    auto_saving_interval: int = 1000
-    """The interval in ms at which Langflow will auto save flows."""
-    health_check_max_retries: int = 5
-    """The maximum number of retries for the health check."""
-    max_file_size_upload: int = 1024
-    """The maximum file size for the upload in MB."""
-    deactivate_tracing: bool = False
-    """If set to True, tracing will be deactivated."""
-    max_transactions_to_keep: int = 3000
-    """The maximum number of transactions to keep in the database."""
-    max_vertex_builds_to_keep: int = 3000
-    """The maximum number of vertex builds to keep in the database."""
-    max_vertex_builds_per_vertex: int = 50
-    """The maximum number of builds to keep per vertex. Older builds will be deleted."""
-    max_flow_version_entries_per_flow: int = 50
-    """Max version history entries per flow. Oldest entries pruned on next snapshot.
-
-    If retroactively lowered below the current count for a flow,
-    the oldest entries are deleted only when the next entry is created.
-    """
-    webhook_polling_interval: int = 0
-    """The polling interval for the webhook in ms. Set to 0 to disable (SSE provides real-time updates)."""
-    fs_flows_polling_interval: int = 10000
-    """The polling interval in milliseconds for synchronizing flows from the file system."""
-    ssl_cert_file: str | None = None
-    """Path to the SSL certificate file on the local system."""
-    ssl_key_file: str | None = None
-    """Path to the SSL key file on the local system."""
-    max_text_length: int = MAX_TEXT_LENGTH
-    """Maximum number of characters to store and display in the UI. Responses longer than this
-    will be truncated when displayed in the UI. Does not truncate responses between components nor outputs."""
-    max_items_length: int = MAX_ITEMS_LENGTH
-    """Maximum number of items to store and display in the UI. Lists longer than this
-    will be truncated when displayed in the UI. Does not affect data passed between components nor outputs."""
-
-    # MCP Server
-    mcp_server_enabled: bool = True
-    """If set to False, Langflow will not enable the MCP server."""
-    mcp_server_enable_progress_notifications: bool = False
-    """If set to False, Langflow will not send progress notifications in the MCP server."""
-
-    # Add projects to MCP servers automatically on creation
-    add_projects_to_mcp_servers: bool = True
-    """If set to True, newly created projects will be added to the user's MCP servers config automatically."""
-    # MCP Composer
-    mcp_composer_enabled: bool = True
-    """If set to False, Langflow will not start the MCP Composer service."""
-    mcp_composer_version: str = "==0.1.0.8.10"
-    """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
-
-    # Agentic Experience
-    agentic_experience: bool = False
-    """If set to True, Langflow will start the agentic MCP server that provides tools for
-    flow/component operations, template search, and graph visualization."""
-
-    # Developer API
-    developer_api_enabled: bool = False
-    """If set to True, Langflow will enable developer API endpoints for advanced debugging and introspection."""
-
-    # Public Flow Settings
-    public_flow_cleanup_interval: int = Field(default=3600, gt=600)
-    """The interval in seconds at which public temporary flows will be cleaned up.
-    Default is 1 hour (3600 seconds). Minimum is 600 seconds (10 minutes)."""
-    public_flow_expiration: int = Field(default=86400, gt=600)
-    """The time in seconds after which a public temporary flow will be considered expired and eligible for cleanup.
-    Default is 24 hours (86400 seconds). Minimum is 600 seconds (10 minutes)."""
-    event_delivery: Literal["polling", "streaming", "direct"] = "streaming"
-    """How to deliver build events to the frontend. Can be 'polling', 'streaming' or 'direct'."""
-    lazy_load_components: bool = False
-    """If set to True, Langflow will only partially load components at startup and fully load them on demand.
-    This significantly reduces startup time but may cause a slight delay when a component is first used."""
-
-    # Starter Projects
-    create_starter_projects: bool = True
-    """If set to True, Langflow will create starter projects. If False, skips all starter project setup.
-    Note that this doesn't check if the starter projects are already loaded in the db;
-    this is intended to be used to skip all startup project logic."""
-    update_starter_projects: bool = True
-    """If set to True, Langflow will update starter projects."""
-
-    # Custom Component Security
-    allow_custom_components: bool = True
-    """If set to False, blocks execution of components whose code does not match a known
-    server template.
-
-    The server validates node code against its component template cache;
-    when the cache is not yet loaded (e.g., during startup), all flow execution is blocked
-    as a safety measure.
-
-    Note: LANGFLOW_COMPONENTS_PATH can be used to define an allow-list of custom components
-    that will be allowed to execute, even when allow_custom_components is False.
-
-    Note: this is a beta feature. For security in a multi-tenant environment,
-    use hardware-level isolation to restrict access."""
-
-    # SSRF Protection
-    ssrf_protection_enabled: bool = True
-    """If set to True, Langflow will enable SSRF (Server-Side Request Forgery) protection.
-    When enabled, blocks requests to private IP ranges, localhost, and cloud metadata endpoints.
-    When False, no URL validation is performed, allowing requests to any destination
-    including internal services, private networks, and cloud metadata endpoints.
-    Default is True to protect against SSRF attacks including DNS rebinding.
-
-    Note: When ssrf_protection_enabled is disabled, the ssrf_allowed_hosts setting is ignored and has no effect."""
-    ssrf_allowed_hosts: list[str] = []
-    """Comma-separated list of hosts/IPs/CIDR ranges to allow despite SSRF protection.
-    Examples: 'internal-api.company.local,192.168.1.0/24,10.0.0.5,*.dev.internal'
-    Supports exact hostnames, wildcard domains (*.example.com), exact IPs, and CIDR ranges.
-
-    Note: This setting only takes effect when ssrf_protection_enabled is True.
-    When protection is disabled, all hosts are allowed regardless of this setting."""
-
-    @field_validator("runtime_port", mode="before")
-    @classmethod
-    def validate_runtime_port(cls, value):
-        """Parse port from Kubernetes service discovery env vars.
-
-        Kubernetes auto-creates env vars like LANGFLOW_RUNTIME_PORT=tcp://<ip>:<port>
-        for services, which collides with the LANGFLOW_ env prefix. Extract the port
-        number from URL-like values instead of failing.
-        """
-        if value is None:
-            return None
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str):
-            if value.isdigit():
-                return int(value)
-            if "://" in value:
-                from urllib.parse import urlparse
-
-                try:
-                    parsed_port = urlparse(value).port
-                except ValueError:
-                    return None
-                if parsed_port is not None:
-                    return parsed_port
-        return None
-
-    @field_validator("cors_origins", mode="before")
-    @classmethod
-    def validate_cors_origins(cls, value):
-        """Convert comma-separated string to list if needed.
-
-        Pydantic-settings on Python 3.14 parses the env var "*" into ["*"]
-        before this validator runs (the union list[str] | str resolves
-        differently). Collapse that back to the bare-string wildcard so
-        downstream consumers see the same shape on every Python version.
-        """
-        if isinstance(value, list) and value == ["*"]:
-            return "*"
-        if isinstance(value, str) and value != "*":
-            if "," in value:
-                # Convert comma-separated string to list
-                return [origin.strip() for origin in value.split(",")]
-            # Convert single origin to list for consistency
-            return [value]
-        return value
-
-    @field_validator("use_noop_database", mode="before")
-    @classmethod
-    def set_use_noop_database(cls, value):
-        if value:
-            logger.info("Running with NOOP database session. All DB operations are disabled.")
-        return value
-
-    @field_validator("event_delivery", mode="before")
-    @classmethod
-    def set_event_delivery(cls, value, info):
-        # If workers > 1, we need to use direct delivery
-        # because polling and streaming are not supported
-        # in multi-worker environments
-        if info.data.get("workers", 1) > 1:
-            logger.warning("Multi-worker environment detected, using direct event delivery")
-            return "direct"
-        return value
-
-    @field_validator("user_agent", mode="after")
-    @classmethod
-    def set_user_agent(cls, value):
-        if not value:
-            value = "Langflow"
-        import os
-
-        os.environ["USER_AGENT"] = value
-        logger.debug(f"Setting user agent to {value}")
-        return value
-
-    @field_validator("mcp_composer_version", mode="before")
-    @classmethod
-    def validate_mcp_composer_version(cls, value):
-        """Ensure the version string has a version specifier prefix.
-
-        If a bare version like '0.1.0.7' is provided, prepend '~=' to allow patch updates.
-        Supports PEP 440 specifiers: ==, !=, <=, >=, <, >, ~=, ===
-        """
-        if not value:
-            return "==0.1.0.8.10"  # Default
-
-        # Check if it already has a version specifier
-        # Order matters: check longer specifiers first to avoid false matches
-        specifiers = ["===", "==", "!=", "<=", ">=", "~=", "<", ">"]
-        if any(value.startswith(spec) for spec in specifiers):
-            return value
-
-        # If it's a bare version number, add ~= prefix
-        # This regex matches version numbers like 0.1.0.7, 1.2.3, etc.
-        import re
-
-        if re.match(r"^\d+(\.\d+)*", value):
-            logger.debug(f"Adding ~= prefix to bare version '{value}' -> '~={value}'")
-            return f"~={value}"
-
-        # If we can't determine, return as-is and let uvx handle it
-        return value
-
-    @field_validator("variables_to_get_from_environment", mode="before")
-    @classmethod
-    def set_variables_to_get_from_environment(cls, value):
-        import os
-
-        if isinstance(value, str):
-            value = value.split(",")
-
-        result = list(set(VARIABLES_TO_GET_FROM_ENVIRONMENT + value))
-
-        # Add agentic variables if agentic_experience is enabled
-        # Check env var directly since we can't access instance attributes in validator
-        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
-            result.extend(AGENTIC_VARIABLES)
-
-        return list(set(result))
-
-    @field_validator("log_file", mode="before")
-    @classmethod
-    def set_log_file(cls, value):
-        if isinstance(value, Path):
-            value = str(value)
-        return value
-
-    @field_validator("config_dir", mode="before")
-    @classmethod
-    def set_langflow_dir(cls, value):
-        if not value:
-            from platformdirs import user_cache_dir
-
-            # Define the app name and author
-            app_name = "langflow"
-            app_author = "langflow"
-
-            # Get the cache directory for the application
-            cache_dir = user_cache_dir(app_name, app_author)
-
-            # Create a .langflow directory inside the cache directory
-            value = Path(cache_dir)
-            value.mkdir(parents=True, exist_ok=True)
-
-        if isinstance(value, str):
-            value = Path(value)
-        # Resolve to absolute path to handle relative paths correctly
-        value = value.resolve()
-        if not value.exists():
-            value.mkdir(parents=True, exist_ok=True)
-
-        return str(value)
-
-    @field_validator("database_url", mode="before")
-    @classmethod
-    def set_database_url(cls, value, info):
-        if value and not is_valid_database_url(value):
-            sanitized = sanitize_database_url(value)
-            msg = f"Invalid database_url provided: '{sanitized}'"
-            raise ValueError(msg)
-
-        if langflow_database_url := os.getenv("LANGFLOW_DATABASE_URL"):
-            value = langflow_database_url
-            logger.debug("Using LANGFLOW_DATABASE_URL env variable")
-        else:
-            # Originally, we used sqlite:///./langflow.db
-            # so we need to migrate to the new format
-            # if there is a database in that location
-            if not info.data["config_dir"]:
-                msg = "config_dir not set, please set it or provide a database_url"
-                raise ValueError(msg)
-
-            from lfx.utils.version import get_version_info
-            from lfx.utils.version import is_pre_release as langflow_is_pre_release
-
-            version = get_version_info()["version"]
-            is_pre_release = langflow_is_pre_release(version)
-
-            if info.data["save_db_in_config_dir"]:
-                database_dir = info.data["config_dir"]
-            else:
-                # Use langflow package path, not lfx, for backwards compatibility
-                try:
-                    import langflow
-
-                    database_dir = Path(langflow.__file__).parent.resolve()
-                except ImportError:
-                    database_dir = Path(__file__).parent.parent.parent.resolve()
-
-            pre_db_file_name = "langflow-pre.db"
-            db_file_name = "langflow.db"
-            new_pre_path = f"{database_dir}/{pre_db_file_name}"
-            new_path = f"{database_dir}/{db_file_name}"
-            final_path = None
-            if is_pre_release:
-                if Path(new_pre_path).exists():
-                    final_path = new_pre_path
-                elif Path(new_path).exists() and info.data["save_db_in_config_dir"]:
-                    # We need to copy the current db to the new location
-                    logger.debug("Copying existing database to new location")
-                    copy2(new_path, new_pre_path)
-                    logger.debug(f"Copied existing database to {new_pre_path}")
-                elif Path(f"./{db_file_name}").exists() and info.data["save_db_in_config_dir"]:
-                    logger.debug("Copying existing database to new location")
-                    copy2(f"./{db_file_name}", new_pre_path)
-                    logger.debug(f"Copied existing database to {new_pre_path}")
-                else:
-                    logger.debug(f"Creating new database at {new_pre_path}")
-                    final_path = new_pre_path
-            elif Path(new_path).exists():
-                final_path = new_path
-            elif Path(f"./{db_file_name}").exists():
-                try:
-                    logger.debug("Copying existing database to new location")
-                    copy2(f"./{db_file_name}", new_path)
-                    logger.debug(f"Copied existing database to {new_path}")
-                except OSError:
-                    logger.exception("Failed to copy database, using default path")
-                    new_path = f"./{db_file_name}"
-            else:
-                final_path = new_path
-
-            if final_path is None:
-                final_path = new_pre_path if is_pre_release else new_path
-
-            value = f"sqlite:///{final_path}"
-
-        return value
-
-    @field_validator("components_path", mode="before")
-    @classmethod
-    def set_components_path(cls, value):
-        """Processes and updates the components path list, incorporating environment variable overrides.
-
-        If the `LANGFLOW_COMPONENTS_PATH` environment variable is set and points to an existing path, it is
-        appended to the provided list if not already present. If the input list is empty or missing, it is
-        set to an empty list.
-        """
-        if os.getenv("LANGFLOW_COMPONENTS_PATH"):
-            logger.debug("Adding LANGFLOW_COMPONENTS_PATH to components_path")
-            langflow_component_path = os.getenv("LANGFLOW_COMPONENTS_PATH")
-            if Path(langflow_component_path).exists() and langflow_component_path not in value:
-                if isinstance(langflow_component_path, list):
-                    for path in langflow_component_path:
-                        if path not in value:
-                            value.append(path)
-                    logger.debug(f"Extending {langflow_component_path} to components_path")
-                elif langflow_component_path not in value:
-                    value.append(langflow_component_path)
-                    logger.debug(f"Appending {langflow_component_path} to components_path")
-
-        if not value:
-            value = [BASE_COMPONENTS_PATH]
-        elif isinstance(value, Path):
-            value = [str(value)]
-        elif isinstance(value, list):
-            value = [str(p) if isinstance(p, Path) else p for p in value]
-        return value
 
     model_config = SettingsConfigDict(validate_assignment=True, extra="ignore", env_prefix="LANGFLOW_")
 
@@ -733,6 +167,8 @@ def save_settings_to_yaml(settings: Settings, file_path: str) -> None:
 
 
 async def load_settings_from_yaml(file_path: str) -> Settings:
+    from lfx.log.logger import logger
+
     # Check if a string is a valid path or a file name
     if "/" not in file_path:
         # Get current path

--- a/src/lfx/src/lfx/services/settings/groups/__init__.py
+++ b/src/lfx/src/lfx/services/settings/groups/__init__.py
@@ -1,0 +1,39 @@
+"""Logical groupings of Langflow settings.
+
+Each module defines a ``BaseModel`` mixin that owns a cohesive subset of fields
+plus their intra-group validators. They are composed into the final
+``Settings`` class in :mod:`lfx.services.settings.base`.
+
+Mixins inherit from ``BaseModel`` (not ``BaseSettings``) and are not intended
+to be instantiated directly.
+"""
+
+from lfx.services.settings.groups.cache import CacheSettings
+from lfx.services.settings.groups.components import ComponentsSettings
+from lfx.services.settings.groups.database import DatabaseSettings
+from lfx.services.settings.groups.mcp import McpSettings
+from lfx.services.settings.groups.observability import ObservabilitySettings
+from lfx.services.settings.groups.paths import PathSettings
+from lfx.services.settings.groups.runtime import RuntimeSettings
+from lfx.services.settings.groups.security import SecuritySettings
+from lfx.services.settings.groups.server import ServerSettings
+from lfx.services.settings.groups.storage import StorageSettings
+from lfx.services.settings.groups.telemetry import TelemetrySettings
+from lfx.services.settings.groups.ui import UiSettings
+from lfx.services.settings.groups.variables import VariablesSettings
+
+__all__ = [
+    "CacheSettings",
+    "ComponentsSettings",
+    "DatabaseSettings",
+    "McpSettings",
+    "ObservabilitySettings",
+    "PathSettings",
+    "RuntimeSettings",
+    "SecuritySettings",
+    "ServerSettings",
+    "StorageSettings",
+    "TelemetrySettings",
+    "UiSettings",
+    "VariablesSettings",
+]

--- a/src/lfx/src/lfx/services/settings/groups/cache.py
+++ b/src/lfx/src/lfx/services/settings/groups/cache.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class CacheSettings(BaseModel):
+    """In-memory, disk, and Redis cache settings."""
+
+    cache_type: Literal["async", "redis", "memory", "disk"] = "async"
+    """The cache type can be 'async' or 'redis'."""
+    cache_expire: int = 3600
+    """The cache expire in seconds."""
+    langchain_cache: str = "InMemoryCache"
+
+    # Redis
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    redis_db: int = 0
+    redis_url: str | None = None
+    redis_cache_expire: int = 3600

--- a/src/lfx/src/lfx/services/settings/groups/components.py
+++ b/src/lfx/src/lfx/services/settings/groups/components.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, field_validator
+
+from lfx.constants import BASE_COMPONENTS_PATH
+from lfx.log.logger import logger
+
+
+class ComponentsSettings(BaseModel):
+    """Component discovery, indexing, and startup-load behavior."""
+
+    components_path: list[str] = []
+    """List of paths to custom components.
+
+    Security: This setting defines an allow-list of custom components
+    permitted to execute, even when LANGFLOW_ALLOW_CUSTOM_COMPONENTS is False.
+    """
+    components_index_path: str | None = None
+    """Path or URL to a prebuilt component index JSON file.
+
+    If None, uses the built-in index at lfx/_assets/component_index.json.
+    Set to a file path (e.g., '/path/to/index.json') or URL (e.g., 'https://example.com/index.json')
+    to use a custom index.
+    """
+
+    load_flows_path: str | None = None
+    bundle_urls: list[str] = []
+
+    lazy_load_components: bool = False
+    """If set to True, Langflow will only partially load components at startup and fully load them on demand.
+    This significantly reduces startup time but may cause a slight delay when a component is first used."""
+
+    # Starter Projects
+    create_starter_projects: bool = True
+    """If set to True, Langflow will create starter projects. If False, skips all starter project setup.
+    Note that this doesn't check if the starter projects are already loaded in the db;
+    this is intended to be used to skip all startup project logic."""
+    update_starter_projects: bool = True
+    """If set to True, Langflow will update starter projects."""
+
+    @field_validator("components_path", mode="before")
+    @classmethod
+    def set_components_path(cls, value):
+        """Processes and updates the components path list, incorporating environment variable overrides.
+
+        If the `LANGFLOW_COMPONENTS_PATH` environment variable is set and points to an existing path, it is
+        appended to the provided list if not already present. If the input list is empty or missing, it is
+        set to an empty list.
+        """
+        if os.getenv("LANGFLOW_COMPONENTS_PATH"):
+            logger.debug("Adding LANGFLOW_COMPONENTS_PATH to components_path")
+            langflow_component_path = os.getenv("LANGFLOW_COMPONENTS_PATH")
+            if Path(langflow_component_path).exists() and langflow_component_path not in value:
+                if isinstance(langflow_component_path, list):
+                    for path in langflow_component_path:
+                        if path not in value:
+                            value.append(path)
+                    logger.debug(f"Extending {langflow_component_path} to components_path")
+                elif langflow_component_path not in value:
+                    value.append(langflow_component_path)
+                    logger.debug(f"Appending {langflow_component_path} to components_path")
+
+        if not value:
+            value = [BASE_COMPONENTS_PATH]
+        elif isinstance(value, Path):
+            value = [str(value)]
+        elif isinstance(value, list):
+            value = [str(p) if isinstance(p, Path) else p for p in value]
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/database.py
+++ b/src/lfx/src/lfx/services/settings/groups/database.py
@@ -1,0 +1,157 @@
+import os
+from pathlib import Path
+from shutil import copy2
+
+from pydantic import BaseModel, field_validator
+
+from lfx.log.logger import logger
+from lfx.utils.util_strings import is_valid_database_url, sanitize_database_url
+
+
+class DatabaseSettings(BaseModel):
+    """Database connection, pooling, and migration settings.
+
+    Note: ``database_url`` is validated at the :class:`Settings` level because
+    it reads ``config_dir`` from :class:`PathSettings`.
+    """
+
+    save_db_in_config_dir: bool = False
+    """Define if langflow database should be saved in LANGFLOW_CONFIG_DIR or in the langflow directory
+    (i.e. in the package directory)."""
+
+    database_url: str | None = None
+    """Database URL for Langflow. If not provided, Langflow will use a SQLite database.
+    The driver shall be an async one like `sqlite+aiosqlite` (`sqlite` and `postgresql`
+    will be automatically converted to the async drivers `sqlite+aiosqlite` and
+    `postgresql+psycopg` respectively)."""
+
+    database_connection_retry: bool = False
+    """If True, Langflow will retry to connect to the database if it fails."""
+
+    pool_size: int = 20
+    """The number of connections to keep open in the connection pool.
+    For high load scenarios, this should be increased based on expected concurrent users."""
+
+    max_overflow: int = 30
+    """The number of connections to allow that can be opened beyond the pool size.
+    Should be 2x the pool_size for optimal performance under load."""
+
+    db_connect_timeout: int = 30
+    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
+    database."""
+
+    migration_lock_namespace: str | None = None
+    """Optional namespace identifier for PostgreSQL advisory lock during migrations.
+    If not provided, a hash of the database URL will be used. Useful when multiple Langflow
+    instances share the same database and need coordinated migration locking."""
+
+    sqlite_pragmas: dict | None = {"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000}
+    """SQLite pragmas to use when connecting to the database."""
+
+    db_driver_connection_settings: dict | None = None
+    """Database driver connection settings."""
+
+    db_connection_settings: dict | None = {
+        "pool_size": 20,
+        "max_overflow": 30,
+        "pool_timeout": 30,
+        "pool_pre_ping": True,
+        "pool_recycle": 1800,
+        "echo": False,
+    }
+    """Database connection settings optimized for high load scenarios.
+    Note: These settings are most effective with PostgreSQL. For SQLite:
+    - Reduce pool_size and max_overflow if experiencing lock contention
+    - SQLite has limited concurrent write capability even with WAL mode
+    - Best for read-heavy or moderate write workloads
+
+    Settings:
+    - pool_size: Number of connections to maintain (increase for higher concurrency)
+    - max_overflow: Additional connections allowed beyond pool_size
+    - pool_timeout: Seconds to wait for an available connection
+    - pool_pre_ping: Validates connections before use to prevent stale connections
+    - pool_recycle: Seconds before connections are recycled (prevents timeouts)
+    - echo: Enable SQL query logging (development only)
+    """
+
+    use_noop_database: bool = False
+    """If True, disables all database operations and uses a no-op session.
+    Controlled by LANGFLOW_USE_NOOP_DATABASE env variable."""
+
+    @field_validator("use_noop_database", mode="before")
+    @classmethod
+    def set_use_noop_database(cls, value):
+        if value:
+            logger.info("Running with NOOP database session. All DB operations are disabled.")
+        return value
+
+    @field_validator("database_url", mode="before")
+    @classmethod
+    def set_database_url(cls, value, info):
+        if value and not is_valid_database_url(value):
+            sanitized = sanitize_database_url(value)
+            msg = f"Invalid database_url provided: '{sanitized}'"
+            raise ValueError(msg)
+
+        if langflow_database_url := os.getenv("LANGFLOW_DATABASE_URL"):
+            value = langflow_database_url
+            logger.debug("Using LANGFLOW_DATABASE_URL env variable")
+        else:
+            if not info.data.get("config_dir"):
+                msg = "config_dir not set, please set it or provide a database_url"
+                raise ValueError(msg)
+
+            from lfx.utils.version import get_version_info
+            from lfx.utils.version import is_pre_release as langflow_is_pre_release
+
+            version = get_version_info()["version"]
+            is_pre_release = langflow_is_pre_release(version)
+
+            if info.data["save_db_in_config_dir"]:
+                database_dir = info.data["config_dir"]
+            else:
+                try:
+                    import langflow
+
+                    database_dir = Path(langflow.__file__).parent.resolve()
+                except ImportError:
+                    database_dir = Path(__file__).parent.parent.parent.parent.resolve()
+
+            pre_db_file_name = "langflow-pre.db"
+            db_file_name = "langflow.db"
+            new_pre_path = f"{database_dir}/{pre_db_file_name}"
+            new_path = f"{database_dir}/{db_file_name}"
+            final_path = None
+            if is_pre_release:
+                if Path(new_pre_path).exists():
+                    final_path = new_pre_path
+                elif Path(new_path).exists() and info.data["save_db_in_config_dir"]:
+                    logger.debug("Copying existing database to new location")
+                    copy2(new_path, new_pre_path)
+                    logger.debug(f"Copied existing database to {new_pre_path}")
+                elif Path(f"./{db_file_name}").exists() and info.data["save_db_in_config_dir"]:
+                    logger.debug("Copying existing database to new location")
+                    copy2(f"./{db_file_name}", new_pre_path)
+                    logger.debug(f"Copied existing database to {new_pre_path}")
+                else:
+                    logger.debug(f"Creating new database at {new_pre_path}")
+                    final_path = new_pre_path
+            elif Path(new_path).exists():
+                final_path = new_path
+            elif Path(f"./{db_file_name}").exists():
+                try:
+                    logger.debug("Copying existing database to new location")
+                    copy2(f"./{db_file_name}", new_path)
+                    logger.debug(f"Copied existing database to {new_path}")
+                except OSError:
+                    logger.exception("Failed to copy database, using default path")
+                    new_path = f"./{db_file_name}"
+            else:
+                final_path = new_path
+
+            if final_path is None:
+                final_path = new_pre_path if is_pre_release else new_path
+
+            value = f"sqlite:///{final_path}"
+
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -1,0 +1,71 @@
+import re
+
+from pydantic import BaseModel, field_validator
+
+from lfx.log.logger import logger
+
+
+class McpSettings(BaseModel):
+    """MCP server, session manager, and composer settings."""
+
+    mcp_base_url: str = ""
+    """External base URL used to build MCP server URLs in the UI configuration JSON
+    (e.g. 'https://langflow.example.com'). When empty, the frontend falls back to
+    the browser's window.location.origin."""
+
+    mcp_server_timeout: int = 20
+    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
+    database."""
+
+    # ---------------------------------------------------------------------
+    # MCP Session-manager tuning
+    # ---------------------------------------------------------------------
+    mcp_max_sessions_per_server: int = 10
+    """Maximum number of MCP sessions to keep per unique server (command/url).
+    Mirrors the default constant MAX_SESSIONS_PER_SERVER in util.py. Adjust to
+    control resource usage or concurrency per server."""
+
+    mcp_session_idle_timeout: int = 400  # seconds
+    """How long (in seconds) an MCP session can stay idle before the background
+    cleanup task disposes of it. Defaults to 5 minutes."""
+
+    mcp_session_cleanup_interval: int = 120  # seconds
+    """Frequency (in seconds) at which the background cleanup task wakes up to
+    reap idle sessions."""
+
+    # MCP Server
+    mcp_server_enabled: bool = True
+    """If set to False, Langflow will not enable the MCP server."""
+    mcp_server_enable_progress_notifications: bool = False
+    """If set to False, Langflow will not send progress notifications in the MCP server."""
+
+    # Add projects to MCP servers automatically on creation
+    add_projects_to_mcp_servers: bool = True
+    """If set to True, newly created projects will be added to the user's MCP servers config automatically."""
+
+    # MCP Composer
+    mcp_composer_enabled: bool = True
+    """If set to False, Langflow will not start the MCP Composer service."""
+    mcp_composer_version: str = "==0.1.0.8.10"
+    """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
+
+    @field_validator("mcp_composer_version", mode="before")
+    @classmethod
+    def validate_mcp_composer_version(cls, value):
+        """Ensure the version string has a version specifier prefix.
+
+        If a bare version like '0.1.0.7' is provided, prepend '~=' to allow patch updates.
+        Supports PEP 440 specifiers: ==, !=, <=, >=, <, >, ~=, ===
+        """
+        if not value:
+            return "==0.1.0.8.10"  # Default
+
+        specifiers = ["===", "==", "!=", "<=", ">=", "~=", "<", ">"]
+        if any(value.startswith(spec) for spec in specifiers):
+            return value
+
+        if re.match(r"^\d+(\.\d+)*", value):
+            logger.debug(f"Adding ~= prefix to bare version '{value}' -> '~={value}'")
+            return f"~={value}"
+
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -14,8 +14,7 @@ class McpSettings(BaseModel):
     the browser's window.location.origin."""
 
     mcp_server_timeout: int = 20
-    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
-    database."""
+    """Timeout in seconds for MCP server operations (tool calls, server requests)."""
 
     # ---------------------------------------------------------------------
     # MCP Session-manager tuning
@@ -25,9 +24,9 @@ class McpSettings(BaseModel):
     Mirrors the default constant MAX_SESSIONS_PER_SERVER in util.py. Adjust to
     control resource usage or concurrency per server."""
 
-    mcp_session_idle_timeout: int = 400  # seconds
+    mcp_session_idle_timeout: int = 400  # seconds (~6.7 minutes)
     """How long (in seconds) an MCP session can stay idle before the background
-    cleanup task disposes of it. Defaults to 5 minutes."""
+    cleanup task disposes of it."""
 
     mcp_session_cleanup_interval: int = 120  # seconds
     """Frequency (in seconds) at which the background cleanup task wakes up to

--- a/src/lfx/src/lfx/services/settings/groups/observability.py
+++ b/src/lfx/src/lfx/services/settings/groups/observability.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class ObservabilitySettings(BaseModel):
+    """Metrics exposure and historical record retention."""
+
+    prometheus_enabled: bool = False
+    """If set to True, Langflow will expose Prometheus metrics."""
+    prometheus_port: int = 9090
+    """The port on which Langflow will expose Prometheus metrics. 9090 is the default port."""
+
+    max_transactions_to_keep: int = 3000
+    """The maximum number of transactions to keep in the database."""
+    max_vertex_builds_to_keep: int = 3000
+    """The maximum number of vertex builds to keep in the database."""
+    max_vertex_builds_per_vertex: int = 50
+    """The maximum number of builds to keep per vertex. Older builds will be deleted."""
+    max_flow_version_entries_per_flow: int = 50
+    """Max version history entries per flow. Oldest entries pruned on next snapshot.
+
+    If retroactively lowered below the current count for a flow,
+    the oldest entries are deleted only when the next entry is created.
+    """

--- a/src/lfx/src/lfx/services/settings/groups/paths.py
+++ b/src/lfx/src/lfx/services/settings/groups/paths.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+
+class PathSettings(BaseModel):
+    """Filesystem paths Langflow reads from and writes to."""
+
+    config_dir: str | None = None
+    """Base directory for Langflow data (db, logs, caches)."""
+
+    knowledge_bases_dir: str | None = "~/.langflow/knowledge_bases"
+    """The directory to store knowledge bases."""
+
+    @field_validator("config_dir", mode="before")
+    @classmethod
+    def set_langflow_dir(cls, value: Any) -> str:
+        if not value:
+            from platformdirs import user_cache_dir
+
+            app_name = "langflow"
+            app_author = "langflow"
+
+            cache_dir = user_cache_dir(app_name, app_author)
+
+            value = Path(cache_dir)
+            value.mkdir(parents=True, exist_ok=True)
+
+        if isinstance(value, str):
+            value = Path(value)
+        value = value.resolve()
+        if not value.exists():
+            value.mkdir(parents=True, exist_ok=True)
+
+        return str(value)

--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -1,0 +1,54 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from lfx.log.logger import logger
+
+
+class RuntimeSettings(BaseModel):
+    """Runtime behaviors: event delivery, worker timeouts, polling intervals, public flows, misc toggles.
+
+    Note: ``event_delivery`` is validated here but reads ``workers`` from
+    :class:`ServerSettings`. The composition order in :class:`Settings`
+    guarantees ``workers`` is in ``info.data`` when this validator runs.
+    """
+
+    dev: bool = False
+    """If True, Langflow will run in development mode."""
+
+    event_delivery: Literal["polling", "streaming", "direct"] = "streaming"
+    """How to deliver build events to the frontend. Can be 'polling', 'streaming' or 'direct'."""
+
+    worker_timeout: int = 300
+    """Timeout for the API calls in seconds."""
+
+    public_flow_cleanup_interval: int = Field(default=3600, gt=600)
+    """The interval in seconds at which public temporary flows will be cleaned up.
+    Default is 1 hour (3600 seconds). Minimum is 600 seconds (10 minutes)."""
+    public_flow_expiration: int = Field(default=86400, gt=600)
+    """The time in seconds after which a public temporary flow will be considered expired and eligible for cleanup.
+    Default is 24 hours (86400 seconds). Minimum is 600 seconds (10 minutes)."""
+
+    webhook_polling_interval: int = 0
+    """The polling interval for the webhook in ms. Set to 0 to disable (SSE provides real-time updates)."""
+    fs_flows_polling_interval: int = 10000
+    """The polling interval in milliseconds for synchronizing flows from the file system."""
+
+    health_check_max_retries: int = 5
+    """The maximum number of retries for the health check."""
+
+    max_file_size_upload: int = 1024
+    """The maximum file size for the upload in MB."""
+
+    celery_enabled: bool = False
+
+    @field_validator("event_delivery", mode="before")
+    @classmethod
+    def set_event_delivery(cls, value, info):
+        # If workers > 1, we need to use direct delivery
+        # because polling and streaming are not supported
+        # in multi-worker environments
+        if info.data.get("workers", 1) > 1:
+            logger.warning("Multi-worker environment detected, using direct event delivery")
+            return "direct"
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel, field_validator
+
+
+class SecuritySettings(BaseModel):
+    """CORS, SSRF protection, API key handling, and custom-component policy."""
+
+    # CORS
+    cors_origins: list[str] | str = "*"
+    """Allowed origins for CORS. Can be a list of origins or '*' for all origins.
+    Default is '*' for backward compatibility. In production, specify exact origins."""
+    cors_allow_credentials: bool = True
+    """Whether to allow credentials in CORS requests.
+    Default is True for backward compatibility. In v2.0, this will be changed to False when using wildcard origins."""
+    cors_allow_methods: list[str] | str = "*"
+    """Allowed HTTP methods for CORS requests."""
+    cors_allow_headers: list[str] | str = "*"
+    """Allowed headers for CORS requests."""
+
+    # SSRF Protection
+    ssrf_protection_enabled: bool = True
+    """If set to True, Langflow will enable SSRF (Server-Side Request Forgery) protection.
+    When enabled, blocks requests to private IP ranges, localhost, and cloud metadata endpoints.
+    When False, no URL validation is performed, allowing requests to any destination
+    including internal services, private networks, and cloud metadata endpoints.
+    Default is True to protect against SSRF attacks including DNS rebinding.
+
+    Note: When ssrf_protection_enabled is disabled, the ssrf_allowed_hosts setting is ignored and has no effect."""
+    ssrf_allowed_hosts: list[str] = []
+    """Comma-separated list of hosts/IPs/CIDR ranges to allow despite SSRF protection.
+    Examples: 'internal-api.company.local,192.168.1.0/24,10.0.0.5,*.dev.internal'
+    Supports exact hostnames, wildcard domains (*.example.com), exact IPs, and CIDR ranges.
+
+    Note: This setting only takes effect when ssrf_protection_enabled is True.
+    When protection is disabled, all hosts are allowed regardless of this setting."""
+
+    # API key handling
+    disable_track_apikey_usage: bool = False
+    remove_api_keys: bool = False
+
+    # Custom Component Security
+    allow_custom_components: bool = True
+    """If set to False, blocks execution of components whose code does not match a known
+    server template.
+
+    The server validates node code against its component template cache;
+    when the cache is not yet loaded (e.g., during startup), all flow execution is blocked
+    as a safety measure.
+
+    Note: LANGFLOW_COMPONENTS_PATH can be used to define an allow-list of custom components
+    that will be allowed to execute, even when allow_custom_components is False.
+
+    Note: this is a beta feature. For security in a multi-tenant environment,
+    use hardware-level isolation to restrict access."""
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def validate_cors_origins(cls, value):
+        """Convert comma-separated string to list if needed.
+
+        Pydantic-settings on Python 3.14 parses the env var "*" into ["*"]
+        before this validator runs (the union list[str] | str resolves
+        differently). Collapse that back to the bare-string wildcard so
+        downstream consumers see the same shape on every Python version.
+        """
+        if isinstance(value, list) and value == ["*"]:
+            return "*"
+        if isinstance(value, str) and value != "*":
+            if "," in value:
+                return [origin.strip() for origin in value.split(",")]
+            return [value]
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/server.py
+++ b/src/lfx/src/lfx/services/settings/groups/server.py
@@ -1,0 +1,111 @@
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator
+
+from lfx.log.logger import logger
+
+
+class ServerSettings(BaseModel):
+    """ASGI server, process, and logging settings."""
+
+    host: str = "localhost"
+    """The host on which Langflow will run."""
+    port: int = 7860
+    """The port on which Langflow will run."""
+    runtime_port: int | None = Field(default=None, exclude=True)
+    """TEMPORARY: The port detected at runtime after checking for conflicts.
+    This field is system-managed only and will be removed in future versions
+    when strict port enforcement is implemented (errors will be raised if port unavailable)."""
+    workers: int = 1
+    """The number of workers to run."""
+    log_level: str = "critical"
+    """The log level for Langflow."""
+    log_file: str | None = "logs/langflow.log"
+    """The path to log file for Langflow."""
+    alembic_log_file: str = "alembic/alembic.log"
+    """The path to log file for Alembic for SQLAlchemy."""
+    alembic_log_to_stdout: bool = False
+    """If set to True, the log file will be ignored and Alembic will log to stdout."""
+    frontend_path: str | None = None
+    """The path to the frontend directory containing build files. This is for development purposes only."""
+    open_browser: bool = False
+    """If set to True, Langflow will open the browser on startup."""
+    backend_only: bool = False
+    """If set to True, Langflow will not serve the frontend."""
+    ssl_cert_file: str | None = None
+    """Path to the SSL certificate file on the local system."""
+    ssl_key_file: str | None = None
+    """Path to the SSL key file on the local system."""
+    root_path: str = ""
+    """ASGI root_path for deployments behind a reverse proxy that strips a URL
+    prefix (e.g. '/langflow').  When set, the MCP SSE transport includes this
+    prefix in the POST-back URL so clients can reach the correct endpoint.
+    Can also be set via the LANGFLOW_ROOT_PATH environment variable."""
+    user_agent: str = "langflow"
+    """User agent for the API calls."""
+
+    @field_validator("root_path", mode="before")
+    @classmethod
+    def validate_root_path(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        if not isinstance(value, str):
+            msg = "root_path must be a string"
+            raise TypeError(msg)
+
+        value = value.strip()
+        if not value or value == "/":
+            return ""
+
+        if "://" in value or "?" in value or "#" in value:
+            msg = "root_path must be an ASGI path prefix only, without scheme, query string, or fragment"
+            raise ValueError(msg)
+
+        if not value.startswith("/"):
+            value = f"/{value}"
+
+        return value.rstrip("/")
+
+    @field_validator("runtime_port", mode="before")
+    @classmethod
+    def validate_runtime_port(cls, value):
+        """Parse port from Kubernetes service discovery env vars.
+
+        Kubernetes auto-creates env vars like LANGFLOW_RUNTIME_PORT=tcp://<ip>:<port>
+        for services, which collides with the LANGFLOW_ env prefix. Extract the port
+        number from URL-like values instead of failing.
+        """
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            if value.isdigit():
+                return int(value)
+            if "://" in value:
+                try:
+                    parsed_port = urlparse(value).port
+                except ValueError:
+                    return None
+                if parsed_port is not None:
+                    return parsed_port
+        return None
+
+    @field_validator("log_file", mode="before")
+    @classmethod
+    def set_log_file(cls, value):
+        if isinstance(value, Path):
+            value = str(value)
+        return value
+
+    @field_validator("user_agent", mode="after")
+    @classmethod
+    def set_user_agent(cls, value):
+        if not value:
+            value = "Langflow"
+        os.environ["USER_AGENT"] = value
+        logger.debug(f"Setting user agent to {value}")
+        return value

--- a/src/lfx/src/lfx/services/settings/groups/storage.py
+++ b/src/lfx/src/lfx/services/settings/groups/storage.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class StorageSettings(BaseModel):
+    """File storage backend (local filesystem or object storage)."""
+
+    storage_type: str = "local"
+    """Storage type for file storage. Defaults to 'local'. Supports 'local' and 's3'."""
+    object_storage_bucket_name: str | None = "langflow-bucket"
+    """Object storage bucket name for file storage. Defaults to 'langflow-bucket'."""
+    object_storage_prefix: str | None = "files"
+    """Object storage prefix for file storage. Defaults to 'files'."""
+    object_storage_tags: dict[str, str] | None = None
+    """Object storage tags for file storage."""

--- a/src/lfx/src/lfx/services/settings/groups/telemetry.py
+++ b/src/lfx/src/lfx/services/settings/groups/telemetry.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class TelemetrySettings(BaseModel):
+    """Telemetry, error tracking, and tracing settings."""
+
+    # Sentry
+    sentry_dsn: str | None = None
+    sentry_traces_sample_rate: float | None = 1.0
+    sentry_profiles_sample_rate: float | None = 1.0
+
+    # Telemetry
+    do_not_track: bool = False
+    """If set to True, Langflow will not track telemetry."""
+    telemetry_base_url: str = "https://langflow.gateway.scarf.sh"
+
+    transactions_storage_enabled: bool = True
+    """If set to True, Langflow will track transactions between flows."""
+    vertex_builds_storage_enabled: bool = True
+    """If set to True, Langflow will keep track of each vertex builds (outputs) in the UI for any flow."""
+
+    deactivate_tracing: bool = False
+    """If set to True, tracing will be deactivated."""

--- a/src/lfx/src/lfx/services/settings/groups/ui.py
+++ b/src/lfx/src/lfx/services/settings/groups/ui.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+
+from lfx.serialization.constants import MAX_ITEMS_LENGTH, MAX_TEXT_LENGTH
+
+
+class UiSettings(BaseModel):
+    """Frontend, auto-save, display limits, and (legacy) Langflow Store integration."""
+
+    auto_saving: bool = True
+    """If set to True, Langflow will auto save flows."""
+    auto_saving_interval: int = 1000
+    """The interval in ms at which Langflow will auto save flows."""
+
+    max_text_length: int = MAX_TEXT_LENGTH
+    """Maximum number of characters to store and display in the UI. Responses longer than this
+    will be truncated when displayed in the UI. Does not truncate responses between components nor outputs."""
+    max_items_length: int = MAX_ITEMS_LENGTH
+    """Maximum number of items to store and display in the UI. Lists longer than this
+    will be truncated when displayed in the UI. Does not affect data passed between components nor outputs."""
+
+    frontend_timeout: int = 0
+    """Timeout for the frontend API calls in seconds."""
+
+    # Langflow Store (legacy)
+    store: bool | None = True
+    store_url: str | None = "https://api.langflow.store"
+    download_webhook_url: str | None = "https://api.langflow.store/flows/trigger/ec611a61-8460-4438-b187-a4f65e5559d4"
+    like_webhook_url: str | None = "https://api.langflow.store/flows/trigger/64275852-ec00-45c1-984e-3bff814732da"

--- a/src/lfx/src/lfx/services/settings/groups/variables.py
+++ b/src/lfx/src/lfx/services/settings/groups/variables.py
@@ -1,0 +1,46 @@
+import os
+
+from pydantic import BaseModel, field_validator
+
+from lfx.services.settings.constants import AGENTIC_VARIABLES, VARIABLES_TO_GET_FROM_ENVIRONMENT
+
+
+class VariablesSettings(BaseModel):
+    """Global variable store, environment-variable bridge, and experimental feature toggles."""
+
+    variable_store: str = "db"
+    """The store can be 'db' or 'kubernetes'."""
+
+    fallback_to_env_var: bool = True
+    """If set to True, Global Variables set in the UI will fallback to a environment variable
+    with the same name in case Langflow fails to retrieve the variable value."""
+
+    store_environment_variables: bool = True
+    """Whether to store environment variables as Global Variables in the database."""
+
+    variables_to_get_from_environment: list[str] = VARIABLES_TO_GET_FROM_ENVIRONMENT
+    """List of environment variables to get from the environment and store in the database."""
+
+    # Agentic Experience
+    agentic_experience: bool = False
+    """If set to True, Langflow will start the agentic MCP server that provides tools for
+    flow/component operations, template search, and graph visualization."""
+
+    # Developer API
+    developer_api_enabled: bool = False
+    """If set to True, Langflow will enable developer API endpoints for advanced debugging and introspection."""
+
+    @field_validator("variables_to_get_from_environment", mode="before")
+    @classmethod
+    def set_variables_to_get_from_environment(cls, value):
+        if isinstance(value, str):
+            value = value.split(",")
+
+        result = list(set(VARIABLES_TO_GET_FROM_ENVIRONMENT + value))
+
+        # Add agentic variables if agentic_experience is enabled
+        # Check env var directly since we can't access instance attributes in validator
+        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
+            result.extend(AGENTIC_VARIABLES)
+
+        return list(set(result))

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -1,0 +1,318 @@
+"""Structural tests for the composed ``Settings`` class.
+
+These guard the refactor that split ``Settings`` into per-group mixins:
+
+- every field that used to live on ``Settings`` still does (catches an
+  accidental drop of a group from the inheritance list),
+- a sampling of critical defaults is unchanged,
+- cross-group validators still see their dependencies in ``info.data``
+  (workers -> event_delivery, config_dir -> database_url),
+- yaml round-trip and the small utility helpers still work.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from lfx.services.settings.base import (
+    BASE_COMPONENTS_PATH,
+    CustomSource,
+    Settings,
+    is_list_of_any,
+    load_settings_from_yaml,
+    save_settings_to_yaml,
+)
+
+# Fields that existed on the monolithic Settings before the split. Asserted as
+# a set so a missing group in the inheritance chain trips the test loudly.
+EXPECTED_FIELDS = {
+    # PathSettings
+    "config_dir",
+    "knowledge_bases_dir",
+    # ServerSettings
+    "host",
+    "port",
+    "runtime_port",
+    "workers",
+    "log_level",
+    "log_file",
+    "alembic_log_file",
+    "alembic_log_to_stdout",
+    "frontend_path",
+    "open_browser",
+    "backend_only",
+    "ssl_cert_file",
+    "ssl_key_file",
+    "root_path",
+    "user_agent",
+    # DatabaseSettings
+    "save_db_in_config_dir",
+    "database_url",
+    "database_connection_retry",
+    "pool_size",
+    "max_overflow",
+    "db_connect_timeout",
+    "migration_lock_namespace",
+    "sqlite_pragmas",
+    "db_driver_connection_settings",
+    "db_connection_settings",
+    "use_noop_database",
+    # CacheSettings
+    "cache_type",
+    "cache_expire",
+    "langchain_cache",
+    "redis_host",
+    "redis_port",
+    "redis_db",
+    "redis_url",
+    "redis_cache_expire",
+    # StorageSettings
+    "storage_type",
+    "object_storage_bucket_name",
+    "object_storage_prefix",
+    "object_storage_tags",
+    # McpSettings
+    "mcp_base_url",
+    "mcp_server_timeout",
+    "mcp_max_sessions_per_server",
+    "mcp_session_idle_timeout",
+    "mcp_session_cleanup_interval",
+    "mcp_server_enabled",
+    "mcp_server_enable_progress_notifications",
+    "add_projects_to_mcp_servers",
+    "mcp_composer_enabled",
+    "mcp_composer_version",
+    # TelemetrySettings
+    "sentry_dsn",
+    "sentry_traces_sample_rate",
+    "sentry_profiles_sample_rate",
+    "do_not_track",
+    "telemetry_base_url",
+    "transactions_storage_enabled",
+    "vertex_builds_storage_enabled",
+    "deactivate_tracing",
+    # ObservabilitySettings
+    "prometheus_enabled",
+    "prometheus_port",
+    "max_transactions_to_keep",
+    "max_vertex_builds_to_keep",
+    "max_vertex_builds_per_vertex",
+    "max_flow_version_entries_per_flow",
+    # SecuritySettings
+    "cors_origins",
+    "cors_allow_credentials",
+    "cors_allow_methods",
+    "cors_allow_headers",
+    "ssrf_protection_enabled",
+    "ssrf_allowed_hosts",
+    "disable_track_apikey_usage",
+    "remove_api_keys",
+    "allow_custom_components",
+    # ComponentsSettings
+    "components_path",
+    "components_index_path",
+    "load_flows_path",
+    "bundle_urls",
+    "lazy_load_components",
+    "create_starter_projects",
+    "update_starter_projects",
+    # UiSettings
+    "auto_saving",
+    "auto_saving_interval",
+    "max_text_length",
+    "max_items_length",
+    "frontend_timeout",
+    "store",
+    "store_url",
+    "download_webhook_url",
+    "like_webhook_url",
+    # RuntimeSettings
+    "dev",
+    "event_delivery",
+    "worker_timeout",
+    "public_flow_cleanup_interval",
+    "public_flow_expiration",
+    "webhook_polling_interval",
+    "fs_flows_polling_interval",
+    "health_check_max_retries",
+    "max_file_size_upload",
+    "celery_enabled",
+    # VariablesSettings
+    "variable_store",
+    "fallback_to_env_var",
+    "store_environment_variables",
+    "variables_to_get_from_environment",
+    "agentic_experience",
+    "developer_api_enabled",
+}
+
+
+def test_all_expected_fields_present():
+    """Every field that lived on the monolithic Settings is still present.
+
+    Trips loudly if a group is dropped from the inheritance list.
+    """
+    actual = set(Settings.model_fields)
+    missing = EXPECTED_FIELDS - actual
+    assert not missing, f"Settings is missing fields: {sorted(missing)}"
+
+
+def test_field_count_unchanged():
+    """The total field count matches the pre-refactor count."""
+    assert len(Settings.model_fields) == len(EXPECTED_FIELDS)
+
+
+def test_critical_defaults_unchanged():
+    """A sampling of important field defaults survives the split byte-for-byte."""
+    settings = Settings()
+    assert settings.host == "localhost"
+    assert settings.port == 7860
+    assert settings.workers == 1
+    assert settings.cache_type == "async"
+    assert settings.storage_type == "local"
+    assert settings.event_delivery == "streaming"
+    assert settings.cors_origins == "*"
+    assert settings.cors_allow_credentials is True
+    assert settings.ssrf_protection_enabled is True
+    assert settings.allow_custom_components is True
+    assert settings.mcp_server_enabled is True
+    assert settings.mcp_composer_enabled is True
+    assert settings.do_not_track is False
+    assert settings.dev is False
+    assert settings.agentic_experience is False
+    assert settings.developer_api_enabled is False
+
+
+def test_dict_defaults_unchanged():
+    """Dict-typed defaults like sqlite_pragmas and db_connection_settings are intact."""
+    settings = Settings()
+    assert settings.sqlite_pragmas == {
+        "synchronous": "NORMAL",
+        "journal_mode": "WAL",
+        "busy_timeout": 30000,
+    }
+    assert settings.db_connection_settings == {
+        "pool_size": 20,
+        "max_overflow": 30,
+        "pool_timeout": 30,
+        "pool_pre_ping": True,
+        "pool_recycle": 1800,
+        "echo": False,
+    }
+
+
+def test_multi_worker_forces_direct_event_delivery(monkeypatch):
+    """Workers > 1 must flip event_delivery to 'direct'.
+
+    Exercises the cross-group validator dependency: event_delivery lives in
+    RuntimeSettings, workers lives in ServerSettings, and the inheritance
+    order in Settings must ensure workers is in info.data when
+    event_delivery validates.
+    """
+    monkeypatch.setenv("LANGFLOW_WORKERS", "4")
+    monkeypatch.setenv("LANGFLOW_EVENT_DELIVERY", "streaming")
+    settings = Settings()
+    assert settings.workers == 4
+    assert settings.event_delivery == "direct"
+
+
+def test_single_worker_keeps_explicit_event_delivery(monkeypatch):
+    """Workers == 1 leaves an explicit event_delivery setting alone."""
+    monkeypatch.setenv("LANGFLOW_WORKERS", "1")
+    monkeypatch.setenv("LANGFLOW_EVENT_DELIVERY", "polling")
+    settings = Settings()
+    assert settings.event_delivery == "polling"
+
+
+def test_database_url_sees_config_dir(monkeypatch, tmp_path):
+    """database_url validator must see config_dir in info.data.
+
+    With config_dir set and no LANGFLOW_DATABASE_URL env var, the validator
+    falls back to a sqlite path under the langflow package directory. If
+    PathSettings's config_dir wasn't validated first, the validator would
+    raise 'config_dir not set'.
+    """
+    monkeypatch.delenv("LANGFLOW_DATABASE_URL", raising=False)
+    monkeypatch.setenv("LANGFLOW_CONFIG_DIR", str(tmp_path))
+    settings = Settings()
+    assert settings.database_url.startswith("sqlite:///")
+    assert settings.config_dir == str(tmp_path)
+
+
+def test_back_compat_exports():
+    """Symbols that consumers import from settings.base are still exported."""
+    assert is_list_of_any is not None
+    assert CustomSource is not None
+    assert save_settings_to_yaml is not None
+    assert load_settings_from_yaml is not None
+    assert isinstance(BASE_COMPONENTS_PATH, str)
+
+
+def test_update_settings_scalar():
+    """Settings.update_settings replaces scalar fields."""
+    settings = Settings()
+    settings.update_settings(port=9999)
+    assert settings.port == 9999
+
+
+def test_update_settings_list_appends_unique():
+    """Settings.update_settings appends to list fields without duplicates."""
+    settings = Settings()
+    before = list(settings.bundle_urls)
+    settings.update_settings(bundle_urls="https://example.com/bundle")
+    assert "https://example.com/bundle" in settings.bundle_urls
+    # Applying twice doesn't duplicate
+    settings.update_settings(bundle_urls="https://example.com/bundle")
+    assert settings.bundle_urls.count("https://example.com/bundle") == 1
+    # Original entries untouched
+    for url in before:
+        assert url in settings.bundle_urls
+
+
+def test_yaml_round_trip():
+    """save_settings_to_yaml + load_settings_from_yaml preserves field values."""
+    settings = Settings()
+    original_components = list(settings.components_path)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        yaml_path = f.name
+    try:
+        save_settings_to_yaml(settings, yaml_path)
+        assert Path(yaml_path).exists()
+        # load_settings_from_yaml only reads components_path back today, but
+        # the helper should at least round-trip without erroring on a full dump.
+        # We don't assert deep equality because the yaml loader currently
+        # restricts to a subset of fields by design.
+    finally:
+        Path(yaml_path).unlink(missing_ok=True)
+
+    # components_path should be the same after re-instantiation with no env changes
+    settings2 = Settings()
+    assert settings2.components_path == original_components
+
+
+@pytest.mark.parametrize(
+    ("env_var", "env_value", "field", "expected"),
+    [
+        ("LANGFLOW_HOST", "0.0.0.0", "host", "0.0.0.0"),
+        ("LANGFLOW_PORT", "8080", "port", 8080),
+        ("LANGFLOW_WORKERS", "2", "workers", 2),
+        ("LANGFLOW_LOG_LEVEL", "info", "log_level", "info"),
+        ("LANGFLOW_CACHE_TYPE", "memory", "cache_type", "memory"),
+        ("LANGFLOW_STORAGE_TYPE", "s3", "storage_type", "s3"),
+        ("LANGFLOW_PROMETHEUS_ENABLED", "true", "prometheus_enabled", True),
+        ("LANGFLOW_PROMETHEUS_PORT", "9999", "prometheus_port", 9999),
+        ("LANGFLOW_MCP_SERVER_ENABLED", "false", "mcp_server_enabled", False),
+        ("LANGFLOW_DO_NOT_TRACK", "true", "do_not_track", True),
+        ("LANGFLOW_DEV", "true", "dev", True),
+        ("LANGFLOW_BACKEND_ONLY", "true", "backend_only", True),
+        ("LANGFLOW_AUTO_SAVING", "false", "auto_saving", False),
+        ("LANGFLOW_FALLBACK_TO_ENV_VAR", "false", "fallback_to_env_var", False),
+        ("LANGFLOW_VARIABLE_STORE", "kubernetes", "variable_store", "kubernetes"),
+    ],
+)
+def test_env_var_round_trip(monkeypatch, env_var, env_value, field, expected):
+    """A sampling of LANGFLOW_* env vars still populate the right fields."""
+    monkeypatch.setenv(env_var, env_value)
+    settings = Settings()
+    assert getattr(settings, field) == expected


### PR DESCRIPTION
## Summary

`src/lfx/src/lfx/services/settings/base.py` had grown to 755 lines and ~70 fields covering database, cache, MCP, telemetry, CORS, SSRF, storage, UI, server runtime, components, variables, observability, and more. This splits it into 13 cohesive `BaseModel` mixins under `groups/` and reduces `base.py` to 189 lines of composition + YAML helpers.

```
groups/
  paths.py          config_dir, knowledge_bases_dir
  server.py         host, port, runtime_port, workers, log_*, ssl_*, root_path, user_agent
  database.py       database_url, pool_*, sqlite_pragmas, db_*, use_noop_database
  cache.py          cache_type, langchain_cache, redis_*
  storage.py        storage_type, object_storage_*
  mcp.py            mcp_server_*, mcp_session_*, mcp_composer_*
  telemetry.py      sentry_*, do_not_track, transactions/vertex storage flags, deactivate_tracing
  observability.py  prometheus_*, max_transactions/vertex_*/flow_version
  security.py       cors_*, ssrf_*, allow_custom_components, api_key handling
  components.py     components_path, lazy_load, starter_projects, bundle_urls
  ui.py             auto_saving, max_text/items_length, store (legacy)
  runtime.py        event_delivery, worker_timeout, public_flow_*, polling, dev, celery_enabled
  variables.py      variable_store, env-var bridge, agentic_experience, developer_api_enabled
```

## Why mixins (not nested fields)

Nested `BaseModel`s with `env_nested_delimiter` would have been the textbook approach but would rename every env var (e.g. `LANGFLOW_DATABASE_URL` -> `LANGFLOW_DATABASE__URL`), which is a breaking change for users with these set in production.

Mixins keep the env var surface and call-site surface unchanged: `settings.database_url` and `LANGFLOW_DATABASE_URL` both still work.

## Cross-group validator ordering

Two validators read fields from another group through `info.data`:

- `database_url` (DatabaseSettings) needs `config_dir` from PathSettings
- `event_delivery` (RuntimeSettings) needs `workers` from ServerSettings

Pydantic collects fields from the rightmost base first, so the inheritance order in `Settings` is set so the dependency-providing groups appear rightmost: `..., DatabaseSettings, RuntimeSettings, ServerSettings, PathSettings, BaseSettings`. Validators stay co-located with their fields.

## Compatibility

- Zero env var changes.
- Zero call-site changes (`settings.database_url` etc still work flat).
- `BASE_COMPONENTS_PATH` is still importable from `lfx.services.settings.base` for tests that rely on the transitive re-export.
- `AuthSettings` and the `langflow.services.settings.base` shim are untouched.

## Tests

- 65/65 `src/lfx/tests/unit/services/settings/` tests pass.
- 90 backend consumers pass (CORS, db path resolution, MCP reverse proxy, vertex builds, tracing, component loading, endpoints).
- Two failures observed on this branch were verified to fail identically on `main` (custom-components error string mismatch in `test_endpoints.py`, Flow UUID fixture issue in `test_concurrent_stream_run_with_input_type_chat`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized application settings architecture for improved maintainability and configuration management. Settings are now logically grouped by functional area (cache, database, security, server, and more) while maintaining backward compatibility with existing configuration methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->