### PR TITLE
feat: implement RBAC and external auth

### DIFF
--- a/src/backend/base/langflow/alembic/versions/4c6d8e2f9a10_add_flow_access_control_table.py
+++ b/src/backend/base/langflow/alembic/versions/4c6d8e2f9a10_add_flow_access_control_table.py
@@ -1,0 +1,62 @@
+"""add flow access control table
+
+Revision ID: 4c6d8e2f9a10
+Revises: d306e5c17c41
+Create Date: 2026-04-30 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "4c6d8e2f9a10"
+down_revision: str | None = "d306e5c17c41"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "flow_access_control"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if migration.table_exists(TABLE_NAME, conn):
+        return
+
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("flow_id", sa.Uuid(), nullable=False),
+        sa.Column("subject_type", sa.String(length=16), nullable=False),
+        sa.Column("subject_id", sa.String(length=255), nullable=False),
+        sa.Column("permission", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["flow_id"], ["flow.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "flow_id",
+            "subject_type",
+            "subject_id",
+            "permission",
+            name="unique_flow_access_control_entry",
+        ),
+    )
+    op.create_index(op.f("ix_flow_access_control_flow_id"), TABLE_NAME, ["flow_id"])
+    op.create_index(op.f("ix_flow_access_control_subject_type"), TABLE_NAME, ["subject_type"])
+    op.create_index(op.f("ix_flow_access_control_subject_id"), TABLE_NAME, ["subject_id"])
+    op.create_index(op.f("ix_flow_access_control_permission"), TABLE_NAME, ["permission"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if not migration.table_exists(TABLE_NAME, conn):
+        return
+
+    op.drop_index(op.f("ix_flow_access_control_permission"), table_name=TABLE_NAME)
+    op.drop_index(op.f("ix_flow_access_control_subject_id"), table_name=TABLE_NAME)
+    op.drop_index(op.f("ix_flow_access_control_subject_type"), table_name=TABLE_NAME)
+    op.drop_index(op.f("ix_flow_access_control_flow_id"), table_name=TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -17,7 +17,7 @@ from langflow.services.database.models.deployment.exceptions import (
     araise_if_deployment_guard_error_or_skip,
 )
 from langflow.services.database.models.deployment.guards import check_flow_has_deployed_versions
-from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.flow.model import Flow, FlowAccessControl
 from langflow.services.database.models.flow_version.model import FlowVersion
 from langflow.services.database.models.message.model import MessageTable
 from langflow.services.database.models.traces.model import SpanTable, TraceTable
@@ -112,6 +112,7 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         if trace_ids:
             await session.exec(delete(SpanTable).where(col(SpanTable.trace_id).in_(trace_ids)))
             await session.exec(delete(TraceTable).where(col(TraceTable.id).in_(trace_ids)))
+        await session.exec(delete(FlowAccessControl).where(FlowAccessControl.flow_id == flow_id))
         await session.exec(delete(Flow).where(Flow.id == flow_id))
     except Exception as e:
         await araise_if_deployment_guard_error_or_skip(

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -54,6 +54,11 @@ from langflow.helpers.flow import get_flow_by_id_or_endpoint_name
 from langflow.interface.initialize.loading import update_params_with_load_from_db_fields
 from langflow.processing.process import process_tweaks, run_graph_internal
 from langflow.schema.graph import Tweaks
+from langflow.services.auth.flow_rbac import (
+    get_flow_by_id_or_name,
+    get_flow_principal,
+    require_flow_permission,
+)
 from langflow.services.auth.utils import (
     api_key_security,
     get_current_active_user,
@@ -61,7 +66,7 @@ from langflow.services.auth.utils import (
     get_optional_user,
 )
 from langflow.services.cache.utils import save_uploaded_file
-from langflow.services.database.models.flow.model import Flow, FlowRead
+from langflow.services.database.models.flow.model import Flow, FlowPermission, FlowRead
 from langflow.services.database.models.flow.utils import get_all_webhook_components_in_flow
 from langflow.services.database.models.jobs.model import JobType
 from langflow.services.database.models.user.model import User, UserRead
@@ -525,6 +530,8 @@ async def check_flow_user_permission(
     Raises:
         HTTPException: If the user does not have permission to run the flow
     """
+    if get_settings_service().auth_settings.FLOW_RBAC_ENABLED:
+        return
     if flow and flow.user_id != api_key_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have permission to run this flow")
 
@@ -532,6 +539,8 @@ async def check_flow_user_permission(
 async def get_flow_for_api_key_user(
     flow_id_or_name: str,
     api_key_user: Annotated[UserRead, Depends(api_key_security)],
+    request: Request,
+    session: DbSession,
 ) -> FlowRead:
     """Auth-aware wrapper around ``get_flow_by_id_or_endpoint_name`` for API-key routes.
 
@@ -545,15 +554,39 @@ async def get_flow_for_api_key_user(
     layer.  ``check_flow_user_permission`` is kept in the handler chain as
     defense in depth.
     """
-    return await get_flow_by_id_or_endpoint_name(flow_id_or_name, api_key_user.id)
+    if not get_settings_service().auth_settings.FLOW_RBAC_ENABLED:
+        return await get_flow_by_id_or_endpoint_name(flow_id_or_name, api_key_user.id)
+
+    principal = await get_flow_principal(request, api_key_user)
+    flow = await require_flow_permission(
+        session,
+        await get_flow_by_id_or_name(session, flow_id_or_name),
+        principal,
+        FlowPermission.RUN,
+        not_found_detail=f"Flow identifier {flow_id_or_name} not found",
+    )
+    return FlowRead.model_validate(flow, from_attributes=True)
 
 
 async def get_flow_for_current_user(
     flow_id_or_name: str,
     current_user: CurrentActiveUser,
+    request: Request,
+    session: DbSession,
 ) -> FlowRead:
     """Session-auth variant of :func:`get_flow_for_api_key_user`."""
-    return await get_flow_by_id_or_endpoint_name(flow_id_or_name, current_user.id)
+    if not get_settings_service().auth_settings.FLOW_RBAC_ENABLED:
+        return await get_flow_by_id_or_endpoint_name(flow_id_or_name, current_user.id)
+
+    principal = await get_flow_principal(request, current_user)
+    flow = await require_flow_permission(
+        session,
+        await get_flow_by_id_or_name(session, flow_id_or_name),
+        principal,
+        FlowPermission.RUN,
+        not_found_detail=f"Flow identifier {flow_id_or_name} not found",
+    )
+    return FlowRead.model_validate(flow, from_attributes=True)
 
 
 async def get_flow_for_sse_user(
@@ -854,6 +887,8 @@ async def simplified_run_flow_session(
 @router.get("/webhook-events/{flow_id_or_name}", include_in_schema=False)
 async def webhook_events_stream(
     flow: Annotated[FlowRead, Depends(get_flow_for_sse_user)],
+    user: Annotated[User | UserRead, Depends(get_current_user_for_sse)],
+    session: DbSession,
     request: Request,
 ):
     """Server-Sent Events (SSE) endpoint for real-time webhook build updates.
@@ -864,6 +899,14 @@ async def webhook_events_stream(
     Authentication: Requires user to be logged in (via cookie) or provide API key.
     The user must own the flow to subscribe to its events.
     """
+    if get_settings_service().auth_settings.FLOW_RBAC_ENABLED:
+        principal = await get_flow_principal(request, user)
+        await require_flow_permission(session, flow, principal, FlowPermission.RUN)
+    elif str(flow.user_id) != str(user.id):
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail="Access denied: You can only subscribe to events for flows you own",
+        )
 
     async def event_generator() -> AsyncGenerator[str, None]:
         """Generate SSE events from the webhook event manager."""
@@ -1067,7 +1110,7 @@ async def experimental_run_flow(
         try:
             # Get the flow that matches the flow_id and belongs to the user
             # flow = session.query(Flow).filter(Flow.id == flow_id).filter(Flow.user_id == api_key_user.id).first()
-            stmt = select(Flow).where(Flow.id == flow.id).where(Flow.user_id == api_key_user.id)
+            stmt = select(Flow).where(Flow.id == flow.id)
             flow = (await session.exec(stmt)).first()
         except sa.exc.StatementError as exc:
             # StatementError('(builtins.ValueError) badly formed hexadecimal UUID string')

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -37,8 +37,13 @@ from langflow.api.v1.flows_helpers import (
 )
 from langflow.api.v1.mappers.deployments.sync import retry_flow_operation_on_deployment_guard
 from langflow.api.v1.schemas import FlowListCreate
-from langflow.helpers.user import get_user_by_flow_id_or_endpoint_name
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
+from langflow.services.auth.flow_rbac import (
+    get_flow_principal,
+    has_flow_permission,
+    require_flow_permission,
+    viewable_flows_filter,
+)
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.cache.service import ThreadingInMemoryCache
 from langflow.services.database.models.deployment.exceptions import (
@@ -47,8 +52,12 @@ from langflow.services.database.models.deployment.exceptions import (
 from langflow.services.database.models.flow.model import (
     AccessTypeEnum,
     Flow,
+    FlowAccessControl,
+    FlowAccessControlCreate,
+    FlowAccessControlRead,
     FlowCreate,
     FlowHeader,
+    FlowPermission,
     FlowRead,
     FlowUpdate,
 )
@@ -58,6 +67,7 @@ from langflow.services.database.models.flow.model import (
 # and FlowVersionError from the flow_version modules.
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import Folder
+from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_settings_service, get_storage_service
 from langflow.services.storage.service import StorageService
 from langflow.utils.compression import compress_response
@@ -107,6 +117,7 @@ async def create_flow(
 @router.get("/", response_model=list[FlowRead] | Page[FlowRead] | list[FlowHeader], status_code=200)
 async def read_flows(
     *,
+    request: Request,
     current_user: CurrentActiveUser,
     session: DbSession,
     remove_example_flows: bool = False,
@@ -135,7 +146,10 @@ async def read_flows(
         if not folder_id:
             folder_id = default_folder_id
 
-        if auth_settings.AUTO_LOGIN:
+        if auth_settings.FLOW_RBAC_ENABLED:
+            principal = await get_flow_principal(request, current_user)
+            stmt = select(Flow).where(viewable_flows_filter(principal, auth_settings))
+        elif auth_settings.AUTO_LOGIN:
             stmt = select(Flow).where(
                 (Flow.user_id == None) | (Flow.user_id == current_user.id)  # noqa: E711
             )
@@ -184,15 +198,20 @@ async def read_flows(
 @router.get("/{flow_id}", response_model=FlowRead, status_code=200)
 async def read_flow(
     *,
+    request: Request,
     session: DbSession,
     flow_id: UUID,
     current_user: CurrentActiveUser,
 ):
     """Read a flow."""
-    if user_flow := await _read_flow(session, flow_id, current_user.id):
-        # Convert to FlowRead while session is still active to avoid detached instance errors
-        return FlowRead.model_validate(user_flow, from_attributes=True)
-    raise HTTPException(status_code=404, detail="Flow not found")
+    principal = await get_flow_principal(request, current_user)
+    flow = await require_flow_permission(
+        session,
+        await session.get(Flow, flow_id),
+        principal,
+        FlowPermission.VIEW,
+    )
+    return FlowRead.model_validate(flow, from_attributes=True)
 
 
 @router.get("/{flow_id}/note_translations", dependencies=[Depends(get_current_active_user)], status_code=200)
@@ -235,16 +254,19 @@ async def read_public_flow(
 ):
     """Read a public flow."""
     access_type = (await session.exec(select(Flow.access_type).where(Flow.id == flow_id))).first()
-    if access_type is not AccessTypeEnum.PUBLIC:
+    if access_type != AccessTypeEnum.PUBLIC:
         raise HTTPException(status_code=403, detail="Flow is not public")
 
-    current_user = await get_user_by_flow_id_or_endpoint_name(str(flow_id))
-    return await read_flow(session=session, flow_id=flow_id, current_user=current_user)
+    flow = await session.get(Flow, flow_id)
+    if flow is None:
+        raise HTTPException(status_code=404, detail="Flow not found")
+    return FlowRead.model_validate(flow, from_attributes=True)
 
 
 @router.patch("/{flow_id}", response_model=FlowRead, status_code=200)
 async def update_flow(
     *,
+    request: Request,
     session: DbSession,
     flow_id: UUID,
     flow: FlowUpdate,
@@ -253,9 +275,17 @@ async def update_flow(
 ):
     """Update a flow."""
     try:
-        db_flow = await _read_flow(session=session, flow_id=flow_id, user_id=current_user.id)
-        if not db_flow:
-            raise HTTPException(status_code=404, detail="Flow not found")
+        principal = await get_flow_principal(request, current_user)
+        required_permission = (
+            FlowPermission.MANAGE if {"locked", "access_type"} & flow.model_fields_set else FlowPermission.EDIT
+        )
+        db_flow = await require_flow_permission(
+            session,
+            await session.get(Flow, flow_id),
+            principal,
+            required_permission,
+        )
+        owner_id = db_flow.user_id or current_user.id
 
         # Explicit folder_id=None is ignored here because _patch_flow builds
         # update_data with exclude_none=True, so null folder_id is a no-op.
@@ -265,21 +295,24 @@ async def update_flow(
 
         async def operation() -> FlowRead:
             # Re-load inside each attempt so retry after nested rollback never uses an expired ORM instance.
-            db_flow_for_attempt = await _read_flow(session=session, flow_id=flow_id, user_id=current_user.id)
-            if not db_flow_for_attempt:
-                raise HTTPException(status_code=404, detail="Flow not found")
+            db_flow_for_attempt = await require_flow_permission(
+                session,
+                await session.get(Flow, flow_id),
+                principal,
+                required_permission,
+            )
             return await _patch_flow(
                 session=session,
                 db_flow=db_flow_for_attempt,
                 flow=flow,
-                user_id=current_user.id,
+                user_id=owner_id,
                 storage_service=storage_service,
             )
 
         if folder_id_will_change:
             return await retry_flow_operation_on_deployment_guard(
                 db=session,
-                user_id=current_user.id,
+                user_id=owner_id,
                 flow_ids=[flow_id],
                 operation=operation,
             )
@@ -297,6 +330,7 @@ async def update_flow(
 @router.put("/{flow_id}", response_model=FlowRead)
 async def upsert_flow(
     *,
+    request: Request,
     session: DbSession,
     flow_id: UUID,
     flow: FlowCreate,
@@ -310,13 +344,13 @@ async def upsert_flow(
     from fastapi.responses import JSONResponse
 
     try:
+        principal = await get_flow_principal(request, current_user)
         # Check if flow exists (without user filter to distinguish ownership vs CREATE)
         existing_flow = (await session.exec(select(Flow).where(Flow.id == flow_id))).first()
 
         if existing_flow is not None:
-            # Flow exists - check ownership (return 404 to avoid leaking resource existence)
-            if existing_flow.user_id != current_user.id:
-                raise HTTPException(status_code=404, detail="Flow not found")
+            await require_flow_permission(session, existing_flow, principal, FlowPermission.EDIT)
+            owner_id = existing_flow.user_id or current_user.id
 
             # Sync deployment state before folder changes
             # Explicit folder_id=None is ignored here because _update_existing_flow
@@ -329,21 +363,26 @@ async def upsert_flow(
 
             async def update_operation() -> FlowRead:
                 # Re-load inside each attempt so retry after nested rollback never uses an expired ORM instance.
-                existing_flow_for_attempt = await _read_flow(session=session, flow_id=flow_id, user_id=current_user.id)
-                if existing_flow_for_attempt is None:
-                    raise HTTPException(status_code=404, detail="Flow not found")
+                existing_flow_for_attempt = await require_flow_permission(
+                    session,
+                    await session.get(Flow, flow_id),
+                    principal,
+                    FlowPermission.EDIT,
+                )
+                flow_owner = await session.get(User, owner_id) if existing_flow_for_attempt.user_id else None
+                update_user = flow_owner or current_user
                 return await _update_existing_flow(
                     session=session,
                     existing_flow=existing_flow_for_attempt,
                     flow=flow,
-                    current_user=current_user,
+                    current_user=update_user,
                     storage_service=storage_service,
                 )
 
             if folder_id_will_change:
                 flow_read = await retry_flow_operation_on_deployment_guard(
                     db=session,
-                    user_id=current_user.id,
+                    user_id=owner_id,
                     flow_ids=[existing_flow.id],
                     operation=update_operation,
                 )
@@ -378,25 +417,100 @@ async def upsert_flow(
 @router.delete("/{flow_id}", status_code=200)
 async def delete_flow(
     *,
+    request: Request,
     session: DbSession,
     flow_id: UUID,
     current_user: CurrentActiveUser,
 ):
     """Delete a flow."""
-    flow = await _read_flow(
-        session=session,
-        flow_id=flow_id,
-        user_id=current_user.id,
+    principal = await get_flow_principal(request, current_user)
+    flow = await require_flow_permission(
+        session,
+        await session.get(Flow, flow_id),
+        principal,
+        FlowPermission.MANAGE,
     )
-    if not flow:
-        raise HTTPException(status_code=404, detail="Flow not found")
+    owner_id = flow.user_id or current_user.id
     await retry_flow_operation_on_deployment_guard(
         db=session,
-        user_id=current_user.id,
+        user_id=owner_id,
         flow_ids=[flow.id],
         operation=lambda: cascade_delete_flow(session, flow.id),
     )
     return {"message": "Flow deleted successfully"}
+
+
+@router.get("/{flow_id}/acl", response_model=list[FlowAccessControlRead], status_code=200)
+async def read_flow_acl(
+    *,
+    request: Request,
+    session: DbSession,
+    flow_id: UUID,
+    current_user: CurrentActiveUser,
+):
+    principal = await get_flow_principal(request, current_user)
+    await require_flow_permission(
+        session,
+        await session.get(Flow, flow_id),
+        principal,
+        FlowPermission.MANAGE,
+    )
+    entries = (await session.exec(select(FlowAccessControl).where(FlowAccessControl.flow_id == flow_id))).all()
+    return [FlowAccessControlRead.model_validate(entry, from_attributes=True) for entry in entries]
+
+
+@router.post("/{flow_id}/acl", response_model=FlowAccessControlRead, status_code=201)
+async def create_flow_acl_entry(
+    *,
+    request: Request,
+    session: DbSession,
+    flow_id: UUID,
+    acl_entry: FlowAccessControlCreate,
+    current_user: CurrentActiveUser,
+):
+    principal = await get_flow_principal(request, current_user)
+    await require_flow_permission(
+        session,
+        await session.get(Flow, flow_id),
+        principal,
+        FlowPermission.MANAGE,
+    )
+    entry = FlowAccessControl(flow_id=flow_id, **acl_entry.model_dump())
+    session.add(entry)
+    try:
+        await session.flush()
+        await session.refresh(entry)
+    except Exception as exc:
+        raise _handle_unique_constraint_error(exc) from exc
+    return FlowAccessControlRead.model_validate(entry, from_attributes=True)
+
+
+@router.delete("/{flow_id}/acl/{acl_id}", status_code=200)
+async def delete_flow_acl_entry(
+    *,
+    request: Request,
+    session: DbSession,
+    flow_id: UUID,
+    acl_id: UUID,
+    current_user: CurrentActiveUser,
+):
+    principal = await get_flow_principal(request, current_user)
+    await require_flow_permission(
+        session,
+        await session.get(Flow, flow_id),
+        principal,
+        FlowPermission.MANAGE,
+    )
+    entry = (
+        await session.exec(
+            select(FlowAccessControl).where(FlowAccessControl.id == acl_id, FlowAccessControl.flow_id == flow_id)
+        )
+    ).first()
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Flow ACL entry not found")
+
+    await session.delete(entry)
+    return {"message": "Flow ACL entry deleted successfully"}
 
 
 @router.post("/batch/", response_model=list[FlowRead], status_code=201)
@@ -518,6 +632,7 @@ async def upload_file(
 
 @router.delete("/")
 async def delete_multiple_flows(
+    request: Request,
     flow_ids: list[UUID],
     user: CurrentActiveUser,
     db: DbSession,
@@ -528,9 +643,19 @@ async def delete_multiple_flows(
         async def _delete_operation() -> int:
             if not flow_ids:
                 return 0
-            flows_to_delete = (
-                await db.exec(select(Flow).where(col(Flow.id).in_(flow_ids)).where(Flow.user_id == user.id))
-            ).all()
+            auth_settings = get_settings_service().auth_settings
+            if auth_settings.FLOW_RBAC_ENABLED:
+                principal = await get_flow_principal(request, user)
+                candidate_flows = (await db.exec(select(Flow).where(col(Flow.id).in_(flow_ids)))).all()
+                flows_to_delete = [
+                    flow
+                    for flow in candidate_flows
+                    if await has_flow_permission(db, flow, principal, FlowPermission.MANAGE, auth_settings)
+                ]
+            else:
+                flows_to_delete = (
+                    await db.exec(select(Flow).where(col(Flow.id).in_(flow_ids)).where(Flow.user_id == user.id))
+                ).all()
             for flow in flows_to_delete:
                 await cascade_delete_flow(db, flow.id)
             await db.flush()
@@ -557,6 +682,7 @@ async def delete_multiple_flows(
 
 @router.post("/download/", status_code=200)
 async def download_multiple_file(
+    request: Request,
     flow_ids: list[UUID],
     user: CurrentActiveUser,
     db: DbSession,
@@ -565,7 +691,16 @@ async def download_multiple_file(
     # TODO: Full-version download (include_version parameter) is planned as a follow-up feature.
     # When implemented, add an include_version: bool = False parameter and embed version
     # entries in each flow dict using get_flow_versions_with_provider_status and strip_version_data.
-    flows = (await db.exec(select(Flow).where(and_(Flow.user_id == user.id, Flow.id.in_(flow_ids))))).all()  # type: ignore[attr-defined]
+    auth_settings = get_settings_service().auth_settings
+    if auth_settings.FLOW_RBAC_ENABLED:
+        principal = await get_flow_principal(request, user)
+        flows = (
+            await db.exec(
+                select(Flow).where(col(Flow.id).in_(flow_ids)).where(viewable_flows_filter(principal, auth_settings))
+            )
+        ).all()
+    else:
+        flows = (await db.exec(select(Flow).where(and_(Flow.user_id == user.id, Flow.id.in_(flow_ids))))).all()  # type: ignore[attr-defined]
 
     if not flows:
         raise HTTPException(status_code=404, detail="No flows found.")

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from langflow.api.utils import DbSession
 from langflow.api.v1.schemas import Token
 from langflow.initial_setup.setup import get_or_create_default_folder
+from langflow.services.auth.exceptions import AuthenticationError
 from langflow.services.database.models.user.crud import get_user_by_id
 from langflow.services.database.models.user.model import UserRead
 from langflow.services.deps import get_auth_service, get_settings_service, get_variable_service
@@ -209,7 +210,7 @@ async def get_session(
             authenticated=True,
             user=UserRead.model_validate(user, from_attributes=True),
         )
-    except (HTTPException, ValueError) as _:
+    except (AuthenticationError, HTTPException, ValueError) as _:
         # Any authentication error means not authenticated
         return SessionResponse(authenticated=False)
 

--- a/src/backend/base/langflow/services/auth/external.py
+++ b/src/backend/base/langflow/services/auth/external.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypeVar, cast
+
+import httpx
+import jwt
+from jwt import InvalidTokenError as PyJWTInvalidTokenError
+from lfx.log.logger import logger
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from langflow.services.auth.exceptions import InactiveUserError
+from langflow.services.auth.exceptions import InvalidTokenError as AuthInvalidTokenError
+from langflow.services.database.models.auth import SSOUserProfile
+from langflow.services.database.models.user.crud import get_user_by_id, get_user_by_username, update_user_last_login_at
+from langflow.services.database.models.user.model import User
+
+if TYPE_CHECKING:
+    from lfx.services.settings.auth import AuthSettings
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+JWKS_CACHE_TTL_SECONDS = 300
+_jwks_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ExternalIdentity:
+    provider: str
+    subject: str
+    username: str
+    email: str | None
+    name: str | None
+    claims: dict[str, Any]
+
+
+class ExternalIdentityResolver(Protocol):
+    async def resolve(self, token: str, auth_settings: AuthSettings) -> ExternalIdentity | dict[str, Any]: ...
+
+
+ExternalResolverResult: TypeAlias = ExternalIdentity | dict[str, Any]
+ExternalResolverCallable: TypeAlias = Callable[
+    [str, "AuthSettings"],
+    ExternalResolverResult | Awaitable[ExternalResolverResult],
+]
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _claim_as_str(claims: dict[str, Any], claim_name: str | None) -> str | None:
+    if not claim_name:
+        return None
+    value = claims.get(claim_name)
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if value is None:
+        return None
+    return str(value)
+
+
+def _normalize_username(value: str) -> str:
+    username = value.strip()
+    if not username:
+        return "external-user"
+    return username[:255]
+
+
+def _external_username_fallback(provider: str, subject: str) -> str:
+    digest = hashlib.sha256(f"{provider}:{subject}".encode()).hexdigest()[:12]
+    normalized_provider = provider[:200] or "external"
+    return f"{normalized_provider}-{digest}"
+
+
+def _identity_from_claims(claims: dict[str, Any], auth_settings: AuthSettings) -> ExternalIdentity:
+    provider = (auth_settings.EXTERNAL_AUTH_PROVIDER or "external").strip() or "external"
+    subject = _claim_as_str(claims, auth_settings.EXTERNAL_AUTH_SUBJECT_CLAIM)
+    if not subject:
+        msg = f"External credential is missing required claim: {auth_settings.EXTERNAL_AUTH_SUBJECT_CLAIM}"
+        raise AuthInvalidTokenError(msg)
+
+    email = _claim_as_str(claims, auth_settings.EXTERNAL_AUTH_EMAIL_CLAIM)
+    preferred_username = _claim_as_str(claims, auth_settings.EXTERNAL_AUTH_USERNAME_CLAIM)
+    name = _claim_as_str(claims, auth_settings.EXTERNAL_AUTH_NAME_CLAIM)
+    username_claim = preferred_username or email or name or _external_username_fallback(provider, subject)
+    username = _normalize_username(username_claim)
+
+    return ExternalIdentity(
+        provider=provider,
+        subject=subject,
+        username=username,
+        email=email,
+        name=name,
+        claims=claims,
+    )
+
+
+def _validate_trusted_time_claims(claims: dict[str, Any]) -> None:
+    now = datetime.now(timezone.utc).timestamp()
+    exp = claims.get("exp")
+    if exp is not None and now > float(exp):
+        msg = "External credential has expired"
+        raise AuthInvalidTokenError(msg)
+
+    nbf = claims.get("nbf")
+    if nbf is not None and now < float(nbf):
+        msg = "External credential is not valid yet"
+        raise AuthInvalidTokenError(msg)
+
+
+async def _fetch_jwks(jwks_url: str) -> dict[str, Any]:
+    cached = _jwks_cache.get(jwks_url)
+    now = time.monotonic()
+    if cached and cached[0] > now:
+        return cached[1]
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(jwks_url)
+        response.raise_for_status()
+        jwks = response.json()
+
+    _jwks_cache[jwks_url] = (now + JWKS_CACHE_TTL_SECONDS, jwks)
+    return jwks
+
+
+def _select_jwk(jwks: dict[str, Any], token: str) -> dict[str, Any]:
+    keys = jwks.get("keys")
+    if not isinstance(keys, list) or not keys:
+        msg = "External JWKS does not contain signing keys"
+        raise AuthInvalidTokenError(msg)
+
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    if kid:
+        for key in keys:
+            if key.get("kid") == kid:
+                return key
+        msg = "External JWT signing key was not found in JWKS"
+        raise AuthInvalidTokenError(msg)
+
+    if len(keys) == 1:
+        return keys[0]
+
+    msg = "External JWT is missing kid and JWKS contains multiple keys"
+    raise AuthInvalidTokenError(msg)
+
+
+async def decode_external_jwt(token: str, auth_settings: AuthSettings) -> dict[str, Any]:
+    if not auth_settings.EXTERNAL_AUTH_ENABLED:
+        msg = "External authentication is not enabled"
+        raise AuthInvalidTokenError(msg)
+
+    try:
+        if auth_settings.EXTERNAL_AUTH_TRUSTED_JWT_DECODE:
+            claims = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_aud": False,
+                    "verify_iss": False,
+                    "verify_exp": False,
+                    "verify_nbf": False,
+                },
+            )
+            _validate_trusted_time_claims(claims)
+            return claims
+
+        if not auth_settings.EXTERNAL_AUTH_JWKS_URL:
+            msg = "External authentication requires EXTERNAL_AUTH_JWKS_URL unless trusted decode is enabled"
+            raise AuthInvalidTokenError(msg)
+
+        jwks = await _fetch_jwks(auth_settings.EXTERNAL_AUTH_JWKS_URL)
+        jwk = _select_jwk(jwks, token)
+        signing_key = jwt.PyJWK.from_dict(jwk).key
+        audience = _split_csv(auth_settings.EXTERNAL_AUTH_AUDIENCE)
+        issuer = auth_settings.EXTERNAL_AUTH_ISSUER or None
+        algorithms = _split_csv(auth_settings.EXTERNAL_AUTH_ALGORITHMS) or ["RS256"]
+
+        return jwt.decode(
+            token,
+            signing_key,
+            algorithms=algorithms,
+            audience=audience if audience else None,
+            issuer=issuer,
+            options={
+                "verify_aud": bool(audience),
+                "verify_iss": bool(issuer),
+            },
+        )
+    except AuthInvalidTokenError:
+        raise
+    except PyJWTInvalidTokenError as exc:
+        msg = "External credential validation failed"
+        raise AuthInvalidTokenError(msg) from exc
+    except Exception as exc:
+        logger.debug(f"External credential validation failed: {exc}")
+        msg = "External credential validation failed"
+        raise AuthInvalidTokenError(msg) from exc
+
+
+async def resolve_external_identity(token: str, auth_settings: AuthSettings) -> ExternalIdentity:
+    resolver = _load_external_identity_resolver(auth_settings)
+    if hasattr(resolver, "resolve"):
+        result = await _maybe_await(resolver.resolve(token, auth_settings))
+    elif callable(resolver):
+        result = await _maybe_await(resolver(token, auth_settings))
+    else:
+        msg = "External authentication resolver must be callable or expose resolve()"
+        raise AuthInvalidTokenError(msg)
+
+    if isinstance(result, ExternalIdentity):
+        return result
+    if isinstance(result, dict):
+        return _identity_from_claims(result, auth_settings)
+
+    msg = "External authentication resolver returned an invalid identity"
+    raise AuthInvalidTokenError(msg)
+
+
+class JwtExternalIdentityResolver:
+    async def resolve(self, token: str, auth_settings: AuthSettings) -> ExternalIdentity:
+        claims = await decode_external_jwt(token, auth_settings)
+        return _identity_from_claims(claims, auth_settings)
+
+
+def _load_external_identity_resolver(
+    auth_settings: AuthSettings,
+) -> ExternalIdentityResolver | ExternalResolverCallable:
+    resolver_path = auth_settings.EXTERNAL_AUTH_IDENTITY_RESOLVER
+    if not resolver_path:
+        return JwtExternalIdentityResolver()
+
+    from lfx.services.config_discovery import load_object_from_import_path
+
+    resolver = load_object_from_import_path(
+        resolver_path,
+        object_kind="external auth resolver",
+        object_key="EXTERNAL_AUTH_IDENTITY_RESOLVER",
+    )
+    if resolver is None:
+        msg = "External authentication resolver could not be loaded"
+        raise AuthInvalidTokenError(msg)
+
+    if inspect.isclass(resolver):
+        signature = inspect.signature(resolver)
+        required_params = [
+            parameter
+            for parameter in signature.parameters.values()
+            if parameter.default is inspect.Parameter.empty
+            and parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        if required_params:
+            return resolver(auth_settings)
+        return resolver()
+
+    return resolver
+
+
+async def _maybe_await(value: T | Awaitable[T]) -> T:
+    if inspect.isawaitable(value):
+        return await cast("Awaitable[T]", value)
+    return value
+
+
+async def _unique_username(db: AsyncSession, desired_username: str, provider: str, subject: str) -> str:
+    username = _normalize_username(desired_username)
+    existing = await get_user_by_username(db, username)
+    if existing is None:
+        return username
+
+    fallback = _external_username_fallback(provider, subject)
+    if await get_user_by_username(db, fallback) is None:
+        return fallback
+
+    digest = hashlib.sha256(f"{provider}:{subject}:{username}".encode()).hexdigest()[:16]
+    return f"{provider}-{digest}"
+
+
+async def _initialize_jit_user_defaults(user: User, db: AsyncSession) -> None:
+    from langflow.initial_setup.setup import get_or_create_default_folder
+    from langflow.services.deps import get_variable_service
+
+    await get_or_create_default_folder(db, user.id)
+    await get_variable_service().initialize_user_variables(user.id, db)
+
+
+async def get_or_create_external_user(
+    *,
+    token: str,
+    db: AsyncSession,
+    auth_settings: AuthSettings,
+    password_hasher,
+) -> User:
+    identity = await resolve_external_identity(token, auth_settings)
+
+    profile_stmt = select(SSOUserProfile).where(
+        SSOUserProfile.sso_provider == identity.provider,
+        SSOUserProfile.sso_user_id == identity.subject,
+    )
+    profile = (await db.exec(profile_stmt)).first()
+
+    if profile:
+        user = await get_user_by_id(db, profile.user_id)
+        if user is None:
+            msg = "Mapped external user was not found"
+            raise AuthInvalidTokenError(msg)
+        if not user.is_active:
+            msg = "User account is inactive"
+            raise InactiveUserError(msg)
+
+        profile.email = identity.email
+        profile.sso_last_login_at = datetime.now(timezone.utc)
+        profile.updated_at = datetime.now(timezone.utc)
+        await update_user_last_login_at(user.id, db)
+        return user
+
+    username = await _unique_username(db, identity.username, identity.provider, identity.subject)
+    user = User(
+        username=username,
+        password=password_hasher(secrets.token_urlsafe(48)),
+        is_active=True,
+        is_superuser=False,
+        last_login_at=datetime.now(timezone.utc),
+    )
+    profile = SSOUserProfile(
+        user_id=user.id,
+        sso_provider=identity.provider,
+        sso_user_id=identity.subject,
+        email=identity.email,
+        sso_last_login_at=datetime.now(timezone.utc),
+    )
+
+    db.add(user)
+    db.add(profile)
+    try:
+        await db.flush()
+        await db.refresh(user)
+        await _initialize_jit_user_defaults(user, db)
+    except IntegrityError:
+        await db.rollback()
+        profile = (await db.exec(profile_stmt)).first()
+        if profile is None:
+            raise
+        user = await get_user_by_id(db, profile.user_id)
+        if user is None:
+            msg = "Mapped external user was not found"
+            raise AuthInvalidTokenError(msg) from None
+        if not user.is_active:
+            msg = "User account is inactive"
+            raise InactiveUserError(msg) from None
+
+    return user
+
+
+def extract_bearer_or_raw_token(value: str | None) -> str | None:
+    if not value:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    scheme, _, token = stripped.partition(" ")
+    if scheme.lower() == "bearer" and token:
+        return token.strip() or None
+    return stripped
+
+
+def extract_external_token(headers: Any, cookies: Any, auth_settings: AuthSettings) -> str | None:
+    if not auth_settings.EXTERNAL_AUTH_ENABLED:
+        return None
+
+    header_name = auth_settings.EXTERNAL_AUTH_TOKEN_HEADER
+    if header_name:
+        header_value = headers.get(header_name)
+        if token := extract_bearer_or_raw_token(header_value):
+            return token
+
+    cookie_name = auth_settings.EXTERNAL_AUTH_TOKEN_COOKIE
+    if cookie_name:
+        cookie_value = cookies.get(cookie_name)
+        if token := extract_bearer_or_raw_token(cookie_value):
+            return token
+
+    return None

--- a/src/backend/base/langflow/services/auth/flow_rbac.py
+++ b/src/backend/base/langflow/services/auth/flow_rbac.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy import or_, true
+from sqlmodel import col, select
+
+from langflow.services.auth.exceptions import AuthenticationError
+from langflow.services.auth.external import extract_external_token, resolve_external_identity
+from langflow.services.database.models.flow.model import (
+    AccessTypeEnum,
+    Flow,
+    FlowAccessControl,
+    FlowAclSubjectType,
+    FlowPermission,
+)
+from langflow.services.deps import get_settings_service
+
+if TYPE_CHECKING:
+    from lfx.services.settings.auth import AuthSettings
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from langflow.services.database.models.user.model import User, UserRead
+
+
+@dataclass(frozen=True)
+class FlowPrincipal:
+    user_id: UUID
+    is_superuser: bool
+    roles: frozenset[str]
+    groups: frozenset[str]
+
+
+_PERMISSION_GRANTS: dict[FlowPermission, set[FlowPermission]] = {
+    FlowPermission.VIEW: {FlowPermission.VIEW, FlowPermission.RUN, FlowPermission.EDIT, FlowPermission.MANAGE},
+    FlowPermission.RUN: {FlowPermission.RUN, FlowPermission.MANAGE},
+    FlowPermission.EDIT: {FlowPermission.EDIT, FlowPermission.MANAGE},
+    FlowPermission.MANAGE: {FlowPermission.MANAGE},
+}
+
+
+def _split_csv(value: str | None) -> frozenset[str]:
+    if not value:
+        return frozenset()
+    return frozenset(item.strip() for item in value.split(",") if item.strip())
+
+
+def _claim_values(claims: dict[str, Any], claim_name: str | None) -> frozenset[str]:
+    if not claim_name:
+        return frozenset()
+    value = claims.get(claim_name)
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        delimiter = "," if "," in value else None
+        return frozenset(item.strip() for item in value.split(delimiter) if item.strip())
+    if isinstance(value, (list, tuple, set)):
+        return frozenset(str(item).strip() for item in value if str(item).strip())
+    return frozenset({str(value).strip()}) if str(value).strip() else frozenset()
+
+
+async def get_flow_principal(request: Request, user: User | UserRead) -> FlowPrincipal:
+    auth_settings = get_settings_service().auth_settings
+    roles: frozenset[str] = frozenset()
+    groups: frozenset[str] = frozenset()
+
+    token = extract_external_token(request.headers, request.cookies, auth_settings)
+    if token:
+        try:
+            identity = await resolve_external_identity(token, auth_settings)
+        except AuthenticationError as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=exc.message) from exc
+        roles = _claim_values(identity.claims, auth_settings.FLOW_RBAC_ROLE_CLAIM)
+        groups = _claim_values(identity.claims, auth_settings.FLOW_RBAC_GROUP_CLAIM)
+
+    return FlowPrincipal(
+        user_id=user.id,
+        is_superuser=bool(user.is_superuser),
+        roles=roles,
+        groups=groups,
+    )
+
+
+def is_flow_admin(principal: FlowPrincipal, auth_settings: AuthSettings) -> bool:
+    if principal.is_superuser:
+        return True
+    admin_roles = _split_csv(auth_settings.FLOW_RBAC_ADMIN_ROLES)
+    admin_groups = _split_csv(auth_settings.FLOW_RBAC_ADMIN_GROUPS)
+    return bool(principal.roles & admin_roles or principal.groups & admin_groups)
+
+
+def _has_lock_bypass_role(principal: FlowPrincipal, auth_settings: AuthSettings) -> bool:
+    bypass_roles = _split_csv(auth_settings.FLOW_RBAC_LOCK_BYPASS_ROLES)
+    bypass_groups = _split_csv(auth_settings.FLOW_RBAC_LOCK_BYPASS_GROUPS)
+    return bool(principal.roles & bypass_roles or principal.groups & bypass_groups)
+
+
+def _acl_subject_filter(principal: FlowPrincipal):
+    clauses = [
+        (FlowAccessControl.subject_type == FlowAclSubjectType.USER.value)
+        & (FlowAccessControl.subject_id == str(principal.user_id))
+    ]
+    if principal.roles:
+        clauses.append(
+            (FlowAccessControl.subject_type == FlowAclSubjectType.ROLE.value)
+            & col(FlowAccessControl.subject_id).in_(principal.roles)
+        )
+    if principal.groups:
+        clauses.append(
+            (FlowAccessControl.subject_type == FlowAclSubjectType.GROUP.value)
+            & col(FlowAccessControl.subject_id).in_(principal.groups)
+        )
+    return or_(*clauses)
+
+
+async def has_explicit_manage_acl(session: AsyncSession, flow_id: UUID, principal: FlowPrincipal) -> bool:
+    statement = select(FlowAccessControl.id).where(
+        FlowAccessControl.flow_id == flow_id,
+        FlowAccessControl.permission == FlowPermission.MANAGE.value,
+        _acl_subject_filter(principal),
+    )
+    return (await session.exec(statement)).first() is not None
+
+
+async def can_bypass_flow_lock(
+    session: AsyncSession,
+    flow: Flow,
+    principal: FlowPrincipal,
+    auth_settings: AuthSettings,
+) -> bool:
+    if is_flow_admin(principal, auth_settings) or _has_lock_bypass_role(principal, auth_settings):
+        return True
+    return await has_explicit_manage_acl(session, flow.id, principal)
+
+
+async def has_flow_permission(
+    session: AsyncSession,
+    flow: Flow,
+    principal: FlowPrincipal,
+    permission: FlowPermission,
+    auth_settings: AuthSettings | None = None,
+) -> bool:
+    auth_settings = auth_settings or get_settings_service().auth_settings
+    if not auth_settings.FLOW_RBAC_ENABLED:
+        return flow.user_id == principal.user_id
+
+    if is_flow_admin(principal, auth_settings):
+        return True
+
+    permission_allowed = False
+    if flow.user_id == principal.user_id or (
+        permission in {FlowPermission.VIEW, FlowPermission.RUN} and flow.access_type == AccessTypeEnum.PUBLIC
+    ):
+        permission_allowed = True
+    else:
+        granted_permissions = [item.value for item in _PERMISSION_GRANTS[permission]]
+        statement = select(FlowAccessControl.id).where(
+            FlowAccessControl.flow_id == flow.id,
+            col(FlowAccessControl.permission).in_(granted_permissions),
+            _acl_subject_filter(principal),
+        )
+        permission_allowed = (await session.exec(statement)).first() is not None
+
+    if not permission_allowed:
+        return False
+
+    if flow.locked and permission in {FlowPermission.EDIT, FlowPermission.MANAGE}:
+        return await can_bypass_flow_lock(session, flow, principal, auth_settings)
+
+    return True
+
+
+def viewable_flows_filter(principal: FlowPrincipal, auth_settings: AuthSettings):
+    if not auth_settings.FLOW_RBAC_ENABLED:
+        return Flow.user_id == principal.user_id
+
+    if is_flow_admin(principal, auth_settings):
+        return true()
+
+    granted_permissions = [item.value for item in _PERMISSION_GRANTS[FlowPermission.VIEW]]
+    acl_subquery = select(FlowAccessControl.flow_id).where(
+        col(FlowAccessControl.permission).in_(granted_permissions),
+        _acl_subject_filter(principal),
+    )
+    return or_(
+        Flow.user_id == principal.user_id,
+        Flow.access_type == AccessTypeEnum.PUBLIC,
+        col(Flow.id).in_(acl_subquery),
+    )
+
+
+async def get_flow_by_id_or_name(
+    session: AsyncSession,
+    flow_id_or_name: str,
+) -> Flow | None:
+    try:
+        flow_id = UUID(flow_id_or_name)
+        return await session.get(Flow, flow_id)
+    except ValueError:
+        statement = select(Flow).where(Flow.endpoint_name == flow_id_or_name)
+        return (await session.exec(statement)).first()
+
+
+async def require_flow_permission(
+    session: AsyncSession,
+    flow: Flow | None,
+    principal: FlowPrincipal,
+    permission: FlowPermission,
+    *,
+    not_found_detail: str = "Flow not found",
+) -> Flow:
+    if flow is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+
+    if await has_flow_permission(session, flow, principal, permission):
+        return flow
+
+    if not await has_flow_permission(session, flow, principal, FlowPermission.VIEW):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have permission for this flow")

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -424,6 +424,39 @@ class AuthService(BaseAuthService):
             except Exception as exc:
                 raise HTTPException(status_code=404, detail="Flow not found") from exc
 
+        if settings_service.auth_settings.FLOW_RBAC_ENABLED:
+            from langflow.services.auth.external import extract_external_token
+            from langflow.services.auth.flow_rbac import (
+                get_flow_by_id_or_name,
+                get_flow_principal,
+                require_flow_permission,
+            )
+            from langflow.services.database.models.flow.model import FlowPermission
+
+            api_key = request.headers.get("x-api-key") or request.query_params.get("x-api-key")
+            token = extract_external_token(request.headers, request.cookies, settings_service.auth_settings)
+            if not api_key and not token:
+                raise HTTPException(status_code=403, detail="API key or external credential required")
+
+            try:
+                async with session_scope() as db:
+                    authenticated_user = await self.authenticate_with_credentials(token, api_key, db)
+                    user_read = UserRead.model_validate(authenticated_user, from_attributes=True)
+                    principal = await get_flow_principal(request, user_read)
+                    await require_flow_permission(
+                        db,
+                        await get_flow_by_id_or_name(db, flow_id),
+                        principal,
+                        FlowPermission.RUN,
+                        not_found_detail="Flow not found",
+                    )
+                    return user_read
+            except HTTPException:
+                raise
+            except Exception as exc:
+                logger.error(f"Webhook authentication error: {exc}")
+                raise HTTPException(status_code=403, detail="Webhook authentication failed") from exc
+
         api_key_header_val = request.headers.get("x-api-key")
         api_key_query_val = request.query_params.get("x-api-key")
 

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -25,6 +25,7 @@ from langflow.services.auth.exceptions import (
 from langflow.services.auth.exceptions import (
     InvalidTokenError as AuthInvalidTokenError,
 )
+from langflow.services.auth.external import get_or_create_external_user
 from langflow.services.database.models.api_key.crud import check_key
 from langflow.services.database.models.user.crud import (
     get_user_by_id,
@@ -170,10 +171,16 @@ class AuthService(BaseAuthService):
             msg = "Token has expired"
             raise TokenExpiredError(msg) from e
         except InvalidTokenError as e:
+            external_user = await self._authenticate_with_external_token(token, db)
+            if external_user is not None:
+                return external_user
             logger.debug("JWT validation failed: Invalid token format or signature")
             msg = "Invalid token"
             raise AuthInvalidTokenError(msg) from e
         except Exception as e:
+            external_user = await self._authenticate_with_external_token(token, db)
+            if external_user is not None:
+                return external_user
             logger.error(f"Unexpected error decoding token: {e}")
             msg = "Token validation failed"
             raise AuthInvalidTokenError(msg) from e
@@ -191,6 +198,18 @@ class AuthService(BaseAuthService):
             raise InactiveUserError(msg)
 
         return user
+
+    async def _authenticate_with_external_token(self, token: str, db: AsyncSession) -> User | None:
+        settings_service = self.settings
+        if not settings_service.auth_settings.EXTERNAL_AUTH_ENABLED:
+            return None
+
+        return await get_or_create_external_user(
+            token=token,
+            db=db,
+            auth_settings=settings_service.auth_settings,
+            password_hasher=self.get_password_hash,
+        )
 
     async def _authenticate_with_api_key(self, api_key: str, db: AsyncSession) -> UserRead | None:
         """Internal method to authenticate with API key (raises generic exceptions)."""

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -44,6 +44,9 @@ class OAuth2PasswordBearerCookie(OAuth2PasswordBearer):
         if scheme.lower() == "bearer" and param:
             return param
 
+        if token := _get_external_token(request.headers, request.cookies):
+            return token
+
         # Fall back to cookie (for HttpOnly cookie support in browser-based clients)
         token = request.cookies.get("access_token_lf")
         if token:
@@ -70,6 +73,17 @@ def _auth_service():
     using this helper or adding new thin wrapper functions here.
     """
     return get_auth_service()
+
+
+def _get_external_token(headers, cookies) -> str | None:
+    try:
+        from langflow.services.auth.external import extract_external_token
+        from langflow.services.deps import get_settings_service
+
+        auth_settings = get_settings_service().auth_settings
+        return extract_external_token(headers, cookies, auth_settings)
+    except Exception:  # noqa: BLE001
+        return None
 
 
 REFRESH_TOKEN_TYPE: Final[str] = "refresh"  # noqa: S105
@@ -193,7 +207,11 @@ async def get_current_user_for_websocket(
     db: AsyncSession,
 ) -> User | UserRead:
     """Extracts credentials from WebSocket and delegates to auth service."""
-    token = websocket.cookies.get("access_token_lf") or websocket.query_params.get("token")
+    token = (
+        _get_external_token(websocket.headers, websocket.cookies)
+        or websocket.cookies.get("access_token_lf")
+        or websocket.query_params.get("token")
+    )
     api_key = (
         websocket.query_params.get("x-api-key")
         or websocket.query_params.get("api_key")
@@ -215,7 +233,7 @@ async def get_current_user_for_sse(
 
     Accepts cookie (access_token_lf) or API key (x-api-key query param).
     """
-    token = request.cookies.get("access_token_lf")
+    token = _get_external_token(request.headers, request.cookies) or request.cookies.get("access_token_lf")
     api_key = request.query_params.get("x-api-key") or request.headers.get("x-api-key")
 
     try:
@@ -279,7 +297,7 @@ async def get_current_user_optional(
     Checks HttpOnly cookie (access_token_lf), Authorization header, and API key.
     Used by endpoints that support both authenticated and unauthenticated access.
     """
-    token = request.cookies.get("access_token_lf")
+    token = _get_external_token(request.headers, request.cookies) or request.cookies.get("access_token_lf")
     api_key = request.query_params.get("x-api-key") or request.headers.get("x-api-key")
     auth_header = request.headers.get("Authorization")
     if auth_header and auth_header.startswith("Bearer "):

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -145,9 +145,19 @@ def get_jwt_signing_key(settings_service: SettingsService) -> str:
 
 
 async def api_key_security(
+    request: Request,
     query_param: Annotated[str | None, Security(api_key_query)],
     header_param: Annotated[str | None, Security(api_key_header)],
+    db: AsyncSession = Depends(injectable_session_scope),
 ) -> UserRead | None:
+    if token := _get_external_token(request.headers, request.cookies):
+        try:
+            user = await _auth_service().get_current_user(token, query_param, header_param, db)
+        except AuthenticationError as e:
+            raise _auth_error_to_http(e) from e
+        from langflow.services.database.models.user.model import UserRead
+
+        return UserRead.model_validate(user, from_attributes=True)
     return await _auth_service().api_key_security(query_param, header_param)
 
 

--- a/src/backend/base/langflow/services/database/models/__init__.py
+++ b/src/backend/base/langflow/services/database/models/__init__.py
@@ -3,7 +3,7 @@ from .auth import SSOConfig, SSOUserProfile
 from .deployment import Deployment
 from .deployment_provider_account import DeploymentProviderAccount
 from .file import File
-from .flow import Flow
+from .flow import Flow, FlowAccessControl
 from .flow_version import FlowVersion
 from .flow_version_deployment_attachment import FlowVersionDeploymentAttachment
 from .folder import Folder
@@ -23,6 +23,7 @@ __all__ = [
     "DeploymentProviderAccount",
     "File",
     "Flow",
+    "FlowAccessControl",
     "FlowVersion",
     "FlowVersionDeploymentAttachment",
     "Folder",

--- a/src/backend/base/langflow/services/database/models/flow/__init__.py
+++ b/src/backend/base/langflow/services/database/models/flow/__init__.py
@@ -1,3 +1,23 @@
-from .model import Flow, FlowCreate, FlowRead, FlowUpdate
+from .model import (
+    Flow,
+    FlowAccessControl,
+    FlowAccessControlCreate,
+    FlowAccessControlRead,
+    FlowAclSubjectType,
+    FlowCreate,
+    FlowPermission,
+    FlowRead,
+    FlowUpdate,
+)
 
-__all__ = ["Flow", "FlowCreate", "FlowRead", "FlowUpdate"]
+__all__ = [
+    "Flow",
+    "FlowAccessControl",
+    "FlowAccessControlCreate",
+    "FlowAccessControlRead",
+    "FlowAclSubjectType",
+    "FlowCreate",
+    "FlowPermission",
+    "FlowRead",
+    "FlowUpdate",
+]

--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -3,7 +3,7 @@
 import re
 from datetime import datetime, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 from uuid import UUID, uuid4
 
 import emoji
@@ -11,7 +11,7 @@ from emoji import purely_emoji
 from lfx.log.logger import logger
 from pydantic import BaseModel, ValidationInfo, field_serializer, field_validator
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy import Text, UniqueConstraint, text
+from sqlalchemy import String, Text, UniqueConstraint, text
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 from langflow.schema.data import Data
@@ -44,6 +44,19 @@ def _validate_endpoint_name_value(v: str | None) -> str | None:
 class AccessTypeEnum(str, Enum):
     PRIVATE = "PRIVATE"
     PUBLIC = "PUBLIC"
+
+
+class FlowAclSubjectType(str, Enum):
+    USER = "user"
+    GROUP = "group"
+    ROLE = "role"
+
+
+class FlowPermission(str, Enum):
+    VIEW = "view"
+    RUN = "run"
+    EDIT = "edit"
+    MANAGE = "manage"
 
 
 class FlowBase(SQLModel):
@@ -281,3 +294,48 @@ class FlowUpdate(SQLModel):
     @classmethod
     def validate_endpoint_name(cls, v):
         return _validate_endpoint_name_value(v)
+
+
+class FlowAccessControlBase(SQLModel):
+    subject_type: FlowAclSubjectType = Field(sa_column=Column(String(16), nullable=False, index=True))
+    subject_id: str = Field(max_length=255, index=True)
+    permission: FlowPermission = Field(sa_column=Column(String(16), nullable=False, index=True))
+
+    @field_validator("subject_id")
+    @classmethod
+    def validate_subject_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            msg = "ACL subject_id cannot be empty"
+            raise ValueError(msg)
+        return stripped
+
+
+class FlowAccessControl(FlowAccessControlBase, table=True):  # type: ignore[call-arg]
+    __tablename__: ClassVar[str] = "flow_access_control"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, unique=True)
+    flow_id: UUID = Field(foreign_key="flow.id", nullable=False, index=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "flow_id",
+            "subject_type",
+            "subject_id",
+            "permission",
+            name="unique_flow_access_control_entry",
+        ),
+    )
+
+
+class FlowAccessControlCreate(FlowAccessControlBase):
+    pass
+
+
+class FlowAccessControlRead(FlowAccessControlBase):
+    id: UUID
+    flow_id: UUID
+    created_at: datetime
+    updated_at: datetime

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -1,9 +1,80 @@
 import tempfile
 import uuid
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+import jwt
+import pytest
 from fastapi import status
 from httpx import AsyncClient
+from langflow.services.deps import get_settings_service
+
+_FLOW_RBAC_TEST_SECRET = "flow-rbac-test-secret-with-enough-length"  # noqa: S105
+_FLOW_RBAC_EXTERNAL_HEADER = "X-Flow-External-Auth"
+
+
+def _external_flow_token(**claims) -> str:
+    payload = {
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        **claims,
+    }
+    return jwt.encode(payload, _FLOW_RBAC_TEST_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+async def flow_rbac_settings(client):  # noqa: ARG001
+    auth_settings = get_settings_service().auth_settings
+    fields = (
+        "FLOW_RBAC_ENABLED",
+        "FLOW_RBAC_ROLE_CLAIM",
+        "FLOW_RBAC_GROUP_CLAIM",
+        "FLOW_RBAC_ADMIN_ROLES",
+        "FLOW_RBAC_ADMIN_GROUPS",
+        "FLOW_RBAC_LOCK_BYPASS_ROLES",
+        "FLOW_RBAC_LOCK_BYPASS_GROUPS",
+        "EXTERNAL_AUTH_ENABLED",
+        "EXTERNAL_AUTH_PROVIDER",
+        "EXTERNAL_AUTH_TOKEN_HEADER",
+        "EXTERNAL_AUTH_TOKEN_COOKIE",
+        "EXTERNAL_AUTH_IDENTITY_RESOLVER",
+        "EXTERNAL_AUTH_TRUSTED_JWT_DECODE",
+        "EXTERNAL_AUTH_JWKS_URL",
+        "EXTERNAL_AUTH_ISSUER",
+        "EXTERNAL_AUTH_AUDIENCE",
+        "EXTERNAL_AUTH_ALGORITHMS",
+        "EXTERNAL_AUTH_SUBJECT_CLAIM",
+        "EXTERNAL_AUTH_USERNAME_CLAIM",
+        "EXTERNAL_AUTH_EMAIL_CLAIM",
+        "EXTERNAL_AUTH_NAME_CLAIM",
+    )
+    original = {field: getattr(auth_settings, field) for field in fields}
+
+    auth_settings.FLOW_RBAC_ENABLED = True
+    auth_settings.FLOW_RBAC_ROLE_CLAIM = "roles"
+    auth_settings.FLOW_RBAC_GROUP_CLAIM = "groups"
+    auth_settings.FLOW_RBAC_ADMIN_ROLES = "flow-admin"
+    auth_settings.FLOW_RBAC_ADMIN_GROUPS = ""
+    auth_settings.FLOW_RBAC_LOCK_BYPASS_ROLES = ""
+    auth_settings.FLOW_RBAC_LOCK_BYPASS_GROUPS = ""
+    auth_settings.EXTERNAL_AUTH_ENABLED = True
+    auth_settings.EXTERNAL_AUTH_PROVIDER = "test-provider"
+    auth_settings.EXTERNAL_AUTH_TOKEN_HEADER = _FLOW_RBAC_EXTERNAL_HEADER
+    auth_settings.EXTERNAL_AUTH_TOKEN_COOKIE = None
+    auth_settings.EXTERNAL_AUTH_IDENTITY_RESOLVER = None
+    auth_settings.EXTERNAL_AUTH_TRUSTED_JWT_DECODE = True
+    auth_settings.EXTERNAL_AUTH_JWKS_URL = None
+    auth_settings.EXTERNAL_AUTH_ISSUER = None
+    auth_settings.EXTERNAL_AUTH_AUDIENCE = None
+    auth_settings.EXTERNAL_AUTH_ALGORITHMS = "RS256"
+    auth_settings.EXTERNAL_AUTH_SUBJECT_CLAIM = "sub"
+    auth_settings.EXTERNAL_AUTH_USERNAME_CLAIM = "preferred_username"
+    auth_settings.EXTERNAL_AUTH_EMAIL_CLAIM = "email"
+    auth_settings.EXTERNAL_AUTH_NAME_CLAIM = "name"
+
+    yield auth_settings
+
+    for field, value in original.items():
+        setattr(auth_settings, field, value)
 
 
 async def _attach_deployment_to_flow(*, user_id: UUID, flow_id: UUID, project_id: UUID) -> None:
@@ -274,6 +345,145 @@ async def test_patch_flow_updates_access_and_action_fields(client: AsyncClient, 
     assert result["access_type"] == "PUBLIC"
     assert result["action_name"] == "shared_action"
     assert result["action_description"] == "Shared flow action"
+
+
+async def test_flow_rbac_user_acl_grants_view_then_edit(
+    client: AsyncClient,
+    logged_in_headers,
+    user_two,
+    flow_rbac_settings,  # noqa: ARG001
+):
+    create_response = await client.post(
+        "api/v1/flows/",
+        json={"name": "rbac_user_acl_flow", "data": {}},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    flow_id = create_response.json()["id"]
+
+    login_response = await client.post(
+        "api/v1/login",
+        data={"username": user_two.username, "password": "hashed_password"},
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+    other_headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+    read_response = await client.get(f"api/v1/flows/{flow_id}", headers=other_headers)
+    assert read_response.status_code == status.HTTP_404_NOT_FOUND
+
+    view_acl_response = await client.post(
+        f"api/v1/flows/{flow_id}/acl",
+        json={"subject_type": "user", "subject_id": str(user_two.id), "permission": "view"},
+        headers=logged_in_headers,
+    )
+    assert view_acl_response.status_code == status.HTTP_201_CREATED
+
+    read_response = await client.get(f"api/v1/flows/{flow_id}", headers=other_headers)
+    assert read_response.status_code == status.HTTP_200_OK
+
+    update_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"name": "rbac_user_acl_denied"},
+        headers=other_headers,
+    )
+    assert update_response.status_code == status.HTTP_403_FORBIDDEN
+
+    edit_acl_response = await client.post(
+        f"api/v1/flows/{flow_id}/acl",
+        json={"subject_type": "user", "subject_id": str(user_two.id), "permission": "edit"},
+        headers=logged_in_headers,
+    )
+    assert edit_acl_response.status_code == status.HTTP_201_CREATED
+
+    update_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"name": "rbac_user_acl_updated"},
+        headers=other_headers,
+    )
+    assert update_response.status_code == status.HTTP_200_OK
+    assert update_response.json()["name"] == "rbac_user_acl_updated"
+    assert update_response.json()["user_id"] == create_response.json()["user_id"]
+
+
+async def test_flow_rbac_role_acl_uses_external_claims(
+    client: AsyncClient,
+    logged_in_headers,
+    flow_rbac_settings,  # noqa: ARG001
+):
+    create_response = await client.post(
+        "api/v1/flows/",
+        json={"name": "rbac_role_acl_flow", "data": {}},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    flow_id = create_response.json()["id"]
+
+    acl_response = await client.post(
+        f"api/v1/flows/{flow_id}/acl",
+        json={"subject_type": "role", "subject_id": "analyst", "permission": "view"},
+        headers=logged_in_headers,
+    )
+    assert acl_response.status_code == status.HTTP_201_CREATED
+
+    token = _external_flow_token(
+        sub="analyst-subject",
+        preferred_username="analyst-user",
+        roles=["analyst"],
+    )
+    external_headers = {_FLOW_RBAC_EXTERNAL_HEADER: f"Bearer {token}"}
+
+    read_response = await client.get(f"api/v1/flows/{flow_id}", headers=external_headers)
+    assert read_response.status_code == status.HTTP_200_OK
+    assert read_response.json()["id"] == flow_id
+
+    update_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"name": "rbac_role_acl_denied"},
+        headers=external_headers,
+    )
+    assert update_response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_flow_rbac_locked_flow_requires_admin_role(
+    client: AsyncClient,
+    logged_in_headers,
+    flow_rbac_settings,  # noqa: ARG001
+):
+    create_response = await client.post(
+        "api/v1/flows/",
+        json={"name": "rbac_locked_flow", "data": {}},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    flow_id = create_response.json()["id"]
+
+    lock_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"locked": True},
+        headers=logged_in_headers,
+    )
+    assert lock_response.status_code == status.HTTP_200_OK
+    assert lock_response.json()["locked"] is True
+
+    owner_update_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"name": "rbac_locked_owner_denied"},
+        headers=logged_in_headers,
+    )
+    assert owner_update_response.status_code == status.HTTP_403_FORBIDDEN
+
+    token = _external_flow_token(
+        sub="admin-subject",
+        preferred_username="admin-user",
+        roles=["flow-admin"],
+    )
+    admin_update_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"name": "rbac_locked_admin_updated"},
+        headers={_FLOW_RBAC_EXTERNAL_HEADER: f"Bearer {token}"},
+    )
+    assert admin_update_response.status_code == status.HTTP_200_OK
+    assert admin_update_response.json()["name"] == "rbac_locked_admin_updated"
 
 
 async def test_create_flows(client: AsyncClient, logged_in_headers):

--- a/src/backend/tests/unit/services/auth/test_external_auth.py
+++ b/src/backend/tests/unit/services/auth/test_external_auth.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from langflow.services.auth.exceptions import InvalidTokenError
+from langflow.services.auth.external import decode_external_jwt, extract_external_token, resolve_external_identity
+from lfx.services.settings.auth import AuthSettings
+
+_TEST_JWT_SECRET = "external-test-secret-for-jwt-tests"  # noqa: S105
+_EXTERNAL_AUTH_HEADER = "X-External-Auth"
+_EXTERNAL_AUTH_COOKIE = "external-session"
+_OPAQUE_CREDENTIAL = "opaque-token"
+_HEADER_CREDENTIAL = "header-token"
+
+
+def _auth_settings(tmp_path) -> AuthSettings:
+    settings = AuthSettings(CONFIG_DIR=str(tmp_path))
+    settings.EXTERNAL_AUTH_ENABLED = True
+    settings.EXTERNAL_AUTH_PROVIDER = "test-provider"
+    settings.EXTERNAL_AUTH_TRUSTED_JWT_DECODE = True
+    settings.EXTERNAL_AUTH_TOKEN_HEADER = _EXTERNAL_AUTH_HEADER
+    settings.EXTERNAL_AUTH_TOKEN_COOKIE = _EXTERNAL_AUTH_COOKIE
+    return settings
+
+
+@pytest.mark.anyio
+async def test_resolve_external_identity_uses_configured_resolver(tmp_path, monkeypatch):
+    settings = _auth_settings(tmp_path)
+    settings.EXTERNAL_AUTH_IDENTITY_RESOLVER = "tests.fake:resolver"
+
+    async def resolver(token, auth_settings):
+        assert token == _OPAQUE_CREDENTIAL
+        assert auth_settings is settings
+        return {
+            "sub": "opaque-subject",
+            "preferred_username": "opaque-user",
+            "email": "opaque@example.com",
+            "name": "Opaque User",
+        }
+
+    from lfx.services import config_discovery
+
+    def load_resolver(import_path, *, object_kind, object_key):
+        assert import_path == settings.EXTERNAL_AUTH_IDENTITY_RESOLVER
+        assert object_kind == "external auth resolver"
+        assert object_key == "EXTERNAL_AUTH_IDENTITY_RESOLVER"
+        return resolver
+
+    monkeypatch.setattr(config_discovery, "load_object_from_import_path", load_resolver)
+
+    identity = await resolve_external_identity(_OPAQUE_CREDENTIAL, settings)
+
+    assert identity.provider == "test-provider"
+    assert identity.subject == "opaque-subject"
+    assert identity.username == "opaque-user"
+    assert identity.email == "opaque@example.com"
+    assert identity.name == "Opaque User"
+
+
+@pytest.mark.anyio
+async def test_trusted_jwt_decode_validates_time_claims(tmp_path):
+    settings = _auth_settings(tmp_path)
+    token = jwt.encode(
+        {
+            "sub": "expired-subject",
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+        },
+        _TEST_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+    with pytest.raises(InvalidTokenError, match="expired"):
+        await decode_external_jwt(token, settings)
+
+
+def test_extract_external_token_prefers_header_over_cookie(tmp_path):
+    settings = _auth_settings(tmp_path)
+
+    token = extract_external_token(
+        {_EXTERNAL_AUTH_HEADER: f"Bearer {_HEADER_CREDENTIAL}"},
+        {_EXTERNAL_AUTH_COOKIE: "cookie-token"},
+        settings,
+    )
+
+    assert token == _HEADER_CREDENTIAL

--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -1,7 +1,66 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
 import pytest
+from langflow.services.database.models.auth import SSOUserProfile
 from langflow.services.database.models.user import User
-from langflow.services.deps import get_auth_service, session_scope
+from langflow.services.deps import get_auth_service, get_settings_service, session_scope
 from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+_TEST_JWT_SECRET = "external-test-secret-for-jwt-tests"  # noqa: S105
+_EXTERNAL_AUTH_HEADER = "X-Langflow-External-Auth"
+_EXTERNAL_AUTH_COOKIE = "external-session"
+
+
+def _external_token(**claims):
+    payload = {
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        **claims,
+    }
+    return jwt.encode(payload, _TEST_JWT_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+async def external_auth_settings(client):  # noqa: ARG001
+    auth_settings = get_settings_service().auth_settings
+    fields = (
+        "EXTERNAL_AUTH_ENABLED",
+        "EXTERNAL_AUTH_PROVIDER",
+        "EXTERNAL_AUTH_TOKEN_HEADER",
+        "EXTERNAL_AUTH_TOKEN_COOKIE",
+        "EXTERNAL_AUTH_IDENTITY_RESOLVER",
+        "EXTERNAL_AUTH_TRUSTED_JWT_DECODE",
+        "EXTERNAL_AUTH_JWKS_URL",
+        "EXTERNAL_AUTH_ISSUER",
+        "EXTERNAL_AUTH_AUDIENCE",
+        "EXTERNAL_AUTH_ALGORITHMS",
+        "EXTERNAL_AUTH_SUBJECT_CLAIM",
+        "EXTERNAL_AUTH_USERNAME_CLAIM",
+        "EXTERNAL_AUTH_EMAIL_CLAIM",
+        "EXTERNAL_AUTH_NAME_CLAIM",
+    )
+    original = {field: getattr(auth_settings, field) for field in fields}
+
+    auth_settings.EXTERNAL_AUTH_ENABLED = True
+    auth_settings.EXTERNAL_AUTH_PROVIDER = "test-provider"
+    auth_settings.EXTERNAL_AUTH_TOKEN_HEADER = _EXTERNAL_AUTH_HEADER
+    auth_settings.EXTERNAL_AUTH_TOKEN_COOKIE = None
+    auth_settings.EXTERNAL_AUTH_IDENTITY_RESOLVER = None
+    auth_settings.EXTERNAL_AUTH_TRUSTED_JWT_DECODE = True
+    auth_settings.EXTERNAL_AUTH_JWKS_URL = None
+    auth_settings.EXTERNAL_AUTH_ISSUER = None
+    auth_settings.EXTERNAL_AUTH_AUDIENCE = None
+    auth_settings.EXTERNAL_AUTH_ALGORITHMS = "RS256"
+    auth_settings.EXTERNAL_AUTH_SUBJECT_CLAIM = "sub"
+    auth_settings.EXTERNAL_AUTH_USERNAME_CLAIM = "preferred_username"
+    auth_settings.EXTERNAL_AUTH_EMAIL_CLAIM = "email"
+    auth_settings.EXTERNAL_AUTH_NAME_CLAIM = "name"
+
+    yield auth_settings
+
+    for field, value in original.items():
+        setattr(auth_settings, field, value)
 
 
 @pytest.fixture
@@ -77,3 +136,82 @@ async def test_session_endpoint_no_api_key_in_response(client, logged_in_headers
     assert data["authenticated"] is True
     # Verify store_api_key field is None or not present in response
     assert data.get("store_api_key") is None
+
+
+async def test_session_endpoint_jit_creates_user_for_external_header(client, external_auth_settings):  # noqa: ARG001
+    token = _external_token(
+        sub="subject-1",
+        preferred_username="external-user",
+        email="external@example.com",
+        name="External User",
+    )
+
+    response = await client.get("api/v1/session", headers={_EXTERNAL_AUTH_HEADER: f"Bearer {token}"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["authenticated"] is True
+    assert data["user"]["username"] == "external-user"
+    assert data["user"]["is_active"] is True
+    assert data.get("store_api_key") is None
+
+    async with session_scope() as session:
+        statement = select(SSOUserProfile).where(
+            SSOUserProfile.sso_provider == "test-provider",
+            SSOUserProfile.sso_user_id == "subject-1",
+        )
+        profiles = (await session.exec(statement)).all()
+        assert len(profiles) == 1
+        assert str(profiles[0].user_id) == data["user"]["id"]
+        assert profiles[0].email == "external@example.com"
+
+    second_response = await client.get("api/v1/session", headers={_EXTERNAL_AUTH_HEADER: f"Bearer {token}"})
+    assert second_response.status_code == 200
+    assert second_response.json()["user"]["id"] == data["user"]["id"]
+
+
+async def test_session_endpoint_accepts_external_cookie_with_custom_claim_mapping(client, external_auth_settings):
+    external_auth_settings.EXTERNAL_AUTH_TOKEN_HEADER = "X-Disabled-External-Auth"  # noqa: S105
+    external_auth_settings.EXTERNAL_AUTH_TOKEN_COOKIE = _EXTERNAL_AUTH_COOKIE
+    external_auth_settings.EXTERNAL_AUTH_USERNAME_CLAIM = "username"
+    external_auth_settings.EXTERNAL_AUTH_EMAIL_CLAIM = "username"
+    external_auth_settings.EXTERNAL_AUTH_NAME_CLAIM = "display_name"
+
+    token = _external_token(
+        sub="cookie-subject",
+        username="person@example.com",
+        display_name="Person Name",
+    )
+
+    response = await client.get("api/v1/session", headers={"Cookie": f"{_EXTERNAL_AUTH_COOKIE}={token}"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["authenticated"] is True
+    assert data["user"]["username"] == "person@example.com"
+
+    async with session_scope() as session:
+        statement = select(SSOUserProfile).where(
+            SSOUserProfile.sso_provider == "test-provider",
+            SSOUserProfile.sso_user_id == "cookie-subject",
+        )
+        profile = (await session.exec(statement)).first()
+        assert profile is not None
+        assert profile.email == "person@example.com"
+
+
+async def test_session_endpoint_rejects_expired_external_token(client, external_auth_settings):  # noqa: ARG001
+    token = jwt.encode(
+        {
+            "sub": "expired-subject",
+            "preferred_username": "expired-user",
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+        },
+        _TEST_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+    response = await client.get("api/v1/session", headers={_EXTERNAL_AUTH_HEADER: f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is False

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -133,6 +133,70 @@ class AuthSettings(BaseSettings):
     )
     """Path to YAML configuration file for SSO settings. Contains provider-specific configuration."""
 
+    # External trusted identity provider settings.
+    # These are used by Langflow to accept a credential issued or validated by
+    # an external identity layer, then map that identity to a normal local
+    # Langflow user through SSOUserProfile.
+    EXTERNAL_AUTH_ENABLED: bool = Field(
+        default=False,
+        description="Enable trusted external request authentication and JIT local user mapping.",
+    )
+    EXTERNAL_AUTH_PROVIDER: str = Field(
+        default="external",
+        description="Stable provider key used in SSOUserProfile.",
+    )
+    EXTERNAL_AUTH_TOKEN_HEADER: str = Field(
+        default="Authorization",
+        description="Header containing the external credential. Authorization Bearer values are supported.",
+    )
+    EXTERNAL_AUTH_TOKEN_COOKIE: str | None = Field(
+        default=None,
+        description="Optional cookie containing the external credential.",
+    )
+    EXTERNAL_AUTH_IDENTITY_RESOLVER: str | None = Field(
+        default=None,
+        description=(
+            "Optional module:attribute import path for a resolver that converts the external credential into an "
+            "identity. Defaults to built-in JWT validation."
+        ),
+    )
+    EXTERNAL_AUTH_TRUSTED_JWT_DECODE: bool = Field(
+        default=False,
+        description="Decode the external JWT without signature verification when an upstream layer validates it.",
+    )
+    EXTERNAL_AUTH_JWKS_URL: str | None = Field(
+        default=None,
+        description="JWKS URL used to verify external JWT signatures when trusted decode is disabled.",
+    )
+    EXTERNAL_AUTH_ISSUER: str | None = Field(
+        default=None,
+        description="Expected JWT issuer. Leave empty to skip issuer validation.",
+    )
+    EXTERNAL_AUTH_AUDIENCE: str | None = Field(
+        default=None,
+        description="Expected JWT audience. Comma-separated audiences are supported.",
+    )
+    EXTERNAL_AUTH_ALGORITHMS: str = Field(
+        default="RS256",
+        description="Comma-separated JWT algorithms accepted for external JWT validation.",
+    )
+    EXTERNAL_AUTH_SUBJECT_CLAIM: str = Field(
+        default="sub",
+        description="JWT claim used as the stable external user id.",
+    )
+    EXTERNAL_AUTH_USERNAME_CLAIM: str = Field(
+        default="preferred_username",
+        description="JWT claim preferred for the local Langflow username.",
+    )
+    EXTERNAL_AUTH_EMAIL_CLAIM: str = Field(
+        default="email",
+        description="JWT claim containing the user's email.",
+    )
+    EXTERNAL_AUTH_NAME_CLAIM: str = Field(
+        default="name",
+        description="JWT claim containing the user's display name.",
+    )
+
     pwd_context: CryptContext = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     model_config = SettingsConfigDict(validate_assignment=True, extra="ignore", env_prefix="LANGFLOW_")

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -197,6 +197,35 @@ class AuthSettings(BaseSettings):
         description="JWT claim containing the user's display name.",
     )
 
+    FLOW_RBAC_ENABLED: bool = Field(
+        default=False,
+        description="Enable flow-level access control checks for view, run, edit, and manage actions.",
+    )
+    FLOW_RBAC_ROLE_CLAIM: str = Field(
+        default="roles",
+        description="JWT claim containing request-time role names for flow access control.",
+    )
+    FLOW_RBAC_GROUP_CLAIM: str = Field(
+        default="groups",
+        description="JWT claim containing request-time group names for flow access control.",
+    )
+    FLOW_RBAC_ADMIN_ROLES: str = Field(
+        default="",
+        description="Comma-separated role names that can administer all flows.",
+    )
+    FLOW_RBAC_ADMIN_GROUPS: str = Field(
+        default="",
+        description="Comma-separated group names that can administer all flows.",
+    )
+    FLOW_RBAC_LOCK_BYPASS_ROLES: str = Field(
+        default="",
+        description="Comma-separated role names that can edit locked flows.",
+    )
+    FLOW_RBAC_LOCK_BYPASS_GROUPS: str = Field(
+        default="",
+        description="Comma-separated group names that can edit locked flows.",
+    )
+
     pwd_context: CryptContext = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     model_config = SettingsConfigDict(validate_assignment=True, extra="ignore", env_prefix="LANGFLOW_")


### PR DESCRIPTION
This pull request introduces Role-Based Access Control (RBAC) for flows, enhancing security and flexibility by enforcing permissions at the flow level. The main changes include adding a new `flow_access_control` table, updating API endpoints to check flow permissions based on RBAC settings, and refactoring flow-related operations to use permission checks instead of simple user ownership. Below are the most important changes grouped by theme:

**RBAC Infrastructure and Database Changes:**

* Added a new Alembic migration (`4c6d8e2f9a10_add_flow_access_control_table.py`) to create the `flow_access_control` table, which stores access control entries for flows, including subject type, subject id, permission, and relevant indexes and constraints.
* Updated cascade deletion logic in `cascade_delete_flow` to remove related `FlowAccessControl` entries when a flow is deleted.

**API Endpoint Permission Enforcement:**

* Refactored flow retrieval and update endpoints in `flows.py` (e.g., `read_flow`, `update_flow`, `upsert_flow`) to use `get_flow_principal` and `require_flow_permission` for permission checks instead of direct user ownership checks. This ensures that only users with the appropriate permissions can access or modify flows when RBAC is enabled. [[1]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R201-R214) [[2]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26L256-R288) [[3]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R333) [[4]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R347-R353) [[5]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26L332-R385)
* Updated flow listing (`read_flows`) to use `viewable_flows_filter` with the current principal when RBAC is enabled, restricting the flows visible to the user according to their permissions.

**API Utility and Dependency Updates:**

* Updated utility imports and dependency injection to include new RBAC-related functions and models, such as `FlowAccessControl`, `FlowPermission`, and principal/permission helpers. [[1]](diffhunk://#diff-7fcf60491f65c84525e1ac5eac47ab7706d8d7c137a5bfee8e79d288b262e8acL20-R20) [[2]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607R57-R69) [[3]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R55-R60) [[4]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R70) [[5]](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26R120)
* Modified API endpoints (e.g., `get_flow_for_api_key_user`, `get_flow_for_current_user`, `webhook_events_stream`) to check permissions using RBAC when enabled, falling back to ownership checks otherwise. [[1]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607R557-R590) [[2]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607R890-R891) [[3]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607R902-R909)

**Other Notable Changes:**

* Corrected logic in `read_public_flow` to ensure only public flows are accessible and removed dependency on user lookup by flow id.
* Adjusted flow update logic to determine required permission (`EDIT` vs `MANAGE`) based on which fields are being updated (e.g., `locked`, `access_type`).

These changes collectively provide a robust foundation for flow-level RBAC, improving security and enabling more granular access control for flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flow access control (ACL) to manage user/role/group permissions on flows
  * Role-based access control (RBAC) with granular flow permissions (view, run, edit, manage)
  * External authentication support for JWT-based single sign-on scenarios

* **Improvements**
  * Flow deletion now properly cascades and removes related access control records

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->