### PR TITLE
fix(openrouter): validate against /api/v1/auth/key and disconnect all variables

### DIFF
--- a/src/backend/tests/unit/api/v1/test_variable.py
+++ b/src/backend/tests/unit/api/v1/test_variable.py
@@ -417,6 +417,75 @@ async def test_create_variable__ollama_base_url_validation_failure(client: Async
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_create_variable__openrouter_api_key_validation_failure(client: AsyncClient, logged_in_headers):
+    """Test failed OpenRouter API key validation surfaces as HTTP 400.
+
+    Regression for the bug where saving any string as ``OPENROUTER_API_KEY``
+    succeeded with 201 because the validation probe hit OpenRouter's public
+    ``/api/v1/models`` endpoint (which returns 200 for any bearer, including
+    invalid ones). The fix routes validation through ``/api/v1/auth/key``,
+    which returns 401 on invalid keys and turns into a user-facing 400 here.
+    """
+    # Clean up any existing OPENROUTER_API_KEY variables
+    all_vars = await client.get("api/v1/variables/", headers=logged_in_headers)
+    for var in all_vars.json():
+        if var.get("name") == "OPENROUTER_API_KEY":
+            await client.delete(f"api/v1/variables/{var['id']}", headers=logged_in_headers)
+
+    openrouter_variable = {
+        "name": "OPENROUTER_API_KEY",
+        "value": "sk-or-v1-INVALID_FAKE_KEY",
+        "type": CREDENTIAL_TYPE,
+        "default_fields": [],
+    }
+
+    # Mock the OpenRouter validation endpoint returning 401 for an invalid key
+    with mock.patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 401
+        mock_get.return_value.raise_for_status.side_effect = AssertionError(
+            "raise_for_status should not run when the 401 branch triggers"
+        )
+        response = await client.post("api/v1/variables/", json=openrouter_variable, headers=logged_in_headers)
+        result = response.json()
+
+        # The 401 must be translated into a 400 so the frontend can show a
+        # friendly error rather than a silent success.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid OpenRouter API key" in result["detail"]
+        # And the call must target the auth-required endpoint, not the
+        # public /api/v1/models endpoint that always returns 200.
+        called_url = mock_get.call_args.args[0]
+        assert called_url == "https://openrouter.ai/api/v1/auth/key"
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_create_variable__openrouter_api_key_validation_success(client: AsyncClient, logged_in_headers):
+    """A 200 from the OpenRouter validation endpoint creates the variable."""
+    # Clean up any existing OPENROUTER_API_KEY variables
+    all_vars = await client.get("api/v1/variables/", headers=logged_in_headers)
+    for var in all_vars.json():
+        if var.get("name") == "OPENROUTER_API_KEY":
+            await client.delete(f"api/v1/variables/{var['id']}", headers=logged_in_headers)
+
+    openrouter_variable = {
+        "name": "OPENROUTER_API_KEY",
+        "value": "sk-or-v1-valid-fake-key",
+        "type": CREDENTIAL_TYPE,
+        "default_fields": [],
+    }
+
+    with mock.patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.raise_for_status.return_value = None
+        response = await client.post("api/v1/variables/", json=openrouter_variable, headers=logged_in_headers)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["name"] == "OPENROUTER_API_KEY"
+        called_url = mock_get.call_args.args[0]
+        assert called_url == "https://openrouter.ai/api/v1/auth/key"
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_create_variable__model_provider_network_error_allows_creation(client: AsyncClient, logged_in_headers):
     """Test that network errors don't prevent variable creation."""
     # Clean up any existing OPENAI_API_KEY variables

--- a/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
@@ -1,0 +1,314 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { Provider } from "../components/types";
+import { useProviderConfiguration } from "../hooks/useProviderConfiguration";
+
+// ---------------------------------------------------------------------------
+// Shared mock plumbing
+// ---------------------------------------------------------------------------
+
+const mockGlobalVariables: Array<{ id: string; name: string; value?: string }> =
+  [];
+const mockProviderVariablesMapping: Record<
+  string,
+  Array<{
+    variable_name: string;
+    variable_key: string;
+    required: boolean;
+    is_secret: boolean;
+    is_list: boolean;
+    options: string[];
+  }>
+> = {};
+let mockModelProviders: Array<{
+  provider: string;
+  is_enabled?: boolean;
+  is_configured?: boolean;
+  models?: unknown[];
+}> = [];
+
+const deleteCalls: Array<{ id: string | undefined }> = [];
+const mockDeleteMutateAsync = jest.fn((params: { id: string | undefined }) => {
+  deleteCalls.push(params);
+  return Promise.resolve(undefined);
+});
+
+const mockSetSuccessData = jest.fn();
+const mockSetErrorData = jest.fn();
+const mockInvalidateQueries = jest.fn();
+const mockRefetchQueries = jest.fn();
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+    refetchQueries: mockRefetchQueries,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useDeleteGlobalVariables: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    isPending: false,
+  }),
+  useGetGlobalVariables: () => ({ data: mockGlobalVariables }),
+  usePatchGlobalVariables: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+  usePostGlobalVariables: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-model-providers", () => ({
+  useGetModelProviders: () => ({
+    data: mockModelProviders,
+    isFetching: false,
+  }),
+}));
+
+jest.mock(
+  "@/controllers/API/queries/models/use-get-provider-variables",
+  () => ({
+    useGetProviderVariables: () => ({ data: mockProviderVariablesMapping }),
+  }),
+);
+
+jest.mock("@/controllers/API/queries/models/use-validate-provider", () => ({
+  useValidateProvider: () => ({
+    mutateAsync: jest.fn(() => Promise.resolve({ valid: true })),
+  }),
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({
+    refreshAllModelInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({
+      setSuccessData: mockSetSuccessData,
+      setErrorData: mockSetErrorData,
+    }),
+}));
+
+jest.mock("../hooks/useModelToggleQueue", () => ({
+  useModelToggleQueue: () => ({
+    handleModelToggle: jest.fn(),
+    flushPendingChanges: jest.fn(() => Promise.resolve()),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const renderProviderConfiguration = (selectedProvider: Provider) =>
+  // ``initialProps`` ensures the prop object reference is stable across
+  // re-renders. Without this, every render of the hook would create a new
+  // ``selectedProvider`` object and the syncedSelectedProvider useEffect
+  // would never stabilise (setState → render → new prop → setState → ...).
+  renderHook(
+    ({ provider }: { provider: Provider }) =>
+      useProviderConfiguration({ selectedProvider: provider }),
+    { initialProps: { provider: selectedProvider } },
+  );
+
+describe("useProviderConfiguration.handleDisconnect", () => {
+  beforeEach(() => {
+    mockGlobalVariables.length = 0;
+    Object.keys(mockProviderVariablesMapping).forEach(
+      (k) => delete mockProviderVariablesMapping[k],
+    );
+    mockModelProviders = [];
+    deleteCalls.length = 0;
+    mockDeleteMutateAsync.mockClear();
+    mockDeleteMutateAsync.mockImplementation((params) => {
+      deleteCalls.push(params);
+      return Promise.resolve(undefined);
+    });
+    mockSetSuccessData.mockClear();
+    mockSetErrorData.mockClear();
+    mockInvalidateQueries.mockClear();
+    mockRefetchQueries.mockClear();
+  });
+
+  it("deletes every variable for a multi-variable provider (OpenRouter)", async () => {
+    // OpenRouter is the canonical multi-variable provider: API key + two
+    // attribution headers. The pre-fix implementation looked up the variable
+    // name via a static frontend constant that didn't include "OpenRouter",
+    // so disconnect silently no-op'd. This regression test pins the new
+    // behavior: every configured OpenRouter variable is deleted.
+    mockProviderVariablesMapping["OpenRouter"] = [
+      {
+        variable_name: "OpenRouter API Key",
+        variable_key: "OPENROUTER_API_KEY",
+        required: true,
+        is_secret: true,
+        is_list: false,
+        options: [],
+      },
+      {
+        variable_name: "Site URL",
+        variable_key: "OPENROUTER_SITE_URL",
+        required: false,
+        is_secret: false,
+        is_list: false,
+        options: [],
+      },
+      {
+        variable_name: "App Name",
+        variable_key: "OPENROUTER_APP_NAME",
+        required: false,
+        is_secret: false,
+        is_list: false,
+        options: [],
+      },
+    ];
+    mockGlobalVariables.push(
+      { id: "var-key", name: "OPENROUTER_API_KEY" },
+      { id: "var-url", name: "OPENROUTER_SITE_URL", value: "https://x.io" },
+      { id: "var-name", name: "OPENROUTER_APP_NAME", value: "MyApp" },
+      { id: "var-unrelated", name: "OPENAI_API_KEY" },
+    );
+    mockModelProviders = [
+      {
+        provider: "OpenRouter",
+        is_configured: true,
+        is_enabled: true,
+        models: [],
+      },
+    ];
+
+    const { result } = renderProviderConfiguration({
+      provider: "OpenRouter",
+      icon: "OpenRouter",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    });
+
+    await act(async () => {
+      await result.current.handleDisconnect();
+    });
+
+    const deletedIds = deleteCalls.map((c) => c.id).sort();
+    expect(deletedIds).toEqual(["var-key", "var-name", "var-url"]);
+    // The unrelated OpenAI key must not be touched.
+    expect(deleteCalls.map((c) => c.id)).not.toContain("var-unrelated");
+    expect(mockSetSuccessData).toHaveBeenCalled();
+    expect(mockSetErrorData).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the static mapping when the provider-variable API has not resolved", async () => {
+    // If the API mapping is empty, disconnect for a known single-variable
+    // provider (Anthropic) still works via the legacy static mapping. This
+    // preserves the pre-fix behavior for providers like Anthropic that are
+    // in the static map and have a single primary credential.
+    mockGlobalVariables.push({ id: "var-1", name: "ANTHROPIC_API_KEY" });
+    mockModelProviders = [
+      {
+        provider: "Anthropic",
+        is_configured: true,
+        is_enabled: true,
+        models: [],
+      },
+    ];
+
+    const { result } = renderProviderConfiguration({
+      provider: "Anthropic",
+      icon: "Anthropic",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    });
+
+    await act(async () => {
+      await result.current.handleDisconnect();
+    });
+
+    expect(deleteCalls).toEqual([{ id: "var-1" }]);
+    expect(mockSetSuccessData).toHaveBeenCalled();
+  });
+
+  it("is a no-op when the provider has no configured variables", async () => {
+    mockProviderVariablesMapping["OpenRouter"] = [
+      {
+        variable_name: "OpenRouter API Key",
+        variable_key: "OPENROUTER_API_KEY",
+        required: true,
+        is_secret: true,
+        is_list: false,
+        options: [],
+      },
+    ];
+    mockModelProviders = [
+      {
+        provider: "OpenRouter",
+        is_configured: false,
+        is_enabled: false,
+        models: [],
+      },
+    ];
+
+    const { result } = renderProviderConfiguration({
+      provider: "OpenRouter",
+      icon: "OpenRouter",
+      is_enabled: false,
+      is_configured: false,
+      models: [],
+    });
+
+    await act(async () => {
+      await result.current.handleDisconnect();
+    });
+
+    expect(deleteCalls).toHaveLength(0);
+    expect(mockSetSuccessData).not.toHaveBeenCalled();
+    expect(mockSetErrorData).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when one of the deletions fails", async () => {
+    mockProviderVariablesMapping["OpenRouter"] = [
+      {
+        variable_name: "OpenRouter API Key",
+        variable_key: "OPENROUTER_API_KEY",
+        required: true,
+        is_secret: true,
+        is_list: false,
+        options: [],
+      },
+    ];
+    mockGlobalVariables.push({ id: "var-key", name: "OPENROUTER_API_KEY" });
+    mockModelProviders = [
+      {
+        provider: "OpenRouter",
+        is_configured: true,
+        is_enabled: true,
+        models: [],
+      },
+    ];
+    mockDeleteMutateAsync.mockImplementationOnce(() =>
+      Promise.reject(new Error("network down")),
+    );
+
+    const { result } = renderProviderConfiguration({
+      provider: "OpenRouter",
+      icon: "OpenRouter",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    });
+
+    await act(async () => {
+      await result.current.handleDisconnect();
+    });
+
+    await waitFor(() => expect(mockSetErrorData).toHaveBeenCalled());
+    expect(mockSetSuccessData).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -537,17 +537,36 @@ export const useProviderConfiguration = ({
   const handleDisconnect = useCallback(async () => {
     if (!syncedSelectedProvider) return;
 
-    const variableName =
-      PROVIDER_VARIABLE_MAPPING[syncedSelectedProvider.provider];
-    if (!variableName) return;
+    // Resolve every variable key associated with this provider so
+    // multi-variable providers (e.g. OpenRouter's API key + attribution
+    // headers, IBM WatsonX's apikey + project_id + url) are fully removed.
+    // The dynamic ``providerVariables`` list comes from
+    // ``GET /api/v1/models/provider-variable-mapping`` and is the source of
+    // truth; fall back to the deprecated ``PROVIDER_VARIABLE_MAPPING`` only
+    // when the API call has not resolved yet (or the provider is missing
+    // from the dynamic mapping for some reason).
+    const variableKeys = new Set<string>();
+    for (const v of providerVariables) {
+      if (v.variable_key) variableKeys.add(v.variable_key);
+    }
+    if (variableKeys.size === 0) {
+      const staticKey =
+        PROVIDER_VARIABLE_MAPPING[syncedSelectedProvider.provider];
+      if (staticKey) variableKeys.add(staticKey);
+    }
 
-    const existingVariable = globalVariables.find(
-      (v) => v.name === variableName,
+    const variablesToDelete = globalVariables.filter((v) =>
+      variableKeys.has(v.name),
     );
-    if (!existingVariable) return;
+    if (variablesToDelete.length === 0) return;
 
     try {
-      await deleteGlobalVariable({ id: existingVariable.id });
+      // Delete in parallel — backend already cleans up per-provider enabled
+      // and disabled model lists on the primary credential delete, so order
+      // does not matter.
+      await Promise.all(
+        variablesToDelete.map((v) => deleteGlobalVariable({ id: v.id })),
+      );
 
       hasUserMadeChangesRef.current = true;
       setSuccessData({
@@ -567,6 +586,7 @@ export const useProviderConfiguration = ({
     }
   }, [
     syncedSelectedProvider,
+    providerVariables,
     globalVariables,
     deleteGlobalVariable,
     setSuccessData,

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -419,9 +419,13 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
             if not api_key:
                 return
 
+            # ``/api/v1/models`` is a public OpenRouter endpoint (200 for any
+            # bearer, including missing/invalid). Use ``/api/v1/auth/key``
+            # instead — it's documented for key validation, returns 401 on
+            # invalid keys, and only costs a tiny metadata round-trip.
             try:
                 response = requests.get(
-                    "https://openrouter.ai/api/v1/models",
+                    "https://openrouter.ai/api/v1/auth/key",
                     headers={"Authorization": f"Bearer {api_key}"},
                     timeout=5,
                 )

--- a/src/lfx/tests/unit/base/models/test_openrouter_provider.py
+++ b/src/lfx/tests/unit/base/models/test_openrouter_provider.py
@@ -335,7 +335,7 @@ def test_validate_provider_uses_requested_model_name():
 
 
 def test_validate_openrouter_happy_path():
-    """Validation passes when ``GET /api/v1/models`` returns 200.
+    """Validation passes when ``GET /api/v1/auth/key`` returns 200.
 
     Patches ``requests.get`` on the actually-imported module (not via
     ``sys.modules``) so the test stays correct if the lazy import inside
@@ -355,7 +355,10 @@ def test_validate_openrouter_happy_path():
 
     mock_get.assert_called_once()
     call = mock_get.call_args
-    assert call.args[0] == "https://openrouter.ai/api/v1/models"
+    # ``/api/v1/auth/key`` is auth-required (returns 401 on invalid bearer).
+    # The previous ``/api/v1/models`` URL is a public endpoint that returns
+    # 200 for any auth, so it could never detect an invalid key.
+    assert call.args[0] == "https://openrouter.ai/api/v1/auth/key"
     assert call.kwargs["headers"]["Authorization"].startswith("Bearer ")
 
 
@@ -374,6 +377,34 @@ def test_validate_openrouter_raises_on_401():
             "OpenRouter",
             {"OPENROUTER_API_KEY": "dummy-openrouter-bad"},  # pragma: allowlist secret
         )
+
+
+def test_validate_openrouter_uses_auth_endpoint_not_public_models_endpoint():
+    """Regression: the validation endpoint must be auth-required.
+
+    OpenRouter's ``/api/v1/models`` returns 200 regardless of the Authorization
+    header (it is a public catalog). The previous implementation called that
+    endpoint, so invalid keys were accepted silently and the credential save
+    flow returned 201 instead of the documented 400. This test pins the URL to
+    an auth-required endpoint so a future refactor cannot regress it.
+    """
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    with patch.object(requests, "get", return_value=response) as mock_get:
+        validate_model_provider_key(
+            "OpenRouter",
+            {"OPENROUTER_API_KEY": "dummy-openrouter-key"},  # pragma: allowlist secret
+        )
+
+    call_url = mock_get.call_args.args[0]
+    assert call_url != "https://openrouter.ai/api/v1/models", (
+        "OpenRouter /api/v1/models is public — using it for validation cannot detect invalid keys"
+    )
+    assert call_url.startswith("https://openrouter.ai/api/v1/")
 
 
 def test_validate_openrouter_network_error_raises_value_error():


### PR DESCRIPTION
## Summary

Two follow-ups to [#13185](https://github.com/langflow-ai/langflow/pull/13185) surfaced during release-1.10.0 OSS QA.

### BUG-1 (HIGH) — OpenRouter key validation never rejected invalid keys

`validate_model_provider_key` probed OpenRouter's `/api/v1/models`, which is a **public** endpoint that returns 200 for any bearer (verified: `curl -H "Authorization: Bearer sk-or-v1-INVALID" https://openrouter.ai/api/v1/models` → 200). So saving any string as `OPENROUTER_API_KEY` returned 201, the catalog swapped to the live 356-model list, and runs failed at request time. Fix: route the probe through `/api/v1/auth/key` instead — it's documented for key validation, returns 401 on invalid keys, and the existing `ValueError → HTTP 400` mapping in `api/v1/variable.py` does the rest. Same fix lifts **BUG-3** since the generalized validation path is shared.

### BUG-2 (MEDIUM) — OpenRouter "Disconnect" was a no-op

`handleDisconnect` resolved the variable name via the static `PROVIDER_VARIABLE_MAPPING` constant, which doesn't include `"OpenRouter"` (and the constant is deprecated in favour of `GET /api/v1/models/provider-variable-mapping`). It silently returned early. Fix: source the variable keys from `providerVariables` (the dynamic API) and delete every configured one in parallel, so multi-variable providers (OpenRouter's API key + attribution headers, IBM WatsonX's apikey + project_id + url) are fully removed. The static mapping is kept as a fallback for the brief window before the provider-variable API resolves.

## Test plan

- [x] `uv run pytest src/lfx/tests/unit/base/models/test_openrouter_provider.py` — 24 passed (updated existing happy-path / 401 cases to the new URL + added an explicit regression test that the public `/api/v1/models` endpoint is never used for validation)
- [x] `uv run pytest src/backend/tests/unit/api/v1/test_variable.py` — 29 passed (new `POST /api/v1/variables/` integration tests cover both the 401 and 200 paths for `OPENROUTER_API_KEY` and pin the auth-required URL)
- [x] `npx jest src/modals/modelProviderModal/__tests__/` — 74 passed (new `useProviderConfigurationDisconnect.test.tsx` suite covers OpenRouter multi-variable disconnect, Anthropic single-variable fallback, no-op when nothing is configured, and an error toast when a delete fails)
- [ ] Manual verification once merged: save a fake `OPENROUTER_API_KEY` via Settings → Model Providers → OpenRouter should show "Invalid OpenRouter API key" instead of succeeding; clicking Disconnect on a configured OpenRouter provider should show the warning panel and remove all three variables.

Fixes the issues reported against release-1.10.0 OSS QA of [#13185](https://github.com/langflow-ai/langflow/pull/13185).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OpenRouter API key validation to correctly identify invalid credentials
  * Improved provider disconnection to properly remove all associated configuration variables

* **Tests**
  * Added validation tests for credential handling
  * Added test coverage for provider disconnection behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->