### PR TITLE
ref: updates to telemetry writer PR

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -313,11 +313,11 @@ jobs:
   slack-notification:
     name: Send Slack Notification
     needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, stress-tests, release-nightly-build]
-    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
+    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.stress-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Send failure notification to Slack
-        if: ${{ needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' }}
+        if: ${{ needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.stress-tests.result == 'failure' }}
         run: |
           # Determine which job failed
           FAILED_JOB="unknown"
@@ -329,6 +329,8 @@ jobs:
             FAILED_JOB="frontend-tests-windows (non-blocking)"
           elif [ "${{ needs.backend-unit-tests.result }}" == "failure" ]; then
             FAILED_JOB="backend-unit-tests"
+          elif [ "${{ needs.stress-tests.result }}" == "failure" ]; then
+            FAILED_JOB="stress-tests (non-blocking)"
           fi
 
           curl -X POST -H 'Content-type: application/json' \

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -291,7 +291,7 @@ jobs:
       ref: ${{ needs.resolve-release-branch.outputs.branch }}
 
   release-nightly-build:
-    if: github.repository == 'langflow-ai/langflow' && always() && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure' && needs.stress-tests.result != 'failure'
+    if: github.repository == 'langflow-ai/langflow' && always() && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure'
     name: Run Nightly Langflow Build
     needs:
       [validate-inputs, create-nightly-tag, frontend-tests-linux, frontend-tests-windows, backend-unit-tests, stress-tests]
@@ -313,7 +313,7 @@ jobs:
   slack-notification:
     name: Send Slack Notification
     needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, stress-tests, release-nightly-build]
-    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.stress-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
+    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Send failure notification to Slack

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -282,11 +282,19 @@ jobs:
   #     python-versions: '["3.10", "3.11", "3.12", "3.13"]'
   #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
 
+  stress-tests:
+    if: github.repository == 'langflow-ai/langflow' && !inputs.skip_backend_tests
+    name: Run Stress Tests
+    needs: [resolve-release-branch, create-nightly-tag]
+    uses: ./.github/workflows/stress-tests.yml
+    with:
+      ref: ${{ needs.resolve-release-branch.outputs.branch }}
+
   release-nightly-build:
-    if: github.repository == 'langflow-ai/langflow' && always() && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure'
+    if: github.repository == 'langflow-ai/langflow' && always() && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure' && needs.stress-tests.result != 'failure'
     name: Run Nightly Langflow Build
     needs:
-      [validate-inputs, create-nightly-tag, frontend-tests-linux, frontend-tests-windows, backend-unit-tests]
+      [validate-inputs, create-nightly-tag, frontend-tests-linux, frontend-tests-windows, backend-unit-tests, stress-tests]
     uses: ./.github/workflows/release_nightly.yml
     with:
       build_docker_base: true
@@ -304,8 +312,8 @@ jobs:
 
   slack-notification:
     name: Send Slack Notification
-    needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, release-nightly-build]
-    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
+    needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, stress-tests, release-nightly-build]
+    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.stress-tests.result == 'failure' || needs.release-nightly-build.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Send failure notification to Slack

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -1,0 +1,56 @@
+name: Stress Tests
+
+on:
+  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: "Branch or tag to test"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  telemetry-writes:
+    name: Telemetry Writes (Postgres)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: langflow
+          POSTGRES_PASSWORD: langflow
+          POSTGRES_DB: langflow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U langflow"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.12"
+          prune-cache: false
+
+      - name: Install dependencies
+        run: uv sync --extra postgresql
+
+      - name: Run stress test
+        env:
+          DB_URL: "postgresql+psycopg://langflow:langflow@localhost:5432/langflow"  # pragma: allowlist secret
+          LANGFLOW_TELEMETRY_WRITER_ENABLED: "true"
+        run: |
+          uv run python src/backend/tests/stress/stress_telemetry_writes.py \
+            --concurrency 50 --seconds 15

--- a/src/backend/base/langflow/services/telemetry_writer/service.py
+++ b/src/backend/base/langflow/services/telemetry_writer/service.py
@@ -82,7 +82,7 @@ def _host_boot_identity() -> tuple[str, str]:
     except OSError:
         try:
             boot = str(int(time.time() - time.monotonic()))
-        except OSError:
+        except Exception:  # noqa: BLE001
             boot = "unknown"
     return host, boot
 
@@ -304,8 +304,13 @@ class TelemetryWriterService(Service):
         # Stamp host + boot identity so a future process on a different host
         # (or after reboot) will not adopt this PID's spill data if the PID
         # happens to be recycled.
-        with suppress(OSError):
+        try:
             _write_owner_file(own_dir)
+        except OSError as e:
+            logger.error(
+                f"telemetry_writer: failed to write owner file to {own_dir}; "
+                f"disk-spilled rows from this process will not be recoverable on restart: {e}"
+            )
 
         # Drain any rows that were spilled by a previous run of *this* PID and
         # adopt the contents of any orphan (dead-PID) directories.
@@ -352,8 +357,13 @@ class TelemetryWriterService(Service):
                 with suppress(asyncio.CancelledError):
                     await self._writer_task
             except asyncio.CancelledError:
+                # teardown() itself was cancelled (e.g. outer lifespan task killed).
+                # Await the writer's own cancellation so it can put in-flight rows
+                # back in the buffer, then re-raise so the cancellation propagates
+                # up the task tree — swallowing it here breaks asyncio's cancel chain.
                 with suppress(asyncio.CancelledError):
                     await self._writer_task
+                raise
         if self._sweeper_task is not None:
             self._sweeper_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -621,13 +631,16 @@ class TelemetryWriterService(Service):
                 if payloads:
                     logger.info(f"telemetry_writer: adopted {len(payloads)} orphan {kind} from pid={pid}")
             # Best-effort cleanup of the dead-PID directory.
-            with suppress(OSError):
+            try:
                 for child in sorted(entry.rglob("*"), reverse=True):
                     if child.is_file():
                         child.unlink(missing_ok=True)
                     elif child.is_dir():
-                        child.rmdir()
+                        with suppress(OSError):
+                            child.rmdir()
                 entry.rmdir()
+            except OSError as e:
+                logger.debug(f"telemetry_writer: could not remove orphan dir {entry}: {e}")
 
     def _prune_stale_foreign_outboxes(self, outbox_root: Path) -> None:
         """Delete cross-host orphan dirs whose owner file has gone stale.
@@ -664,13 +677,16 @@ class TelemetryWriterService(Service):
                 f"telemetry_writer: pruning stale cross-host outbox {entry} "
                 f"(host={owner.get('host')!r}, age={age:.0f}s)"
             )
-            with suppress(OSError):
+            try:
                 for child in sorted(entry.rglob("*"), reverse=True):
                     if child.is_file():
                         child.unlink(missing_ok=True)
                     elif child.is_dir():
-                        child.rmdir()
+                        with suppress(OSError):
+                            child.rmdir()
                 entry.rmdir()
+            except OSError as e:
+                logger.debug(f"telemetry_writer: could not remove stale foreign outbox {entry}: {e}")
 
     def _heartbeat_owner_file(self) -> None:
         """Refresh the owner file's mtime so foreign hosts can age us out cleanly."""
@@ -723,7 +739,7 @@ class TelemetryWriterService(Service):
                 # Exponential-ish backoff capped at 30s. Avoids hot-looping on a
                 # broken DB while still preserving telemetry across the failure.
                 backoff = min(30.0, 0.5 * (2 ** min(consecutive_failures, 6)))
-                if consecutive_failures == _FAILURE_ESCALATION_THRESHOLD:
+                if consecutive_failures >= _FAILURE_ESCALATION_THRESHOLD:
                     logger.error(
                         f"telemetry_writer: {consecutive_failures} consecutive batch failures, "
                         f"buffer depth tx={len(self._tx_buffer)} vb={len(self._vb_buffer)}"
@@ -772,8 +788,6 @@ class TelemetryWriterService(Service):
     async def _run_retention_pass(self) -> None:
         if self._session_maker is None:
             return
-        from uuid import UUID
-
         settings = self.settings_service.settings
         max_transactions = int(getattr(settings, "max_transactions_to_keep", 3000))
         max_vertex_builds = int(getattr(settings, "max_vertex_builds_to_keep", 3000))

--- a/src/backend/base/langflow/services/telemetry_writer/service.py
+++ b/src/backend/base/langflow/services/telemetry_writer/service.py
@@ -339,45 +339,44 @@ class TelemetryWriterService(Service):
             self._shutdown_event.set()
 
         drain_timeout = float(getattr(self.settings_service.settings, "telemetry_writer_shutdown_drain_s", 5.0))
-        if self._writer_task is not None:
-            try:
-                await asyncio.wait_for(self._writer_task, timeout=drain_timeout)
-            except asyncio.TimeoutError:
-                # Drain budget exceeded. Whatever's still in the in-memory
-                # buffer survives via the disk spill below; rows that were
-                # popped into the in-flight batch are pushed back by the
-                # writer's CancelledError handler before it exits.
-                pending = len(self._tx_buffer) + len(self._vb_buffer)
-                logger.warning(
-                    f"telemetry_writer: shutdown drain exceeded {drain_timeout}s with "
-                    f"{pending} rows still pending — spilling to disk. Consider raising "
-                    f"telemetry_writer_shutdown_drain_s."
-                )
-                self._writer_task.cancel()
+        # The sweeper cancel, disk spill, and engine dispose live in ``finally`` so
+        # they still run when teardown() is itself cancelled (e.g. the outer lifespan
+        # task is killed). On that cancelled path ``wait_for`` cancels and awaits the
+        # writer task before re-raising, so the writer's CancelledError handler has
+        # already pushed in-flight rows back into the buffer by the time we spill.
+        try:
+            if self._writer_task is not None:
+                try:
+                    await asyncio.wait_for(self._writer_task, timeout=drain_timeout)
+                except asyncio.TimeoutError:
+                    # Drain budget exceeded. Whatever's still in the in-memory
+                    # buffer survives via the disk spill below; rows that were
+                    # popped into the in-flight batch are pushed back by the
+                    # writer's CancelledError handler before it exits.
+                    pending = len(self._tx_buffer) + len(self._vb_buffer)
+                    logger.warning(
+                        f"telemetry_writer: shutdown drain exceeded {drain_timeout}s with "
+                        f"{pending} rows still pending — spilling to disk. Consider raising "
+                        f"telemetry_writer_shutdown_drain_s."
+                    )
+                    self._writer_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await self._writer_task
+        finally:
+            if self._sweeper_task is not None:
+                self._sweeper_task.cancel()
                 with suppress(asyncio.CancelledError):
-                    await self._writer_task
-            except asyncio.CancelledError:
-                # teardown() itself was cancelled (e.g. outer lifespan task killed).
-                # Await the writer's own cancellation so it can put in-flight rows
-                # back in the buffer, then re-raise so the cancellation propagates
-                # up the task tree — swallowing it here breaks asyncio's cancel chain.
-                with suppress(asyncio.CancelledError):
-                    await self._writer_task
-                raise
-        if self._sweeper_task is not None:
-            self._sweeper_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await self._sweeper_task
+                    await self._sweeper_task
 
-        # Spill anything still in memory to disk so a future process picks it up.
-        if self._own_outbox_dir is not None:
-            self._spill_to_disk(self._own_outbox_dir, kind="transactions", buffer=self._tx_buffer)
-            self._spill_to_disk(self._own_outbox_dir, kind="vertex_builds", buffer=self._vb_buffer)
+            # Spill anything still in memory to disk so a future process picks it up.
+            if self._own_outbox_dir is not None:
+                self._spill_to_disk(self._own_outbox_dir, kind="transactions", buffer=self._tx_buffer)
+                self._spill_to_disk(self._own_outbox_dir, kind="vertex_builds", buffer=self._vb_buffer)
 
-        if self._engine is not None:
-            await self._engine.dispose()
-            self._engine = None
-        logger.info("telemetry_writer stopped")
+            if self._engine is not None:
+                await self._engine.dispose()
+                self._engine = None
+            logger.info("telemetry_writer stopped")
 
     # ------------------------------------------------------------------ internals
 

--- a/src/backend/tests/unit/services/telemetry_writer/test_service.py
+++ b/src/backend/tests/unit/services/telemetry_writer/test_service.py
@@ -803,3 +803,76 @@ async def test_teardown_spills_remaining_buffer(tmp_path: Path) -> None:
     fallback = Path(tempfile.gettempdir()) / "langflow_telemetry_outbox"
     if fallback.exists() and fallback.is_dir() and not any(fallback.iterdir()):
         fallback.rmdir()
+
+
+async def test_retention_sweep_caps_vertex_builds_per_vertex(writer_with_engine) -> None:
+    """Per-vertex cap must prune the oldest builds for a single vertex."""
+    writer, engine = writer_with_engine
+    writer.settings_service.settings.max_vertex_builds_per_vertex = 3
+    writer.settings_service.settings.max_vertex_builds_to_keep = 10_000
+    flow_id = uuid4()
+    # Insert 8 builds for the same vertex — only 3 should survive.
+    vb_batch = [_make_vertex_build_row(flow_id, vertex_id="v1") for _ in range(8)]
+    await writer._flush([], vb_batch)
+    await writer._run_retention_pass()
+
+    async with AsyncSession(engine) as session:
+        count = await session.scalar(select(func.count()).select_from(VertexBuildTable))
+    assert count == 3
+
+
+def test_either_strategy_trips_on_bytes_first(writer_with_engine) -> None:
+    """'either' strategy must enforce the byte cap when it trips before the row cap."""
+    writer, _ = writer_with_engine
+    writer.settings_service.settings.telemetry_writer_size_strategy = "either"
+    writer.settings_service.settings.telemetry_writer_max_queue = 10_000  # high — must not trigger
+    writer.settings_service.settings.telemetry_writer_max_queue_bytes = 200
+    # Each row encodes to ~123 bytes; two rows (246B) exceed the 200B cap.
+    for i in range(3):
+        writer.enqueue_transaction({"payload": "x" * 100, "i": i})
+    # Byte cap trips first — same drop semantics as the bytes-only strategy.
+    assert writer.dropped_transactions >= 1
+    assert writer._tx_bytes <= 200
+
+
+async def test_writer_retries_on_batch_failure(writer_with_engine) -> None:
+    """Failed flush must increment failed_batches, return rows to buffer, then succeed on retry."""
+    writer, engine = writer_with_engine
+    writer.settings_service.settings.telemetry_writer_batch_size = 100
+    writer.settings_service.settings.telemetry_writer_flush_interval_s = 0.01
+    flow_id = uuid4()
+    for _ in range(5):
+        writer.enqueue_transaction(_make_transaction_row(flow_id))
+
+    fail_count = 0
+
+    real_flush = writer._flush.__func__
+
+    async def _fail_twice(self, tx_batch, vb_batch):
+        nonlocal fail_count
+        if fail_count < 2:
+            fail_count += 1
+            msg = "injected failure"
+            raise RuntimeError(msg)
+        return await real_flush(self, tx_batch, vb_batch)
+
+    import types
+
+    writer._flush = types.MethodType(_fail_twice, writer)
+
+    task = asyncio.create_task(writer._run_writer())
+    # Wait until all rows land in the DB (after retries).
+    for _ in range(50):
+        await asyncio.sleep(0.05)
+        async with AsyncSession(engine) as session:
+            n = await session.scalar(select(func.count()).select_from(TransactionTable))
+        if n == 5:
+            break
+    writer._shutdown_event.set()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert writer.failed_batches == 2
+    assert writer.flushed_rows == 5
+    async with AsyncSession(engine) as session:
+        final = await session.scalar(select(func.count()).select_from(TransactionTable))
+    assert final == 5

--- a/src/backend/tests/unit/services/telemetry_writer/test_service.py
+++ b/src/backend/tests/unit/services/telemetry_writer/test_service.py
@@ -19,6 +19,7 @@ import pytest
 from langflow.services.database.models.transactions.model import TransactionBase, TransactionTable
 from langflow.services.database.models.vertex_builds.model import VertexBuildBase, VertexBuildTable
 from langflow.services.telemetry_writer.service import (
+    _FAILURE_ESCALATION_THRESHOLD,
     TelemetryWriterService,
     _write_owner_file,
 )
@@ -861,18 +862,90 @@ async def test_writer_retries_on_batch_failure(writer_with_engine) -> None:
     writer._flush = types.MethodType(_fail_twice, writer)
 
     task = asyncio.create_task(writer._run_writer())
-    # Wait until all rows land in the DB (after retries).
-    for _ in range(50):
-        await asyncio.sleep(0.05)
-        async with AsyncSession(engine) as session:
-            n = await session.scalar(select(func.count()).select_from(TransactionTable))
-        if n == 5:
-            break
+    # The two injected failures each return the batch to the buffer and back off
+    # via _wait_or_shutdown. Setting the shutdown event short-circuits those
+    # backoffs so the writer reaches its successful retry and drains — the
+    # shutdown, not wall-clock waiting, is what lands the rows.
     writer._shutdown_event.set()
-    await asyncio.wait_for(task, timeout=2)
+    await asyncio.wait_for(task, timeout=5)
 
     assert writer.failed_batches == 2
     assert writer.flushed_rows == 5
     async with AsyncSession(engine) as session:
         final = await session.scalar(select(func.count()).select_from(TransactionTable))
     assert final == 5
+
+
+async def test_writer_escalates_after_threshold_failures(writer_with_engine) -> None:
+    """Consecutive failures past the threshold must keep retrying (exercises the `>=` branch, not `==`)."""
+    import types
+
+    writer, engine = writer_with_engine
+    writer.settings_service.settings.telemetry_writer_batch_size = 100
+    writer.settings_service.settings.telemetry_writer_flush_interval_s = 0.01
+    flow_id = uuid4()
+    for _ in range(5):
+        writer.enqueue_transaction(_make_transaction_row(flow_id))
+
+    # Fail one more than the threshold so the escalation branch runs at counts
+    # both equal to and greater than the threshold — exactly what `>=` covers
+    # and `==` would not.
+    fail_target = _FAILURE_ESCALATION_THRESHOLD + 1
+    fail_count = 0
+    real_flush = writer._flush.__func__
+
+    async def _fail_n_times(self, tx_batch, vb_batch):
+        nonlocal fail_count
+        if fail_count < fail_target:
+            fail_count += 1
+            msg = "injected failure"
+            raise RuntimeError(msg)
+        return await real_flush(self, tx_batch, vb_batch)
+
+    writer._flush = types.MethodType(_fail_n_times, writer)
+
+    task = asyncio.create_task(writer._run_writer())
+    # Short-circuit every backoff so the failures (and the final success) run fast.
+    writer._shutdown_event.set()
+    await asyncio.wait_for(task, timeout=5)
+
+    # Every injected failure was counted (driving consecutive_failures past the
+    # threshold), then the buffer drained on the success.
+    assert writer.failed_batches == fail_target
+    assert writer.flushed_rows == 5
+    async with AsyncSession(engine) as session:
+        final = await session.scalar(select(func.count()).select_from(TransactionTable))
+    assert final == 5
+
+
+async def test_teardown_cancelled_still_spills_buffer(writer_with_engine, tmp_path: Path) -> None:
+    """If teardown() is itself cancelled, the in-memory buffer must still spill to disk."""
+    writer, _ = writer_with_engine
+    own_dir = tmp_path / "pid"
+    own_dir.mkdir()
+    writer._own_outbox_dir = own_dir
+    # Long drain so teardown blocks in the writer-drain await while we cancel it.
+    writer.settings_service.settings.telemetry_writer_shutdown_drain_s = 30.0
+
+    for i in range(3):
+        writer.enqueue_transaction({"cancelled_spill": i})
+    assert len(writer._tx_buffer) == 3
+
+    # A writer task that never finishes on its own, so teardown stays parked in
+    # the drain await until we cancel it.
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    writer._writer_task = asyncio.create_task(_never())
+
+    teardown_task = asyncio.create_task(writer.teardown())
+    await asyncio.sleep(0.05)  # let teardown reach the drain await
+    teardown_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await teardown_task
+
+    # The cancellation must not have dropped the buffer: a fresh reader pointed
+    # at the same outbox sees the spilled rows.
+    reader = _build_writer()
+    reader._restore_from_disk(own_dir, kind="transactions", buffer=reader._tx_buffer)
+    assert [row["cancelled_spill"] for row in reader._tx_buffer] == [0, 1, 2]


### PR DESCRIPTION
## Summary

Follow-up fixes and test coverage additions identified during code review of #13126.

### Error handling fixes

- **`teardown()` re-raises `CancelledError`** — previously the `except asyncio.CancelledError` branch swallowed the exception and continued executing, breaking asyncio's cancellation chain on lifespan task kills (e.g. uvicorn/gunicorn shutdown under load). Now the writer task's own cancellation is awaited for cleanup, then the error is re-raised.

- **Owner file write failure now logs an error** — the `suppress(OSError)` around `_write_owner_file()` silently caused disk-spilled rows to be unrecoverable on the next restart (without the owner file, `_adopt_orphan_outboxes` refuses to adopt the directory). Replaced with an explicit `except` that logs an actionable error.

- **Failure escalation threshold `== 6` → `>= 6`** — the escalation error log only fired exactly once at the 6th consecutive batch failure, then went silent. Changed to `>=` so it fires on every failure past the threshold.

- **Dead `except OSError` on `time.time() - time.monotonic()`** — `time` functions cannot raise `OSError`; the `"unknown"` boot-id fallback was unreachable. Changed to `except Exception`.

- **Redundant local import removed** — `from uuid import UUID` inside `_run_retention_pass` was a duplicate of the module-level import.

- **Orphan directory cleanup no longer silently leaks dirs** — both cleanup loops (`_adopt_orphan_outboxes` and `_prune_stale_foreign_outboxes`) used a blanket `suppress(OSError)` that would swallow `ENOTEMPTY` if a concurrent process wrote into the directory, leaving the parent dir on disk permanently. Restructured so per-child `rmdir` failures are suppressed individually, but a failure removing the parent dir is logged at debug level.

### New tests (3)

- **`test_retention_sweep_caps_vertex_builds_per_vertex`** — the existing global-cap test inserted 8 rows across 8 distinct vertex IDs with `max_vertex_builds_per_vertex=50`, so the per-vertex DELETE subquery never executed. New test uses a single vertex ID with 8 builds and `max_per_vertex=3`.

- **`test_either_strategy_trips_on_bytes_first`** — the existing `either` strategy test only covered the count-first path. New test sets a tiny byte cap with a high row cap so bytes are the first trigger.

- **`test_writer_retries_on_batch_failure`** — injects 2 flush failures then a success via method patching. Verifies `failed_batches` increments, rows are preserved in the buffer across failures, and `flushed_rows` reflects the final successful write.

### CI

Added `stress-tests` job to the nightly build pipeline. It runs the telemetry write stress harness against Postgres 16 at 50 concurrent workers for 15 seconds. A failure is visible in the workflow run and in Slack but does **not** block the nightly release — the job is informational until we've validated the baseline on the nightly cadence.

**Pass/fail condition:** the stress script exits 0 when `error_total=0` (no pool timeouts, lock errors, or deadlocks during the run) and exits 1 otherwise.