### PR TITLE
fix: prevent silent data loss in ArizePhoenix log deduplication

### DIFF
--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -287,7 +287,7 @@ class ArizePhoenixTracer(BaseTracer):
 
         logs_dicts = [log if isinstance(log, dict) else log.model_dump() for log in logs]
         processed_logs = (
-            self._convert_to_arize_phoenix_types({log.get("name"): log for log in logs_dicts}) if logs else {}
+            self._convert_to_arize_phoenix_types({f"log_{i}_{log.get('name', '')}": log for i, log in enumerate(logs_dicts)}) if logs else {}
         )
         if processed_logs:
             child_span.set_attribute("logs", self._safe_json_dumps(processed_logs))

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -287,7 +287,11 @@ class ArizePhoenixTracer(BaseTracer):
 
         logs_dicts = [log if isinstance(log, dict) else log.model_dump() for log in logs]
         processed_logs = (
-            self._convert_to_arize_phoenix_types({f"log_{i}_{log.get('name', '')}": log for i, log in enumerate(logs_dicts)}) if logs else {}
+            self._convert_to_arize_phoenix_types(
+                {f"log_{i}_{log.get('name', '')}": log for i, log in enumerate(logs_dicts)}
+            )
+            if logs
+            else {}
         )
         if processed_logs:
             child_span.set_attribute("logs", self._safe_json_dumps(processed_logs))


### PR DESCRIPTION
## Summary
- Use a unique key per log entry instead of `log.get("name")` as the dict key

## Problem
```python
{log.get("name"): log for log in logs_dicts}
```

This dict comprehension uses log name as the key. When two logs share the same `name`, the later one **silently overwrites** the earlier one, losing trace data. Additionally, `log.get("name")` can be `None`, making `None` a dict key and grouping unrelated logs together.

## Test plan
- [ ] Verify all log entries are preserved in ArizePhoenix traces
- [ ] Verify logs with duplicate or missing names are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trace logging structure to improve consistency and reliability in tracing data collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->