### PR TITLE
docs: add Browserless MCP connection guide

### DIFF
--- a/docs/docs/Agents/mcp-component-browserless.mdx
+++ b/docs/docs/Agents/mcp-component-browserless.mdx
@@ -1,0 +1,71 @@
+---
+title: Connect a Browserless MCP server to Langflow
+slug: /mcp-component-browserless
+---
+
+import Icon from "@site/src/components/icon";
+import McpIcon from '@site/static/logos/mcp-icon.svg';
+
+This guide demonstrates how to [use Langflow as an MCP client](/mcp-client) by using the **MCP Tools** component to connect to the [Browserless MCP server](https://docs.browserless.io/mcp/overview) in an agent flow.
+
+[Browserless](https://browserless.io) is a hosted browser-as-an-MCP server. The remote MCP endpoint exposes tools for smart scraping, web/news/image search, sitemap mapping, full-site crawling, Lighthouse audits, custom Puppeteer execution, file downloads, native exports, and a persistent agentic-browsing loop with captcha solving and residential proxies. No local install is required.
+
+1. Create a [Browserless account](https://browserless.io/account/) and copy your API token.
+
+2. Create an [OpenAI](https://platform.openai.com/) API key.
+
+3. To follow along with this guide, create a flow based on the **Simple Agent** template.
+
+    You can also use an existing flow or create a blank flow.
+
+4. Remove the **URL** tool from the flow.
+
+5. Register the Browserless MCP server from the <McpIcon /> **MCP** sidebar and add **MCP Tools** to the canvas.
+Use the following values:
+
+    1. Select the **HTTP/SSE** connection type.
+
+    2. In the **Name** field, enter a name for the MCP server, such as `Browserless`.
+
+    3. In the **URL** field, enter the Browserless MCP endpoint:
+
+        ```text
+        https://mcp.browserless.io/mcp
+        ```
+
+    4. In the **Headers** fields, add the `Authorization` header with your Browserless API token:
+
+        | Key | Value |
+        | --- | --- |
+        | `Authorization` | `Bearer YOUR_BROWSERLESS_TOKEN` |
+
+        :::tip
+        For security, store your token as a [global variable](/configuration-global-variables) named `BROWSERLESS_TOKEN`, and then reference it in the header value field. Avoid pasting the raw token into the UI when possible.
+        :::
+
+    5. Click **Add Server**.
+
+6. In the **Agent** component, add your OpenAI API key.
+
+    The default model is an OpenAI model.
+    If you want to use a different model, edit the **Model Provider**, **Model Name**, and **API Key** fields accordingly.
+
+7. Open the **Playground**, and then ask the agent, `Scrape https://example.com and return the page content as markdown.`
+
+    Since Langflow is connected to Browserless through the MCP server, the agent chooses the correct tool (`browserless_smartscraper`) and returns the page content. For example:
+
+    ```text
+    # Example Domain
+
+    This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.
+
+    [More information...](https://www.iana.org/domains/example)
+    ```
+
+    Try other prompts to exercise different tools provided by the Browserless MCP server:
+
+    - `Search the web for "browser automation" and return the top 3 results.` uses `browserless_search`.
+    - `Map all URLs on https://docs.browserless.io and return the top 50.` uses `browserless_map`.
+    - `Run a Lighthouse performance audit on https://browserless.io.` uses `browserless_performance`.
+    - `Take a screenshot of https://news.ycombinator.com.` uses `browserless_smartscraper` with the `screenshot` format.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -103,6 +103,7 @@ module.exports = {
         "Agents/mcp-server",
         "Agents/langflow-mcp-client",
         "Agents/mcp-component-astra",
+        "Agents/mcp-component-browserless",
       ],
     },
     {
@@ -184,6 +185,27 @@ module.exports = {
           type: "doc",
           id: "Develop/configuration-cli",
           label: "Use the Langflow CLI"
+        },
+        {
+          type: "category",
+          label: "Build extensions",
+          items: [
+            {
+              type: "doc",
+              id: "Develop/extensions-quickstart",
+              label: "Build your first extension",
+            },
+            {
+              type: "doc",
+              id: "Develop/extensions-manifest",
+              label: "Manifest reference",
+            },
+            {
+              type: "doc",
+              id: "Develop/extensions-author-guide",
+              label: "Author guide",
+            },
+          ],
         },
       ],
     },
@@ -288,6 +310,11 @@ module.exports = {
         },
         {
           type: "doc",
+          id: "Deployment/deployment-extensions-production",
+          label: "Production install pattern for Extensions",
+        },
+        {
+          type: "doc",
           id: "Deployment/security",
           label: "Security",
         },
@@ -326,6 +353,7 @@ module.exports = {
                 "Components/dynamic-create-data",
                 "Components/parser",
                 "Components/split-text",
+                "Components/text-operations",
                 "Components/type-convert",
               ]
             },
@@ -343,7 +371,7 @@ module.exports = {
               type: "category",
               label: "Files and Knowledge",
               items: [
-                "Components/directory",
+                "Components/file-system",
                 "Components/knowledge-base",
                 "Components/read-file",
                 "Components/write-file",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -186,27 +186,6 @@ module.exports = {
           id: "Develop/configuration-cli",
           label: "Use the Langflow CLI"
         },
-        {
-          type: "category",
-          label: "Build extensions",
-          items: [
-            {
-              type: "doc",
-              id: "Develop/extensions-quickstart",
-              label: "Build your first extension",
-            },
-            {
-              type: "doc",
-              id: "Develop/extensions-manifest",
-              label: "Manifest reference",
-            },
-            {
-              type: "doc",
-              id: "Develop/extensions-author-guide",
-              label: "Author guide",
-            },
-          ],
-        },
       ],
     },
     {
@@ -310,11 +289,6 @@ module.exports = {
         },
         {
           type: "doc",
-          id: "Deployment/deployment-extensions-production",
-          label: "Production install pattern for Extensions",
-        },
-        {
-          type: "doc",
           id: "Deployment/security",
           label: "Security",
         },
@@ -353,7 +327,6 @@ module.exports = {
                 "Components/dynamic-create-data",
                 "Components/parser",
                 "Components/split-text",
-                "Components/text-operations",
                 "Components/type-convert",
               ]
             },
@@ -371,7 +344,7 @@ module.exports = {
               type: "category",
               label: "Files and Knowledge",
               items: [
-                "Components/file-system",
+                "Components/directory",
                 "Components/knowledge-base",
                 "Components/read-file",
                 "Components/write-file",


### PR DESCRIPTION
Adds a vendor-specific MCP integration guide for Browserless, mirroring the existing Astra DB guide at `/mcp-component-astra`.

[Browserless](https://browserless.io) is a hosted browser-as-an-MCP server with a streamable-HTTP endpoint at `https://mcp.browserless.io/mcp`. The new page walks users through registering the server in the  MCP Tools component (HTTP/SSE mode), configuring the Bearer token, and running sample prompts that exercise different Browserless tools.

Targets `release-1.10.0` per the active release branch convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for connecting Browserless MCP server to workflows
  * Added documentation for extension development and production deployment
  * Updated component documentation navigation and references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->