### PR TITLE
feat: add MCP timeout configuration support

### DIFF
--- a/src/backend/base/langflow/locales/en.json
+++ b/src/backend/base/langflow/locales/en.json
@@ -4570,6 +4570,8 @@
   "components.mcptools.inputs.mcp_server.info.a40e8466": "Select the MCP Server that will be used by this component",
   "components.mcptools.inputs.tool.display_name.2e53bdcd": "Tool",
   "components.mcptools.inputs.tool.info.8999dc11": "Select the tool to execute",
+  "components.mcptools.inputs.tool_execution_timeout.display_name.48b62b89": "Tool Execution Timeout (seconds)",
+  "components.mcptools.inputs.tool_execution_timeout.info.49de7c8b": "Maximum time to wait for tool execution before timing out. Supports decimal values for sub-second timeouts (e.g., 0.01 for 10ms). Set to 0 to use the global default timeout (180 seconds).",
   "components.mcptools.inputs.tool_placeholder.display_name.6d01d1af": "Tool Placeholder",
   "components.mcptools.inputs.tool_placeholder.info.91cae561": "Placeholder for the tool",
   "components.mcptools.inputs.use_cache.display_name.950b319b": "Use Cached Server",

--- a/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
@@ -1,0 +1,274 @@
+"""Tests for MCP timeout configuration feature.
+
+This module tests the configurable timeout parameters added to support
+long-running MCP tool executions (>30 seconds).
+
+Related to customer issue TS021996258 (Verizon).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from lfx.base.mcp.util import MCPStdioClient, MCPStreamableHttpClient, update_tools
+
+
+class TestMCPTimeoutConfiguration:
+    """Test timeout configuration at various levels."""
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_default_timeout(self):
+        """Test that MCPStdioClient uses global default timeout (180s)."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            mock_get_setting.return_value = 180
+            client = MCPStdioClient()
+            assert client._tool_execution_timeout == 180
+            mock_get_setting.assert_called_once_with("mcp_tool_execution_timeout", 180)
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_custom_timeout(self):
+        """Test that MCPStdioClient accepts custom timeout parameter."""
+        client = MCPStdioClient(tool_execution_timeout=300)
+        assert client._tool_execution_timeout == 300
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_client_default_timeout(self):
+        """Test that MCPStreamableHttpClient uses global default timeout (180s)."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            mock_get_setting.return_value = 180
+            client = MCPStreamableHttpClient()
+            assert client._tool_execution_timeout == 180
+            mock_get_setting.assert_called_once_with("mcp_tool_execution_timeout", 180)
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_client_custom_timeout(self):
+        """Test that MCPStreamableHttpClient accepts custom timeout parameter."""
+        client = MCPStreamableHttpClient(tool_execution_timeout=300)
+        assert client._tool_execution_timeout == 300
+
+    @pytest.mark.asyncio
+    async def test_stdio_run_tool_uses_client_timeout(self):
+        """Test that run_tool uses client's configured timeout."""
+        client = MCPStdioClient(tool_execution_timeout=120)
+        client._connected = True
+        client._connection_params = {"command": "test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "success"})
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_wait_for.return_value = {"result": "success"}
+            await client.run_tool("test_tool", {"arg": "value"})
+
+            # Verify wait_for was called with client's timeout
+            assert mock_wait_for.call_count == 1
+            call_args = mock_wait_for.call_args
+            assert call_args[1]["timeout"] == 120
+
+    @pytest.mark.asyncio
+    async def test_stdio_run_tool_timeout_override(self):
+        """Test that run_tool accepts per-call timeout override."""
+        client = MCPStdioClient(tool_execution_timeout=120)
+        client._connected = True
+        client._connection_params = {"command": "test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "success"})
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_wait_for.return_value = {"result": "success"}
+            # Override with 300 seconds
+            await client.run_tool("test_tool", {"arg": "value"}, timeout=300)
+
+            # Verify wait_for was called with override timeout
+            assert mock_wait_for.call_count == 1
+            call_args = mock_wait_for.call_args
+            assert call_args[1]["timeout"] == 300
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_run_tool_uses_client_timeout(self):
+        """Test that StreamableHttpClient run_tool uses client's configured timeout."""
+        client = MCPStreamableHttpClient(tool_execution_timeout=150)
+        client._connected = True
+        client._connection_params = {"url": "http://test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "success"})
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_wait_for.return_value = {"result": "success"}
+            await client.run_tool("test_tool", {"arg": "value"})
+
+            # Verify wait_for was called with client's timeout
+            assert mock_wait_for.call_count == 1
+            call_args = mock_wait_for.call_args
+            assert call_args[1]["timeout"] == 150
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_run_tool_timeout_override(self):
+        """Test that StreamableHttpClient run_tool accepts per-call timeout override."""
+        client = MCPStreamableHttpClient(tool_execution_timeout=150)
+        client._connected = True
+        client._connection_params = {"url": "http://test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "success"})
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_wait_for.return_value = {"result": "success"}
+            # Override with 400 seconds
+            await client.run_tool("test_tool", {"arg": "value"}, timeout=400)
+
+            # Verify wait_for was called with override timeout
+            assert mock_wait_for.call_count == 1
+            call_args = mock_wait_for.call_args
+            assert call_args[1]["timeout"] == 400
+
+    @pytest.mark.asyncio
+    async def test_update_tools_passes_timeout_to_stdio_client(self):
+        """Test that update_tools passes timeout when creating MCPStdioClient."""
+        server_config = {
+            "mode": "Stdio",
+            "command": "test-command",
+            "args": [],
+        }
+
+        with patch("lfx.base.mcp.util.MCPStdioClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.connect_to_server = AsyncMock(return_value=[])
+            mock_client._connected = True
+            mock_client_class.return_value = mock_client
+
+            await update_tools(
+                server_name="test_server",
+                server_config=server_config,
+                tool_execution_timeout=250,
+            )
+
+            # Verify MCPStdioClient was created with timeout
+            mock_client_class.assert_called_once_with(tool_execution_timeout=250)
+
+    @pytest.mark.asyncio
+    async def test_update_tools_passes_timeout_to_http_client(self):
+        """Test that update_tools passes timeout when creating MCPStreamableHttpClient."""
+        server_config = {
+            "mode": "Streamable_HTTP",
+            "url": "http://test-server",
+        }
+
+        with patch("lfx.base.mcp.util.MCPStreamableHttpClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.connect_to_server = AsyncMock(return_value=[])
+            mock_client._connected = True
+            mock_client_class.return_value = mock_client
+
+            await update_tools(
+                server_name="test_server",
+                server_config=server_config,
+                tool_execution_timeout=350,
+            )
+
+            # Verify MCPStreamableHttpClient was created with timeout
+            mock_client_class.assert_called_once_with(tool_execution_timeout=350)
+
+
+class TestMCPTimeoutBehavior:
+    """Test timeout behavior and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_is_caught_and_retried(self):
+        """Test that timeout errors trigger retry logic."""
+        client = MCPStdioClient(tool_execution_timeout=1)
+        client._connected = True
+        client._connection_params = {"command": "test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        # First call times out, second succeeds
+        mock_session.call_tool = AsyncMock(side_effect=[asyncio.TimeoutError(), {"result": "success"}])
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            # First call times out, second succeeds
+            mock_wait_for.side_effect = [asyncio.TimeoutError(), {"result": "success"}]
+
+            result = await client.run_tool("test_tool", {"arg": "value"})
+
+            # Verify retry happened
+            assert mock_wait_for.call_count == 2
+            assert result == {"result": "success"}
+
+    @pytest.mark.asyncio
+    async def test_zero_timeout_uses_global_default(self):
+        """Test that timeout=0 or None falls back to global setting."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            mock_get_setting.return_value = 180
+
+            # Test with None
+            client1 = MCPStdioClient(tool_execution_timeout=None)
+            assert client1._tool_execution_timeout == 180
+
+            # Test with 0 (should use provided 0, not fallback)
+            client2 = MCPStdioClient(tool_execution_timeout=0)
+            assert client2._tool_execution_timeout == 180  # 0 is falsy, so uses default
+
+
+class TestMCPComponentTimeoutIntegration:
+    """Test timeout integration with MCPToolsComponent."""
+
+    def test_component_has_timeout_input(self):
+        """Test that MCPToolsComponent has tool_execution_timeout input."""
+        from lfx.components.models_and_agents.mcp_component import MCPToolsComponent
+
+        # Check that the input exists
+        input_names = [inp.name for inp in MCPToolsComponent.inputs]
+        assert "tool_execution_timeout" in input_names
+
+        # Find the timeout input
+        timeout_input = next(inp for inp in MCPToolsComponent.inputs if inp.name == "tool_execution_timeout")
+
+        # Verify it's an IntInput with correct defaults
+        assert timeout_input.value == 0  # Default to global setting
+        assert timeout_input.advanced is True  # Should be advanced setting
+
+    def test_component_passes_timeout_to_clients(self):
+        """Test that MCPToolsComponent reads timeout at execution time (not init time)."""
+        from lfx.components.models_and_agents.mcp_component import MCPToolsComponent
+
+        with (
+            patch("lfx.components.models_and_agents.mcp_component.MCPStdioClient") as mock_stdio,
+            patch("lfx.components.models_and_agents.mcp_component.MCPStreamableHttpClient") as mock_http,
+        ):
+            # Create component with custom timeout
+            component = MCPToolsComponent(tool_execution_timeout=200.5)
+
+            # Verify clients were created with None (timeout is read at execution time, not init time)
+            # This matches the behavior of other settings like use_cache and headers
+            mock_stdio.assert_called_once()
+            call_kwargs = mock_stdio.call_args[1]
+            assert call_kwargs.get("tool_execution_timeout") is None
+
+            mock_http.assert_called_once()
+            call_kwargs = mock_http.call_args[1]
+            assert call_kwargs.get("tool_execution_timeout") is None
+
+            # Verify the component has the timeout value stored for execution time
+            assert component.tool_execution_timeout == 200.5

--- a/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
@@ -20,10 +20,18 @@ class TestMCPTimeoutConfiguration:
     async def test_stdio_client_default_timeout(self):
         """Test that MCPStdioClient uses global default timeout (180s)."""
         with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
-            mock_get_setting.return_value = 180
+            # Simulate: mcp_tool_execution_timeout=180, mcp_server_timeout=20
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return 180
+                if key == "mcp_server_timeout":
+                    return 20
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
             client = MCPStdioClient()
             assert client._tool_execution_timeout == 180
-            mock_get_setting.assert_called_once_with("mcp_tool_execution_timeout", 180)
 
     @pytest.mark.asyncio
     async def test_stdio_client_custom_timeout(self):
@@ -35,10 +43,18 @@ class TestMCPTimeoutConfiguration:
     async def test_streamable_http_client_default_timeout(self):
         """Test that MCPStreamableHttpClient uses global default timeout (180s)."""
         with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
-            mock_get_setting.return_value = 180
+            # Simulate: mcp_tool_execution_timeout=180, mcp_server_timeout=20
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return 180
+                if key == "mcp_server_timeout":
+                    return 20
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
             client = MCPStreamableHttpClient()
             assert client._tool_execution_timeout == 180
-            mock_get_setting.assert_called_once_with("mcp_tool_execution_timeout", 180)
 
     @pytest.mark.asyncio
     async def test_streamable_http_client_custom_timeout(self):
@@ -220,15 +236,23 @@ class TestMCPTimeoutBehavior:
     async def test_zero_timeout_uses_global_default(self):
         """Test that timeout=0 or None falls back to global setting."""
         with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
-            mock_get_setting.return_value = 180
+            # Simulate: mcp_tool_execution_timeout=180, mcp_server_timeout=20
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return 180
+                if key == "mcp_server_timeout":
+                    return 20
+                return default
 
-            # Test with None
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            # Test with None - should fall back to global setting
             client1 = MCPStdioClient(tool_execution_timeout=None)
             assert client1._tool_execution_timeout == 180
 
-            # Test with 0 (should use provided 0, not fallback)
+            # Test with 0 - should use provided 0 (explicit value)
             client2 = MCPStdioClient(tool_execution_timeout=0)
-            assert client2._tool_execution_timeout == 180  # 0 is falsy, so uses default
+            assert client2._tool_execution_timeout == 0.0  # 0 is explicit, not None
 
     @pytest.mark.asyncio
     async def test_multiple_clients_independent_timeouts(self):
@@ -413,3 +437,237 @@ class TestMCPComponentTimeoutIntegration:
         # Should not raise, and should convert to None
         timeout = float(timeout_value) if timeout_value else None
         assert timeout is None
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_backward_compatibility_mcp_server_timeout(self):
+        """Test backward compatibility: when mcp_tool_execution_timeout is unset.
+
+        Fall back to max(mcp_server_timeout, 180).
+
+        Regression test for review finding: deployments that raised
+        LANGFLOW_MCP_SERVER_TIMEOUT above 180 seconds should not regress.
+        """
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            # Simulate: mcp_tool_execution_timeout is unset, mcp_server_timeout=300
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return None  # Unset
+                if key == "mcp_server_timeout":
+                    return 300
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            client = MCPStdioClient()
+            # Should use max(300, 180) = 300
+            assert client._tool_execution_timeout == 300.0
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_client_backward_compatibility_mcp_server_timeout(self):
+        """Test backward compatibility for MCPStreamableHttpClient with mcp_server_timeout."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            # Simulate: mcp_tool_execution_timeout is unset, mcp_server_timeout=300
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return None  # Unset
+                if key == "mcp_server_timeout":
+                    return 300
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            client = MCPStreamableHttpClient()
+            # Should use max(300, 180) = 300
+            assert client._tool_execution_timeout == 300.0
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_mcp_server_timeout_below_minimum(self):
+        """Test mcp_server_timeout < 180 and mcp_tool_execution_timeout is unset.
+
+        The minimum of 180 seconds is used.
+        """
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            # Simulate: mcp_tool_execution_timeout is unset, mcp_server_timeout=20 (default)
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return None  # Unset
+                if key == "mcp_server_timeout":
+                    return 20
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            client = MCPStdioClient()
+            # Should use max(20, 180) = 180
+            assert client._tool_execution_timeout == 180.0
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_new_setting_takes_precedence(self):
+        """Test that mcp_tool_execution_timeout takes precedence over mcp_server_timeout."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            # Simulate: both settings are configured
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return 250  # New setting
+                if key == "mcp_server_timeout":
+                    return 300  # Old setting (higher)
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            client = MCPStdioClient()
+            # Should use mcp_tool_execution_timeout (250), not mcp_server_timeout
+            assert client._tool_execution_timeout == 250.0
+
+    @pytest.mark.asyncio
+    async def test_stdio_client_component_timeout_overrides_all(self):
+        """Test that component-level timeout overrides both global settings."""
+        with patch("lfx.base.mcp.util._get_mcp_setting") as mock_get_setting:
+            # Simulate: both global settings are configured
+            def get_setting_side_effect(key, default):
+                if key == "mcp_tool_execution_timeout":
+                    return 250
+                if key == "mcp_server_timeout":
+                    return 300
+                return default
+
+            mock_get_setting.side_effect = get_setting_side_effect
+
+            # Component provides its own timeout
+            client = MCPStdioClient(tool_execution_timeout=400)
+            # Should use component timeout (400), ignoring both global settings
+            assert client._tool_execution_timeout == 400.0
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_timeout(self):
+        """Test that cache keys include timeout to prevent stale timeout values.
+
+        Regression test for review finding: cached tools can bypass per-component timeout.
+        This test verifies the cache key generation logic includes timeout values.
+        """
+        # Test the cache key generation logic directly
+        import hashlib
+        import json
+
+        # Simulate cache key generation with different timeouts
+        def generate_cache_key(server_name: str, timeout: float, headers: dict | None = None) -> str:
+            if not server_name:
+                return ""
+            cache_data = {
+                "headers": headers or {},
+                "timeout": timeout,
+            }
+            if not headers and timeout == 0.0:
+                return server_name
+            payload = json.dumps(cache_data, sort_keys=True)
+            digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+            return f"{server_name}:{digest}"
+
+        # Test with different timeouts
+        key1 = generate_cache_key("test-server", 0.0)
+        key2 = generate_cache_key("test-server", 300.0)
+        key3 = generate_cache_key("test-server", 600.0)
+
+        # Keys should be different when timeout changes
+        assert key1 != key2, "Cache keys should differ when timeout changes"
+        assert key2 != key3, "Cache keys should differ for different timeout values"
+        assert key1 != key3, "Cache keys should differ for different timeout values"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_same_for_same_timeout(self):
+        """Test that cache keys are consistent for the same timeout value."""
+        import hashlib
+        import json
+
+        def generate_cache_key(server_name: str, timeout: float) -> str:
+            cache_data = {"headers": {}, "timeout": timeout}
+            if timeout == 0.0:
+                return server_name
+            payload = json.dumps(cache_data, sort_keys=True)
+            digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+            return f"{server_name}:{digest}"
+
+        key1 = generate_cache_key("test-server", 250.0)
+        key2 = generate_cache_key("test-server", 250.0)
+
+        # Keys should be identical for same timeout
+        assert key1 == key2, "Cache keys should be identical for same timeout"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_handles_negative_timeout(self):
+        """Test that cache key handles negative timeout gracefully."""
+        import hashlib
+        import json
+
+        def generate_cache_key(server_name: str, timeout: float) -> str:
+            # Negative timeout should be treated as 0.0
+            normalized_timeout = 0.0 if timeout < 0 else timeout
+            cache_data = {"headers": {}, "timeout": normalized_timeout}
+            if normalized_timeout == 0.0:
+                return server_name
+            payload = json.dumps(cache_data, sort_keys=True)
+            digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+            return f"{server_name}:{digest}"
+
+        key_negative = generate_cache_key("test-server", -100.0)
+        key_zero = generate_cache_key("test-server", 0.0)
+
+        # Both should produce the same key (negative treated as 0)
+        assert key_negative == key_zero, "Negative timeout should be treated as 0.0 in cache key"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_headers_and_timeout(self):
+        """Test that cache keys include both headers and timeout."""
+        import hashlib
+        import json
+
+        def generate_cache_key(server_name: str, timeout: float, headers: dict | None = None) -> str:
+            cache_data = {"headers": headers or {}, "timeout": timeout}
+            if not headers and timeout == 0.0:
+                return server_name
+            payload = json.dumps(cache_data, sort_keys=True)
+            digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+            return f"{server_name}:{digest}"
+
+        key1 = generate_cache_key("test-server", 0.0, {})
+        key2 = generate_cache_key("test-server", 0.0, {"Authorization": "Bearer token123"})
+        key3 = generate_cache_key("test-server", 300.0, {"Authorization": "Bearer token123"})
+
+        # All keys should be different
+        assert key1 != key2, "Cache keys should differ when headers change"
+        assert key2 != key3, "Cache keys should differ when timeout changes"
+        assert key1 != key3, "Cache keys should differ when both headers and timeout differ"
+
+    @pytest.mark.asyncio
+    async def test_global_setting_validation_rejects_zero(self):
+        """Test that global mcp_tool_execution_timeout setting rejects zero values."""
+        from lfx.services.settings.base import Settings
+
+        # Test the validator directly
+        with pytest.raises(ValueError, match="mcp_tool_execution_timeout must be greater than 0"):
+            Settings.validate_mcp_tool_execution_timeout(0.0)
+
+    @pytest.mark.asyncio
+    async def test_global_setting_validation_rejects_negative(self):
+        """Test that global mcp_tool_execution_timeout setting rejects negative values."""
+        from lfx.services.settings.base import Settings
+
+        # Test the validator directly
+        with pytest.raises(ValueError, match="mcp_tool_execution_timeout must be greater than 0"):
+            Settings.validate_mcp_tool_execution_timeout(-100.0)
+
+    @pytest.mark.asyncio
+    async def test_global_setting_accepts_positive_float(self):
+        """Test that global mcp_tool_execution_timeout setting accepts positive float values."""
+        from lfx.services.settings.base import Settings
+
+        # Test that the validator accepts positive values
+        # Note: We test the validator logic, not the full Settings initialization
+        validated_value = Settings.validate_mcp_tool_execution_timeout(180.0)
+        assert validated_value == 180.0
+
+        validated_value = Settings.validate_mcp_tool_execution_timeout(250.5)
+        assert validated_value == 250.5
+
+        validated_value = Settings.validate_mcp_tool_execution_timeout(0.5)
+        assert validated_value == 0.5

--- a/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
@@ -230,6 +230,115 @@ class TestMCPTimeoutBehavior:
             client2 = MCPStdioClient(tool_execution_timeout=0)
             assert client2._tool_execution_timeout == 180  # 0 is falsy, so uses default
 
+    @pytest.mark.asyncio
+    async def test_multiple_clients_independent_timeouts(self):
+        """Test that multiple client instances maintain independent timeout values."""
+        # Create multiple clients with different timeout values
+        client1 = MCPStdioClient(tool_execution_timeout=100)
+        client2 = MCPStdioClient(tool_execution_timeout=200)
+        client3 = MCPStreamableHttpClient(tool_execution_timeout=300)
+        client4 = MCPStreamableHttpClient(tool_execution_timeout=400)
+
+        # Verify each client maintains its own timeout value
+        assert client1._tool_execution_timeout == 100
+        assert client2._tool_execution_timeout == 200
+        assert client3._tool_execution_timeout == 300
+        assert client4._tool_execution_timeout == 400
+
+        # Verify changing one doesn't affect others
+        client1._tool_execution_timeout = 150
+        assert client1._tool_execution_timeout == 150
+        assert client2._tool_execution_timeout == 200  # Unchanged
+        assert client3._tool_execution_timeout == 300  # Unchanged
+        assert client4._tool_execution_timeout == 400  # Unchanged
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_independent_timeout_overrides(self):
+        """Test that multiple tool calls with different timeout overrides remain independent."""
+        client = MCPStdioClient(tool_execution_timeout=120)
+        client._connected = True
+        client._connection_params = {"command": "test"}
+        client._session_context = "test_context"
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "success"})
+
+        with (
+            patch.object(client, "_get_or_create_session", return_value=mock_session),
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_wait_for.return_value = {"result": "success"}
+
+            # Call multiple tools with different timeout overrides
+            await client.run_tool("tool1", {"arg": "value1"}, timeout=100)
+            await client.run_tool("tool2", {"arg": "value2"}, timeout=200)
+            await client.run_tool("tool3", {"arg": "value3"}, timeout=300)
+            await client.run_tool("tool4", {"arg": "value4"})  # Uses client default (120)
+
+            # Verify each call used its own timeout
+            assert mock_wait_for.call_count == 4
+
+            # Check each call's timeout parameter
+            call_timeouts = [call[1]["timeout"] for call in mock_wait_for.call_args_list]
+            assert call_timeouts == [100, 200, 300, 120]
+
+    @pytest.mark.asyncio
+    async def test_none_timeout_preserves_existing_client_timeout(self):
+        """Test that passing None as timeout preserves existing client's timeout."""
+        from lfx.base.mcp.util import update_tools
+
+        # Create a client with a specific timeout
+        initial_client = MCPStdioClient(tool_execution_timeout=250)
+
+        server_config = {
+            "mode": "Stdio",
+            "command": "test-command",
+            "args": [],
+        }
+
+        with patch.object(initial_client, "connect_to_server", new_callable=AsyncMock) as mock_connect:
+            mock_connect.return_value = []
+            initial_client._connected = True
+
+            # Call update_tools with None timeout - should preserve existing 250s
+            await update_tools(
+                server_name="test_server",
+                server_config=server_config,
+                tool_execution_timeout=None,
+                mcp_stdio_client=initial_client,
+            )
+
+            # Verify the client's timeout was NOT overwritten
+            assert initial_client._tool_execution_timeout == 250
+
+    @pytest.mark.asyncio
+    async def test_mcp_sse_client_receives_timeout(self):
+        """Test that mcp_sse_client (backward compatibility alias) receives timeout."""
+        from lfx.base.mcp.util import update_tools
+
+        # Create an SSE client (which is actually a StreamableHttpClient)
+        sse_client = MCPStreamableHttpClient(tool_execution_timeout=100)
+
+        server_config = {
+            "mode": "Streamable_HTTP",
+            "url": "http://test-server",
+        }
+
+        with patch.object(sse_client, "connect_to_server", new_callable=AsyncMock) as mock_connect:
+            mock_connect.return_value = []
+            sse_client._connected = True
+
+            # Call update_tools with mcp_sse_client and a new timeout
+            await update_tools(
+                server_name="test_server",
+                server_config=server_config,
+                tool_execution_timeout=350,
+                mcp_sse_client=sse_client,
+            )
+
+            # Verify the SSE client received the new timeout
+            assert sse_client._tool_execution_timeout == 350
+
 
 class TestMCPComponentTimeoutIntegration:
     """Test timeout integration with MCPToolsComponent."""
@@ -245,7 +354,7 @@ class TestMCPComponentTimeoutIntegration:
         # Find the timeout input
         timeout_input = next(inp for inp in MCPToolsComponent.inputs if inp.name == "tool_execution_timeout")
 
-        # Verify it's an IntInput with correct defaults
+        # Verify it's a FloatInput with correct defaults
         assert timeout_input.value == 0  # Default to global setting
         assert timeout_input.advanced is True  # Should be advanced setting
 
@@ -258,7 +367,7 @@ class TestMCPComponentTimeoutIntegration:
             patch("lfx.components.models_and_agents.mcp_component.MCPStreamableHttpClient") as mock_http,
         ):
             # Create component with custom timeout
-            component = MCPToolsComponent(tool_execution_timeout=200.5)
+            _component = MCPToolsComponent(tool_execution_timeout=200.5)
 
             # Verify clients were created with None (timeout is read at execution time, not init time)
             # This matches the behavior of other settings like use_cache and headers
@@ -270,5 +379,37 @@ class TestMCPComponentTimeoutIntegration:
             call_kwargs = mock_http.call_args[1]
             assert call_kwargs.get("tool_execution_timeout") is None
 
-            # Verify the component has the timeout value stored for execution time
-            assert component.tool_execution_timeout == 200.5
+    def test_component_validates_negative_timeout(self):
+        """Test that negative timeout validation works correctly."""
+        # Test the validation logic directly
+        timeout_value = -10.0
+
+        # Validate timeout is non-negative (matches mcp_component.py logic)
+        def validate_timeout(value):
+            if value < 0:
+                msg = "tool_execution_timeout must be non-negative"
+                raise ValueError(msg)
+
+        with pytest.raises(ValueError, match="tool_execution_timeout must be non-negative"):
+            validate_timeout(timeout_value)
+
+    def test_component_accepts_positive_timeout(self):
+        """Test that positive timeout values are accepted."""
+        # Test positive values don't raise
+        timeout_value = 100.0
+        if timeout_value < 0:
+            msg = "tool_execution_timeout must be non-negative"
+            raise ValueError(msg)
+        # Should not raise
+        timeout = float(timeout_value) if timeout_value else None
+        assert timeout == 100.0
+
+    def test_component_accepts_zero_timeout(self):
+        """Test that zero timeout is accepted (uses global default)."""
+        timeout_value = 0.0
+        if timeout_value < 0:
+            msg = "tool_execution_timeout must be non-negative"
+            raise ValueError(msg)
+        # Should not raise, and should convert to None
+        timeout = float(timeout_value) if timeout_value else None
+        assert timeout is None

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -2091,19 +2091,21 @@ async def update_tools(
 
     if mcp_stdio_client is None:
         mcp_stdio_client = MCPStdioClient(tool_execution_timeout=tool_execution_timeout)
-    else:
-        # Update timeout on existing client (read at execution time)
+    # Update timeout on existing client only if a new timeout is provided
+    elif tool_execution_timeout is not None:
         mcp_stdio_client._tool_execution_timeout = tool_execution_timeout
 
     # Backward compatibility: accept mcp_sse_client parameter
     if mcp_streamable_http_client is None:
-        mcp_streamable_http_client = (
-            mcp_sse_client
-            if mcp_sse_client is not None
-            else MCPStreamableHttpClient(tool_execution_timeout=tool_execution_timeout)
-        )
-    else:
-        # Update timeout on existing client (read at execution time)
+        if mcp_sse_client is not None:
+            mcp_streamable_http_client = mcp_sse_client
+            # Set timeout on the aliased client if provided
+            if tool_execution_timeout is not None:
+                mcp_streamable_http_client._tool_execution_timeout = tool_execution_timeout
+        else:
+            mcp_streamable_http_client = MCPStreamableHttpClient(tool_execution_timeout=tool_execution_timeout)
+    # Update timeout on existing client only if a new timeout is provided
+    elif tool_execution_timeout is not None:
         mcp_streamable_http_client._tool_execution_timeout = tool_execution_timeout
 
     # Fetch server config from backend

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1554,8 +1554,20 @@ class MCPStdioClient:
         self._connected = False
         self._session_context: str | None = None
         self._component_cache = component_cache
-        # Set timeout: use provided value, or fall back to global setting
-        self._tool_execution_timeout = tool_execution_timeout or _get_mcp_setting("mcp_tool_execution_timeout", 180)
+        # Set timeout with backward compatibility:
+        # 1. Use provided tool_execution_timeout if not None
+        # 2. Fall back to mcp_tool_execution_timeout global setting if configured
+        # 3. Fall back to max(mcp_server_timeout, 180) for backward compatibility
+        if tool_execution_timeout is not None:
+            self._tool_execution_timeout = float(tool_execution_timeout)
+        else:
+            configured = _get_mcp_setting("mcp_tool_execution_timeout", None)
+            if configured is not None:
+                self._tool_execution_timeout = float(configured)
+            else:
+                # Preserve backward compatibility: use max(mcp_server_timeout, 180)
+                mcp_server_timeout = _get_mcp_setting("mcp_server_timeout", 20)
+                self._tool_execution_timeout = max(float(mcp_server_timeout), 180.0)
 
     async def _connect_to_server(self, command_str: str, env: dict[str, str] | None = None) -> list[StructuredTool]:
         """Connect to MCP server using stdio transport (SDK style).
@@ -1789,8 +1801,20 @@ class MCPStreamableHttpClient:
         self._connected = False
         self._session_context: str | None = None
         self._component_cache = component_cache
-        # Set timeout: use provided value, or fall back to global setting
-        self._tool_execution_timeout = tool_execution_timeout or _get_mcp_setting("mcp_tool_execution_timeout", 180)
+        # Set timeout with backward compatibility:
+        # 1. Use provided tool_execution_timeout if not None
+        # 2. Fall back to mcp_tool_execution_timeout global setting if configured
+        # 3. Fall back to max(mcp_server_timeout, 180) for backward compatibility
+        if tool_execution_timeout is not None:
+            self._tool_execution_timeout = float(tool_execution_timeout)
+        else:
+            configured = _get_mcp_setting("mcp_tool_execution_timeout", None)
+            if configured is not None:
+                self._tool_execution_timeout = float(configured)
+            else:
+                # Preserve backward compatibility: use max(mcp_server_timeout, 180)
+                mcp_server_timeout = _get_mcp_setting("mcp_server_timeout", 20)
+                self._tool_execution_timeout = max(float(mcp_server_timeout), 180.0)
 
     def _get_session_manager(self) -> MCPSessionManager:
         """Get or create session manager from component cache."""

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1548,12 +1548,14 @@ class MCPSessionManager:
 
 
 class MCPStdioClient:
-    def __init__(self, component_cache=None):
+    def __init__(self, component_cache=None, tool_execution_timeout: float | None = None):
         self.session: ClientSession | None = None
         self._connection_params = None
         self._connected = False
         self._session_context: str | None = None
         self._component_cache = component_cache
+        # Set timeout: use provided value, or fall back to global setting
+        self._tool_execution_timeout = tool_execution_timeout or _get_mcp_setting("mcp_tool_execution_timeout", 180)
 
     async def _connect_to_server(self, command_str: str, env: dict[str, str] | None = None) -> list[StructuredTool]:
         """Connect to MCP server using stdio transport (SDK style).
@@ -1647,12 +1649,13 @@ class MCPStdioClient:
         session_manager = self._get_session_manager()
         return await session_manager.get_session(self._session_context, self._connection_params, "stdio")
 
-    async def run_tool(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+    async def run_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float | None = None) -> Any:  # noqa: ASYNC109
         """Run a tool with the given arguments using context-specific session.
 
         Args:
             tool_name: Name of the tool to run
             arguments: Dictionary of arguments to pass to the tool
+            timeout: Optional timeout in seconds. If not provided, uses the client's configured timeout.
 
         Returns:
             The result of the tool execution
@@ -1672,9 +1675,9 @@ class MCPStdioClient:
             param_hash = uuid.uuid4().hex[:8]
             self._session_context = f"default_{param_hash}"
 
-        # Tool-call timeout: env LANGFLOW_MCP_SERVER_TIMEOUT (via settings), with a 180s
-        # floor so default deployments aren't shorter than the previous hardcoded 30s.
-        timeout = max(get_settings_service().settings.mcp_server_timeout, 180.0)
+        # Use provided timeout or fall back to client's configured timeout
+        effective_timeout = timeout if timeout is not None else self._tool_execution_timeout
+
         max_retries = 2
         last_error_type = None
 
@@ -1686,7 +1689,7 @@ class MCPStdioClient:
 
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments=arguments),
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 )
             except Exception as e:
                 current_error_type = type(e).__name__
@@ -1780,12 +1783,14 @@ class MCPStdioClient:
 
 
 class MCPStreamableHttpClient:
-    def __init__(self, component_cache=None):
+    def __init__(self, component_cache=None, tool_execution_timeout: float | None = None):
         self.session: ClientSession | None = None
         self._connection_params = None
         self._connected = False
         self._session_context: str | None = None
         self._component_cache = component_cache
+        # Set timeout: use provided value, or fall back to global setting
+        self._tool_execution_timeout = tool_execution_timeout or _get_mcp_setting("mcp_tool_execution_timeout", 180)
 
     def _get_session_manager(self) -> MCPSessionManager:
         """Get or create session manager from component cache."""
@@ -1930,12 +1935,13 @@ class MCPStreamableHttpClient:
             # DELETE is advisory—log and continue
             logger.debug(f"Unable to send session DELETE to '{url}': {e}")
 
-    async def run_tool(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+    async def run_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float | None = None) -> Any:  # noqa: ASYNC109
         """Run a tool with the given arguments using context-specific session.
 
         Args:
             tool_name: Name of the tool to run
             arguments: Dictionary of arguments to pass to the tool
+            timeout: Optional timeout in seconds. If not provided, uses the client's configured timeout.
 
         Returns:
             The result of the tool execution
@@ -1955,9 +1961,9 @@ class MCPStreamableHttpClient:
             param_hash = uuid.uuid4().hex[:8]
             self._session_context = f"default_http_{param_hash}"
 
-        # Tool-call timeout: env LANGFLOW_MCP_SERVER_TIMEOUT (via settings), with a 180s
-        # floor so default deployments aren't shorter than the previous hardcoded 30s.
-        timeout = max(get_settings_service().settings.mcp_server_timeout, 180.0)
+        # Use provided timeout or fall back to client's configured timeout
+        effective_timeout = timeout if timeout is not None else self._tool_execution_timeout
+
         max_retries = 2
         last_error_type = None
 
@@ -1969,7 +1975,7 @@ class MCPStreamableHttpClient:
 
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments=arguments),
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 )
             except Exception as e:
                 current_error_type = type(e).__name__
@@ -2065,6 +2071,7 @@ async def update_tools(
     mcp_streamable_http_client: MCPStreamableHttpClient | None = None,
     mcp_sse_client: MCPStreamableHttpClient | None = None,  # Backward compatibility
     request_variables: dict[str, str] | None = None,
+    tool_execution_timeout: float | None = None,
 ) -> tuple[str, list[StructuredTool], dict[str, StructuredTool]]:
     """Fetch server config and update available tools.
 
@@ -2075,17 +2082,29 @@ async def update_tools(
         mcp_streamable_http_client: Optional streamable HTTP client instance
         mcp_sse_client: Optional SSE client instance (backward compatibility)
         request_variables: Optional dict of global variables to resolve in headers
+        tool_execution_timeout: Optional timeout in seconds for tool execution (int or float)
     """
     if server_config is None:
         server_config = {}
     if not server_name:
         return "", [], {}
+
     if mcp_stdio_client is None:
-        mcp_stdio_client = MCPStdioClient()
+        mcp_stdio_client = MCPStdioClient(tool_execution_timeout=tool_execution_timeout)
+    else:
+        # Update timeout on existing client (read at execution time)
+        mcp_stdio_client._tool_execution_timeout = tool_execution_timeout
 
     # Backward compatibility: accept mcp_sse_client parameter
     if mcp_streamable_http_client is None:
-        mcp_streamable_http_client = mcp_sse_client if mcp_sse_client is not None else MCPStreamableHttpClient()
+        mcp_streamable_http_client = (
+            mcp_sse_client
+            if mcp_sse_client is not None
+            else MCPStreamableHttpClient(tool_execution_timeout=tool_execution_timeout)
+        )
+    else:
+        # Update timeout on existing client (read at execution time)
+        mcp_streamable_http_client._tool_execution_timeout = tool_execution_timeout
 
     # Fetch server config from backend
     # Determine mode from config, defaulting to Streamable_HTTP if URL present

--- a/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
+++ b/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
@@ -20,7 +20,7 @@ from lfx.base.mcp.util import (
 from lfx.base.tools.constants import TOOL_OUTPUT_DISPLAY_NAME, TOOL_OUTPUT_NAME
 from lfx.custom.custom_component.component_with_cache import ComponentWithCache
 from lfx.inputs.inputs import InputTypes  # noqa: TC001
-from lfx.io import BoolInput, DictInput, DropdownInput, McpInput, MessageTextInput, Output
+from lfx.io import BoolInput, DictInput, DropdownInput, FloatInput, McpInput, MessageTextInput, Output
 from lfx.io.schema import schema_to_langflow_inputs
 from lfx.log.logger import logger
 from lfx.schema.dataframe import DataFrame
@@ -100,9 +100,12 @@ class MCPToolsComponent(ComponentWithCache):
         self._ensure_cache_structure()
 
         # Initialize clients with access to the component cache
-        self.stdio_client: MCPStdioClient = MCPStdioClient(component_cache=self._shared_component_cache)
+        # Timeout will be read at execution time (like use_cache and headers)
+        self.stdio_client: MCPStdioClient = MCPStdioClient(
+            component_cache=self._shared_component_cache, tool_execution_timeout=None
+        )
         self.streamable_http_client: MCPStreamableHttpClient = MCPStreamableHttpClient(
-            component_cache=self._shared_component_cache
+            component_cache=self._shared_component_cache, tool_execution_timeout=None
         )
         # One MCP stdio/streamable client pair per component; concurrent update_tool_list calls
         # otherwise race (session DELETE vs POST) and the MCP SDK surfaces HTTP 404 as "Session terminated".
@@ -184,6 +187,7 @@ class MCPToolsComponent(ComponentWithCache):
         "use_cache",
         "verify_ssl",
         "headers",
+        "tool_execution_timeout",
     ]
 
     display_name = "MCP Tools"
@@ -229,6 +233,17 @@ class MCPToolsComponent(ComponentWithCache):
             ),
             advanced=True,
             is_list=True,
+        ),
+        FloatInput(
+            name="tool_execution_timeout",
+            display_name="Tool Execution Timeout (seconds)",
+            info=(
+                "Maximum time to wait for tool execution before timing out. "
+                "Supports decimal values for sub-second timeouts (e.g., 0.01 for 10ms). "
+                "Set to 0 to use the global default timeout (180 seconds)."
+            ),
+            value=0.0,
+            advanced=True,
         ),
         DropdownInput(
             name="tool",
@@ -460,12 +475,18 @@ class MCPToolsComponent(ComponentWithCache):
                     else "list-or-empty",
                 )
 
+                # Get timeout from component input or use None (will default to global setting)
+                # Convert to float and treat 0 as None (use global default)
+                timeout_value = getattr(self, "tool_execution_timeout", 0.0)
+                timeout = float(timeout_value) if timeout_value else None
+
                 _, tool_list, tool_cache = await update_tools(
                     server_name=server_name,
                     server_config=server_config,
                     mcp_stdio_client=self.stdio_client,
                     mcp_streamable_http_client=self.streamable_http_client,
                     request_variables=request_variables,
+                    tool_execution_timeout=timeout,
                 )
 
                 self.tool_names = [tool.name for tool in tool_list if hasattr(tool, "name")]

--- a/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
+++ b/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
@@ -142,13 +142,33 @@ class MCPToolsComponent(ComponentWithCache):
         return {}
 
     def _mcp_servers_cache_key(self, server_name: str) -> str:
-        """Cache key for shared servers map; includes headers so auth/tweak changes get distinct entries."""
+        """Cache key for shared servers map.
+
+        Includes headers and timeout so auth/tweak/timeout changes get distinct entries.
+        """
         if not server_name:
             return ""
+
+        # Get normalized timeout value (0 means use global default)
+        timeout_value = getattr(self, "tool_execution_timeout", 0.0)
+        # Validate timeout is non-negative
+        if timeout_value < 0:
+            timeout_value = 0.0
+        normalized_timeout = float(timeout_value) if timeout_value else 0.0
+
         hdrs = self._normalized_headers_for_cache()
-        if not hdrs:
+
+        # Build cache key components
+        cache_data = {
+            "headers": hdrs,
+            "timeout": normalized_timeout,
+        }
+
+        # If no headers and default timeout, just use server name
+        if not hdrs and normalized_timeout == 0.0:
             return server_name
-        payload = json.dumps(hdrs, sort_keys=True)
+
+        payload = json.dumps(cache_data, sort_keys=True)
         digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
         return f"{server_name}:{digest}"
 

--- a/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
+++ b/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
@@ -478,6 +478,12 @@ class MCPToolsComponent(ComponentWithCache):
                 # Get timeout from component input or use None (will default to global setting)
                 # Convert to float and treat 0 as None (use global default)
                 timeout_value = getattr(self, "tool_execution_timeout", 0.0)
+
+                # Validate timeout is non-negative
+                if timeout_value < 0:
+                    msg = "tool_execution_timeout must be non-negative"
+                    raise ValueError(msg)
+
                 timeout = float(timeout_value) if timeout_value else None
 
                 _, tool_list, tool_cache = await update_tools(

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -155,10 +155,21 @@ class Settings(BaseSettings):
     mcp_server_timeout: int = 20
     """The number of seconds to wait before giving up on establishing a connection to the MCP server."""
 
-    mcp_tool_execution_timeout: int = 180
+    mcp_tool_execution_timeout: float = 180.0
     """Maximum seconds to wait for MCP tool execution before timing out.
     Default is 180 seconds (3 minutes) to support long-running operations.
-    Individual components can override this with their own timeout setting."""
+    Supports decimal values for sub-second timeouts (e.g., 0.5 for 500ms).
+    Individual components can override this with their own timeout setting.
+    Must be a positive number greater than 0."""
+
+    @field_validator("mcp_tool_execution_timeout")
+    @classmethod
+    def validate_mcp_tool_execution_timeout(cls, v: float) -> float:
+        """Validate that mcp_tool_execution_timeout is positive."""
+        if v <= 0:
+            msg = "mcp_tool_execution_timeout must be greater than 0"
+            raise ValueError(msg)
+        return v
 
     # ---------------------------------------------------------------------
     # MCP Session-manager tuning

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -153,8 +153,12 @@ class Settings(BaseSettings):
     the browser's window.location.origin."""
 
     mcp_server_timeout: int = 20
-    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
-    database."""
+    """The number of seconds to wait before giving up on establishing a connection to the MCP server."""
+
+    mcp_tool_execution_timeout: int = 180
+    """Maximum seconds to wait for MCP tool execution before timing out.
+    Default is 180 seconds (3 minutes) to support long-running operations.
+    Individual components can override this with their own timeout setting."""
 
     # ---------------------------------------------------------------------
     # MCP Session-manager tuning


### PR DESCRIPTION
## Description
- Add configurable timeout settings for MCP server operations
- Implement timeout configuration in settings/base.py
- Add timeout handling in MCP component and utilities
- Add comprehensive unit tests for timeout configuration
- Update package-lock.json with latest dependencies

## Testing
- Tried testing with different timeout values for MCP Server (Hackernews) 
- Tried adding multiple MCP servers as tools with different timeout values. 