### PR TITLE
fix: handle unpickleable chat cache writes

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/services/chat/service.py
+++ b/src/backend/base/langflow/services/chat/service.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from threading import RLock
 from typing import Any
 
+from lfx.log.logger import logger
+
 from langflow.services.base import Service
 from langflow.services.cache.base import AsyncBaseCacheService, CacheService
 from langflow.services.deps import get_cache_service
@@ -33,12 +35,19 @@ class ChatService(Service):
             "result": data,
             "type": type(data),
         }
-        if isinstance(self.cache_service, AsyncBaseCacheService):
-            await self.cache_service.upsert(str(key), result_dict, lock=lock or self.async_cache_locks[key])
+        is_async_cache = isinstance(self.cache_service, AsyncBaseCacheService)
+        try:
+            if is_async_cache:
+                await self.cache_service.upsert(str(key), result_dict, lock=lock or self.async_cache_locks[key])
+            else:
+                await asyncio.to_thread(
+                    self.cache_service.upsert, str(key), result_dict, lock=lock or self._sync_cache_locks[key]
+                )
+        except TypeError as exc:
+            await logger.awarning(f"Could not cache chat data for key '{key}': {exc}")
+            return False
+        if is_async_cache:
             return await self.cache_service.contains(key)
-        await asyncio.to_thread(
-            self.cache_service.upsert, str(key), result_dict, lock=lock or self._sync_cache_locks[key]
-        )
         return key in self.cache_service
 
     async def get_cache(self, key: str, lock: asyncio.Lock | None = None) -> Any:

--- a/src/backend/tests/unit/services/test_chat_service_cache.py
+++ b/src/backend/tests/unit/services/test_chat_service_cache.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from threading import RLock
 from typing import Any
 
-from langflow.services.cache.base import AsyncBaseCacheService
+from langflow.services.cache.base import AsyncBaseCacheService, CacheService
 from langflow.services.chat.service import ChatService
 from lfx.services.cache.utils import CACHE_MISS
 
@@ -14,6 +14,8 @@ CONTAINS_AFTER_FAILURE_MESSAGE = "contains should not be called after a rejected
 
 
 class RejectingAsyncCache(AsyncBaseCacheService):
+    """Async cache double that rejects writes like Redis can when dill fails."""
+
     async def get(self, _key, lock=None):
         _ = lock
         return CACHE_MISS
@@ -37,6 +39,8 @@ class RejectingAsyncCache(AsyncBaseCacheService):
 
 
 class RecordingAsyncCache(AsyncBaseCacheService):
+    """Async cache double that stores successful writes in memory."""
+
     def __init__(self) -> None:
         self.values: dict[str, Any] = {}
 
@@ -64,7 +68,86 @@ class RecordingAsyncCache(AsyncBaseCacheService):
         return key in self.values
 
 
-def _chat_service_with_cache(cache: AsyncBaseCacheService) -> ChatService:
+class RejectingSyncCache(CacheService):
+    """Sync cache double that rejects writes like Redis can when dill fails."""
+
+    def get(self, _key, lock=None):
+        _ = lock
+        return CACHE_MISS
+
+    def set(self, _key, _value, lock=None):
+        _ = lock
+        raise TypeError(PICKLE_ERROR_MESSAGE)
+
+    def upsert(self, _key, _value, lock=None):
+        _ = lock
+        raise TypeError(PICKLE_ERROR_MESSAGE)
+
+    def delete(self, _key, lock=None):
+        _ = lock
+
+    def clear(self, lock=None):
+        _ = lock
+
+    def contains(self, _key) -> bool:
+        raise AssertionError(CONTAINS_AFTER_FAILURE_MESSAGE)
+
+    def __contains__(self, _key) -> bool:
+        raise AssertionError(CONTAINS_AFTER_FAILURE_MESSAGE)
+
+    def __getitem__(self, _key):
+        return CACHE_MISS
+
+    def __setitem__(self, _key, _value) -> None:
+        raise TypeError(PICKLE_ERROR_MESSAGE)
+
+    def __delitem__(self, _key) -> None:
+        return None
+
+
+class RecordingSyncCache(CacheService):
+    """Sync cache double that stores successful writes in memory."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+
+    def get(self, key, lock=None):
+        _ = lock
+        return self.values.get(key, CACHE_MISS)
+
+    def set(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    def upsert(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    def delete(self, key, lock=None):
+        _ = lock
+        self.values.pop(key, None)
+
+    def clear(self, lock=None):
+        _ = lock
+        self.values.clear()
+
+    def contains(self, key) -> bool:
+        return key in self.values
+
+    def __contains__(self, key) -> bool:
+        return key in self.values
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def __setitem__(self, key, value) -> None:
+        self.values[key] = value
+
+    def __delitem__(self, key) -> None:
+        del self.values[key]
+
+
+def _chat_service_with_cache(cache: AsyncBaseCacheService | CacheService) -> ChatService:
     service = ChatService.__new__(ChatService)
     service.async_cache_locks = defaultdict(asyncio.Lock)
     service._sync_cache_locks = defaultdict(RLock)
@@ -86,6 +169,30 @@ def test_set_cache_returns_false_when_async_cache_rejects_unpickleable_value():
 def test_set_cache_preserves_successful_async_cache_writes():
     async def run_test() -> None:
         cache = RecordingAsyncCache()
+        service = _chat_service_with_cache(cache)
+
+        cached = await service.set_cache("flow-id", "graph")
+
+        assert cached is True
+        assert cache.values["flow-id"] == {"result": "graph", "type": str}
+
+    asyncio.run(run_test())
+
+
+def test_set_cache_returns_false_when_sync_cache_rejects_unpickleable_value():
+    async def run_test() -> None:
+        service = _chat_service_with_cache(RejectingSyncCache())
+
+        cached = await service.set_cache("flow-id", object())
+
+        assert cached is False
+
+    asyncio.run(run_test())
+
+
+def test_set_cache_preserves_successful_sync_cache_writes():
+    async def run_test() -> None:
+        cache = RecordingSyncCache()
         service = _chat_service_with_cache(cache)
 
         cached = await service.set_cache("flow-id", "graph")

--- a/src/backend/tests/unit/services/test_chat_service_cache.py
+++ b/src/backend/tests/unit/services/test_chat_service_cache.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from threading import RLock
+from typing import Any
+
+from langflow.services.cache.base import AsyncBaseCacheService
+from langflow.services.chat.service import ChatService
+from lfx.services.cache.utils import CACHE_MISS
+
+PICKLE_ERROR_MESSAGE = "cannot pickle 'ConsoleThreadLocals' object"
+CONTAINS_AFTER_FAILURE_MESSAGE = "contains should not be called after a rejected cache write"
+
+
+class RejectingAsyncCache(AsyncBaseCacheService):
+    async def get(self, _key, lock=None):
+        _ = lock
+        return CACHE_MISS
+
+    async def set(self, _key, _value, lock=None):
+        _ = lock
+        raise TypeError(PICKLE_ERROR_MESSAGE)
+
+    async def upsert(self, _key, _value, lock=None):
+        _ = lock
+        raise TypeError(PICKLE_ERROR_MESSAGE)
+
+    async def delete(self, _key, lock=None):
+        _ = lock
+
+    async def clear(self, lock=None):
+        _ = lock
+
+    async def contains(self, _key) -> bool:
+        raise AssertionError(CONTAINS_AFTER_FAILURE_MESSAGE)
+
+
+class RecordingAsyncCache(AsyncBaseCacheService):
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+
+    async def get(self, key, lock=None):
+        _ = lock
+        return self.values.get(key, CACHE_MISS)
+
+    async def set(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    async def upsert(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    async def delete(self, key, lock=None):
+        _ = lock
+        self.values.pop(key, None)
+
+    async def clear(self, lock=None):
+        _ = lock
+        self.values.clear()
+
+    async def contains(self, key) -> bool:
+        return key in self.values
+
+
+def _chat_service_with_cache(cache: AsyncBaseCacheService) -> ChatService:
+    service = ChatService.__new__(ChatService)
+    service.async_cache_locks = defaultdict(asyncio.Lock)
+    service._sync_cache_locks = defaultdict(RLock)
+    service.cache_service = cache
+    return service
+
+
+def test_set_cache_returns_false_when_async_cache_rejects_unpickleable_value():
+    async def run_test() -> None:
+        service = _chat_service_with_cache(RejectingAsyncCache())
+
+        cached = await service.set_cache("flow-id", object())
+
+        assert cached is False
+
+    asyncio.run(run_test())
+
+
+def test_set_cache_preserves_successful_async_cache_writes():
+    async def run_test() -> None:
+        cache = RecordingAsyncCache()
+        service = _chat_service_with_cache(cache)
+
+        cached = await service.set_cache("flow-id", "graph")
+
+        assert cached is True
+        assert cache.values["flow-id"] == {"result": "graph", "type": str}
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- prevent optional chat cache writes from failing the whole flow build when Redis/dill rejects an unpickleable graph object
- keep successful cache writes unchanged for async and sync cache services
- add focused ChatService tests for the rejected-cache-write path and the successful async write path

Fixes #8476.

## Testing
- `python -m pytest --noconftest C:\Users\sebas\workspaces\payout-audits\langflow\src\backend\tests\unit\services\test_chat_service_cache.py -q`
- `python -m ruff check C:\Users\sebas\workspaces\payout-audits\langflow\src\backend\base\langflow\services\chat\service.py C:\Users\sebas\workspaces\payout-audits\langflow\src\backend\tests\unit\services\test_chat_service_cache.py`
- `python -m py_compile C:\Users\sebas\workspaces\payout-audits\langflow\src\backend\base\langflow\services\chat\service.py C:\Users\sebas\workspaces\payout-audits\langflow\src\backend\tests\unit\services\test_chat_service_cache.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced error handling for cache operations to gracefully recover when storage failures occur, allowing the system to continue functioning while logging diagnostic information.

## Tests
- Added test coverage to validate cache error handling and recovery behavior across successful and failed cache operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->