### PR TITLE
fix: move validation before Metric construction in _add_metric

### DIFF
--- a/src/backend/base/langflow/services/telemetry/opentelemetry.py
+++ b/src/backend/base/langflow/services/telemetry/opentelemetry.py
@@ -115,11 +115,11 @@ class OpenTelemetry(metaclass=ThreadSafeSingletonMetaUsingWeakref):
     def _add_metric(
         self, name: str, description: str, unit: str, metric_type: MetricType, labels: dict[str, bool]
     ) -> None:
-        metric = Metric(name=name, description=description, metric_type=metric_type, unit=unit, labels=labels)
-        self._metrics_registry[name] = metric
         if labels is None or len(labels) == 0:
             msg = "Labels must be provided for the metric upon registration"
             raise ValueError(msg)
+        metric = Metric(name=name, description=description, metric_type=metric_type, unit=unit, labels=labels)
+        self._metrics_registry[name] = metric
 
     def _register_metric(self) -> None:
         """Define any custom metrics here.


### PR DESCRIPTION
## Summary
- Move the `labels` validation check before `Metric()` construction

## Problem
```python
metric = Metric(name=..., labels=labels)  # Metric.__init__ calls labels.items()
self._metrics_registry[name] = metric
if labels is None or len(labels) == 0:    # Dead code for None case!
    raise ValueError(...)
```

`Metric.__init__` executes `labels.items()` (line 75). If `labels` is `None`, this raises `AttributeError: 'NoneType' object has no attribute 'items'` **before** the validation check at line 120 is ever reached. The validation is dead code for the `None` case.

## Test plan
- [ ] Verify `_add_metric(name, desc, unit, type, None)` raises `ValueError` instead of `AttributeError`
- [ ] Verify normal metric registration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized telemetry metric validation for improved system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->