### PR TITLE
docs: openrouter promoted to global provider

### DIFF
--- a/docs/docs/Components/bundles-openrouter.mdx
+++ b/docs/docs/Components/bundles-openrouter.mdx
@@ -29,9 +29,8 @@ For more information, see [Language model components](/components-models).
 | Name | Type | Description |
 |------|------|-------------|
 | api_key | SecretString | Input parameter. Your OpenRouter API key for authentication. |
-| site_url | String | Input parameter. Your site URL for OpenRouter rankings. |
-| app_name | String | Input parameter. Your app name for OpenRouter rankings. |
-| provider | String | Input parameter. The AI model provider to use. |
-| model_name | String | Input parameter. The specific model to use for chat completion. |
+| model_name | Dropdown | Input parameter. The model to use for chat completion. Options are fetched live from the OpenRouter model catalog. |
 | temperature | Float | Input parameter. Controls randomness in the output. Range: [0.0, 2.0]. Default: 0.7. |
 | max_tokens | Integer | Input parameter. The maximum number of tokens to generate. |
+| site_url | String | Input parameter. Your site URL for attribution in OpenRouter rankings. |
+| app_name | String | Input parameter. Your app name for attribution in OpenRouter rankings. |

--- a/docs/docs/_partial-global-model-providers.mdx
+++ b/docs/docs/_partial-global-model-providers.mdx
@@ -4,12 +4,13 @@ To edit Langflow's global model provider configuration, do the following:
 
 1. To open the **Model Providers** pane, click your profile icon, select **Settings**, and then click <Icon name="Brain" aria-hidden="true"/> **Model Providers**.
 2. In the **Model Providers** pane, select a provider.
-3. In the **API Key** field, add your provider's API key.
+3. In the **API Key** field, add your provider's API key. Some providers require additional configuration fields. For more information, see the model provider's documentation.
 
     The key must have permission to call the models you want to use in your flow, and your account must have sufficient credits for the actions you want to perform.
 
     You can only add one key for each provider. Make sure the key has access to _all_ models that you want to use in Langflow.
-4. Enable the specific models that you want to use in Langflow.
+4. Click **Save**.
+5. Enable the specific models that you want to use in Langflow.
 The available models depend on the provider and your API key's permissions.
 Models that generate text are listed under **Language Models**.
 Models that generate embeddings are listed under **Embedding Models**.


### PR DESCRIPTION
OpenRouter is now promoted as a global provider.
Doublecheck the bundle documentation and the global model provider partial code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * OpenRouter bundle documentation updated: the model selection parameter now uses a dynamic dropdown that fetches available models live from OpenRouter's catalog
  * Global model provider setup instructions refined to provide clearer API key configuration guidance with clarification on additional setup fields that some providers may require

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->