### PR TITLE
fix(files): remove tooltip from upload button to prevent ghost tooltip  after file picker closes

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
@@ -7,7 +7,6 @@ import type { AgGridReact } from "ag-grid-react";
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import ShadTooltip from "@/components/common/shadTooltipComponent";
 import CardsWrapComponent from "@/components/core/cardsWrapComponent";
 import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
 import { Button } from "@/components/ui/button";
@@ -273,25 +272,23 @@ const FilesTab = ({
 
   const UploadButtonComponent = useMemo(() => {
     return (
-      <ShadTooltip content={t("files.uploadFile")} side="bottom">
-        <Button
-          className="!px-3 md:!px-4 md:!pl-3.5"
-          onClick={async () => {
-            await handleUpload();
-          }}
-          id="upload-file-btn"
-          data-testid="upload-file-btn"
-        >
-          <ForwardedIconComponent
-            name="Plus"
-            aria-hidden="true"
-            className="h-4 w-4"
-          />
-          <span className="hidden whitespace-nowrap font-semibold md:inline">
-            {t("files.uploadFiles")}
-          </span>
-        </Button>
-      </ShadTooltip>
+      <Button
+        className="!px-3 md:!px-4 md:!pl-3.5"
+        onClick={async () => {
+          await handleUpload();
+        }}
+        id="upload-file-btn"
+        data-testid="upload-file-btn"
+      >
+        <ForwardedIconComponent
+          name="Plus"
+          aria-hidden="true"
+          className="h-4 w-4"
+        />
+        <span className="hidden whitespace-nowrap font-semibold md:inline">
+          {t("files.uploadFiles")}
+        </span>
+      </Button>
     );
   }, []);
 


### PR DESCRIPTION
## Summary

- Removes the `ShadTooltip` wrapper from the **Upload Files** button on the Files page.
- Removes the now-unused `ShadTooltip` import from `FilesTab.tsx`.

## Problem

After clicking **"+ Upload Files"**, the OS native file picker dialog opens. When
the dialog is dismissed (cancel or successful upload), the browser automatically
returns focus to the button that triggered it. Radix UI's `Tooltip` responds to
both hover **and** focus events — so focus returning to the button opens the
tooltip. With no subsequent mouse movement or blur, the tooltip stays rendered
in the UI indefinitely.

## Fix

Removed the `ShadTooltip` wrapper entirely. The button already shows
**"Upload Files"** as visible text on `md+` viewports, making the tooltip
redundant. On smaller viewports where the label is hidden, the `+` icon
alongside the button's established position in the toolbar is sufficient.

## Test plan
- [ ] Click **"+ Upload Files"** and cancel the file picker — no tooltip appears
- [ ] Click **"+ Upload Files"**, select and upload a file — no tooltip appears after upload
- [ ] Button renders correctly (`+` icon + "Upload Files" label) on desktop and mobile widths
- [ ] Upload functionality is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Removed tooltip from the upload button interface, streamlining the file upload experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->