### PR TITLE
fix(ci): gate nightly release on successful tag creation

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -286,7 +286,7 @@ jobs:
   #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
 
   release-nightly-build:
-    if: github.repository == 'langflow-ai/langflow' && always() && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure'
+    if: github.repository == 'langflow-ai/langflow' && always() && needs.create-nightly-tag.result == 'success' && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure'
     name: Run Nightly Langflow Build
     needs:
       [validate-inputs, create-nightly-tag, frontend-tests-linux, frontend-tests-windows, backend-unit-tests]


### PR DESCRIPTION
When the nightly workflow was manually dispatched with `push_to_registry=true`
(the default) plus `skip_frontend_tests` or `skip_backend_tests`,
`validate-inputs` correctly failed, which skipped `create-nightly-tag`. The
test jobs were also skipped (input flags). But `release-nightly-build`'s
condition only blocked on test `result != 'failure'` while using `always()`,
so a `skipped` result let it run anyway. With no upstream tag outputs,
`release_nightly.yml` checked out the default branch where `src/sdk/pyproject.toml`
still names the package `langflow-sdk`, and the "Verify SDK Nightly Name and
Version" step exited with `Name langflow-sdk does not match langflow-sdk-nightly`.

Add `needs.create-nightly-tag.result == 'success'` to the gate so the release
job only runs when the renaming/tagging step actually produced a tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration workflow conditions to improve build reliability and execution order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->