### PR TITLE
fix(vertex): omit non-pickleable custom_component from cache serialization

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -228,7 +228,7 @@ class Vertex:
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
         # Component instances can carry runtime/thread-local state that is not pickle-safe.
-        # We rebuild components after cache restore, so don't persist the live instance.
+        # Components are instantiated lazily during the next build, so don't persist live instances.
         state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -227,6 +227,9 @@ class Vertex:
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
+        # Component instances can carry runtime/thread-local state that is not pickle-safe.
+        # We rebuild components after cache restore, so don't persist the live instance.
+        state["custom_component"] = None
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -1,5 +1,7 @@
 import copy
 import json
+import pickle
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -297,6 +299,18 @@ def test_update_source_handle():
     updated_edge = update_source_handle(new_edge, flow_data["nodes"], flow_data["edges"])
     assert updated_edge["source"] == "last_node"
     assert updated_edge["data"]["sourceHandle"]["id"] == "last_node"
+
+
+def test_vertex_serialization_drops_runtime_custom_component():
+    vertex = Vertex.__new__(Vertex)
+    vertex._lock = None
+    vertex.custom_component = threading.local()
+    vertex.built_object = None
+    vertex.built_result = None
+
+    restored = pickle.loads(pickle.dumps(vertex))
+
+    assert restored.custom_component is None
 
 
 # TODO: Move to Langflow tests

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -308,7 +308,6 @@ def test_vertex_serialization_drops_runtime_custom_component():
     vertex.built_object = None
     vertex.built_result = None
 
-    # noqa: S301 - trusted test-only pickle roundtrip for serialization behavior.
     restored = pickle.loads(pickle.dumps(vertex))
 
     assert restored.custom_component is None

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -308,6 +308,7 @@ def test_vertex_serialization_drops_runtime_custom_component():
     vertex.built_object = None
     vertex.built_result = None
 
+    # noqa: S301 - trusted test-only pickle roundtrip for serialization behavior.
     restored = pickle.loads(pickle.dumps(vertex))
 
     assert restored.custom_component is None


### PR DESCRIPTION
## Summary

- Clear `Vertex.custom_component` in `__getstate__` so Redis/graph cache pickles do not fail when the component carries runtime/thread-local state.
- Add a regression test that pickles a minimally constructed vertex with `threading.local()` as `custom_component` and verifies it restores as `None`.

Fixes langflow-ai/langflow#8476.

## Test plan

- `uv run pytest src/lfx/tests/unit/graph/test_graph.py -k serialization -v`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization handling for vertex objects to ensure runtime components are properly managed during pickle operations, enhancing cache and persistence reliability.

* **Tests**
  * Added test coverage for vertex serialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->