### PR TITLE
feat(graph): improve flow control for merge nodes downstream of conditional branches

### DIFF
--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1010,6 +1010,22 @@ class Graph:
 
     def mark_branch(self, vertex_id: str, state: str, output_name: str | None = None) -> None:
         visited = self._mark_branch(vertex_id=vertex_id, state=state, output_name=output_name)
+
+        # Reactivate common downstream vertices that have at least one active predecessor
+        # outside the stopped branch. Without this, merge/combine nodes that receive input
+        # from both active and inactive branches would be blocked forever.
+        if state == VertexStates.INACTIVE:
+            for v_id in list(visited):
+                vertex = self.get_vertex(v_id)
+                active_predecessors = [
+                    p_id
+                    for p_id in self.predecessor_map.get(v_id, [])
+                    if p_id not in visited and self.get_vertex(p_id).is_active()
+                ]
+                if active_predecessors:
+                    self.mark_vertex(v_id, VertexStates.ACTIVE)
+                    visited.discard(v_id)
+
         new_predecessor_map, _ = self.build_adjacency_maps(self.edges)
         new_predecessor_map = {k: v for k, v in new_predecessor_map.items() if k in visited}
         if vertex_id in self.cycle_vertices:
@@ -1052,6 +1068,12 @@ class Graph:
         # Track which vertices this source excluded
         if excluded:
             self.conditional_exclusion_sources[vertex_id] = excluded
+
+        # Remove conditionally excluded vertices from the run_manager's predecessor
+        # lists so that downstream merge/combine nodes can proceed with available
+        # inputs instead of waiting forever for data from the excluded branch.
+        for excluded_id in excluded:
+            self.run_manager.remove_from_predecessors(excluded_id)
 
     def _exclude_branch_conditionally(
         self, vertex_id: str, visited: set, excluded: set, output_name: str | None = None, *, skip_first: bool = False

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -646,11 +646,15 @@ class Vertex:
 
     async def _build_vertex_and_update_params(self, key, vertex: Vertex) -> None:
         """Builds a given vertex and updates the params dictionary accordingly."""
-        result = await vertex.get_result(self, target_handle_name=key)
+        try:
+            result = await vertex.get_result(self, target_handle_name=key)
+        except ValueError:
+            result = None
         self._handle_func(key, result)
         if isinstance(result, list):
             self._extend_params_list_with_result(key, result)
-        self.params[key] = result
+        if result is not None:
+            self.params[key] = result
 
     async def _build_list_of_vertices_and_update_params(
         self,

--- a/src/lfx/src/lfx/graph/vertex/vertex_types.py
+++ b/src/lfx/src/lfx/graph/vertex/vertex_types.py
@@ -108,6 +108,10 @@ class ComponentVertex(Vertex):
                     else:
                         default_value = requester.get_value_from_template_dict(edge.target_param)
 
+            if default_value is UNDEFINED and self.graph:
+                if self.id in self.graph.conditionally_excluded_vertices or not self.is_active():
+                    default_value = None
+
             if default_value is not UNDEFINED:
                 return default_value
             msg = f"Component {self.display_name} has not been built yet"


### PR DESCRIPTION
## Summary

When a `ConditionalRouter` (If-Else) excludes one branch, merge/combine nodes at the intersection of active and excluded branches were blocked indefinitely. This fixes four points in the graph engine that caused the bottleneck.

- `mark_branch()`: after marking vertices `INACTIVE`, reactivate any vertex that has at least one active predecessor outside the stopped branch. Keeps merge/combine nodes runnable when they still receive data from the active path.
- `exclude_branch_conditionally()`: remove conditionally excluded vertices from the run manager's predecessor lists via `remove_from_predecessors()` so downstream nodes don't wait for data that will never arrive.
- `ComponentVertex._get_result()`: return `None` instead of raising `ValueError` when the vertex is in `conditionally_excluded_vertices` or `not is_active()`.
- `Vertex._build_vertex_and_update_params()`: wrap `get_result()` in `try/except ValueError` and skip assigning `None` to `params[key]` so components fall back to their natural input defaults instead of receiving `NoneType` (which fails Pydantic validation).

## Provenance

Replaces #13366. Same commit by @chalitbkb cherry-picked onto a clean branch off `release-1.10.0` so the diff isolates the engine change (the original PR's head branch was a fork of `main`, so it pulled in ~50 unrelated upstream files).

Co-authored-by: chalitbkb <chalitsuporntawee@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch reactivation when merging graph branches with multiple upstream dependencies
  * Enhanced handling of conditionally excluded branches to prevent downstream processing blockage
  * More robust parameter building with improved error handling and graceful fallback behavior for unset defaults

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->