### PR TITLE
fix: preserve falsey vertex cache state

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -234,8 +234,8 @@ class Vertex:
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._lock = asyncio.Lock()  # Reinitialize the lock
-        self.built_object = state.get("built_object") or UnbuiltObject()
-        self.built_result = state.get("built_result") or UnbuiltResult()
+        self.built_object = UnbuiltObject() if state.get("built_object") is None else state["built_object"]
+        self.built_result = UnbuiltResult() if state.get("built_result") is None else state["built_result"]
 
     def set_top_level(self, top_level_vertices: list[str]) -> None:
         self.parent_is_top_level = self.parent_node_id in top_level_vertices

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -11,6 +11,7 @@ import pytest
 from ag_ui.core import StepFinishedEvent, StepStartedEvent
 from lfx.components.input_output import ChatInput
 from lfx.graph.edge.base import Edge
+from lfx.graph.utils import UnbuiltObject, UnbuiltResult
 from lfx.graph.vertex import base as vertex_base_module
 from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
@@ -440,6 +441,27 @@ def test_vertex_base_extract_messages_coerces_uuid_session_id():
 
     messages = vertex_base_module.Vertex.extract_messages_from_artifacts(vertex, artifacts)
     assert messages[0]["session_id"] == str(session_id)
+
+
+@pytest.mark.parametrize("cached_value", [0, False, "", [], {}])
+def test_vertex_setstate_preserves_falsey_cached_values(cached_value):
+    """Falsey cache values are valid results and should not become unbuilt sentinels."""
+    vertex = object.__new__(Vertex)
+
+    vertex.__setstate__({"built_object": cached_value, "built_result": cached_value})
+
+    assert vertex.built_object == cached_value
+    assert vertex.built_result == cached_value
+
+
+def test_vertex_setstate_restores_unbuilt_sentinels_for_none_values():
+    """None remains the marker used for omitted unbuilt state during serialization."""
+    vertex = object.__new__(Vertex)
+
+    vertex.__setstate__({"built_object": None, "built_result": None})
+
+    assert isinstance(vertex.built_object, UnbuiltObject)
+    assert isinstance(vertex.built_result, UnbuiltResult)
 
 
 class TestStrFieldWithNonStringListElements:


### PR DESCRIPTION
## Summary

- preserve falsey cached `Vertex` state values during unpickle / cache restoration
- keep `None` as the marker that restores `UnbuiltObject` / `UnbuiltResult`
- add regression coverage for `0`, `False`, empty string/list/dict, and `None`

## Context

While checking the crowded fixes around #8476, I noticed the adjacent serialization restore path used `state.get(...) or Unbuilt...`. That means valid cached values like `0`, `False`, `""`, `[]`, and `{}` are treated as missing/unbuilt after restore.

This PR does not duplicate the broader `custom_component` pickling fix already open in other PRs. It only tightens the existing `__setstate__` behavior for cache correctness.

## Validation

- `python3 -m py_compile src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/vertex/test_vertex_base.py`
- `git diff --check`

Note: I attempted to install the LFX test dependencies in a temporary venv, but dependency installation hung and was stopped, so I did not run the full pytest target locally.
