### PR TITLE
fix(ci): backport bundle rename step to nightly workflow on main

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -163,6 +163,8 @@ jobs:
           uv run --no-sync ./scripts/ci/update_sdk_version.py $SDK_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run --no-sync ./scripts/ci/update_lfx_version.py $LFX_TAG $SDK_TAG
+          echo "Renaming bundle packages to their -nightly counterparts (lfx dev suffix: $LFX_TAG)"
+          uv run --no-sync ./scripts/ci/update_bundle_versions.py $LFX_TAG
           echo "Updating base project version to $BASE_TAG and updating main project version to $RELEASE_TAG"
           uv run --no-sync ./scripts/ci/update_pyproject_combined.py main $RELEASE_TAG $BASE_TAG $LFX_TAG
 
@@ -170,7 +172,7 @@ jobs:
           cd src/backend/base && uv lock && cd ../../..
           cd src/lfx && uv lock && cd ../..
 
-          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock src/backend/base/uv.lock
+          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml src/bundles/*/pyproject.toml uv.lock src/backend/base/uv.lock
           git commit -m "Update version and project name"
 
           echo "Tagging main with $RELEASE_TAG"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -163,8 +163,12 @@ jobs:
           uv run --no-sync ./scripts/ci/update_sdk_version.py $SDK_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run --no-sync ./scripts/ci/update_lfx_version.py $LFX_TAG $SDK_TAG
-          echo "Renaming bundle packages to their -nightly counterparts (lfx dev suffix: $LFX_TAG)"
-          uv run --no-sync ./scripts/ci/update_bundle_versions.py $LFX_TAG
+          if [ -f ./scripts/ci/update_bundle_versions.py ]; then
+            echo "Renaming bundle packages to their -nightly counterparts (lfx dev suffix: $LFX_TAG)"
+            uv run --no-sync ./scripts/ci/update_bundle_versions.py $LFX_TAG
+          else
+            echo "Skipping bundle rename: scripts/ci/update_bundle_versions.py not present on this branch"
+          fi
           echo "Updating base project version to $BASE_TAG and updating main project version to $RELEASE_TAG"
           uv run --no-sync ./scripts/ci/update_pyproject_combined.py main $RELEASE_TAG $BASE_TAG $LFX_TAG
 
@@ -172,7 +176,10 @@ jobs:
           cd src/backend/base && uv lock && cd ../../..
           cd src/lfx && uv lock && cd ../..
 
-          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml src/bundles/*/pyproject.toml uv.lock src/backend/base/uv.lock
+          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock src/backend/base/uv.lock
+          if compgen -G "src/bundles/*/pyproject.toml" > /dev/null; then
+            git add src/bundles/*/pyproject.toml
+          fi
           git commit -m "Update version and project name"
 
           echo "Tagging main with $RELEASE_TAG"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 299,
         "is_secret": false
       }
     ],
@@ -8287,5 +8287,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-18T20:45:13Z"
+  "generated_at": "2026-05-19T01:39:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 299,
+        "line_number": 306,
         "is_secret": false
       }
     ],
@@ -8287,5 +8287,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T01:39:18Z"
+  "generated_at": "2026-05-19T01:41:00Z"
 }


### PR DESCRIPTION
## Summary

Follow-up to [#13193](https://github.com/langflow-ai/langflow/pull/13193) (release-1.10.0). The nightly job is scheduled (`cron: 0 0 * * *`), so GitHub Actions runs the workflow YAML from the default branch (`main`) — not from the resolved release branch. Without this change on `main`, the new `update_bundle_versions.py` step is never invoked and `uv lock` fails with `lfx-arxiv requirements unsatisfiable`, even though the script + fix have been merged to release-1.10.0.

## What this PR does

1. **Calls `update_bundle_versions.py`** between the LFX-version step and the combined-version step (same as the release-1.10.0 PR).
2. **Adds rewritten bundle pyprojects to the nightly commit** via `git add src/bundles/*/pyproject.toml`.
3. **Defensive guards** so the workflow keeps working on release branches that don't carry the new script or the `src/bundles/` folder:
   - `if [ -f ./scripts/ci/update_bundle_versions.py ]` around the script invocation.
   - `if compgen -G "src/bundles/*/pyproject.toml" > /dev/null` around the bundle `git add`.

These guards are forward-looking: today every viable release branch (`release-1.10.0`) already has the script and bundles, so the guards short-circuit to the same behavior. They protect against pathological combos (e.g., backport branches without the new script) and against `bash -e` killing the step on a literal-glob `git add` if no bundles exist.

## Why YAML-only?

Per scheduled-trigger semantics, only the workflow YAML on `main` needs the change — the workflow checks out the latest `release-*` branch before running scripts, and `release-1.10.0` already carries `scripts/ci/update_bundle_versions.py`. If you'd prefer to also bring the script onto `main` (e.g., so future release-branch cuts inherit it), happy to follow up with a separate PR.

## Test plan

- [x] Diff against release-1.10.0 confirms identical YAML additions plus the new guards.
- [x] Bash guard syntax validated locally (compgen + `-f`).
- [ ] Next scheduled nightly run completes past `uv lock` (the step that previously failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly build workflow to conditionally process bundle configurations based on branch setup.
  * Updated internal baseline configuration metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->