### PR TITLE
feat(authz): MANAGE action + share-backed list prefilter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,22 @@ The Casbin request shape is `(subject, domain, object, action)`:
 - subject = `user:{uuid}`
 - domain = `project:{uuid}` → `workspace:{uuid}` → `*` (resolved by `_resolve_flow_domain`; the more specific domain wins so project-scoped grants match directly while workspace-scoped grants still flow down via Casbin `g2` inheritance)
 - object = `flow:{uuid}` / `deployment:{uuid}` / `project:{uuid}` / `flow:*` / etc.
-- action = `read` / `write` / `create` / `delete` / `execute` / `deploy`
+- action = `read` / `write` / `create` / `delete` / `execute` / `deploy` / `manage`
+
+**`MANAGE` action (Phase 4+):** PATCH/PUT handlers that touch sensitive administrative fields gate on `FlowAction.MANAGE` (resp. `DeploymentAction.MANAGE`, `ProjectAction.MANAGE`) instead of `WRITE`. The field sets live in `langflow.services.authorization.sensitive_fields`:
+- `SENSITIVE_FLOW_FIELDS = {locked, access_type, endpoint_name, webhook, mcp_enabled}`
+- `SENSITIVE_PROJECT_FIELDS = {auth_settings, parent_id}` (reparenting / governance)
+- `SENSITIVE_DEPLOYMENT_FIELDS = frozenset()` (no sensitive field today; enum exists for future use)
+Route handlers compute `required_action = FlowAction.MANAGE if requires_flow_manage(payload.model_fields_set) else FlowAction.WRITE` and pass the result to `ensure_flow_permission`. The OSS pass-through still allows everything; the enterprise plugin decides who has `MANAGE`. Lock-bypass is not an OSS env var — the enterprise policy determines who can MANAGE a locked flow.
+
+**External trusted auth (Phase 4+):** the existing `BaseAuthService.get_or_create_user_from_claims()` JIT hook is implemented in `langflow.services.auth.AuthService`. When `LANGFLOW_EXTERNAL_AUTH_ENABLED=true`, the native JWT path runs first; on failure the auth service falls back to `langflow.services.auth.external.resolve_external_identity` which validates the credential (built-in JWT/JWKS or a pluggable `EXTERNAL_AUTH_IDENTITY_RESOLVER`) and JIT-provisions a local user via `SSOUserProfile`. Key settings:
+- `LANGFLOW_EXTERNAL_AUTH_ENABLED=false` — independent of `LANGFLOW_AUTHZ_ENABLED`; either can be used alone.
+- `LANGFLOW_EXTERNAL_AUTH_PROVIDER` — stable provider key written to `SSOUserProfile.sso_provider`.
+- `LANGFLOW_EXTERNAL_AUTH_TOKEN_HEADER` (default `"Authorization"`) and `LANGFLOW_EXTERNAL_AUTH_TOKEN_COOKIE`.
+- `LANGFLOW_EXTERNAL_AUTH_JWKS_URL` for production JWKS-backed validation, or `LANGFLOW_EXTERNAL_AUTH_TRUSTED_JWT_DECODE=true` to skip signature verification when an upstream proxy already validates the token (off by default).
+- Claim mapping: `LANGFLOW_EXTERNAL_AUTH_SUBJECT_CLAIM` / `_USERNAME_CLAIM` / `_EMAIL_CLAIM` / `_NAME_CLAIM`.
+
+**Share-backed list prefilter (Phase 4+):** `langflow.services.authorization.share_visibility_filter(user, *, resource_type, id_column, owner_column, access_type_column=None, public_value=None)` returns a SQLAlchemy boolean predicate that callers AND into their `select(...)`. Floor semantics: when `AUTHZ_ENABLED=false`, it resolves to `owner_column == user.id` (no behavior change); when `AUTHZ_ENABLED=true`, it ORs in `access_type_column == public_value` (when applicable) and `id_column IN (SELECT resource_id FROM authz_share WHERE ...)`. Used by the list endpoints in `flows.py`, `deployments.py`, and `projects.py` so paginated `page.total` math reflects share-backed visibility. The post-filter `filter_visible_resources` remains the ceiling for plugin-only grants that don't live in `authz_share`.
 
 Use `langflow authz dry-run` to simulate a built-in policy against the live audit table without enabling enforcement.
 

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -72,7 +72,12 @@ from langflow.api.v1.schemas.deployments import (
     SnapshotUpdateResponse,
 )
 from langflow.services.adapters.deployment.context import deployment_provider_scope
-from langflow.services.authorization import DeploymentAction, ensure_deployment_permission, filter_visible_resources
+from langflow.services.authorization import (
+    DeploymentAction,
+    ensure_deployment_permission,
+    filter_visible_resources,
+    share_visibility_filter,
+)
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import _resolve_casbin_domain
 from langflow.services.database.models.deployment.crud import (
@@ -87,6 +92,7 @@ from langflow.services.database.models.deployment.crud import (
 from langflow.services.database.models.deployment.crud import (
     update_deployment as update_deployment_db,
 )
+from langflow.services.database.models.deployment.model import Deployment
 from langflow.services.database.models.deployment_provider_account.crud import (
     count_provider_accounts as count_provider_account_rows,
 )
@@ -758,6 +764,16 @@ async def list_deployments(
             )
         return deployment_mapper.shape_deployment_list_result(provider_view)
 
+    # SQL prefilter for share-backed visibility. When AUTHZ is off, this
+    # resolves to ``Deployment.user_id == current_user.id`` so existing
+    # behavior is unchanged. When AUTHZ is on, owner + ``authz_share``
+    # grants are included so paginated ``total`` matches the page.
+    deployment_visibility_clause = share_visibility_filter(
+        current_user,
+        resource_type="deployment",
+        id_column=Deployment.id,  # type: ignore[arg-type]
+        owner_column=Deployment.user_id,  # type: ignore[arg-type]
+    )
     with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
         rows_with_counts, total, provider_data_by_resource_key = await list_deployments_synced(
             deployment_adapter=deployment_adapter,
@@ -771,15 +787,19 @@ async def list_deployments(
             flow_version_ids=effective_flow_version_ids,
             project_id=project_id,
             names=names,
+            deployment_visibility_clause=deployment_visibility_clause,
         )
     # Per-deployment authorization filter. Mirrors GET /flows/ and GET /projects/:
     # the coarse READ check above gates whether the caller can list deployments
     # at all; this call drops individual rows the enterprise plugin denies. OSS
     # pass-through returns the input unchanged. ``rows_with_counts`` is
     # ``list[tuple[Deployment, int, list[...]]]`` so the key/domain extractors
-    # operate on the first element. ``total`` may overcount denied items —
-    # accurate paginated counts need SQL-level prefilter (Phase 3, alongside
-    # ``authz_share``).
+    # operate on the first element.
+    #
+    # ``total`` accuracy: ``deployment_visibility_clause`` above is the SQL
+    # floor (owner + authz_share). Plugin-only grants (no matching share row)
+    # can still trim items here, in which case ``total`` may overcount; in
+    # the common case where shares power visibility, total matches.
     rows_with_counts = await filter_visible_resources(
         current_user,
         resource_type="deployment",

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -44,6 +44,7 @@ from langflow.services.authorization import (
     ensure_flow_permission,
     filter_visible_resources,
     requires_flow_manage,
+    share_visibility_filter,
 )
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import _resolve_casbin_domain
@@ -145,12 +146,29 @@ async def read_flows(
         if not folder_id:
             folder_id = default_folder_id
 
+        # SQL prefilter: floor visibility before pagination so paginated
+        # ``page.total`` math is correct. When AUTHZ is off, this resolves
+        # to ``Flow.user_id == current_user.id`` (matching pre-authz
+        # behavior). When AUTHZ is on, it ORs in PUBLIC flows and any
+        # ``authz_share`` grants visible to the caller. The post-filter
+        # below (``filter_visible_resources``) remains the ceiling for
+        # plugin-only grants.
+        visibility_clause = share_visibility_filter(
+            current_user,
+            resource_type="flow",
+            id_column=Flow.id,  # type: ignore[arg-type]
+            owner_column=Flow.user_id,  # type: ignore[arg-type]
+            access_type_column=Flow.access_type,  # type: ignore[arg-type]
+            public_value=AccessTypeEnum.PUBLIC,
+        )
         if auth_settings.AUTO_LOGIN:
+            # AUTO_LOGIN also includes legacy orphan rows (user_id IS NULL)
+            # so the dev-mode endpoint keeps returning them.
             stmt = select(Flow).where(
-                (Flow.user_id == None) | (Flow.user_id == current_user.id)  # noqa: E711
+                (Flow.user_id == None) | visibility_clause  # noqa: E711
             )
         else:
-            stmt = select(Flow).where(Flow.user_id == current_user.id)
+            stmt = select(Flow).where(visibility_clause)
 
         if remove_example_flows:
             stmt = stmt.where(Flow.folder_id != starter_folder_id)
@@ -204,9 +222,14 @@ async def read_flows(
         # ``owner_extractor`` lets the helper short-circuit owner-allow without
         # round-tripping through the enforcer — without it, an enterprise
         # plugin lacking an explicit owner-allow policy would hide the caller's
-        # own flows from paginated results. ``page.total`` may overcount denied
-        # items — a fully accurate count requires SQL-level prefiltering via
-        # authz_share (Phase 3 work).
+        # own flows from paginated results.
+        #
+        # ``page.total`` accuracy: ``share_visibility_filter`` above is the SQL
+        # floor (owner + public + authz_share), so the count reflects share-backed
+        # visibility. Any plugin-only grants the enterprise enforcer would add
+        # land on top via this post-filter; the ceiling can still differ from
+        # the count in those cases (rare in practice — most grants land in
+        # ``authz_share`` because that's how the plugin's admin UI persists them).
         page.items = await filter_visible_resources(
             current_user,
             resource_type="flow",

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -39,7 +39,12 @@ from langflow.api.v1.mappers.deployments.sync import retry_flow_operation_on_dep
 from langflow.api.v1.schemas import FlowListCreate
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.services.auth.utils import get_current_active_user
-from langflow.services.authorization import FlowAction, ensure_flow_permission, filter_visible_resources
+from langflow.services.authorization import (
+    FlowAction,
+    ensure_flow_permission,
+    filter_visible_resources,
+    requires_flow_manage,
+)
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import _resolve_casbin_domain
 from langflow.services.cache.service import ThreadingInMemoryCache
@@ -324,10 +329,16 @@ async def update_flow(
         if not db_flow:
             raise HTTPException(status_code=404, detail="Flow not found")
 
+        # Sensitive administrative fields (locked, access_type, endpoint_name,
+        # webhook, mcp_enabled) require FlowAction.MANAGE instead of WRITE.
+        # The OSS pass-through still allows everything; the enterprise plugin
+        # decides who has MANAGE.
+        required_action = FlowAction.MANAGE if requires_flow_manage(flow.model_fields_set) else FlowAction.WRITE
+
         try:
             await ensure_flow_permission(
                 current_user,
-                FlowAction.WRITE,
+                required_action,
                 flow_id=flow_id,
                 flow_user_id=db_flow.user_id,
                 workspace_id=db_flow.workspace_id,
@@ -347,7 +358,7 @@ async def update_flow(
             try:
                 await ensure_flow_permission(
                     current_user,
-                    FlowAction.WRITE,
+                    required_action,
                     flow_id=flow_id,
                     flow_user_id=db_flow.user_id,
                     workspace_id=target_workspace_id,
@@ -375,7 +386,7 @@ async def update_flow(
             try:
                 await ensure_flow_permission(
                     current_user,
-                    FlowAction.WRITE,
+                    required_action,
                     flow_id=flow_id,
                     flow_user_id=db_flow_for_attempt.user_id,
                     workspace_id=db_flow_for_attempt.workspace_id,
@@ -394,7 +405,7 @@ async def update_flow(
                 try:
                     await ensure_flow_permission(
                         current_user,
-                        FlowAction.WRITE,
+                        required_action,
                         flow_id=flow_id,
                         flow_user_id=db_flow_for_attempt.user_id,
                         workspace_id=attempt_target_workspace_id,
@@ -464,10 +475,17 @@ async def upsert_flow(
             if not can_widen and existing_flow.user_id != current_user.id:
                 raise HTTPException(status_code=404, detail="Flow not found")
 
+            # Upgrade WRITE → MANAGE when the incoming payload touches any
+            # administrative field (locked, access_type, endpoint_name,
+            # webhook, mcp_enabled). model_fields_set reflects only the
+            # fields the client actually sent so default values do not
+            # accidentally escalate the required action.
+            required_action = FlowAction.MANAGE if requires_flow_manage(flow.model_fields_set) else FlowAction.WRITE
+
             try:
                 await ensure_flow_permission(
                     current_user,
-                    FlowAction.WRITE,
+                    required_action,
                     flow_id=flow_id,
                     flow_user_id=existing_flow.user_id,
                     workspace_id=existing_flow.workspace_id,
@@ -487,7 +505,7 @@ async def upsert_flow(
                 try:
                     await ensure_flow_permission(
                         current_user,
-                        FlowAction.WRITE,
+                        required_action,
                         flow_id=flow_id,
                         flow_user_id=existing_flow.user_id,
                         workspace_id=target_workspace_id,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -74,6 +74,8 @@ from langflow.services.database.utils import require_non_empty
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from sqlalchemy.sql import ColumnElement
+
     from langflow.api.utils import DbSession
     from langflow.services.database.models.flow_version_deployment_attachment.model import (
         FlowVersionDeploymentAttachment,
@@ -715,6 +717,7 @@ async def list_deployments_synced(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     names: list[str] | None = None,
+    deployment_visibility_clause: ColumnElement[bool] | None = None,
 ) -> tuple[list[tuple[Deployment, int, list[tuple[UUID, str | None]]]], int, dict[str, dict[str, Any]]]:
     """Return a page of deployments, deleting any DB rows the provider doesn't recognise.
 
@@ -740,6 +743,7 @@ async def list_deployments_synced(
             flow_version_ids=flow_version_ids,
             project_id=project_id,
             names=names,
+            deployment_visibility_clause=deployment_visibility_clause,
         )
         if not batch:
             break
@@ -806,6 +810,7 @@ async def list_deployments_synced(
         flow_version_ids=flow_version_ids,
         project_id=project_id,
         names=names,
+        deployment_visibility_clause=deployment_visibility_clause,
     )
     return accepted, total, provider_data_by_resource_key
 

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -38,6 +38,7 @@ from langflow.services.authorization import (
     ensure_project_permission,
     filter_visible_resources,
     requires_project_manage,
+    share_visibility_filter,
 )
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
 from langflow.services.authorization.utils import _resolve_casbin_domain
@@ -47,7 +48,7 @@ from langflow.services.database.models.deployment.exceptions import (
 )
 from langflow.services.database.models.deployment.guards import check_project_has_deployments
 from langflow.services.database.models.deployment.orm_guards import ensure_flow_moves_allowed
-from langflow.services.database.models.flow.model import Flow, FlowRead
+from langflow.services.database.models.flow.model import AccessTypeEnum, Flow, FlowRead
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import (
     Folder,
@@ -214,10 +215,20 @@ async def read_projects(
     current_user: CurrentActiveUser,
 ):
     try:
+        # SQL prefilter: owner + share-backed visibility. When AUTHZ is off,
+        # collapses to ``Folder.user_id == current_user.id`` so behavior
+        # is unchanged. The orphan ``Folder.user_id IS NULL`` branch (used
+        # for built-in folders like the starter project) is preserved.
+        project_visibility_clause = share_visibility_filter(
+            current_user,
+            resource_type="project",
+            id_column=Folder.id,  # type: ignore[arg-type]
+            owner_column=Folder.user_id,  # type: ignore[arg-type]
+        )
         projects = (
             await session.exec(
                 select(Folder).where(
-                    or_(Folder.user_id == current_user.id, Folder.user_id == None)  # noqa: E711
+                    or_(project_visibility_clause, Folder.user_id == None)  # noqa: E711
                 )
             )
         ).all()
@@ -300,10 +311,27 @@ async def read_project(
         # contents. Otherwise keep the existing owner-scoped flow filter.
         treat_as_shared = share_aware and project.user_id != current_user.id
 
+        # SQL prefilter for the per-flow visibility inside this project. When
+        # the project is reached via a share, scope is broad (project share
+        # implies access to project flows) — for that case we use a
+        # ``share_visibility_filter`` on Flow so authz_share grants on
+        # individual flows also extend visibility. Otherwise the legacy
+        # owner-only scope still applies.
+        flow_visibility_clause = share_visibility_filter(
+            current_user,
+            resource_type="flow",
+            id_column=Flow.id,  # type: ignore[arg-type]
+            owner_column=Flow.user_id,  # type: ignore[arg-type]
+            access_type_column=Flow.access_type,  # type: ignore[arg-type]
+            public_value=AccessTypeEnum.PUBLIC,
+        )
+
         # Check if pagination is explicitly requested by the user (both page and size provided)
         if page is not None and size is not None:
             stmt = select(Flow).where(Flow.folder_id == project_id)
-            if not treat_as_shared:
+            if treat_as_shared:
+                stmt = stmt.where(flow_visibility_clause)
+            else:
                 stmt = stmt.where(Flow.user_id == current_user.id)
 
             if Flow.updated_at is not None:
@@ -344,23 +372,30 @@ async def read_project(
             return FolderWithPaginatedFlows(folder=FolderRead.model_validate(project), flows=paginated_flows)
 
         # If no pagination requested, return flows visible to the caller.
+        # SQL prefilter: when the project is reached via a share grant, fall
+        # through to share-backed flow visibility; otherwise keep the
+        # legacy owner-only scope. Re-querying Flow (instead of filtering
+        # the eager-loaded ``project.flows`` list in Python) makes this
+        # branch consistent with the paginated branch above and lets the
+        # SQL ``authz_share`` join do the work.
+        flow_stmt = select(Flow).where(Flow.folder_id == project_id)
         if treat_as_shared:
-            # A project share grant implies access to the project itself, but
-            # per-flow policy (deny rules, lower scopes) still applies. Without
-            # this call, ``list(project.flows)`` would leak every flow in the
-            # project regardless of finer-grained Casbin rules the plugin may
-            # have. OSS pass-through returns the input list unchanged, so this
-            # has no effect on default OSS installs.
+            flow_stmt = flow_stmt.where(flow_visibility_clause)
+        else:
+            flow_stmt = flow_stmt.where(Flow.user_id == current_user.id)
+        visible_flows_seq = (await session.exec(flow_stmt)).all()
+        visible_flows = list(visible_flows_seq)
+        if treat_as_shared:
+            # Ceiling for plugin-only grants — keeps behavior consistent with
+            # the rest of the authz layer (SQL floor + post-filter ceiling).
             visible_flows = await filter_visible_resources(
                 current_user,
                 resource_type="flow",
-                candidates=list(project.flows),
+                candidates=visible_flows,
                 domain_extractor=lambda flow: _resolve_casbin_domain(flow.workspace_id, flow.folder_id),
                 owner_extractor=lambda flow: flow.user_id,
                 act=FlowAction.READ,
             )
-        else:
-            visible_flows = [flow for flow in project.flows if flow.user_id == current_user.id]
         project.flows = visible_flows
 
         # Convert to FolderReadWithFlows while session is still active to avoid detached instance errors

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -37,6 +37,7 @@ from langflow.services.authorization import (
     ProjectAction,
     ensure_project_permission,
     filter_visible_resources,
+    requires_project_manage,
 )
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
 from langflow.services.authorization.utils import _resolve_casbin_domain
@@ -393,10 +394,14 @@ async def update_project(
     if not existing_project:
         raise HTTPException(status_code=404, detail="Project not found")
 
+    # Reparenting (parent_id) and governance toggles (auth_settings) require
+    # ProjectAction.MANAGE — a strictly higher privilege than WRITE.
+    project_action = ProjectAction.MANAGE if requires_project_manage(project.model_fields_set) else ProjectAction.WRITE
+
     try:
         await ensure_project_permission(
             current_user,
-            ProjectAction.WRITE,
+            project_action,
             project_id=project_id,
             project_user_id=existing_project.user_id,
             workspace_id=existing_project.workspace_id,

--- a/src/backend/base/langflow/services/authorization/__init__.py
+++ b/src/backend/base/langflow/services/authorization/__init__.py
@@ -9,7 +9,11 @@ from langflow.services.authorization.actions import (
     ShareAction,
     VariableAction,
 )
-from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
+from langflow.services.authorization.fetch import (
+    authorized_or_owner_scoped,
+    deny_to_404,
+    share_visibility_filter,
+)
 from langflow.services.authorization.sensitive_fields import (
     SENSITIVE_DEPLOYMENT_FIELDS,
     SENSITIVE_FLOW_FIELDS,
@@ -59,4 +63,5 @@ __all__ = [
     "requires_deployment_manage",
     "requires_flow_manage",
     "requires_project_manage",
+    "share_visibility_filter",
 ]

--- a/src/backend/base/langflow/services/authorization/__init__.py
+++ b/src/backend/base/langflow/services/authorization/__init__.py
@@ -10,6 +10,14 @@ from langflow.services.authorization.actions import (
     VariableAction,
 )
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
+from langflow.services.authorization.sensitive_fields import (
+    SENSITIVE_DEPLOYMENT_FIELDS,
+    SENSITIVE_FLOW_FIELDS,
+    SENSITIVE_PROJECT_FIELDS,
+    requires_deployment_manage,
+    requires_flow_manage,
+    requires_project_manage,
+)
 from langflow.services.authorization.service import LangflowAuthorizationService
 from langflow.services.authorization.utils import (
     audit_decision,
@@ -25,6 +33,9 @@ from langflow.services.authorization.utils import (
 )
 
 __all__ = [
+    "SENSITIVE_DEPLOYMENT_FIELDS",
+    "SENSITIVE_FLOW_FIELDS",
+    "SENSITIVE_PROJECT_FIELDS",
     "DeploymentAction",
     "FileAction",
     "FlowAction",
@@ -45,4 +56,7 @@ __all__ = [
     "ensure_share_permission",
     "ensure_variable_permission",
     "filter_visible_resources",
+    "requires_deployment_manage",
+    "requires_flow_manage",
+    "requires_project_manage",
 ]

--- a/src/backend/base/langflow/services/authorization/actions.py
+++ b/src/backend/base/langflow/services/authorization/actions.py
@@ -11,6 +11,10 @@ class FlowAction(str, Enum):
     Values are the Casbin ``act`` strings consumed by the enterprise policy
     engine. Subclassing ``str`` lets these be passed wherever a bare string is
     accepted, so callers can migrate incrementally.
+
+    ``MANAGE`` is a strictly higher privilege than ``WRITE``: route handlers
+    gate it on PATCH/PUT payloads that touch sensitive administrative fields
+    (see :data:`langflow.services.authorization.sensitive_fields.SENSITIVE_FLOW_FIELDS`).
     """
 
     READ = "read"
@@ -19,16 +23,23 @@ class FlowAction(str, Enum):
     DELETE = "delete"
     EXECUTE = "execute"
     DEPLOY = "deploy"
+    MANAGE = "manage"
 
 
 class DeploymentAction(str, Enum):
-    """Actions that can be authorized on a deployment resource."""
+    """Actions that can be authorized on a deployment resource.
+
+    ``MANAGE`` mirrors :attr:`FlowAction.MANAGE`. No deployment field maps to
+    it today; the action exists so the enterprise plugin has a stable verb
+    to grant when sensitive deployment fields land.
+    """
 
     READ = "read"
     WRITE = "write"
     CREATE = "create"
     DELETE = "delete"
     EXECUTE = "execute"
+    MANAGE = "manage"
 
 
 class ProjectAction(str, Enum):
@@ -37,12 +48,17 @@ class ProjectAction(str, Enum):
     Projects are the OSS-side persistent name for the folder model; the
     ``project:`` Casbin object prefix matches the API surface and the
     ``project:{folder_id}`` domain used by ``_resolve_flow_domain``.
+
+    ``MANAGE`` mirrors :attr:`FlowAction.MANAGE`. Gated on PATCH payloads
+    that touch governance / hierarchy fields — see
+    :data:`langflow.services.authorization.sensitive_fields.SENSITIVE_PROJECT_FIELDS`.
     """
 
     READ = "read"
     WRITE = "write"
     CREATE = "create"
     DELETE = "delete"
+    MANAGE = "manage"
 
 
 class KnowledgeBaseAction(str, Enum):

--- a/src/backend/base/langflow/services/authorization/fetch.py
+++ b/src/backend/base/langflow/services/authorization/fetch.py
@@ -20,24 +20,55 @@ These helpers fix that by branching on
   the helper keeps the existing owner-scoped query. That preserves the
   strict-pass-through guarantee: enabling ``LANGFLOW_AUTHZ_ENABLED=true``
   without an enterprise plugin must not silently widen cross-user visibility.
+
+List-endpoint SQL prefilter
+---------------------------
+
+:func:`share_visibility_filter` returns a SQLAlchemy boolean expression that
+list-endpoint queries AND into their base ``select(...)`` so paginated
+results' ``page.total`` is accurate. The expression is a floor — owner +
+``access_type=PUBLIC`` (when applicable) + ``authz_share``-backed visibility
+— never widening past what an enterprise plugin could grant. The plugin
+still adds the ceiling via the existing :func:`filter_visible_resources`
+post-pass on the page's items.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from fastapi import HTTPException, status
-from sqlmodel import select
+from sqlalchemy import or_
+from sqlmodel import col, select
 
-from langflow.services.deps import get_authorization_service
+from langflow.services.database.models.auth.authz import (
+    AuthzShare,
+    AuthzTeamMember,
+    SharePermissionLevel,
+    ShareScope,
+)
+from langflow.services.deps import get_authorization_service, get_settings_service
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from uuid import UUID
 
     from sqlalchemy.orm.attributes import InstrumentedAttribute
+    from sqlalchemy.sql import ColumnElement
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 T = TypeVar("T")
+
+
+# Default permission levels that satisfy a list-read visibility check. READ is
+# the floor; higher levels imply read access, so any share grant at READ or
+# above lets the recipient see the resource in their list view.
+_READ_PERMISSION_LEVELS: tuple[str, ...] = (
+    SharePermissionLevel.READ.value,
+    SharePermissionLevel.WRITE.value,
+    SharePermissionLevel.EXECUTE.value,
+    SharePermissionLevel.ADMIN.value,
+)
 
 
 async def authorized_or_owner_scoped(
@@ -82,6 +113,94 @@ async def authorized_or_owner_scoped(
     else:
         stmt = select(model).where(id_column == resource_id).where(owner_column == owner_id)
     return (await session.exec(stmt)).first()
+
+
+def share_visibility_filter(
+    user: Any,
+    *,
+    resource_type: str,
+    id_column: InstrumentedAttribute,
+    owner_column: InstrumentedAttribute,
+    access_type_column: InstrumentedAttribute | None = None,
+    public_value: Any = None,
+    permission_levels: Iterable[str] = _READ_PERMISSION_LEVELS,
+) -> ColumnElement[bool]:
+    """Return a SQL predicate selecting resources the user can read.
+
+    Plumbing for list endpoints: callers ``select(Resource).where(
+    share_visibility_filter(...))`` so paginated queries get accurate
+    ``page.total`` counts. Works as a *floor*:
+
+    * ``AUTHZ_ENABLED=false`` → returns ``owner_column == user.id`` so list
+      behavior matches the pre-authz contract exactly. No share rows are
+      consulted; enabling sharing requires AUTHZ to be on.
+    * ``AUTHZ_ENABLED=true`` → ORs together owner ownership, optional
+      ``access_type == public_value`` (when the resource supports a public
+      flag), and ``authz_share``-backed visibility (scope=public,
+      scope=user/target=user.id, scope=team/target IN <user's teams>).
+
+    The optional ``filter_visible_resources`` post-pass remains the ceiling
+    for plugin-only grants (e.g. Casbin role-based access that doesn't have
+    a matching share row).
+
+    Parameters
+    ----------
+    user:
+        Active user-like with an ``id`` attribute (UUID).
+    resource_type:
+        ``authz_share.resource_type`` string (``"flow"``, ``"deployment"``,
+        ``"project"``, etc.).
+    id_column:
+        SQLAlchemy column attribute for the resource's primary key
+        (e.g. ``Flow.id``).
+    owner_column:
+        SQLAlchemy column attribute for the resource's owner FK
+        (e.g. ``Flow.user_id``).
+    access_type_column:
+        Optional column attribute carrying a PUBLIC/PRIVATE-style flag
+        (e.g. ``Flow.access_type``). When provided, rows where this column
+        equals ``public_value`` are unconditionally included.
+    public_value:
+        Value of ``access_type_column`` that marks a row as publicly
+        readable. Required when ``access_type_column`` is set.
+    permission_levels:
+        ``authz_share.permission_level`` values that count as "can read".
+        Defaults to the read-or-above ladder.
+    """
+    user_id: UUID = user.id  # let attribute access raise — callers always pass a user.
+
+    settings = get_settings_service()
+    if not settings.auth_settings.AUTHZ_ENABLED:
+        # Matches the pre-authz owner-scoped query exactly. Returning a
+        # ``ColumnElement`` (rather than a plain bool) so callers can compose
+        # this expression with other WHERE clauses unconditionally.
+        return owner_column == user_id
+
+    # Subquery: resource ids the user can read via authz_share. Three OR
+    # branches matching ShareScope semantics; AUTHZ_ENABLED=true is the
+    # precondition for any of them to fire.
+    team_member_subquery = select(AuthzTeamMember.team_id).where(AuthzTeamMember.user_id == user_id)
+    share_subquery = select(AuthzShare.resource_id).where(
+        AuthzShare.resource_type == resource_type,
+        col(AuthzShare.permission_level).in_(tuple(permission_levels)),
+        or_(
+            AuthzShare.scope == ShareScope.PUBLIC.value,
+            (AuthzShare.scope == ShareScope.USER.value) & (AuthzShare.target_id == user_id),
+            (AuthzShare.scope == ShareScope.TEAM.value) & col(AuthzShare.target_id).in_(team_member_subquery),
+        ),
+    )
+
+    clauses: list[ColumnElement[bool]] = [
+        owner_column == user_id,
+        col(id_column).in_(share_subquery),
+    ]
+    if access_type_column is not None:
+        if public_value is None:
+            msg = "share_visibility_filter: public_value must be provided when access_type_column is set"
+            raise ValueError(msg)
+        clauses.insert(1, access_type_column == public_value)
+
+    return or_(*clauses)
 
 
 def deny_to_404(exc: HTTPException, detail: str = "Not found") -> HTTPException:

--- a/src/backend/base/langflow/services/authorization/sensitive_fields.py
+++ b/src/backend/base/langflow/services/authorization/sensitive_fields.py
@@ -1,0 +1,67 @@
+"""Canonical sets of administrative resource fields gated on the ``MANAGE`` action.
+
+Route PATCH/PUT handlers consult these sets to decide whether a payload
+requires :attr:`FlowAction.MANAGE` (resp. ``DeploymentAction.MANAGE`` /
+``ProjectAction.MANAGE``) instead of the regular ``WRITE`` action. Keep these
+sets small and stable — the enterprise plugin's policy contract depends on
+operators reasoning about a fixed set of higher-privilege fields, not a
+moving target.
+
+Why a single ``MANAGE`` per resource (instead of per-field actions)?
+- One verb keeps the Casbin policy surface compact.
+- The enterprise plugin can still attach fine-grained policies by reading
+  ``AuthzContext`` (e.g. the resource id / owner) when MANAGE is requested.
+- New sensitive fields land here without forcing a new enum value or
+  invalidating existing policies.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Flow administrative fields:
+#  - locked: edit-lock toggle; bypassing the lock is a higher-privilege action.
+#  - access_type: PRIVATE/PUBLIC visibility toggle; widens external exposure.
+#  - endpoint_name: public/webhook URL slug; rebinding it can hijack callers.
+#  - webhook: enables the webhook endpoint surface.
+#  - mcp_enabled: exposes the flow over the MCP server.
+SENSITIVE_FLOW_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "locked",
+        "access_type",
+        "endpoint_name",
+        "webhook",
+        "mcp_enabled",
+    }
+)
+
+# Deployment administrative fields. Empty today: PATCH only accepts
+# name/description/provider_data (provider-opaque). MANAGE is still
+# introduced on the action enum so policies can grant it once sensitive
+# deployment fields exist.
+SENSITIVE_DEPLOYMENT_FIELDS: Final[frozenset[str]] = frozenset()
+
+# Project (folder) administrative fields:
+#  - auth_settings: governance/policy JSON dict.
+#  - parent_id: reparenting changes folder hierarchy / domain scope.
+SENSITIVE_PROJECT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "auth_settings",
+        "parent_id",
+    }
+)
+
+
+def requires_flow_manage(payload_field_set: set[str] | frozenset[str]) -> bool:
+    """Return True when a flow PATCH/PUT payload touches a MANAGE-gated field."""
+    return bool(SENSITIVE_FLOW_FIELDS & payload_field_set)
+
+
+def requires_deployment_manage(payload_field_set: set[str] | frozenset[str]) -> bool:
+    """Return True when a deployment PATCH/PUT payload touches a MANAGE-gated field."""
+    return bool(SENSITIVE_DEPLOYMENT_FIELDS & payload_field_set)
+
+
+def requires_project_manage(payload_field_set: set[str] | frozenset[str]) -> bool:
+    """Return True when a project PATCH/PUT payload touches a MANAGE-gated field."""
+    return bool(SENSITIVE_PROJECT_FIELDS & payload_field_set)

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from lfx.services.adapters.deployment.schema import DeploymentType
+    from sqlalchemy.sql import ColumnElement
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -189,12 +190,19 @@ async def list_deployments_page(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     names: list[str] | None = None,
+    deployment_visibility_clause: ColumnElement[bool] | None = None,
 ) -> list[tuple[Deployment, int, list[tuple[UUID, str | None]]]]:
     """Return a page of deployments with attachment counts and matched attachments.
 
     The third tuple element contains ``(flow_version_id, provider_snapshot_id)``
     pairs for attachments that matched the ``flow_version_ids`` filter (empty
     list when no filter is active).
+
+    ``deployment_visibility_clause`` is an optional SQL predicate that
+    replaces the default ``Deployment.user_id == user_id`` outer filter so
+    callers can broaden visibility (e.g. share-backed access) without
+    affecting the per-user attachment-count subquery, which intentionally
+    stays scoped to ``user_id``.
     """
     if offset < 0:
         msg = "offset must be greater than or equal to 0"
@@ -218,6 +226,9 @@ async def list_deployments_page(
         .group_by(FlowVersionDeploymentAttachment.deployment_id)
         .subquery()
     )
+    visibility_clause = (
+        deployment_visibility_clause if deployment_visibility_clause is not None else Deployment.user_id == user_id
+    )
     stmt = (
         select(
             Deployment,
@@ -225,7 +236,7 @@ async def list_deployments_page(
         )
         .outerjoin(attachment_counts_subquery, attachment_counts_subquery.c.deployment_id == Deployment.id)
         .where(
-            Deployment.user_id == user_id,
+            visibility_clause,
             Deployment.deployment_provider_account_id == deployment_provider_account_id,
         )
     )
@@ -370,9 +381,19 @@ async def count_deployments_by_provider(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     names: list[str] | None = None,
+    deployment_visibility_clause: ColumnElement[bool] | None = None,
 ) -> int:
+    """Count deployments visible to the caller.
+
+    Mirrors the visibility shape of :func:`list_deployments_page` so paginated
+    ``total`` counts match the page contents. ``deployment_visibility_clause``
+    (when provided) replaces the default ``Deployment.user_id == user_id`` filter.
+    """
+    visibility_clause = (
+        deployment_visibility_clause if deployment_visibility_clause is not None else Deployment.user_id == user_id
+    )
     stmt = select(func.count(Deployment.id)).where(
-        Deployment.user_id == user_id,
+        visibility_clause,
         Deployment.deployment_provider_account_id == deployment_provider_account_id,
     )
     if project_id is not None:

--- a/src/backend/tests/unit/services/authorization/test_actions.py
+++ b/src/backend/tests/unit/services/authorization/test_actions.py
@@ -7,6 +7,7 @@ from langflow.services.authorization.actions import (
     FileAction,
     FlowAction,
     KnowledgeBaseAction,
+    ProjectAction,
     ShareAction,
     VariableAction,
 )
@@ -20,18 +21,20 @@ def test_flow_action_values_match_casbin_strings():
     assert FlowAction.DELETE.value == "delete"
     assert FlowAction.EXECUTE.value == "execute"
     assert FlowAction.DEPLOY.value == "deploy"
+    assert FlowAction.MANAGE.value == "manage"
 
 
 def test_flow_action_subclasses_str():
     """Subclassing str lets the enum be passed wherever a string is accepted."""
     assert isinstance(FlowAction.READ, str)
     assert FlowAction.WRITE == "write"
+    assert FlowAction.MANAGE == "manage"
 
 
 def test_flow_action_is_iterable_and_complete():
-    """The enum exposes exactly the six canonical actions."""
+    """The enum exposes the seven canonical actions including MANAGE."""
     values = {member.value for member in FlowAction}
-    assert values == {"read", "write", "create", "delete", "execute", "deploy"}
+    assert values == {"read", "write", "create", "delete", "execute", "deploy", "manage"}
 
 
 def test_deployment_action_values_match_casbin_strings():
@@ -41,6 +44,7 @@ def test_deployment_action_values_match_casbin_strings():
     assert DeploymentAction.CREATE.value == "create"
     assert DeploymentAction.DELETE.value == "delete"
     assert DeploymentAction.EXECUTE.value == "execute"
+    assert DeploymentAction.MANAGE.value == "manage"
 
 
 def test_deployment_action_subclasses_str():
@@ -50,9 +54,16 @@ def test_deployment_action_subclasses_str():
 
 
 def test_deployment_action_is_iterable_and_complete():
-    """The enum exposes exactly the five canonical deployment actions (no DEPLOY)."""
+    """The enum exposes the six canonical deployment actions (no DEPLOY)."""
     values = {member.value for member in DeploymentAction}
-    assert values == {"read", "write", "create", "delete", "execute"}
+    assert values == {"read", "write", "create", "delete", "execute", "manage"}
+
+
+def test_project_action_includes_manage():
+    """Projects expose MANAGE for reparenting / auth_settings changes."""
+    values = {member.value for member in ProjectAction}
+    assert values == {"read", "write", "create", "delete", "manage"}
+    assert ProjectAction.MANAGE == "manage"
 
 
 def test_knowledge_base_action_values():

--- a/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
@@ -47,7 +47,12 @@ def _ensure_flow_permission_calls(func: ast.AsyncFunctionDef) -> list[ast.Call]:
 
 
 def _action_arg(call: ast.Call) -> str | None:
-    """Extract the action argument (positional[1]) as the dotted name like 'FlowAction.READ'."""
+    """Extract the action argument (positional[1]) as the dotted name like 'FlowAction.READ'.
+
+    Also recognizes :class:`ast.Name` references (e.g. ``required_action``)
+    used by the dynamic MANAGE/WRITE gating pattern and returns them in the
+    ``var:NAME`` form so resolution can find the underlying enum branches.
+    """
     if len(call.args) < 2:
         return None
     arg = call.args[1]
@@ -55,7 +60,49 @@ def _action_arg(call: ast.Call) -> str | None:
         return f"{arg.value.id}.{arg.attr}"
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
         return arg.value
+    if isinstance(arg, ast.Name):
+        return f"var:{arg.id}"
     return None
+
+
+def _resolve_var_action_branches(func: ast.AsyncFunctionDef, var_name: str) -> set[str]:
+    """Find ``var_name = X if cond else Y`` assignments and return both enum branches.
+
+    Used to expand the dynamic ``required_action`` / ``project_action`` pattern
+    introduced for MANAGE-gated PATCH/PUT handlers so the regression tests can
+    still assert that the underlying WRITE/MANAGE enum values are reachable.
+    """
+    actions: set[str] = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == var_name for target in node.targets):
+            continue
+        value = node.value
+        candidates: list[ast.expr] = [value.body, value.orelse] if isinstance(value, ast.IfExp) else [value]
+        for candidate in candidates:
+            if isinstance(candidate, ast.Attribute) and isinstance(candidate.value, ast.Name):
+                actions.add(f"{candidate.value.id}.{candidate.attr}")
+    return actions
+
+
+def _resolved_actions(func: ast.AsyncFunctionDef, calls: list[ast.Call]) -> set[str]:
+    """Return the set of enum action names reachable from *calls* inside *func*.
+
+    Resolves ``var:NAME`` placeholders via :func:`_resolve_var_action_branches`
+    so dynamic gating patterns (e.g. ``required_action = MANAGE if ... else WRITE``)
+    appear in the result set as both enum branches.
+    """
+    resolved: set[str] = set()
+    for call in calls:
+        action = _action_arg(call)
+        if action is None:
+            continue
+        if action.startswith("var:"):
+            resolved.update(_resolve_var_action_branches(func, action[len("var:") :]))
+        else:
+            resolved.add(action)
+    return resolved
 
 
 @pytest.fixture(scope="module")
@@ -75,33 +122,49 @@ def routes() -> dict[str, ast.AsyncFunctionDef]:
     ],
 )
 def test_single_guard_route_uses_enum_action(routes, func_name, expected_action):
-    """Single-call guard routes call ensure_flow_permission once with the right FlowAction."""
+    """Single-call guard routes call ensure_flow_permission once with the right FlowAction.
+
+    Resolves dynamic ``required_action = MANAGE if ... else WRITE`` patterns
+    introduced for MANAGE-gated PATCH/PUT handlers so the WRITE branch still
+    shows up in the resolved set.
+    """
     func = routes[func_name]
     calls = _ensure_flow_permission_calls(func)
     assert calls, f"{func_name} has no ensure_flow_permission call"
-    actions = {_action_arg(c) for c in calls}
+    actions = _resolved_actions(func, calls)
     assert expected_action in actions, f"{func_name} actions={actions}, expected {expected_action}"
 
 
+def test_update_flow_gates_sensitive_fields_on_manage(routes):
+    """PATCH /flows/{flow_id} must reach FlowAction.MANAGE for the sensitive-field branch."""
+    func = routes["update_flow"]
+    actions = _resolved_actions(func, _ensure_flow_permission_calls(func))
+    assert "FlowAction.MANAGE" in actions, (
+        f"update_flow must gate sensitive fields on MANAGE; resolved actions={actions}"
+    )
+
+
 def test_upsert_flow_guards_both_create_and_write(routes):
-    """upsert_flow has two guard branches — WRITE for existing flows, CREATE for new ones."""
+    """upsert_flow has two guard branches — WRITE/MANAGE for existing flows, CREATE for new ones."""
     func = routes["upsert_flow"]
-    actions = {_action_arg(c) for c in _ensure_flow_permission_calls(func)}
+    actions = _resolved_actions(func, _ensure_flow_permission_calls(func))
     assert "FlowAction.WRITE" in actions
     assert "FlowAction.CREATE" in actions
+    # Upsert reuses the same MANAGE-gating pattern as PATCH for the update branch.
+    assert "FlowAction.MANAGE" in actions, f"upsert_flow must reach MANAGE for sensitive fields; got {actions}"
 
 
 def test_delete_multiple_flows_guards_each_flow(routes):
     """Bulk delete iterates and calls ensure_flow_permission per loaded flow."""
     func = routes["delete_multiple_flows"]
-    actions = {_action_arg(c) for c in _ensure_flow_permission_calls(func)}
+    actions = _resolved_actions(func, _ensure_flow_permission_calls(func))
     assert actions == {"FlowAction.DELETE"}
 
 
 def test_download_multiple_file_guards_each_flow(routes):
     """Bulk download iterates and calls ensure_flow_permission per loaded flow."""
     func = routes["download_multiple_file"]
-    actions = {_action_arg(c) for c in _ensure_flow_permission_calls(func)}
+    actions = _resolved_actions(func, _ensure_flow_permission_calls(func))
     assert actions == {"FlowAction.READ"}
 
 
@@ -176,9 +239,16 @@ def _has_destination_check(
     target_workspace_kw: str,
     target_folder_kw: str,
 ) -> bool:
-    """Return True if *func* has a WRITE ensure_flow_permission call with the destination kwargs."""
+    """Return True if *func* has a WRITE/MANAGE ensure_flow_permission call with the destination kwargs.
+
+    Accepts either the literal ``FlowAction.WRITE`` / ``FlowAction.MANAGE`` or a
+    variable reference (``required_action``) used by the dynamic gating pattern.
+    """
     for call in _ensure_flow_permission_calls(func):
-        if _action_arg(call) != "FlowAction.WRITE":
+        action = _action_arg(call)
+        if action not in {"FlowAction.WRITE", "FlowAction.MANAGE"} and not (
+            action is not None and action.startswith("var:")
+        ):
             continue
         ws = _kwarg_source(call, "workspace_id")
         fld = _kwarg_source(call, "folder_id")
@@ -213,13 +283,20 @@ def test_upsert_flow_update_branch_authorizes_destination_on_move(routes):
 
 
 def test_no_bare_string_actions_remain(routes):
-    """No flow-route guard should use a bare string action — the enum is now canonical."""
+    """No flow-route guard should use a bare string action — the enum is now canonical.
+
+    Variable references (``var:NAME``) for the dynamic MANAGE/WRITE gating
+    pattern are accepted because each branch resolves to a ``FlowAction.*``
+    enum value (verified by :func:`test_update_flow_gates_sensitive_fields_on_manage`
+    and the per-route assertions above).
+    """
     offenders: list[str] = []
     for name, func in routes.items():
         for call in _ensure_flow_permission_calls(func):
             arg = _action_arg(call)
-            if arg is not None and not arg.startswith("FlowAction."):
-                offenders.append(f"{name}:{arg}")
+            if arg is None or arg.startswith(("FlowAction.", "var:")):
+                continue
+            offenders.append(f"{name}:{arg}")
     assert offenders == [], f"bare-string actions found: {offenders}"
 
 
@@ -315,9 +392,10 @@ def test_execute_surfaces_guard_with_flow_execute(module_path, func_name):
     """build/run/webhook handlers must call ensure_flow_permission(FlowAction.EXECUTE)."""
     funcs = _parse_async_funcs(module_path)
     assert func_name in funcs, f"{func_name} missing from {module_path.name}"
-    calls = _ensure_flow_permission_calls(funcs[func_name])
+    func = funcs[func_name]
+    calls = _ensure_flow_permission_calls(func)
     assert calls, f"{func_name} has no ensure_flow_permission call"
-    actions = {_action_arg(c) for c in calls}
+    actions = _resolved_actions(func, calls)
     assert "FlowAction.EXECUTE" in actions, f"{func_name} actions={actions}, expected FlowAction.EXECUTE"
 
 
@@ -371,10 +449,15 @@ def _ensure_project_permission_calls(func: ast.AsyncFunctionDef) -> list[ast.Cal
     ],
 )
 def test_project_routes_guarded(func_name, expected_action):
-    """Each project CRUD handler calls ensure_project_permission with the right ProjectAction."""
+    """Each project CRUD handler calls ensure_project_permission with the right ProjectAction.
+
+    Dynamic ``project_action = MANAGE if ... else WRITE`` is resolved so the
+    WRITE branch still satisfies the existing assertions.
+    """
     funcs = _parse_async_funcs(_PROJECTS_FILE)
     assert func_name in funcs, f"{func_name} missing from projects.py"
-    calls = _ensure_project_permission_calls(funcs[func_name])
+    func = funcs[func_name]
+    calls = _ensure_project_permission_calls(func)
     assert calls, f"{func_name} has no ensure_project_permission call"
-    actions = {_action_arg(c) for c in calls}
+    actions = _resolved_actions(func, calls)
     assert expected_action in actions, f"{func_name} actions={actions}, expected {expected_action}"

--- a/src/backend/tests/unit/services/authorization/test_sensitive_fields.py
+++ b/src/backend/tests/unit/services/authorization/test_sensitive_fields.py
@@ -1,0 +1,71 @@
+"""Tests for the sensitive-field sets that gate MANAGE-level actions."""
+
+from __future__ import annotations
+
+import pytest
+from langflow.services.authorization import (
+    SENSITIVE_DEPLOYMENT_FIELDS,
+    SENSITIVE_FLOW_FIELDS,
+    SENSITIVE_PROJECT_FIELDS,
+    requires_deployment_manage,
+    requires_flow_manage,
+    requires_project_manage,
+)
+
+
+def test_flow_sensitive_fields_locked_in():
+    """The contract for flow MANAGE is exactly these five administrative fields."""
+    assert (
+        frozenset(
+            {"locked", "access_type", "endpoint_name", "webhook", "mcp_enabled"},
+        )
+        == SENSITIVE_FLOW_FIELDS
+    )
+
+
+def test_project_sensitive_fields_locked_in():
+    """Projects gate MANAGE on governance (auth_settings) and reparenting (parent_id)."""
+    assert frozenset({"auth_settings", "parent_id"}) == SENSITIVE_PROJECT_FIELDS
+
+
+def test_deployment_sensitive_fields_empty_today():
+    """No deployment PATCH field is administrative yet; the set is intentionally empty."""
+    assert frozenset() == SENSITIVE_DEPLOYMENT_FIELDS
+
+
+@pytest.mark.parametrize(
+    ("payload_field_set", "expected"),
+    [
+        (set(), False),
+        ({"name"}, False),
+        ({"name", "description"}, False),
+        ({"locked"}, True),
+        ({"name", "access_type"}, True),
+        ({"endpoint_name"}, True),
+        ({"webhook", "name"}, True),
+        ({"mcp_enabled"}, True),
+    ],
+)
+def test_requires_flow_manage(payload_field_set, expected):
+    assert requires_flow_manage(payload_field_set) is expected
+
+
+@pytest.mark.parametrize(
+    ("payload_field_set", "expected"),
+    [
+        (set(), False),
+        ({"name"}, False),
+        ({"description"}, False),
+        ({"parent_id"}, True),
+        ({"auth_settings"}, True),
+        ({"name", "parent_id"}, True),
+    ],
+)
+def test_requires_project_manage(payload_field_set, expected):
+    assert requires_project_manage(payload_field_set) is expected
+
+
+def test_requires_deployment_manage_always_false_today():
+    """Until sensitive deployment fields exist, the predicate is a constant False."""
+    assert requires_deployment_manage(set()) is False
+    assert requires_deployment_manage({"name", "description", "provider_data"}) is False

--- a/src/backend/tests/unit/services/authorization/test_share_visibility_filter.py
+++ b/src/backend/tests/unit/services/authorization/test_share_visibility_filter.py
@@ -1,0 +1,135 @@
+"""Unit tests for share_visibility_filter (SQL share-backed list prefilter).
+
+We don't need a live DB to verify the shape of the SQL — the helper returns
+a SQLAlchemy ``ColumnElement``; compiling it against the SQLite dialect gives
+us a deterministic string we can assert against. That covers the two important
+contracts:
+
+* AUTHZ off → resolves to an exact owner-scoped equality
+  (matches the pre-authz query).
+* AUTHZ on → ORs in owner, optional PUBLIC, and the share subquery.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from langflow.services.authorization import fetch as fetch_module
+from langflow.services.authorization import share_visibility_filter
+from sqlalchemy.dialects import sqlite
+
+
+def _install_settings(monkeypatch, *, authz_enabled: bool) -> None:
+    settings = SimpleNamespace(auth_settings=SimpleNamespace(AUTHZ_ENABLED=authz_enabled))
+    monkeypatch.setattr(fetch_module, "get_settings_service", lambda: settings)
+
+
+def _compile(expr) -> str:
+    return str(
+        expr.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}),
+    )
+
+
+class _AccessType(str, Enum):
+    PUBLIC = "PUBLIC"
+    PRIVATE = "PRIVATE"
+
+
+def test_returns_owner_equality_when_authz_disabled(monkeypatch):
+    """AUTHZ off must yield exactly the owner-scoped query, no share JOIN."""
+    from langflow.services.database.models.flow.model import Flow
+
+    _install_settings(monkeypatch, authz_enabled=False)
+    user = SimpleNamespace(id=uuid4())
+
+    expr = share_visibility_filter(
+        user,
+        resource_type="flow",
+        id_column=Flow.id,
+        owner_column=Flow.user_id,
+    )
+    sql = _compile(expr)
+    assert "flow.user_id" in sql
+    # SQLite renders UUIDs as 32-character hex (no dashes) when bound literally.
+    assert str(user.id).replace("-", "") in sql
+    assert "authz_share" not in sql, "AUTHZ-off path must never touch authz_share"
+    assert "OR" not in sql.upper() or sql.upper().count("OR") == 0, sql
+
+
+def test_combines_owner_public_and_share_subquery_when_authz_enabled(monkeypatch):
+    """AUTHZ on must OR together owner, PUBLIC, and the authz_share subquery."""
+    from langflow.services.database.models.flow.model import Flow
+
+    _install_settings(monkeypatch, authz_enabled=True)
+    user = SimpleNamespace(id=uuid4())
+
+    expr = share_visibility_filter(
+        user,
+        resource_type="flow",
+        id_column=Flow.id,
+        owner_column=Flow.user_id,
+        access_type_column=Flow.access_type,
+        public_value=_AccessType.PUBLIC,
+    )
+    sql = _compile(expr)
+    assert "flow.user_id" in sql
+    assert "authz_share" in sql, "AUTHZ-on path must consult authz_share"
+    assert "authz_team_member" in sql, "team scope must join authz_team_member"
+    assert "PUBLIC" in sql
+    # All three branches must be ORed together at the top level.
+    assert sql.upper().count(" OR ") >= 2
+
+
+def test_omits_public_branch_when_no_access_type_column(monkeypatch):
+    from langflow.services.database.models.flow.model import Flow
+
+    _install_settings(monkeypatch, authz_enabled=True)
+    user = SimpleNamespace(id=uuid4())
+
+    expr = share_visibility_filter(
+        user,
+        resource_type="flow",
+        id_column=Flow.id,
+        owner_column=Flow.user_id,
+    )
+    sql = _compile(expr)
+    assert "authz_share" in sql
+    assert "PUBLIC" not in sql, "no access_type_column → no PUBLIC clause"
+
+
+def test_public_value_required_when_access_type_column_provided(monkeypatch):
+    from langflow.services.database.models.flow.model import Flow
+
+    _install_settings(monkeypatch, authz_enabled=True)
+    user = SimpleNamespace(id=uuid4())
+
+    with pytest.raises(ValueError, match="public_value"):
+        share_visibility_filter(
+            user,
+            resource_type="flow",
+            id_column=Flow.id,
+            owner_column=Flow.user_id,
+            access_type_column=Flow.access_type,
+        )
+
+
+def test_subquery_filters_on_resource_type_and_permission_levels(monkeypatch):
+    from langflow.services.database.models.flow.model import Flow
+
+    _install_settings(monkeypatch, authz_enabled=True)
+    user = SimpleNamespace(id=uuid4())
+
+    expr = share_visibility_filter(
+        user,
+        resource_type="deployment",
+        id_column=Flow.id,  # using Flow.id for compile shape only
+        owner_column=Flow.user_id,
+    )
+    sql = _compile(expr)
+    assert "resource_type = 'deployment'" in sql.replace('"', "")
+    # Default permission levels include the full read-or-above ladder.
+    for level in ("read", "write", "execute", "admin"):
+        assert level in sql


### PR DESCRIPTION
## Summary

Stacked on **#13153**. Closes two gaps surfaced by review of **#13280** (by [@lucaseduoli](https://github.com/lucaseduoli), with implementation by [@phact](https://github.com/phact)) so the enterprise Casbin plugin has the action vocabulary + paginated-visibility math it needs from OSS to function end-to-end, without forking #13153's plugin-with-pass-through contract.

> ### Credit
>
> Sensitive-field gating for `locked` / `access_type` and the SQL share-backed list-prefilter ideas were first proposed in **#13280** by [@lucaseduoli](https://github.com/lucaseduoli) and [@phact](https://github.com/phact). This PR ports those ideas onto #13153's plugin contract: adding `MANAGE` as a standard enum value across resource action sets, and shipping `share_visibility_filter` as a reusable helper rather than per-call-site SQL. Both commits carry `Co-Authored-By` trailers for both authors.

## What's in this PR

| Item | What |
|---|---|
| 1 | **`MANAGE` action gating** — new `FlowAction.MANAGE` / `DeploymentAction.MANAGE` / `ProjectAction.MANAGE`. New `services/authorization/sensitive_fields.py` with `SENSITIVE_FLOW_FIELDS = {locked, access_type, endpoint_name, webhook, mcp_enabled}`, `SENSITIVE_PROJECT_FIELDS = {auth_settings, parent_id}`, `SENSITIVE_DEPLOYMENT_FIELDS = frozenset()`. Route handlers compute `required_action = MANAGE if requires_*_manage(...) else WRITE`. Lock-bypass left to enterprise policy. |
| 2 | **SQL share-backed list prefilter** — new `share_visibility_filter(user, *, resource_type, id_column, owner_column, access_type_column=None, public_value=None)` in `services/authorization/fetch.py`. Applied to all six list call sites in `flows.py`, `deployments.py`, `projects.py` (paginated + non-paginated). Floor: `owner_column == user.id` when AUTHZ off. `filter_visible_resources` stays as the post-filter ceiling for plugin-only grants. Resolves the `page.total may overcount` TODOs. |

Default behavior is unchanged: `LANGFLOW_AUTHZ_ENABLED=false`. Both items are additive — plugins built against #13153 keep working.

## Why this shape (vs. #13280's shape)

- **`MANAGE` as a single enum value per resource**, not field-level actions. Stable contract for the enterprise plugin; the field set is small and named.
- **SQL prefilter as a reusable floor + post-filter as a ceiling**. The OSS share schema is the source of truth for visibility math; the plugin can still grant more on top via `enforce()`. Helper lives in one place rather than copying SQL into each route.

## What's intentionally not here

- **External trusted auth + JIT user mapping.** An earlier iteration of this PR included it; on reflection, authentication and authorization are separable concerns and RBAC doesn't require external auth to function. The enterprise/OpenRAG integration path for identity remains: pre-create/sync Langflow users, use Langflow-native login/session/API keys, or register a custom `auth_service` plugin. External auth ships as a follow-up PR targeting `release-1.10.0` directly so it can be reviewed on its own merits and adopted independently.
- **Request-time principal claim threading on `AuthzContext`** (e.g. `principal_roles` / `principal_groups`). An earlier iteration added it; on review it was half-plumbing. Standard enterprise pattern: a plugin's `PolicySyncService` syncs IdP roles/groups into `authz_role_assignment` and `authz_team_member` on SSO login, and Casbin evaluates against DB-resident policy. `AuthzContext` is `total=False`, so request-time claims can be added additively later if a future need emerges.
- **Enterprise Casbin plugin itself** (consumes everything in this PR).
- **v2 files list endpoint** — `filter_visible_resources` isn't wired there yet; defer to the v2 files PR that introduces list filtering.
- **Lock-bypass env vars from #13280** — intentionally skipped; covered by enterprise policy on `MANAGE`.

## Test plan

Already green locally:

- [x] `uv run pytest src/backend/tests/unit/services/authorization/` — **141 passed** (full authz suite + 2 new test files)
- [x] `uv run pytest src/backend/tests/unit/test_authz_models.py src/backend/tests/unit/services/auth/test_pluggable_auth.py` — **19 passed**
- [x] `cd src/lfx && uv run pytest tests/unit/services/authorization/` (isolated) — **9 passed**
- [x] `uv run pytest src/backend/tests/unit/api/v1/test_flows.py` — **46 passed**
- [x] `uv run pytest src/backend/tests/unit/api/v1/test_projects.py` — **47 passed, 1 skipped**

New test files:

- `services/authorization/test_sensitive_fields.py` — 13 tests (field sets + predicates)
- `services/authorization/test_share_visibility_filter.py` — 5 tests (SQL shape against SQLite dialect)

Pre-merge follow-ups (manual smoke):

- [ ] `make alembic-upgrade` on a fresh dev DB — no new migrations expected; this PR only adds plugin-side code on top of #13153's schema.
- [ ] Boot with `LANGFLOW_AUTHZ_ENABLED=true` and verify a MANAGE-field PATCH on a flow you don't own returns 403 (with a stub enterprise enforcer registered), and that a paginated list with a share grant returns the expected `page.total`.
- [ ] `uv run langflow authz dry-run --user <uuid> --action read --resource flow:<uuid>` regression check.