### PR TITLE
fix(playground): hide session-row checkbox until hover or selection

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/session-selector-checkbox-visibility.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/__tests__/session-selector-checkbox-visibility.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SessionSelector } from "../session-selector";
+
+// ---------------------------------------------------------------------------
+// Minimal mocks — keep the test focused on the checkbox visibility logic.
+// ---------------------------------------------------------------------------
+
+// Override the global no-op mock so we can read the className passed to
+// the icon and assert the hover/visibility utility classes are wired.
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className} />
+  ),
+}));
+
+jest.mock("@/controllers/API/queries/messages/use-rename-session", () => ({
+  useUpdateSessionName: () => ({ mutate: jest.fn() }),
+}));
+
+type VoiceState = { setNewSessionCloseVoiceAssistant: jest.Mock };
+jest.mock("@/stores/voiceStore", () => ({
+  useVoiceStore: <TResult,>(selector: (state: VoiceState) => TResult) =>
+    selector({ setNewSessionCloseVoiceAssistant: jest.fn() }),
+}));
+
+jest.mock("../../hooks/use-session-has-messages", () => ({
+  useSessionHasMessages: () => true,
+}));
+
+jest.mock("../session-more-menu", () => ({
+  SessionMoreMenu: () => <div data-testid="session-more-menu" />,
+}));
+
+jest.mock("../session-rename", () => ({
+  SessionRename: () => <div data-testid="session-rename" />,
+}));
+
+const baseProps = {
+  session: "New Session 0",
+  currentFlowId: "flow-1",
+  deleteSession: jest.fn(),
+  toggleVisibility: jest.fn(),
+  updateVisibleSession: jest.fn(),
+  handleRename: jest.fn().mockResolvedValue(undefined),
+  onMenuOpenChange: jest.fn(),
+  showCheckbox: true,
+};
+
+describe("SessionSelector — checkbox visibility", () => {
+  it("hides the checkbox icon by default and reveals it on row hover", () => {
+    render(
+      <SessionSelector
+        {...baseProps}
+        isVisible={false}
+        isSelected={false}
+        onToggleSelect={jest.fn()}
+      />,
+    );
+    const wrapper = screen.getByTestId(`session-${baseProps.session}-checkbox`);
+    const icon = wrapper.firstElementChild as HTMLElement;
+    expect(icon.className).toContain("invisible");
+    expect(icon.className).toContain("group-hover:visible");
+    // The row carries the `group` class so the group-hover utility resolves.
+    expect(screen.getByTestId("session-selector").className).toContain("group");
+  });
+
+  it("keeps the checkbox icon always visible when the session is selected", () => {
+    render(
+      <SessionSelector
+        {...baseProps}
+        isVisible={false}
+        isSelected={true}
+        onToggleSelect={jest.fn()}
+      />,
+    );
+    const wrapper = screen.getByTestId(`session-${baseProps.session}-checkbox`);
+    const icon = wrapper.firstElementChild as HTMLElement;
+    expect(icon.className).not.toContain("invisible");
+    expect(icon.className).not.toContain("group-hover:visible");
+    expect(icon.className).toContain("text-status-red");
+  });
+
+  it("still reserves the 16x16 column when the icon is hidden so the layout does not jump", () => {
+    render(
+      <SessionSelector
+        {...baseProps}
+        isVisible={false}
+        isSelected={false}
+        onToggleSelect={jest.fn()}
+      />,
+    );
+    const wrapper = screen.getByTestId(`session-${baseProps.session}-checkbox`);
+    expect(wrapper.className).toContain("w-4");
+    expect(wrapper.className).toContain("h-4");
+  });
+
+  it("toggles selection when the checkbox column is clicked and stops row propagation", () => {
+    const onToggleSelect = jest.fn();
+    const toggleVisibility = jest.fn();
+    render(
+      <SessionSelector
+        {...baseProps}
+        isVisible={false}
+        isSelected={false}
+        toggleVisibility={toggleVisibility}
+        onToggleSelect={onToggleSelect}
+      />,
+    );
+    fireEvent.click(
+      screen.getByTestId(`session-${baseProps.session}-checkbox`),
+    );
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    // Row click must NOT fire as a side-effect of the checkbox click.
+    expect(toggleVisibility).not.toHaveBeenCalled();
+  });
+
+  it("does not render a checkbox column when showCheckbox is false", () => {
+    render(
+      <SessionSelector
+        {...baseProps}
+        isVisible={false}
+        isSelected={false}
+        showCheckbox={false}
+        onToggleSelect={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId(`session-${baseProps.session}-checkbox`),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx
@@ -129,11 +129,21 @@ export function SessionSelector({
               className="cursor-pointer flex items-center justify-center w-4 h-4 flex-shrink-0"
               data-testid={`session-${session}-checkbox`}
             >
+              {/* The 16x16 column is always reserved so the row layout
+                  does not jump. The icon itself is hidden by default and
+                  revealed on row hover (via the row's `group` class).
+                  A checked box stays visible regardless so users can see
+                  their selection without re-hovering each row.
+                  `invisible` (visibility: hidden) also disables pointer
+                  events so stray clicks on the hidden column cannot
+                  toggle selection. */}
               <ForwardedIconComponent
                 name={isSelected ? "SquareCheck" : "Square"}
                 className={cn(
-                  "h-4 w-4",
-                  isSelected ? "text-status-red" : "text-muted-foreground",
+                  "h-4 w-4 transition-opacity",
+                  isSelected
+                    ? "text-status-red"
+                    : "text-muted-foreground invisible group-hover:visible",
                 )}
               />
             </div>


### PR DESCRIPTION
## Summary

The selectable-row checkbox in the playground sessions sidebar was rendered at full opacity on every row, adding persistent visual noise to a UI that mostly shows session names. This PR hides the checkbox by default and reveals it only when the row is hovered, while keeping already-checked boxes permanently visible so the user can still see their selection without re-hovering each row.

## Visibility rules

| Row state                          | Checkbox icon                                                                 |
|------------------------------------|--------------------------------------------------------------------------------|
| Not selected + not hovered         | hidden (`invisible`) — column space reserved, no layout jump                  |
| Not selected + row hovered         | visible (`group-hover:visible`)                                               |
| Selected (any pointer state)       | visible (`text-status-red`) — no `invisible`, no `group-hover:` gating        |

The Select All checkbox at the top of the multi-select region stays always visible because it is the entry-point affordance for multi-select — without it, the user has no way to discover the feature.



## Tests

New `__tests__/session-selector-checkbox-visibility.test.tsx` (5 cases):

1. Default state → icon className contains `invisible` + `group-hover:visible`; row carries the `group` class so the utility resolves.
2. Selected state → icon className contains neither `invisible` nor `group-hover:visible`; `text-status-red` present (always-visible regression guard).
3. Hidden state still reserves `w-4 h-4` (layout-jump regression guard).
4. Clicking the checkbox column toggles selection **and** does NOT trigger row `toggleVisibility` (event propagation guard).
5. `showCheckbox={false}` → no checkbox column rendered at all.

Locally overrode the global `genericIconComponent` mock so the icon renders a `<span>` with className, letting tests assert the utility classes are wired correctly (the global jest setup mocks it to `null` for the rest of the suite).

- Full `playgroundComponent` jest suite: **141 / 141 ✅**
- `@biomejs/biome check` clean on both changed files (0 errors; 3 pre-existing a11y warnings on the edit-mode wrapper and other rows are untouched).
- `make format_frontend` clean.

## Test plan

- [ ] `cd src/frontend && npm start`, open playground for any flow.
- [ ] Session rows show **no checkboxes** by default — only session name and the `⋮` MoreMenu.
- [ ] Hover a row → checkbox appears in the leftmost 16×16 column, aligned with the session name, no layout jump.
- [ ] Click checkbox on hover → row becomes selected; checkbox stays visible after pointer leaves.
- [ ] Move pointer to a different row → that row's checkbox appears; previously-selected row's checkbox is still shown.
- [ ] Untick a selected row → checkbox hides again when the pointer leaves.
- [ ] Select All checkbox at the top stays always visible (regression check: only session-row checkboxes are hover-gated).
- [ ] Click the **row body** (not the checkbox) while the row is unhovered/unchecked → session becomes active (no accidental selection toggle from the hidden checkbox column).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session selector checkbox visibility with smooth hover interactions and enhanced layout stability to prevent content shifting.

* **Tests**
  * Added comprehensive test coverage for session selector checkbox visibility, interaction behavior, and layout preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->