### PR TITLE
fix: avoid pickling workflow graph in celery background tasks

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -442,21 +442,11 @@ async def execute_workflow_background(
         # Headers with prefix X-LANGFLOW-GLOBAL-VAR-* are extracted and made available to components
         request_variables = extract_global_variables_from_headers(http_request.headers)
 
-        # Build context from request variables (similar to V1's _run_flow_internal)
-        context = {"request_variables": request_variables} if request_variables else None
-
-        # Build the graph once
+        # Keep the original flow data serializable for Celery. The worker
+        # rebuilds the live Graph object in its own process.
         flow_id_str = str(flow.id)
         user_id = str(api_key_user.id)
         graph_data = deepcopy(flow.data)
-        graph_data = process_tweaks(graph_data, tweaks, stream=False)
-        graph = Graph.from_payload(
-            graph_data, flow_id=flow_id_str, user_id=user_id, flow_name=flow.name, context=context
-        )
-        graph.set_run_id(job_id)
-
-        # Get terminal nodes
-        terminal_node_ids = graph.get_terminal_nodes()
 
         # Launch background task
         task_service = get_task_service()
@@ -470,17 +460,40 @@ async def execute_workflow_background(
             user_id=api_key_user.id,
         )
 
-        await task_service.fire_and_forget_task(
-            job_service.execute_with_status,
-            job_id=job_id,
-            run_coro_func=run_graph_internal,
-            graph=graph,
-            flow_id=flow_id_str,
-            session_id=session_id,
-            inputs=None,
-            outputs=terminal_node_ids,
-            stream=False,
-        )
+        if task_service.backend_name == "celery":
+            from langflow.worker import run_workflow_job
+
+            await task_service.fire_and_forget_task(
+                run_workflow_job,
+                job_id=str(job_id),
+                flow_id=flow_id_str,
+                user_id=user_id,
+                flow_name=flow.name,
+                graph_data=graph_data,
+                tweaks=tweaks,
+                session_id=session_id,
+                request_variables=request_variables,
+            )
+        else:
+            # Build context from request variables (similar to V1's _run_flow_internal)
+            context = {"request_variables": request_variables} if request_variables else None
+            graph_data = process_tweaks(graph_data, tweaks, stream=False)
+            graph = Graph.from_payload(
+                graph_data, flow_id=flow_id_str, user_id=user_id, flow_name=flow.name, context=context
+            )
+            graph.set_run_id(job_id)
+
+            await task_service.fire_and_forget_task(
+                job_service.execute_with_status,
+                job_id=job_id,
+                run_coro_func=run_graph_internal,
+                graph=graph,
+                flow_id=flow_id_str,
+                session_id=session_id,
+                inputs=None,
+                outputs=graph.get_terminal_nodes(),
+                stream=False,
+            )
         status = JobStatus.QUEUED
         return WorkflowJobResponse(job_id=str(job_id), flow_id=workflow_request.flow_id, status=status)
 

--- a/src/backend/base/langflow/worker.py
+++ b/src/backend/base/langflow/worker.py
@@ -74,6 +74,7 @@ async def _run_workflow_job(
     session_id: str | None,
     request_variables: dict[str, str] | None = None,
 ) -> None:
+    """Reconstruct and execute a workflow graph inside the Celery worker process."""
     from copy import deepcopy
 
     from lfx.graph.graph.base import Graph

--- a/src/backend/base/langflow/worker.py
+++ b/src/backend/base/langflow/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from asgiref.sync import async_to_sync
 from celery.exceptions import SoftTimeLimitExceeded
@@ -35,3 +36,71 @@ def build_vertex(self, vertex: Vertex) -> Vertex:
 def process_graph_cached_task() -> dict[str, Any]:
     msg = "This task is not implemented yet"
     raise NotImplementedError(msg)
+
+
+@celery_app.task(name="langflow.worker.run_workflow_job", acks_late=True)
+def run_workflow_job(
+    *,
+    job_id: str,
+    flow_id: str,
+    user_id: str,
+    flow_name: str | None,
+    graph_data: dict[str, Any],
+    tweaks: dict[str, dict[str, Any]],
+    session_id: str | None,
+    request_variables: dict[str, str] | None = None,
+) -> None:
+    """Run a background workflow from serializable inputs in a Celery worker."""
+    async_to_sync(_run_workflow_job)(
+        job_id=job_id,
+        flow_id=flow_id,
+        user_id=user_id,
+        flow_name=flow_name,
+        graph_data=graph_data,
+        tweaks=tweaks,
+        session_id=session_id,
+        request_variables=request_variables,
+    )
+
+
+async def _run_workflow_job(
+    *,
+    job_id: str,
+    flow_id: str,
+    user_id: str,
+    flow_name: str | None,
+    graph_data: dict[str, Any],
+    tweaks: dict[str, dict[str, Any]],
+    session_id: str | None,
+    request_variables: dict[str, str] | None = None,
+) -> None:
+    from copy import deepcopy
+
+    from lfx.graph.graph.base import Graph
+
+    from langflow.processing.process import process_tweaks, run_graph_internal
+    from langflow.services.deps import get_job_service
+
+    context = {"request_variables": request_variables} if request_variables else None
+    processed_graph_data = process_tweaks(deepcopy(graph_data), tweaks, stream=False)
+    graph = Graph.from_payload(
+        processed_graph_data,
+        flow_id=flow_id,
+        user_id=user_id,
+        flow_name=flow_name,
+        context=context,
+    )
+    graph.set_run_id(UUID(job_id))
+    outputs = graph.get_terminal_nodes()
+
+    job_service = get_job_service()
+    await job_service.execute_with_status(
+        UUID(job_id),
+        run_graph_internal,
+        graph=graph,
+        flow_id=flow_id,
+        session_id=session_id,
+        inputs=None,
+        outputs=outputs,
+        stream=False,
+    )

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -233,7 +233,7 @@ class TestWorkflowDeveloperAPIProtection:
 
             # Should return 200 because flow is valid (empty nodes/edges is valid)
             # The execution will complete successfully with no outputs
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
             result = response.json()
 
             # Verify response contains expected fields with proper structure
@@ -1208,6 +1208,65 @@ class TestWorkflowBackgroundQueueing:
                 assert "links" in result
                 assert "status" in result["links"]
                 assert mock_job_id in result["links"]["status"]
+
+        finally:
+            async with session_scope() as session:
+                flow = await session.get(Flow, flow_id)
+                if flow:
+                    await session.delete(flow)
+
+    async def test_background_execution_with_celery_queues_serializable_worker_task(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        mock_settings_dev_api_enabled,  # noqa: ARG002
+    ):
+        """Celery background execution must not enqueue a live Graph object."""
+        flow_id = uuid4()
+        flow_data = {"nodes": [], "edges": []}
+
+        async with session_scope() as session:
+            flow = Flow(
+                id=flow_id,
+                name="Celery Background Flow",
+                description="Flow for celery background queueing",
+                data=flow_data,
+                user_id=created_api_key.user_id,
+            )
+            session.add(flow)
+            await session.flush()
+            await session.refresh(flow)
+
+        try:
+            request_data = {
+                "flow_id": str(flow_id),
+                "background": True,
+                "inputs": {"ChatInput-abc.input_value": "hello"},
+            }
+            headers = {"x-api-key": created_api_key.api_key}
+            mock_job_id = "550e8400-e29b-41d4-a716-446655440001"
+
+            with (
+                patch("langflow.api.v2.workflow.get_task_service") as mock_get_task_service,
+                patch("langflow.api.v2.workflow.uuid4", return_value=UUID(mock_job_id)),
+            ):
+                mock_task_service = MagicMock()
+                mock_task_service.backend_name = "celery"
+                mock_task_service.fire_and_forget_task = AsyncMock()
+                mock_get_task_service.return_value = mock_task_service
+
+                response = await client.post("api/v2/workflows", json=request_data, headers=headers)
+
+            assert response.status_code == 200, response.text
+            task_func = mock_task_service.fire_and_forget_task.call_args.args[0]
+            task_kwargs = mock_task_service.fire_and_forget_task.call_args.kwargs
+
+            assert hasattr(task_func, "delay")
+            assert "graph" not in task_kwargs
+            assert task_kwargs["graph_data"] == flow_data
+            assert task_kwargs["flow_id"] == str(flow_id)
+            assert task_kwargs["user_id"] == str(created_api_key.user_id)
+            assert task_kwargs["tweaks"] == {"ChatInput-abc": {"input_value": "hello"}}
 
         finally:
             async with session_scope() as session:

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -1262,6 +1262,7 @@ class TestWorkflowBackgroundQueueing:
             task_kwargs = mock_task_service.fire_and_forget_task.call_args.kwargs
 
             assert hasattr(task_func, "delay")
+            assert task_func.name == "langflow.worker.run_workflow_job"
             assert "graph" not in task_kwargs
             assert task_kwargs["graph_data"] == flow_data
             assert task_kwargs["flow_id"] == str(flow_id)

--- a/src/backend/tests/unit/test_worker.py
+++ b/src/backend/tests/unit/test_worker.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from langflow import worker
+
+
+def test_run_workflow_job_task_delegates_to_async_helper():
+    """The Celery task should pass serialized inputs to the async workflow runner."""
+    payload = {
+        "job_id": "550e8400-e29b-41d4-a716-446655440001",
+        "flow_id": "flow-123",
+        "user_id": "user-123",
+        "flow_name": "Background Flow",
+        "graph_data": {"nodes": [], "edges": []},
+        "tweaks": {"ChatInput-abc": {"input_value": "hello"}},
+        "session_id": "session-123",
+        "request_variables": {"x-langflow-global-var-token": "value"},
+    }
+    sync_runner = MagicMock()
+
+    with patch("langflow.worker.async_to_sync", return_value=sync_runner) as mock_async_to_sync:
+        worker.run_workflow_job.run(**payload)
+
+    mock_async_to_sync.assert_called_once_with(worker._run_workflow_job)
+    sync_runner.assert_called_once_with(**payload)
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_job_reconstructs_graph_and_executes_with_status():
+    """The worker should rebuild the Graph in-process before executing the job."""
+    job_id = "550e8400-e29b-41d4-a716-446655440001"
+    graph_data = {"nodes": [{"id": "ChatInput-abc"}], "edges": []}
+    tweaks = {"ChatInput-abc": {"input_value": "hello"}}
+    request_variables = {"x-langflow-global-var-token": "value"}
+    processed_graph_data = {"nodes": [{"id": "ChatInput-abc", "data": {"input_value": "hello"}}], "edges": []}
+    graph = MagicMock()
+    graph.get_terminal_nodes.return_value = ["ChatOutput-def"]
+    job_service = MagicMock()
+    job_service.execute_with_status = AsyncMock()
+
+    def fake_process_tweaks(data, received_tweaks, *, stream):
+        assert data == graph_data
+        assert data is not graph_data
+        assert received_tweaks == tweaks
+        assert stream is False
+        data["mutated"] = True
+        return processed_graph_data
+
+    with (
+        patch("langflow.processing.process.process_tweaks", side_effect=fake_process_tweaks),
+        patch("lfx.graph.graph.base.Graph.from_payload", return_value=graph) as mock_from_payload,
+        patch("langflow.services.deps.get_job_service", return_value=job_service),
+    ):
+        await worker._run_workflow_job(
+            job_id=job_id,
+            flow_id="flow-123",
+            user_id="user-123",
+            flow_name="Background Flow",
+            graph_data=graph_data,
+            tweaks=tweaks,
+            session_id="session-123",
+            request_variables=request_variables,
+        )
+
+    mock_from_payload.assert_called_once_with(
+        processed_graph_data,
+        flow_id="flow-123",
+        user_id="user-123",
+        flow_name="Background Flow",
+        context={"request_variables": request_variables},
+    )
+    graph.set_run_id.assert_called_once_with(UUID(job_id))
+    graph.get_terminal_nodes.assert_called_once_with()
+    job_service.execute_with_status.assert_awaited_once()
+    args, kwargs = job_service.execute_with_status.await_args
+    assert args[0] == UUID(job_id)
+    assert args[1].__name__ == "run_graph_internal"
+    assert kwargs == {
+        "graph": graph,
+        "flow_id": "flow-123",
+        "session_id": "session-123",
+        "inputs": None,
+        "outputs": ["ChatOutput-def"],
+        "stream": False,
+    }
+    assert graph_data == {"nodes": [{"id": "ChatInput-abc"}], "edges": []}
+
+
+def test_worker_tasks_have_docstrings():
+    """Public worker tasks and helpers should stay documented."""
+    assert worker.test_celery.__doc__
+    assert worker.process_graph_cached_task.__doc__
+    assert worker.run_workflow_job.__doc__
+    assert worker._run_workflow_job.__doc__

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None  # Runtime component instances can carry unpickleable thread-local state.
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -4,13 +4,17 @@ This module contains tests for verifying the functionality of the ParameterHandl
 which is responsible for processing and managing parameters in vertices.
 """
 
+import asyncio
+import threading
 from unittest.mock import Mock
 from uuid import uuid4
 
+import dill
 import pytest
 from ag_ui.core import StepFinishedEvent, StepStartedEvent
 from lfx.components.input_output import ChatInput
 from lfx.graph.edge.base import Edge
+from lfx.graph.utils import UnbuiltObject, UnbuiltResult
 from lfx.graph.vertex import base as vertex_base_module
 from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
@@ -440,6 +444,30 @@ def test_vertex_base_extract_messages_coerces_uuid_session_id():
 
     messages = vertex_base_module.Vertex.extract_messages_from_artifacts(vertex, artifacts)
     assert messages[0]["session_id"] == str(session_id)
+
+
+def test_vertex_pickle_drops_runtime_component_instance():
+    """Graph cache serialization should not include live component instances."""
+
+    class ComponentWithThreadLocal:
+        def __init__(self):
+            self.local = threading.local()
+
+    vertex = object.__new__(Vertex)
+    vertex._lock = asyncio.Lock()
+    vertex.built_object = UnbuiltObject()
+    vertex.built_result = UnbuiltResult()
+    vertex.custom_component = ComponentWithThreadLocal()
+    vertex.graph = None
+
+    state = vertex.__getstate__()
+    payload = dill.dumps(vertex, recurse=True)
+
+    assert state["_lock"] is None
+    assert state["custom_component"] is None
+    assert state["built_object"] is None
+    assert state["built_result"] is None
+    assert payload
 
 
 class TestStrFieldWithNonStringListElements:


### PR DESCRIPTION
## Summary

Addresses #8476.

Fixes background workflow execution with the Celery task backend by avoiding queuing a live `Graph` object through Celery.

The previous path built the `Graph` in the API process and passed it into `TaskService.fire_and_forget_task`. When the Celery backend is active, Celery has to serialize queued task arguments, and live graph instances can contain non-picklable objects such as Rich console locks. That matches issue #8476's `cannot pickle Console` failure.

This change adds a dedicated Celery worker task that receives only serializable workflow inputs, then reconstructs and runs the graph inside the worker process.

## Changes

- Added `run_workflow_job` Celery task in `langflow.worker`.
- Changed the v2 background workflow path to queue `run_workflow_job` when the task backend is Celery.
- Kept the existing AnyIO/local path using the in-process `Graph` object.
- Added a regression test that asserts the Celery path queues the named worker task with `.delay` and does not enqueue a `graph` kwarg.
- Added unit tests for the worker task delegation and `_run_workflow_job` graph reconstruction/execution path.

## Verification

- `.venv\Scripts\python -m pytest src\backend\tests\unit\test_worker.py src\backend\tests\unit\api\v2\test_workflow.py::TestWorkflowBackgroundQueueing -q`
- `.venv\Scripts\python -m py_compile src\backend\base\langflow\worker.py src\backend\base\langflow\api\v2\workflow.py src\backend\tests\unit\api\v2\test_workflow.py src\backend\tests\unit\test_worker.py`
- `.venv\Scripts\python -m ruff check src\backend\base\langflow\worker.py src\backend\tests\unit\api\v2\test_workflow.py src\backend\tests\unit\test_worker.py`
- `git diff --check`