### PR TITLE
fix: skip unpickleable Redis cache values

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.3.2"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -242,14 +242,17 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
     @override
     async def set(self, key, value, lock=None) -> None:
         try:
-            if pickled := dill.dumps(value, recurse=True):
-                result = await self._client.setex(str(key), self.expiration_time, pickled)
-                if not result:
-                    msg = "RedisCache could not set the value."
-                    raise ValueError(msg)
-        except pickle.PicklingError as exc:
-            msg = "RedisCache only accepts values that can be pickled. "
-            raise TypeError(msg) from exc
+            pickled = dill.dumps(value, recurse=True)
+        except (pickle.PicklingError, TypeError, AttributeError) as exc:
+            await logger.awarning(
+                f"RedisCache skipped caching key '{key}' because the value could not be pickled: {exc}"
+            )
+            return
+        if pickled:
+            result = await self._client.setex(str(key), self.expiration_time, pickled)
+            if not result:
+                msg = "RedisCache could not set the value."
+                raise ValueError(msg)
 
     @override
     async def upsert(self, key, value, lock=None) -> None:

--- a/src/backend/tests/unit/services/test_cache_service.py
+++ b/src/backend/tests/unit/services/test_cache_service.py
@@ -1,14 +1,17 @@
+import threading
+
 import pytest
 from langflow.services.cache import service as cache_service
 
 
 class FakeRedisClient:
-    def __init__(self) -> None:
+    def __init__(self, *, setex_result=True) -> None:
+        self.setex_result = setex_result
         self.setex_calls = []
 
     async def setex(self, *args):
         self.setex_calls.append(args)
-        return True
+        return self.setex_result
 
 
 def make_redis_cache(client: FakeRedisClient):
@@ -24,22 +27,17 @@ async def test_redis_cache_set_skips_values_that_dill_cannot_pickle(monkeypatch)
     cache = make_redis_cache(client)
     warnings = []
 
-    def raise_type_error(*_args, **_kwargs):
-        msg = "cannot pickle 'ConsoleThreadLocals' object"
-        raise TypeError(msg)
-
     async def record_warning(message):
         warnings.append(message)
 
-    monkeypatch.setattr(cache_service.dill, "dumps", raise_type_error)
     monkeypatch.setattr(cache_service.logger, "awarning", record_warning)
 
-    await cache.set("flow-cache-key", {"result": object()})
+    await cache.set("flow-cache-key", {"result": threading.local()})
 
     assert client.setex_calls == []
     assert len(warnings) == 1
     assert "flow-cache-key" in warnings[0]
-    assert "ConsoleThreadLocals" in warnings[0]
+    assert "_thread._local" in warnings[0]
 
 
 @pytest.mark.asyncio
@@ -53,3 +51,12 @@ async def test_redis_cache_set_stores_pickled_values():
     assert client.setex_calls[0][0] == "flow-cache-key"
     assert client.setex_calls[0][1] == 3600
     assert cache_service.dill.loads(client.setex_calls[0][2]) == {"result": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_set_raises_when_redis_setex_fails():
+    client = FakeRedisClient(setex_result=False)
+    cache = make_redis_cache(client)
+
+    with pytest.raises(ValueError, match=r"RedisCache could not set the value\."):
+        await cache.set("flow-cache-key", {"result": "ok"})

--- a/src/backend/tests/unit/services/test_cache_service.py
+++ b/src/backend/tests/unit/services/test_cache_service.py
@@ -1,0 +1,55 @@
+import pytest
+from langflow.services.cache import service as cache_service
+
+
+class FakeRedisClient:
+    def __init__(self) -> None:
+        self.setex_calls = []
+
+    async def setex(self, *args):
+        self.setex_calls.append(args)
+        return True
+
+
+def make_redis_cache(client: FakeRedisClient):
+    cache = cache_service.RedisCache.__new__(cache_service.RedisCache)
+    cache._client = client
+    cache.expiration_time = 3600
+    return cache
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_set_skips_values_that_dill_cannot_pickle(monkeypatch):
+    client = FakeRedisClient()
+    cache = make_redis_cache(client)
+    warnings = []
+
+    def raise_type_error(*_args, **_kwargs):
+        msg = "cannot pickle 'ConsoleThreadLocals' object"
+        raise TypeError(msg)
+
+    async def record_warning(message):
+        warnings.append(message)
+
+    monkeypatch.setattr(cache_service.dill, "dumps", raise_type_error)
+    monkeypatch.setattr(cache_service.logger, "awarning", record_warning)
+
+    await cache.set("flow-cache-key", {"result": object()})
+
+    assert client.setex_calls == []
+    assert len(warnings) == 1
+    assert "flow-cache-key" in warnings[0]
+    assert "ConsoleThreadLocals" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_set_stores_pickled_values():
+    client = FakeRedisClient()
+    cache = make_redis_cache(client)
+
+    await cache.set("flow-cache-key", {"result": "ok"})
+
+    assert len(client.setex_calls) == 1
+    assert client.setex_calls[0][0] == "flow-cache-key"
+    assert client.setex_calls[0][1] == 3600
+    assert cache_service.dill.loads(client.setex_calls[0][2]) == {"result": "ok"}


### PR DESCRIPTION
## Summary
- skip Redis cache writes when dill cannot serialize a value, including `TypeError`/`AttributeError` failures raised for runtime-only objects
- keep successful Redis writes and Redis write failures unchanged
- add focused `RedisCache` tests for unpickleable values and normal pickled writes

Fixes #8476.

## Why
When Langflow runs with Redis cache enabled, flow/session graph values can contain runtime-only objects such as Rich console thread locals. `dill.dumps(..., recurse=True)` then raises `TypeError: cannot pickle 'ConsoleThreadLocals' object`, and the cache write failure bubbles out as a flow execution failure. The Redis cache is an optional performance layer, so values that cannot be serialized should behave like cache misses instead of stopping the flow.

## Tests
- `uv run pytest src/backend/tests/unit/services/test_cache_service.py`
- `uv run pytest src/backend/tests/unit/services/test_cache_service.py src/backend/tests/unit/graph/test_cache_restoration.py`
- `uv run ruff check src/backend/base/langflow/services/cache/service.py src/backend/tests/unit/services/test_cache_service.py`
- `uv run ruff format --check src/backend/base/langflow/services/cache/service.py src/backend/tests/unit/services/test_cache_service.py`
- `git diff --check -- src/backend/base/langflow/services/cache/service.py src/backend/tests/unit/services/test_cache_service.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all starter project configurations to use langchain_core version 1.4.0.

* **Bug Fixes**
  * Enhanced cache service to gracefully handle serialization failures instead of raising exceptions.

* **Tests**
  * Added comprehensive unit tests for cache service serialization and storage behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->