### PR TITLE
fix: quiet extension migration warnings

### DIFF
--- a/src/lfx/src/lfx/extension/migration/rewrite.py
+++ b/src/lfx/src/lfx/extension/migration/rewrite.py
@@ -27,7 +27,10 @@ can emit one ``flow-migrated`` event per flow per session.
 from __future__ import annotations
 
 import difflib
+import sys
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, Literal
 
 from lfx.extension.errors import ExtensionError
@@ -42,7 +45,7 @@ from lfx.extension.migration.schema import (
 # Report
 # ---------------------------------------------------------------------------
 
-RewriteOutcome = Literal["rewritten", "already_canonical", "unmapped", "ambiguous"]
+RewriteOutcome = Literal["rewritten", "already_canonical", "known_current_component", "unmapped", "ambiguous"]
 
 
 @dataclass(frozen=True)
@@ -152,6 +155,66 @@ def _closest_matches(value: str, known: list[str], *, n: int = 3) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Current component detection
+# ---------------------------------------------------------------------------
+
+
+def _component_type_aliases(components: Mapping[str, Any]) -> set[str]:
+    """Return component names plus locally-derived aliases for a category."""
+    from lfx.utils.component_aliases import get_component_type_aliases
+
+    known: set[str] = set()
+    for component_name, component_data in components.items():
+        if not isinstance(component_name, str) or not component_name:
+            continue
+        metadata = component_data if isinstance(component_data, Mapping) else None
+        known.update(get_component_type_aliases(component_name, metadata))
+    return known
+
+
+@lru_cache(maxsize=1)
+def _known_current_types_from_index() -> frozenset[str]:
+    """Return current component type names from the bundled component index.
+
+    This intentionally reads the local index without building component
+    templates or mutating the runtime component cache.
+    """
+    try:
+        from lfx.graph.flow_builder.builder import load_local_registry
+
+        registry = load_local_registry()
+    except Exception:  # noqa: BLE001
+        return frozenset()
+
+    return frozenset(_component_type_aliases(registry))
+
+
+def _known_current_types_from_cache() -> set[str]:
+    """Return aliases from the live component cache if it is already loaded."""
+    components_module = sys.modules.get("lfx.interface.components")
+    if components_module is None:
+        return set()
+
+    component_cache = getattr(components_module, "component_cache", None)
+    all_types_dict = getattr(component_cache, "all_types_dict", None)
+    if not isinstance(all_types_dict, Mapping):
+        return set()
+
+    known: set[str] = set()
+    components = all_types_dict.get("components")
+    categories = components if isinstance(components, Mapping) else all_types_dict
+    for category_components in categories.values():
+        if isinstance(category_components, Mapping):
+            known.update(_component_type_aliases(category_components))
+    return known
+
+
+def _known_current_types() -> frozenset[str]:
+    """Return component type names that are current, not migration misses."""
+    return frozenset(_known_current_types_from_index() | _known_current_types_from_cache())
+
+
+# ---------------------------------------------------------------------------
 # Node-level rewrite
 # ---------------------------------------------------------------------------
 
@@ -194,6 +257,7 @@ def _rewrite_one_node(
     *,
     table: MigrationTable,
     known_legacy: list[str],
+    known_current_types: Collection[str],
     node_index: int,
 ) -> NodeRewriteRecord | None:
     """Rewrite ``node["data"]["type"]`` if needed.
@@ -204,6 +268,10 @@ def _rewrite_one_node(
     """
     if not isinstance(node, dict):
         return None
+    react_flow_type = node.get("type")
+    if isinstance(react_flow_type, str) and react_flow_type != "genericNode":
+        return None
+
     legacy_value, container = _read_type(node)
     if legacy_value is None or container is None:
         return None
@@ -288,6 +356,15 @@ def _rewrite_one_node(
                 error=err,
             )
 
+        if legacy_value in known_current_types:
+            return NodeRewriteRecord(
+                node_id=node_id,
+                legacy_value=legacy_value,
+                new_value=legacy_value,
+                legacy_form_kind=None,
+                outcome="known_current_component",
+            )
+
         suggestions = _closest_matches(legacy_value, known_legacy)
         if suggestions:
             hint = (
@@ -339,6 +416,7 @@ def migrate_flow_payload(
     payload: dict[str, Any],
     *,
     table: MigrationTable | None = None,
+    known_current_types: Collection[str] | None = None,
 ) -> MigrationReport:
     """Rewrite legacy component references in ``payload`` in place.
 
@@ -351,6 +429,10 @@ def migrate_flow_payload(
             fails, the deserializer falls back to an empty table so every
             legacy reference becomes unmapped (with hint) instead of the
             entire flow load crashing.
+        known_current_types: Current component type names and aliases that
+            should be left unchanged without emitting migration errors.
+            ``None`` means derive them from the bundled index and any already
+            populated component cache.
 
     Returns:
         A :class:`MigrationReport` summarizing every node that was visited
@@ -395,11 +477,13 @@ def migrate_flow_payload(
     # the suggestion list in the typed error's hint -- the user-facing
     # signal (the rewrite itself or the typed error) is unaffected.
     suggestion_pool: list[str] = table.all_known_legacy_values() if len(nodes) <= _SUGGESTION_NODE_THRESHOLD else []
+    current_types = known_current_types if known_current_types is not None else _known_current_types()
     for index, node in enumerate(nodes):
         record = _rewrite_one_node(
             node,
             table=table,
             known_legacy=suggestion_pool,
+            known_current_types=current_types,
             node_index=index,
         )
         if record is None:

--- a/src/lfx/tests/unit/extension/migration/test_rewrite.py
+++ b/src/lfx/tests/unit/extension/migration/test_rewrite.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 from lfx.extension.migration.rewrite import migrate_flow_payload
 from lfx.extension.migration.schema import (
@@ -19,6 +22,19 @@ def _node(node_id: str, type_value: str) -> dict:
         "data": {
             "id": node_id,
             "type": type_value,
+            "node": {"template": {}},
+        },
+    }
+
+
+def _note_node(node_id: str) -> dict:
+    """Build a note node that still carries a data.type value."""
+    return {
+        "id": node_id,
+        "type": "noteNode",
+        "data": {
+            "id": node_id,
+            "type": "note",
             "node": {"template": {}},
         },
     }
@@ -116,6 +132,101 @@ def test_already_canonical_left_alone(table: MigrationTable) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "type_value",
+    [
+        "Prompt",
+        "ChatOutput",
+        "ParserComponent",
+        "URLComponent",
+        "LanguageModelComponent",
+    ],
+)
+def test_known_current_components_left_alone_without_errors(table: MigrationTable, type_value: str) -> None:
+    payload = _payload(_node(f"{type_value}-1", type_value))
+    known_current_types = {
+        "Prompt",
+        "ChatOutput",
+        "ParserComponent",
+        "URLComponent",
+        "LanguageModelComponent",
+    }
+
+    report = migrate_flow_payload(payload, table=table, known_current_types=known_current_types)
+
+    assert report.rewritten_count == 0
+    assert report.errors == []
+    [record] = report.records
+    assert record.outcome == "known_current_component"
+    assert record.error is None
+    assert payload["data"]["nodes"][0]["data"]["type"] == type_value
+
+
+@pytest.mark.unit
+def test_note_node_with_data_type_is_skipped(table: MigrationTable) -> None:
+    payload = _payload(_note_node("note-1"))
+
+    report = migrate_flow_payload(payload, table=table, known_current_types=set())
+
+    assert report.records == []
+    assert report.errors == []
+    assert payload["data"]["nodes"][0]["data"]["type"] == "note"
+
+
+@pytest.mark.unit
+def test_migration_table_entry_wins_over_known_current_type(table: MigrationTable) -> None:
+    payload = _payload(_node("OpenAIEmbeddings-1", "OpenAIEmbeddings"))
+
+    report = migrate_flow_payload(payload, table=table, known_current_types={"OpenAIEmbeddings"})
+
+    assert report.rewritten_count == 1
+    assert report.errors == []
+    [record] = report.records
+    assert record.outcome == "rewritten"
+    assert payload["data"]["nodes"][0]["data"]["type"] == "ext:openai:OpenAIEmbeddings@official"
+
+
+@pytest.mark.unit
+def test_bundled_index_alias_suppresses_current_component_noise() -> None:
+    payload = _payload(_node("Prompt-1", "Prompt"))
+    table = MigrationTable(schema_version=1, entries=[])
+
+    report = migrate_flow_payload(payload, table=table)
+
+    assert report.rewritten_count == 0
+    assert report.errors == []
+    [record] = report.records
+    assert record.outcome == "known_current_component"
+    assert payload["data"]["nodes"][0]["data"]["type"] == "Prompt"
+
+
+@pytest.mark.unit
+def test_loaded_component_cache_suppresses_current_component_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _payload(_node("CustomCurrent-1", "CustomCurrent"))
+    table = MigrationTable(schema_version=1, entries=[])
+    fake_components_module = SimpleNamespace(
+        component_cache=SimpleNamespace(
+            all_types_dict={
+                "custom": {
+                    "CustomCurrent": {
+                        "display_name": "Custom Current",
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setitem(sys.modules, "lfx.interface.components", fake_components_module)
+
+    report = migrate_flow_payload(payload, table=table)
+
+    assert report.rewritten_count == 0
+    assert report.errors == []
+    [record] = report.records
+    assert record.outcome == "known_current_component"
+    assert payload["data"]["nodes"][0]["data"]["type"] == "CustomCurrent"
+
+
+@pytest.mark.unit
 def test_unmapped_reference_emits_typed_error_with_suggestion(table: MigrationTable) -> None:
     # A near-miss on an existing entry: should produce a close-match hint.
     payload = _payload(_node("x", "OpenAIEmbedding"))  # missing trailing 's'
@@ -201,7 +312,7 @@ def test_ambiguous_bare_name_surfaces_component_name_ambiguous() -> None:
     )
 
     payload = _payload(_node("n1", "MergeDataComponent"))
-    report = migrate_flow_payload(payload, table=table)
+    report = migrate_flow_payload(payload, table=table, known_current_types={"MergeDataComponent"})
 
     [record] = report.records
     assert record.outcome == "ambiguous"


### PR DESCRIPTION
## Summary
- suppress extension migration warnings for known current Langflow component types
- skip non-component React Flow nodes such as notes before migration lookup
- keep migration-table rewrites, ambiguity errors, and true unknown-component warnings intact

## Tests
- uv run ruff check src/lfx/extension/migration/rewrite.py tests/unit/extension/migration/test_rewrite.py
- uv run pytest tests/unit/extension/migration/test_rewrite.py
- uv run pytest tests/integration/extension/test_pilot_arxiv_upgrade.py tests/integration/extension/test_pilot_duckduckgo_upgrade.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Migration system now gracefully handles already-current component type aliases without emitting unnecessary errors.
  * Expanded component type detection improves overall migration tolerance.

* **Tests**
  * Added comprehensive test coverage for new migration behaviors with current component types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->