### PR TITLE
fix: prevent AttributeError from chained dict.get() in setup.py

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -68,8 +68,8 @@ def update_projects_components_with_latest_component_versions(project_data, all_
     project_data_copy = deepcopy(project_data)
 
     for node in project_data_copy.get("nodes", []):
-        node_data = node.get("data").get("node")
-        node_type = node.get("data").get("type")
+        node_data = node.get("data", {}).get("node")
+        node_type = node.get("data", {}).get("type")
 
         if node_type in all_types_dict_flat:
             latest_node = all_types_dict_flat.get(node_type)


### PR DESCRIPTION
## Summary
- Add default `{}` to `node.get("data")` calls to prevent `AttributeError` when key is missing

## Problem
```python
node_data = node.get("data").get("node")  # crashes if "data" is missing
```
`node.get("data")` returns `None` when the key doesn't exist. Calling `.get("node")` on `None` raises `AttributeError: 'NoneType' object has no attribute 'get'`.

Every other place in the same file uses the safe pattern `node.get("data", {}).get("node")` (lines 334, 346, etc.).

## Test plan
- [ ] Verify starter project loading handles nodes without "data" key gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the initial setup process that could trigger errors when node configuration data was missing, ensuring the project component update process completes successfully even with incomplete data entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->