### PR TITLE
fix(playground): distinguish active session row during multi-select

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/session-selector.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/session-selector.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { SessionSelector } from "../session-selector";
+
+jest.mock("@/controllers/API/queries/messages/use-rename-session", () => ({
+  useUpdateSessionName: () => ({ mutate: jest.fn() }),
+}));
+
+type VoiceState = { setNewSessionCloseVoiceAssistant: jest.Mock };
+jest.mock("@/stores/voiceStore", () => ({
+  useVoiceStore: <TResult,>(selector: (state: VoiceState) => TResult) =>
+    selector({ setNewSessionCloseVoiceAssistant: jest.fn() }),
+}));
+
+jest.mock("../../hooks/use-session-has-messages", () => ({
+  useSessionHasMessages: () => true,
+}));
+
+jest.mock("../session-more-menu", () => ({
+  SessionMoreMenu: () => <div data-testid="session-more-menu" />,
+}));
+
+jest.mock("../session-rename", () => ({
+  SessionRename: () => <div data-testid="session-rename" />,
+}));
+
+const baseProps = {
+  session: "New Session 0",
+  currentFlowId: "flow-1",
+  deleteSession: jest.fn(),
+  toggleVisibility: jest.fn(),
+  updateVisibleSession: jest.fn(),
+  handleRename: jest.fn().mockResolvedValue(undefined),
+  onMenuOpenChange: jest.fn(),
+  onToggleSelect: jest.fn(),
+  showCheckbox: true,
+};
+
+const getRoot = () => screen.getByTestId("session-selector");
+
+// Matches `bg-accent` only when used as its own utility, not as a variant
+// suffix such as `hover:bg-accent`. The negative lookbehind excludes the
+// pseudo-prefix colon so we test the row-level (non-hover) state.
+const ROW_BG_ACCENT = /(?<!:)\bbg-accent\b/;
+
+describe("SessionSelector — visual focus cue", () => {
+  it("renders neutral styling when the session is neither active nor selected", () => {
+    render(
+      <SessionSelector {...baseProps} isVisible={false} isSelected={false} />,
+    );
+    const root = getRoot();
+    expect(root).not.toHaveAttribute("aria-current");
+    expect(root).not.toHaveAttribute("data-active");
+    expect(root.className).toContain("font-normal");
+    expect(root.className).not.toMatch(ROW_BG_ACCENT);
+  });
+
+  it("highlights only the active session with bg + bold + aria-current", () => {
+    render(
+      <SessionSelector {...baseProps} isVisible={true} isSelected={false} />,
+    );
+    const root = getRoot();
+    expect(root).toHaveAttribute("aria-current", "page");
+    expect(root).toHaveAttribute("data-active", "true");
+    expect(root.className).toContain("font-semibold");
+    expect(root.className).toMatch(ROW_BG_ACCENT);
+  });
+
+  it("keeps the active styling when the session is also checked in multi-select", () => {
+    render(
+      <SessionSelector {...baseProps} isVisible={true} isSelected={true} />,
+    );
+    const root = getRoot();
+    expect(root).toHaveAttribute("aria-current", "page");
+    expect(root.className).toContain("font-semibold");
+    expect(root.className).toMatch(ROW_BG_ACCENT);
+  });
+
+  it("does NOT add a row background when a non-active session is checked", () => {
+    // The red checkbox icon alone signals selection. Adding bg-accent here
+    // would make peer-selected rows visually indistinguishable from the
+    // single in-focus row — which is the bug this PR fixes.
+    render(
+      <SessionSelector {...baseProps} isVisible={false} isSelected={true} />,
+    );
+    const root = getRoot();
+    expect(root).not.toHaveAttribute("aria-current");
+    expect(root).not.toHaveAttribute("data-active");
+    expect(root.className).toContain("font-normal");
+    expect(root.className).not.toMatch(ROW_BG_ACCENT);
+  });
+});

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx
@@ -107,6 +107,8 @@ export function SessionSelector({
   return (
     <div
       data-testid="session-selector"
+      data-active={isVisible ? "true" : undefined}
+      aria-current={isVisible ? "page" : undefined}
       onClick={(e) => {
         setNewSessionCloseVoiceAssistant(true);
         if (isEditing) e.stopPropagation();
@@ -114,8 +116,7 @@ export function SessionSelector({
       }}
       className={cn(
         "file-component-accordion-div group cursor-pointer rounded-md text-left text-mmd hover:bg-accent",
-        isVisible && !isSelected ? "bg-accent font-semibold" : "font-normal",
-        isSelected && "bg-accent",
+        isVisible ? "bg-accent font-semibold" : "font-normal",
       )}
     >
       <div className="flex h-8 items-center justify-between overflow-hidden w-full">


### PR DESCRIPTION
## Summary

When the user multi-selected sessions in the playground sidebar, every checked row got the same `bg-accent` background — including whichever row was *currently in focus* (the one whose messages the chat panel was rendering). The active row became visually indistinguishable from its peer-selected rows, and screen readers had no `aria-current` hook to fall back on either.

This PR tightens the row-state rules so the active row is the only row that carries a row-level background and bold weight. Peer-selected rows are signalled purely by the red checkbox icon, which keeps the multi-select state legible without competing with the in-focus indicator.

## Root cause

`session-selector.tsx` previously composed three className clauses:

```ts
isVisible && !isSelected ? "bg-accent font-semibold" : "font-normal",
isSelected && "bg-accent",
```

The `!isSelected` guard on the active clause meant that the moment a user checked the active row, its `font-semibold` (and the conceptual "active" treatment) disappeared. The `isSelected && "bg-accent"` clause then painted every selected row identically, so the active row could not be picked out of the multi-selection.

## Fix

Replace the three-clause composition with a single in-focus rule:

```ts
isVisible ? "bg-accent font-semibold" : "font-normal",
```

Plus `aria-current="page"` and `data-active="true"` on the active row for accessibility / CSS hooks.

Result:

| State                       | Row background | Font weight    | aria-current  |
|-----------------------------|----------------|----------------|----------------|
| Active                      | `bg-accent`    | `font-semibold`| `page`         |
| Active + selected           | `bg-accent`    | `font-semibold`| `page`         |
| Selected (not active)       | none           | `font-normal`  | —              |
| Neither                     | none           | `font-normal`  | —              |

The red checkbox icon already exists on every selected row, so the selection state stays fully visible. The active row is now the sole row with a background, making it unambiguously the in-focus one in any multi-select combination.

## Trade-offs / alternatives considered

- **Left accent stripe (`border-l-2 border-primary`)** — first attempt; the stripe fought the rounded-md card corners and read as crude in dark mode. Dropped.
- **Different bg tone for selected (`bg-muted/40`)** — would still create two competing row backgrounds and demand colour-balancing across light/dark themes. The red checkbox is already a strong, free signal — leaning on it costs nothing and avoids the balance problem.
- **Active dot indicator** — works but adds a 9th visual element to a dense row; redundant with the bg + bold combination.

## Tests

New `__tests__/session-selector.test.tsx` (4 cases) covers every combination of `isVisible` × `isSelected`:

1. Neither → no `aria-current`, no `data-active`, no row `bg-accent`, `font-normal`.
2. Active only → `aria-current="page"`, `data-active="true"`, row `bg-accent`, `font-semibold`.
3. Active + selected → same as active only (active dominates).
4. Selected only → no `aria-current`, no `data-active`, no row `bg-accent`, `font-normal`.

`bg-accent` is matched with a negative-lookbehind regex (`/(?<!:)\bbg-accent\b/`) so the always-present `hover:bg-accent` utility does not trip the assertion.

- `useUpdateSessionName`, `useVoiceStore`, `useSessionHasMessages`, `SessionMoreMenu`, and `SessionRename` are mocked at the module boundary so the test exercises only the className/aria logic.
- Full `playgroundComponent` jest suite: **140 / 140 ✅**
- Biome clean on the two changed files (3 pre-existing warnings on the edit-mode wrapper are untouched).
- `tsc --noEmit` clean for the new test file.
- `make format_frontend` clean.

## Test plan

- [ ] `cd src/frontend && npm start`, open playground for any flow.
- [ ] Create 3-4 sessions via the **New Chat** button.
- [ ] Click any session — its row gets a darker background and bold name, no other row does.
- [ ] Tick the **Select All** checkbox — every selectable row's checkbox turns red.
- [ ] Verify only the active row has a row background; all other selected rows show just the red checkbox.
- [ ] Untick the active session's checkbox — the row stays active (bg + bold preserved).
- [ ] Switch active session by clicking a different (selected) row — background + bold move with the new active row.
- [ ] Screen reader smoke test (VoiceOver: `Cmd+F5`): tab through sessions — active row announces "current page".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for SessionSelector component validating visual focus styling and active state behavior.

* **Style**
  * Updated SessionSelector component styling logic to properly reflect active state with appropriate visual indicators and attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->