### PR TITLE
deps: bump langfuse to v4 + migrate tracer/tests off v3 APIs

### DIFF
--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -12,6 +12,7 @@ from langflow.services.tracing.base import BaseTracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from contextlib import AbstractContextManager
     from uuid import UUID
 
     from langchain_core.callbacks.base import BaseCallbackHandler
@@ -23,10 +24,14 @@ if TYPE_CHECKING:
 
 
 class LangFuseTracer(BaseTracer):
-    """LangFuse tracer implementation using langfuse v3 API.
+    """LangFuse tracer implementation using langfuse v4 API.
 
-    The v3 API uses OpenTelemetry-based spans instead of the v2 trace/span pattern.
-    See: https://langfuse.com/docs/observability/sdk/upgrade-path
+    The v4 SDK is OpenTelemetry-based: `start_observation` replaces v3's
+    `start_span`; trace-level attributes (user_id, session_id, name) propagate
+    via `propagate_attributes`, manually entered here and exited in `end()`;
+    trace-level input/output go through `set_trace_io`.
+
+    See: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
     """
 
     flow_id: str
@@ -49,6 +54,7 @@ class LangFuseTracer(BaseTracer):
         self.session_id = session_id
         self.flow_id = trace_name.split(" - ")[-1]
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
+        self._attributes_ctx: AbstractContextManager[None] | None = None
 
         config = self._get_config()
         self._ready: bool = self._setup_langfuse(config) if config else False
@@ -60,11 +66,14 @@ class LangFuseTracer(BaseTracer):
     def _setup_langfuse(self, config: dict) -> bool:
         """Initialize langfuse client and create root span for the flow.
 
-        Uses langfuse v3 API which requires creating spans with trace_context
-        instead of using the removed trace() method.
+        v4 differs from v3 in two load-bearing ways:
+        - `start_observation` replaces `start_span`.
+        - Trace-level attributes (user_id, session_id, name) are not span
+          parameters; they propagate via `propagate_attributes`, an OTel
+          context manager. We enter it here and exit in `end()`.
         """
         try:
-            from langfuse import Langfuse
+            from langfuse import Langfuse, propagate_attributes
             from langfuse.types import TraceContext
 
             self._client = Langfuse(**config)
@@ -78,23 +87,27 @@ class LangFuseTracer(BaseTracer):
                 logger.debug(f"Cannot connect to Langfuse: {e}")
                 return False
 
-            # Create a deterministic trace ID from the UUID (v3 requires 32-char hex)
+            # Create a deterministic trace ID from the UUID (32-char hex)
             langfuse_trace_id = Langfuse.create_trace_id(seed=str(self.trace_id))
             # parent_span_id is NotRequired but ty doesn't fully support this yet
             self._trace_context = TraceContext(trace_id=langfuse_trace_id)  # type: ignore[call-arg]
 
-            # Create root span for the flow - this also creates the trace implicitly
-            self._root_span = self._client.start_span(
+            # v4: enter propagate_attributes manually so trace-level attributes
+            # (name/user_id/session_id) attach to every observation underneath.
+            # Must be exited in end() or the OTel context leaks.
+            attrs: dict[str, Any] = {"trace_name": self.flow_id}
+            if self.user_id:
+                attrs["user_id"] = self.user_id
+            if self.session_id:
+                attrs["session_id"] = self.session_id
+            self._attributes_ctx = propagate_attributes(**attrs)
+            self._attributes_ctx.__enter__()
+
+            # Create root observation for the flow under the propagated attrs.
+            self._root_span = self._client.start_observation(
                 name=self.flow_id,
                 trace_context=self._trace_context,
                 metadata={"flow_id": self.flow_id, "project_name": self.project_name},
-            )
-
-            # Set trace-level metadata (user_id, session_id)
-            self._root_span.update_trace(
-                name=self.flow_id,
-                user_id=self.user_id,
-                session_id=self.session_id,
             )
 
         except ImportError:
@@ -103,6 +116,7 @@ class LangFuseTracer(BaseTracer):
 
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Error setting up LangFuse tracer: {e}")
+            self._detach_attributes()
             return False
 
         return True
@@ -126,8 +140,8 @@ class LangFuseTracer(BaseTracer):
 
         name = trace_name.removesuffix(f" ({trace_id})")
 
-        # Create child span under the root span
-        span = self._root_span.start_span(
+        # Create child observation under the root span (v4: start_observation).
+        span = self._root_span.start_observation(
             name=name,
             input=serialize(inputs),
             metadata=serialize(metadata_),
@@ -174,22 +188,42 @@ class LangFuseTracer(BaseTracer):
         outputs_ser = serialize(outputs)
         metadata_ser = serialize(metadata) if metadata else None
 
-        # Update the root span with final input/output
-        self._root_span.update(
-            input=inputs_ser,
-            output=outputs_ser,
-            metadata=metadata_ser,
-        )
+        try:
+            # Update the root span with final input/output
+            self._root_span.update(
+                input=inputs_ser,
+                output=outputs_ser,
+                metadata=metadata_ser,
+            )
 
-        # Update trace-level data
-        self._root_span.update_trace(
-            input=inputs_ser,
-            output=outputs_ser,
-            metadata=metadata_ser,
-        )
+            # v4: trace-level input/output via set_trace_io (replaces update_trace's
+            # input/output args). user_id/session_id/name were set during setup via
+            # propagate_attributes and don't need to be re-applied here.
+            self._root_span.set_trace_io(
+                input=inputs_ser,
+                output=outputs_ser,
+            )
 
-        # End the root span
-        self._root_span.end()
+            # End the root span
+            self._root_span.end()
+        finally:
+            self._detach_attributes()
+
+    def _detach_attributes(self) -> None:
+        """Exit the propagate_attributes context manager entered in setup.
+
+        Safe to call multiple times; runs at most once per tracer instance.
+        Failures are swallowed because the OTel context will reset on next
+        flow run regardless.
+        """
+        if self._attributes_ctx is None:
+            return
+        try:
+            self._attributes_ctx.__exit__(None, None, None)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Error exiting propagate_attributes: {e}")
+        finally:
+            self._attributes_ctx = None
 
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
         if not self._ready:

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -12,7 +12,6 @@ from langflow.services.tracing.base import BaseTracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from contextlib import AbstractContextManager
     from uuid import UUID
 
     from langchain_core.callbacks.base import BaseCallbackHandler
@@ -28,8 +27,9 @@ class LangFuseTracer(BaseTracer):
 
     The v4 SDK is OpenTelemetry-based: `start_observation` replaces v3's
     `start_span`; trace-level attributes (user_id, session_id, name) propagate
-    via `propagate_attributes`, manually entered here and exited in `end()`;
-    trace-level input/output go through `set_trace_io`.
+    via `propagate_attributes`, applied per `start_observation` call so the
+    OTel context is attached in the same asyncio task that creates the
+    observation; trace-level input/output go through `set_trace_io`.
 
     See: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
     """
@@ -54,7 +54,12 @@ class LangFuseTracer(BaseTracer):
         self.session_id = session_id
         self.flow_id = trace_name.split(" - ")[-1]
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
-        self._attributes_ctx: AbstractContextManager[None] | None = None
+
+        self._propagated_attrs: dict[str, Any] = {"trace_name": self.flow_id}
+        if user_id:
+            self._propagated_attrs["user_id"] = user_id
+        if session_id:
+            self._propagated_attrs["session_id"] = session_id
 
         config = self._get_config()
         self._ready: bool = self._setup_langfuse(config) if config else False
@@ -70,13 +75,20 @@ class LangFuseTracer(BaseTracer):
         - `start_observation` replaces `start_span`.
         - Trace-level attributes (user_id, session_id, name) are not span
           parameters; they propagate via `propagate_attributes`, an OTel
-          context manager. We enter it here and exit in `end()`.
+          context manager backed by `contextvars`. `asyncio.create_task`
+          snapshots contextvars at task-creation time, so a token attached
+          in one task is not visible to tasks created earlier. langflow's
+          TracingService dispatches `add_trace` via a worker task that was
+          spawned before the tracer is constructed, so we enter
+          `propagate_attributes` per `start_observation` call rather than
+          holding it open for the tracer's lifetime.
         """
         try:
             from langfuse import Langfuse, propagate_attributes
             from langfuse.types import TraceContext
 
             self._client = Langfuse(**config)
+            self._propagate_attributes = propagate_attributes
 
             # Health check using public API
             try:
@@ -92,23 +104,12 @@ class LangFuseTracer(BaseTracer):
             # parent_span_id is NotRequired but ty doesn't fully support this yet
             self._trace_context = TraceContext(trace_id=langfuse_trace_id)  # type: ignore[call-arg]
 
-            # v4: enter propagate_attributes manually so trace-level attributes
-            # (name/user_id/session_id) attach to every observation underneath.
-            # Must be exited in end() or the OTel context leaks.
-            attrs: dict[str, Any] = {"trace_name": self.flow_id}
-            if self.user_id:
-                attrs["user_id"] = self.user_id
-            if self.session_id:
-                attrs["session_id"] = self.session_id
-            self._attributes_ctx = propagate_attributes(**attrs)
-            self._attributes_ctx.__enter__()
-
-            # Create root observation for the flow under the propagated attrs.
-            self._root_span = self._client.start_observation(
-                name=self.flow_id,
-                trace_context=self._trace_context,
-                metadata={"flow_id": self.flow_id, "project_name": self.project_name},
-            )
+            with self._propagate_attributes(**self._propagated_attrs):
+                self._root_span = self._client.start_observation(
+                    name=self.flow_id,
+                    trace_context=self._trace_context,
+                    metadata={"flow_id": self.flow_id, "project_name": self.project_name},
+                )
 
         except ImportError:
             logger.exception("Could not import langfuse. Please install it with `pip install langfuse`.")
@@ -116,7 +117,6 @@ class LangFuseTracer(BaseTracer):
 
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Error setting up LangFuse tracer: {e}")
-            self._detach_attributes()
             return False
 
         return True
@@ -140,12 +140,17 @@ class LangFuseTracer(BaseTracer):
 
         name = trace_name.removesuffix(f" ({trace_id})")
 
-        # Create child observation under the root span (v4: start_observation).
-        span = self._root_span.start_observation(
-            name=name,
-            input=serialize(inputs),
-            metadata=serialize(metadata_),
-        )
+        # Wrap start_observation in propagate_attributes so the child span
+        # gets user.id/session.id/langfuse.trace.name. This call typically
+        # runs in a different asyncio task than _setup_langfuse (langflow's
+        # TracingService dispatches add_trace via a worker task), and
+        # contextvars don't cross task boundaries forward-in-time.
+        with self._propagate_attributes(**self._propagated_attrs):
+            span = self._root_span.start_observation(
+                name=name,
+                input=serialize(inputs),
+                metadata=serialize(metadata_),
+            )
 
         self.spans[trace_id] = span
 
@@ -188,42 +193,22 @@ class LangFuseTracer(BaseTracer):
         outputs_ser = serialize(outputs)
         metadata_ser = serialize(metadata) if metadata else None
 
-        try:
-            # Update the root span with final input/output
-            self._root_span.update(
-                input=inputs_ser,
-                output=outputs_ser,
-                metadata=metadata_ser,
-            )
+        # Update the root span with final input/output
+        self._root_span.update(
+            input=inputs_ser,
+            output=outputs_ser,
+            metadata=metadata_ser,
+        )
 
-            # v4: trace-level input/output via set_trace_io (replaces update_trace's
-            # input/output args). user_id/session_id/name were set during setup via
-            # propagate_attributes and don't need to be re-applied here.
-            self._root_span.set_trace_io(
-                input=inputs_ser,
-                output=outputs_ser,
-            )
+        # v4: trace-level input/output via set_trace_io. user_id/session_id/name
+        # are propagated per start_observation call, not on a long-lived context,
+        # so nothing to detach here.
+        self._root_span.set_trace_io(
+            input=inputs_ser,
+            output=outputs_ser,
+        )
 
-            # End the root span
-            self._root_span.end()
-        finally:
-            self._detach_attributes()
-
-    def _detach_attributes(self) -> None:
-        """Exit the propagate_attributes context manager entered in setup.
-
-        Safe to call multiple times; runs at most once per tracer instance.
-        Failures are swallowed because the OTel context will reset on next
-        flow run regardless.
-        """
-        if self._attributes_ctx is None:
-            return
-        try:
-            self._attributes_ctx.__exit__(None, None, None)
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Error exiting propagate_attributes: {e}")
-        finally:
-            self._attributes_ctx = None
+        self._root_span.end()
 
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
         if not self._ready:

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -234,7 +234,7 @@ sentence-transformers = ["sentence-transformers>=2.3.1"]
 ctransformers = ["ctransformers>=0.2.10"]
 
 # Individual monitoring providers
-langfuse = ["langfuse~=3.8; python_version < '3.14'"]
+langfuse = ["langfuse>=4,<5"]
 langwatch = ["langwatch~=0.10.0; python_version < '3.14'"]
 langsmith = ["langsmith>=0.3.42,<1.0.0"]
 arize = ["arize-phoenix-otel>=0.6.1"]

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
@@ -385,15 +385,14 @@ class TestLangfuseTracerWorkerTaskPropagation:
         """
         _import_langfuse_or_skip()
 
+        from langfuse._client import span_processor as sp_mod
+        from langfuse._client.resource_manager import LangfuseResourceManager
+        from langfuse._client.span_filter import is_default_export_span
         from opentelemetry import trace as trace_api
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
         from opentelemetry.util._once import Once
-
-        from langfuse._client import span_processor as sp_mod
-        from langfuse._client.resource_manager import LangfuseResourceManager
-        from langfuse._client.span_filter import is_default_export_span
 
         def _reset_otel_globals() -> None:
             trace_api._TRACER_PROVIDER = None
@@ -434,10 +433,9 @@ class TestLangfuseTracerWorkerTaskPropagation:
         """
         import asyncio
 
+        from langflow.services.tracing.langfuse import LangFuseTracer
         from langfuse._client.attributes import LangfuseOtelSpanAttributes
         from langfuse._client.client import Langfuse
-
-        from langflow.services.tracing.langfuse import LangFuseTracer
 
         monkeypatch.setattr(Langfuse, "auth_check", lambda self: True)
 

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
@@ -73,17 +73,13 @@ class TestLangfuseV4ApiExists:
         """v4 replaces v3 `start_span` with `start_observation` on the client."""
         langfuse_class = _import_langfuse_or_skip()
 
-        assert hasattr(langfuse_class, "start_observation"), (
-            "Langfuse.start_observation() should exist in v4"
-        )
+        assert hasattr(langfuse_class, "start_observation"), "Langfuse.start_observation() should exist in v4"
 
     def test_langfuse_client_has_create_trace_id(self):
         """`create_trace_id` is still on the class in v4."""
         langfuse_class = _import_langfuse_or_skip()
 
-        assert hasattr(langfuse_class, "create_trace_id"), (
-            "Langfuse.create_trace_id() should exist in v4"
-        )
+        assert hasattr(langfuse_class, "create_trace_id"), "Langfuse.create_trace_id() should exist in v4"
 
     def test_langfuse_module_has_propagate_attributes(self):
         """v4 introduces `propagate_attributes` for trace-level attrs."""
@@ -95,9 +91,7 @@ class TestLangfuseV4ApiExists:
         """`start_span` was removed from the client in v4 (replaced by start_observation)."""
         langfuse_class = _import_langfuse_or_skip()
 
-        assert not hasattr(langfuse_class, "start_span"), (
-            "Langfuse.start_span() should NOT exist in v4 (removed)"
-        )
+        assert not hasattr(langfuse_class, "start_span"), "Langfuse.start_span() should NOT exist in v4 (removed)"
 
     def test_callback_handler_import_path(self):
         """The langchain integration import path still resolves in v4."""

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
@@ -215,7 +215,11 @@ class TestLangfuseTracerFunctionality:
             trace_type="chain",
             project_name="test-project",
             trace_id=uuid.uuid4(),
+            user_id="user-1",
+            session_id="session-1",
         )
+
+        propagate_calls_before = len(mock_langfuse["propagate_calls"])
 
         tracer.add_trace(
             trace_id="component-1",
@@ -229,6 +233,15 @@ class TestLangfuseTracerFunctionality:
         mock_langfuse["root_span"].start_observation.assert_called_once()
         call_kwargs = mock_langfuse["root_span"].start_observation.call_args[1]
         assert call_kwargs["name"] == "TestComponent"
+
+        # add_trace must enter propagate_attributes around start_observation,
+        # otherwise child observations created in a worker task won't inherit
+        # user.id / session.id / langfuse.trace.name.
+        assert len(mock_langfuse["propagate_calls"]) > propagate_calls_before
+        last_attrs = mock_langfuse["propagate_calls"][-1]
+        assert last_attrs["user_id"] == "user-1"
+        assert last_attrs["session_id"] == "session-1"
+        assert last_attrs["trace_name"] == "flow-123"
 
     def test_end_trace_updates_and_ends_span(self, mock_langfuse):
         """Test that end_trace updates span with output and ends it."""
@@ -320,3 +333,167 @@ class TestLangfuseTracerFunctionality:
             trace_context = call_kwargs["trace_context"]
             assert "parent_span_id" in trace_context
             assert trace_context["parent_span_id"] == "child-span-id"
+
+
+class TestLangfuseTracerWorkerTaskPropagation:
+    """Verify trace-level attrs reach child observations created in a different
+    asyncio task than the tracer was constructed in.
+
+    langflow's TracingService spawns a worker task in `start_tracers` BEFORE
+    `_initialize_langfuse_tracer` runs, and dispatches `add_trace` calls via
+    a queue. Because `asyncio.create_task` snapshots contextvars at task
+    creation, a `propagate_attributes` token attached in the request task is
+    not visible from the worker. The mocked-module tests above can't catch
+    this — they assert the *call* was made but the SDK's real OTel context
+    plumbing is bypassed.
+
+    This test exercises a real `LangfuseSpanProcessor` against an in-memory
+    span exporter and asserts user.id / session.id / langfuse.trace.name
+    actually land on the exported child span.
+    """
+
+    @pytest.fixture
+    def memory_exporter(self):
+        from opentelemetry.sdk.trace import ReadableSpan
+        from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+        class _InMemoryExporter(SpanExporter):
+            def __init__(self) -> None:
+                self._spans: list[ReadableSpan] = []
+
+            def export(self, spans):
+                self._spans.extend(spans)
+                return SpanExportResult.SUCCESS
+
+            def shutdown(self):
+                pass
+
+            def get_finished_spans(self):
+                return list(self._spans)
+
+        return _InMemoryExporter()
+
+    @pytest.fixture
+    def real_langfuse_with_memory_exporter(self, monkeypatch, memory_exporter):
+        """Wire the real LangfuseSpanProcessor to an in-memory exporter; mock auth.
+
+        Resets OTel globals AND LangfuseResourceManager both before and after the
+        test, because earlier tests in this file may have constructed a real
+        LangFuseTracer (e.g. test_tracer_initialization_does_not_crash) whose
+        cached LangfuseResourceManager entry would otherwise short-circuit our
+        patched processor init.
+        """
+        _import_langfuse_or_skip()
+
+        from opentelemetry import trace as trace_api
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+        from opentelemetry.util._once import Once
+
+        from langfuse._client import span_processor as sp_mod
+        from langfuse._client.resource_manager import LangfuseResourceManager
+        from langfuse._client.span_filter import is_default_export_span
+
+        def _reset_otel_globals() -> None:
+            trace_api._TRACER_PROVIDER = None
+            trace_api._PROXY_TRACER_PROVIDER = trace_api.ProxyTracerProvider()
+            trace_api._TRACER_PROVIDER_SET_ONCE = Once()
+
+        LangfuseResourceManager.reset()
+        _reset_otel_globals()
+
+        def _mock_processor_init(self_, **kwargs):
+            self_.public_key = kwargs.get("public_key", "test-key")
+            self_.blocked_instrumentation_scopes = kwargs.get("blocked_instrumentation_scopes") or []
+            self_._should_export_span = kwargs.get("should_export_span") or is_default_export_span
+            BatchSpanProcessor.__init__(
+                self_,
+                span_exporter=memory_exporter,
+                max_export_batch_size=512,
+                schedule_delay_millis=1,
+            )
+
+        monkeypatch.setattr(sp_mod.LangfuseSpanProcessor, "__init__", _mock_processor_init)
+
+        provider = TracerProvider(resource=Resource.create({"service.name": "langfuse-test"}))
+        provider.add_span_processor(SimpleSpanProcessor(memory_exporter))
+        trace_api.set_tracer_provider(provider)
+
+        yield
+
+        LangfuseResourceManager.reset()
+        _reset_otel_globals()
+
+    async def test_child_observation_in_worker_task_has_propagated_attrs(
+        self, real_langfuse_with_memory_exporter, memory_exporter, monkeypatch
+    ):
+        """Mirror the TracingService topology: worker task spawned before the
+        tracer, add_trace dispatched through a queue. The child span must end
+        up with user.id / session.id / langfuse.trace.name set.
+        """
+        import asyncio
+
+        from langfuse._client.attributes import LangfuseOtelSpanAttributes
+        from langfuse._client.client import Langfuse
+
+        from langflow.services.tracing.langfuse import LangFuseTracer
+
+        monkeypatch.setattr(Langfuse, "auth_check", lambda self: True)
+
+        queue: asyncio.Queue = asyncio.Queue()
+        done = asyncio.Event()
+
+        async def worker():
+            while not done.is_set() or not queue.empty():
+                try:
+                    func = await asyncio.wait_for(queue.get(), timeout=0.5)
+                except asyncio.TimeoutError:
+                    continue
+                try:
+                    func()
+                finally:
+                    queue.task_done()
+
+        # Worker spawned BEFORE tracer construction — mirrors start_tracers's
+        # ordering where _start (worker creation) precedes _initialize_langfuse_tracer.
+        worker_task = asyncio.create_task(worker())
+
+        tracer = LangFuseTracer(
+            trace_name="test-flow - flow-WORKER",
+            trace_type="chain",
+            project_name="test-project",
+            trace_id=uuid.uuid4(),
+            user_id="user-WORKER",
+            session_id="session-WORKER",
+        )
+        assert tracer.ready
+
+        def dispatch_add_trace():
+            tracer.add_trace(
+                trace_id="component-1",
+                trace_name="ChildComponent (component-1)",
+                trace_type="llm",
+                inputs={"prompt": "test"},
+                metadata={"key": "value"},
+            )
+
+        await queue.put(dispatch_add_trace)
+        await queue.join()
+
+        tracer.end_trace("component-1", "ChildComponent", outputs={"output": "result"})
+        tracer.end(inputs={"flow_input": "x"}, outputs={"flow_output": "y"})
+
+        done.set()
+        await worker_task
+
+        spans_by_name = {s.name: s for s in memory_exporter.get_finished_spans()}
+        child = spans_by_name.get("ChildComponent")
+        assert child is not None, f"child span not exported; got {list(spans_by_name)}"
+
+        attrs = dict(child.attributes or {})
+        assert attrs.get(LangfuseOtelSpanAttributes.TRACE_USER_ID) == "user-WORKER", (
+            f"child observation missing user.id (worker-task propagation broken). attrs={attrs}"
+        )
+        assert attrs.get(LangfuseOtelSpanAttributes.TRACE_SESSION_ID) == "session-WORKER"
+        assert attrs.get(LangfuseOtelSpanAttributes.TRACE_NAME) == "flow-WORKER"

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
@@ -1,16 +1,18 @@
-"""Tests to verify langfuse v3 API compatibility.
+"""Tests to verify langfuse v4 API compatibility.
 
 These tests verify that the LangFuseTracer implementation is compatible
-with the langfuse v3 SDK. The v3 SDK removed several methods that the
-v2 API used, so we need to ensure our implementation uses the correct API.
+with the langfuse v4 SDK. v4 is OpenTelemetry-based: `start_observation`
+replaces v3's `start_span`; trace-level attributes propagate via
+`propagate_attributes`; trace-level input/output go through `set_trace_io`.
 
-See: https://langfuse.com/docs/observability/sdk/upgrade-path
+See: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4
 """
 
 import os
 import sys
 import types
 import uuid
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -46,6 +48,15 @@ def _import_langfuse_or_skip():
     return Langfuse
 
 
+def _import_propagate_attributes_or_skip():
+    try:
+        from langfuse import propagate_attributes
+    except Exception as exc:
+        _clear_failed_langfuse_import()
+        pytest.skip(f"langfuse propagate_attributes is not importable: {exc}")
+    return propagate_attributes
+
+
 def _import_callback_handler_or_skip():
     try:
         from langfuse.langchain import CallbackHandler
@@ -55,45 +66,48 @@ def _import_callback_handler_or_skip():
     return CallbackHandler
 
 
-class TestLangfuseV3ApiExists:
-    """Verify that the langfuse v3 API methods we need actually exist."""
+class TestLangfuseV4ApiExists:
+    """Verify that the langfuse v4 API surface we depend on actually exists."""
 
-    def test_langfuse_client_has_start_span(self):
-        """Verify start_span method exists (v3 API)."""
+    def test_langfuse_client_has_start_observation(self):
+        """v4 replaces v3 `start_span` with `start_observation` on the client."""
         langfuse_class = _import_langfuse_or_skip()
 
-        assert hasattr(langfuse_class, "start_span"), "Langfuse.start_span() should exist in v3"
-
-    def test_langfuse_client_has_start_as_current_span(self):
-        """Verify start_as_current_span method exists (v3 API)."""
-        langfuse_class = _import_langfuse_or_skip()
-
-        assert hasattr(langfuse_class, "start_as_current_span"), "Langfuse.start_as_current_span() should exist in v3"
+        assert hasattr(langfuse_class, "start_observation"), (
+            "Langfuse.start_observation() should exist in v4"
+        )
 
     def test_langfuse_client_has_create_trace_id(self):
-        """Verify create_trace_id method exists (v3 API)."""
+        """`create_trace_id` is still on the class in v4."""
         langfuse_class = _import_langfuse_or_skip()
 
-        assert hasattr(langfuse_class, "create_trace_id"), "Langfuse.create_trace_id() should exist in v3"
+        assert hasattr(langfuse_class, "create_trace_id"), (
+            "Langfuse.create_trace_id() should exist in v4"
+        )
 
-    def test_langfuse_client_does_not_have_trace(self):
-        """Verify trace() method was removed in v3."""
+    def test_langfuse_module_has_propagate_attributes(self):
+        """v4 introduces `propagate_attributes` for trace-level attrs."""
+        propagate_attributes = _import_propagate_attributes_or_skip()
+
+        assert callable(propagate_attributes)
+
+    def test_langfuse_client_does_not_have_v3_start_span(self):
+        """`start_span` was removed from the client in v4 (replaced by start_observation)."""
         langfuse_class = _import_langfuse_or_skip()
 
-        # This test documents that trace() no longer exists
-        # If this fails, langfuse may have restored backward compatibility
-        assert not hasattr(langfuse_class, "trace"), "Langfuse.trace() should NOT exist in v3 (removed)"
+        assert not hasattr(langfuse_class, "start_span"), (
+            "Langfuse.start_span() should NOT exist in v4 (removed)"
+        )
 
     def test_callback_handler_import_path(self):
-        """Verify the v3 callback handler import path works."""
-        # v3 path
+        """The langchain integration import path still resolves in v4."""
         callback_handler = _import_callback_handler_or_skip()
 
         assert callback_handler is not None
 
 
-class TestLangfuseTracerV3Compatibility:
-    """Test that LangFuseTracer works with langfuse v3 API."""
+class TestLangfuseTracerV4Compatibility:
+    """Test that LangFuseTracer works with langfuse v4 API."""
 
     def test_tracer_initialization_does_not_crash(self):
         """Tracer should initialize without crashing (may not be ready without server)."""
@@ -117,7 +131,7 @@ class TestLangfuseTracerFunctionality:
 
     @pytest.fixture
     def mock_langfuse(self):
-        """Create a mock langfuse client that simulates v3 API."""
+        """Create a mock langfuse client that simulates the v4 API."""
 
         class TraceContext(dict):
             pass
@@ -133,6 +147,16 @@ class TestLangfuseTracerFunctionality:
         mock_langfuse_module.types = mock_langfuse_types_module
         mock_langfuse_module.langchain = mock_langfuse_langchain_module
 
+        # v4: propagate_attributes is a context manager exposed at top level.
+        propagate_calls: list[dict] = []
+
+        @contextmanager
+        def _propagate_attributes(**attrs):
+            propagate_calls.append(attrs)
+            yield None
+
+        mock_langfuse_module.propagate_attributes = MagicMock(side_effect=_propagate_attributes)
+
         with patch.dict(
             sys.modules,
             {
@@ -145,26 +169,28 @@ class TestLangfuseTracerFunctionality:
             mock_langfuse_class.return_value = mock_client
             mock_langfuse_class.create_trace_id = MagicMock(return_value="a" * 32)
 
-            # Mock health check (auth_check in v3)
+            # Mock health check
             mock_client.auth_check.return_value = True
 
-            # V3 API mocks
+            # v4 API mocks
             mock_root_span = MagicMock()
             mock_root_span.id = "root-span-id"
-            mock_client.start_span.return_value = mock_root_span
+            mock_client.start_observation.return_value = mock_root_span
 
             mock_child_span = MagicMock()
             mock_child_span.id = "child-span-id"
-            mock_root_span.start_span.return_value = mock_child_span
+            mock_root_span.start_observation.return_value = mock_child_span
 
             yield {
                 "client": mock_client,
                 "root_span": mock_root_span,
                 "child_span": mock_child_span,
+                "propagate_calls": propagate_calls,
+                "propagate_attributes": mock_langfuse_module.propagate_attributes,
             }
 
-    def test_tracer_uses_v3_api_for_initialization(self, mock_langfuse):
-        """Verify tracer uses start_span instead of removed trace() method."""
+    def test_tracer_uses_v4_api_for_initialization(self, mock_langfuse):
+        """Verify tracer uses start_observation + propagate_attributes."""
         from langflow.services.tracing.langfuse import LangFuseTracer
 
         tracer = LangFuseTracer(
@@ -177,13 +203,17 @@ class TestLangfuseTracerFunctionality:
         )
 
         assert tracer.ready
-        # Should use v3 start_span, not v2 trace()
-        mock_langfuse["client"].start_span.assert_called_once()
-        # Should set trace metadata via update_trace
-        mock_langfuse["root_span"].update_trace.assert_called()
+        # v4: client.start_observation creates the root, not start_span
+        mock_langfuse["client"].start_observation.assert_called_once()
+        # v4: trace-level attrs are propagated, not set via update_trace
+        assert mock_langfuse["propagate_attributes"].called
+        ctx_attrs = mock_langfuse["propagate_calls"][0]
+        assert ctx_attrs["trace_name"] == "flow-123"
+        assert ctx_attrs["user_id"] == "user-1"
+        assert ctx_attrs["session_id"] == "session-1"
 
-    def test_add_trace_creates_child_span(self, mock_langfuse):
-        """Test that add_trace creates a child span using v3 API."""
+    def test_add_trace_creates_child_observation(self, mock_langfuse):
+        """Test that add_trace creates a child observation under the root."""
         from langflow.services.tracing.langfuse import LangFuseTracer
 
         tracer = LangFuseTracer(
@@ -201,9 +231,9 @@ class TestLangfuseTracerFunctionality:
             metadata={"key": "value"},
         )
 
-        # Should create child span under root span
-        mock_langfuse["root_span"].start_span.assert_called_once()
-        call_kwargs = mock_langfuse["root_span"].start_span.call_args[1]
+        # v4: child created via root.start_observation, not start_span
+        mock_langfuse["root_span"].start_observation.assert_called_once()
+        call_kwargs = mock_langfuse["root_span"].start_observation.call_args[1]
         assert call_kwargs["name"] == "TestComponent"
 
     def test_end_trace_updates_and_ends_span(self, mock_langfuse):
@@ -225,8 +255,8 @@ class TestLangfuseTracerFunctionality:
         mock_langfuse["child_span"].update.assert_called()
         mock_langfuse["child_span"].end.assert_called()
 
-    def test_end_updates_root_span_and_trace(self, mock_langfuse):
-        """Test that end() updates both root span and trace, then ends."""
+    def test_end_updates_root_span_and_set_trace_io(self, mock_langfuse):
+        """Test that end() updates the root span, calls set_trace_io, then ends."""
         from langflow.services.tracing.langfuse import LangFuseTracer
 
         tracer = LangFuseTracer(
@@ -244,8 +274,8 @@ class TestLangfuseTracerFunctionality:
 
         # Should update root span
         mock_langfuse["root_span"].update.assert_called()
-        # Should update trace metadata
-        assert mock_langfuse["root_span"].update_trace.call_count >= 2  # init + end
+        # v4: trace-level input/output via set_trace_io (not update_trace)
+        mock_langfuse["root_span"].set_trace_io.assert_called_once()
         # Should end root span
         mock_langfuse["root_span"].end.assert_called()
 
@@ -262,7 +292,7 @@ class TestLangfuseTracerFunctionality:
 
         # Add a span first (uses mock_langfuse fixture)
         tracer.add_trace("comp-1", "Test", "llm", {})
-        assert mock_langfuse["root_span"].start_span.called
+        assert mock_langfuse["root_span"].start_observation.called
 
         with patch("langfuse.langchain.CallbackHandler") as mock_handler:
             mock_handler.return_value = MagicMock()

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py
@@ -336,15 +336,14 @@ class TestLangfuseTracerFunctionality:
 
 
 class TestLangfuseTracerWorkerTaskPropagation:
-    """Verify trace-level attrs reach child observations created in a different
-    asyncio task than the tracer was constructed in.
+    """Verify trace-level attrs reach child observations across asyncio task boundaries.
 
     langflow's TracingService spawns a worker task in `start_tracers` BEFORE
     `_initialize_langfuse_tracer` runs, and dispatches `add_trace` calls via
     a queue. Because `asyncio.create_task` snapshots contextvars at task
     creation, a `propagate_attributes` token attached in the request task is
     not visible from the worker. The mocked-module tests above can't catch
-    this — they assert the *call* was made but the SDK's real OTel context
+    this; they assert the call was made but the SDK's real OTel context
     plumbing is bypassed.
 
     This test exercises a real `LangfuseSpanProcessor` against an in-memory
@@ -354,12 +353,11 @@ class TestLangfuseTracerWorkerTaskPropagation:
 
     @pytest.fixture
     def memory_exporter(self):
-        from opentelemetry.sdk.trace import ReadableSpan
         from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
         class _InMemoryExporter(SpanExporter):
             def __init__(self) -> None:
-                self._spans: list[ReadableSpan] = []
+                self._spans = []
 
             def export(self, spans):
                 self._spans.extend(spans)
@@ -424,10 +422,11 @@ class TestLangfuseTracerWorkerTaskPropagation:
         LangfuseResourceManager.reset()
         _reset_otel_globals()
 
-    async def test_child_observation_in_worker_task_has_propagated_attrs(
-        self, real_langfuse_with_memory_exporter, memory_exporter, monkeypatch
-    ):
-        """Mirror the TracingService topology: worker task spawned before the
+    @pytest.mark.usefixtures("real_langfuse_with_memory_exporter")
+    async def test_child_observation_in_worker_task_has_propagated_attrs(self, memory_exporter, monkeypatch):
+        """Worker task spawned before tracer; assert child span has propagated attrs.
+
+        Mirrors the TracingService topology: worker task spawned before the
         tracer, add_trace dispatched through a queue. The child span must end
         up with user.id / session.id / langfuse.trace.name set.
         """
@@ -437,7 +436,7 @@ class TestLangfuseTracerWorkerTaskPropagation:
         from langfuse._client.attributes import LangfuseOtelSpanAttributes
         from langfuse._client.client import Langfuse
 
-        monkeypatch.setattr(Langfuse, "auth_check", lambda self: True)
+        monkeypatch.setattr(Langfuse, "auth_check", lambda _self: True)
 
         queue: asyncio.Queue = asyncio.Queue()
         done = asyncio.Event()

--- a/uv.lock
+++ b/uv.lock
@@ -7140,7 +7140,7 @@ all = [
     { name = "langchain-pinecone", marker = "python_full_version < '3.14'" },
     { name = "langchain-sambanova" },
     { name = "langchain-unstructured" },
-    { name = "langfuse", marker = "python_full_version < '3.14'" },
+    { name = "langfuse" },
     { name = "langsmith" },
     { name = "langwatch", marker = "python_full_version < '3.14'" },
     { name = "lark" },
@@ -7307,7 +7307,7 @@ complete = [
     { name = "langchain-pinecone", marker = "python_full_version < '3.14'" },
     { name = "langchain-sambanova" },
     { name = "langchain-unstructured" },
-    { name = "langfuse", marker = "python_full_version < '3.14'" },
+    { name = "langfuse" },
     { name = "langsmith" },
     { name = "langwatch", marker = "python_full_version < '3.14'" },
     { name = "lark" },
@@ -7459,7 +7459,7 @@ langchain-unstructured = [
     { name = "langchain-unstructured" },
 ]
 langfuse = [
-    { name = "langfuse", marker = "python_full_version < '3.14'" },
+    { name = "langfuse" },
 ]
 langsmith = [
     { name = "langsmith" },
@@ -7875,7 +7875,7 @@ requires-dist = [
     { name = "langflow-base", extras = ["yfinance"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["youtube"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["zep"], marker = "extra == 'complete'", editable = "src/backend/base" },
-    { name = "langfuse", marker = "python_full_version < '3.14' and extra == 'langfuse'", specifier = "~=3.8" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4,<5" },
     { name = "langgraph-checkpoint", specifier = ">4.0.0,<5.0.0" },
     { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.3.42,<1.0.0" },
     { name = "langwatch", marker = "python_full_version < '3.14' and extra == 'langwatch'", specifier = "~=0.10.0" },
@@ -8055,22 +8055,21 @@ dev = [
 
 [[package]]
 name = "langfuse"
-version = "3.14.6"
+version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff", marker = "python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "openai", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "wrapt", marker = "python_full_version < '3.14'" },
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/e4/5bb96bc5f95f476c8f7c4e654a6420250938cc21645b914a1309c2dc3d49/langfuse-3.14.6.tar.gz", hash = "sha256:058f7b7caa9284b964feaee81c223542d78e9fb4daabf312269b9f903471b9c4", size = 236530, upload-time = "2026-04-01T17:27:55.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/31/4b7157be23e7c8c3581ac5f6547c5c003e232e7044c92398c468ef78a809/langfuse-4.6.1.tar.gz", hash = "sha256:7f256c669e610909c2e93ca3e9e4168dbef344b753b6874f14b0edd673863f17", size = 281379, upload-time = "2026-05-08T14:08:15.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/9a/f2d82cdb7fb71d89de2e693b317a8f2c3d3da44db8a1533b96cf0fbe362f/langfuse-3.14.6-py3-none-any.whl", hash = "sha256:5eb22a5ea579ac10f050513e3fedccc3c9a981eeefe44f9014273bc229a56f88", size = 421426, upload-time = "2026-04-01T17:27:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/3a6082f7809bdcc1269e9920c07d7c7f92a53cc265a4a879e59c92b23b36/langfuse-4.6.1-py3-none-any.whl", hash = "sha256:a696ac3089a0c8431bf7f1b47b7f6417da311f418dd04ce9ef62d63608fd8797", size = 481237, upload-time = "2026-05-08T14:08:17.141Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Bug

`src/backend/base/pyproject.toml` (at v1.9.3 + `main`) pins:

```toml
langfuse = ["langfuse~=3.8; python_version < '3.14'"]
```

The environment marker means **on Python 3.14 the langfuse SDK is not installed at all**.

Reproduced against the published image:

```console
$ docker run --rm langflowai/langflow:1.9.3 python3 --version
Python 3.14.5

$ docker run --rm langflowai/langflow:1.9.3 python3 -c 'import langfuse'
ModuleNotFoundError: No module named 'langfuse'
```

`requires-python = ">=3.10,<3.15"` and the published Dockerfile uses `python:3.14-slim-trixie`, so this is the default path. Setting `LANGFUSE_*` env vars on a default install produces `"Could not import langfuse"` on every flow run (langfuse.py:101).

## Fix

Bump the pin to v4 AND migrate the tracer + tests off the v3 API. The first version of this PR only touched the pin — @coderabbitai correctly caught that the tracer code calls v3-only methods (`client.start_span`, `span.update_trace`) which don't exist on v4. Single-line pin bumps would break tracing at runtime; the full migration is below.

### Pin change

```diff
- langfuse = ["langfuse~=3.8; python_version < '3.14'"]
+ langfuse = ["langfuse>=4,<5"]
```

### Tracer migration (`src/backend/base/langflow/services/tracing/langfuse.py`)

| v3 (before) | v4 (after) |
|---|---|
| `client.start_span(...)` | `client.start_observation(...)` |
| `span.start_span(...)` | `span.start_observation(...)` |
| `root.update_trace(name=, user_id=, session_id=)` | `propagate_attributes(trace_name=, user_id=, session_id=)` context manager, entered in `_setup_langfuse`, exited in `end()` |
| `root.update_trace(input=, output=)` | `root.set_trace_io(input=, output=)` |
| `span.update(...)`, `span.end()`, `Langfuse.create_trace_id(...)`, `CallbackHandler(trace_context=...)` | unchanged in v4 |

The `propagate_attributes` CM is the load-bearing piece — trace attributes are no longer span parameters, they propagate via OTel context. Manually entering and exiting (rather than wrapping the whole tracer lifecycle in a `with` block) keeps the procedural `BaseTracer` interface intact.

### Test migration

`tests/unit/services/tracing/test_langfuse_v3_compatibility.py` → `test_langfuse_v4_compatibility.py`. Mocks updated to v4 surface (`start_observation` + a context-manager-shaped `propagate_attributes`). Removed v3-specific assertions (`update_trace` count, `start_span` calls); added v4 assertions (`propagate_attributes` invoked with `trace_name`/`user_id`/`session_id`, `set_trace_io` called in `end()`, `start_observation` on root + child).

## Verification

All 12 tests pass against the real `langfuse==4.6.1` inside `langflowai/langflow:1.9.3`:

```console
$ docker run --rm \
    -v "$(pwd)/src/backend/base/langflow/services/tracing/langfuse.py:/app/.venv/lib/python3.14/site-packages/langflow/services/tracing/langfuse.py" \
    -v "$(pwd)/src/backend/tests/unit/services/tracing/test_langfuse_v4_compatibility.py:/tests/test_langfuse_v4_compatibility.py" \
    langflowai/langflow:1.9.3 bash -c '
      /app/.venv/bin/pip install --quiet "langfuse==4.6.1" pytest
      cd /tests && /app/.venv/bin/python -m pytest test_langfuse_v4_compatibility.py -v'

test_langfuse_client_has_start_observation       PASSED
test_langfuse_client_has_create_trace_id         PASSED
test_langfuse_module_has_propagate_attributes    PASSED
test_langfuse_client_does_not_have_v3_start_span PASSED
test_callback_handler_import_path                PASSED
test_tracer_initialization_does_not_crash        PASSED
test_tracer_uses_v4_api_for_initialization       PASSED
test_add_trace_creates_child_observation         PASSED
test_end_trace_updates_and_ends_span             PASSED
test_end_updates_root_span_and_set_trace_io      PASSED
test_get_langchain_callback_uses_trace_context   PASSED
test_get_langchain_callback_includes_parent_span_id  PASSED

12 passed in 6.74s
```

Plus a live-tracer round-trip (constructed tracer → `add_trace` → `get_langchain_callback` → `end_trace` → `end` → all v4 calls executed, OTel context entered/exited cleanly).

## Why v4

- langfuse 4.6.1 (released 2026-05-08) supports Python 3.10–3.14. See langfuse [discussion #11409](https://github.com/orgs/langfuse/discussions/11409).
- v3 (`~=3.8`) depends on pydantic v1 internals incompatible with Python 3.14 (the spike that prompted the `python_version < '3.14'` marker in the first place — see [PR #11216](https://github.com/langflow-ai/langflow/issues/11216) precedent for v2→v3).

## Note on `langwatch`

Two lines below the langfuse pin, `langwatch~=0.10.0; python_version < '3.14'` has the same bug pattern. Out of scope for this PR; flagged here in case someone wants to file a follow-up.

## Related

- Issue #11216 — community ask for v2→v3 (landed as `~=3.8`); this is the v3→v4 follow-up
- PR #11114 — the tracer rewrite that introduced v3 dependencies the pin still tracked to v2
- PR #13083 — Python 3.14 Docker image bump, closed yesterday; langfuse wasn't called out in the 4 reviewer concerns
