### PR TITLE
fix(graph): omit runtime component from serialized vertex

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -115,6 +115,32 @@ def test_invalid_node_types():
         g.add_nodes_and_edges(graph_data["nodes"], graph_data["edges"])
 
 
+def test_graph_pickle_omits_unpickleable_custom_component():
+    import pickle
+    import threading
+
+    graph = Graph(flow_id="flow-with-unpickleable-component")
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "id": "model-node",
+            "_lock": None,
+            "built_object": None,
+            "built_result": None,
+            "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
+            "full_data": {"id": "model-node"},
+        }
+    )
+    graph.vertices = [vertex]
+    graph._vertices = [vertex.full_data]
+
+    restored = pickle.loads(  # noqa: S301 - trusted in-process regression fixture
+        pickle.dumps({"result": graph, "type": type(graph)})
+    )["result"]
+
+    assert restored.vertices[0].custom_component is None
+
+
 def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
     monkeypatch.setattr(
         "lfx.services.deps.get_settings_service",

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -125,8 +125,8 @@ def test_graph_pickle_omits_unpickleable_custom_component():
         {
             "id": "model-node",
             "_lock": None,
-            "built_object": None,
-            "built_result": None,
+            "built_object": "built-value",
+            "built_result": {"result": "built-value"},
             "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
             "full_data": {"id": "model-node"},
         }
@@ -139,6 +139,11 @@ def test_graph_pickle_omits_unpickleable_custom_component():
     )["result"]
 
     assert restored.vertices[0].custom_component is None
+    assert restored.vertices[0].id == "model-node"
+    assert restored.vertices[0].built_object == "built-value"
+    assert restored.vertices[0].built_result == {"result": "built-value"}
+    assert restored.vertices[0].full_data == {"id": "model-node"}
+    assert restored._vertices == [{"id": "model-node"}]
 
 
 def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):


### PR DESCRIPTION
## Summary
- Omit runtime-only `custom_component` state when serializing a `Vertex`.
- Add a regression test covering cached graph serialization when the component carries unpickleable thread-local state.

Fixes #8476.

## Tests
- `uv run ruff check src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/test_graph.py`
- `cd src/lfx && uv sync && uv run pytest tests/unit/graph/test_graph.py -q` -> `12 passed, 1 skipped`
- `cd src/lfx && uv run pytest tests/unit/graph/graph/test_runnable_vertices_manager.py -q` -> `20 passed`
- `uv sync --group dev --package langflow-base && uv run pytest src/backend/tests/unit/graph/test_cache_restoration.py -q` -> `11 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Graphs can now be successfully serialized and pickled regardless of custom component type.

* **Tests**
  * Added test coverage for graph serialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->