### PR TITLE
fix(lfx/upgrade): preserve envelope on run, apply nested upgrades

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -8308,7 +8308,7 @@
         "filename": "src/lfx/tests/unit/run/test_base.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 803,
         "is_secret": false
       }
     ],
@@ -8425,5 +8425,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T12:22:58Z"
+  "generated_at": "2026-05-19T14:04:47Z"
 }

--- a/src/lfx/src/lfx/run/base.py
+++ b/src/lfx/src/lfx/run/base.py
@@ -95,6 +95,9 @@ async def run_flow(
         user_id: Optional user ID for tracking purposes
         session_id: Optional session ID for memory isolation
         event_manager: Optional EventManager for streaming token events
+        upgrade_flow: Component compatibility mode. ``'check'`` refuses to run if any
+            component is outdated or blocked. ``'safe'`` auto-applies safe upgrades and
+            aborts on breaking or blocked components.
 
     Returns:
         dict: Result data containing the execution results, logs, and optionally timing info
@@ -193,10 +196,7 @@ async def run_flow(
     if upgrade_flow and flow_dict is None and script_path is not None:
         if script_path.suffix.lower() == ".json":
             try:
-                import json as _json
-
-                raw = _json.loads(script_path.read_text(encoding="utf-8"))
-                flow_dict = raw.get("data", raw)  # unwrap outer envelope if present
+                flow_dict = json.loads(script_path.read_text(encoding="utf-8"))
             except Exception as e:
                 error_msg = f"--upgrade-flow: could not read flow file '{script_path}': {e}"
                 output_error(error_msg, verbose=verbose)
@@ -219,8 +219,16 @@ async def run_flow(
         from lfx.upgrade.applier import apply_safe_upgrades
         from lfx.upgrade.checker import check_flow_compatibility
 
+        # Exported Langflow flows have an outer envelope:
+        #   {"name": ..., "data": {"nodes": [...], "edges": [...]}}
+        # The checker/applier work on the inner graph. After upgrade we re-attach
+        # the (possibly upgraded) inner graph to the envelope so aload_flow_from_json
+        # still gets the {"data": ...} shape it expects.
+        has_envelope = "data" in flow_dict and "nodes" in flow_dict.get("data", {})
+        inner = flow_dict["data"] if has_envelope else flow_dict
+
         all_types = component_cache.all_types_dict or {}
-        report = check_flow_compatibility(flow_dict, all_types)
+        report = check_flow_compatibility(inner, all_types)
 
         if upgrade_flow == "check":
             if not report.is_clean:
@@ -238,7 +246,8 @@ async def run_flow(
                 output_error(error_msg, verbose=verbose)
                 raise RunError(error_msg, None)
             if report.has_safe_updates:
-                flow_dict, count = apply_safe_upgrades(flow_dict, all_types, report, return_count=True)
+                new_inner, count = apply_safe_upgrades(inner, all_types, report, return_count=True)
+                flow_dict = {**flow_dict, "data": new_inner} if has_envelope else new_inner
                 if verbose:
                     sys.stderr.write(f"Applied {count} safe component upgrade(s).\n")
 

--- a/src/lfx/src/lfx/upgrade/applier.py
+++ b/src/lfx/src/lfx/upgrade/applier.py
@@ -41,21 +41,30 @@ def apply_safe_upgrades(
 
     registry = build_registry_lookup(all_types_dict)
     updated = copy.deepcopy(flow_data)
-    count = 0
-
-    for node in updated.get("nodes", []):
-        node_id = node.get("data", {}).get("id") or node.get("id")
-        if node_id not in safe_ids:
-            continue
-        component_type = node["data"].get("type", "")
-        entry = registry.get(component_type)
-        if not entry:
-            continue
-        registry_code_field = entry.get("template", {}).get("code")
-        new_code = registry_code_field.get("value") if isinstance(registry_code_field, dict) else None
-        if new_code is None:
-            continue
-        node["data"]["node"]["template"]["code"]["value"] = new_code
-        count += 1
+    count = _apply_to_nodes(updated.get("nodes", []), safe_ids, registry)
 
     return (updated, count) if return_count else updated
+
+
+def _apply_to_nodes(nodes: list[dict], safe_ids: set[str], registry: dict[str, dict]) -> int:
+    """Walk top-level nodes and (one level of) nested flow nodes, applying safe upgrades.
+
+    Mirrors check_flow_compatibility's recursion into ``node.data.node.flow.data.nodes``
+    so safe-upgradeable nodes inside grouped components are written, not silently skipped.
+    """
+    count = 0
+    for node in nodes:
+        node_id = node.get("data", {}).get("id") or node.get("id")
+        if node_id in safe_ids:
+            component_type = node.get("data", {}).get("type", "")
+            entry = registry.get(component_type)
+            if entry:
+                registry_code_field = entry.get("template", {}).get("code")
+                new_code = registry_code_field.get("value") if isinstance(registry_code_field, dict) else None
+                if new_code is not None:
+                    node["data"]["node"]["template"]["code"]["value"] = new_code
+                    count += 1
+        nested = node.get("data", {}).get("node", {}).get("flow", {}).get("data", {}).get("nodes")
+        if nested:
+            count += _apply_to_nodes(nested, safe_ids, registry)
+    return count

--- a/src/lfx/src/lfx/upgrade/checker.py
+++ b/src/lfx/src/lfx/upgrade/checker.py
@@ -105,9 +105,7 @@ def _has_breaking_change(registry_entry: dict, node_info: dict) -> bool:
     user_template = node_info.get("template") or {}
     if orig_template and not _template_keys_equal(orig_template, user_template):
         return True
-    if orig_template and not _input_types_contained(orig_template, user_template):
-        return True
-    return False
+    return bool(orig_template) and not _input_types_contained(orig_template, user_template)
 
 
 def _classify_node(node: dict, registry: dict[str, dict]) -> NodeStatus | None:

--- a/src/lfx/tests/unit/run/test_base.py
+++ b/src/lfx/tests/unit/run/test_base.py
@@ -1484,7 +1484,10 @@ class TestUpgradeFlowOption:
 
     @pytest.mark.asyncio
     async def test_upgrade_flow_check_rejects_outer_envelope_file(self, tmp_path):
-        """Exported flows use an outer envelope {"name":..., "data":{...}}; the checker must unwrap it before inspecting nodes."""
+        """Exported flows use an outer envelope; the checker must unwrap it before inspecting nodes.
+
+        Shape: {"name":..., "data": {"nodes": [...], "edges": [...]}}.
+        """
         import json as _json
 
         envelope = {"name": "My Flow", "data": self._flow_dict(code=self.NODE_CODE)}
@@ -1525,3 +1528,89 @@ class TestUpgradeFlowOption:
             mock_cache.all_types_dict = self._registry()
             with pytest.raises(RunError, match="Unknown --upgrade-flow"):
                 await run_flow(flow_json=flow_json, upgrade_flow="typo")
+
+    @pytest.mark.asyncio
+    async def test_upgrade_flow_safe_envelope_file_loads_successfully(self, tmp_path):
+        """Happy path: --upgrade-flow=safe on an envelope file must proceed to load.
+
+        Regression: when the upgrade block unwrapped the envelope and handed the inner
+        dict to aload_flow_from_json, the loader raised ``KeyError: 'data'`` because it
+        expects the envelope shape. The fix re-attaches the (possibly upgraded) inner
+        graph to the envelope before loading.
+        """
+        import json as _json
+
+        envelope = {"name": "My Flow", "description": "x", "data": self._flow_dict(code=self.NODE_CODE)}
+        f = tmp_path / "flow.json"
+        f.write_text(_json.dumps(envelope))
+
+        mock_graph = MagicMock()
+        mock_graph.context = {}
+        mock_graph.vertices = []
+        mock_graph.edges = []
+        mock_graph.prepare = MagicMock()
+
+        async def _async_start(_inputs, **_kwargs):
+            yield
+
+        mock_graph.async_start = _async_start
+
+        with (
+            patch("lfx.interface.components.component_cache") as mock_cache,
+            patch("lfx.load.aload_flow_from_json") as mock_load,
+            patch("lfx.run.base.validate_global_variables_for_env") as mock_validate,
+            patch("lfx.run.base.extract_structured_result") as mock_extract,
+        ):
+            mock_cache.all_types_dict = self._registry()
+            mock_load.return_value = mock_graph
+            mock_validate.return_value = []
+            mock_extract.return_value = {"success": True, "result": "ok"}
+
+            await run_flow(script_path=f, upgrade_flow="safe")
+
+            mock_load.assert_called_once()
+            loaded_arg = mock_load.call_args[0][0]
+            # Loader must receive the envelope shape, not the unwrapped inner dict.
+            assert "data" in loaded_arg, f"loader got unwrapped dict (KeyError regression): {list(loaded_arg)}"
+            assert loaded_arg["data"]["nodes"][0]["data"]["node"]["template"]["code"]["value"] == self.REGISTRY_CODE
+            # Envelope metadata must be preserved.
+            assert loaded_arg.get("name") == "My Flow"
+            assert loaded_arg.get("description") == "x"
+
+    @pytest.mark.asyncio
+    async def test_upgrade_flow_safe_flat_file_loads_successfully(self, tmp_path):
+        """Flat-shape file with --upgrade-flow=safe must still reach the loader without crashing."""
+        import json as _json
+
+        f = tmp_path / "flow.json"
+        f.write_text(_json.dumps(self._flow_dict(code=self.NODE_CODE)))
+
+        mock_graph = MagicMock()
+        mock_graph.context = {}
+        mock_graph.vertices = []
+        mock_graph.edges = []
+        mock_graph.prepare = MagicMock()
+
+        async def _async_start(_inputs, **_kwargs):
+            yield
+
+        mock_graph.async_start = _async_start
+
+        with (
+            patch("lfx.interface.components.component_cache") as mock_cache,
+            patch("lfx.load.aload_flow_from_json") as mock_load,
+            patch("lfx.run.base.validate_global_variables_for_env") as mock_validate,
+            patch("lfx.run.base.extract_structured_result") as mock_extract,
+        ):
+            mock_cache.all_types_dict = self._registry()
+            mock_load.return_value = mock_graph
+            mock_validate.return_value = []
+            mock_extract.return_value = {"success": True, "result": "ok"}
+
+            await run_flow(script_path=f, upgrade_flow="safe")
+
+            mock_load.assert_called_once()
+            loaded_arg = mock_load.call_args[0][0]
+            # For flat input, the loader receives the upgraded flat dict.
+            assert "nodes" in loaded_arg
+            assert loaded_arg["nodes"][0]["data"]["node"]["template"]["code"]["value"] == self.REGISTRY_CODE

--- a/src/lfx/tests/unit/upgrade/test_applier.py
+++ b/src/lfx/tests/unit/upgrade/test_applier.py
@@ -112,5 +112,39 @@ def test_apply_returns_count_of_updated_nodes():
     registry = _registry(code=REGISTRY_CODE)
     report = check_flow_compatibility(flow, registry)
 
+    _, count = apply_safe_upgrades(flow, registry, report, return_count=True)
+    assert count == 1
+
+
+def test_apply_updates_nested_flow_safe_node_code():
+    """Safe upgrades inside a grouped component's nested flow must be written, not skipped.
+
+    Counterpart to test_nested_flow_nodes_are_classified in test_checker.py: the checker
+    classifies nested nodes, so the applier must also write them, otherwise the report
+    advertises a safe upgrade that never actually lands on disk.
+    """
+    nested = _node(code=NODE_CODE)
+    nested["id"] = "nested-1"
+    nested["data"]["id"] = "nested-1"
+    outer = {
+        "id": "group-1",
+        "data": {
+            "id": "group-1",
+            "type": "SomeGrouping",
+            "node": {
+                "display_name": "Group",
+                "template": {},
+                "outputs": [],
+                "flow": {"data": {"nodes": [nested], "edges": []}},
+            },
+        },
+    }
+    flow = _flow(outer)
+    registry = _registry(code=REGISTRY_CODE)
+    report = check_flow_compatibility(flow, registry)
+    assert any(n.node_id == "nested-1" and n.status == "outdated_safe" for n in report.nodes)
+
     updated, count = apply_safe_upgrades(flow, registry, report, return_count=True)
     assert count == 1
+    written = updated["nodes"][0]["data"]["node"]["flow"]["data"]["nodes"][0]
+    assert written["data"]["node"]["template"]["code"]["value"] == REGISTRY_CODE

--- a/src/lfx/tests/unit/upgrade/test_upgrade_command.py
+++ b/src/lfx/tests/unit/upgrade/test_upgrade_command.py
@@ -171,9 +171,13 @@ def test_upgrade_outer_envelope_flow_finds_nodes(tmp_path):
 
 
 def test_upgrade_outer_envelope_write_updates_inner_nodes(tmp_path):
-    """--write on an outer-envelope flow must update nodes inside data.nodes."""
+    """--write on an outer-envelope flow must update nodes inside data.nodes AND preserve envelope metadata."""
     envelope_flow = {
         "name": "My Flow",
+        "description": "envelope flow",
+        "endpoint_name": "my-endpoint",
+        "is_component": False,
+        "tags": ["fixture"],
         "data": {
             "nodes": [
                 {
@@ -203,7 +207,12 @@ def test_upgrade_outer_envelope_write_updates_inner_nodes(tmp_path):
 
     assert result.exit_code == 0
     written = json.loads(f.read_text())
-    # The written file is the unwrapped graph (the data key's content)
-    nodes = written.get("nodes", [])
-    assert nodes, "Expected nodes in written output"
+    # The envelope must be preserved on write so the flow remains re-importable into Langflow.
+    assert written.get("name") == "My Flow"
+    assert written.get("description") == "envelope flow"
+    assert written.get("endpoint_name") == "my-endpoint"
+    assert written.get("is_component") is False
+    assert written.get("tags") == ["fixture"]
+    nodes = written.get("data", {}).get("nodes", [])
+    assert nodes, "Expected nodes inside data.nodes"
     assert nodes[0]["data"]["node"]["template"]["code"]["value"] == REGISTRY_CODE


### PR DESCRIPTION
Follow-ups on top of #13176 closing the three issues I flagged in the inline review there.

## What's in here

**1. `lfx run --upgrade-flow` no longer crashes the loader.**
The upgrade block was unwrapping `{"data": ...}` and passing the inner dict to `aload_flow_from_json`, which does `flow_graph["data"]` unconditionally and raised `KeyError: 'data'`. Now the inner graph is re-attached to the envelope before the loader sees it. Repro before the fix:

```
$ lfx run envelope_flow.json "hello" --upgrade-flow=safe
{"exception_type": "KeyError", "exception_message": "'data'"}
```

Adds happy-path tests for both envelope and flat file inputs — there was no test that exercised the path from upgrade through to a successful load, which is why the bug shipped.

**2. Applier recurses into nested flow nodes.**
`check_flow_compatibility` already walks one level of `node.data.node.flow.data.nodes` (grouped components / subflows), so `report.nodes` could contain a nested node id with `outdated_safe`. The applier was iterating only top-level nodes, so the nested safe upgrade was reported but never written — `--write` would say "Wrote N safe upgrade(s)" with N lower than the report. Now matched.

**3. `test_upgrade_outer_envelope_write_updates_inner_nodes`.**
This test was asserting the old destructive behavior (unwrapped graph output). After the envelope-preservation fix in `b92013416f`, it started failing on CI. Updated to assert the envelope is preserved AND the upgrade is applied inside `data.nodes`.

**4. Drive-by ruff cleanup.**
D417 docstring for `upgrade_flow` on `run_flow`, SIM103 in checker, SIM108 in run/base, E501 docstring line, RUF059 unused tuple unpack. The pre-existing four were blocking Ruff Style Check on #13176.

## Verification

- 120/120 tests pass in `tests/unit/upgrade` + `tests/unit/run/test_base.py`
- 1015/1015 tests pass across `tests/unit/{run,cli,upgrade}`
- `ruff check .` clean, `ruff format --check .` clean
- End-to-end CLI repros:
  - `lfx run envelope.json --upgrade-flow=safe` reaches the loader without KeyError
  - `lfx upgrade --write` on an envelope keeps name/description/endpoint_name/tags
  - `lfx upgrade --write` on a flow with a grouped component applies the upgrade inside the nested flow

Targets `sync-langflow-lfx` so this folds into #13176 when that merges.