### PR TITLE
ci: stop transient Windows npm/cache flakes from failing frontend tests (1.10.0)

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -227,8 +227,22 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
 
       - name: Install Frontend Dependencies
         run: npm ci
@@ -298,8 +312,23 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
+
       - name: Install Frontend Dependencies
         run: npm ci
         working-directory: ./src/frontend
@@ -308,6 +337,7 @@ jobs:
       - name: Cache Playwright Browsers
         id: cache-playwright
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium-${{ runner.os }}
@@ -366,6 +396,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: blob-report-${{ runner.os }}-${{ matrix.shardIndex }}
@@ -375,6 +406,7 @@ jobs:
 
       - name: Upload Playwright Coverage Artifact
         if: always() && hashFiles('src/frontend/coverage/playwright/**') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: playwright-coverage-${{ matrix.shardIndex }}


### PR DESCRIPTION
This pull request updates the TypeScript test GitHub Actions workflow to improve reliability and resilience, especially around dependency caching and artifact uploads. The main changes decouple npm caching from the Node setup process to avoid transient cache failures, and add error tolerance to several caching and upload steps.

**Workflow reliability and caching improvements:**

* Decoupled npm caching from the `setup-node` step by explicitly determining the npm cache directory and using a separate `actions/cache` step. This prevents job failures due to transient cache service issues, particularly on Windows runners. (`.github/workflows/typescript_test.yml`) [[1]](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03L230-R245) [[2]](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03L301-R331)
* Added `continue-on-error: true` to the npm cache, Playwright browsers cache, and artifact upload steps to ensure that workflow execution continues even if these steps encounter errors. (`.github/workflows/typescript_test.yml`) [[1]](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03R340) [[2]](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03R399) [[3]](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03R409)