### PR TITLE
fix: avoid serializing vertex component instances

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state
@@ -384,6 +385,13 @@ class Vertex:
                 user_id=user_id,
                 vertex=self,
             )
+        self._apply_graph_output_cache_rules()
+
+    def _apply_graph_output_cache_rules(self) -> None:
+        if self.id in self.graph.cycle_vertices or any(
+            vertex.id.split("-")[0] in {"Listen", "Notify"} for vertex in self.graph.vertices
+        ):
+            self.apply_on_outputs(lambda output_object: setattr(output_object, "cache", False))
 
     async def _build(
         self,

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -111,9 +111,7 @@ def test_vertex_cache_state_drops_component_instance():
         (set(), ["Notify-test-id"]),
     ],
 )
-def test_instantiate_component_reapplies_graph_output_cache_rules(
-    monkeypatch, cycle_vertices, graph_vertex_ids
-):
+def test_instantiate_component_reapplies_graph_output_cache_rules(monkeypatch, cycle_vertices, graph_vertex_ids):
     """Deserialized vertices should keep graph-level cache disabling rules."""
     output = Mock(cache=True)
     component = Mock()

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -4,6 +4,7 @@ This module contains tests for verifying the functionality of the ParameterHandl
 which is responsible for processing and managing parameters in vertices.
 """
 
+import pickle
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -11,6 +12,7 @@ import pytest
 from ag_ui.core import StepFinishedEvent, StepStartedEvent
 from lfx.components.input_output import ChatInput
 from lfx.graph.edge.base import Edge
+from lfx.graph.utils import UnbuiltObject, UnbuiltResult
 from lfx.graph.vertex import base as vertex_base_module
 from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
@@ -68,6 +70,78 @@ def mock_edge() -> Mock:
 def parameter_handler(mock_vertex, mock_storage_service) -> ParameterHandler:
     """Create a parameter handler instance for testing."""
     return ParameterHandler(mock_vertex, mock_storage_service)
+
+
+def test_vertex_cache_state_drops_component_instance():
+    """Component instances can hold console/thread locals that Redis cache cannot pickle."""
+
+    class UnpickleableComponent:
+        def __getstate__(self):
+            msg = "cannot pickle Console Threaded object"
+            raise TypeError(msg)
+
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "_lock": None,
+            "custom_component": UnpickleableComponent(),
+            "built_object": UnbuiltObject(),
+            "built_result": UnbuiltResult(),
+        }
+    )
+
+    state = vertex.__getstate__()
+
+    assert state["custom_component"] is None
+    assert state["built_object"] is None
+    assert state["built_result"] is None
+    restored_vertex = pickle.loads(pickle.dumps(vertex))
+
+    assert restored_vertex.custom_component is None
+    assert isinstance(restored_vertex.built_object, UnbuiltObject)
+    assert isinstance(restored_vertex.built_result, UnbuiltResult)
+    assert restored_vertex._lock is not None
+
+
+@pytest.mark.parametrize(
+    ("cycle_vertices", "graph_vertex_ids"),
+    [
+        ({"test-vertex-id"}, []),
+        (set(), ["Listen-test-id"]),
+        (set(), ["Notify-test-id"]),
+    ],
+)
+def test_instantiate_component_reapplies_graph_output_cache_rules(
+    monkeypatch, cycle_vertices, graph_vertex_ids
+):
+    """Deserialized vertices should keep graph-level cache disabling rules."""
+    output = Mock(cache=True)
+    component = Mock()
+    component.outputs = [output]
+    component.get_outputs_map.return_value = {"output": output}
+
+    graph = Mock()
+    graph.cycle_vertices = cycle_vertices
+    graph.vertices = [Mock(id=vertex_id) for vertex_id in graph_vertex_ids]
+
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "id": "test-vertex-id",
+            "graph": graph,
+            "custom_component": None,
+        }
+    )
+
+    monkeypatch.setattr(
+        vertex_base_module.initialize.loading,
+        "instantiate_class",
+        Mock(return_value=(component, {})),
+    )
+
+    vertex.instantiate_component()
+
+    assert output.cache is False
 
 
 def test_process_edge_parameters(parameter_handler, mock_edge):

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -95,7 +95,7 @@ def test_vertex_cache_state_drops_component_instance():
     assert state["custom_component"] is None
     assert state["built_object"] is None
     assert state["built_result"] is None
-    restored_vertex = pickle.loads(pickle.dumps(vertex))
+    restored_vertex = pickle.loads(pickle.dumps(vertex))  # noqa: S301 - trusted test fixture
 
     assert restored_vertex.custom_component is None
     assert isinstance(restored_vertex.built_object, UnbuiltObject)


### PR DESCRIPTION
## Summary

- avoid serializing `Vertex.custom_component` into cached graph state
- reapply graph-level output cache rules when deserialized vertices re-instantiate components
- add regression tests for unpickleable component state plus cycle and Listen/Notify cache behavior

Fixes #8476.

## Context

This targets the Redis/Celery cache path discussed in #8476, where `dill.dumps(...)` can fail with `cannot pickle Console Threaded object` when a graph vertex holds a component instance with thread-local or console state.

## Testing

- `python -m py_compile src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/vertex/test_vertex_base.py`
- Lightweight local pickle reproduction: old behavior fails with `cannot pickle Console Threaded object`; patched behavior returns `pickle_ok`.
- Full pytest was not run locally because the current Windows Python environment did not have the project test dependencies installed.