### PR TITLE
fix(graph): omit runtime component from serialized vertex

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None  # Runtime component instances can hold non-serializable state.
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,5 +1,7 @@
 import copy
 import json
+import pickle
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -113,6 +115,37 @@ def test_invalid_node_types():
     g = Graph()
     with pytest.raises(KeyError):
         g.add_nodes_and_edges(graph_data["nodes"], graph_data["edges"])
+
+
+def test_graph_pickle_drops_unpickleable_runtime_component_state():
+    graph = Graph(flow_id="flow-with-runtime-component-state")
+    vertex = object.__new__(Vertex)
+    vertex.__dict__.update(
+        {
+            "id": "model-node",
+            "_lock": None,
+            "built_object": "cached-object",
+            "built_result": {"result": "cached-result"},
+            "custom_component": SimpleNamespace(console_thread_locals=threading.local()),
+            "full_data": {"id": "model-node"},
+        }
+    )
+    graph.vertices = [vertex]
+    graph._vertices = [vertex.full_data]
+
+    with pytest.raises(TypeError, match="cannot pickle"):
+        pickle.dumps(vertex.__dict__)
+
+    cache_payload = pickle.dumps({"result": graph, "type": type(graph)})
+    restored_cache_entry = pickle.loads(cache_payload)  # noqa: S301 - trusted local fixture
+    restored_vertex = restored_cache_entry["result"].vertices[0]
+
+    assert restored_cache_entry["type"] is Graph
+    assert restored_vertex.id == "model-node"
+    assert restored_vertex.built_object == "cached-object"
+    assert restored_vertex.built_result == {"result": "cached-result"}
+    assert restored_vertex.full_data == {"id": "model-node"}
+    assert restored_vertex.custom_component is None
 
 
 def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):


### PR DESCRIPTION
## Summary
- Drop runtime `custom_component` instances from `Vertex.__getstate__` so graph cache serialization does not try to pickle thread-local component state.
- Add a graph pickle regression covering an unpickleable `threading.local()` held by the runtime component while preserving cached build fields.

Fixes #8476

## Tests
- `uv run --project src/lfx ruff check src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/test_graph.py`
- `uv run --project src/lfx pytest src/lfx/tests/unit/graph/test_graph.py -q -k graph_pickle_drops_unpickleable_runtime_component_state`
- `uv run --project src/lfx pytest src/lfx/tests/unit/graph/test_graph.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph serialization to properly handle non-serializable runtime components, ensuring cache payloads can be successfully pickled and restored with key cached fields preserved.

* **Tests**
  * Added unit test verifying graph serialization behavior with unpickleable runtime state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->