### PR TITLE
fix(playground): auto-focus chat input when active session changes

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/__tests__/chat-input.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/__tests__/chat-input.test.tsx
@@ -1,0 +1,169 @@
+import { render } from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Stores & hooks — mocked at module boundary so ChatInput renders in isolation.
+// ---------------------------------------------------------------------------
+
+let activeSessionId: string | null = null;
+jest.mock("@/stores/sessionManagerStore", () => ({
+  useSessionManagerStore: (selector: any) =>
+    selector({ activeSessionId, setActiveSessionId: jest.fn() }),
+}));
+
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: any) => selector({ currentFlowId: "flow-1" }),
+}));
+
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector: any) =>
+    selector({ stopBuilding: jest.fn(), isBuilding: false }),
+}));
+
+let chatValueStoreValue = "";
+jest.mock("@/stores/utilityStore", () => ({
+  useUtilityStore: Object.assign(
+    (selector: any) =>
+      selector({
+        chatValueStore: chatValueStoreValue,
+        setChatValueStore: jest.fn((v: string) => {
+          chatValueStoreValue = v;
+        }),
+        setAwaitingBotResponse: jest.fn(),
+      }),
+    {
+      getState: () => ({
+        chatValueStore: chatValueStoreValue,
+        setChatValueStore: jest.fn(),
+        setAwaitingBotResponse: jest.fn(),
+      }),
+    },
+  ),
+}));
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: any) => selector({ setErrorData: jest.fn() }),
+}));
+
+jest.mock("@/shared/hooks/use-chat-file-upload", () => ({
+  useChatFileUpload: () => ({ handleFileChange: jest.fn() }),
+}));
+
+jest.mock("../hooks/use-audio-recording", () => ({
+  useAudioRecording: () => ({
+    state: { status: "idle" },
+    startRecording: jest.fn(),
+    stopRecording: jest.fn(),
+    isSupported: false,
+  }),
+}));
+
+const focusMock = jest.fn();
+jest.mock("../components/input-wrapper", () => ({
+  __esModule: true,
+  default: ({
+    inputRef,
+  }: {
+    inputRef: React.RefObject<HTMLTextAreaElement>;
+  }) => (
+    <textarea
+      ref={(el) => {
+        if (el && inputRef) {
+          (inputRef as React.MutableRefObject<HTMLTextAreaElement>).current =
+            el;
+          el.focus = focusMock;
+        }
+      }}
+      data-testid="chat-textarea"
+    />
+  ),
+}));
+
+jest.mock("../components/no-input", () => ({
+  __esModule: true,
+  default: () => <div data-testid="chat-noinput" />,
+}));
+
+jest.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: { div: (props: any) => <div {...props} /> },
+}));
+
+import ChatInput from "../chat-input";
+
+const flushRaf = async () => {
+  await new Promise((r) => requestAnimationFrame(r));
+};
+
+const baseProps = {
+  noInput: false,
+  files: [],
+  setFiles: jest.fn(),
+  isDragging: false,
+  sendMessage: jest.fn(),
+  playgroundPage: true,
+};
+
+describe("ChatInput — auto-focus on session change", () => {
+  beforeEach(() => {
+    focusMock.mockReset();
+    activeSessionId = null;
+    chatValueStoreValue = "";
+  });
+
+  it("does not focus when there is no active session yet", async () => {
+    render(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("focuses the textarea once on mount when an active session exists", async () => {
+    activeSessionId = "flow-1";
+    render(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-focuses the textarea when the active session changes", async () => {
+    activeSessionId = "flow-1";
+    const { rerender } = render(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).toHaveBeenCalledTimes(1);
+
+    activeSessionId = "New Chat 0";
+    rerender(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not focus when noInput is true (textarea is not rendered)", async () => {
+    activeSessionId = "flow-1";
+    render(<ChatInput {...baseProps} noInput />);
+    await flushRaf();
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending focus when the component unmounts before rAF fires", async () => {
+    activeSessionId = "flow-1";
+    const { unmount } = render(<ChatInput {...baseProps} />);
+    unmount();
+    await flushRaf();
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fire focus when the active session stays the same across renders", async () => {
+    activeSessionId = "flow-1";
+    const { rerender } = render(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).toHaveBeenCalledTimes(1);
+
+    rerender(<ChatInput {...baseProps} />);
+    await flushRaf();
+    expect(focusMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/__tests__/chat-input.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/__tests__/chat-input.test.tsx
@@ -5,27 +5,44 @@ import React from "react";
 // Stores & hooks — mocked at module boundary so ChatInput renders in isolation.
 // ---------------------------------------------------------------------------
 
+// Generic Zustand selector type local to the test mocks. Avoids `any`
+// while remaining permissive enough for ad-hoc state shapes.
+type Selector<TState, TResult> = (state: TState) => TResult;
+
 let activeSessionId: string | null = null;
+type SessionManagerState = {
+  activeSessionId: string | null;
+  setActiveSessionId: jest.Mock;
+};
 jest.mock("@/stores/sessionManagerStore", () => ({
-  useSessionManagerStore: (selector: any) =>
-    selector({ activeSessionId, setActiveSessionId: jest.fn() }),
+  useSessionManagerStore: <TResult,>(
+    selector: Selector<SessionManagerState, TResult>,
+  ) => selector({ activeSessionId, setActiveSessionId: jest.fn() }),
 }));
 
+type FlowsManagerState = { currentFlowId: string };
 jest.mock("@/stores/flowsManagerStore", () => ({
   __esModule: true,
-  default: (selector: any) => selector({ currentFlowId: "flow-1" }),
+  default: <TResult,>(selector: Selector<FlowsManagerState, TResult>) =>
+    selector({ currentFlowId: "flow-1" }),
 }));
 
+type FlowStoreState = { stopBuilding: jest.Mock; isBuilding: boolean };
 jest.mock("@/stores/flowStore", () => ({
   __esModule: true,
-  default: (selector: any) =>
+  default: <TResult,>(selector: Selector<FlowStoreState, TResult>) =>
     selector({ stopBuilding: jest.fn(), isBuilding: false }),
 }));
 
 let chatValueStoreValue = "";
+type UtilityState = {
+  chatValueStore: string;
+  setChatValueStore: jest.Mock;
+  setAwaitingBotResponse: jest.Mock;
+};
 jest.mock("@/stores/utilityStore", () => ({
   useUtilityStore: Object.assign(
-    (selector: any) =>
+    <TResult,>(selector: Selector<UtilityState, TResult>) =>
       selector({
         chatValueStore: chatValueStoreValue,
         setChatValueStore: jest.fn((v: string) => {
@@ -34,7 +51,7 @@ jest.mock("@/stores/utilityStore", () => ({
         setAwaitingBotResponse: jest.fn(),
       }),
     {
-      getState: () => ({
+      getState: (): UtilityState => ({
         chatValueStore: chatValueStoreValue,
         setChatValueStore: jest.fn(),
         setAwaitingBotResponse: jest.fn(),
@@ -43,9 +60,11 @@ jest.mock("@/stores/utilityStore", () => ({
   ),
 }));
 
+type AlertState = { setErrorData: jest.Mock };
 jest.mock("@/stores/alertStore", () => ({
   __esModule: true,
-  default: (selector: any) => selector({ setErrorData: jest.fn() }),
+  default: <TResult,>(selector: Selector<AlertState, TResult>) =>
+    selector({ setErrorData: jest.fn() }),
 }));
 
 jest.mock("@/shared/hooks/use-chat-file-upload", () => ({
@@ -91,7 +110,9 @@ jest.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  motion: { div: (props: any) => <div {...props} /> },
+  motion: {
+    div: (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+  },
 }));
 
 import ChatInput from "../chat-input";

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/chat-input.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/chat-input.tsx
@@ -5,6 +5,7 @@ import { useChatFileUpload } from "@/shared/hooks/use-chat-file-upload";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
+import { useSessionManagerStore } from "@/stores/sessionManagerStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import type { ChatInputType, FilePreviewType } from "@/types/components";
 import InputWrapper from "./components/input-wrapper";
@@ -39,11 +40,26 @@ export default function ChatInput({
   );
 
   const inputRef = useRef<HTMLTextAreaElement>(null!);
+  const activeSessionId = useSessionManagerStore((s) => s.activeSessionId);
   const { handleFileChange } = useChatFileUpload({
     currentFlowId,
     setFiles,
     playgroundPage: true,
   });
+
+  // Auto-focus the textarea whenever the active session changes (covers
+  // "New Chat" creation, sidebar session selection, and the initial
+  // playground mount). Skipped when noInput is true because the textarea
+  // is not rendered in that branch. requestAnimationFrame defers the
+  // focus call until after AnimatePresence/motion settles so the focus
+  // is not stolen back by an in-flight mount transition.
+  useEffect(() => {
+    if (noInput || !activeSessionId) return;
+    const raf = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [activeSessionId, noInput]);
 
   // Audio transcription handler - appends transcribed text to the chat input
   const handleTranscriptionComplete = useCallback(


### PR DESCRIPTION
## Summary

When a new playground session was created — or when the user switched between sessions in the sidebar, or simply opened the playground for the first time — the chat textarea did not receive focus. The cursor sat idle, forcing an extra click before the user could start typing. This PR removes that friction.

`ChatInput` now subscribes to `useSessionManagerStore.activeSessionId` and focuses the textarea whenever that id changes. The focus call is wrapped in `requestAnimationFrame` so it runs *after* the `AnimatePresence` / `motion` mount transition settles — otherwise the framer-motion lifecycle would steal focus back. Cleanup cancels any pending rAF if the component unmounts or the effect re-runs before the frame fires.

