### PR TITLE
fix(tracing): sync LangSmith environment variables with official documentation

### DIFF
--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -76,7 +76,7 @@ class LangSmithTracer(BaseTracer):
         return run_type
 
     def setup_langsmith(self) -> bool:
-        if os.getenv("LANGCHAIN_API_KEY") is None:
+        if os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY")) is None:
             return False
         try:
             from langsmith import Client
@@ -85,6 +85,7 @@ class LangSmithTracer(BaseTracer):
         except ImportError:
             logger.exception("Could not import langsmith. Please install it with `pip install langsmith`.")
             return False
+        os.environ["LANGSMITH_TRACING"] = "true"
         os.environ["LANGCHAIN_TRACING_V2"] = "true"
         return True
 

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -279,7 +279,7 @@ class TracingService(Service):
         if self.deactivated:
             return
         try:
-            project_name = project_name or os.getenv("LANGCHAIN_PROJECT", "Langflow")
+            project_name = project_name or os.getenv("LANGSMITH_PROJECT", os.getenv("LANGCHAIN_PROJECT", "Langflow"))
             trace_context = TraceContext(run_id, run_name, project_name, user_id, session_id, flow_id)
             trace_context_var.set(trace_context)
             await self._start(trace_context)
@@ -452,7 +452,7 @@ class TracingService(Service):
     @property
     def project_name(self):
         if self.deactivated:
-            return os.getenv("LANGCHAIN_PROJECT", "Langflow")
+            return os.getenv("LANGSMITH_PROJECT", os.getenv("LANGCHAIN_PROJECT", "Langflow"))
         trace_context = trace_context_var.get()
         if trace_context is None:
             msg = "called project_name but no trace context found"

--- a/src/backend/tests/unit/services/tracing/test_langsmith_env_vars.py
+++ b/src/backend/tests/unit/services/tracing/test_langsmith_env_vars.py
@@ -1,0 +1,159 @@
+"""Tests to verify LangSmith tracing configuration, fallback, and precedence.
+
+These tests verify that LangSmithTracer and TracingService handle environment
+variables (like LANGSMITH_API_KEY, LANGSMITH_PROJECT, LANGSMITH_TRACING) in
+accordance with precedence and fallback behavior.
+"""
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langflow.services.tracing.langsmith import LangSmithTracer
+from langflow.services.tracing.service import (
+    TracingService,
+    trace_context_var,
+)
+from lfx.services.settings.base import Settings
+from lfx.services.settings.service import SettingsService
+
+
+@pytest.fixture
+def mock_settings_service():
+    """Create a mock settings service for TracingService initialization."""
+    settings = Settings()
+    settings.deactivate_tracing = False
+    return SettingsService(settings, MagicMock())
+
+
+@pytest.fixture
+def tracing_service(mock_settings_service):
+    """Initialize TracingService with mock settings."""
+    return TracingService(mock_settings_service)
+
+
+@pytest.fixture
+def stop_tracer_initialization():
+    """Mock TracingService._start to raise an exception, preventing tracer initialization."""
+    with patch.object(TracingService, "_start", side_effect=RuntimeError("Stop initialization")):
+        yield
+
+
+@pytest.fixture
+def clear_trace_context():
+    """Ensure trace_context_var is cleared even if a test assertion fails."""
+    yield
+    trace_context_var.set(None)
+
+
+class TestLangSmithConfiguration:
+    """Verify setup_langsmith environment variable precedence and tracing injection."""
+
+    @pytest.fixture
+    def mock_tracer(self):
+        """Fixture providing an uninitialized LangSmithTracer.
+
+        Consider changing setup_langsmith to a @staticmethod if it doesn't use self.
+        """
+        return LangSmithTracer.__new__(LangSmithTracer)
+
+    def test_setup_langsmith_no_keys(self, mock_tracer):
+        """Verify setup_langsmith returns False when no API keys are present in the environment."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert mock_tracer.setup_langsmith() is False
+
+    def test_setup_langsmith_with_langsmith_key(self, mock_tracer):
+        """Verify setup_langsmith succeeds and injects variables when only LANGSMITH_API_KEY is present."""
+        with patch.dict(os.environ, {"LANGSMITH_API_KEY": "smith-key"}, clear=True), patch(
+            "langsmith.Client", MagicMock()
+        ):
+            assert mock_tracer.setup_langsmith() is True
+            assert os.environ.get("LANGSMITH_TRACING") == "true"
+            assert os.environ.get("LANGCHAIN_TRACING_V2") == "true"
+
+    def test_setup_langsmith_with_langchain_key_fallback(self, mock_tracer):
+        """Verify setup_langsmith succeeds and injects variables when only LANGCHAIN_API_KEY is present."""
+        with patch.dict(os.environ, {"LANGCHAIN_API_KEY": "chain-key"}, clear=True), patch(
+            "langsmith.Client", MagicMock()
+        ):
+            assert mock_tracer.setup_langsmith() is True
+            assert os.environ.get("LANGSMITH_TRACING") == "true"
+            assert os.environ.get("LANGCHAIN_TRACING_V2") == "true"
+
+    def test_setup_langsmith_api_key_precedence(self, mock_tracer):
+        """Verify setup_langsmith gives precedence to LANGSMITH_API_KEY when both keys are present."""
+        with patch.dict(
+            os.environ,
+            {"LANGSMITH_API_KEY": "smith-priority-key", "LANGCHAIN_API_KEY": "chain-fallback-key"},
+            clear=True,
+        ), patch("langsmith.Client", MagicMock()):
+            assert mock_tracer.setup_langsmith() is True
+            assert os.getenv("LANGSMITH_API_KEY") == "smith-priority-key"
+
+
+class TestTracingServiceProjectName:
+    """Verify TracingService resolves LANGSMITH_PROJECT with fallback to LANGCHAIN_PROJECT."""
+
+    def test_tracing_service_project_name_deactivated_defaults(self, mock_settings_service):
+        """Verify TracingService project_name defaults to 'Langflow' when tracing is deactivated and env is empty."""
+        mock_settings_service.settings.deactivate_tracing = True
+        ts = TracingService(mock_settings_service)
+        with patch.dict(os.environ, {}, clear=True):
+            assert ts.project_name == "Langflow"
+
+    def test_tracing_service_project_name_deactivated_langchain_fallback(self, mock_settings_service):
+        """Verify TracingService project_name falls back to LANGCHAIN_PROJECT when tracing is deactivated."""
+        mock_settings_service.settings.deactivate_tracing = True
+        ts = TracingService(mock_settings_service)
+        with patch.dict(os.environ, {"LANGCHAIN_PROJECT": "fallback-project"}, clear=True):
+            assert ts.project_name == "fallback-project"
+
+    def test_tracing_service_project_name_deactivated_langsmith_priority(self, mock_settings_service):
+        """Verify TracingService project_name prioritizes LANGSMITH_PROJECT over LANGCHAIN_PROJECT."""
+        mock_settings_service.settings.deactivate_tracing = True
+        ts = TracingService(mock_settings_service)
+        with patch.dict(
+            os.environ, {"LANGSMITH_PROJECT": "smith-project", "LANGCHAIN_PROJECT": "chain-project"}, clear=True
+        ):
+            assert ts.project_name == "smith-project"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("stop_tracer_initialization", "clear_trace_context")
+    async def test_start_tracers_project_name_defaults(self, tracing_service):
+        """Verify start_tracers sets project_name to 'Langflow' by default when tracing is active."""
+        run_id = uuid.uuid4()
+        with patch.dict(os.environ, {}, clear=True):
+            await tracing_service.start_tracers(run_id, "test_run", "test_user", "test_session", project_name=None)
+            assert tracing_service.project_name == "Langflow"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("stop_tracer_initialization", "clear_trace_context")
+    async def test_start_tracers_project_name_langchain_fallback(self, tracing_service):
+        """Verify start_tracers sets project_name to LANGCHAIN_PROJECT when active."""
+        run_id = uuid.uuid4()
+        with patch.dict(os.environ, {"LANGCHAIN_PROJECT": "fallback-project"}, clear=True):
+            await tracing_service.start_tracers(run_id, "test_run", "test_user", "test_session", project_name=None)
+            assert tracing_service.project_name == "fallback-project"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("stop_tracer_initialization", "clear_trace_context")
+    async def test_start_tracers_project_name_langsmith_priority(self, tracing_service):
+        """Verify start_tracers prioritizes LANGSMITH_PROJECT over LANGCHAIN_PROJECT when active."""
+        run_id = uuid.uuid4()
+        with patch.dict(
+            os.environ, {"LANGSMITH_PROJECT": "smith-project", "LANGCHAIN_PROJECT": "chain-project"}, clear=True
+        ):
+            await tracing_service.start_tracers(run_id, "test_run", "test_user", "test_session", project_name=None)
+            assert tracing_service.project_name == "smith-project"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("stop_tracer_initialization", "clear_trace_context")
+    async def test_start_tracers_project_name_explicit_param(self, tracing_service):
+        """Verify start_tracers explicit parameter overrides all environment variables."""
+        run_id = uuid.uuid4()
+        with patch.dict(os.environ, {"LANGSMITH_PROJECT": "smith-project"}, clear=True):
+            await tracing_service.start_tracers(
+                run_id, "test_run", "test_user", "test_session", project_name="explicit-project"
+            )
+            assert tracing_service.project_name == "explicit-project"


### PR DESCRIPTION
## Summary
Langflow's tracing service was strictly looking for legacy `LANGCHAIN_` environment variables, causing a fragmented tracing experience for users following the current official documentation (which uses `LANGSMITH_`). When only `LANGSMITH_API_KEY` is set, Langflow's custom `LangSmithTracer` fails to initialize. However, the underlying LangChain LLM components natively recognize the key and trigger their own tracing, resulting in isolated LLM traces without the overall Langflow graph context. 

This PR updates the tracing initialization to prioritize `LANGSMITH_` variables with a fallback to legacy `LANGCHAIN_` variables, ensuring full compatibility with both the official documentation and existing configurations.

## What changed
* `src/backend/base/langflow/services/tracing/langsmith.py`: `setup_langsmith` now checks for `LANGSMITH_API_KEY` first, falling back to `LANGCHAIN_API_KEY`. It also injects `LANGSMITH_TRACING=true` for latest SDK compatibility.
* `src/backend/base/langflow/services/tracing/service.py`: `TracingService.start_tracers` and the `project_name` property now prioritize `LANGSMITH_PROJECT` over `LANGCHAIN_PROJECT` before defaulting to `"Langflow"`.
* `src/backend/tests/unit/services/tracing/test_langsmith_env_vars.py`: Added comprehensive unit tests explicitly verifying the environment variable precedence and fallback logic.

## Verification
End-to-end testing confirms that using only `LANGSMITH_` configs successfully activates the Langflow tracer, captures the entire graph (not just the LLM), and routes it to the specified project. The fallback mechanism was also tested and works perfectly without breaking existing setups. Unit tests explicitly cover the `patch.dict(os.environ)` logic for API keys and project names.

**Tested Flow:**
<img width="1219" height="491" alt="flow" src="https://github.com/user-attachments/assets/a4e36123-966b-4227-9af3-017bd90b4a3d" />


**Before (Bug):** Langflow tracer is deactivated. Only the LLM component trace is logged independently.
<img width="388" height="131" alt="before" src="https://github.com/user-attachments/assets/a28f6c9b-5f80-48d8-a445-fd1cc0b4731a" />


**After (Fix):** Langflow tracer is properly activated, capturing the entire graph structure.
<img width="381" height="258" alt="after" src="https://github.com/user-attachments/assets/f77d615f-5f0e-43c6-bf8c-1dc4ce742eb3" />


## Related Issues
N/A

## Notes
* This is a resubmission of `#13119`, which was automatically closed due to the deletion of the `release-1.9.3` base branch during the recent release. Retargeted to `release-1.10.0` and included the unit tests requested by the AI reviewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LangSmith tracing configuration with improved environment variable precedence handling for API keys and project name resolution.

* **Tests**
  * Added comprehensive test coverage for tracing environment variable configuration and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->