### PR TITLE
Avoid caching live vertex component instances

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -4,6 +4,9 @@ This module contains tests for verifying the functionality of the ParameterHandl
 which is responsible for processing and managing parameters in vertices.
 """
 
+import pickle
+import threading
+from types import SimpleNamespace
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -16,6 +19,14 @@ from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
 from lfx.services.storage.service import StorageService
 from lfx.utils.util import unescape_string
+
+
+class ComponentWithThreadLocal:
+    def __init__(self) -> None:
+        self._console_thread_local = threading.local()
+
+    def set_vertex(self, vertex) -> None:
+        self.vertex = vertex
 
 
 @pytest.fixture
@@ -205,6 +216,30 @@ def test_process_field_parameters_valid(parameter_handler, mock_vertex):
     assert "hidden_field" not in params
     # Validate str_list_field has been processed correctly
     assert params["str_list_field"] == [unescape_string("a"), unescape_string("b")]
+
+
+def test_vertex_cache_state_omits_live_component_instance():
+    """Graph cache snapshots should not pickle live component instances."""
+    graph = SimpleNamespace(flow_id=None)
+    node_data = {
+        "id": "chat_input",
+        "data": {
+            "type": "ChatInput",
+            "node": {
+                "base_classes": [],
+                "display_name": "Chat Input",
+                "outputs": [],
+                "template": {"_type": "Component"},
+            },
+        },
+    }
+    vertex = Vertex(node_data, graph, base_type="components")
+    vertex.add_component_instance(ComponentWithThreadLocal())
+
+    state = vertex.__getstate__()
+
+    assert state["custom_component"] is None
+    pickle.dumps(vertex)
 
 
 def test_process_field_parameters_invalid(parameter_handler, mock_vertex):

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -22,10 +22,13 @@ from lfx.utils.util import unescape_string
 
 
 class ComponentWithThreadLocal:
+    """Component stub carrying thread-local state that cannot be pickled."""
+
     def __init__(self) -> None:
         self._console_thread_local = threading.local()
 
     def set_vertex(self, vertex) -> None:
+        """Attach the vertex like real Langflow component instances do."""
         self.vertex = vertex
 
 


### PR DESCRIPTION
## Summary

This avoids serializing live component instances in cached graph vertices. When RedisCache/dill serializes a graph for Redis/Celery-backed runs, component instances can carry console or thread-local state that is not pickleable. The cached vertex state already stores built outputs, artifacts, result metadata, and graph/node data, so retaining the live component instance in the cache snapshot is unnecessary and can make Redis-backed flow execution fail.

## Change

- Drop `custom_component` from `Vertex.__getstate__()` cache/pickle snapshots.
- Add a regression test that attaches a component with `threading.local()` state to a vertex and verifies the vertex can still be pickled while the cached state omits the live component instance.

## Validation

- `uv run --isolated --no-project --with-editable /Users/kyletree/Documents/Codex/2026-05-19/can-you-please-do-a-ton/langflow-taskbounty-8476/src/lfx --with pytest --with pytest-asyncio python -m pytest /Users/kyletree/Documents/Codex/2026-05-19/can-you-please-do-a-ton/langflow-taskbounty-8476/src/lfx/tests/unit/graph/vertex/test_vertex_base.py -q`
  - 23 passed
- `python3 -m py_compile src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/vertex/test_vertex_base.py`
- `git diff --check -- src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/vertex/test_vertex_base.py`

Fixes #8476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertex object serialization to properly exclude custom component instances, resolving issues with pickling operations when components contain thread-local storage.

* **Tests**
  * Added regression test to verify vertex serialization correctly handles custom components with thread-local attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->