### PR TITLE
ci(nightly): re-pin bundle lfx deps to lfx-nightly during nightly build

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -171,6 +171,12 @@ jobs:
           cd src/lfx && uv lock && cd ../..
 
           git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock src/backend/base/uv.lock
+          # update_lfx_version.py re-pins each bundle's `lfx` dep to
+          # lfx-nightly==<dev>, so any modified bundle pyprojects need to
+          # ride the same commit/tag as the rest of the version bumps.
+          if compgen -G "src/bundles/*/pyproject.toml" > /dev/null; then
+            git add src/bundles/*/pyproject.toml
+          fi
           git commit -m "Update version and project name"
 
           echo "Tagging main with $RELEASE_TAG"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 303,
         "is_secret": false
       }
     ],
@@ -8287,5 +8287,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T16:19:23Z"
+  "generated_at": "2026-05-19T16:42:30Z"
 }

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -50,6 +50,42 @@ def update_sdk_dependency_in_lfx(pyproject_path: str, sdk_version: str) -> None:
     filepath.write_text(content, encoding="utf-8")
 
 
+# Match an `lfx` (or `lfx-nightly`) dependency specifier inside a quoted
+# string. The lookahead enforces a version operator immediately after the
+# name so we don't accidentally match sibling packages like `lfx-arxiv` or
+# `lfx-duckduckgo`.
+_BUNDLE_LFX_DEP_PATTERN = re.compile(r'"lfx(?:-nightly)?(?=[<>=!~])[^"]*"')
+
+
+def update_lfx_dep_in_bundles(lfx_version: str) -> None:
+    """Pin every bundle's `lfx` dep to the renamed `lfx-nightly==<version>`.
+
+    Each `src/bundles/*/pyproject.toml` declares an `lfx>=X.Y,<Z` style pin
+    against the published `lfx` package. During nightly builds the
+    workspace `lfx` package gets renamed to `lfx-nightly`, so those pins
+    no longer resolve against the workspace member — and PyPI may not yet
+    ship a matching `lfx` either. Rewrite each bundle's pin to
+    `lfx-nightly==<exact dev version>` so `uv lock` resolves cleanly.
+
+    No-op when no bundles exist (e.g. on a branch that hasn't picked up
+    the bundle extraction) or when a bundle has no `lfx` dep.
+    """
+    bundles_dir = BASE_DIR / "src" / "bundles"
+    if not bundles_dir.is_dir():
+        return
+
+    replacement = f'"lfx-nightly=={lfx_version}"'
+    for bundle_pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
+        content = bundle_pyproject.read_text(encoding="utf-8")
+        if not _BUNDLE_LFX_DEP_PATTERN.search(content):
+            continue
+        new_content = _BUNDLE_LFX_DEP_PATTERN.sub(replacement, content)
+        if new_content == content:
+            continue
+        bundle_pyproject.write_text(new_content, encoding="utf-8")
+        print(f"Updated lfx dep in {bundle_pyproject.relative_to(BASE_DIR)} -> lfx-nightly=={lfx_version}")
+
+
 def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
     """Update LFX package for nightly build.
 
@@ -71,6 +107,10 @@ def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
 
     sdk_version = sdk_tag.lstrip("v")
     update_sdk_dependency_in_lfx(lfx_pyproject_path, sdk_version)
+
+    # Re-pin every bundle's lfx dep to the renamed workspace package so
+    # `uv lock` resolves cleanly. No-op when no bundles are present.
+    update_lfx_dep_in_bundles(version)
 
     print(f"Updated LFX package to lfx-nightly version {version}")
 


### PR DESCRIPTION
## Summary

`uv lock` in the nightly `create-nightly-tag` job fails on branches that ship bundle pyprojects (e.g. `release-1.10.0`):

```
× No solution found when resolving dependencies for split [...]
╰─▶ Because only lfx<=0.4.3 is available and lfx-arxiv depends on
    lfx>=0.5.0,<0.6.0, we can conclude that lfx-arxiv's requirements
    are unsatisfiable.
```

Same shape as #13207. Nightly renames the workspace `lfx` package to `lfx-nightly` and updates the workspace dep in the root pyproject, but each `src/bundles/*/pyproject.toml` still pins `"lfx>=0.5.0,<0.6.0"` against the package name that no longer exists in the workspace — and PyPI only has `lfx 0.4.3`.

## What changed

- **`scripts/ci/update_lfx_version.py`** — added `update_lfx_dep_in_bundles(lfx_version)`. Iterates `src/bundles/*/pyproject.toml` and rewrites any `"lfx[<>=!~]..."` or already-rewritten `"lfx-nightly==..."` spec to `"lfx-nightly==<dev version>"`. A regex lookahead requires a version operator immediately after the package name, so sibling packages like `lfx-arxiv` / `lfx-duckduckgo` are not matched. Called from `update_lfx_for_nightly` after the existing SDK rewrite.
- **`.github/workflows/nightly_build.yml`** — restored the guarded `git add src/bundles/*/pyproject.toml` step so the rewritten bundle pyprojects ride the same commit/tag as the other version bumps.

No-op on branches without bundle pyprojects (e.g. `main` today), so this is safe to merge ahead of the bundle extraction landing on `main`.

## Verification

Inline regex tests covered:

| Input | Result |
|---|---|
| `"lfx>=0.5.0,<0.6.0"` | rewritten to `"lfx-nightly==<v>"` |
| `"lfx-nightly==0.5.0.dev10"` | rewritten to `"lfx-nightly==<v>"` (idempotent re-runs) |
| `"lfx-arxiv>=0.1.0"` | no match (sibling left alone) |
| `"lfx-duckduckgo>=0.1.0"` | no match |
| `"defusedxml>=0.7.1,<1.0.0"` | no match |

Functional test against a fake workspace with three bundle pyprojects (one with `lfx>=...`, one already on `lfx-nightly==...`, one with no `lfx` dep) confirmed the script rewrites only the first two and skips the third.

Cherry-pick to `release-1.10.0` to unblock nightlies cut from that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly build workflow to properly include bundle dependency updates during version tagging.
  * Improved automated dependency version management for nightly releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->