### PR TITLE
fix: tolerate unpickleable chat cache writes

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -242,14 +242,16 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
     @override
     async def set(self, key, value, lock=None) -> None:
         try:
-            if pickled := dill.dumps(value, recurse=True):
-                result = await self._client.setex(str(key), self.expiration_time, pickled)
-                if not result:
-                    msg = "RedisCache could not set the value."
-                    raise ValueError(msg)
-        except pickle.PicklingError as exc:
+            pickled = dill.dumps(value, recurse=True)
+        except (pickle.PicklingError, TypeError, AttributeError) as exc:
             msg = "RedisCache only accepts values that can be pickled. "
             raise TypeError(msg) from exc
+
+        if pickled:
+            result = await self._client.setex(str(key), self.expiration_time, pickled)
+            if not result:
+                msg = "RedisCache could not set the value."
+                raise ValueError(msg)
 
     @override
     async def upsert(self, key, value, lock=None) -> None:

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -247,11 +247,14 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
             msg = "RedisCache only accepts values that can be pickled. "
             raise TypeError(msg) from exc
 
-        if pickled:
-            result = await self._client.setex(str(key), self.expiration_time, pickled)
-            if not result:
-                msg = "RedisCache could not set the value."
-                raise ValueError(msg)
+        if not pickled:
+            msg = "RedisCache serialization returned empty result."
+            raise ValueError(msg)
+
+        result = await self._client.setex(str(key), self.expiration_time, pickled)
+        if not result:
+            msg = "RedisCache could not set the value."
+            raise ValueError(msg)
 
     @override
     async def upsert(self, key, value, lock=None) -> None:

--- a/src/backend/base/langflow/services/chat/service.py
+++ b/src/backend/base/langflow/services/chat/service.py
@@ -3,9 +3,21 @@ from collections import defaultdict
 from threading import RLock
 from typing import Any
 
+from lfx.log.logger import logger
+
 from langflow.services.base import Service
 from langflow.services.cache.base import AsyncBaseCacheService, CacheService
 from langflow.services.deps import get_cache_service
+
+
+def _cache_type_name(data: Any) -> str:
+    data_type = type(data)
+    return f"{data_type.__module__}.{data_type.__qualname__}"
+
+
+def _is_pickle_error(exc: TypeError) -> bool:
+    message = str(exc).lower()
+    return "pickle" in message or "pickled" in message
 
 
 class ChatService(Service):
@@ -31,15 +43,21 @@ class ChatService(Service):
         """
         result_dict = {
             "result": data,
-            "type": type(data),
+            "type": _cache_type_name(data),
         }
-        if isinstance(self.cache_service, AsyncBaseCacheService):
-            await self.cache_service.upsert(str(key), result_dict, lock=lock or self.async_cache_locks[key])
-            return await self.cache_service.contains(key)
-        await asyncio.to_thread(
-            self.cache_service.upsert, str(key), result_dict, lock=lock or self._sync_cache_locks[key]
-        )
-        return key in self.cache_service
+        try:
+            if isinstance(self.cache_service, AsyncBaseCacheService):
+                await self.cache_service.upsert(str(key), result_dict, lock=lock or self.async_cache_locks[key])
+                return await self.cache_service.contains(key)
+            await asyncio.to_thread(
+                self.cache_service.upsert, str(key), result_dict, lock=lock or self._sync_cache_locks[key]
+            )
+            return key in self.cache_service
+        except TypeError as exc:
+            if not _is_pickle_error(exc):
+                raise
+            await logger.awarning(f"Skipping cache write for unpickleable value at key {key!r}: {exc}")
+            return False
 
     async def get_cache(self, key: str, lock: asyncio.Lock | None = None) -> Any:
         """Get the cache for a client.

--- a/src/backend/tests/unit/services/test_chat_service_cache.py
+++ b/src/backend/tests/unit/services/test_chat_service_cache.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from threading import RLock
+from typing import Any
+
+import pytest
+from langflow.services.cache.base import AsyncBaseCacheService
+from langflow.services.cache.service import RedisCache
+from langflow.services.chat.service import ChatService, _cache_type_name
+from lfx.services.cache.utils import CACHE_MISS
+
+
+class RecordingAsyncCache(AsyncBaseCacheService):
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+
+    async def get(self, key, lock=None):
+        _ = lock
+        return self.values.get(key, CACHE_MISS)
+
+    async def set(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    async def upsert(self, key, value, lock=None):
+        _ = lock
+        self.values[key] = value
+
+    async def delete(self, key, lock=None):
+        _ = lock
+        self.values.pop(key, None)
+
+    async def clear(self, lock=None):
+        _ = lock
+        self.values.clear()
+
+    async def contains(self, key) -> bool:
+        return key in self.values
+
+
+class RejectingAsyncCache(RecordingAsyncCache):
+    async def upsert(self, key, value, lock=None):
+        _ = key, value, lock
+        raise TypeError("cannot pickle 'ConsoleThreadLocals' object")
+
+    async def contains(self, key) -> bool:
+        _ = key
+        raise AssertionError("contains should not run after a rejected cache write")
+
+
+class UnexpectedTypeErrorAsyncCache(RecordingAsyncCache):
+    async def upsert(self, key, value, lock=None):
+        _ = key, value, lock
+        raise TypeError("missing required argument")
+
+
+class UnpickleableValue:
+    def __getstate__(self):
+        raise TypeError("cannot pickle test value")
+
+
+def make_chat_service(cache_service: AsyncBaseCacheService) -> ChatService:
+    service = ChatService.__new__(ChatService)
+    service.async_cache_locks = defaultdict(asyncio.Lock)
+    service._sync_cache_locks = defaultdict(RLock)
+    service.cache_service = cache_service
+    return service
+
+
+@pytest.mark.asyncio
+async def test_set_cache_stores_type_name_instead_of_class_object() -> None:
+    cache = RecordingAsyncCache()
+    service = make_chat_service(cache)
+    value = object()
+
+    assert await service.set_cache("flow-id", value) is True
+
+    assert cache.values["flow-id"] == {"result": value, "type": _cache_type_name(value)}
+    assert isinstance(cache.values["flow-id"]["type"], str)
+
+
+@pytest.mark.asyncio
+async def test_set_cache_returns_false_for_unpickleable_cache_values() -> None:
+    service = make_chat_service(RejectingAsyncCache())
+
+    assert await service.set_cache("flow-id", object()) is False
+
+
+@pytest.mark.asyncio
+async def test_set_cache_reraises_unrelated_type_errors() -> None:
+    service = make_chat_service(UnexpectedTypeErrorAsyncCache())
+
+    with pytest.raises(TypeError, match="missing required argument"):
+        await service.set_cache("flow-id", object())
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_rejects_unpickleable_values_before_network_write() -> None:
+    cache = RedisCache.__new__(RedisCache)
+    cache.expiration_time = 60
+
+    class FailingClient:
+        async def setex(self, key, expiration_time, value):
+            _ = key, expiration_time, value
+            pytest.fail("Redis should not be called when serialization fails")
+
+    cache._client = FailingClient()
+
+    with pytest.raises(TypeError, match="RedisCache only accepts values that can be pickled"):
+        await cache.set("flow-id", UnpickleableValue())

--- a/src/backend/tests/unit/services/test_chat_service_cache.py
+++ b/src/backend/tests/unit/services/test_chat_service_cache.py
@@ -6,6 +6,7 @@ from threading import RLock
 from typing import Any
 
 import pytest
+from langflow.services.cache import service as cache_service_module
 from langflow.services.cache.base import AsyncBaseCacheService
 from langflow.services.cache.service import RedisCache
 from langflow.services.chat.service import ChatService, _cache_type_name
@@ -69,7 +70,6 @@ def make_chat_service(cache_service: AsyncBaseCacheService) -> ChatService:
     return service
 
 
-@pytest.mark.asyncio
 async def test_set_cache_stores_type_name_instead_of_class_object() -> None:
     cache = RecordingAsyncCache()
     service = make_chat_service(cache)
@@ -81,14 +81,12 @@ async def test_set_cache_stores_type_name_instead_of_class_object() -> None:
     assert isinstance(cache.values["flow-id"]["type"], str)
 
 
-@pytest.mark.asyncio
 async def test_set_cache_returns_false_for_unpickleable_cache_values() -> None:
     service = make_chat_service(RejectingAsyncCache())
 
     assert await service.set_cache("flow-id", object()) is False
 
 
-@pytest.mark.asyncio
 async def test_set_cache_reraises_unrelated_type_errors() -> None:
     service = make_chat_service(UnexpectedTypeErrorAsyncCache())
 
@@ -96,7 +94,6 @@ async def test_set_cache_reraises_unrelated_type_errors() -> None:
         await service.set_cache("flow-id", object())
 
 
-@pytest.mark.asyncio
 async def test_redis_cache_rejects_unpickleable_values_before_network_write() -> None:
     cache = RedisCache.__new__(RedisCache)
     cache.expiration_time = 60
@@ -110,3 +107,19 @@ async def test_redis_cache_rejects_unpickleable_values_before_network_write() ->
 
     with pytest.raises(TypeError, match="RedisCache only accepts values that can be pickled"):
         await cache.set("flow-id", UnpickleableValue())
+
+
+async def test_redis_cache_rejects_empty_serialization_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = RedisCache.__new__(RedisCache)
+    cache.expiration_time = 60
+
+    class FailingClient:
+        async def setex(self, key, expiration_time, value):
+            _ = key, expiration_time, value
+            pytest.fail("Redis should not be called when serialization returns an empty value")
+
+    cache._client = FailingClient()
+    monkeypatch.setattr(cache_service_module.dill, "dumps", lambda value, recurse=True: b"")
+
+    with pytest.raises(ValueError, match="RedisCache serialization returned empty result"):
+        await cache.set("flow-id", object())


### PR DESCRIPTION
Fixes #8476

## Summary
- Store chat cache type metadata as a module-qualified type name instead of a raw class object.
- Wrap Redis dill serialization failures that raise `TypeError` or `AttributeError`, not just `pickle.PicklingError`.
- Skip only pickle-related chat cache write failures so a Redis cache miss does not fail flow execution.
- Add focused unit coverage for successful cache writes, unpickleable cache values, unrelated `TypeError` propagation, and Redis serialization failure before any network write.

## Why
The reported failure happens while Redis cache writes serialize the graph payload with `dill.dumps(..., recurse=True)`. The cached payload included both the graph and `type(data)`, which can make dill walk runtime module state and hit objects like `ConsoleThreadLocals`. Cache write failure should not break the flow run.

I kept this patch narrow and avoided generated starter-project churn.

## Verification
- `python -m py_compile src/backend/base/langflow/services/chat/service.py src/backend/base/langflow/services/cache/service.py src/backend/tests/unit/services/test_chat_service_cache.py`
- `git diff --check`
- Local isolated cache harness covering the new behavior passed.

I could not run full pytest or ruff in this Termux environment. `uv run --frozen pytest ...` fails before setup because uv cannot detect glibc or musl here, and native packages such as `orjson` and `ruff` start source builds instead of using wheels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache serialization handling: unpickleable values are detected early and handled gracefully (cache writes skipped, non-serialization TypeErrors still surface).
  * Empty or failed serializations now raise explicit errors instead of silently skipping writes; failed backend writes are detected and reported.

* **Tests**
  * Added unit tests covering cache behavior, serialization failures, early rejection of unpickleable values, and error-path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->