### PR TITLE
fix: resolve deadlock in AsyncInMemoryCache and AsyncDiskCache upsert

### DIFF
--- a/src/backend/base/langflow/services/cache/disk.py
+++ b/src/backend/base/langflow/services/cache/disk.py
@@ -85,7 +85,7 @@ class AsyncDiskCache(AsyncBaseCacheService, Generic[AsyncLockType]):
         if existing_value is not CACHE_MISS and isinstance(existing_value, dict) and isinstance(value, dict):
             existing_value.update(value)
             value = existing_value
-        await self.set(key, value)
+        await self._set(key, value)
 
     async def contains(self, key) -> bool:
         return await asyncio.to_thread(self.cache.__contains__, key)

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -345,11 +345,12 @@ class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
         await self._upsert(key, value, lock)
 
     async def _upsert(self, key, value, lock: asyncio.Lock | None = None) -> None:
-        existing_value = await self.get(key, lock)
-        if existing_value is not None and isinstance(existing_value, dict) and isinstance(value, dict):
-            existing_value.update(value)
-            value = existing_value
-        await self.set(key, value, lock)
+        async with lock or self.lock:
+            existing_value = await self._get(key)
+            if existing_value is not CACHE_MISS and isinstance(existing_value, dict) and isinstance(value, dict):
+                existing_value.update(value)
+                value = existing_value
+            await self._set(key, value)
 
     async def contains(self, key) -> bool:
         return key in self.cache


### PR DESCRIPTION
## Summary
- Fix `_upsert()` in `AsyncInMemoryCache` to use `_get()`/`_set()` instead of `get()`/`set()`, acquiring the lock once at the `_upsert` level
- Fix `_upsert()` in `AsyncDiskCache` to use `_set()` instead of `set()` to avoid re-acquiring the same lock

## Problem
`asyncio.Lock` is **not reentrant**. In `AsyncInMemoryCache._upsert()`, `self.get(key, lock)` acquires the lock, and then `self.set(key, value, lock)` tries to acquire the same lock again — causing a **permanent deadlock** on every `upsert()` call.

The same issue exists in `AsyncDiskCache._upsert()` where `self.set()` tries to acquire `self.lock` that's already held by the outer `upsert()` method.

## Test plan
- [ ] Verify `cache_service.upsert()` no longer deadlocks
- [ ] Verify existing cache upsert behavior (dict merge) is preserved
- [ ] Run `make unit_tests` for cache-related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized cache operations to reduce unnecessary lock overhead during update operations, improving efficiency in caching services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->