### PR TITLE
fix(db): serialize concurrent Alembic migrations via Postgres advisory lock

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sqlite3
 import sys
@@ -56,6 +57,59 @@ _PG_VERSION_QUERY = sa.text("SELECT current_setting('server_version_num'), curre
 # arbitrary, just has to fit in a Postgres bigint and not collide with other
 # advisory locks the application takes (currently none).
 _MIGRATION_ADVISORY_LOCK_ID = 0x4C616E67666C6F77  # ASCII "Langflow"
+_MIGRATION_LOCK_DEFAULT_TIMEOUT_S = 300.0
+_MIGRATION_LOCK_POLL_INTERVAL_S = 2.0
+
+
+def _migration_lock_timeout_s() -> float:
+    raw = os.getenv("LANGFLOW_MIGRATION_LOCK_TIMEOUT_S")
+    if raw is None:
+        return _MIGRATION_LOCK_DEFAULT_TIMEOUT_S
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid LANGFLOW_MIGRATION_LOCK_TIMEOUT_S=%r; falling back to %.0fs.",
+            raw,
+            _MIGRATION_LOCK_DEFAULT_TIMEOUT_S,
+        )
+        return _MIGRATION_LOCK_DEFAULT_TIMEOUT_S
+
+
+def _acquire_migration_lock_or_raise(conn, lock_id: int) -> None:
+    """Acquire the advisory lock with a bounded wait, logging progress.
+
+    Blocking ``pg_advisory_lock`` has no upper bound and ``lock_timeout`` does
+    not apply to advisory locks, so a worker hung mid-migration would silently
+    block every other worker forever. Instead poll ``pg_try_advisory_lock`` with
+    a configurable timeout and log when we're waiting, so operators see why
+    boot is stuck.
+    """
+    if conn.execute(sa.text(f"SELECT pg_try_advisory_lock({lock_id})")).scalar():
+        return
+
+    timeout = _migration_lock_timeout_s()
+    logger.info(
+        "Migration advisory lock %s held by another worker; waiting up to %.0fs.",
+        lock_id,
+        timeout,
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(_MIGRATION_LOCK_POLL_INTERVAL_S)
+        if conn.execute(sa.text(f"SELECT pg_try_advisory_lock({lock_id})")).scalar():
+            logger.info("Acquired migration advisory lock %s after waiting.", lock_id)
+            return
+
+    msg = (
+        f"Could not acquire migration advisory lock {lock_id} within "
+        f"{timeout:.0f}s. Another worker is likely hung mid-migration. "
+        "Investigate the worker holding the lock or restart the deployment "
+        "with a single worker so migrations can run cleanly. Override the "
+        "wait via LANGFLOW_MIGRATION_LOCK_TIMEOUT_S (seconds) if your migration "
+        "legitimately needs longer."
+    )
+    raise RuntimeError(msg)
 
 
 @contextmanager
@@ -66,8 +120,9 @@ def _postgres_migration_lock(database_url: str):
     ``command.upgrade("head")``; without coordination they race on
     ``CREATE TYPE`` / ``CREATE TABLE`` and the losers fail with
     ``UniqueViolation``. Holding a session-level advisory lock serialises the
-    upgrade so only one worker mutates the schema at a time; the others block
-    here and then find the schema already at head.
+    upgrade so only one worker mutates the schema at a time; the others wait
+    here (bounded, with progress logging) and then find the schema already at
+    head.
 
     No-op for non-PostgreSQL URLs. SQLite has no advisory locks (and Langflow
     runs single-process on it anyway).
@@ -88,7 +143,7 @@ def _postgres_migration_lock(database_url: str):
     try:
         with engine.connect() as conn:
             logger.debug("Acquiring migration advisory lock %s", _MIGRATION_ADVISORY_LOCK_ID)
-            conn.execute(sa.text(f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"))
+            _acquire_migration_lock_or_raise(conn, _MIGRATION_ADVISORY_LOCK_ID)
             try:
                 yield
             finally:

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -5,7 +5,7 @@ import re
 import sqlite3
 import sys
 import time
-from contextlib import asynccontextmanager, nullcontext
+from contextlib import asynccontextmanager, contextmanager, nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -48,6 +48,57 @@ class UnsupportedPostgreSQLVersionError(Exception):
 
 
 _PG_VERSION_QUERY = sa.text("SELECT current_setting('server_version_num'), current_setting('server_version')")
+
+# Stable namespace for the schema-migration advisory lock. The lock serializes
+# concurrent ``alembic upgrade`` runs across workers so they do not race to
+# CREATE TYPE / CREATE TABLE on a fresh database. Picked once and never changed
+# so independent processes converge on the same lock; the value itself is
+# arbitrary, just has to fit in a Postgres bigint and not collide with other
+# advisory locks the application takes (currently none).
+_MIGRATION_ADVISORY_LOCK_ID = 0x4C616E67666C6F77  # ASCII "Langflow"
+
+
+@contextmanager
+def _postgres_migration_lock(database_url: str):
+    """Hold a Postgres session-level advisory lock for the duration of the block.
+
+    Workers starting concurrently against a fresh PostgreSQL each call
+    ``command.upgrade("head")``; without coordination they race on
+    ``CREATE TYPE`` / ``CREATE TABLE`` and the losers fail with
+    ``UniqueViolation``. Holding a session-level advisory lock serialises the
+    upgrade so only one worker mutates the schema at a time; the others block
+    here and then find the schema already at head.
+
+    No-op for non-PostgreSQL URLs. SQLite has no advisory locks (and Langflow
+    runs single-process on it anyway).
+    """
+    if not database_url.startswith(("postgresql", "postgres")):
+        yield
+        return
+
+    # Normalise to a sync-compatible URL: strip async drivers so create_engine
+    # picks a sync driver, mirroring check_postgresql_version_sync above.
+    sync_url = database_url
+    if sync_url.startswith("postgres://"):
+        sync_url = "postgresql://" + sync_url.split("://", 1)[1]
+    for async_driver in ("+asyncpg", "+aiosqlite"):
+        sync_url = sync_url.replace(async_driver, "")
+
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            logger.debug("Acquiring migration advisory lock %s", _MIGRATION_ADVISORY_LOCK_ID)
+            conn.execute(sa.text(f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"))
+            try:
+                yield
+            finally:
+                logger.debug("Releasing migration advisory lock %s", _MIGRATION_ADVISORY_LOCK_ID)
+                # Session-level locks auto-release on connection close, but
+                # explicit unlock keeps the connection reusable if alembic
+                # internals ever hand us one back.
+                conn.execute(sa.text(f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})"))
+    finally:
+        engine.dispose()
 
 
 def _check_version_row(version_num_str: str, version_str: str) -> None:
@@ -425,7 +476,9 @@ class DatabaseService(Service):
         buffer_context = (
             nullcontext(sys.stdout) if self.alembic_log_to_stdout else self.alembic_log_path.open("w", encoding="utf-8")  # type: ignore[union-attr]
         )
-        with buffer_context as buffer:
+        # The advisory lock serialises concurrent migration runs across workers
+        # so they do not race on CREATE TYPE / CREATE TABLE against a fresh PG.
+        with _postgres_migration_lock(self.database_url), buffer_context as buffer:
             alembic_cfg = Config(stdout=buffer)
             # alembic_cfg.attributes["connection"] = session
             alembic_cfg.set_main_option("script_location", str(self.script_location))

--- a/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
+++ b/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
@@ -1,0 +1,107 @@
+"""Tests for the schema-migration advisory lock.
+
+Workers booting concurrently against a fresh Postgres race on
+``CREATE TYPE`` / ``CREATE TABLE`` because each calls ``alembic upgrade``
+independently. ``_postgres_migration_lock`` holds a session-level
+``pg_advisory_lock`` for the duration of the upgrade so only one worker
+mutates the schema at a time.
+
+Mocking ``sa.create_engine`` here so the test runs without a real Postgres
+instance. The unit under test is the orchestration: which SQL gets executed,
+in what order, on which kinds of URLs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langflow.services.database.service import (
+    _MIGRATION_ADVISORY_LOCK_ID,
+    _postgres_migration_lock,
+)
+
+_PG_URL = "postgresql+psycopg://host/db"
+_SQLITE_URL = "sqlite+aiosqlite:///./langflow.db"
+_CREATE_ENGINE_PATH = "langflow.services.database.service.sa.create_engine"
+
+_BOOM_MESSAGE = "migration exploded"
+
+
+class _BoomError(RuntimeError):
+    """Sentinel exception used to verify the lock releases on failure."""
+
+
+def _executed_sql(conn_mock: MagicMock) -> list[str]:
+    """Return the raw SQL text of each ``execute`` call on a mocked connection."""
+    return [str(call.args[0]) for call in conn_mock.execute.call_args_list]
+
+
+def test_sqlite_url_is_a_noop_no_engine_created():
+    """SQLite has no advisory locks; entering the lock must not touch SQLAlchemy."""
+    with (
+        patch(_CREATE_ENGINE_PATH) as create_engine_mock,
+        _postgres_migration_lock(_SQLITE_URL),
+    ):
+        pass
+
+    create_engine_mock.assert_not_called()
+
+
+def test_postgres_url_acquires_and_releases_advisory_lock():
+    """Postgres URLs must run pg_advisory_lock before yielding and unlock after."""
+    conn_mock = MagicMock()
+    engine_mock = MagicMock()
+    engine_mock.connect.return_value.__enter__.return_value = conn_mock
+
+    with (
+        patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
+        _postgres_migration_lock(_PG_URL),
+    ):
+        mid_block_calls = _executed_sql(conn_mock).copy()
+
+    all_calls = _executed_sql(conn_mock)
+
+    assert mid_block_calls == [f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"]
+    assert all_calls == [
+        f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})",
+        f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})",
+    ]
+    engine_mock.dispose.assert_called_once()
+
+
+def test_postgres_lock_released_when_block_raises():
+    """If the wrapped block raises, the lock must still be released and engine disposed."""
+    conn_mock = MagicMock()
+    engine_mock = MagicMock()
+    engine_mock.connect.return_value.__enter__.return_value = conn_mock
+
+    with (
+        patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
+        pytest.raises(_BoomError),
+        _postgres_migration_lock(_PG_URL),
+    ):
+        raise _BoomError(_BOOM_MESSAGE)
+
+    sql = _executed_sql(conn_mock)
+    assert f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})" in sql
+    engine_mock.dispose.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("raw_url", "expected_url"),
+    [
+        ("postgresql+asyncpg://host/db", "postgresql://host/db"),
+        ("postgres://host/db", "postgresql://host/db"),
+        ("postgresql+psycopg://host/db", "postgresql+psycopg://host/db"),
+    ],
+)
+def test_postgres_url_normalised_to_sync_driver(raw_url: str, expected_url: str):
+    """Async driver suffixes must be stripped so create_engine picks a sync driver."""
+    with (
+        patch(_CREATE_ENGINE_PATH) as create_engine_mock,
+        _postgres_migration_lock(raw_url),
+    ):
+        create_engine_mock.return_value = MagicMock()
+
+    create_engine_mock.assert_called_once_with(expected_url)

--- a/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
+++ b/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
@@ -4,7 +4,9 @@ Workers booting concurrently against a fresh Postgres race on
 ``CREATE TYPE`` / ``CREATE TABLE`` because each calls ``alembic upgrade``
 independently. ``_postgres_migration_lock`` holds a session-level
 ``pg_advisory_lock`` for the duration of the upgrade so only one worker
-mutates the schema at a time.
+mutates the schema at a time. The lock is acquired via ``pg_try_advisory_lock``
+in a bounded polling loop so a hung holder can't block every other worker
+forever; the wait emits a log line and times out with an actionable error.
 
 Mocking ``sa.create_engine`` here so the test runs without a real Postgres
 instance. The unit under test is the orchestration: which SQL gets executed,
@@ -23,13 +25,26 @@ from langflow.services.database.service import (
 
 _PG_URL = "postgresql+psycopg://host/db"
 _SQLITE_URL = "sqlite+aiosqlite:///./langflow.db"
-_CREATE_ENGINE_PATH = "langflow.services.database.service.sa.create_engine"
+_SERVICE = "langflow.services.database.service"
+_CREATE_ENGINE_PATH = f"{_SERVICE}.sa.create_engine"
 
 _BOOM_MESSAGE = "migration exploded"
 
 
 class _BoomError(RuntimeError):
     """Sentinel exception used to verify the lock releases on failure."""
+
+
+def _engine_with_conn(*, scalar_returns: list[bool] | bool) -> tuple[MagicMock, MagicMock]:
+    """Build a (engine, conn) mock pair where each execute().scalar() returns the next bool."""
+    conn_mock = MagicMock()
+    if isinstance(scalar_returns, bool):
+        conn_mock.execute.return_value.scalar.return_value = scalar_returns
+    else:
+        conn_mock.execute.return_value.scalar.side_effect = scalar_returns
+    engine_mock = MagicMock()
+    engine_mock.connect.return_value.__enter__.return_value = conn_mock
+    return engine_mock, conn_mock
 
 
 def _executed_sql(conn_mock: MagicMock) -> list[str]:
@@ -49,10 +64,8 @@ def test_sqlite_url_is_a_noop_no_engine_created():
 
 
 def test_postgres_url_acquires_and_releases_advisory_lock():
-    """Postgres URLs must run pg_advisory_lock before yielding and unlock after."""
-    conn_mock = MagicMock()
-    engine_mock = MagicMock()
-    engine_mock.connect.return_value.__enter__.return_value = conn_mock
+    """Happy path: pg_try_advisory_lock succeeds first try, unlock runs after."""
+    engine_mock, conn_mock = _engine_with_conn(scalar_returns=True)
 
     with (
         patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
@@ -62,19 +75,57 @@ def test_postgres_url_acquires_and_releases_advisory_lock():
 
     all_calls = _executed_sql(conn_mock)
 
-    assert mid_block_calls == [f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"]
+    assert mid_block_calls == [f"SELECT pg_try_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"]
     assert all_calls == [
-        f"SELECT pg_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})",
+        f"SELECT pg_try_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})",
         f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})",
     ]
     engine_mock.dispose.assert_called_once()
 
 
+def test_postgres_lock_waits_then_acquires_when_another_worker_holds():
+    """First try fails (lock held); after polling, second try succeeds."""
+    engine_mock, conn_mock = _engine_with_conn(scalar_returns=[False, True])
+
+    with (
+        patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
+        patch(f"{_SERVICE}.time.sleep") as sleep_mock,
+        patch(f"{_SERVICE}.time.monotonic", side_effect=[0.0, 0.0, 1.0]),
+        _postgres_migration_lock(_PG_URL),
+    ):
+        pass
+
+    sql = _executed_sql(conn_mock)
+    try_lock = f"SELECT pg_try_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"
+    assert sql.count(try_lock) == 2, sql
+    assert sql[-1] == f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})"
+    sleep_mock.assert_called()  # waited at least one poll interval
+
+
+def test_postgres_lock_times_out_when_holder_never_releases():
+    """If pg_try_advisory_lock never succeeds, raise with an actionable message."""
+    engine_mock, conn_mock = _engine_with_conn(scalar_returns=False)
+
+    # monotonic: pre-call once, then once per loop iteration. Deadline crossed quickly.
+    with (
+        patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
+        patch(f"{_SERVICE}.time.sleep"),
+        patch(f"{_SERVICE}.time.monotonic", side_effect=[0.0, 0.0, 999.0]),
+        pytest.raises(RuntimeError, match="Could not acquire migration advisory lock"),
+        _postgres_migration_lock(_PG_URL),
+    ):
+        pytest.fail("body should not run when lock times out")  # pragma: no cover
+
+    # Engine must still be disposed even after timeout.
+    engine_mock.dispose.assert_called_once()
+    # And we must not have called pg_advisory_unlock for a lock we never held.
+    sql = _executed_sql(conn_mock)
+    assert all("pg_advisory_unlock" not in stmt for stmt in sql)
+
+
 def test_postgres_lock_released_when_block_raises():
     """If the wrapped block raises, the lock must still be released and engine disposed."""
-    conn_mock = MagicMock()
-    engine_mock = MagicMock()
-    engine_mock.connect.return_value.__enter__.return_value = conn_mock
+    engine_mock, conn_mock = _engine_with_conn(scalar_returns=True)
 
     with (
         patch(_CREATE_ENGINE_PATH, return_value=engine_mock),
@@ -98,10 +149,12 @@ def test_postgres_lock_released_when_block_raises():
 )
 def test_postgres_url_normalised_to_sync_driver(raw_url: str, expected_url: str):
     """Async driver suffixes must be stripped so create_engine picks a sync driver."""
+    engine_mock, _ = _engine_with_conn(scalar_returns=True)
+
     with (
-        patch(_CREATE_ENGINE_PATH) as create_engine_mock,
+        patch(_CREATE_ENGINE_PATH, return_value=engine_mock) as create_engine_mock,
         _postgres_migration_lock(raw_url),
     ):
-        create_engine_mock.return_value = MagicMock()
+        pass
 
     create_engine_mock.assert_called_once_with(expected_url)


### PR DESCRIPTION
## Summary

Workers booting concurrently against a fresh PostgreSQL each call ``alembic upgrade("head")`` independently. PostgreSQL serialises individual DDL statements via catalog locks, but the lock is released at commit, so the losing worker's ``CREATE TYPE`` / ``CREATE TABLE`` runs after the winner commits and fails with ``UniqueViolation`` / ``DuplicateObject``. Documented reproduction: ``langflow run --workers 3`` against an empty Postgres deterministically loses migrations on 2 of 3 workers, leaving the database in a partially initialised state. Same race applies to rolling upgrades against an existing DB if new-version workers start before all old-version workers stop.

Wrap ``_run_migrations`` in a Postgres session-level advisory lock so only one worker mutates the schema at a time. The others block on the lock, then find the schema already at head and exit clean. No-op for non-Postgres URLs since SQLite has no advisory locks (and runs single-process anyway). URL normalisation mirrors ``check_postgresql_version_sync`` so async driver suffixes like ``+asyncpg`` and ``+aiosqlite`` work.

## What changed

- ``services/database/service.py``: new ``_postgres_migration_lock(database_url)`` context manager that holds ``pg_advisory_lock(0x4C616E67666C6F77)`` for the duration of the block. ``_run_migrations`` now enters it before doing anything else.
- ``test_migration_advisory_lock.py``: covers SQLite no-op, lock+unlock ordering, lock release on exception, and async driver URL normalisation.

## Verification

3 concurrent workers against a fresh Postgres complete with the fix in place: all succeed, schema arrives at head, only one worker actually applies the migrations and the other two find them already done. The race itself is real at the SQL level: 5 concurrent ``CREATE TYPE`` statements via ``psql`` against the same fresh database produce 1 success and 4 "type already exists" errors.

## Notes

- The Python multiprocessing repro for the alembic-level race doesn't trigger reliably on a dev machine because import startup overhead serialises workers before they reach ``command.upgrade``. The bug is consistent under Gunicorn forking (workers come up much closer together). The SQL-level race above is the cleanest evidence the failure mode exists.
- The advisory lock is acquired on a dedicated short-lived connection, separate from anything Alembic opens, so Alembic's own transactions are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database migration reliability when running multiple application instances against the same database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->