### PR TITLE
fix: omit vertex components from graph cache state

### DIFF
--- a/src/backend/tests/unit/graph/test_cache_restoration.py
+++ b/src/backend/tests/unit/graph/test_cache_restoration.py
@@ -16,6 +16,7 @@ Reset vertex.built = False when cache restoration fails, so build()
 runs fully and sets vertex.result correctly.
 """
 
+import asyncio
 import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -163,8 +164,8 @@ def test_redis_graph_cache_serialization_omits_runtime_component_state():
         {
             "id": "model-node",
             "_lock": None,
-            "built_object": None,
-            "built_result": None,
+            "built_object": "cached-object",
+            "built_result": {"result": "cached-result"},
             "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
             "full_data": {"id": "model-node"},
         }
@@ -172,9 +173,19 @@ def test_redis_graph_cache_serialization_omits_runtime_component_state():
     graph.vertices = [vertex]
     graph._vertices = [vertex.full_data]
 
-    restored = dill.loads(dill.dumps(graph, recurse=True))  # noqa: S301 - trusted local regression fixture
+    with pytest.raises(TypeError, match="cannot pickle"):
+        dill.dumps(vertex.__dict__, recurse=True)
 
-    assert restored.vertices[0].custom_component is None
+    restored = dill.loads(dill.dumps(graph, recurse=True))  # noqa: S301 - trusted local regression fixture
+    restored_vertex = restored.vertices[0]
+
+    assert restored.flow_id == graph.flow_id
+    assert restored_vertex.id == vertex.id
+    assert restored_vertex.full_data == vertex.full_data
+    assert restored_vertex.built_object == "cached-object"
+    assert restored_vertex.built_result == {"result": "cached-result"}
+    assert restored_vertex.custom_component is None
+    assert isinstance(restored_vertex.lock, asyncio.Lock)
 
 
 class TestCacheRestorationSuccessCase:

--- a/src/backend/tests/unit/graph/test_cache_restoration.py
+++ b/src/backend/tests/unit/graph/test_cache_restoration.py
@@ -16,9 +16,14 @@ Reset vertex.built = False when cache restoration fails, so build()
 runs fully and sets vertex.result correctly.
 """
 
+import threading
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import dill
 import pytest
+from lfx.graph import Graph
+from lfx.graph.vertex.base import Vertex
 
 
 class TestCacheRestorationBuiltFlagReset:
@@ -149,6 +154,27 @@ class TestCacheRestorationBuiltFlagReset:
 
         # Assert - build() should NOT return early
         assert should_return_early is False, "build() should continue with reset built flag"
+
+
+def test_redis_graph_cache_serialization_omits_runtime_component_state():
+    graph = Graph(flow_id="flow-with-runtime-component-state")
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "id": "model-node",
+            "_lock": None,
+            "built_object": None,
+            "built_result": None,
+            "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
+            "full_data": {"id": "model-node"},
+        }
+    )
+    graph.vertices = [vertex]
+    graph._vertices = [vertex.full_data]
+
+    restored = dill.loads(dill.dumps(graph, recurse=True))  # noqa: S301 - trusted local regression fixture
+
+    assert restored.vertices[0].custom_component is None
 
 
 class TestCacheRestorationSuccessCase:

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None  # Component instances can hold non-serializable runtime state.
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,5 +1,7 @@
 import copy
 import json
+import pickle
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -113,6 +115,27 @@ def test_invalid_node_types():
     g = Graph()
     with pytest.raises(KeyError):
         g.add_nodes_and_edges(graph_data["nodes"], graph_data["edges"])
+
+
+def test_graph_pickle_omits_unpickleable_vertex_component():
+    graph = Graph(flow_id="flow-with-runtime-component-state")
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "id": "model-node",
+            "_lock": None,
+            "built_object": None,
+            "built_result": None,
+            "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
+            "full_data": {"id": "model-node"},
+        }
+    )
+    graph.vertices = [vertex]
+    graph._vertices = [vertex.full_data]
+
+    restored = pickle.loads(pickle.dumps(graph))  # noqa: S301 - trusted local regression fixture
+
+    assert restored.vertices[0].custom_component is None
 
 
 def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import pickle
@@ -124,8 +125,8 @@ def test_graph_pickle_omits_unpickleable_vertex_component():
         {
             "id": "model-node",
             "_lock": None,
-            "built_object": None,
-            "built_result": None,
+            "built_object": "cached-object",
+            "built_result": {"result": "cached-result"},
             "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
             "full_data": {"id": "model-node"},
         }
@@ -133,9 +134,19 @@ def test_graph_pickle_omits_unpickleable_vertex_component():
     graph.vertices = [vertex]
     graph._vertices = [vertex.full_data]
 
-    restored = pickle.loads(pickle.dumps(graph))  # noqa: S301 - trusted local regression fixture
+    with pytest.raises(TypeError, match="cannot pickle"):
+        pickle.dumps(vertex.__dict__)
 
-    assert restored.vertices[0].custom_component is None
+    restored = pickle.loads(pickle.dumps(graph))  # noqa: S301 - trusted local regression fixture
+    restored_vertex = restored.vertices[0]
+
+    assert restored.flow_id == graph.flow_id
+    assert restored_vertex.id == vertex.id
+    assert restored_vertex.full_data == vertex.full_data
+    assert restored_vertex.built_object == "cached-object"
+    assert restored_vertex.built_result == {"result": "cached-result"}
+    assert restored_vertex.custom_component is None
+    assert isinstance(restored_vertex.lock, asyncio.Lock)
 
 
 def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):


### PR DESCRIPTION
Fixes #8476.

This prevents cached graph serialization from trying to pickle live `Vertex.custom_component` instances. Those component instances can carry runtime-only state such as thread locals, locks, or console objects, which breaks Redis/Celery cache writes when `dill.dumps(..., recurse=True)` walks the graph.

The serialized vertex state already preserves the graph/node data needed to rebuild components later, so the runtime component instance should not be part of the cache payload.

Verification:
- `uv run ruff check src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/test_graph.py src/backend/tests/unit/graph/test_cache_restoration.py`
- `uv run pytest src/backend/tests/unit/graph/test_cache_restoration.py::test_redis_graph_cache_serialization_omits_runtime_component_state -q`
- `cd src/lfx && uv sync && uv run pytest tests/unit/graph/test_graph.py::test_graph_pickle_omits_unpickleable_vertex_component -q`