### PR TITLE
fix(server): refuse to start with multiple workers and the default in-memory job queue

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -233,10 +233,16 @@ def ensure_multi_worker_safe(num_workers: int) -> None:
     configure a shared queue anyway; this check refuses to start because the
     process cannot know which delivery mode every future client will pick.
 
+    Skipped entirely when ``LANGFLOW_JOB_QUEUE_TYPE=redis`` is configured —
+    Redis-backed queues share state across workers and support every delivery
+    mode, so the race the check guards against cannot occur.
+
     Only called on the Gunicorn (Linux) path — the direct-uvicorn path on
     Windows/macOS clamps workers to 1, so the race cannot occur there.
     """
     if num_workers <= 1:
+        return
+    if get_settings_service().settings.job_queue_type == "redis":
         return
     msg = (
         f"Refusing to start with {num_workers} workers and the default in-memory "

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -216,6 +216,44 @@ def build_direct_uvicorn_kwargs(
     }
 
 
+def ensure_multi_worker_safe(num_workers: int) -> None:
+    """Refuse to start with multiple workers when the job queue is worker-local.
+
+    The default JobQueueService keeps build queues in process-local memory.
+    POLLING and STREAMING event delivery rely on a follow-up
+    ``GET /api/v1/build/<job_id>/events`` request after the initial
+    ``POST /api/v1/build/.../flow``; Gunicorn round-robins those two requests
+    across workers, so the polling worker finds no queue and returns
+    "Job queue not found for job_id" roughly 45-66% of the time under load.
+
+    ``event_delivery=direct`` is the exception: the POST endpoint streams events
+    back on the same request that started the build, so the build and event
+    consumption stay on a single worker and never cross worker boundaries.
+    Operators who only need direct delivery should run with ``--workers 1`` or
+    configure a shared queue anyway; this check refuses to start because the
+    process cannot know which delivery mode every future client will pick.
+
+    Only called on the Gunicorn (Linux) path — the direct-uvicorn path on
+    Windows/macOS clamps workers to 1, so the race cannot occur there.
+    """
+    if num_workers <= 1:
+        return
+    msg = (
+        f"Refusing to start with {num_workers} workers and the default in-memory "
+        "job queue. POLLING and STREAMING event delivery fail with 'Job not found' "
+        "roughly half the time because the build queue lives in one worker's "
+        "memory and the follow-up GET /api/v1/build/<job_id>/events request lands "
+        "on a different worker. Pick one of:\n"
+        "  * Configure a shared job queue: LANGFLOW_JOB_QUEUE_TYPE=redis. Works "
+        "for every event_delivery mode.\n"
+        "  * Run with --workers 1. Single worker, no cross-worker routing.\n"
+        "Note: event_delivery=direct works in multi-worker because the POST "
+        "endpoint streams events back inline, but every client must opt into "
+        "direct delivery; the server cannot enforce that at startup."
+    )
+    raise RuntimeError(msg)
+
+
 def display_results(results) -> None:
     """Display the results of the migration."""
     for table_results in results:
@@ -518,9 +556,11 @@ def run(
                 msg = "Gunicorn startup requires an application factory."
                 raise RuntimeError(msg)
 
+            num_workers = get_number_of_workers(workers)
+            ensure_multi_worker_safe(num_workers)
             options = {
                 "bind": f"{host}:{port}",
-                "workers": get_number_of_workers(workers),
+                "workers": num_workers,
                 "timeout": worker_timeout,
                 "certfile": ssl_cert_file_path,
                 "keyfile": ssl_key_file_path,

--- a/src/backend/tests/unit/test_cli.py
+++ b/src/backend/tests/unit/test_cli.py
@@ -13,6 +13,7 @@ from langflow.__main__ import (
     app,
     build_direct_uvicorn_kwargs,
     clamp_uvicorn_workers,
+    ensure_multi_worker_safe,
     get_number_of_workers,
     use_direct_uvicorn,
 )
@@ -331,3 +332,41 @@ def test_build_direct_uvicorn_kwargs_pins_full_shape():
         "ssl_keyfile",
     }
     assert result["reload"] is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_multi_worker_safe: refuse to boot with the in-memory queue and N>1
+# workers. The bug is silent: ~45-66% of build polls return "Job not found"
+# because Gunicorn round-robins the POST and the follow-up GET across workers,
+# but the queue is worker-local.
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_multi_worker_safe_allows_single_worker():
+    """Single worker means no cross-worker routing; must not raise."""
+    ensure_multi_worker_safe(num_workers=1)
+
+
+def test_ensure_multi_worker_safe_refuses_multiple_workers():
+    """Default in-memory queue + workers > 1 must refuse to start."""
+    with pytest.raises(RuntimeError) as exc_info:
+        ensure_multi_worker_safe(num_workers=3)
+
+    msg = str(exc_info.value)
+    assert "3 workers" in msg
+    assert "in-memory job queue" in msg
+
+
+def test_ensure_multi_worker_safe_error_lists_workarounds():
+    """Error must point operators at concrete fixes, not just describe the bug."""
+    with pytest.raises(RuntimeError) as exc_info:
+        ensure_multi_worker_safe(num_workers=3)
+
+    msg = str(exc_info.value)
+    # Shared queue is the proper fix for any event_delivery mode.
+    assert "LANGFLOW_JOB_QUEUE_TYPE=redis" in msg
+    # Single worker sidesteps cross-worker routing entirely.
+    assert "--workers 1" in msg
+    # event_delivery=direct works but cannot be enforced at startup, so it's a
+    # note, not a "pick one of" option — call that out explicitly.
+    assert "event_delivery=direct" in msg

--- a/src/backend/tests/unit/test_cli.py
+++ b/src/backend/tests/unit/test_cli.py
@@ -347,9 +347,16 @@ def test_ensure_multi_worker_safe_allows_single_worker():
     ensure_multi_worker_safe(num_workers=1)
 
 
+def _settings_service_with_queue(queue_type: str) -> SimpleNamespace:
+    return SimpleNamespace(settings=SimpleNamespace(job_queue_type=queue_type))
+
+
 def test_ensure_multi_worker_safe_refuses_multiple_workers():
     """Default in-memory queue + workers > 1 must refuse to start."""
-    with pytest.raises(RuntimeError) as exc_info:
+    with (
+        patch("langflow.__main__.get_settings_service", return_value=_settings_service_with_queue("asyncio")),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
         ensure_multi_worker_safe(num_workers=3)
 
     msg = str(exc_info.value)
@@ -359,7 +366,10 @@ def test_ensure_multi_worker_safe_refuses_multiple_workers():
 
 def test_ensure_multi_worker_safe_error_lists_workarounds():
     """Error must point operators at concrete fixes, not just describe the bug."""
-    with pytest.raises(RuntimeError) as exc_info:
+    with (
+        patch("langflow.__main__.get_settings_service", return_value=_settings_service_with_queue("asyncio")),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
         ensure_multi_worker_safe(num_workers=3)
 
     msg = str(exc_info.value)
@@ -370,3 +380,9 @@ def test_ensure_multi_worker_safe_error_lists_workarounds():
     # event_delivery=direct works but cannot be enforced at startup, so it's a
     # note, not a "pick one of" option — call that out explicitly.
     assert "event_delivery=direct" in msg
+
+
+def test_ensure_multi_worker_safe_allows_redis_queue():
+    """Redis-backed job queue shares state across workers; multi-worker is safe."""
+    with patch("langflow.__main__.get_settings_service", return_value=_settings_service_with_queue("redis")):
+        ensure_multi_worker_safe(num_workers=4)


### PR DESCRIPTION
## Summary

The default `JobQueueService` keeps build queues in process-local memory. With `--workers > 1`, Gunicorn round-robins `POST /api/v1/build/<flow>/flow` and the follow-up `GET /api/v1/build/<job>/events` across workers, so the polling worker finds no queue and returns `Job queue not found for job_id` roughly 45-66% of the time under load.

This refuses to start in that config rather than letting operators discover it in production. The `RuntimeError` lists the two operator-actionable workarounds (configure a Redis-backed shared queue, or run `--workers 1`) and notes that `event_delivery=direct` also works, since the POST endpoint streams events back inline on the same worker. I'm not enforcing direct mode at startup because the server cannot know which delivery mode every future client will pick.

Only triggered on the Gunicorn (Linux) path. The direct-uvicorn path on Windows and macOS already clamps workers to 1, so the race cannot happen there.

## What changed

- `__main__.py`: new `ensure_multi_worker_safe(num_workers)`. Called on the Gunicorn path right before `LangflowApplication` boots.
- `test_cli.py`: three tests covering single-worker (silent), multi-worker (raises with worker count and queue mention), and message shape (all three workarounds appear in the error).

## Open questions

- Should the message also point at the deployment docs? Right now it's self-contained. Happy to add a docs section in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added startup validation to detect and prevent incompatible configurations between worker count and job queue settings that could cause event delivery failures.
  * Application now validates compatibility during startup and provides guidance for correcting configuration issues.

* **Tests**
  * Added test coverage for new startup configuration validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->