### PR TITLE
fix: preserve user cancellation during job cleanup

### DIFF
--- a/src/backend/base/langflow/services/job_queue/service.py
+++ b/src/backend/base/langflow/services/job_queue/service.py
@@ -242,21 +242,11 @@ class JobQueueService(Service):
         # Cancel the associated task if it is still running.
         if task and not task.done():
             await logger.adebug(f"Cancelling active task for job_id {job_id}")
-            task.cancel()
+            task.cancel("LANGFLOW_USER_CANCELLED")
             try:
                 await task
-            except asyncio.CancelledError as exc:
-                # Check if this was a user-initiated cancellation (user called task.cancel())
-                if task.cancelled():
-                    # User-initiated cancellation so we explicitly called task.cancel() above
-                    await logger.adebug(f"Task for job_id {job_id} was successfully cancelled.")
-                    # Re-raise with user cancellation message code
-                    exc.args = ("LANGFLOW_USER_CANCELLED",)
-                    raise
-                # System-initiated cancellation for other reasons
-                await logger.adebug(f"Task for job_id {job_id} was cancelled by system.")
-                exc.args = ("LANGFLOW_SYSTEM_CANCELLED",)
-                raise
+            except asyncio.CancelledError:
+                await logger.adebug(f"Task for job_id {job_id} was successfully cancelled.")
             except Exception as exc:
                 await logger.aerror(f"Error in task for job_id {job_id} during cancellation: {exc}")
                 raise

--- a/src/backend/tests/unit/services/test_job_queue_service.py
+++ b/src/backend/tests/unit/services/test_job_queue_service.py
@@ -1,0 +1,34 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+from langflow.services.job_queue.service import JobQueueNotFoundError, JobQueueService
+
+
+@pytest.mark.asyncio
+async def test_cleanup_job_passes_user_cancel_reason_and_releases_queue():
+    service = JobQueueService()
+    job_id = str(uuid4())
+    user_id = uuid4()
+    started = asyncio.Event()
+    cancel_args: list[tuple[object, ...]] = []
+
+    async def cancellable_job():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            cancel_args.append(exc.args)
+            raise
+
+    service.create_queue(job_id)
+    service.register_job_owner(job_id, user_id)
+    service.start_job(job_id, cancellable_job())
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await service.cleanup_job(job_id)
+
+    assert cancel_args == [("LANGFLOW_USER_CANCELLED",)]
+    assert service.get_job_owner(job_id) is None
+    with pytest.raises(JobQueueNotFoundError):
+        service.get_queue_data(job_id)


### PR DESCRIPTION
## Summary
Job queue cleanup now sends the user-cancellation reason at the moment the task is cancelled, and cleanup continues through queue/owner release after the task acknowledges cancellation.

## Why
`cleanup_job()` previously called `task.cancel()` without a message, waited for the task to raise `CancelledError`, then rewrote the exception args and re-raised it. That made the cancellation reason arrive too late for the running job wrapper to classify the cancellation as user-initiated, and it also prevented the cleanup path from reaching the registry removal code.

## What changed
- pass `LANGFLOW_USER_CANCELLED` directly to `task.cancel(...)`
- treat the expected cancellation acknowledgement as successful cleanup instead of re-raising it
- add a regression test that proves the task observes the cancellation reason and that queue/owner state is released

Validated with:
`uv run pytest src/backend/tests/unit/services/test_job_queue_service.py src/backend/tests/unit/test_chat_endpoint.py::test_job_owner_cleaned_up_after_cleanup_job`
`uv run ruff check src/backend/base/langflow/services/job_queue/service.py src/backend/tests/unit/services/test_job_queue_service.py`
