### PR TITLE
fix(playground): align Select All bulk-delete icon with session ⋮ column

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/chat-sidebar.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/chat-sidebar.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChatSidebar } from "../chat-sidebar";
+
+jest.mock(
+  "@/components/core/playgroundComponent/hooks/use-get-flow-id",
+  () => ({
+    useGetFlowId: () => "flow-1",
+  }),
+);
+
+type FlowState = { playgroundPage: boolean };
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: <TResult,>(selector: (state: FlowState) => TResult) =>
+    selector({ playgroundPage: false }),
+}));
+
+type AlertState = { setSuccessData: jest.Mock };
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: <TResult,>(selector: (state: AlertState) => TResult) =>
+    selector({ setSuccessData: jest.fn() }),
+}));
+
+jest.mock("../session-selector", () => ({
+  SessionSelector: ({
+    session,
+    onToggleSelect,
+  }: {
+    session: string;
+    onToggleSelect?: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid={`session-row-${session}`}
+      onClick={onToggleSelect}
+    >
+      {session}
+    </button>
+  ),
+}));
+
+const baseProps = {
+  sessions: ["flow-1", "New Session 0", "New Session 1"],
+  onSessionSelect: jest.fn(),
+  currentSessionId: "flow-1",
+  onDeleteSession: jest.fn(),
+  onRenameSession: jest.fn().mockResolvedValue(undefined),
+  onBulkDeleteSessions: jest.fn(),
+};
+
+const checkAll = () =>
+  fireEvent.click(screen.getByTestId("select-all-checkbox"));
+
+describe("ChatSidebar — Select All row alignment", () => {
+  it("does not render the bulk-delete button while nothing is selected", () => {
+    render(<ChatSidebar {...baseProps} />);
+    expect(screen.queryByTestId("bulk-delete-button")).not.toBeInTheDocument();
+  });
+
+  it("renders the bulk-delete button with the same h-8 w-8 p-2 shape as a SessionMoreMenu trigger", () => {
+    render(<ChatSidebar {...baseProps} />);
+    checkAll();
+    const trash = screen.getByTestId("bulk-delete-button");
+    expect(trash).toBeInTheDocument();
+    expect(trash.className).toContain("h-8");
+    expect(trash.className).toContain("w-8");
+    expect(trash.className).toContain("p-2");
+    // No leftover sm-button padding that would skew horizontal centering.
+    expect(trash.className).not.toContain("p-0");
+  });
+
+  it("hosts the bulk-delete button in an h-8 row with no extra vertical padding", () => {
+    render(<ChatSidebar {...baseProps} />);
+    checkAll();
+    const trash = screen.getByTestId("bulk-delete-button");
+    // Walk up to the Select All row wrapper. Its className must include
+    // `h-8` and must not add `py-1` / `py-*` padding that would push the
+    // trash button's center down relative to the SessionSelector rows.
+    const row = trash.closest("div.flex.items-center.justify-between");
+    expect(row).not.toBeNull();
+    expect(row!.className).toContain("h-8");
+    expect(row!.className).not.toMatch(/\bpy-\d/);
+    expect(row!.className).not.toMatch(/\bmb-\d/);
+  });
+
+  it("calls onBulkDeleteSessions with the checked sessions when clicked", () => {
+    const onBulkDeleteSessions = jest.fn();
+    render(
+      <ChatSidebar
+        {...baseProps}
+        onBulkDeleteSessions={onBulkDeleteSessions}
+      />,
+    );
+    checkAll();
+    fireEvent.click(screen.getByTestId("bulk-delete-button"));
+    expect(onBulkDeleteSessions).toHaveBeenCalledTimes(1);
+    const [ids] = onBulkDeleteSessions.mock.calls[0];
+    expect(ids).toEqual(
+      expect.arrayContaining(["New Session 0", "New Session 1"]),
+    );
+    // Default session (currentFlowId) is non-selectable and must not be
+    // included in the bulk delete payload.
+    expect(ids).not.toContain("flow-1");
+  });
+});

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import { Button } from "@/components/ui/button";
-import useFlowStore from "@/stores/flowStore";
 import useAlertStore from "@/stores/alertStore";
+import useFlowStore from "@/stores/flowStore";
 import { cn } from "@/utils/utils";
 import { useGetFlowId } from "../../../hooks/use-get-flow-id";
 import { SessionSelector } from "./session-selector";
@@ -142,18 +142,23 @@ export function ChatSidebar({
       ) : (
         <div className="flex flex-col gap-1">
           {sessions.map((session, index) => {
-            const isDefaultSession = session === currentFlowId;
             const isFirstNonDefaultSession =
               index > 0 && sessions[index - 1] === currentFlowId;
 
             return (
               <div key={session}>
-                {/* Show Select All controls after the default session */}
+                {/* Show Select All controls after the default session.
+                    Wrapper is sized + padded to mirror a SessionSelector
+                    row (h-8, no extra vertical padding) so the trash
+                    button lines up vertically and horizontally with the
+                    `⋮` MoreMenu triggers in the session rows below. */}
                 {isFirstNonDefaultSession && selectableSessions.length > 0 && (
-                  <div className="flex items-center justify-between px-2 py-1 mb-1">
-                    <div
-                      className="flex items-center gap-2 cursor-pointer"
+                  <div className="flex h-8 items-center justify-between">
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 cursor-pointer px-2 bg-transparent border-0 p-0"
                       onClick={handleSelectAll}
+                      aria-pressed={allSelected}
                       data-testid="select-all-checkbox"
                     >
                       <div className="flex items-center justify-center w-4 h-4 flex-shrink-0">
@@ -170,31 +175,29 @@ export function ChatSidebar({
                       <span className="text-sm text-muted-foreground select-none">
                         {t("chat.selectAll")}
                       </span>
-                    </div>
-                    <div className="w-8 h-8 flex items-center justify-center">
-                      {selectedSessions.size > 0 && (
-                        <ShadTooltip
-                          styleClasses="z-50"
-                          content={t("chat.deleteSessionsCount", {
-                            count: selectedSessions.size,
-                          })}
-                          side="top"
+                    </button>
+                    {selectedSessions.size > 0 && (
+                      <ShadTooltip
+                        styleClasses="z-50"
+                        content={t("chat.deleteSessionsCount", {
+                          count: selectedSessions.size,
+                        })}
+                        side="top"
+                      >
+                        <Button
+                          data-testid="bulk-delete-button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 p-2 rounded text-status-red hover:text-status-red hover:bg-error-background"
+                          onClick={handleBulkDelete}
                         >
-                          <Button
-                            data-testid="bulk-delete-button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0 text-status-red hover:text-status-red hover:bg-error-background"
-                            onClick={handleBulkDelete}
-                          >
-                            <ForwardedIconComponent
-                              name="Trash2"
-                              className="h-4 w-4"
-                            />
-                          </Button>
-                        </ShadTooltip>
-                      )}
-                    </div>
+                          <ForwardedIconComponent
+                            name="Trash2"
+                            className="h-4 w-4"
+                          />
+                        </Button>
+                      </ShadTooltip>
+                    )}
                   </div>
                 )}
                 <SessionSelector


### PR DESCRIPTION
## Summary

The bulk-delete trash icon in the Select All row of the playground sessions sidebar did not line up with the `⋮` MoreMenu icons of the session rows below — both vertically (different row heights) and horizontally (different inner-padding shape). This PR aligns the Select All row to the exact same shape and dimensions as a `SessionSelector` row so the icons sit in the same column on the same baseline.

## Root cause

Old Select All wrapper:

```tsx
<div className="flex items-center justify-between px-2 py-1 mb-1">
  …
  <div className="w-8 h-8 flex items-center justify-center">
    <Button … className="h-8 w-8 p-0 …"><Trash2 h-4 w-4 /></Button>
  </div>
</div>
```

Compared with each `SessionSelector` row (`h-8 flex items-center` with a `SessionMoreMenu` trigger of `h-8 w-8 p-2`):

- `py-1 mb-1` made the Select All row taller and pushed the trash icon's center **down** relative to the `⋮` centers in the rows beneath it.
- The trash button used `p-0` and sat in an unpadded host column, so its right edge landed 8 px **left** of where the `SessionMoreMenu` trigger's right edge sits (the trigger has its own `p-2`).

## Fix

Mirror the `SessionSelector` row shape exactly:

- **Outer wrapper**: `flex h-8 items-center justify-between` — no extra vertical padding, no bottom margin. Row height now matches a session row.
- **Trash button**: drop the wrapper div; render `<Button size="icon" className="h-8 w-8 p-2 rounded …">` directly, matching the `SessionMoreMenu` trigger's inner padding. The icon centers in the same 32×32 column as `⋮`.
- **Left cluster**: move `px-2` from the outer wrapper onto the Select All checkbox cluster so the left edge still aligns with the SessionSelector's internal left padding.

### Drive-bys (lines biome would re-flag because they were touched)

- Removed an unused `isDefaultSession` local in the sessions map.
- Sorted `useAlertStore` / `useFlowStore` imports per biome `organizeImports`.
- Converted the Select All click target from `<div onClick>` to a real `<button type="button" aria-pressed>` so keyboard users can toggle it and biome's a11y warning no longer fires.

## Trade-offs / alternatives considered

- **Add right padding to the trash column** instead of changing the button shape — works visually but leaves two different button shapes for the same conceptual control (row action). Mirroring the `SessionMoreMenu` shape keeps the codebase consistent.
- **Refactor `SessionMoreMenu` + bulk-delete into a shared `RowActionButton` primitive** — the right long-term call once a third call site appears. With only two today it would be premature; covered as a future follow-up.

## Tests

New `__tests__/chat-sidebar.test.tsx` (4 cases):

1. Bulk-delete button **not** rendered when nothing is selected.
2. Bulk-delete button renders with `h-8 w-8 p-2` shape (regression guard against drift back to `p-0`).
3. Host row uses `h-8` with no `py-*` / `mb-*` padding (regression guard against re-introducing `py-1 mb-1`).
4. Clicking the bulk-delete button calls `onBulkDeleteSessions` with the checked sessions and **excludes** the default `currentFlowId` session.

`useGetFlowId`, `useFlowStore`, `useAlertStore`, and `SessionSelector` are mocked at the module boundary so the test exercises only the Select All row composition.

- Full `playgroundComponent` jest suite: **140 / 140 ✅**
- `@biomejs/biome check` clean on both changed files (0 errors, 0 warnings).
- `make format_frontend` clean.

## Test plan

- [ ] `cd src/frontend && npm start`, open playground for any flow.
- [ ] Create 3-4 sessions via the **New Chat** button.
- [ ] Tick at least one session — the trash icon appears in the Select All row.
- [ ] Visually verify: trash icon center aligns horizontally with the `⋮` icons in the session rows below; row height matches.
- [ ] Click trash → bulk delete fires, success toast appears.
- [ ] Keyboard test: tab to **Select All** label, press `Enter`/`Space` → toggles selection (`aria-pressed` flips). Previously the `<div>` was not focusable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the alignment and styling of the select-all and bulk-delete controls in the chat sidebar to ensure better visual consistency and proper positioning relative to session rows.

* **Tests**
  * Added comprehensive test coverage for select-all button behavior, including validation of visibility states, button styling and sizing, layout alignment, and correct execution of bulk-delete actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->