### PR TITLE
fix: graph cache serialization of runtime components

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None  # Runtime component instances may hold non-serializable state.
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/graph/test_base.py
+++ b/src/lfx/tests/unit/graph/graph/test_base.py
@@ -1,4 +1,5 @@
 import contextvars
+import pickle
 from collections import deque
 
 import pytest
@@ -104,6 +105,31 @@ def test_graph_functional_start_end():
     assert len(results) == len(ids) + 1
     assert all(result.vertex.id in ids for result in results if hasattr(result, "vertex"))
     assert results[-1] == Finish()
+
+
+def test_graph_cache_serialization_omits_runtime_component_state():
+    """Graph cache serialization should not include live component instances."""
+
+    class UnserializableComponent:
+        def __getstate__(self):
+            msg = "cannot serialize runtime component"
+            raise TypeError(msg)
+
+    chat_input = ChatInput(_id="chat_input")
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    graph = Graph(chat_input, chat_output)
+
+    graph.vertices[0].custom_component = UnserializableComponent()
+
+    payload = {"result": graph, "type": type(graph)}
+    serialized_payload = pickle.dumps(payload)
+    deserialized_payload = pickle.loads(serialized_payload)  # noqa: S301 - trusted test payload.
+    deserialized_graph = deserialized_payload["result"]
+
+    assert serialized_payload
+    assert graph.vertices[0].__getstate__()["custom_component"] is None
+    assert deserialized_graph.vertices[0].custom_component is None
 
 
 def test_get_terminal_nodes():


### PR DESCRIPTION
Fixes #8476

## Summary

This avoids storing live runtime component instances in cached graph state.

When the Redis/Celery path caches a `Graph`, each `Vertex` is serialized as part of that graph. Some runtime component instances can hold non-serializable state such as thread-local console objects, which can make cache serialization fail even for simple built-in flows.

The patch omits `custom_component` from `Vertex.__getstate__`. The component instance is runtime state and can be re-instantiated from vertex data during build.

## Scope

- Focused LFX graph-cache serialization fix only.
- Changes only `src/lfx/src/lfx/graph/vertex/base.py` and `src/lfx/tests/unit/graph/graph/test_base.py`.
- No generated starter-project, dependency, or unrelated frontend changes.

## Regression Coverage

The test injects an unserializable runtime component into a graph vertex, serializes a payload containing the graph, deserializes it, and asserts that `custom_component` is omitted from both the serialized state and the restored graph vertex.

## Validation

- `uv run ruff check src/lfx/graph/vertex/base.py tests/unit/graph/graph/test_base.py`
- `uv run pytest tests/unit/graph/graph/test_base.py -q` (`16 passed, 1 skipped`)
