### PR TITLE
fix: avoid serializing runtime graph state

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -242,14 +242,17 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
     @override
     async def set(self, key, value, lock=None) -> None:
         try:
-            if pickled := dill.dumps(value, recurse=True):
-                result = await self._client.setex(str(key), self.expiration_time, pickled)
-                if not result:
-                    msg = "RedisCache could not set the value."
-                    raise ValueError(msg)
-        except pickle.PicklingError as exc:
-            msg = "RedisCache only accepts values that can be pickled. "
-            raise TypeError(msg) from exc
+            pickled = dill.dumps(value, recurse=True)
+        except (pickle.PicklingError, TypeError, AttributeError) as exc:
+            await logger.awarning(f"Skipping Redis cache write for unpickleable value at key {key!r}: {exc}")
+            await self.delete(key)
+            return
+
+        if pickled:
+            result = await self._client.setex(str(key), self.expiration_time, pickled)
+            if not result:
+                msg = "RedisCache could not set the value."
+                raise ValueError(msg)
 
     @override
     async def upsert(self, key, value, lock=None) -> None:

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -234,6 +234,7 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
     @override
     async def get(self, key, lock=None):
+        """Retrieve a cached value from Redis using a normalized key."""
         if key is None:
             return CACHE_MISS
         value = await self._client.get(str(key))
@@ -241,6 +242,7 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
     @override
     async def set(self, key, value, lock=None) -> None:
+        """Store a pickled cache value in Redis when it can be serialized."""
         try:
             pickled = dill.dumps(value, recurse=True)
         except (pickle.PicklingError, TypeError, AttributeError) as exc:
@@ -276,7 +278,8 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
     @override
     async def delete(self, key, lock=None) -> None:
-        await self._client.delete(key)
+        """Delete a cached value from Redis using the same key normalization as get and set."""
+        await self._client.delete(str(key))
 
     @override
     async def clear(self, lock=None) -> None:

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -245,7 +245,7 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
             pickled = dill.dumps(value, recurse=True)
         except (pickle.PicklingError, TypeError, AttributeError) as exc:
             await logger.awarning(f"Skipping Redis cache write for unpickleable value at key {key!r}: {exc}")
-            await self.delete(key)
+            await self.delete(str(key))
             return
 
         if pickled:

--- a/src/backend/tests/unit/services/test_redis_cache.py
+++ b/src/backend/tests/unit/services/test_redis_cache.py
@@ -1,0 +1,38 @@
+import pytest
+from langflow.services.cache.service import RedisCache
+from lfx.services.cache.utils import CACHE_MISS
+
+
+class _FakeRedisClient:
+    def __init__(self) -> None:
+        self.values = {}
+
+    async def get(self, key):
+        return self.values.get(key)
+
+    async def setex(self, key, _expiration_time, value):
+        self.values[key] = value
+        return True
+
+    async def delete(self, key):
+        self.values.pop(key, None)
+        return 1
+
+
+class _UnpickleableValue:
+    def __getstate__(self):
+        raise TypeError
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_skips_unpickleable_values_and_clears_stale_entry():
+    cache = RedisCache.__new__(RedisCache)
+    cache._client = _FakeRedisClient()
+    cache.expiration_time = 3600
+
+    await cache.set("flow-id", {"previous": "value"})
+    assert await cache.get("flow-id") == {"previous": "value"}
+
+    await cache.set("flow-id", _UnpickleableValue())
+
+    assert await cache.get("flow-id") is CACHE_MISS

--- a/src/backend/tests/unit/services/test_redis_cache.py
+++ b/src/backend/tests/unit/services/test_redis_cache.py
@@ -1,11 +1,16 @@
+import pickle
+
 import pytest
 from langflow.services.cache.service import RedisCache
 from lfx.services.cache.utils import CACHE_MISS
 
 
 class _FakeRedisClient:
+    """Minimal Redis client double that records cache mutations."""
+
     def __init__(self) -> None:
         self.values = {}
+        self.deleted_keys = []
 
     async def get(self, key):
         return self.values.get(key)
@@ -15,17 +20,25 @@ class _FakeRedisClient:
         return True
 
     async def delete(self, key):
+        self.deleted_keys.append(key)
         self.values.pop(key, None)
         return 1
 
 
 class _UnpickleableValue:
+    """Value that raises a configured exception during pickling."""
+
+    def __init__(self, exception_type: type[Exception]) -> None:
+        self.exception_type = exception_type
+
     def __getstate__(self):
-        raise TypeError
+        raise self.exception_type
 
 
+@pytest.mark.parametrize("exception_type", [pickle.PicklingError, TypeError, AttributeError])
 @pytest.mark.asyncio
-async def test_redis_cache_skips_unpickleable_values_and_clears_stale_entry():
+async def test_redis_cache_skips_unpickleable_values_and_clears_stale_entry(exception_type):
+    """Unpickleable values should not leave stale Redis entries behind."""
     cache = RedisCache.__new__(RedisCache)
     cache._client = _FakeRedisClient()
     cache.expiration_time = 3600
@@ -33,7 +46,24 @@ async def test_redis_cache_skips_unpickleable_values_and_clears_stale_entry():
     cache_key = 123
     await cache.set(cache_key, {"previous": "value"})
     assert await cache.get(cache_key) == {"previous": "value"}
+    assert "123" in cache._client.values
+    assert 123 not in cache._client.values
 
-    await cache.set(cache_key, _UnpickleableValue())
+    await cache.set(cache_key, _UnpickleableValue(exception_type))
 
     assert await cache.get(cache_key) is CACHE_MISS
+    assert cache._client.deleted_keys == ["123"]
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_delete_normalizes_keys():
+    """Direct Redis cache deletes should normalize keys like get and set."""
+    cache = RedisCache.__new__(RedisCache)
+    cache._client = _FakeRedisClient()
+    cache.expiration_time = 3600
+
+    await cache.set(123, {"value": "cached"})
+    await cache.delete(123)
+
+    assert await cache.get(123) is CACHE_MISS
+    assert cache._client.deleted_keys == ["123"]

--- a/src/backend/tests/unit/services/test_redis_cache.py
+++ b/src/backend/tests/unit/services/test_redis_cache.py
@@ -30,9 +30,10 @@ async def test_redis_cache_skips_unpickleable_values_and_clears_stale_entry():
     cache._client = _FakeRedisClient()
     cache.expiration_time = 3600
 
-    await cache.set("flow-id", {"previous": "value"})
-    assert await cache.get("flow-id") == {"previous": "value"}
+    cache_key = 123
+    await cache.set(cache_key, {"previous": "value"})
+    assert await cache.get(cache_key) == {"previous": "value"}
 
-    await cache.set("flow-id", _UnpickleableValue())
+    await cache.set(cache_key, _UnpickleableValue())
 
-    assert await cache.get("flow-id") is CACHE_MISS
+    assert await cache.get(cache_key) is CACHE_MISS

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,8 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        # Component instances carry request-local runtime state and are recreated from node data after restore.
+        state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state
@@ -234,6 +236,7 @@ class Vertex:
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._lock = asyncio.Lock()  # Reinitialize the lock
+        self.custom_component = state.get("custom_component")
         self.built_object = state.get("built_object") or UnbuiltObject()
         self.built_result = state.get("built_result") or UnbuiltResult()
 

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -225,6 +225,7 @@ class Vertex:
         return self.graph.successor_map.get(self.id, [])
 
     def __getstate__(self):
+        """Return pickle state without request-local runtime objects."""
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
         # Component instances carry request-local runtime state and are recreated from node data after restore.
@@ -234,11 +235,14 @@ class Vertex:
         return state
 
     def __setstate__(self, state):
+        """Restore pickle state and recreate runtime-only defaults."""
         self.__dict__.update(state)
         self._lock = asyncio.Lock()  # Reinitialize the lock
         self.custom_component = state.get("custom_component")
-        self.built_object = state.get("built_object") or UnbuiltObject()
-        self.built_result = state.get("built_result") or UnbuiltResult()
+        built_object = state.get("built_object")
+        built_result = state.get("built_result")
+        self.built_object = UnbuiltObject() if built_object is None else built_object
+        self.built_result = UnbuiltResult() if built_result is None else built_result
 
     def set_top_level(self, top_level_vertices: list[str]) -> None:
         self.parent_is_top_level = self.parent_node_id in top_level_vertices

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import pickle
+from asyncio import Lock
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,7 @@ from lfx.graph.graph.utils import (
     update_target_handle,
     update_template,
 )
+from lfx.graph.utils import UnbuiltObject, UnbuiltResult
 from lfx.graph.vertex.base import Vertex
 from lfx.interface.components import component_cache
 from lfx.utils.flow_validation import CustomComponentValidationError
@@ -26,6 +28,8 @@ from lfx.utils.flow_validation import CustomComponentValidationError
 
 
 class _UnpickleableRuntimeComponent:
+    """Runtime component double that cannot be pickled."""
+
     def __getstate__(self):
         raise TypeError
 
@@ -135,16 +139,32 @@ def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
 
 
 def test_graph_pickle_omits_runtime_component_instances():
+    """Graph pickling should omit runtime-only vertex state and restore safe defaults."""
     chat_input = ChatInput(_id="chat_input")
     chat_output = ChatOutput(_id="chat_output")
     chat_output.set(input_value=chat_input.message_response)
     graph = Graph(chat_input, chat_output)
-    graph.get_vertex("chat_input").custom_component = _UnpickleableRuntimeComponent()
+    vertex = graph.get_vertex("chat_input")
+    vertex.custom_component = _UnpickleableRuntimeComponent()
+    vertex.built_object = UnbuiltObject()
+    vertex.built_result = UnbuiltResult()
+    original_lock = vertex.lock
+
+    state = vertex.__getstate__()
+    assert state["_lock"] is None
+    assert state["custom_component"] is None
+    assert state["built_object"] is None
+    assert state["built_result"] is None
 
     restored = pickle.loads(pickle.dumps(graph))  # noqa: S301
+    restored_vertex = restored.get_vertex("chat_input")
 
-    assert restored.get_vertex("chat_input").custom_component is None
-    assert restored.get_vertex("chat_input").display_name == graph.get_vertex("chat_input").display_name
+    assert restored_vertex.custom_component is None
+    assert isinstance(restored_vertex.built_object, UnbuiltObject)
+    assert isinstance(restored_vertex.built_result, UnbuiltResult)
+    assert isinstance(restored_vertex._lock, Lock)
+    assert restored_vertex._lock is not original_lock
+    assert restored_vertex.display_name == vertex.display_name
 
 
 def test_find_last_node(grouped_chat_json_flow):

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,8 +1,10 @@
 import copy
 import json
+import pickle
 from types import SimpleNamespace
 
 import pytest
+from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.graph import Graph
 from lfx.graph.graph.utils import (
     find_last_node,
@@ -21,6 +23,11 @@ from lfx.utils.flow_validation import CustomComponentValidationError
 
 # now we have three types of graph:
 # BASIC_EXAMPLE_PATH, COMPLEX_EXAMPLE_PATH, OPENAPI_EXAMPLE_PATH
+
+
+class _UnpickleableRuntimeComponent:
+    def __getstate__(self):
+        raise TypeError
 
 
 @pytest.fixture
@@ -125,6 +132,19 @@ def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
 
     with pytest.raises(CustomComponentValidationError, match="custom components are not allowed"):
         Graph.from_payload(_blocked_custom_flow())
+
+
+def test_graph_pickle_omits_runtime_component_instances():
+    chat_input = ChatInput(_id="chat_input")
+    chat_output = ChatOutput(_id="chat_output")
+    chat_output.set(input_value=chat_input.message_response)
+    graph = Graph(chat_input, chat_output)
+    graph.get_vertex("chat_input").custom_component = _UnpickleableRuntimeComponent()
+
+    restored = pickle.loads(pickle.dumps(graph))  # noqa: S301
+
+    assert restored.get_vertex("chat_input").custom_component is None
+    assert restored.get_vertex("chat_input").display_name == graph.get_vertex("chat_input").display_name
 
 
 def test_find_last_node(grouped_chat_json_flow):


### PR DESCRIPTION
Fixes #8476

Summary:
- Omit live component instances from Vertex pickle state so graph and vertex payloads do not carry request-local runtime objects through Redis or Celery.
- Make Redis cache writes skip unpickleable runtime values and clear stale entries instead of failing the flow run.
- Add regression coverage for graph serialization and Redis cache skip behavior.

Tests:
- env LFX_TEST_ALLOW_LANGFLOW=1 uv run pytest src/lfx/tests/unit/graph/test_graph.py::test_graph_pickle_omits_runtime_component_instances -q
- uv run pytest src/backend/tests/unit/services/test_redis_cache.py -q
- uv run ruff check src/lfx/src/lfx/graph/vertex/base.py src/backend/base/langflow/services/cache/service.py src/lfx/tests/unit/graph/test_graph.py src/backend/tests/unit/services/test_redis_cache.py