### PR TITLE
ci(release_bundles): build lfx wheel locally for smoke test

### DIFF
--- a/.github/workflows/release_bundles.yml
+++ b/.github/workflows/release_bundles.yml
@@ -65,12 +65,31 @@ jobs:
           done
           echo "bundles-found=1" >> $GITHUB_OUTPUT
           ls -la bundles-dist/
+      # Bundles pin lfx (e.g. lfx>=0.5.0,<0.6.0). The smoke test below
+      # installs the bundles in a fresh venv, so it needs an lfx wheel that
+      # satisfies the pin available locally — PyPI may not yet have a
+      # matching lfx published when bundles are released ahead of a main
+      # release. We build the lfx wheel from the current ref so the smoke
+      # test resolves against it; this artifact is not published.
+      - name: Build lfx wheel for smoke test
+        if: steps.build.outputs.bundles-found == '1'
+        run: |
+          mkdir -p lfx-dist
+          LFX_DIST="$PWD/lfx-dist"
+          (cd src/lfx && uv build --wheel --out-dir "$LFX_DIST")
+          ls -la lfx-dist/
       - name: Upload bundles artifact
         if: steps.build.outputs.bundles-found == '1'
         uses: actions/upload-artifact@v6
         with:
           name: dist-bundles
           path: bundles-dist
+      - name: Upload lfx artifact (smoke-test only; not published)
+        if: steps.build.outputs.bundles-found == '1'
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist-lfx-smoketest
+          path: lfx-dist
 
   test-install:
     name: Install Smoke Test - ${{ matrix.os }} ${{ matrix.python-version }}
@@ -108,32 +127,47 @@ jobs:
         with:
           name: dist-bundles
           path: ./bundles-dist
+      - name: Download lfx artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-lfx-smoketest
+          path: ./lfx-dist
       - name: Create fresh virtual environment
         run: uv venv test-env --seed
         shell: bash
-      - name: Install bundle wheels (Unix)
+      - name: Install lfx + bundle wheels (Unix)
         if: matrix.os != 'windows'
         run: |
           shopt -s nullglob
           BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          LFX_WHEELS=(./lfx-dist/*.whl)
           if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
             echo "No bundle wheels found in ./bundles-dist/"
             exit 1
           fi
-          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=allow --python ./test-env/bin/python "${BUNDLE_WHEELS[@]}"
+          if [ ${#LFX_WHEELS[@]} -eq 0 ]; then
+            echo "No lfx wheel found in ./lfx-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/bin/python "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
-      - name: Install bundle wheels (Windows)
+      - name: Install lfx + bundle wheels (Windows)
         if: matrix.os == 'windows'
         run: |
           shopt -s nullglob
           BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          LFX_WHEELS=(./lfx-dist/*.whl)
           if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
             echo "No bundle wheels found in ./bundles-dist/"
             exit 1
           fi
-          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=allow --python ./test-env/Scripts/python.exe "${BUNDLE_WHEELS[@]}"
+          if [ ${#LFX_WHEELS[@]} -eq 0 ]; then
+            echo "No lfx wheel found in ./lfx-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/Scripts/python.exe "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
 
   publish-bundles:


### PR DESCRIPTION
## Summary

The bundle smoke test in `release_bundles.yml` installs the freshly built bundle wheels into a clean venv, which makes `uv` resolve their `lfx>=X.Y,<Z` pin against PyPI. When bundles are released ahead of a matching `lfx` (the typical case — bundles ship more often than `lfx` bumps land on PyPI), the resolve fails:

```
× No solution found when resolving dependencies:
╰─▶ Because only lfx<=0.4.3 is available and lfx-arxiv==0.1.0 depends on
    lfx>=0.5.0,<0.6.0, we can conclude that lfx-arxiv==0.1.0 cannot be used.
```

Hit this trying to publish the first stable `lfx-arxiv` / `lfx-duckduckgo` off `release-1.10.0`, which already has `lfx` at `0.5.0` locally but `lfx 0.5.0` isn't on PyPI yet.

## What changed

`release_bundles.yml`:
- Build the `lfx` wheel from the current ref in the `build-bundles` job and upload it as a separate `dist-lfx-smoketest` artifact.
- In `test-install`, download the lfx artifact and pass the lfx wheel + bundle wheels together to `uv pip install`. The local `lfx` wheel satisfies the bundle pin, and remaining transitive deps resolve normally from PyPI.
- `publish-bundles` is unchanged — it still only downloads the `dist-bundles` artifact, so only bundle wheels get pushed to PyPI.

Once this lands on `main`, cherry-pick to `release-1.10.0` to use the workflow from that branch (or trigger from main with `release_tag=release-1.10.0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to build and test the locally constructed wheel component alongside bundle wheels. Improved installation testing to validate both components together in a fresh environment, strengthening the release quality assurance process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->