### PR TITLE
fix: exclude custom_component from Vertex serialization to fix Redis cache pickle error

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -229,6 +229,7 @@ class Vertex:
         state["_lock"] = None  # Locks are not serializable
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
+        state["custom_component"] = None  # custom_component may carry unpicklable state (e.g. thread-local, console objects)
         return state
 
     def __setstate__(self, state):
@@ -236,6 +237,7 @@ class Vertex:
         self._lock = asyncio.Lock()  # Reinitialize the lock
         self.built_object = state.get("built_object") or UnbuiltObject()
         self.built_result = state.get("built_result") or UnbuiltResult()
+        # custom_component is lazily re-initialized via _build() if needed
 
     def set_top_level(self, top_level_vertices: list[str]) -> None:
         self.parent_is_top_level = self.parent_node_id in top_level_vertices

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -229,7 +229,9 @@ class Vertex:
         state["_lock"] = None  # Locks are not serializable
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
-        state["custom_component"] = None  # custom_component may carry unpicklable state (e.g. thread-local, console objects)
+        state["custom_component"] = (
+            None  # custom_component may carry unpicklable state (e.g. thread-local, console objects)
+        )
         return state
 
     def __setstate__(self, state):


### PR DESCRIPTION
## Description

Fixes #8476

When using Celery with RabbitMQ/Redis as the cache backend, `RedisCache.set()` calls `dill.dumps()` on the Graph object. `Vertex.__getstate__()` previously preserved `custom_component` in serialized state, which could carry unpicklable objects (thread-local state, console objects, etc.) causing:

```
TypeError: cannot pickle Console Threaded object
```

## Fix

- Exclude `custom_component` from serialized state in `Vertex.__getstate__()` by setting it to `None`
- `custom_component` is lazily re-initialized via the existing `_build()` method when needed (lines 384, 403)
- `__setstate__` comment documents that lazy re-initialization handles this automatically

## Root cause analysis

The error chain when using Redis cache:
1. `ChatService.set_cache()` → `RedisCache.set()` → `dill.dumps(value, recurse=True)`
2. The `value` is a `Graph` object containing `Vertex` objects
3. `Vertex.__getstate__()` already excluded `_lock` and `built_object`, but not `custom_component`
4. Some component instances carry thread-local/console state that cannot be pickled

## Verification

- `custom_component` lazy loading already exists in `_build()` (lines 384, 403), so setting it to `None` in serialized state is safe
- The fix is minimal (2 lines) and follows the existing pattern of excluding non-serializable attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization reliability by preventing runtime objects from persisting during serialization, ensuring vertex objects can be reliably saved and restored without errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->