### PR TITLE
fix(mcp): close superuser fallback ownership gap in project-scoped MC…

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -158,7 +158,14 @@ async def verify_project_auth(
 
         return user
 
-    return await _superuser_fallback(db, settings_service)
+    # SECURITY (PVR0755110): validate that the project is actually owned by the superuser
+    # before granting access.  On AUTO_LOGIN deployments the fallback previously returned the
+    # superuser identity for *any* project, allowing unauthenticated cross-user access to
+    # resources and tools belonging to other users.
+    superuser = await _superuser_fallback(db, settings_service)
+    if not project.user_id or project.user_id != superuser.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return superuser
 
 
 async def _superuser_fallback(db: AsyncSession, settings_service) -> User:
@@ -478,6 +485,19 @@ async def _dispatch_project_streamable_http(
     current_user: User,
 ) -> Response:
     """Common handler for project-specific Streamable HTTP requests."""
+    # SECURITY (PVR0755110): mirror the ownership check that handle_project_sse already
+    # enforces.  Without this, the Streamable path skipped the check even when the auth
+    # dependency returned the superuser via the AUTO_LOGIN fallback, allowing unauthenticated
+    # requests to access projects owned by other users.
+    async with session_scope() as _ownership_session:
+        _project = (
+            await _ownership_session.exec(
+                select(Folder).where(Folder.id == project_id, Folder.user_id == current_user.id)
+            )
+        ).first()
+    if not _project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     # Lazily initialize the project's Streamable HTTP manager
     # to pick up new projects as they are created.
     project_server = get_project_mcp_server(project_id)

--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -401,8 +401,21 @@ async def handle_list_tools(project_id=None, *, mcp_enabled_only=False):
         async with session_scope() as session:
             # Build query based on parameters
             if project_id:
-                # Filter flows by project and optionally by MCP enabled status
-                flows_query = select(Flow).where(Flow.folder_id == project_id, Flow.is_component == False)  # noqa: E712
+                # SECURITY (PVR0755110): scope to the authenticated caller so that a
+                # superuser-fallback identity cannot enumerate tools from projects owned by
+                # other users.  Without this filter, tools/list exposed all flows in the
+                # project folder regardless of their owner.
+                if current_user is None:
+                    await logger.awarning(
+                        "handle_list_tools called without a current user for project %s; returning empty list",
+                        project_id,
+                    )
+                    return tools
+                flows_query = select(Flow).where(
+                    Flow.folder_id == project_id,
+                    Flow.user_id == current_user.id,
+                    Flow.is_component == False,  # noqa: E712
+                )
                 if mcp_enabled_only:
                     flows_query = flows_query.where(Flow.mcp_enabled == True)  # noqa: E712
             elif current_user is not None:


### PR DESCRIPTION
…P endpoints (PVR0755110)

Three changes that together seal the remaining authorization bypass on the Streamable HTTP transport path:

1. verify_project_auth: after resolving the superuser via the AUTO_LOGIN fallback, verify that the target project is actually owned by that superuser.  Previously the fallback returned the superuser identity for any project, letting unauthenticated requests access resources and tools belonging to other users (PoCs 1-4).

2. _dispatch_project_streamable_http: add an explicit project-ownership check that mirrors the one already present in handle_project_sse.  Acts as a second layer of defence so the Streamable path cannot be reached even if the auth dependency is extended or refactored in the future.

3. handle_list_tools: when a project_id is provided, scope the flow query to current_user.id in addition to folder_id.  Without this, tools/list returned flows owned by any user inside the project folder, enabling cross-user tool enumeration even when the endpoint was otherwise properly authenticated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Enhanced Project Access Security**: Strengthened authentication checks to prevent unauthorized access to projects owned by other users, particularly when using superuser fallback mechanisms.
* **User-Scoped Tool Listing**: Tool discovery now properly restricts results to the authenticated user's own projects, preventing visibility into other users' tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->