### PR TITLE
ci: backport bundle/nightly CI fixes from main (#13206, #13207, #13208)

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -171,6 +171,12 @@ jobs:
           cd src/lfx && uv lock && cd ../..
 
           git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock src/backend/base/uv.lock
+          # update_lfx_version.py re-pins each bundle's `lfx` dep to
+          # lfx-nightly==<dev>, so any modified bundle pyprojects need to
+          # ride the same commit/tag as the rest of the version bumps.
+          if compgen -G "src/bundles/*/pyproject.toml" > /dev/null; then
+            git add src/bundles/*/pyproject.toml
+          fi
           git commit -m "Update version and project name"
 
           echo "Tagging main with $RELEASE_TAG"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -163,8 +163,6 @@ jobs:
           uv run --no-sync ./scripts/ci/update_sdk_version.py $SDK_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run --no-sync ./scripts/ci/update_lfx_version.py $LFX_TAG $SDK_TAG
-          echo "Renaming bundle packages to their -nightly counterparts (lfx dev suffix: $LFX_TAG)"
-          uv run --no-sync ./scripts/ci/update_bundle_versions.py $LFX_TAG
           echo "Updating base project version to $BASE_TAG and updating main project version to $RELEASE_TAG"
           uv run --no-sync ./scripts/ci/update_pyproject_combined.py main $RELEASE_TAG $BASE_TAG $LFX_TAG
 
@@ -172,7 +170,7 @@ jobs:
           cd src/backend/base && uv lock && cd ../../..
           cd src/lfx && uv lock && cd ../..
 
-          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml src/bundles/*/pyproject.toml uv.lock src/backend/base/uv.lock
+          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock src/backend/base/uv.lock
           git commit -m "Update version and project name"
 
           echo "Tagging main with $RELEASE_TAG"

--- a/.github/workflows/release_bundles.yml
+++ b/.github/workflows/release_bundles.yml
@@ -65,12 +65,31 @@ jobs:
           done
           echo "bundles-found=1" >> $GITHUB_OUTPUT
           ls -la bundles-dist/
+      # Bundles pin lfx (e.g. lfx>=0.5.0,<0.6.0). The smoke test below
+      # installs the bundles in a fresh venv, so it needs an lfx wheel that
+      # satisfies the pin available locally — PyPI may not yet have a
+      # matching lfx published when bundles are released ahead of a main
+      # release. We build the lfx wheel from the current ref so the smoke
+      # test resolves against it; this artifact is not published.
+      - name: Build lfx wheel for smoke test
+        if: steps.build.outputs.bundles-found == '1'
+        run: |
+          mkdir -p lfx-dist
+          LFX_DIST="$PWD/lfx-dist"
+          (cd src/lfx && uv build --wheel --out-dir "$LFX_DIST")
+          ls -la lfx-dist/
       - name: Upload bundles artifact
         if: steps.build.outputs.bundles-found == '1'
         uses: actions/upload-artifact@v6
         with:
           name: dist-bundles
           path: bundles-dist
+      - name: Upload lfx artifact (smoke-test only; not published)
+        if: steps.build.outputs.bundles-found == '1'
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist-lfx-smoketest
+          path: lfx-dist
 
   test-install:
     name: Install Smoke Test - ${{ matrix.os }} ${{ matrix.python-version }}
@@ -108,32 +127,47 @@ jobs:
         with:
           name: dist-bundles
           path: ./bundles-dist
+      - name: Download lfx artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-lfx-smoketest
+          path: ./lfx-dist
       - name: Create fresh virtual environment
         run: uv venv test-env --seed
         shell: bash
-      - name: Install bundle wheels (Unix)
+      - name: Install lfx + bundle wheels (Unix)
         if: matrix.os != 'windows'
         run: |
           shopt -s nullglob
           BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          LFX_WHEELS=(./lfx-dist/*.whl)
           if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
             echo "No bundle wheels found in ./bundles-dist/"
             exit 1
           fi
-          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=allow --python ./test-env/bin/python "${BUNDLE_WHEELS[@]}"
+          if [ ${#LFX_WHEELS[@]} -eq 0 ]; then
+            echo "No lfx wheel found in ./lfx-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/bin/python "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
-      - name: Install bundle wheels (Windows)
+      - name: Install lfx + bundle wheels (Windows)
         if: matrix.os == 'windows'
         run: |
           shopt -s nullglob
           BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          LFX_WHEELS=(./lfx-dist/*.whl)
           if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
             echo "No bundle wheels found in ./bundles-dist/"
             exit 1
           fi
-          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=allow --python ./test-env/Scripts/python.exe "${BUNDLE_WHEELS[@]}"
+          if [ ${#LFX_WHEELS[@]} -eq 0 ]; then
+            echo "No lfx wheel found in ./lfx-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/Scripts/python.exe "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
 
   publish-bundles:

--- a/.github/workflows/release_bundles.yml
+++ b/.github/workflows/release_bundles.yml
@@ -1,0 +1,189 @@
+name: Release Bundles
+
+# Manually-triggered workflow for publishing stable `lfx-<name>` bundle wheels
+# from src/bundles/* to PyPI. Bundles change infrequently, so we release them
+# on demand rather than on a schedule. Re-running the workflow without a
+# version bump is a no-op (PyPI rejects the duplicate upload and we tolerate
+# the conflict).
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Git ref to build from (branch, tag, or SHA). Defaults to the workflow's checked-out ref."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Build and test only; skip the PyPI publish step."
+        required: false
+        type: boolean
+        default: false
+
+env:
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  build-bundles:
+    name: Build Langflow Bundles
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      bundles-found: ${{ steps.build.outputs.bundles-found }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: ${{ env.PYTHON_VERSION }}
+          prune-cache: false
+      - name: Install the project
+        run: uv sync
+      - name: Build bundle wheels
+        id: build
+        run: |
+          shopt -s nullglob
+          bundles=(src/bundles/*/pyproject.toml)
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "No bundles found under src/bundles/*/"
+            echo "bundles-found=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          mkdir -p bundles-dist
+          BUNDLES_DIST="$PWD/bundles-dist"
+          for bundle_pyproject in "${bundles[@]}"; do
+            bundle_dir=$(dirname "$bundle_pyproject")
+            echo "Building wheel for $bundle_dir"
+            (cd "$bundle_dir" && uv build --wheel --out-dir "$BUNDLES_DIST")
+          done
+          echo "bundles-found=1" >> $GITHUB_OUTPUT
+          ls -la bundles-dist/
+      - name: Upload bundles artifact
+        if: steps.build.outputs.bundles-found == '1'
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist-bundles
+          path: bundles-dist
+
+  test-install:
+    name: Install Smoke Test - ${{ matrix.os }} ${{ matrix.python-version }}
+    needs: [build-bundles]
+    if: needs.build-bundles.outputs.bundles-found == '1'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+            python-version: "3.10"
+          - os: linux
+            runner: ubuntu-latest
+            python-version: "3.12"
+          - os: macos
+            runner: macos-latest
+            python-version: "3.12"
+          - os: windows
+            runner: windows-latest
+            python-version: "3.12"
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
+      - name: Download bundles artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-bundles
+          path: ./bundles-dist
+      - name: Create fresh virtual environment
+        run: uv venv test-env --seed
+        shell: bash
+      - name: Install bundle wheels (Unix)
+        if: matrix.os != 'windows'
+        run: |
+          shopt -s nullglob
+          BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
+            echo "No bundle wheels found in ./bundles-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/bin/python "${BUNDLE_WHEELS[@]}"
+        shell: bash
+      - name: Install bundle wheels (Windows)
+        if: matrix.os == 'windows'
+        run: |
+          shopt -s nullglob
+          BUNDLE_WHEELS=(./bundles-dist/*.whl)
+          if [ ${#BUNDLE_WHEELS[@]} -eq 0 ]; then
+            echo "No bundle wheels found in ./bundles-dist/"
+            exit 1
+          fi
+          printf 'Installing: %s\n' "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=allow --python ./test-env/Scripts/python.exe "${BUNDLE_WHEELS[@]}"
+        shell: bash
+
+  publish-bundles:
+    name: Publish Bundles to PyPI
+    needs: [build-bundles, test-install]
+    if: |
+      always() &&
+      !cancelled() &&
+      !inputs.dry_run &&
+      needs.build-bundles.result == 'success' &&
+      needs.build-bundles.outputs.bundles-found == '1' &&
+      needs.test-install.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download bundles artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-bundles
+          path: bundles-dist
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Publish bundles to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          shopt -s nullglob
+          wheels=(bundles-dist/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "No bundle wheels to publish."
+            exit 0
+          fi
+          failed=0
+          for wheel in "${wheels[@]}"; do
+            echo "Publishing $wheel"
+            # Capture stderr so we can tolerate "already exists" without failing
+            # the whole run — re-running this workflow without bumping a bundle
+            # version should be a no-op for that bundle.
+            if ! err=$(uv publish "$wheel" 2>&1); then
+              echo "$err"
+              if echo "$err" | grep -qiE 'already exists|file already exists|HTTP 400|duplicate'; then
+                echo "Skipping $wheel: already published."
+              else
+                echo "Publish failed for $wheel"
+                failed=1
+              fi
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            exit 1
+          fi

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -437,6 +437,7 @@ jobs:
   publish-nightly-main:
     name: Publish Langflow Main Nightly to PyPI
     needs: [build-nightly-main, test-cross-platform, publish-nightly-base]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 299,
+        "line_number": 297,
         "is_secret": false
       }
     ],
@@ -207,7 +207,7 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 473,
+        "line_number": 474,
         "is_secret": false
       }
     ],
@@ -9031,5 +9031,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T13:48:21Z"
+  "generated_at": "2026-05-19T17:11:24Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 303,
         "is_secret": false
       }
     ],
@@ -9031,5 +9031,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T17:11:24Z"
+  "generated_at": "2026-05-19T17:11:47Z"
 }

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -50,6 +50,42 @@ def update_sdk_dependency_in_lfx(pyproject_path: str, sdk_version: str) -> None:
     filepath.write_text(content, encoding="utf-8")
 
 
+# Match an `lfx` (or `lfx-nightly`) dependency specifier inside a quoted
+# string. The lookahead enforces a version operator immediately after the
+# name so we don't accidentally match sibling packages like `lfx-arxiv` or
+# `lfx-duckduckgo`.
+_BUNDLE_LFX_DEP_PATTERN = re.compile(r'"lfx(?:-nightly)?(?=[<>=!~])[^"]*"')
+
+
+def update_lfx_dep_in_bundles(lfx_version: str) -> None:
+    """Pin every bundle's `lfx` dep to the renamed `lfx-nightly==<version>`.
+
+    Each `src/bundles/*/pyproject.toml` declares an `lfx>=X.Y,<Z` style pin
+    against the published `lfx` package. During nightly builds the
+    workspace `lfx` package gets renamed to `lfx-nightly`, so those pins
+    no longer resolve against the workspace member — and PyPI may not yet
+    ship a matching `lfx` either. Rewrite each bundle's pin to
+    `lfx-nightly==<exact dev version>` so `uv lock` resolves cleanly.
+
+    No-op when no bundles exist (e.g. on a branch that hasn't picked up
+    the bundle extraction) or when a bundle has no `lfx` dep.
+    """
+    bundles_dir = BASE_DIR / "src" / "bundles"
+    if not bundles_dir.is_dir():
+        return
+
+    replacement = f'"lfx-nightly=={lfx_version}"'
+    for bundle_pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
+        content = bundle_pyproject.read_text(encoding="utf-8")
+        if not _BUNDLE_LFX_DEP_PATTERN.search(content):
+            continue
+        new_content = _BUNDLE_LFX_DEP_PATTERN.sub(replacement, content)
+        if new_content == content:
+            continue
+        bundle_pyproject.write_text(new_content, encoding="utf-8")
+        print(f"Updated lfx dep in {bundle_pyproject.relative_to(BASE_DIR)} -> lfx-nightly=={lfx_version}")
+
+
 def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
     """Update LFX package for nightly build.
 
@@ -71,6 +107,10 @@ def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
 
     sdk_version = sdk_tag.lstrip("v")
     update_sdk_dependency_in_lfx(lfx_pyproject_path, sdk_version)
+
+    # Re-pin every bundle's lfx dep to the renamed workspace package so
+    # `uv lock` resolves cleanly. No-op when no bundles are present.
+    update_lfx_dep_in_bundles(version)
 
     print(f"Updated LFX package to lfx-nightly version {version}")
 


### PR DESCRIPTION
## Summary

Cherry-picks three CI fixes from `main` that are needed to unblock nightly tag creation and bundle publishing on `release-1.10.0`. Direct cause of the `uv lock` failure currently breaking nightlies cut from this branch.

## Cherry-picked

- [`135bc177f1`](https://github.com/langflow-ai/langflow/commit/135bc177f1) — `ci: stop publishing -nightly bundle variants; release bundles on demand` (#13206)
- [`704c79b226`](https://github.com/langflow-ai/langflow/commit/704c79b226) — `ci(release_bundles): build lfx wheel locally for smoke test` (#13207)
- [`51365a5b8c`](https://github.com/langflow-ai/langflow/commit/51365a5b8c) — `ci(nightly): re-pin bundle lfx deps to lfx-nightly during nightly build` (#13208)

## Conflicts resolved

`nightly_build.yml`:
- `release-1.10.0` had an inline call to `update_bundle_versions.py` (no guard) — dropped, since #13206 removes that script call.
- `release-1.10.0` had `src/bundles/*/pyproject.toml` directly in the `git add` line — dropped from the inline list. #13208 reintroduces it via the guarded `if compgen -G ... ; then git add ... ; fi` block.

`release_nightly.yml`:
- `publish-nightly-main`'s `if:` and `needs:` reconciled to the post-#13206 form (no bundle gating).

`.secrets.baseline`:
- Kept HEAD; pre-commit `detect-secrets` regenerated line numbers on the chained commit.

## Verified locally

Ran `update_lfx_dep_in_bundles("0.5.0.dev99")` against the actual `release-1.10.0` bundle pyprojects:

```
Updated lfx dep in src/bundles/arxiv/pyproject.toml -> lfx-nightly==0.5.0.dev99
Updated lfx dep in src/bundles/duckduckgo/pyproject.toml -> lfx-nightly==0.5.0.dev99
```

Both bundles end up with `"lfx-nightly==0.5.0.dev99"` in their deps array, so `uv lock` will see the workspace `lfx-nightly` package and resolve cleanly instead of trying PyPI's `lfx 0.4.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly build workflow with improved bundle dependency management and staged file handling.
  * Added automated bundle release workflow with cross-platform smoke testing and PyPI publishing.
  * Updated bundle dependency versioning during nightly releases for improved consistency.
  * Refined release workflow conditional dependencies to ensure proper build sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->