### PR TITLE
fix: correct mismatched zip in create_state_model_from_graph

### DIFF
--- a/src/lfx/src/lfx/graph/graph/state_model.py
+++ b/src/lfx/src/lfx/graph/graph/state_model.py
@@ -54,13 +54,14 @@ def create_state_model_from_graph(graph: BaseModel) -> type[BaseModel]:
             msg = f"Vertex {vertex.id} does not have a component instance."
             raise ValueError(msg)
 
-    state_model_getters = [
-        vertex.custom_component.get_state_model_instance_getter()
-        for vertex in graph.vertices
-        if hasattr(vertex, "custom_component") and hasattr(vertex.custom_component, "get_state_model_instance_getter")
-    ]
+    filtered_vertices = []
+    state_model_getters = []
+    for vertex in graph.vertices:
+        if hasattr(vertex, "custom_component") and hasattr(vertex.custom_component, "get_state_model_instance_getter"):
+            filtered_vertices.append(vertex)
+            state_model_getters.append(vertex.custom_component.get_state_model_instance_getter())
     fields = {
-        camel_to_snake(vertex.id): state_model_getter
-        for vertex, state_model_getter in zip(graph.vertices, state_model_getters, strict=False)
+        camel_to_snake(v.id): getter
+        for v, getter in zip(filtered_vertices, state_model_getters)
     }
     return create_state_model(model_name="GraphStateModel", validate=False, **fields)

--- a/src/lfx/src/lfx/graph/graph/state_model.py
+++ b/src/lfx/src/lfx/graph/graph/state_model.py
@@ -60,8 +60,5 @@ def create_state_model_from_graph(graph: BaseModel) -> type[BaseModel]:
         if hasattr(vertex, "custom_component") and hasattr(vertex.custom_component, "get_state_model_instance_getter"):
             filtered_vertices.append(vertex)
             state_model_getters.append(vertex.custom_component.get_state_model_instance_getter())
-    fields = {
-        camel_to_snake(v.id): getter
-        for v, getter in zip(filtered_vertices, state_model_getters)
-    }
+    fields = {camel_to_snake(v.id): getter for v, getter in zip(filtered_vertices, state_model_getters, strict=False)}
     return create_state_model(model_name="GraphStateModel", validate=False, **fields)


### PR DESCRIPTION
## Summary
- Build a parallel `filtered_vertices` list to ensure correct vertex-to-getter pairing in `zip()`

## Problem
```python
state_model_getters = [
    vertex.custom_component.get_state_model_instance_getter()
    for vertex in graph.vertices
    if hasattr(vertex, "custom_component") and hasattr(vertex.custom_component, "get_state_model_instance_getter")
]
fields = {
    camel_to_snake(vertex.id): state_model_getter
    for vertex, state_model_getter in zip(graph.vertices, state_model_getters, strict=False)
}
```

The list comprehension **filters** vertices (only those with `get_state_model_instance_getter`), producing fewer items than `graph.vertices`. The `zip` then pairs the filtered getters with the **unfiltered** vertices, producing a state model with fields mapped to **incorrect** component states.

## Test plan
- [ ] Test with a graph containing vertices both with and without `get_state_model_instance_getter`
- [ ] Verify state model fields map to the correct component IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the alignment of state model getters with graph vertices to ensure state associations are mapped and associated properly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->