### PR TITLE
fix: prevent StopIteration crash in update_memory_keys

### DIFF
--- a/src/backend/base/langflow/interface/run.py
+++ b/src/backend/base/langflow/interface/run.py
@@ -27,16 +27,26 @@ def update_memory_keys(langchain_object, possible_new_mem_key) -> None:
     to the possible new key.
     """
     input_key = next(
-        key
-        for key in langchain_object.input_keys
-        if key not in {langchain_object.memory.memory_key, possible_new_mem_key}
+        (
+            key
+            for key in langchain_object.input_keys
+            if key not in {langchain_object.memory.memory_key, possible_new_mem_key}
+        ),
+        None,
     )
+    if input_key is None:
+        return
 
     output_key = next(
-        key
-        for key in langchain_object.output_keys
-        if key not in {langchain_object.memory.memory_key, possible_new_mem_key}
+        (
+            key
+            for key in langchain_object.output_keys
+            if key not in {langchain_object.memory.memory_key, possible_new_mem_key}
+        ),
+        None,
     )
+    if output_key is None:
+        return
 
     for key, attr in [(input_key, "input_key"), (output_key, "output_key"), (possible_new_mem_key, "memory_key")]:
         try:


### PR DESCRIPTION
## Summary
- Add `None` default to `next()` calls in `update_memory_keys()`
- Return early when no valid input/output key is found

## Problem
`next()` without a default raises `StopIteration` if the generator produces no items. If `input_keys` or `output_keys` contains only keys that are in the exclusion set (e.g., a chain with only the memory key), this crashes with an unhandled `StopIteration`.

## Test plan
- [ ] Test with a LangChain object where `input_keys` only contains memory keys
- [ ] Verify the function returns gracefully instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory key handling to gracefully manage scenarios where expected keys are absent, preventing potential failures during memory updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->