### PR TITLE
fix: lfx serve no_env_fallback, deepcopy cycle, cross-worker delete

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -8590,7 +8590,7 @@
         "filename": "src/lfx/src/lfx/cli/serve_app.py",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 49,
         "is_secret": false
       }
     ],
@@ -9031,5 +9031,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-21T17:18:56Z"
+  "generated_at": "2026-05-22T17:38:33Z"
 }

--- a/src/lfx/src/lfx/cli/serve_app.py
+++ b/src/lfx/src/lfx/cli/serve_app.py
@@ -194,7 +194,12 @@ class FlowRegistry:
         self._store_ids_cache: list[str] | None = None
         self._store_ids_cache_ts: float = 0.0
 
-    def _stamp(self, graph: Graph) -> None:
+    def stamp(self, graph: Graph) -> None:
+        """Apply the registry's env-fallback policy to ``graph.context``.
+
+        Called again after ``deepcopy`` in the run/stream endpoints, since
+        ``Graph.__deepcopy__`` does not carry ``context`` over.
+        """
         if self._no_env_fallback:
             graph.context["no_env_fallback"] = True
 
@@ -225,7 +230,7 @@ class FlowRegistry:
             self._store.write(meta.id, raw_json)
             if getattr(self._store, "is_persistent", False):
                 self._store_sourced.add(meta.id)
-        self._stamp(graph)
+        self.stamp(graph)
         self._flows[meta.id] = (graph, meta)
         self._store_meta_cache.pop(meta.id, None)
         self._invalidate_store_ids_cache()
@@ -280,7 +285,7 @@ class FlowRegistry:
         graph = load_flow_from_json(raw_json)
         graph.prepare()
         graph.flow_id = meta.id
-        self._stamp(graph)
+        self.stamp(graph)
         if getattr(self._store, "is_persistent", False):
             self._store_sourced.add(meta.id)
         return graph, meta
@@ -305,9 +310,11 @@ class FlowRegistry:
                 continue
             # Skip flows deleted by another worker (still in our cache but gone from store).
             # Use the real store key (may be a filename stem for pre-placed flows).
+            # Check the store directly rather than the TTL-cached id list, so a delete
+            # by another worker is reflected immediately (same as the get() stale check).
             if meta.id in self._store_sourced:
                 store_key = self._store_keys.get(meta.id, meta.id)
-                if store_key not in store_ids:
+                if not self._store.exists(store_key):
                     continue
             result.append(meta)
             seen.add(meta.id)
@@ -654,6 +661,8 @@ def create_multi_serve_app(
         try:
             validate_flow_for_current_settings(graph)
             graph_copy = deepcopy(graph)
+            # deepcopy() drops graph.context; re-apply the registry's env policy.
+            registry.stamp(graph_copy)
             if request.global_vars:
                 if "request_variables" not in graph_copy.context:
                     graph_copy.context["request_variables"] = {}
@@ -717,6 +726,8 @@ def create_multi_serve_app(
             event_manager = create_stream_tokens_event_manager(queue=asyncio_queue)
 
             graph_copy = deepcopy(graph)
+            # deepcopy() drops graph.context; re-apply the registry's env policy.
+            registry.stamp(graph_copy)
             if request.global_vars:
                 if "request_variables" not in graph_copy.context:
                     graph_copy.context["request_variables"] = {}

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -430,6 +430,10 @@ class Component(CustomComponent):
         kwargs = dict(config)
         kwargs["inputs"] = dict(inputs_raw)
         new_component = type(self)(**kwargs)
+        # Register in memo before the recursive deepcopy calls below so reference
+        # cycles (e.g. components linked through _components) resolve to this same
+        # copy instead of producing a duplicate.
+        memo[id(self)] = new_component
         new_component._code = self._code
         # Must deep-copy so each graph_copy has independent Output objects.
         # Output.cache=True by default, and output.value is set during execution.
@@ -478,7 +482,6 @@ class Component(CustomComponent):
         new_component._attributes = dict(self._attributes)
         new_component._output_logs = self._output_logs
         new_component._logs = self._logs  # type: ignore[attr-defined]
-        memo[id(self)] = new_component
         return new_component
 
     def set_class_code(self) -> None:

--- a/src/lfx/tests/unit/cli/test_serve_app.py
+++ b/src/lfx/tests/unit/cli/test_serve_app.py
@@ -311,6 +311,9 @@ class TestFlowRegistry:
             def list_ids(self):
                 return list(self._data)
 
+            def exists(self, fid):
+                return fid in self._data
+
         store = DeletableStore()
         registry = FlowRegistry(store=store)
 
@@ -708,8 +711,9 @@ class TestFlowRegistry:
         assert "prompt_one" in deleted, "must delete the correct file (by stem, not UUID)"
 
     def test_remove_deletes_both_stem_and_uuid_files_for_cross_worker_propagation(self):
-        """remove() must delete both the stem file and UUID file so that any worker
-        — regardless of which key its stale check uses — sees the deletion.
+        """remove() must delete both the stem file and the UUID file.
+
+        Any worker, regardless of which key its stale check uses, must see the deletion.
 
         Scenario: flow-dir has my-flow.json (pre-placed) and {uuid}.json (written by add()).
         Worker A deletes by UUID; Worker B cached by stem alias.  Both files must be gone.
@@ -978,8 +982,9 @@ class TestCreateServeAppFactory:
         assert "/flows/upload/" in routes
 
     def test_create_serve_app_startup_paths_cleaned_from_env_by_caller(self):
-        """LFX_SERVE_STARTUP_PATHS must be consumed by create_serve_app() but not deleted —
-        cleanup is the caller's (serve_command's) responsibility via the prefix sweep.
+        """LFX_SERVE_STARTUP_PATHS must be consumed by create_serve_app() but not deleted.
+
+        Cleanup is the caller's (serve_command's) responsibility via the prefix sweep.
         """
         import json
         import os
@@ -1521,11 +1526,14 @@ class TestServeAppEndpoints:
         ):
             client.post(
                 "/flows/00000000-0000-0000-0000-000000000001/run",
-                json={"input_value": "hello", "global_vars": {"MY_API_KEY": "secret-value"}},
+                json={
+                    "input_value": "hello",
+                    "global_vars": {"MY_API_KEY": "secret-value"},  # pragma: allowlist secret
+                },
                 headers=headers,
             )
 
-        assert captured["request_variables"] == {"MY_API_KEY": "secret-value"}
+        assert captured["request_variables"] == {"MY_API_KEY": "secret-value"}  # pragma: allowlist secret
 
     def test_run_endpoint_global_vars_do_not_mutate_registry_graph(self, real_graph_with_async, monkeypatch):
         """global_vars must only be set on the deepcopy; the registry's original graph must be unchanged."""
@@ -1553,13 +1561,93 @@ class TestServeAppEndpoints:
         ):
             client.post(
                 "/flows/00000000-0000-0000-0000-000000000001/run",
-                json={"input_value": "hello", "global_vars": {"MY_API_KEY": "secret-value"}},
+                json={
+                    "input_value": "hello",
+                    "global_vars": {"MY_API_KEY": "secret-value"},  # pragma: allowlist secret
+                },
                 headers=headers,
             )
 
         original_graph = registry.get("00000000-0000-0000-0000-000000000001")[0]
         rv = original_graph.context.get("request_variables") or {}
         assert "MY_API_KEY" not in rv
+
+    def test_run_endpoint_preserves_no_env_fallback_after_deepcopy(self, real_graph_with_async, monkeypatch):
+        """no_env_fallback must reach the executed graph_copy, not only the registry graph.
+
+        deepcopy() drops graph.context, so run_flow must re-apply the stamp after the copy.
+        """
+        from lfx.services.deps import get_settings_service
+
+        meta = FlowMeta(
+            id="00000000-0000-0000-0000-000000000001",
+            relative_path="test.json",
+            title="Test Flow",
+            description=None,
+        )
+        registry = FlowRegistry(no_env_fallback=True)
+        registry.add(real_graph_with_async, meta)
+        app = create_multi_serve_app(registry=registry)
+        monkeypatch.setattr(get_settings_service().settings, "allow_custom_components", True)
+
+        captured: dict = {}
+
+        async def mock_execute_capture(graph, input_value, session_id=None):  # noqa: ARG001
+            captured["no_env_fallback"] = graph.context.get("no_env_fallback")
+            return [], ""
+
+        headers = {"x-api-key": "test-api-key"}
+        with (
+            patch.dict(os.environ, {"LANGFLOW_API_KEY": "test-api-key"}),  # pragma: allowlist secret
+            patch("lfx.cli.serve_app.execute_graph_with_capture", mock_execute_capture),
+            TestClient(app) as client,
+        ):
+            client.post(
+                "/flows/00000000-0000-0000-0000-000000000001/run",
+                json={"input_value": "hello"},
+                headers=headers,
+            )
+
+        assert captured["no_env_fallback"] is True
+
+    def test_stream_endpoint_preserves_no_env_fallback_after_deepcopy(self, real_graph_with_async, monkeypatch):
+        """no_env_fallback must reach the executed graph_copy on the stream path too."""
+        from lfx.services.deps import get_settings_service
+
+        meta = FlowMeta(
+            id="00000000-0000-0000-0000-000000000001",
+            relative_path="test.json",
+            title="Test Flow",
+            description=None,
+        )
+        registry = FlowRegistry(no_env_fallback=True)
+        registry.add(real_graph_with_async, meta)
+        app = create_multi_serve_app(registry=registry)
+        monkeypatch.setattr(get_settings_service().settings, "allow_custom_components", True)
+
+        captured: dict = {}
+
+        async def mock_execute_capture(graph, input_value, session_id=None):  # noqa: ARG001
+            captured["no_env_fallback"] = graph.context.get("no_env_fallback")
+            return [], ""
+
+        headers = {"x-api-key": "test-api-key"}
+        with (
+            patch.dict(os.environ, {"LANGFLOW_API_KEY": "test-api-key"}),  # pragma: allowlist secret
+            patch("lfx.cli.serve_app.execute_graph_with_capture", mock_execute_capture),
+            TestClient(app) as client,
+            client.stream(
+                "POST",
+                "/flows/00000000-0000-0000-0000-000000000001/stream",
+                json={"input_value": "hello"},
+                headers=headers,
+            ) as response,
+        ):
+            assert response.status_code == 200
+            for _ in response.iter_bytes():
+                pass
+
+        assert captured["no_env_fallback"] is True
 
     def test_stream_endpoint_injects_global_vars_into_context(self, real_graph_with_async, monkeypatch):
         """global_vars in StreamRequest must appear in graph_copy.context['request_variables']."""
@@ -1590,7 +1678,10 @@ class TestServeAppEndpoints:
             client.stream(
                 "POST",
                 "/flows/00000000-0000-0000-0000-000000000001/stream",
-                json={"input_value": "hello", "global_vars": {"STREAM_KEY": "stream-secret"}},
+                json={
+                    "input_value": "hello",
+                    "global_vars": {"STREAM_KEY": "stream-secret"},  # pragma: allowlist secret
+                },
                 headers=headers,
             ) as response,
         ):
@@ -1598,7 +1689,7 @@ class TestServeAppEndpoints:
             for _ in response.iter_bytes():
                 pass
 
-        assert captured["request_variables"] == {"STREAM_KEY": "stream-secret"}
+        assert captured["request_variables"] == {"STREAM_KEY": "stream-secret"}  # pragma: allowlist secret
 
     def test_stream_endpoint_no_global_vars_leaves_context_clean(self, real_graph_with_async, monkeypatch):
         """Omitting global_vars must not create request_variables in the graph context."""
@@ -1665,7 +1756,10 @@ class TestServeAppEndpoints:
             client.stream(
                 "POST",
                 "/flows/00000000-0000-0000-0000-000000000001/stream",
-                json={"input_value": "hello", "global_vars": {"STREAM_KEY": "stream-secret"}},
+                json={
+                    "input_value": "hello",
+                    "global_vars": {"STREAM_KEY": "stream-secret"},  # pragma: allowlist secret
+                },
                 headers=headers,
             ) as response,
         ):
@@ -1878,34 +1972,6 @@ class TestUploadEndpoint:
         )
         assert response.status_code == 201
         assert response.json()["description"] == "my desc"
-
-    def test_upload_concurrent_conflict_returns_409_not_500(self, app_with_empty_registry, valid_flow_data):
-        """registry.add() raising FlowAlreadyRegisteredError (concurrent race) must surface as 409, not 500."""
-        from lfx.cli.serve_app import FlowAlreadyRegisteredError
-
-        mock_graph = MagicMock()
-        mock_graph.prepare = MagicMock()
-        mock_graph.context = {}
-
-        with (
-            patch("lfx.cli.serve_app.load_flow_from_json", return_value=mock_graph),
-            # Simulate the race: registry.get() returns None but registry.add() still raises.
-            patch("lfx.cli.serve_app.FlowRegistry.get", return_value=None),
-            patch(
-                "lfx.cli.serve_app.FlowRegistry.add",
-                side_effect=FlowAlreadyRegisteredError(
-                    "Flow 'x' is already registered. Pass overwrite=True to replace it."
-                ),
-            ),
-        ):
-            response = app_with_empty_registry.post(
-                "/flows/upload/",
-                json={"name": "Flow", "data": valid_flow_data},
-                headers={"x-api-key": "test-key"},
-            )
-
-        assert response.status_code == 409
-        assert "already exists" in response.json()["detail"]
 
     # ------------------------------------------------------------------
     # Execution failures return HTTP 500 not HTTP 200

--- a/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
+++ b/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
@@ -220,6 +220,28 @@ def test_should_isolate_inputs_when_input_has_non_picklable_value():
     assert product_ids == {"P1", "P2"}
 
 
+def test_deepcopy_preserves_component_reference_cycles():
+    """Component.__deepcopy__ must register itself in memo before copying _components.
+
+    A feedback loop links components through _components in a cycle (A -> B -> A).
+    If the memo entry is set only after the recursive deepcopy calls, the cycle is
+    duplicated into a second copy instead of preserved.
+    """
+    a = SlowLabelComponent(_id="a")
+    b = SlowLabelComponent(_id="b")
+    a._components = [b]
+    b._components = [a]
+
+    a_copy = deepcopy(a)
+    b_copy = a_copy._components[0]
+
+    # The cycle must round-trip back to the same copied objects.
+    assert b_copy._components[0] is a_copy
+    # And the copies must be distinct from the originals.
+    assert a_copy is not a
+    assert b_copy is not b
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes for #13121, targeting its branch so merging this updates that PR directly. Found while reviewing it.

### no_env_fallback was a no-op at request time

`run_flow` and `stream_flow` execute `deepcopy(graph)`, and `Graph.__deepcopy__` rebuilds the graph without carrying `context`. `no_env_fallback` is stamped on the registry graph, but the deep-copied graph that actually runs had an empty context, so credential resolution fell back to `os.environ` regardless of the flag. The endpoints now re-apply the registry's env policy to the copy. `FlowRegistry._stamp` is now public (`stamp`) since the endpoint layer calls it.

### Component.__deepcopy__ duplicated reference cycles

`memo[id(self)]` was registered after the recursive `deepcopy` of `_components`/`_edges`, so a feedback loop between components produced a duplicate copy instead of preserving the cycle. The memo entry is now set right after construction.

### list_metas served flows deleted by another worker for up to 1s

`list_metas` checked the 1s TTL-cached store id list, so a flow another worker deleted kept showing up until the cache expired. It now checks the store directly, matching the per-flow `get()` stale check.

### Removed a redundant test

`test_upload_concurrent_conflict_returns_409_not_500` exercised a handler that no longer exists and was unreachable anyway. The real 409 path is already covered by `test_upload_duplicate_without_replace_returns_409`.

New tests cover the no_env_fallback fix (run and stream) and the deepcopy cycle. The commit also marks test secrets with allowlist pragmas and fixes two docstring lint warnings in the touched test file.
