### PR TITLE
fix: Model handling for tool calling in agents and update IBM models

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3141,7 +3141,7 @@
         "filename": "src/backend/tests/unit/base/models/test_model_utils.py",
         "hashed_secret": "c053ecf9ed41df0311b9df13cc6c3b6078d2d3c2",
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 97,
         "is_secret": false
       }
     ],
@@ -8287,5 +8287,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-15T00:15:30Z"
+  "generated_at": "2026-05-18T20:45:13Z"
 }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.3.2"
+                    "version": "1.4.0"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/tests/unit/base/models/test_model_utils.py
+++ b/src/backend/tests/unit/base/models/test_model_utils.py
@@ -16,7 +16,8 @@ except (ImportError, TypeError):
     pytest.skip("langchain-ibm not available on Python 3.14+", allow_module_level=True)
 
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
-from lfx.base.models.model_utils import get_model_name
+from lfx.base.models.model_metadata import create_model_metadata
+from lfx.base.models.model_utils import fetch_live_watsonx_models, get_model_name
 
 
 class _AttrBag:
@@ -106,3 +107,84 @@ class TestGetModelName:
             project_id="fake",
         )
         assert get_model_name(llm) == "meta-llama/llama-3-3-70b-instruct"
+
+
+class TestFetchLiveWatsonxModelsRespectsStaticToolCalling:
+    """Live-fetched WatsonX models must honor static tool_calling metadata.
+
+    Regression: ``fetch_live_watsonx_models`` blanket-sets ``tool_calling=True``
+    for every LLM returned from the WatsonX foundation_model_specs endpoint,
+    even when the static catalog declares the model as ``tool_calling=False``
+    (e.g. code-instruct or guardian variants). The Agent dropdown filters on
+    ``tool_calling=True`` and consequently surfaces models that will fail at
+    runtime when bound with tools.
+    """
+
+    NON_TOOL_MODEL = "ibm/granite-3b-code-instruct"
+
+    @staticmethod
+    def _fake_static_llm_metadata():
+        """Static catalog entry declaring the model as non-tool-calling."""
+        return [
+            create_model_metadata(
+                provider="IBM WatsonX",
+                name=TestFetchLiveWatsonxModelsRespectsStaticToolCalling.NON_TOOL_MODEL,
+                icon="IBM",
+                model_type="llm",
+                tool_calling=False,
+            ),
+        ]
+
+    def test_live_fetch_preserves_static_tool_calling_false(self, monkeypatch):
+        """A model whose static metadata says tool_calling=False must come back as False."""
+        # Force the live API to return the model name we declared as non-tool-calling.
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.get_provider_variable_value",
+            lambda *_args, **_kwargs: "https://us-south.ml.cloud.ibm.com",
+        )
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.get_watsonx_llm_models",
+            lambda *_args, **_kwargs: [self.NON_TOOL_MODEL],
+        )
+        # Static catalog: the model is known and explicitly marked non-tool-calling.
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.WATSONX_LLM_METADATA",
+            self._fake_static_llm_metadata(),
+        )
+
+        models = fetch_live_watsonx_models(user_id="test-user", model_type="llm")
+
+        assert models, "Expected the live fetch to return the mocked model"
+        match = next((m for m in models if m["name"] == self.NON_TOOL_MODEL), None)
+        assert match is not None, f"{self.NON_TOOL_MODEL} missing from live results"
+        assert match["tool_calling"] is False, (
+            f"{self.NON_TOOL_MODEL} is declared tool_calling=False in static metadata "
+            "but fetch_live_watsonx_models returned tool_calling=True. The live-fetch "
+            "path is overriding static capability flags and will surface non-tool-capable "
+            "models in the Agent dropdown."
+        )
+
+    def test_live_fetch_defaults_unknown_models_to_tool_calling_true(self, monkeypatch):
+        """Models not in the static catalog default to tool_calling=True (current behavior)."""
+        unknown_model = "ibm/some-future-model-xyz"
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.get_provider_variable_value",
+            lambda *_args, **_kwargs: "https://us-south.ml.cloud.ibm.com",
+        )
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.get_watsonx_llm_models",
+            lambda *_args, **_kwargs: [unknown_model],
+        )
+        monkeypatch.setattr(
+            "lfx.base.models.model_utils.WATSONX_LLM_METADATA",
+            self._fake_static_llm_metadata(),  # does not contain unknown_model
+        )
+
+        models = fetch_live_watsonx_models(user_id="test-user", model_type="llm")
+
+        match = next((m for m in models if m["name"] == unknown_model), None)
+        assert match is not None
+        assert match["tool_calling"] is True, (
+            "Unknown models (not present in static catalog) should default to "
+            "tool_calling=True to preserve current behavior for unenumerated models."
+        )

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -348,21 +348,34 @@ def fetch_live_watsonx_models(user_id: UUID | str | None, model_type: str = "llm
         else:
             model_names = get_watsonx_embedding_models(watsonx_url)
 
-        # Convert to model metadata format
-        return [
-            create_model_metadata(
-                provider="IBM WatsonX",
-                name=name,
-                icon="IBM",
-                model_type=model_type if model_type == "llm" else "embeddings",
-                tool_calling=model_type == "llm",
-                default=i < MIN_DEFAULT_MODELS,  # Mark first 5 as default
+        # Look up capability flags from the static catalog when known; otherwise
+        # fall back to defaults. Without this, the live API path blanket-marks
+        # every LLM as tool_calling=True, surfacing models like
+        # ibm/granite-3b-code-instruct and ibm/granite-guardian-3-8b in the
+        # Agent dropdown even though they don't support tool calling.
+        static_metadata = WATSONX_LLM_METADATA if model_type == "llm" else WATSONX_EMBEDDING_METADATA
+        known_by_name = {m["name"]: m for m in static_metadata}
+        default_tool_calling = model_type == "llm"
+
+        result: list[dict] = []
+        for i, name in enumerate(model_names):
+            known = known_by_name.get(name)
+            result.append(
+                create_model_metadata(
+                    provider="IBM WatsonX",
+                    name=name,
+                    icon="IBM",
+                    model_type=model_type if model_type == "llm" else "embeddings",
+                    tool_calling=known.get("tool_calling", default_tool_calling) if known else default_tool_calling,
+                    deprecated=bool(known.get("deprecated", False)) if known else False,
+                    default=i < MIN_DEFAULT_MODELS,  # Mark first 5 as default
+                )
             )
-            for i, name in enumerate(model_names)
-        ]
     except Exception:  # noqa: BLE001
         logger.debug(f"Could not fetch live WatsonX {model_type} models from {watsonx_url}")
         return []
+    else:
+        return result
 
 
 def get_live_models_for_provider(

--- a/src/lfx/src/lfx/base/models/watsonx_constants.py
+++ b/src/lfx/src/lfx/base/models/watsonx_constants.py
@@ -3,27 +3,19 @@ from .model_metadata import create_model_metadata
 WATSONX_DEFAULT_LLM_MODELS = [
     create_model_metadata(
         provider="IBM WatsonX",
-        name="ibm/granite-3-2b-instruct",
+        name="ibm/granite-8b-code-instruct",
         icon="IBM",
         model_type="llm",
         tool_calling=True,
-        default=True,
+        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
-        name="ibm/granite-3-8b-instruct",
+        name="ibm/granite-guardian-3-8b",
         icon="IBM",
         model_type="llm",
-        tool_calling=True,
-        default=True,
-    ),
-    create_model_metadata(
-        provider="IBM WatsonX",
-        name="ibm/granite-13b-instruct-v2",
-        icon="IBM",
-        model_type="llm",
-        tool_calling=True,
-        default=True,
+        tool_calling=False,
+        deprecated=True,
     ),
 ]
 


### PR DESCRIPTION
Updates IBM models labeling deprecated and non tool calling where relevant.

`fetch_live_watsonx_models` now consults the static catalog (`WATSONX_DEFAULT_LLM_MODELS` / `WATSONX_DEFAULT_EMBEDDING_MODELS`) for any returned model name and inherits its tool_calling and deprecated flags.    
Unknown model names retain the previous default behavior, preserving forward compatibility with newly-released models.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regression test coverage for IBM WatsonX model tool calling configuration behavior

* **Bug Fixes**
  * Fixed IBM WatsonX model handling to properly respect tool calling settings from static model metadata

* **Chores**
  * Updated langchain_core dependency to version 1.4.0 across all starter projects and component configurations
  * Updated additional framework dependencies (langchain_classic, git, and pytest) to latest versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->