### PR TITLE
fix(lfx): harden request-scoped variable resolution + add isolation t…

### DIFF
--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -33,7 +33,12 @@ from lfx.cli.script_loader import (
 from lfx.load import load_flow_from_json
 from lfx.run._defaults import apply_run_defaults, resolve_fallback_to_env_vars
 from lfx.schema.schema import InputValueRequest
-from lfx.services.variable.request_scope import activate_request_variables, reset_request_variables
+from lfx.services.variable.request_scope import (
+    activate_no_env_fallback,
+    activate_request_variables,
+    reset_no_env_fallback,
+    reset_request_variables,
+)
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -340,6 +345,7 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
 
     scope_vars = build_request_variables_from_global_vars(graph.context.get("request_variables"))
     scope_token = activate_request_variables(scope_vars or None)
+    no_env_fallback_token = activate_no_env_fallback(disabled=bool(graph.context.get("no_env_fallback")))
 
     try:
         sys.stdout = captured_stdout
@@ -353,6 +359,7 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
             exc.args = (f"{exc.args[0] if exc.args else str(exc)}\n\nCaptured stderr:\n{error_output}",)
         raise
     finally:
+        reset_no_env_fallback(no_env_fallback_token)
         reset_request_variables(scope_token)
         # Restore original stdout/stderr
         sys.stdout = original_stdout

--- a/src/lfx/src/lfx/cli/runtime_variables.py
+++ b/src/lfx/src/lfx/cli/runtime_variables.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from lfx.log.logger import logger
+
 if TYPE_CHECKING:
     from lfx.graph.graph.base import Graph
 
@@ -20,7 +22,8 @@ def build_request_variables_from_global_vars(global_vars: dict[str, str] | None)
     - ``x-langflow-global-var-*`` aliases
 
     Parsed JSON is applied first; explicit keys in *global_vars* (except the JSON
-    blob key itself) override on collision so connection_details wins over context.
+    blob key itself) override on collision. Under the TRM contract connection_details
+    is sent as raw keys and context inside the JSON blob, so connection_details wins.
     """
     if not global_vars:
         return {}
@@ -30,10 +33,18 @@ def build_request_variables_from_global_vars(global_vars: dict[str, str] | None)
     if raw_json:
         try:
             parsed = json.loads(raw_json)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                f"Failed to parse {_LANGFLOW_REQUEST_VARIABLES_KEY} JSON ({exc}); "
+                "credentials carried only in this blob will be unavailable."
+            )
             parsed = None
         if isinstance(parsed, dict):
             merged.update({str(key): str(value) for key, value in parsed.items()})
+        elif parsed is not None:
+            logger.warning(
+                f"{_LANGFLOW_REQUEST_VARIABLES_KEY} must be a JSON object, got {type(parsed).__name__}; ignoring blob."
+            )
 
     for key, value in global_vars.items():
         if key == _LANGFLOW_REQUEST_VARIABLES_KEY:

--- a/src/lfx/src/lfx/services/variable/request_scope.py
+++ b/src/lfx/src/lfx/services/variable/request_scope.py
@@ -4,16 +4,23 @@ TRM/WXO inject credentials via ``global_vars`` on ``POST /flows/{id}/run`` witho
 mutating process-wide ``os.environ``. This module holds the active request's flat
 lookup table in a ContextVar so :class:`~lfx.services.variable.service.VariableService`
 can resolve the same names as the ``lfx run`` subprocess path.
+
+A second ContextVar mirrors ``graph.context['no_env_fallback']`` so the service can
+honor the same "do not read ``os.environ``" contract that ``load_from_env_vars``
+enforces for ``load_from_db`` fields — keeping the two resolution paths consistent.
 """
 
 from __future__ import annotations
 
 import contextvars
-from typing import Any
 
 _request_variables: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
     "lfx_request_variables",
     default=None,
+)
+_no_env_fallback: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "lfx_no_env_fallback",
+    default=False,
 )
 
 
@@ -22,11 +29,32 @@ def get_active_request_variables() -> dict[str, str] | None:
     return _request_variables.get()
 
 
-def activate_request_variables(variables: dict[str, str] | None) -> contextvars.Token[Any]:
-    """Bind *variables* for the current async task / thread."""
+def is_env_fallback_disabled() -> bool:
+    """Return whether the current request forbids falling back to ``os.environ``."""
+    return _no_env_fallback.get()
+
+
+def activate_no_env_fallback(*, disabled: bool) -> contextvars.Token[bool]:
+    """Bind the no-env-fallback flag for the current async task / thread."""
+    return _no_env_fallback.set(disabled)
+
+
+def reset_no_env_fallback(token: contextvars.Token[bool]) -> None:
+    """Restore the previous no-env-fallback flag."""
+    _no_env_fallback.reset(token)
+
+
+def activate_request_variables(variables: dict[str, str] | None) -> contextvars.Token[dict[str, str] | None]:
+    """Bind *variables* for the current async task / thread.
+
+    Pass ``None`` to mean "no active scope" — lookups then fall back to the
+    ``LANGFLOW_REQUEST_VARIABLES`` env var. An empty ``{}`` is an *active* empty
+    scope that suppresses that env fallback, so callers normalizing an empty
+    result should pass ``... or None`` to preserve it.
+    """
     return _request_variables.set(variables)
 
 
-def reset_request_variables(token: contextvars.Token[Any]) -> None:
+def reset_request_variables(token: contextvars.Token[dict[str, str] | None]) -> None:
     """Restore the previous request scope."""
     _request_variables.reset(token)

--- a/src/lfx/src/lfx/services/variable/service.py
+++ b/src/lfx/src/lfx/services/variable/service.py
@@ -5,7 +5,7 @@ import os
 
 from lfx.log.logger import logger
 from lfx.services.base import Service
-from lfx.services.variable.request_scope import get_active_request_variables
+from lfx.services.variable.request_scope import get_active_request_variables, is_env_fallback_disabled
 
 
 class VariableService(Service):
@@ -51,9 +51,20 @@ class VariableService(Service):
     async def get_variable(self, name: str, **kwargs) -> str | None:  # noqa: ARG002
         """Get a variable value.
 
-        First checks in-memory cache, then request-scoped variables (serve ContextVar
-        or LANGFLOW_REQUEST_VARIABLES), then environment variables, then
-        ``x-langflow-global-var-*`` normalized keys.
+        Resolution order (first match wins):
+          1. In-memory cache (``set_variable``).
+          2. Request-scoped exact name (serve ContextVar or ``LANGFLOW_REQUEST_VARIABLES``).
+          3. Environment variable (exact name).
+          4. Request-scoped ``x-langflow-global-var-*`` alias.
+          5. Environment variable (``x-langflow-global-var-*`` alias).
+
+        Note: the exact-name environment lookup (3) runs *before* the request-scoped
+        alias lookup (4), so an env var named ``name`` beats a request-scoped alias.
+
+        When the active request disables env fallback (``graph.context['no_env_fallback']``,
+        propagated via the request scope), steps 3 and 5 are skipped so resolution
+        never reads ``os.environ`` — matching ``load_from_env_vars`` for ``load_from_db``
+        fields and keeping served flows isolated from process-wide credentials.
         """
         if name in self._variables:
             return self._variables[name]
@@ -63,20 +74,24 @@ class VariableService(Service):
             logger.debug(f"Variable '{name}' loaded from request-scoped variables")
             return request_variables[name]
 
-        value = os.getenv(name)
-        if value:
-            logger.debug(f"Variable '{name}' loaded from environment")
-            return value
+        env_fallback_enabled = not is_env_fallback_disabled()
+
+        if env_fallback_enabled:
+            value = os.getenv(name)
+            if value:
+                logger.debug(f"Variable '{name}' loaded from environment")
+                return value
 
         global_alias = self._normalize_global_var_key(name)
         if global_alias in request_variables:
             logger.debug(f"Variable '{name}' loaded from request-scoped alias '{global_alias}'")
             return request_variables[global_alias]
 
-        value = os.getenv(global_alias)
-        if value:
-            logger.debug(f"Variable '{name}' loaded from global alias '{global_alias}'")
-            return value
+        if env_fallback_enabled:
+            value = os.getenv(global_alias)
+            if value:
+                logger.debug(f"Variable '{name}' loaded from global alias '{global_alias}'")
+                return value
 
         return None
 

--- a/src/lfx/tests/unit/cli/test_common.py
+++ b/src/lfx/tests/unit/cli/test_common.py
@@ -213,6 +213,7 @@ class TestGraphExecution:
             yield mock_result
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
 
         results, logs = await execute_graph_with_capture(mock_graph, "test input")
@@ -234,12 +235,49 @@ class TestGraphExecution:
             yield mock_result
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
 
         results, _ = await execute_graph_with_capture(mock_graph, "test input")
 
         assert len(results) == 1
         assert results[0].message.text == "Message text"
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_activates_request_scope_from_context(self):
+        """Activate the request scope + no_env_fallback from graph.context, then reset them.
+
+        The flag and variables must be live during execution and cleared afterward so
+        nothing leaks to the next request. Covers the wiring (graph.context -> ContextVars)
+        that the serve_app tests skip by mocking out execute_graph_with_capture.
+        """
+        from lfx.services.variable.request_scope import (
+            get_active_request_variables,
+            is_env_fallback_disabled,
+        )
+
+        observed: dict[str, object] = {}
+
+        async def mock_async_start(inputs, **kwargs):  # noqa: ARG001
+            observed["scope"] = get_active_request_variables()
+            observed["no_env_fallback"] = is_env_fallback_disabled()
+            yield MagicMock(results={"text": "ok"})
+
+        mock_graph = MagicMock()
+        mock_graph.context = {
+            "request_variables": {"access_token": "secret"},
+            "no_env_fallback": True,
+        }
+        mock_graph.async_start = mock_async_start
+
+        await execute_graph_with_capture(mock_graph, "test input")
+
+        # During execution the scope reflected this request's global_vars + flag.
+        assert observed["scope"] == {"access_token": "secret"}
+        assert observed["no_env_fallback"] is True
+        # After execution both ContextVars are reset (no bleed into the next request).
+        assert get_active_request_variables() is None
+        assert is_env_fallback_disabled() is False
 
     @pytest.mark.asyncio
     async def test_execute_graph_with_capture_error(self):
@@ -251,6 +289,7 @@ class TestGraphExecution:
             yield  # This line never executes but makes it an async generator
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start_error
 
         with pytest.raises(RuntimeError, match="Execution failed"):
@@ -268,6 +307,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
 
         await execute_graph_with_capture(mock_graph, "test input")
@@ -283,6 +323,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
 
         await execute_graph_with_capture(mock_graph, "test input", session_id="fixed-session")
@@ -302,6 +343,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
         memory_vertex = MagicMock()
         memory_vertex.raw_params = {}
@@ -324,6 +366,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
         pinned_vertex = MagicMock()
         pinned_vertex.raw_params = {"session_id": "hardcoded-in-flow"}
@@ -348,6 +391,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
         mock_graph.user_id = None
 
@@ -364,6 +408,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
         mock_graph.user_id = "preset-user-uuid"
 
@@ -385,6 +430,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
 
         await execute_graph_with_capture(mock_graph, "test input")
@@ -401,6 +447,7 @@ class TestGraphExecution:
             yield MagicMock(results={"text": "ok"})
 
         mock_graph = MagicMock()
+        mock_graph.context = {}
         mock_graph.async_start = mock_async_start
         mock_settings = MagicMock()
         mock_settings.settings.fallback_to_env_var = False

--- a/src/lfx/tests/unit/cli/test_runtime_variables.py
+++ b/src/lfx/tests/unit/cli/test_runtime_variables.py
@@ -12,9 +12,50 @@ def test_build_request_variables_parses_langflow_request_variables():
         "x-langflow-global-var-access-token": "alias-value",
     }
     flat = build_request_variables_from_global_vars(global_vars)
-    assert flat["access_token"] == "from-raw-override"
+    assert flat["access_token"] == "from-raw-override"  # noqa: S105  # test value, not a credential
     assert flat["USER_ID"] == "u1"
     assert flat["x-langflow-global-var-access-token"] == "alias-value"
+
+
+def test_build_request_variables_keeps_raw_keys_when_blob_is_malformed():
+    """A malformed LANGFLOW_REQUEST_VARIABLES blob is skipped; raw keys still merge."""
+    global_vars = {
+        "LANGFLOW_REQUEST_VARIABLES": "{not valid json",
+        "access_token": "raw-tok",
+    }
+    flat = build_request_variables_from_global_vars(global_vars)
+    assert flat == {"access_token": "raw-tok"}
+
+
+def test_build_request_variables_ignores_non_dict_blob():
+    """A JSON blob that is not an object is ignored; raw keys still merge."""
+    global_vars = {
+        "LANGFLOW_REQUEST_VARIABLES": json.dumps(["a", "b"]),
+        "access_token": "raw-tok",
+    }
+    flat = build_request_variables_from_global_vars(global_vars)
+    assert flat == {"access_token": "raw-tok"}
+
+
+def test_reset_request_variables_restores_previous_scope():
+    """Nested activate/reset restores the prior scope, not None."""
+    from lfx.services.variable.request_scope import (
+        activate_request_variables,
+        get_active_request_variables,
+        reset_request_variables,
+    )
+
+    outer = activate_request_variables({"A": "1"})
+    try:
+        inner = activate_request_variables({"A": "2"})
+        try:
+            assert get_active_request_variables() == {"A": "2"}
+        finally:
+            reset_request_variables(inner)
+        assert get_active_request_variables() == {"A": "1"}
+    finally:
+        reset_request_variables(outer)
+    assert get_active_request_variables() is None
 
 
 async def test_variable_service_reads_active_request_scope():

--- a/src/lfx/tests/unit/services/test_minimal_services.py
+++ b/src/lfx/tests/unit/services/test_minimal_services.py
@@ -305,6 +305,29 @@ class TestVariableService:
         finally:
             reset_request_variables(token)
 
+    async def test_request_scope_overrides_env(self, variables):
+        """A request-scoped variable wins over an env var of the same name (core feature)."""
+        from lfx.services.variable.request_scope import activate_request_variables, reset_request_variables
+
+        os.environ["SHARED_VAR"] = "env-value"
+        token = activate_request_variables({"SHARED_VAR": "request-value"})
+        try:
+            assert await variables.get_variable("SHARED_VAR") == "request-value"
+        finally:
+            reset_request_variables(token)
+            del os.environ["SHARED_VAR"]
+
+    async def test_in_memory_overrides_request_scope(self, variables):
+        """An in-memory variable wins over a request-scoped variable of the same name."""
+        from lfx.services.variable.request_scope import activate_request_variables, reset_request_variables
+
+        variables.set_variable("SHARED_VAR", "memory-value")
+        token = activate_request_variables({"SHARED_VAR": "request-value"})
+        try:
+            assert await variables.get_variable("SHARED_VAR") == "memory-value"
+        finally:
+            reset_request_variables(token)
+
     async def test_teardown(self, variables):
         """Test service teardown clears variables."""
         variables.set_variable("test_key", "test_value")

--- a/src/lfx/tests/unit/services/test_request_scope_isolation.py
+++ b/src/lfx/tests/unit/services/test_request_scope_isolation.py
@@ -1,0 +1,181 @@
+"""Isolation guarantees for request-scoped variables (lfx serve concurrency).
+
+These tests verify the two properties that matter for running multiple flows in a
+single ``lfx serve`` process:
+
+1. **Per-request isolation** - one request's ``global_vars`` must never be visible
+   to a concurrently-running request. This is provided by the ContextVar in
+   :mod:`lfx.services.variable.request_scope`: each asyncio task gets its own
+   context copy, so activating a scope in one task cannot leak into another.
+2. **No accidental env fallback for supplied credentials** - when a request scope
+   provides a variable, resolution must use it and must not consult ``os.environ``
+   for that name (so a stale/foreign env var can never shadow a request credential).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+from lfx.services.variable.request_scope import (
+    activate_no_env_fallback,
+    activate_request_variables,
+    get_active_request_variables,
+    reset_no_env_fallback,
+    reset_request_variables,
+)
+from lfx.services.variable.service import VariableService
+
+
+async def test_concurrent_request_scopes_are_isolated():
+    """Two concurrent requests each see only their own request-scoped variable."""
+    service = VariableService()
+    observed: dict[str, str | None] = {}
+
+    async def handle(request_id: str, secret: str) -> None:
+        token = activate_request_variables({"access_token": secret})
+        try:
+            # Yield so the sibling task activates its own scope before we read;
+            # if the ContextVar leaked across tasks this read would see it.
+            await asyncio.sleep(0.01)
+            observed[request_id] = await service.get_variable("access_token")
+            # Read again after another yield to catch any cross-task overwrite.
+            await asyncio.sleep(0.01)
+            observed[f"{request_id}-recheck"] = await service.get_variable("access_token")
+        finally:
+            reset_request_variables(token)
+
+    await asyncio.gather(handle("A", "secret-A"), handle("B", "secret-B"))
+
+    assert observed["A"] == "secret-A"
+    assert observed["A-recheck"] == "secret-A"
+    assert observed["B"] == "secret-B"
+    assert observed["B-recheck"] == "secret-B"
+
+
+async def test_unscoped_request_does_not_see_a_concurrent_scope():
+    """A request with no active scope must not observe another request's live scope."""
+    service = VariableService()
+    scope_active = asyncio.Event()
+    scope_may_exit = asyncio.Event()
+    observed: dict[str, str | None] = {}
+
+    async def scoped() -> None:
+        token = activate_request_variables({"access_token": "secret-A"})
+        try:
+            scope_active.set()
+            await scope_may_exit.wait()  # hold the scope open while the other task reads
+        finally:
+            reset_request_variables(token)
+
+    async def unscoped() -> None:
+        await scope_active.wait()  # read while scoped()'s scope is definitely active
+        observed["value"] = await service.get_variable("access_token")
+        scope_may_exit.set()
+
+    await asyncio.gather(scoped(), unscoped())
+
+    assert observed["value"] is None
+
+
+async def test_scope_does_not_leak_after_reset():
+    """After reset, the variable is no longer resolvable (request teardown is clean)."""
+    service = VariableService()
+
+    token = activate_request_variables({"access_token": "secret"})
+    assert await service.get_variable("access_token") == "secret"
+    reset_request_variables(token)
+
+    assert get_active_request_variables() is None
+    assert await service.get_variable("access_token") is None
+
+
+async def test_scoped_value_used_without_consulting_env_for_that_name():
+    """A request-supplied variable is returned without falling back to os.environ.
+
+    Guards against a regression where the env tier runs first (or in addition),
+    which would let a process env var shadow a per-request credential.
+    """
+    service = VariableService()
+    token = activate_request_variables({"access_token": "from-request"})
+    with (
+        patch.dict(os.environ, {"access_token": "from-env"}),
+        patch("lfx.services.variable.service.os.getenv") as mock_getenv,
+    ):
+        try:
+            assert await service.get_variable("access_token") == "from-request"
+        finally:
+            reset_request_variables(token)
+
+    name_lookups = [c for c in mock_getenv.call_args_list if c.args and c.args[0] == "access_token"]
+    assert not name_lookups, f"os.getenv('access_token') must not be consulted, got: {name_lookups}"
+
+
+async def test_env_fallback_enabled_by_default():
+    """Without the no-env-fallback flag, env resolution still works (default preserved)."""
+    service = VariableService()
+    with patch.dict(os.environ, {"DEFAULT_SECRET": "from-env"}):
+        assert await service.get_variable("DEFAULT_SECRET") == "from-env"
+
+
+async def test_no_env_fallback_suppresses_env_in_variable_service():
+    """With env fallback disabled, a variable only in os.environ resolves to None.
+
+    Closes the gap where VariableService (model/KB credential path) ignored
+    ``no_env_fallback`` and leaked process env credentials even under --no-env-fallback.
+    """
+    service = VariableService()
+    scope_token = activate_request_variables({"access_token": "from-request"})
+    flag_token = activate_no_env_fallback(disabled=True)
+    with (
+        patch.dict(os.environ, {"OTHER_SECRET": "from-env"}),
+        patch("lfx.services.variable.service.os.getenv") as mock_getenv,
+    ):
+        try:
+            # Supplied via the request scope -> still resolves.
+            assert await service.get_variable("access_token") == "from-request"
+            # Only in process env -> must NOT resolve when fallback is disabled.
+            assert await service.get_variable("OTHER_SECRET") is None
+        finally:
+            reset_no_env_fallback(flag_token)
+            reset_request_variables(scope_token)
+
+    assert not mock_getenv.call_args_list, f"os.getenv must not be consulted, got: {mock_getenv.call_args_list}"
+
+
+async def test_no_env_fallback_flag_is_isolated_per_request():
+    """The no-env-fallback flag is per-request.
+
+    One request disabling it must not affect a concurrent request that allows
+    env fallback.
+    """
+    service = VariableService()
+    observed: dict[str, str | None] = {}
+
+    async def strict_request() -> None:
+        # Active (non-None) scope so resolution never reads LANGFLOW_REQUEST_VARIABLES.
+        scope = activate_request_variables({"unused": "x"})
+        flag = activate_no_env_fallback(disabled=True)
+        try:
+            await asyncio.sleep(0.01)  # let the lenient request run concurrently
+            observed["strict"] = await service.get_variable("SHARED_ENV")
+        finally:
+            reset_no_env_fallback(flag)
+            reset_request_variables(scope)
+
+    async def lenient_request() -> None:
+        scope = activate_request_variables({"unused": "y"})
+        flag = activate_no_env_fallback(disabled=False)
+        try:
+            await asyncio.sleep(0.01)
+            observed["lenient"] = await service.get_variable("SHARED_ENV")
+        finally:
+            reset_no_env_fallback(flag)
+            reset_request_variables(scope)
+
+    with patch.dict(os.environ, {"SHARED_ENV": "from-env"}):
+        await asyncio.gather(strict_request(), lenient_request())
+
+    assert observed["strict"] is None  # env fallback disabled for this request
+    assert observed["lenient"] == "from-env"  # env fallback allowed for this request


### PR DESCRIPTION
fix(lfx): harden request-scoped variable resolution + add isolation tests

Addresses PR review of WXO/TRM request-scoped variables for lfx serve:

- service: honor no_env_fallback in VariableService so model/KB credential resolution no longer falls back to os.environ under --no-env-fallback; correct the get_variable precedence docstring (5-step interleaved order)
- request_scope: add a per-request no_env_fallback ContextVar; use precise Token type; document the None-vs-empty scope contract
- common: activate/reset the no_env_fallback scope from graph.context
- runtime_variables: log (instead of silently swallowing) a malformed or non-object LANGFLOW_REQUEST_VARIABLES blob; anchor the override comment to the TRM contract

Tests:
- add request-scope concurrency isolation + no-env-fallback suite
- add execute_graph_with_capture wiring test (graph.context -> ContextVars)
- give TestGraphExecution mock graphs a real context, fixing 11 tests that broke once the helper began reading graph.context