### PR TITLE
ci: stop transient Windows npm/cache flakes from failing frontend tests

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -227,8 +227,22 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
 
       - name: Install Frontend Dependencies
         run: npm ci
@@ -298,8 +312,23 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
+
       - name: Install Frontend Dependencies
         run: npm ci
         working-directory: ./src/frontend
@@ -308,6 +337,7 @@ jobs:
       - name: Cache Playwright Browsers
         id: cache-playwright
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium-${{ runner.os }}
@@ -361,6 +391,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: blob-report-${{ runner.os }}-${{ matrix.shardIndex }}
@@ -370,6 +401,7 @@ jobs:
 
       - name: Upload Playwright Coverage Artifact
         if: always() && hashFiles('src/frontend/coverage/playwright/**') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: playwright-coverage-${{ matrix.shardIndex }}


### PR DESCRIPTION
## Problem

The nightly **Run Frontend Tests - Windows** job goes red almost every day, but **never because of an actual test failure**. Recent nightlies:

| Date | Failing job | Failing step |
|---|---|---|
| 05-17 | Windows Shard 10/70 | Setup Node.js Environment |
| 05-16 | Windows Shard 30/70 | Setup Node.js Environment |
| 05-15 | Windows Shard 36/70 | Upload Playwright Coverage Artifact |
| 05-14 | Windows Shard 25/70 | Cache Playwright Browsers |

All failures are **GitHub Actions cache/artifact-service flakes** on a single Windows shard. With `fail-fast: false` over ~70 shards (each making several cache/artifact calls), the probability that at least one transient hiccup occurs per night is very high. Any single shard failure flips `needs.setup-and-test.result` to `failure`, reds the whole nightly, and fails `merge-reports`.

The step in the linked run dies right after `npm config get cache` → `C:\npm\cache`: the well-known intermittent `actions/setup-node` npm-cache-restore failure on Windows.

## Fix

- **Decouple npm caching from `actions/setup-node`** in both `setup-node` jobs. Its internal cache step can't be made non-fatal, so it's replaced with a standalone `actions/cache@v5` step marked `continue-on-error: true`. `npm ci` still uses the cache; a cache-service blip just means a slower install instead of a failed job.
- **`continue-on-error: true`** on `Cache Playwright Browsers`, `Upload Test Results`, and `Upload Playwright Coverage Artifact` — infra steps should never fail a test shard.

Net effect: only a real test/browser failure can fail a shard now. No change to what is actually tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline caching strategy for improved build performance
  * Increased pipeline resilience by making browser cache and artifact upload steps non-fatal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->