### PR TITLE
fix: avoid pickling vertex component runtime state

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,7 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        state["custom_component"] = None  # Runtime component instances are rebuilt and may not be serializable
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -4,6 +4,7 @@ This module contains tests for verifying the functionality of the ParameterHandl
 which is responsible for processing and managing parameters in vertices.
 """
 
+import pickle
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -16,6 +17,29 @@ from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
 from lfx.services.storage.service import StorageService
 from lfx.utils.util import unescape_string
+
+
+def test_vertex_getstate_drops_custom_component_runtime_state():
+    """Graph cache serialization should rebuild component instances instead of pickling live runtime state."""
+
+    class UnpickleableComponent:
+        """Component stand-in that fails if live runtime state is serialized."""
+
+        def __getstate__(self):
+            """Raise when pickle tries to serialize the component instance."""
+            msg = "cannot pickle component runtime state"
+            raise TypeError(msg)
+
+    vertex = object.__new__(Vertex)
+    vertex._lock = Mock()
+    vertex.custom_component = UnpickleableComponent()
+    vertex.built_object = object()
+    vertex.built_result = object()
+
+    state = vertex.__getstate__()
+
+    assert state["custom_component"] is None
+    pickle.dumps(state)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Fixes #8476 on `main` by removing live `custom_component` runtime instances from `Vertex.__getstate__()` output.
- Keeps serializable graph state while allowing component instances to be rebuilt after deserialization.
- Adds a focused regression test with an intentionally unpickleable component to ensure vertex state remains pickleable.

## Root cause
Distributed/Celery execution can pickle vertex state. A live component instance may contain runtime-only objects that cannot be pickled, so keeping `custom_component` in the serialized vertex state can fail with errors like `cannot pickle ... object`.

## Verification
- `uv run --package lfx pytest src/lfx/tests/unit/graph/vertex/test_vertex_base.py -k getstate -q`
- `uv run --package lfx pytest src/lfx/tests/unit/graph/vertex/test_vertex_base.py -q`
- `uv run ruff check src/lfx/src/lfx/graph/vertex/base.py src/lfx/tests/unit/graph/vertex/test_vertex_base.py`
- `git diff --check`

Result: targeted test passed, full vertex test file passed (23 passed), ruff passed, and git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vertex objects now properly serialize without including runtime component state, preventing serialization errors.

* **Tests**
  * Added regression test to verify vertex serialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->