### PR TITLE
fix(ci): force pull latest base images in release Docker builds

### DIFF
--- a/.github/workflows/docker-build-v2.yml
+++ b/.github/workflows/docker-build-v2.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -211,6 +212,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -270,6 +272,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -282,6 +285,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -334,6 +338,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           build-args: |
             LANGFLOW_IMAGE=langflowai/langflow:${{ steps.version.outputs.version }}-${{ matrix.arch }}
           file: ./docker/build_and_push_backend.Dockerfile
@@ -355,6 +360,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           build-args: |
             LANGFLOW_IMAGE=ghcr.io/langflow-ai/langflow:${{ steps.version.outputs.version }}-${{ matrix.arch }}
           file: ./docker/build_and_push_backend.Dockerfile
@@ -409,6 +415,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/frontend/build_and_push_frontend.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -428,6 +435,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/frontend/build_and_push_frontend.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -487,6 +495,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_ep.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -499,6 +508,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_ep.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -558,6 +568,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -570,6 +581,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow for Docker builds to always pull the latest base images when building and pushing multi-architecture images across all services to both Docker Hub and GHCR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->