### PR TITLE
fix(tracing): forward request body user_id to Langfuse trace

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3965,7 +3965,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "1230f71eec8a61a625a18b6fa03b9bdd046a8931",
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 414,
         "is_secret": false
       },
       {
@@ -3973,7 +3973,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "2d63069839e1cab99da0a0bbbbeb8f2ceb455cc8",
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 415,
         "is_secret": false
       },
       {
@@ -3981,7 +3981,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "3b96880b8e11758bbf9796b9cd90aaa3ab4bab6e",
         "is_verified": false,
-        "line_number": 373,
+        "line_number": 416,
         "is_secret": false
       }
     ],
@@ -9031,5 +9031,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-21T02:37:45Z"
+  "generated_at": "2026-05-21T17:18:56Z"
 }

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -94,6 +94,7 @@ _SIMPLIFIED_API_FORM_FIELDS = (
     "output_type",
     "output_component",
     "session_id",
+    "user_id",
 )
 
 
@@ -242,6 +243,11 @@ async def simple_run_flow(
         graph = Graph.from_payload(
             graph_data, flow_id=flow_id_str, user_id=str(user_id), flow_name=flow.name, context=context
         )
+        # Forward the caller-supplied identifier to tracing providers without
+        # affecting authn/authz. The API-key owner remains the effective user
+        # for permissions, global variables, and job ownership.
+        if input_request.user_id:
+            graph.tracing_user_id = input_request.user_id
         run_id_uuid = uuid4() if run_id is None else UUID(run_id)
         run_id = str(run_id_uuid)
         graph.set_run_id(run_id)

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -353,6 +353,14 @@ class SimplifiedAPIRequest(BaseModel):
     )
     tweaks: Tweaks | None = Field(default=None, description="The tweaks")
     session_id: str | None = Field(default=None, description="The session id")
+    user_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional end-user identifier forwarded to tracing providers (e.g. Langfuse) "
+            "as the trace's user_id. Does not affect authentication or authorization — the "
+            "API key owner remains the effective Langflow user."
+        ),
+    )
 
 
 # (alias) type ReactFlowJsonObject<NodeData = any, EdgeData = any> = {

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -171,17 +171,19 @@ class LangFuseTracer(BaseTracer):
         trace_id: UUID,
         user_id: str | None = None,
         session_id: str | None = None,
-        auth_user_id: str | None = None,
+        tracing_user_id: str | None = None,
     ) -> None:
         self.project_name = project_name
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.trace_id = trace_id
+        # ``user_id`` remains the authenticated Langflow user for backwards
+        # compatibility. ``tracing_user_id`` is an optional caller-supplied
+        # label; when set it overrides ``user_id`` only for the Langfuse trace
+        # label (``trace.userId``), and ``user_id`` is stamped into trace
+        # metadata so consumers can still recover the auth identity.
         self.user_id = user_id
-        # The authenticated Langflow user — preserved as trace metadata so
-        # downstream consumers can recover it even when ``user_id`` carries a
-        # caller-supplied label (e.g. an end-user identifier).
-        self.auth_user_id = auth_user_id
+        self.tracing_user_id = tracing_user_id
         self.session_id = session_id
         self.flow_id = trace_name.split(" - ")[-1]
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
@@ -228,17 +230,19 @@ class LangFuseTracer(BaseTracer):
                 metadata={"flow_id": self.flow_id, "project_name": self.project_name},
             )
 
-            # Set trace-level metadata (user_id, session_id). When the caller
-            # supplied a tracing label distinct from the auth user, stamp the
-            # auth user under ``langflow.auth_user_id`` so consumers that need
-            # the original Langflow user can still recover it.
+            # ``trace.userId`` reflects the caller-supplied tracing label when
+            # provided so the Langfuse "Users" tab groups by end-user. When the
+            # override is in effect, stamp the auth identity under
+            # ``langflow.auth_user_id`` so consumers that need the original
+            # Langflow user can still recover it from trace metadata.
+            effective_user_id = self.tracing_user_id or self.user_id
             trace_kwargs: dict[str, Any] = {
                 "name": self.flow_id,
-                "user_id": self.user_id,
+                "user_id": effective_user_id,
                 "session_id": self.session_id,
             }
-            if self.auth_user_id and self.auth_user_id != self.user_id:
-                trace_kwargs["metadata"] = {"langflow.auth_user_id": self.auth_user_id}
+            if self.tracing_user_id and self.user_id and self.tracing_user_id != self.user_id:
+                trace_kwargs["metadata"] = {"langflow.auth_user_id": self.user_id}
             self._root_span.update_trace(**trace_kwargs)
 
         except ImportError:

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -177,11 +177,11 @@ class LangFuseTracer(BaseTracer):
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.trace_id = trace_id
-        # ``user_id`` remains the authenticated Langflow user for backwards
-        # compatibility. ``tracing_user_id`` is an optional caller-supplied
-        # label; when set it overrides ``user_id`` only for the Langfuse trace
-        # label (``trace.userId``), and ``user_id`` is stamped into trace
-        # metadata so consumers can still recover the auth identity.
+        # ``user_id`` remains the authenticated Langflow user and drives
+        # ``trace.userId`` unchanged from pre-#9505 behavior. ``tracing_user_id``
+        # is an optional caller-supplied label; when set, it is stamped into
+        # trace metadata as ``langflow.tracing_user_id`` so consumers can still
+        # access the override without redefining ``trace.userId``.
         self.user_id = user_id
         self.tracing_user_id = tracing_user_id
         self.session_id = session_id
@@ -230,19 +230,18 @@ class LangFuseTracer(BaseTracer):
                 metadata={"flow_id": self.flow_id, "project_name": self.project_name},
             )
 
-            # ``trace.userId`` reflects the caller-supplied tracing label when
-            # provided so the Langfuse "Users" tab groups by end-user. When the
-            # override is in effect, stamp the auth identity under
-            # ``langflow.auth_user_id`` so consumers that need the original
-            # Langflow user can still recover it from trace metadata.
-            effective_user_id = self.tracing_user_id or self.user_id
+            # ``trace.userId`` stays the authenticated Langflow user so existing
+            # Langfuse consumers keep getting the same identity. When a caller
+            # provides an override via ``tracing_user_id``, stamp it under
+            # ``langflow.tracing_user_id`` so it is still recoverable from trace
+            # metadata without changing the meaning of ``trace.userId``.
             trace_kwargs: dict[str, Any] = {
                 "name": self.flow_id,
-                "user_id": effective_user_id,
+                "user_id": self.user_id,
                 "session_id": self.session_id,
             }
-            if self.tracing_user_id and self.user_id and self.tracing_user_id != self.user_id:
-                trace_kwargs["metadata"] = {"langflow.auth_user_id": self.user_id}
+            if self.tracing_user_id and self.tracing_user_id != self.user_id:
+                trace_kwargs["metadata"] = {"langflow.tracing_user_id": self.tracing_user_id}
             self._root_span.update_trace(**trace_kwargs)
 
         except ImportError:

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -171,12 +171,17 @@ class LangFuseTracer(BaseTracer):
         trace_id: UUID,
         user_id: str | None = None,
         session_id: str | None = None,
+        auth_user_id: str | None = None,
     ) -> None:
         self.project_name = project_name
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.trace_id = trace_id
         self.user_id = user_id
+        # The authenticated Langflow user — preserved as trace metadata so
+        # downstream consumers can recover it even when ``user_id`` carries a
+        # caller-supplied label (e.g. an end-user identifier).
+        self.auth_user_id = auth_user_id
         self.session_id = session_id
         self.flow_id = trace_name.split(" - ")[-1]
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
@@ -223,12 +228,18 @@ class LangFuseTracer(BaseTracer):
                 metadata={"flow_id": self.flow_id, "project_name": self.project_name},
             )
 
-            # Set trace-level metadata (user_id, session_id)
-            self._root_span.update_trace(
-                name=self.flow_id,
-                user_id=self.user_id,
-                session_id=self.session_id,
-            )
+            # Set trace-level metadata (user_id, session_id). When the caller
+            # supplied a tracing label distinct from the auth user, stamp the
+            # auth user under ``langflow.auth_user_id`` so consumers that need
+            # the original Langflow user can still recover it.
+            trace_kwargs: dict[str, Any] = {
+                "name": self.flow_id,
+                "user_id": self.user_id,
+                "session_id": self.session_id,
+            }
+            if self.auth_user_id and self.auth_user_id != self.user_id:
+                trace_kwargs["metadata"] = {"langflow.auth_user_id": self.auth_user_id}
+            self._root_span.update_trace(**trace_kwargs)
 
         except ImportError:
             logger.exception("Could not import langfuse. Please install it with `pip install langfuse`.")

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -194,17 +194,18 @@ class TracingService(Service):
         if self.deactivated:
             return
         langfuse_tracer = _get_langfuse_tracer()
-        # ``user_id`` carries the caller-supplied tracing label when supplied so
-        # the Langfuse "Users" tab groups by end-user. The original auth identity
-        # is forwarded separately and stamped into trace metadata.
+        # ``user_id`` carries the authenticated Langflow user (unchanged from
+        # pre-#9505 behavior for backwards compatibility). ``tracing_user_id``
+        # is the optional caller-supplied override; LangFuseTracer reconciles
+        # them when populating the actual trace fields.
         trace_context.tracers["langfuse"] = langfuse_tracer(
             trace_name=trace_context.run_name,
             trace_type="chain",
             project_name=trace_context.project_name,
             trace_id=trace_context.run_id,
-            user_id=trace_context.tracing_user_id or trace_context.user_id,
+            user_id=trace_context.user_id,
             session_id=trace_context.session_id,
-            auth_user_id=trace_context.user_id,
+            tracing_user_id=trace_context.tracing_user_id,
         )
 
     def _initialize_arize_phoenix_tracer(self, trace_context: TraceContext) -> None:

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -84,11 +84,17 @@ class TraceContext:
         user_id: str | None,
         session_id: str | None,
         flow_id: str | None = None,
+        tracing_user_id: str | None = None,
     ):
         self.run_id: UUID | None = run_id
         self.run_name: str | None = run_name
         self.project_name: str | None = project_name
+        # ``user_id`` is the authenticated Langflow user (e.g. API-key owner).
+        # ``tracing_user_id`` is an optional caller-supplied label used solely
+        # by tracing providers as the trace's user_id; ``user_id`` is preserved
+        # so the auth identity can be stamped into trace metadata.
         self.user_id: str | None = user_id
+        self.tracing_user_id: str | None = tracing_user_id
         self.session_id: str | None = session_id
         self.flow_id: str | None = flow_id
         self.tracers: dict[str, BaseTracer] = {}
@@ -188,13 +194,17 @@ class TracingService(Service):
         if self.deactivated:
             return
         langfuse_tracer = _get_langfuse_tracer()
+        # ``user_id`` carries the caller-supplied tracing label when supplied so
+        # the Langfuse "Users" tab groups by end-user. The original auth identity
+        # is forwarded separately and stamped into trace metadata.
         trace_context.tracers["langfuse"] = langfuse_tracer(
             trace_name=trace_context.run_name,
             trace_type="chain",
             project_name=trace_context.project_name,
             trace_id=trace_context.run_id,
-            user_id=trace_context.user_id,
+            user_id=trace_context.tracing_user_id or trace_context.user_id,
             session_id=trace_context.session_id,
+            auth_user_id=trace_context.user_id,
         )
 
     def _initialize_arize_phoenix_tracer(self, trace_context: TraceContext) -> None:
@@ -269,18 +279,32 @@ class TracingService(Service):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        tracing_user_id: str | None = None,
     ) -> None:
         """Start a trace for a graph run.
 
         - create a trace context
         - start a worker for this trace context
         - initialize the tracers
+
+        ``user_id`` is the authenticated Langflow user (e.g. API-key owner).
+        ``tracing_user_id`` is an optional caller-supplied label forwarded to
+        tracing providers; when set it takes precedence over ``user_id`` for
+        trace labels while ``user_id`` is preserved for metadata stamping.
         """
         if self.deactivated:
             return
         try:
             project_name = project_name or os.getenv("LANGCHAIN_PROJECT", "Langflow")
-            trace_context = TraceContext(run_id, run_name, project_name, user_id, session_id, flow_id)
+            trace_context = TraceContext(
+                run_id,
+                run_name,
+                project_name,
+                user_id,
+                session_id,
+                flow_id,
+                tracing_user_id=tracing_user_id,
+            )
             trace_context_var.set(trace_context)
             await self._start(trace_context)
             self._initialize_langsmith_tracer(trace_context)

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -89,10 +89,11 @@ class TraceContext:
         self.run_id: UUID | None = run_id
         self.run_name: str | None = run_name
         self.project_name: str | None = project_name
-        # ``user_id`` is the authenticated Langflow user (e.g. API-key owner).
-        # ``tracing_user_id`` is an optional caller-supplied label used solely
-        # by tracing providers as the trace's user_id; ``user_id`` is preserved
-        # so the auth identity can be stamped into trace metadata.
+        # ``user_id`` is the authenticated Langflow user (e.g. API-key owner)
+        # and drives ``trace.userId`` for tracing providers. ``tracing_user_id``
+        # is an optional caller-supplied label that providers surface separately
+        # (e.g. LangFuseTracer stamps it into trace metadata as
+        # ``langflow.tracing_user_id``).
         self.user_id: str | None = user_id
         self.tracing_user_id: str | None = tracing_user_id
         self.session_id: str | None = session_id
@@ -194,10 +195,10 @@ class TracingService(Service):
         if self.deactivated:
             return
         langfuse_tracer = _get_langfuse_tracer()
-        # ``user_id`` carries the authenticated Langflow user (unchanged from
-        # pre-#9505 behavior for backwards compatibility). ``tracing_user_id``
-        # is the optional caller-supplied override; LangFuseTracer reconciles
-        # them when populating the actual trace fields.
+        # ``user_id`` carries the authenticated Langflow user and drives
+        # ``trace.userId`` (unchanged from pre-#9505 behavior for backwards
+        # compatibility). ``tracing_user_id`` is the optional caller-supplied
+        # label that LangFuseTracer stamps into trace metadata.
         trace_context.tracers["langfuse"] = langfuse_tracer(
             trace_name=trace_context.run_name,
             trace_type="chain",
@@ -288,10 +289,11 @@ class TracingService(Service):
         - start a worker for this trace context
         - initialize the tracers
 
-        ``user_id`` is the authenticated Langflow user (e.g. API-key owner).
-        ``tracing_user_id`` is an optional caller-supplied label forwarded to
-        tracing providers; when set it takes precedence over ``user_id`` for
-        trace labels while ``user_id`` is preserved for metadata stamping.
+        ``user_id`` is the authenticated Langflow user (e.g. API-key owner)
+        and drives ``trace.userId`` for tracing providers. ``tracing_user_id``
+        is an optional caller-supplied label forwarded to providers, which
+        surface it separately (e.g. LangFuseTracer stamps it into trace metadata
+        as ``langflow.tracing_user_id``).
         """
         if self.deactivated:
             return

--- a/src/backend/tests/unit/api/v1/test_parse_input_request_from_body.py
+++ b/src/backend/tests/unit/api/v1/test_parse_input_request_from_body.py
@@ -64,6 +64,45 @@ async def test_multipart_form_data_preserves_session_id_and_input(parser_client:
 
 
 @pytest.mark.asyncio
+async def test_json_body_preserves_user_id(parser_client: AsyncClient):
+    """JSON body ``user_id`` must round-trip into ``SimplifiedAPIRequest`` (regression for #9505)."""
+    async with parser_client as client:
+        response = await client.post(
+            "/parse",
+            json={
+                "input_value": "What are the recommendations for this user?",
+                "user_id": "test123",
+                "session_id": "api-test-final",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["user_id"] == "test123"
+    assert payload["session_id"] == "api-test-final"
+
+
+@pytest.mark.asyncio
+async def test_multipart_form_data_preserves_user_id(parser_client: AsyncClient):
+    """Multipart form fields must map ``user_id`` onto ``SimplifiedAPIRequest`` (regression for #9505)."""
+    async with parser_client as client:
+        response = await client.post(
+            "/parse",
+            data={
+                "input_value": "hello",
+                "user_id": "test123",
+                "session_id": "api-test-final",
+            },
+            files={"file": ("a.bin", io.BytesIO(b"bytes"), "application/octet-stream")},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["user_id"] == "test123"
+    assert payload["session_id"] == "api-test-final"
+
+
+@pytest.mark.asyncio
 async def test_multipart_tweaks_parsed_as_json(parser_client: AsyncClient):
     tweaks = {"some-component-id": {"input_value": "abc"}}
 

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
@@ -192,6 +192,66 @@ class TestLangfuseTracerFunctionality:
         # Should set trace metadata via update_trace
         mock_langfuse["root_span"].update_trace.assert_called()
 
+    def test_trace_user_id_uses_auth_user_when_no_tracing_override(self, mock_langfuse):
+        """``trace.userId`` should be the authenticated Langflow user (pre-#9505 behavior)."""
+        from langflow.services.tracing.langfuse import LangFuseTracer
+
+        LangFuseTracer(
+            trace_name="test-flow - flow-123",
+            trace_type="chain",
+            project_name="test-project",
+            trace_id=uuid.uuid4(),
+            user_id="auth-user",
+            session_id="session-1",
+        )
+
+        update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
+        assert update_kwargs["user_id"] == "auth-user"
+        # No override → no metadata payload was supplied for the override.
+        assert "metadata" not in update_kwargs
+
+    def test_trace_user_id_stays_auth_user_and_override_goes_to_metadata(self, mock_langfuse):
+        """``tracing_user_id`` must not redefine ``trace.userId``; it is stamped in metadata.
+
+        Regression for GitHub issue #9505 / PR #13266 review: external Langfuse
+        consumers depend on ``trace.userId`` continuing to mean the authenticated
+        Langflow user. The caller-supplied override surfaces as
+        ``metadata.langflow.tracing_user_id`` instead.
+        """
+        from langflow.services.tracing.langfuse import LangFuseTracer
+
+        LangFuseTracer(
+            trace_name="test-flow - flow-123",
+            trace_type="chain",
+            project_name="test-project",
+            trace_id=uuid.uuid4(),
+            user_id="auth-user",
+            session_id="session-1",
+            tracing_user_id="end-user-456",
+        )
+
+        update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
+        assert update_kwargs["user_id"] == "auth-user"
+        assert update_kwargs["metadata"] == {"langflow.tracing_user_id": "end-user-456"}
+
+    def test_tracing_user_id_equal_to_auth_user_is_not_stamped(self, mock_langfuse):
+        """When the override matches the auth user there is nothing extra to record."""
+        from langflow.services.tracing.langfuse import LangFuseTracer
+
+        LangFuseTracer(
+            trace_name="test-flow - flow-123",
+            trace_type="chain",
+            project_name="test-project",
+            trace_id=uuid.uuid4(),
+            user_id="same-user",
+            session_id="session-1",
+            tracing_user_id="same-user",
+        )
+
+        update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
+        assert update_kwargs["user_id"] == "same-user"
+        assert "metadata" not in update_kwargs
+
     def test_add_trace_creates_child_span(self, mock_langfuse):
         """Test that add_trace creates a child span using v3 API."""
         from langflow.services.tracing.langfuse import LangFuseTracer

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -214,8 +214,8 @@ async def test_start_tracers_forwards_tracing_user_id_to_langfuse(tracing_servic
 
     Regression for GitHub issue #9505: the LangFuseTracer keeps ``user_id`` as
     the authenticated Langflow user (backwards compat) and exposes the override
-    on ``tracing_user_id``. Merge into ``trace.userId`` happens inside the
-    tracer when calling the Langfuse SDK.
+    on ``tracing_user_id``. The tracer stamps the override into trace metadata
+    rather than redefining ``trace.userId``.
     """
     run_id = uuid.uuid4()
     await tracing_service.start_tracers(

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -24,7 +24,7 @@ class MockTracer(BaseTracer):
         flow_id: str | None = None,
         user_id: str | None = None,
         session_id: str | None = None,
-        auth_user_id: str | None = None,
+        tracing_user_id: str | None = None,
     ) -> None:
         self.trace_name = trace_name
         self.trace_type = trace_type
@@ -33,7 +33,7 @@ class MockTracer(BaseTracer):
         self.flow_id = flow_id
         self.user_id = user_id
         self.session_id = session_id
-        self.auth_user_id = auth_user_id
+        self.tracing_user_id = tracing_user_id
         self._ready = True
         self.end_called = False
         self.get_langchain_callback_called = False
@@ -210,10 +210,12 @@ async def test_start_end_tracers(tracing_service):
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_tracers")
 async def test_start_tracers_forwards_tracing_user_id_to_langfuse(tracing_service):
-    """``tracing_user_id`` overrides the trace label; ``user_id`` becomes ``auth_user_id``.
+    """``tracing_user_id`` reaches Langfuse as a distinct field; ``user_id`` stays the auth user.
 
-    Regression for GitHub issue #9505: trace.userId should reflect the
-    caller-supplied identifier while the auth user remains recoverable.
+    Regression for GitHub issue #9505: the LangFuseTracer keeps ``user_id`` as
+    the authenticated Langflow user (backwards compat) and exposes the override
+    on ``tracing_user_id``. Merge into ``trace.userId`` happens inside the
+    tracer when calling the Langfuse SDK.
     """
     run_id = uuid.uuid4()
     await tracing_service.start_tracers(
@@ -227,25 +229,23 @@ async def test_start_tracers_forwards_tracing_user_id_to_langfuse(tracing_servic
 
     trace_context = trace_context_var.get()
     langfuse = trace_context.tracers["langfuse"]
-    # Langfuse receives the override as its user_id (the trace's userId field)
-    # and the auth identity is preserved separately for metadata stamping.
-    assert langfuse.user_id == "end-user-123"
-    assert langfuse.auth_user_id == "auth-uuid"
-    # The shared trace context still records the auth user under user_id.
+    assert langfuse.user_id == "auth-uuid"
+    assert langfuse.tracing_user_id == "end-user-123"
+    # The shared trace context mirrors the same separation.
     assert trace_context.user_id == "auth-uuid"
     assert trace_context.tracing_user_id == "end-user-123"
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_tracers")
-async def test_start_tracers_without_override_keeps_auth_user_as_label(tracing_service):
-    """Without an override, Langfuse keeps using the auth user as the trace label."""
+async def test_start_tracers_without_override_keeps_auth_user_and_no_tracing_user_id(tracing_service):
+    """Without an override, ``user_id`` is the auth user and ``tracing_user_id`` is None."""
     run_id = uuid.uuid4()
     await tracing_service.start_tracers(run_id, "run", "auth-uuid", "session-abc", "project")
 
     langfuse = trace_context_var.get().tracers["langfuse"]
     assert langfuse.user_id == "auth-uuid"
-    assert langfuse.auth_user_id == "auth-uuid"
+    assert langfuse.tracing_user_id is None
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -24,6 +24,7 @@ class MockTracer(BaseTracer):
         flow_id: str | None = None,
         user_id: str | None = None,
         session_id: str | None = None,
+        auth_user_id: str | None = None,
     ) -> None:
         self.trace_name = trace_name
         self.trace_type = trace_type
@@ -32,6 +33,7 @@ class MockTracer(BaseTracer):
         self.flow_id = flow_id
         self.user_id = user_id
         self.session_id = session_id
+        self.auth_user_id = auth_user_id
         self._ready = True
         self.end_called = False
         self.get_langchain_callback_called = False
@@ -203,6 +205,47 @@ async def test_start_end_tracers(tracing_service):
     # Verify worker_task is cancelled
     assert trace_context.worker_task is None
     assert not trace_context.running
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tracers")
+async def test_start_tracers_forwards_tracing_user_id_to_langfuse(tracing_service):
+    """``tracing_user_id`` overrides the trace label; ``user_id`` becomes ``auth_user_id``.
+
+    Regression for GitHub issue #9505: trace.userId should reflect the
+    caller-supplied identifier while the auth user remains recoverable.
+    """
+    run_id = uuid.uuid4()
+    await tracing_service.start_tracers(
+        run_id,
+        "run",
+        "auth-uuid",
+        "session-abc",
+        "project",
+        tracing_user_id="end-user-123",
+    )
+
+    trace_context = trace_context_var.get()
+    langfuse = trace_context.tracers["langfuse"]
+    # Langfuse receives the override as its user_id (the trace's userId field)
+    # and the auth identity is preserved separately for metadata stamping.
+    assert langfuse.user_id == "end-user-123"
+    assert langfuse.auth_user_id == "auth-uuid"
+    # The shared trace context still records the auth user under user_id.
+    assert trace_context.user_id == "auth-uuid"
+    assert trace_context.tracing_user_id == "end-user-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tracers")
+async def test_start_tracers_without_override_keeps_auth_user_as_label(tracing_service):
+    """Without an override, Langfuse keeps using the auth user as the trace label."""
+    run_id = uuid.uuid4()
+    await tracing_service.start_tracers(run_id, "run", "auth-uuid", "session-abc", "project")
+
+    langfuse = trace_context_var.get().tracers["langfuse"]
+    assert langfuse.user_id == "auth-uuid"
+    assert langfuse.auth_user_id == "auth-uuid"
 
 
 @pytest.mark.asyncio

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -91,9 +91,10 @@ class Graph:
         self.flow_name = flow_name
         self.description = description
         self.user_id = user_id
-        # Optional override forwarded to tracing providers as the trace's user_id.
-        # Distinct from self.user_id so request-supplied identifiers can label
-        # external traces (e.g. Langfuse) without leaking into authn/authz paths.
+        # Optional caller-supplied label forwarded to tracing providers. Kept
+        # distinct from ``self.user_id`` so request-supplied identifiers can be
+        # surfaced in external traces (e.g. Langfuse trace metadata) without
+        # leaking into authn/authz paths.
         self.tracing_user_id: str | None = None
         self._is_input_vertices: list[str] = []
         self._is_output_vertices: list[str] = []

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -676,9 +676,10 @@ class Graph:
             await self.tracing_service.start_tracers(
                 run_id=uuid.UUID(self._run_id),
                 run_name=run_name,
-                user_id=self.tracing_user_id or self.user_id,
+                user_id=self.user_id,
                 session_id=self.session_id,
                 flow_id=self.flow_id,
+                tracing_user_id=self.tracing_user_id,
             )
 
     def _end_all_traces_async(self, outputs: dict[str, Any] | None = None, error: Exception | None = None) -> None:

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -91,6 +91,10 @@ class Graph:
         self.flow_name = flow_name
         self.description = description
         self.user_id = user_id
+        # Optional override forwarded to tracing providers as the trace's user_id.
+        # Distinct from self.user_id so request-supplied identifiers can label
+        # external traces (e.g. Langfuse) without leaking into authn/authz paths.
+        self.tracing_user_id: str | None = None
         self._is_input_vertices: list[str] = []
         self._is_output_vertices: list[str] = []
         self._is_state_vertices: list[str] | None = None
@@ -672,7 +676,7 @@ class Graph:
             await self.tracing_service.start_tracers(
                 run_id=uuid.UUID(self._run_id),
                 run_name=run_name,
-                user_id=self.user_id,
+                user_id=self.tracing_user_id or self.user_id,
                 session_id=self.session_id,
                 flow_id=self.flow_id,
             )

--- a/src/lfx/src/lfx/services/tracing/base.py
+++ b/src/lfx/src/lfx/services/tracing/base.py
@@ -37,16 +37,21 @@ class BaseTracingService(Service, ABC):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        tracing_user_id: str | None = None,
     ) -> None:
         """Start tracers for a graph run.
 
         Args:
             run_id: Unique identifier for the run
             run_name: Name of the run
-            user_id: User identifier (optional)
+            user_id: Authenticated Langflow user identifier (optional)
             session_id: Session identifier (optional)
             project_name: Project name (optional)
             flow_id: Flow identifier (optional)
+            tracing_user_id: Optional override forwarded to tracing providers as
+                the trace's user_id. When set, takes precedence over ``user_id``
+                for trace labels; ``user_id`` is preserved as the auth identity
+                in trace metadata.
         """
 
     @abstractmethod

--- a/src/lfx/src/lfx/services/tracing/base.py
+++ b/src/lfx/src/lfx/services/tracing/base.py
@@ -48,10 +48,11 @@ class BaseTracingService(Service, ABC):
             session_id: Session identifier (optional)
             project_name: Project name (optional)
             flow_id: Flow identifier (optional)
-            tracing_user_id: Optional override forwarded to tracing providers as
-                the trace's user_id. When set, takes precedence over ``user_id``
-                for trace labels; ``user_id`` is preserved as the auth identity
-                in trace metadata.
+            tracing_user_id: Optional caller-supplied label forwarded to tracing
+                providers. Does not change ``trace.userId`` (which stays as the
+                auth ``user_id``); each provider decides how to surface it (e.g.
+                LangFuseTracer stamps it under ``langflow.tracing_user_id`` in
+                trace metadata).
         """
 
     @abstractmethod

--- a/src/lfx/src/lfx/services/tracing/service.py
+++ b/src/lfx/src/lfx/services/tracing/service.py
@@ -60,7 +60,7 @@ class TracingService(BaseTracingService):
             user_id: Authenticated Langflow user identifier
             session_id: Session identifier
             project_name: Project name
-            tracing_user_id: Optional override forwarded to tracing providers
+            tracing_user_id: Optional caller-supplied label forwarded to tracing providers
         """
         logger.debug(f"Trace started: {run_name}")
 

--- a/src/lfx/src/lfx/services/tracing/service.py
+++ b/src/lfx/src/lfx/services/tracing/service.py
@@ -49,6 +49,7 @@ class TracingService(BaseTracingService):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        tracing_user_id: str | None = None,
     ) -> None:
         """Start tracers (minimal implementation - just logs).
 
@@ -56,9 +57,10 @@ class TracingService(BaseTracingService):
             run_id: Run identifier
             flow_id: Flow identifier
             run_name: Run name
-            user_id: User identifier
+            user_id: Authenticated Langflow user identifier
             session_id: Session identifier
             project_name: Project name
+            tracing_user_id: Optional override forwarded to tracing providers
         """
         logger.debug(f"Trace started: {run_name}")
 

--- a/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
+++ b/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
@@ -3,7 +3,9 @@
 When the caller supplies a ``user_id`` separate from the authenticated user
 (e.g. via the ``/api/v1/run/{flow_id}`` request body), it must reach the
 tracing layer untouched. The auth user_id remains the source of truth for
-authentication and authorization; only tracing providers see the override.
+authentication and authorization and for ``trace.userId``; the caller-supplied
+label is forwarded as ``tracing_user_id`` so providers can surface it
+separately (e.g. in trace metadata).
 """
 
 from __future__ import annotations
@@ -19,9 +21,8 @@ from lfx.graph import Graph
 async def test_initialize_run_forwards_both_user_id_and_tracing_user_id():
     """Auth ``user_id`` and ``tracing_user_id`` must be passed as distinct kwargs.
 
-    The merge policy (``tracing_user_id or user_id`` for trace labels) lives in
-    the tracing service, not in Graph — Graph just forwards both fields so
-    individual providers can stamp the auth identity separately when needed.
+    Graph just forwards both fields untouched; how the override surfaces (e.g.
+    LangFuseTracer stamps it into trace metadata) is the provider's concern.
     """
     graph = Graph(flow_id="11111111-1111-1111-1111-111111111111", flow_name="t", user_id="auth-user")
     graph.tracing_user_id = "test123"
@@ -44,7 +45,7 @@ async def test_initialize_run_forwards_both_user_id_and_tracing_user_id():
 
 @pytest.mark.asyncio
 async def test_initialize_run_passes_none_tracing_user_id_when_no_override():
-    """Without an override, ``tracing_user_id`` is None — merge happens downstream."""
+    """Without an override, ``tracing_user_id`` is None and only ``user_id`` reaches the tracers."""
     graph = Graph(flow_id="22222222-2222-2222-2222-222222222222", flow_name="t", user_id="auth-user")
     graph.session_id = "s"
     graph.set_run_id(uuid.uuid4())

--- a/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
+++ b/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
@@ -16,8 +16,13 @@ from lfx.graph import Graph
 
 
 @pytest.mark.asyncio
-async def test_initialize_run_uses_tracing_user_id_override():
-    """``Graph.tracing_user_id`` must be forwarded to ``start_tracers``."""
+async def test_initialize_run_forwards_both_user_id_and_tracing_user_id():
+    """Auth ``user_id`` and ``tracing_user_id`` must be passed as distinct kwargs.
+
+    The merge policy (``tracing_user_id or user_id`` for trace labels) lives in
+    the tracing service, not in Graph — Graph just forwards both fields so
+    individual providers can stamp the auth identity separately when needed.
+    """
     graph = Graph(flow_id="11111111-1111-1111-1111-111111111111", flow_name="t", user_id="auth-user")
     graph.tracing_user_id = "test123"
     graph.session_id = "session-abc"
@@ -32,13 +37,14 @@ async def test_initialize_run_uses_tracing_user_id_override():
 
     fake_service.start_tracers.assert_awaited_once()
     kwargs = fake_service.start_tracers.await_args.kwargs
-    assert kwargs["user_id"] == "test123"
+    assert kwargs["user_id"] == "auth-user"
+    assert kwargs["tracing_user_id"] == "test123"
     assert kwargs["session_id"] == "session-abc"
 
 
 @pytest.mark.asyncio
-async def test_initialize_run_falls_back_to_auth_user_when_no_override():
-    """Without an override, the auth ``user_id`` is still forwarded (existing behavior)."""
+async def test_initialize_run_passes_none_tracing_user_id_when_no_override():
+    """Without an override, ``tracing_user_id`` is None — merge happens downstream."""
     graph = Graph(flow_id="22222222-2222-2222-2222-222222222222", flow_name="t", user_id="auth-user")
     graph.session_id = "s"
     graph.set_run_id(uuid.uuid4())
@@ -52,6 +58,7 @@ async def test_initialize_run_falls_back_to_auth_user_when_no_override():
 
     kwargs = fake_service.start_tracers.await_args.kwargs
     assert kwargs["user_id"] == "auth-user"
+    assert kwargs["tracing_user_id"] is None
 
 
 def test_tracing_user_id_default_is_none():

--- a/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
+++ b/src/lfx/tests/unit/graph/test_tracing_user_id_override.py
@@ -1,0 +1,61 @@
+"""Regression test for issue #9505.
+
+When the caller supplies a ``user_id`` separate from the authenticated user
+(e.g. via the ``/api/v1/run/{flow_id}`` request body), it must reach the
+tracing layer untouched. The auth user_id remains the source of truth for
+authentication and authorization; only tracing providers see the override.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from lfx.graph import Graph
+
+
+@pytest.mark.asyncio
+async def test_initialize_run_uses_tracing_user_id_override():
+    """``Graph.tracing_user_id`` must be forwarded to ``start_tracers``."""
+    graph = Graph(flow_id="11111111-1111-1111-1111-111111111111", flow_name="t", user_id="auth-user")
+    graph.tracing_user_id = "test123"
+    graph.session_id = "session-abc"
+    graph.set_run_id(uuid.uuid4())
+
+    fake_service = AsyncMock()
+    fake_service.start_tracers = AsyncMock()
+    graph._tracing_service = fake_service
+    graph._tracing_service_initialized = True
+
+    await graph.initialize_run()
+
+    fake_service.start_tracers.assert_awaited_once()
+    kwargs = fake_service.start_tracers.await_args.kwargs
+    assert kwargs["user_id"] == "test123"
+    assert kwargs["session_id"] == "session-abc"
+
+
+@pytest.mark.asyncio
+async def test_initialize_run_falls_back_to_auth_user_when_no_override():
+    """Without an override, the auth ``user_id`` is still forwarded (existing behavior)."""
+    graph = Graph(flow_id="22222222-2222-2222-2222-222222222222", flow_name="t", user_id="auth-user")
+    graph.session_id = "s"
+    graph.set_run_id(uuid.uuid4())
+
+    fake_service = AsyncMock()
+    fake_service.start_tracers = AsyncMock()
+    graph._tracing_service = fake_service
+    graph._tracing_service_initialized = True
+
+    await graph.initialize_run()
+
+    kwargs = fake_service.start_tracers.await_args.kwargs
+    assert kwargs["user_id"] == "auth-user"
+
+
+def test_tracing_user_id_default_is_none():
+    """Defaults must not change for existing call sites."""
+    graph = Graph(flow_id="33333333-3333-3333-3333-333333333333", flow_name="t", user_id="auth-user")
+    assert graph.tracing_user_id is None
+    assert graph.user_id == "auth-user"


### PR DESCRIPTION
## Summary

Fixes [#9505](https://github.com/langflow-ai/langflow/issues/9505).

`POST /api/v1/run/{flow_id}` was silently dropping the `user_id` field from the request body, so Langfuse traces were always tagged with the API-key owner's UUID instead of the end-user identifier supplied by the caller.

Root cause (verified in source):

- `SimplifiedAPIRequest` (`src/backend/base/langflow/api/v1/schemas/__init__.py`) had no `user_id` field, so Pydantic discarded it from the body.
- `simple_run_flow()` hardcoded `user_id = api_key_user.id if api_key_user else None` (`src/backend/base/langflow/api/v1/endpoints.py`), and that value flowed unchanged into `Graph.from_payload(...)` → `TracingService.start_tracers(...)` → `LangFuseTracer.__init__(...)`.

## Changes

- Added an optional `user_id` field to `SimplifiedAPIRequest` and registered it in `_SIMPLIFIED_API_FORM_FIELDS` for multipart/form-data support.
- Added a separate `Graph.tracing_user_id` attribute that overrides the auth `user_id` only when forwarding to `start_tracers`. The auth user (API-key owner) remains the security boundary for authentication, authorization, global-variable lookup, and job ownership.
- `simple_run_flow` now sets `graph.tracing_user_id = input_request.user_id` after `Graph.from_payload(...)` when the caller provides one.

## Behavior

| Field | Before | After |
| --- | --- | --- |
| `session.id` | request value | request value (unchanged) |
| `user.id` (Langfuse trace) | API-key owner's UUID | request `user_id` if provided, else API-key owner's UUID |
| Authn/Authz | API-key owner | API-key owner (unchanged) |

## Test plan

- [x] `uv run pytest src/lfx/tests/unit/graph/test_tracing_user_id_override.py` — new tests for Graph override and fallback.
- [x] `uv run pytest src/backend/tests/unit/api/v1/test_parse_input_request_from_body.py` — extended with JSON + multipart `user_id` round-trip cases.
- [x] `uv run pytest src/backend/tests/unit/services/tracing/test_tracing_service.py` — no regressions (17 passed).
- [x] `uv run ruff check` and `uv run ruff format --check` — clean on all touched files.
- [ ] Manual smoke test with Langfuse credentials: confirm a request with `"user_id": "test123"` produces a trace whose `userId == "test123"` and that a `test123` user appears in the Langfuse dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified API requests now accept an optional `user_id` parameter that is forwarded to connected tracing and observability services for improved user identification, tracking, and request attribution.

* **Tests**
  * Added comprehensive test coverage to ensure user_id is correctly preserved and handled across different API request formats and tracing service integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->