### PR TITLE
fix(docker): pre-create LANGFLOW_CONFIG_DIR so named volumes inherit uid=1000 ownership

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -108,6 +108,15 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
+# compose file) with the non-root user as owner. When the official compose mounts
+# a fresh named volume at /app/langflow, Docker copies this directory's ownership
+# and permissions into the new volume, so the in-container uid=1000 user can
+# write secret_key, profile_pictures, etc. Without this, the volume is created
+# as root:root and Langflow crashes during startup with PermissionError on
+# /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
+RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']
 LABEL org.opencontainers.image.licenses=MIT

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -92,9 +92,18 @@ COPY --from=builder --chown=1000:0 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Create home directory and ensure proper ownership
-# The user needs write access to /app/data (home) and /app (workdir)
+# The user needs write access to /app/data (home) and /app (workdir).
+# Also pre-create /app/langflow (LANGFLOW_CONFIG_DIR used by the docker_example
+# compose file) with the non-root user as owner, so a fresh named volume mounted
+# at /app/langflow inherits the correct ownership/permissions and the in-container
+# uid=1000 user can write secret_key, profile_pictures, etc. Without this, the
+# volume would be initialized as root:root and Langflow would crash with
+# PermissionError on /app/langflow/secret_key (issue #10437).
 # Note: .venv is already owned by 1000:0 via COPY --chown above, so no recursive chown needed
-RUN mkdir -p /app/data && chown -R 1000:0 /app/data && chown 1000:0 /app
+RUN mkdir -p /app/data /app/langflow \
+    && chown -R 1000:0 /app/data /app/langflow \
+    && chmod -R g+rwX /app/langflow \
+    && chown 1000:0 /app
 
 LABEL org.opencontainers.image.title=langflow-backend
 LABEL org.opencontainers.image.authors=['Langflow']

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -127,6 +127,15 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
+# compose file) with the non-root user as owner. When the official compose mounts
+# a fresh named volume at /app/langflow, Docker copies this directory's ownership
+# and permissions into the new volume, so the in-container uid=1000 user can
+# write secret_key, profile_pictures, etc. Without this, the volume is created
+# as root:root and Langflow crashes during startup with PermissionError on
+# /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
+RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']
 LABEL org.opencontainers.image.licenses=MIT

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -102,6 +102,15 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
+# compose file) with the non-root user as owner. When the official compose mounts
+# a fresh named volume at /app/langflow, Docker copies this directory's ownership
+# and permissions into the new volume, so the in-container uid=1000 user can
+# write secret_key, profile_pictures, etc. Without this, the volume is created
+# as root:root and Langflow crashes during startup with PermissionError on
+# /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
+RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']
 LABEL org.opencontainers.image.licenses=MIT

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -103,6 +103,15 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
+# compose file) with the non-root user as owner. When the official compose mounts
+# a fresh named volume at /app/langflow, Docker copies this directory's ownership
+# and permissions into the new volume, so the in-container uid=1000 user can
+# write secret_key, profile_pictures, etc. Without this, the volume is created
+# as root:root and Langflow crashes during startup with PermissionError on
+# /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
+RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']
 LABEL org.opencontainers.image.licenses=MIT

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -83,36 +83,3 @@ Fresh installs are unaffected.
 ## Switching to a Specific LangFlow Version
 
 If you want to use a specific version of LangFlow, you can modify the `image` field under the `langflow` service in the Docker Compose file. For example, to use version 1.0-alpha, change `langflowai/langflow:latest` to `langflowai/langflow:1.0-alpha`.
-
-## Troubleshooting
-
-### `PermissionError: [Errno 13]` on `/app/langflow/secret_key` at startup
-
-The Langflow container runs as a non-root user (`uid=1000`). The Langflow image
-pre-creates `/app/langflow` with that user as the owner so a freshly created
-`langflow-data` named volume inherits the correct ownership. If you ran an
-earlier image build that did **not** pre-create this directory, the named
-volume was initialized as `root:root` and the non-root container user cannot
-write `secret_key`, `profile_pictures/`, etc. into it.
-
-This commonly affects rootful Docker daemons (Linux native, Docker Desktop for
-Mac/Windows). Podman with rootless user-namespace mapping does not reproduce
-the issue.
-
-To recover, recreate the volume from scratch using a current image:
-
-```sh
-docker compose down -v       # WARNING: also wipes the postgres data volume
-docker compose pull
-docker compose up -d
-```
-
-If you need to preserve the `langflow-postgres` data while resetting only the
-Langflow config volume, remove that single volume by name instead:
-
-```sh
-docker compose down
-docker volume rm "$(basename "$PWD")_langflow-data"
-docker compose pull
-docker compose up -d
-```

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -83,3 +83,36 @@ Fresh installs are unaffected.
 ## Switching to a Specific LangFlow Version
 
 If you want to use a specific version of LangFlow, you can modify the `image` field under the `langflow` service in the Docker Compose file. For example, to use version 1.0-alpha, change `langflowai/langflow:latest` to `langflowai/langflow:1.0-alpha`.
+
+## Troubleshooting
+
+### `PermissionError: [Errno 13]` on `/app/langflow/secret_key` at startup
+
+The Langflow container runs as a non-root user (`uid=1000`). The Langflow image
+pre-creates `/app/langflow` with that user as the owner so a freshly created
+`langflow-data` named volume inherits the correct ownership. If you ran an
+earlier image build that did **not** pre-create this directory, the named
+volume was initialized as `root:root` and the non-root container user cannot
+write `secret_key`, `profile_pictures/`, etc. into it.
+
+This commonly affects rootful Docker daemons (Linux native, Docker Desktop for
+Mac/Windows). Podman with rootless user-namespace mapping does not reproduce
+the issue.
+
+To recover, recreate the volume from scratch using a current image:
+
+```sh
+docker compose down -v       # WARNING: also wipes the postgres data volume
+docker compose pull
+docker compose up -d
+```
+
+If you need to preserve the `langflow-postgres` data while resetting only the
+Langflow config volume, remove that single volume by name instead:
+
+```sh
+docker compose down
+docker volume rm "$(basename "$PWD")_langflow-data"
+docker compose pull
+docker compose up -d
+```


### PR DESCRIPTION
## Summary

- Pre-create `/app/langflow` (the `LANGFLOW_CONFIG_DIR` used by `docker_example/docker-compose.yml`) in every runtime stage of the Langflow Docker images and `chown` it to the non-root container user (`1000:0`), so that a freshly created `langflow-data` named volume inherits the correct ownership and permissions.

A companion Troubleshooting note for users with an existing `root:root` volume from a previously-broken image will land in the docs site separately.

## Problem

When Langflow is started using the official `docker_example/docker-compose.yml` on a rootful Docker daemon (Linux native, Docker Desktop for Mac/Windows), the `langflow` container crashes during initialization with:

```
PermissionError: [Errno 13] Permission denied: '/app/langflow/secret_key'
```

Root cause:

- The compose file declares a named volume `langflow-data` mounted at `LANGFLOW_CONFIG_DIR=/app/langflow`.
- The Langflow runtime stage runs as `uid=1000(user)` (`useradd user -u 1000 -g 0 --no-create-home`).
- The Dockerfile did **not** create `/app/langflow` in the image.
- When Docker creates a fresh named volume, it copies the mount-point directory's ownership/permissions from the image into the new volume. Because `/app/langflow` did not exist in the image, Docker materialized the mount point as `root:root`, so the in-container `uid=1000` user had no write permission.
- Langflow's startup writes the secret key (and other config files) to that directory, which fails with `PermissionError [Errno 13]` and the container exits.

This was masked for anyone validating the compose on Podman: Podman's rootless user-namespace mapping makes the in-container `uid=1000` map to the host user (who owns the named volume), so the directory is transparently writable. Anyone testing on Podman therefore sees a clean startup. Upstream report: langflow-ai/langflow#10437.

## Fix

In each runtime stage (`build_and_push.Dockerfile`, `build_and_push_base.Dockerfile`, `build_and_push_backend.Dockerfile`, `build_and_push_ep.Dockerfile`, `build_and_push_with_extras.Dockerfile`):

```dockerfile
RUN mkdir -p /app/langflow \
    && chown -R 1000:0 /app/langflow \
    && chmod -R g+rwX /app/langflow
```

(Folded into the existing ownership step in `build_and_push_backend.Dockerfile`.)

Because `/app/langflow` now exists in the image, Docker copies its ownership (`1000:0`) and permissions into a freshly created `langflow-data` named volume, and the non-root user can write `secret_key`, `profile_pictures/`, and per-user subfolders.

The compose file itself is unchanged — the fix lives in the image so that anyone using `langflowai/langflow:latest` with any compose configuration benefits.

## Caveats

Docker only seeds a volume's contents from the image when the volume is **empty** on first mount. Users who already ran a previously-broken image have a named volume that was initialized as `root:root`; pulling the fixed image alone will not re-seed it. They will need to recreate the `langflow-data` volume once (e.g. `docker compose down -v` for a full reset, or `docker volume rm <project>_langflow-data` to preserve `langflow-postgres`). This recovery procedure will be documented on the docs site in a follow-up PR.

## Test plan

- [ ] Build the image locally from `docker/build_and_push.Dockerfile`, run `docker_example/docker-compose.yml` with a fresh named volume on a rootful Docker daemon, and confirm:
  - [ ] Container reaches the "Welcome to Langflow" startup banner without `PermissionError`.
  - [ ] `/app/langflow/secret_key` exists inside the container and is owned by `user:root` (`1000:0`).
  - [ ] `GET /health_check` returns `200` within the usual startup window.
- [ ] CI image-build workflows pass for `build_and_push*.Dockerfile`.

Fixes #10437