### PR TITLE
fix(ci): narrow --prerelease=allow to wheels in cross-platform instal…

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -293,7 +293,12 @@ jobs:
             printf 'Installing %s wheel(s):\n' "$label"
             printf '%s\n' "$@"
             refresh_find_links
-            uv pip install --prerelease=allow --python "$PYTHON" "${FIND_LINKS[@]}" "$@"
+            # Use `if-necessary-or-explicit` (not `allow`): nightly langflow* wheels
+            # are .dev pre-releases so we need to allow them explicitly, but `allow`
+            # leaks to transitive deps and resolves pre-release pydantic alphas
+            # (e.g. 2.14.0a1) which break langchain-core's module-level
+            # `RunnablePassthrough()` call at import time.
+            uv pip install --prerelease=if-necessary-or-explicit --python "$PYTHON" "${FIND_LINKS[@]}" "$@"
           }
 
           SDK_WHEELS=(./sdk-dist/*.whl)
@@ -581,7 +586,8 @@ jobs:
             printf 'Installing %s wheel(s):\n' "$label"
             printf '%s\n' "$@"
             refresh_find_links
-            uv pip install --prerelease=allow --python "$PYTHON" "${FIND_LINKS[@]}" "$@"
+            # See stable job above for rationale on --prerelease=if-necessary-or-explicit.
+            uv pip install --prerelease=if-necessary-or-explicit --python "$PYTHON" "${FIND_LINKS[@]}" "$@"
           }
 
           SDK_WHEELS=(./sdk-dist/*.whl)
@@ -631,7 +637,7 @@ jobs:
               if [ "${{ inputs.pre_release }}" = "true" ]; then
                 NO_DEPS=""
               fi
-              uv pip install --force-reinstall $NO_DEPS --prerelease=allow --python ./test-env/Scripts/python.exe "${INSTALL_WHEELS[@]}"
+              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe "${INSTALL_WHEELS[@]}"
             fi
           fi
 
@@ -643,7 +649,7 @@ jobs:
             if [ "${{ inputs.pre_release }}" = "true" ]; then
               NO_DEPS=""
             fi
-            uv pip install --force-reinstall $NO_DEPS --prerelease=allow --python ./test-env/Scripts/python.exe "$BASE_WHEEL"
+            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe "$BASE_WHEEL"
           fi
         shell: bash
 
@@ -668,7 +674,7 @@ jobs:
               if [ "${{ inputs.pre_release }}" = "true" ]; then
                 NO_DEPS=""
               fi
-              uv pip install --force-reinstall $NO_DEPS --prerelease=allow --python ./test-env/bin/python "${INSTALL_WHEELS[@]}"
+              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/bin/python "${INSTALL_WHEELS[@]}"
             fi
           fi
 
@@ -680,7 +686,7 @@ jobs:
             if [ "${{ inputs.pre_release }}" = "true" ]; then
               NO_DEPS=""
             fi
-            uv pip install --force-reinstall $NO_DEPS --prerelease=allow --python ./test-env/bin/python "$BASE_WHEEL"
+            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/bin/python "$BASE_WHEEL"
           fi
         shell: bash
 


### PR DESCRIPTION
…l tests

Nightly cross-platform install tests were failing on Python 3.12/3.13 with a pydantic ValidationError at langchain_core import time:

  File ".../langchain_core/runnables/passthrough.py", line 349, in <module>
      _graph_passthrough: RunnablePassthrough = RunnablePassthrough()
  pydantic_core._pydantic_core.ValidationError: 1 validation error for
  RunnablePassthrough
  name
    Field required ...

Cause: --prerelease=allow was pulling pydantic 2.14.0a1 as a transitive dep, which is incompatible with langchain-core 1.4.0's top-level RunnablePassthrough() initialization.

We need pre-releases enabled for the nightly langflow* .dev wheels we pass on the command line, but not for transitive deps. Switch to --prerelease=if-necessary-or-explicit, which keeps the explicit .dev wheel installs working while resolving stable pydantic for everything else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cross-platform test workflow's prerelease wheel installation behavior to be more selective across all test environments (stable and experimental jobs).
  * Improved consistency in test wheel installation handling across different platforms and configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->