### PR TITLE
feat(authz): add `langflow authz dry-run` CLI for policy simulation

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -81,6 +81,14 @@ except ImportError:
     # LFX not available, skip adding the sub-app
     pass
 
+# Add authz utilities (`langflow authz dry-run`, ...).
+try:
+    from langflow.cli.authz_dry_run import authz_app
+
+    app.add_typer(authz_app, name="authz")
+except ImportError:
+    pass
+
 
 class ProcessManager:
     """Manages the lifecycle of the backend process."""

--- a/src/backend/base/langflow/cli/authz_dry_run.py
+++ b/src/backend/base/langflow/cli/authz_dry_run.py
@@ -1,0 +1,435 @@
+"""``langflow authz dry-run`` — simulate every flow guard against a stub policy.
+
+The OSS ``LangflowAuthorizationService`` always allows, so a real install can't
+demonstrate enforcement without the enterprise Casbin plugin. This subcommand
+replaces the live authorization service with a small in-memory stub for one
+invocation, walks every flow-CRUD guard site, and prints what *would* happen
+under the chosen policy — including the Casbin tuple, the audit row that
+would have been written, and the resulting HTTP outcome. Useful for:
+
+* Validating that ``AUTHZ_ENABLED=true`` + a future Casbin policy will produce
+  the expected behaviour before shipping it to production.
+* Showing operators what the audit log will look like.
+* Smoke-testing the guard wiring after a refactor.
+
+The command never hits the network or writes to the real database; it patches
+the helpers in :mod:`langflow.services.authorization.utils` for the duration
+of the run and restores them on exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path  # noqa: TC003 — typer resolves this annotation at runtime
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import typer
+from fastapi import HTTPException
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+authz_app = typer.Typer(
+    name="authz",
+    help="Authorization (RBAC) utilities.",
+    no_args_is_help=True,
+)
+
+_console = Console()
+
+
+# --------------------------------------------------------------------------- #
+# Stub policies
+# --------------------------------------------------------------------------- #
+
+
+class StubPolicy(str, Enum):
+    """Built-in stand-ins for an enterprise Casbin policy."""
+
+    ALLOW_ALL = "allow-all"
+    DENY_NON_OWNER = "deny-non-owner"
+    DENY_WRITES = "deny-writes"
+    OWNER_ONLY = "owner-only"
+
+
+_POLICY_DESCRIPTIONS = {
+    StubPolicy.ALLOW_ALL: "Pass-through (matches the OSS default).",
+    StubPolicy.DENY_NON_OWNER: "Owners and superusers allowed; everyone else denied.",
+    StubPolicy.DENY_WRITES: "Read/execute allowed; write/create/delete denied.",
+    StubPolicy.OWNER_ONLY: "Only the flow owner allowed (no superuser bypass).",
+}
+
+
+class _StubAuthorizationService:
+    """Configurable enforce stub used only during ``dry-run``."""
+
+    def __init__(self, policy: StubPolicy) -> None:
+        self.policy = policy
+
+    async def enforce(
+        self,
+        *,
+        user_id: UUID,
+        domain: str,  # noqa: ARG002
+        obj: str,  # noqa: ARG002
+        act: str,
+        context: dict[str, Any] | None = None,
+    ) -> bool:
+        """Decide allow/deny per the configured stub policy."""
+        ctx = context or {}
+        if self.policy is StubPolicy.ALLOW_ALL:
+            return True
+        if self.policy is StubPolicy.DENY_NON_OWNER:
+            if ctx.get("is_superuser"):
+                return True
+            return ctx.get("flow_user_id") == user_id
+        if self.policy is StubPolicy.DENY_WRITES:
+            return act in {"read", "execute"}
+        if self.policy is StubPolicy.OWNER_ONLY:
+            return ctx.get("flow_user_id") == user_id
+        return True
+
+    async def batch_enforce(
+        self,
+        *,
+        user_id: UUID,
+        domain: str,
+        requests: list[tuple[str, str]],
+        context: dict[str, Any] | None = None,
+    ) -> list[bool]:
+        """Apply :meth:`enforce` to each request, returning a parallel list."""
+        return [
+            await self.enforce(user_id=user_id, domain=domain, obj=obj, act=act, context=context)
+            for obj, act in requests
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario definitions
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _GuardSite:
+    """Static description of one ``ensure_flow_permission`` call site in flows.py."""
+
+    name: str
+    route: str
+    action: str  # FlowAction value
+    has_flow_id: bool  # True ⇒ obj=flow:{id}, False ⇒ obj=flow:*
+    has_owner: bool  # True ⇒ flow_user_id is provided
+
+
+_FLOW_GUARDS: tuple[_GuardSite, ...] = (
+    _GuardSite("create_flow", "POST /flows/", "create", has_flow_id=False, has_owner=False),
+    _GuardSite("read_flow", "GET /flows/{id}", "read", has_flow_id=True, has_owner=True),
+    _GuardSite("update_flow", "PATCH /flows/{id}", "write", has_flow_id=True, has_owner=True),
+    _GuardSite("upsert_flow (existing)", "PUT /flows/{id}", "write", has_flow_id=True, has_owner=True),
+    _GuardSite("upsert_flow (new)", "PUT /flows/{id}", "create", has_flow_id=False, has_owner=False),
+    _GuardSite("delete_flow", "DELETE /flows/{id}", "delete", has_flow_id=True, has_owner=True),
+    _GuardSite("create_flows (batch)", "POST /flows/batch/", "create", has_flow_id=False, has_owner=False),
+    _GuardSite("upload_file", "POST /flows/upload/", "create", has_flow_id=False, has_owner=False),
+    _GuardSite("delete_multiple_flows", "DELETE /flows/", "delete", has_flow_id=True, has_owner=True),
+    _GuardSite("download_multiple_file", "POST /flows/download/", "read", has_flow_id=True, has_owner=True),
+)
+
+
+@dataclass(frozen=True)
+class _Actor:
+    """Simulated caller of a flow route."""
+
+    name: str
+    is_superuser: bool
+    is_flow_owner: bool
+
+
+@dataclass
+class DryRunResult:
+    """One row in the dry-run report."""
+
+    scenario: str
+    route: str
+    actor: str
+    action: str
+    obj: str
+    domain: str
+    decision: str  # allow / deny / owner_override
+    http_status: int
+    audit_action: str
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+
+@contextmanager
+def _install_stubs(stub: _StubAuthorizationService, audit_sink: list[dict[str, Any]]):
+    """Swap the live authz helpers for the dry-run stubs for the duration of the run."""
+    from langflow.services.authorization import utils as authz_utils
+
+    settings = SimpleNamespace(
+        auth_settings=SimpleNamespace(
+            AUTHZ_ENABLED=True,
+            AUTHZ_AUDIT_ENABLED=True,
+            AUTHZ_SUPERUSER_BYPASS=True,
+        )
+    )
+
+    async def _record_audit(**kwargs: Any) -> None:
+        audit_sink.append(kwargs)
+
+    saved_settings = authz_utils.get_settings_service
+    saved_authz = authz_utils.get_authorization_service
+    saved_audit = authz_utils.audit_decision
+
+    authz_utils.get_settings_service = lambda: settings  # type: ignore[assignment]
+    authz_utils.get_authorization_service = lambda: stub  # type: ignore[assignment]
+    authz_utils.audit_decision = _record_audit  # type: ignore[assignment]
+
+    try:
+        yield
+    finally:
+        authz_utils.get_settings_service = saved_settings  # type: ignore[assignment]
+        authz_utils.get_authorization_service = saved_authz  # type: ignore[assignment]
+        authz_utils.audit_decision = saved_audit  # type: ignore[assignment]
+
+
+async def _run_one(
+    guard: _GuardSite,
+    actor: _Actor,
+    *,
+    owner_id: UUID,
+    flow_id: UUID,
+    workspace_id: UUID,
+    folder_id: UUID,
+    audit_sink: list[dict[str, Any]],
+) -> DryRunResult:
+    """Invoke ``ensure_flow_permission`` for one (guard, actor) pair and record the outcome."""
+    from langflow.services.authorization import utils as authz_utils
+    from langflow.services.authorization.actions import FlowAction
+
+    actor_id = owner_id if actor.is_flow_owner else uuid4()
+    user_proxy = SimpleNamespace(id=actor_id, is_superuser=actor.is_superuser)
+
+    kwargs: dict[str, Any] = {
+        "workspace_id": workspace_id,
+        "folder_id": folder_id,
+    }
+    if guard.has_flow_id:
+        kwargs["flow_id"] = flow_id
+    if guard.has_owner:
+        kwargs["flow_user_id"] = owner_id
+
+    audit_before = len(audit_sink)
+    http_status = 200
+
+    try:
+        await authz_utils.ensure_flow_permission(
+            user_proxy,  # type: ignore[arg-type]
+            FlowAction(guard.action),
+            **kwargs,
+        )
+    except HTTPException as exc:
+        http_status = exc.status_code
+
+    rows_written = audit_sink[audit_before:]
+    decision = rows_written[-1]["result"] if rows_written else "skipped"
+    audit_action = rows_written[-1]["action"] if rows_written else ""
+    obj = rows_written[-1]["obj"] if rows_written else (f"flow:{flow_id}" if guard.has_flow_id else "flow:*")
+    domain = (
+        rows_written[-1]["details"].get("domain", "")
+        if rows_written and isinstance(rows_written[-1].get("details"), dict)
+        else f"workspace:{workspace_id}"
+    )
+
+    return DryRunResult(
+        scenario=guard.name,
+        route=guard.route,
+        actor=actor.name,
+        action=guard.action,
+        obj=obj,
+        domain=domain,
+        decision=decision,
+        http_status=http_status,
+        audit_action=audit_action,
+    )
+
+
+async def _run_all(policy: StubPolicy) -> list[DryRunResult]:
+    """Run every guard x actor combo under ``policy`` and return result rows."""
+    owner_id = uuid4()
+    flow_id = uuid4()
+    workspace_id = uuid4()
+    folder_id = uuid4()
+
+    actors = (
+        _Actor("alice (owner)", is_superuser=False, is_flow_owner=True),
+        _Actor("bob (non-owner)", is_superuser=False, is_flow_owner=False),
+        _Actor("carol (superuser)", is_superuser=True, is_flow_owner=False),
+    )
+
+    stub = _StubAuthorizationService(policy)
+    audit_sink: list[dict[str, Any]] = []
+
+    rows: list[DryRunResult] = []
+    with _install_stubs(stub, audit_sink):
+        for guard in _FLOW_GUARDS:
+            for actor in actors:
+                row = await _run_one(
+                    guard,
+                    actor,
+                    owner_id=owner_id,
+                    flow_id=flow_id,
+                    workspace_id=workspace_id,
+                    folder_id=folder_id,
+                    audit_sink=audit_sink,
+                )
+                rows.append(row)
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Output formatters
+# --------------------------------------------------------------------------- #
+
+
+_DECISION_STYLE = {
+    "allow": "green",
+    "deny": "red",
+    "owner_override": "cyan",
+    "skipped": "dim",
+}
+
+
+_UUID_PREFIX_LEN = 8
+
+
+def _short_uuid(value: str) -> str:
+    """Trim a UUID-bearing string to its first 8 hex characters for table readability."""
+    if ":" in value:
+        prefix, _, suffix = value.partition(":")
+        if len(suffix) >= _UUID_PREFIX_LEN and "-" in suffix:
+            return f"{prefix}:{suffix[:_UUID_PREFIX_LEN]}…"
+    return value
+
+
+def _render_table(policy: StubPolicy, rows: list[DryRunResult]) -> Table:
+    """Build a Rich table summarising every dry-run result."""
+    table = Table(
+        title=f"authz dry-run · policy={policy.value} · {_POLICY_DESCRIPTIONS[policy]}",
+        box=box.SIMPLE_HEAVY,
+        show_lines=False,
+    )
+    table.add_column("Scenario", style="bold")
+    table.add_column("Route")
+    table.add_column("Actor")
+    table.add_column("Action")
+    table.add_column("Domain")
+    table.add_column("Obj")
+    table.add_column("Decision")
+    table.add_column("HTTP", justify="right")
+    for row in rows:
+        style = _DECISION_STYLE.get(row.decision, "white")
+        table.add_row(
+            row.scenario,
+            row.route,
+            row.actor,
+            row.action,
+            _short_uuid(row.domain),
+            _short_uuid(row.obj),
+            f"[{style}]{row.decision}[/{style}]",
+            str(row.http_status),
+        )
+    return table
+
+
+def _summary_counts(rows: list[DryRunResult]) -> dict[str, int]:
+    """Aggregate decisions across all rows for the footer line."""
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row.decision] = counts.get(row.decision, 0) + 1
+    return counts
+
+
+def _emit_json(policy: StubPolicy, rows: list[DryRunResult], output: Path | None) -> None:
+    """Serialise the report as JSON to stdout (or a file)."""
+    payload = {
+        "policy": policy.value,
+        "policy_description": _POLICY_DESCRIPTIONS[policy],
+        "results": [asdict(r) for r in rows],
+        "summary": _summary_counts(rows),
+    }
+    text = json.dumps(payload, indent=2, default=str)
+    if output is not None:
+        output.write_text(text)
+        _console.print(f"[green]wrote[/green] {output} ({len(rows)} rows)")
+    else:
+        sys.stdout.write(text + "\n")
+
+
+def _emit_table(policy: StubPolicy, rows: list[DryRunResult], output: Path | None) -> None:
+    """Render the report as a Rich table to stdout (or a plain-text file)."""
+    table = _render_table(policy, rows)
+    summary = _summary_counts(rows)
+    summary_line = "  ".join(
+        f"[{_DECISION_STYLE.get(k, 'white')}]{v} {k}[/{_DECISION_STYLE.get(k, 'white')}]"
+        for k, v in sorted(summary.items())
+    )
+    if output is not None:
+        with output.open("w") as fh:
+            file_console = Console(file=fh, force_terminal=False, width=200)
+            file_console.print(table)
+            file_console.print(f"summary: {summary_line}")
+        _console.print(f"[green]wrote[/green] {output} ({len(rows)} rows)")
+    else:
+        _console.print(table)
+        _console.print(f"summary: {summary_line}")
+
+
+# --------------------------------------------------------------------------- #
+# Typer command
+# --------------------------------------------------------------------------- #
+
+
+@authz_app.command(name="dry-run")
+def dry_run(
+    policy: StubPolicy = typer.Option(
+        StubPolicy.DENY_NON_OWNER,
+        "--policy",
+        "-p",
+        help="Which stub policy to simulate.",
+        case_sensitive=False,
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Write the report to this file instead of stdout.",
+    ),
+    *,
+    as_json: bool = typer.Option(
+        False,  # noqa: FBT003 — typer requires positional default value
+        "--json",
+        help="Emit structured JSON instead of the Rich table.",
+    ),
+) -> None:
+    """Simulate every flow guard under a stub policy and print what *would* happen.
+
+    The command runs entirely in-process. No HTTP request is made, no row is
+    written to the real ``authz_audit_log`` table — the report describes the
+    Casbin tuple and audit row that *would* be produced if an enterprise
+    plugin enforcing ``--policy`` were registered.
+    """
+    rows = asyncio.run(_run_all(policy))
+    if as_json:
+        _emit_json(policy, rows, output)
+    else:
+        _emit_table(policy, rows, output)

--- a/src/backend/tests/unit/test_authz_dry_run_cli.py
+++ b/src/backend/tests/unit/test_authz_dry_run_cli.py
@@ -1,0 +1,237 @@
+"""Tests for ``langflow authz dry-run`` (CLI scenario runner)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path  # noqa: TC003 — used at runtime by the pytest tmp_path fixture annotation
+
+import pytest
+from langflow.cli.authz_dry_run import (
+    _FLOW_GUARDS,
+    DryRunResult,
+    StubPolicy,
+    _run_all,
+    _StubAuthorizationService,
+    authz_app,
+)
+from typer.testing import CliRunner
+
+_ACTOR_COUNT = 3  # alice, bob, carol — see _run_all
+_EXPECTED_ROWS = len(_FLOW_GUARDS) * _ACTOR_COUNT
+
+
+# --------------------------------------------------------------------------- #
+# Stub policy
+# --------------------------------------------------------------------------- #
+
+
+def _run(coro):
+    """Synchronous wrapper for tests that exercise the async stub directly."""
+    return asyncio.run(coro)
+
+
+def test_stub_allow_all_returns_true_unconditionally():
+    """allow-all policy permits every request regardless of context."""
+    stub = _StubAuthorizationService(StubPolicy.ALLOW_ALL)
+    assert _run(stub.enforce(user_id="u", domain="*", obj="flow:x", act="delete")) is True
+
+
+def test_stub_deny_non_owner_blocks_non_owner_non_superuser():
+    """deny-non-owner: only owners and superusers pass."""
+    stub = _StubAuthorizationService(StubPolicy.DENY_NON_OWNER)
+    assert (
+        _run(
+            stub.enforce(
+                user_id="alice",
+                domain="*",
+                obj="flow:x",
+                act="read",
+                context={"is_superuser": False, "flow_user_id": "alice"},
+            )
+        )
+        is True
+    )
+    assert (
+        _run(
+            stub.enforce(
+                user_id="bob",
+                domain="*",
+                obj="flow:x",
+                act="read",
+                context={"is_superuser": False, "flow_user_id": "alice"},
+            )
+        )
+        is False
+    )
+    assert (
+        _run(
+            stub.enforce(
+                user_id="carol",
+                domain="*",
+                obj="flow:x",
+                act="delete",
+                context={"is_superuser": True, "flow_user_id": "alice"},
+            )
+        )
+        is True
+    )
+
+
+def test_stub_deny_writes_allows_reads():
+    """deny-writes: read/execute pass, everything else denied."""
+    stub = _StubAuthorizationService(StubPolicy.DENY_WRITES)
+    assert _run(stub.enforce(user_id="u", domain="*", obj="flow:x", act="read")) is True
+    assert _run(stub.enforce(user_id="u", domain="*", obj="flow:x", act="execute")) is True
+    assert _run(stub.enforce(user_id="u", domain="*", obj="flow:x", act="write")) is False
+    assert _run(stub.enforce(user_id="u", domain="*", obj="flow:x", act="delete")) is False
+
+
+def test_stub_owner_only_ignores_superuser():
+    """owner-only: only the owner passes, even a superuser is denied."""
+    stub = _StubAuthorizationService(StubPolicy.OWNER_ONLY)
+    assert (
+        _run(
+            stub.enforce(
+                user_id="alice",
+                domain="*",
+                obj="flow:x",
+                act="write",
+                context={"is_superuser": True, "flow_user_id": "alice"},
+            )
+        )
+        is True
+    )
+    assert (
+        _run(
+            stub.enforce(
+                user_id="carol",
+                domain="*",
+                obj="flow:x",
+                act="read",
+                context={"is_superuser": True, "flow_user_id": "alice"},
+            )
+        )
+        is False
+    )
+
+
+def test_stub_batch_enforce_mirrors_enforce():
+    """batch_enforce applies enforce to each (obj, act) pair."""
+    stub = _StubAuthorizationService(StubPolicy.DENY_WRITES)
+    results = _run(
+        stub.batch_enforce(
+            user_id="u",
+            domain="*",
+            requests=[("flow:1", "read"), ("flow:2", "write")],
+        )
+    )
+    assert results == [True, False]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario runner
+# --------------------------------------------------------------------------- #
+
+
+def test_run_all_produces_one_row_per_guard_per_actor():
+    """Every (guard, actor) pair appears exactly once in the report."""
+    rows = asyncio.run(_run_all(StubPolicy.ALLOW_ALL))
+    assert len(rows) == _EXPECTED_ROWS
+
+
+def test_allow_all_policy_yields_no_denials():
+    """Under allow-all, no row decision should be 'deny'."""
+    rows = asyncio.run(_run_all(StubPolicy.ALLOW_ALL))
+    denied = [r for r in rows if r.decision == "deny"]
+    assert denied == []
+    # Every flow-bearing scenario reports flow:{uuid}, never flow:*.
+    flow_obj_rows = [r for r in rows if r.scenario.startswith("read_flow")]
+    assert all(":*" not in r.obj for r in flow_obj_rows)
+
+
+def test_deny_non_owner_denies_bob():
+    """Bob (non-owner, non-superuser) is denied wherever an owner is present."""
+    rows = asyncio.run(_run_all(StubPolicy.DENY_NON_OWNER))
+    bob_rows = [r for r in rows if r.actor.startswith("bob")]
+    # Scenarios that carry an owner pointer → bob is denied.
+    owner_bearing = [r for r in bob_rows if "flow_id" not in r.scenario or "(new)" not in r.scenario]
+    denials = [r for r in owner_bearing if r.decision == "deny"]
+    assert denials, "expected at least one deny for bob under deny-non-owner"
+
+
+def test_owner_override_records_decision_for_alice():
+    """Alice owns the flow → owner_override fires on every per-flow scenario."""
+    rows = asyncio.run(_run_all(StubPolicy.OWNER_ONLY))
+    alice_rows = [r for r in rows if r.actor.startswith("alice") and ":" in r.obj and r.obj != "flow:*"]
+    assert alice_rows, "expected per-flow rows for alice"
+    assert all(r.decision == "owner_override" for r in alice_rows)
+
+
+def test_deny_writes_blocks_writes_allows_reads():
+    """Under deny-writes, read/execute pass and write/create/delete deny."""
+    rows = asyncio.run(_run_all(StubPolicy.DENY_WRITES))
+    # Restrict to bob (no owner override, no superuser bypass).
+    bob_rows = [r for r in rows if r.actor.startswith("bob")]
+    for row in bob_rows:
+        if row.action in {"read", "execute"}:
+            assert row.decision == "allow", row
+        else:
+            assert row.decision == "deny", row
+
+
+def test_domain_is_workspace_prefixed():
+    """The recorded domain uses the workspace:{uuid} form for in-scope scenarios."""
+    rows = asyncio.run(_run_all(StubPolicy.ALLOW_ALL))
+    workspace_rows = [r for r in rows if r.domain.startswith("workspace:")]
+    assert workspace_rows, "expected at least one row with a workspace domain"
+
+
+# --------------------------------------------------------------------------- #
+# Typer integration
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_table_output_runs_clean():
+    """`langflow authz dry-run` renders without raising.
+
+    When ``authz_app`` has a single command, Typer collapses the subcommand
+    namespace, so ``CliRunner`` invokes it without the ``dry-run`` segment.
+    The fully-namespaced ``langflow authz dry-run`` path is exercised when the
+    parent ``app`` is built — see ``test_cli.py`` for that integration.
+    """
+    runner = CliRunner()
+    result = runner.invoke(authz_app, ["--policy", "allow-all"])
+    assert result.exit_code == 0, result.output
+    assert "allow-all" in result.output
+
+
+def test_cli_json_output_is_valid_json(tmp_path: Path):
+    """`--json --output FILE` writes a parseable JSON document."""
+    runner = CliRunner()
+    out = tmp_path / "report.json"
+    result = runner.invoke(authz_app, ["--policy", "deny-writes", "--json", "--output", str(out)])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(out.read_text())
+    assert payload["policy"] == "deny-writes"
+    assert isinstance(payload["results"], list)
+    assert len(payload["results"]) == _EXPECTED_ROWS
+    # Every result entry has the expected keys.
+    expected_keys = {f.name for f in DryRunResult.__dataclass_fields__.values()}
+    assert expected_keys <= set(payload["results"][0].keys())
+
+
+def test_cli_rejects_unknown_policy():
+    """An unknown policy value exits non-zero with a typer error."""
+    runner = CliRunner()
+    result = runner.invoke(authz_app, ["--policy", "nope"])
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize("policy", list(StubPolicy))
+def test_cli_runs_for_every_built_in_policy(policy: StubPolicy):
+    """Every built-in policy produces a clean run."""
+    runner = CliRunner()
+    result = runner.invoke(authz_app, ["--policy", policy.value])
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
> **Stacks on #13220** (Phase 1 finish). The diff in this PR currently includes #13220's commits because that branch hasn't merged yet — review the single new commit titled \`feat(authz): add \`langflow authz dry-run\` CLI for policy simulation\`.

## Summary

A self-contained CLI subcommand that **simulates every flow-CRUD guard site under a configurable stub policy** and prints what *would* happen — the Casbin tuple \`(user, domain, obj, act)\`, the audit row that would be written, and the resulting HTTP outcome. Pure in-process: no network, no DB writes.

```text
$ langflow authz dry-run --policy deny-non-owner

authz dry-run · policy=deny-non-owner · Owners and superusers allowed; everyone else denied.

┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━┓
┃ Scenario    ┃ Route               ┃ Actor            ┃ Action ┃ Domain      ┃ Obj         ┃ Decision       ┃ HTTP ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━┩
│ read_flow   │ GET /flows/{id}     │ alice (owner)    │ read   │ workspace:… │ flow:bf...  │ owner_override │ 200  │
│ read_flow   │ GET /flows/{id}     │ bob (non-owner)  │ read   │ workspace:… │ flow:bf...  │ deny           │ 403  │
│ read_flow   │ GET /flows/{id}     │ carol (superus.) │ read   │ workspace:… │ flow:bf...  │ allow          │ 200  │
│ ...         │                     │                  │        │             │             │                │      │
└─────────────┴─────────────────────┴──────────────────┴────────┴─────────────┴─────────────┴────────────────┴──────┘

summary: 10 allow · 14 deny · 6 owner_override
```

## Why this matters

The OSS \`LangflowAuthorizationService\` is a pass-through that always allows — operators can't see what enforcement *will* look like until the enterprise Casbin plugin is registered. This CLI lets them:

- **Validate** that \`AUTHZ_ENABLED=true\` + a future Casbin policy will produce the expected behaviour before shipping it to production.
- **Show** what the audit log will look like.
- **Smoke-test** guard wiring after a refactor (which routes call \`ensure_flow_permission\`, with what \`FlowAction\`, with which domain).

## Built-in stub policies

| Policy | Behaviour |
|---|---|
| \`allow-all\` | Pass-through (matches the OSS default) |
| \`deny-non-owner\` | Owners + superusers allowed |
| \`deny-writes\` | Read/execute allowed; write/create/delete denied |
| \`owner-only\` | Only the flow owner; no superuser bypass |

## Implementation

- New module: [\`src/backend/base/langflow/cli/authz_dry_run.py\`](src/backend/base/langflow/cli/authz_dry_run.py)
- Wired into the top-level CLI: \`app.add_typer(authz_app, name=\"authz\")\` (mirrors the existing \`lfx\` sub-app)
- Monkey-patches the three helpers in \`langflow.services.authorization.utils\` for the duration of the run, restores them on exit via context manager
- Walks \`_FLOW_GUARDS\` (10 guard sites that mirror the routes in \`flows.py\`) × 3 actors (owner / non-owner / superuser)
- Output: Rich table by default, \`--json [--output PATH]\` for structured emission

## Tests (18 cases)

| Category | Coverage |
|---|---|
| Stub policy unit tests | One per policy: allow-all / deny-non-owner / deny-writes / owner-only; batch_enforce parity |
| Scenario runner | Row count, allow-all has no denials, owner_override fires for alice, deny-non-owner denies bob, deny-writes splits by action, workspace-prefixed domain |
| CLI integration | Table output, JSON output writes valid JSON to file, unknown policy exits non-zero, every built-in policy runs clean (parametrised) |

Uses the existing \`monkeypatch\`-based stub pattern from PR (a)/(b); no new mocking style.

## Out of scope

- Hitting a real running deployment over HTTP (\`--target URL --token TOKEN\`) — would require auth + DB access; future extension.
- Custom user-supplied policies — current stubs cover the common patterns; YAML/JSON policy loading is enterprise plugin territory.
- Reading actual \`AuthzAuditLog\` rows from the live DB — separate read-only debug endpoint, future PR.

## Test plan

- [x] \`uv run pytest src/backend/tests/unit/test_authz_dry_run_cli.py -v\` — 18/18 pass
- [x] \`uv run pytest src/backend/tests/unit/services/authorization/ src/backend/tests/unit/test_authz_models.py -q\` — 62/62 (no regression from PR (b))
- [x] \`uv run ruff check\` on touched files — clean
- [x] \`uv run langflow authz dry-run --policy deny-non-owner\` — produces the table above
- [x] \`uv run langflow authz dry-run --policy deny-writes --json\` — produces valid JSON to stdout
- [ ] CodeRabbit pre-merge checks pass