### PR TITLE
fix(auth): address review findings on PR #13192

### DIFF
--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -264,6 +264,11 @@ class AuthService(BaseAuthService):
             if not query_param and not header_param:
                 if settings_service.auth_settings.skip_auth_auto_login:
                     result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+                    if result is None:
+                        raise HTTPException(
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            detail="Superuser not found in database",
+                        )
                     logger.warning(AUTO_LOGIN_WARNING)
                     return UserRead.model_validate(result, from_attributes=True)
                 raise HTTPException(
@@ -313,6 +318,16 @@ class AuthService(BaseAuthService):
                 if not api_key:
                     if settings.auth_settings.skip_auth_auto_login:
                         result = await get_user_by_username(db, settings.auth_settings.SUPERUSER)
+                        if result is None:
+                            raise WebSocketException(
+                                code=status.WS_1011_INTERNAL_ERROR,
+                                reason="Superuser not found",
+                            )
+                        if not result.is_active:
+                            raise WebSocketException(
+                                code=status.WS_1008_POLICY_VIOLATION,
+                                reason="User account is inactive",
+                            )
                         logger.warning(AUTO_LOGIN_WARNING)
                     else:
                         raise WebSocketException(

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -269,6 +269,11 @@ class AuthService(BaseAuthService):
                             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                             detail="Superuser not found in database",
                         )
+                    if not result.is_active:
+                        raise HTTPException(
+                            status_code=status.HTTP_403_FORBIDDEN,
+                            detail="User account is inactive",
+                        )
                     logger.warning(AUTO_LOGIN_WARNING)
                     return UserRead.model_validate(result, from_attributes=True)
                 raise HTTPException(

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -750,3 +750,36 @@ async def test_ws_api_key_security_auto_login_skip_rejects_inactive_superuser(
         await auth_service.ws_api_key_security(api_key=None)
 
     assert exc.value.code == status.WS_1008_POLICY_VIOLATION
+
+
+# =============================================================================
+# _api_key_security_impl Tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_api_key_security_impl_auto_login_skip_rejects_inactive_superuser(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """_api_key_security_impl must enforce is_active in the AUTO_LOGIN + skip_auth bypass path."""
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
+    inactive_superuser = _dummy_user(uuid4(), active=False)
+
+    with (
+        patch(
+            "langflow.services.auth.service.get_user_by_username",
+            new=AsyncMock(return_value=inactive_superuser),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await auth_service._api_key_security_impl(
+            query_param=None,
+            header_param=None,
+            db=AsyncMock(),
+            settings_service=auth_service.settings,
+        )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -7,7 +8,8 @@ from uuid import UUID, uuid4
 
 import jwt
 import pytest
-from fastapi import HTTPException, status
+from fastapi import HTTPException, WebSocketException, status
+from langflow.services.auth.constants import AUTO_LOGIN_WARNING
 from langflow.services.auth.exceptions import (
     InactiveUserError,
     InvalidTokenError,
@@ -138,7 +140,6 @@ async def test_authenticate_with_credentials_auto_login_alone_still_rejects(
 async def test_authenticate_with_credentials_auto_login_skip_returns_superuser(
     auth_service: AuthService,
     auth_settings: AuthSettings,
-    caplog: pytest.LogCaptureFixture,
 ):
     """With AUTO_LOGIN + skip_auth_auto_login, missing creds fall back to the superuser.
 
@@ -156,12 +157,13 @@ async def test_authenticate_with_credentials_auto_login_skip_returns_superuser(
             "langflow.services.auth.service.get_user_by_username",
             new=AsyncMock(return_value=superuser),
         ) as mock_lookup,
-        caplog.at_level("WARNING", logger="lfx.log.logger"),
+        patch("langflow.services.auth.service.logger") as mock_logger,
     ):
         result = await auth_service.authenticate_with_credentials(token=None, api_key=None, db=AsyncMock())
 
     assert result is superuser
     mock_lookup.assert_awaited_once()
+    mock_logger.warning.assert_called_once_with(AUTO_LOGIN_WARNING)
 
 
 @pytest.mark.anyio
@@ -176,6 +178,7 @@ async def test_authenticate_with_credentials_auto_login_skip_missing_superuser_r
     """
     auth_settings.AUTO_LOGIN = True
     auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
 
     from langflow.services.auth.exceptions import InvalidCredentialsError
 
@@ -187,6 +190,31 @@ async def test_authenticate_with_credentials_auto_login_skip_missing_superuser_r
         pytest.raises(InvalidCredentialsError),
     ):
         await auth_service.authenticate_with_credentials(token=None, api_key=None, db=AsyncMock())
+
+
+@pytest.mark.anyio
+async def test_authenticate_with_credentials_auto_login_skip_empty_superuser_config_raises(
+    tmp_path,
+):
+    """AUTO_LOGIN + skip_auth_auto_login with an empty SUPERUSER config rejects without a DB lookup.
+
+    The ``if not auth_settings.SUPERUSER:`` guard at the top of the bypass branch
+    must fire before ``get_user_by_username`` is called. Uses SimpleNamespace to
+    bypass Pydantic model validation so SUPERUSER can be set to an empty string.
+    """
+    from langflow.services.auth.exceptions import InvalidCredentialsError
+
+    settings_service = SimpleNamespace(
+        auth_settings=SimpleNamespace(
+            AUTO_LOGIN=True,
+            skip_auth_auto_login=True,
+            SUPERUSER="",
+        )
+    )
+    service = AuthService(settings_service)
+
+    with pytest.raises(InvalidCredentialsError):
+        await service.authenticate_with_credentials(token=None, api_key=None, db=AsyncMock())
 
 
 @pytest.mark.anyio
@@ -665,3 +693,60 @@ async def test_get_current_active_user_mcp_inactive(auth_service: AuthService):
         await auth_service.get_current_active_user_mcp(user)
 
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# =============================================================================
+# ws_api_key_security Tests
+# =============================================================================
+
+
+@asynccontextmanager
+async def _mock_session_scope():
+    yield AsyncMock()
+
+
+@pytest.mark.anyio
+async def test_ws_api_key_security_auto_login_skip_rejects_missing_superuser(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """ws_api_key_security must reject with WS_1011 when the superuser row is absent from DB."""
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
+
+    with (
+        patch("langflow.services.auth.service.session_scope", _mock_session_scope),
+        patch(
+            "langflow.services.auth.service.get_user_by_username",
+            new=AsyncMock(return_value=None),
+        ),
+        pytest.raises(WebSocketException) as exc,
+    ):
+        await auth_service.ws_api_key_security(api_key=None)
+
+    assert exc.value.code == status.WS_1011_INTERNAL_ERROR
+
+
+@pytest.mark.anyio
+async def test_ws_api_key_security_auto_login_skip_rejects_inactive_superuser(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """ws_api_key_security must enforce is_active in the AUTO_LOGIN + skip_auth bypass path."""
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
+    inactive_superuser = _dummy_user(uuid4(), active=False)
+
+    with (
+        patch("langflow.services.auth.service.session_scope", _mock_session_scope),
+        patch(
+            "langflow.services.auth.service.get_user_by_username",
+            new=AsyncMock(return_value=inactive_superuser),
+        ),
+        pytest.raises(WebSocketException) as exc,
+    ):
+        await auth_service.ws_api_key_security(api_key=None)
+
+    assert exc.value.code == status.WS_1008_POLICY_VIOLATION

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
@@ -552,7 +552,7 @@ describe("ModelInputComponent", () => {
       expect(screen.queryByTestId("gpt-4-option")).not.toBeInTheDocument();
     });
 
-    it("should call refresh with silent flag exactly once per click", async () => {
+    it("should call refresh with silent=false exactly once per click", async () => {
       const user = userEvent.setup();
       renderWithQueryClient(<ModelInputComponent {...defaultProps} />);
 
@@ -567,7 +567,7 @@ describe("ModelInputComponent", () => {
       await user.click(refreshButton);
 
       expect(mockRefreshAllModelInputs).toHaveBeenCalledTimes(1);
-      expect(mockRefreshAllModelInputs).toHaveBeenCalledWith({ silent: true });
+      expect(mockRefreshAllModelInputs).toHaveBeenCalledWith({ silent: false });
 
       mockRefreshResolve();
     });
@@ -1154,7 +1154,7 @@ describe("ModelInputComponent", () => {
       });
     });
 
-    it("falls back to the loading spinner while an error refetch is in flight", () => {
+    it("hides the error UI while an error refetch is in flight", () => {
       const mockedProviders = useGetModelProviders as jest.MockedFunction<
         typeof useGetModelProviders
       >;
@@ -1184,6 +1184,36 @@ describe("ModelInputComponent", () => {
       expect(
         screen.queryByTestId("model-input-load-failed"),
       ).not.toBeInTheDocument();
+    });
+
+    it("renders the retry button when only the enabled-models query fails", () => {
+      const mockedProviders = useGetModelProviders as jest.MockedFunction<
+        typeof useGetModelProviders
+      >;
+      const mockedEnabled = useGetEnabledModels as jest.MockedFunction<
+        typeof useGetEnabledModels
+      >;
+
+      // Symmetric case: providers succeed, enabled-models alone errors with no data.
+      mockedProviders.mockReturnValue({
+        data: mockProvidersData,
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: jest.fn(),
+      } as unknown as ReturnType<typeof useGetModelProviders>);
+      mockedEnabled.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isFetching: false,
+        error: new Error("Request failed with status code 401"),
+        refetch: jest.fn(),
+      } as unknown as ReturnType<typeof useGetEnabledModels>);
+
+      renderWithQueryClient(<ModelInputComponent {...defaultProps} />);
+
+      expect(screen.getByTestId("model-input-load-failed")).toBeInTheDocument();
+      expect(screen.queryByText("Loading models")).not.toBeInTheDocument();
     });
   });
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -518,7 +518,7 @@ export default function ModelInputComponent({
     setOpen(false);
     setRefreshOptions(true);
     try {
-      await refreshAllModelInputs({ silent: true });
+      await refreshAllModelInputs({ silent: false });
     } catch {
       // refreshAllModelInputs handles its own error notifications via alertStore
     } finally {

--- a/src/frontend/src/controllers/API/__tests__/api-auth-maintenance.test.ts
+++ b/src/frontend/src/controllers/API/__tests__/api-auth-maintenance.test.ts
@@ -26,13 +26,17 @@ describe("isAuthMaintenanceURL", () => {
   });
 
   it("does not cross-match login vs auto_login (separate paths)", () => {
-    // ``/login`` and ``/auto_login`` both appear in the list; verify the
-    // matcher recognises them via the leading slash anchor so an
-    // ``/auto_login`` URL is not mis-classified as ``login``.
-    const autoLogin = "/api/v1/auto_login";
-    expect(autoLogin.includes("/login")).toBe(false);
-    expect(autoLogin.includes("/auto_login")).toBe(true);
-    expect(isAuthMaintenanceURL(autoLogin)).toBe(true);
+    // Both /login and /auto_login are in the list. Verify the matcher
+    // classifies each correctly and does not confuse one for the other.
+    expect(isAuthMaintenanceURL("/api/v1/auto_login")).toBe(true);
+    expect(isAuthMaintenanceURL("/api/v1/login")).toBe(true);
+  });
+
+  it("does not match URLs that share a path segment prefix with a maintenance path", () => {
+    // Substring matching would false-positive on these — path-segment matching must not.
+    expect(isAuthMaintenanceURL("/api/v1/refresh_tokens")).toBe(false);
+    expect(isAuthMaintenanceURL("/api/v1/login_history")).toBe(false);
+    expect(isAuthMaintenanceURL("/api/v1/logout_sessions")).toBe(false);
   });
 
   it("returns false for empty or undefined urls", () => {

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -39,7 +39,17 @@ export const AUTH_MAINTENANCE_PATHS = [
 
 export function isAuthMaintenanceURL(url: string | undefined): boolean {
   if (!url) return false;
-  return AUTH_MAINTENANCE_PATHS.some((path) => url.includes(path));
+  return AUTH_MAINTENANCE_PATHS.some((path) => {
+    const idx = url.indexOf(path);
+    if (idx === -1) return false;
+    const charAfter = url[idx + path.length];
+    return (
+      charAfter === undefined ||
+      charAfter === "/" ||
+      charAfter === "?" ||
+      charAfter === "#"
+    );
+  });
 }
 
 function ApiInterceptor() {
@@ -108,16 +118,6 @@ function ApiInterceptor() {
             await clearBuildVerticesState(error);
             return Promise.reject(error);
           }
-          // One-shot guard: if we've already retried this exact request
-          // once after a refresh, don't retry again. Without this, a
-          // request that 401s post-refresh would loop back through here.
-          const requestConfig = error?.config as
-            | (AxiosRequestConfig & { _retry?: boolean })
-            | undefined;
-          if (requestConfig?._retry) {
-            await clearBuildVerticesState(error);
-            return Promise.reject(error);
-          }
           const stillRefresh = checkErrorCount();
           if (!stillRefresh) {
             return Promise.reject(error);
@@ -132,16 +132,7 @@ function ApiInterceptor() {
             await clearBuildVerticesState(error);
             return Promise.reject(error);
           }
-          // Refresh succeeded — replay the original request and resolve
-          // the interceptor with its response so the caller transparently
-          // gets the retried result. Without this, callers used to
-          // resolve with ``undefined`` after a successful refresh because
-          // the interceptor fell through without returning the retried
-          // response.
           await clearBuildVerticesState(error);
-          if (requestConfig) {
-            requestConfig._retry = true;
-          }
           return await remakeRequest(error);
         }
 
@@ -239,8 +230,8 @@ function ApiInterceptor() {
     };
   }, [accessToken, setErrorData, customHeaders, autoLogin]);
 
-  function checkErrorCount() {
-    if (isLoginPage) return;
+  function checkErrorCount(): boolean {
+    if (isLoginPage) return false;
 
     setAuthenticationErrorCount(authenticationErrorCount + 1);
 
@@ -254,7 +245,7 @@ function ApiInterceptor() {
   }
 
   async function tryToRenewAccessToken(error: AxiosError) {
-    if (isLoginPage) return;
+    if (isLoginPage) throw error;
     if (error.config?.headers) {
       for (const [key, value] of Object.entries(customHeaders)) {
         error.config.headers[key] = value;
@@ -265,7 +256,11 @@ function ApiInterceptor() {
       setAuthenticationErrorCount(0);
     } catch (refreshError) {
       console.error(refreshError);
-      mutationLogout();
+      const isNetworkError =
+        (refreshError as AxiosError)?.response === undefined;
+      if (!isNetworkError) {
+        mutationLogout();
+      }
       throw refreshError;
     }
   }


### PR DESCRIPTION
Backend:
- _api_key_security_impl: guard model_validate against None superuser (503 vs silent 500)
- ws_api_key_security: add None guard + is_active enforcement in skip_auth bypass; move AUTO_LOGIN_WARNING log after both guards
- test_auth_service: patch logger directly to assert warning; add SimpleNamespace-based test for empty SUPERUSER guard; add explicit SUPERUSER="admin" to missing-row test; add ws_api_key_security tests for None and inactive-superuser rejection

Frontend:
- isAuthMaintenanceURL: replace substring .includes() with character-boundary matching so /refresh_tokens etc. are not false-positively excluded from retry path
- checkErrorCount: explicit boolean return type; return false instead of undefined on login page
- tryToRenewAccessToken: throw original error on login page instead of silent return; distinguish network errors from auth failures before calling mutationLogout
- remove dead _retry flag code (remakeRequest uses bare axios bypassing interceptors)
- handleRefreshButtonPress: drop silent:true so refresh failures surface via alertStore

Tests:
- api-auth-maintenance: rewrite cross-match test against function; add path-segment collision test for /refresh_tokens, /login_history, /logout_sessions
- ModelInputComponent: rename misleading spinner test title; add "enabledModels fails alone" case; update silent flag assertion to false