### PR TITLE
feat(ci): add nightly fresh-install smoke test workflow

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -314,14 +314,31 @@ jobs:
       nightly_tag: langflowai/langflow-nightly:${{ needs.create-nightly-tag.outputs.release_tag }}
     secrets: inherit
 
+  nightly-fresh-install:
+    name: Run Nightly Fresh Install Smoke Test
+    needs: [create-nightly-tag, release-nightly-build]
+    if: ${{ github.repository == 'langflow-ai/langflow' && always() && needs.release-nightly-build.result == 'success' }}
+    uses: ./.github/workflows/nightly_fresh_install.yml
+    with:
+      # Same Docker tag shape as db-migration-validation; the called workflow uses
+      # this for the docker-run and docker-compose scenarios.
+      nightly_tag: langflowai/langflow-nightly:${{ needs.create-nightly-tag.outputs.release_tag }}
+      # pypi_version intentionally left blank — the called workflow's
+      # resolve-versions step fetches the latest from PyPI itself. By the time
+      # release-nightly-build completes, the just-published nightly is the
+      # PyPI latest, so resolve-versions picks it up. If PyPI hasn't indexed
+      # the new version yet, the workflow emits a `::warning::` on the
+      # PyPI-vs-image drift instead of false-failing.
+    secrets: inherit
+
   slack-notification:
     name: Send Slack Notification
-    needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, release-nightly-build, db-migration-validation]
-    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.db-migration-validation.result == 'failure' || needs.release-nightly-build.result == 'success') }}
+    needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, release-nightly-build, db-migration-validation, nightly-fresh-install]
+    if: ${{ github.repository == 'langflow-ai/langflow' && !inputs.skip_slack && always() && (needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.db-migration-validation.result == 'failure' || needs.nightly-fresh-install.result == 'failure' || needs.release-nightly-build.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Send failure notification to Slack
-        if: ${{ needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.db-migration-validation.result == 'failure' }}
+        if: ${{ needs.release-nightly-build.result == 'failure' || needs.frontend-tests-linux.result == 'failure' || needs.frontend-tests-windows.result == 'failure' || needs.backend-unit-tests.result == 'failure' || needs.db-migration-validation.result == 'failure' || needs.nightly-fresh-install.result == 'failure' }}
         run: |
           # Determine which job failed
           FAILED_JOB="unknown"
@@ -335,6 +352,8 @@ jobs:
             FAILED_JOB="backend-unit-tests"
           elif [ "${{ needs.db-migration-validation.result }}" == "failure" ]; then
             FAILED_JOB="db-migration-validation"
+          elif [ "${{ needs.nightly-fresh-install.result }}" == "failure" ]; then
+            FAILED_JOB="nightly-fresh-install"
           fi
 
           curl -X POST -H 'Content-type: application/json' \
@@ -380,7 +399,7 @@ jobs:
           }" ${{ secrets.LANGFLOW_ENG_SLACK_WEBHOOK_URL }}
 
       - name: Send success notification to Slack
-        if: ${{ !inputs.skip_slack && needs.release-nightly-build.result == 'success' && needs.db-migration-validation.result != 'failure' }}
+        if: ${{ !inputs.skip_slack && needs.release-nightly-build.result == 'success' && needs.db-migration-validation.result != 'failure' && needs.nightly-fresh-install.result != 'failure' }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
           --data '{

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -94,6 +94,19 @@ jobs:
             PYPI_VER=$(curl -fsSL https://pypi.org/pypi/langflow-nightly/json \
               | python3 -c "import json,sys;print(json.load(sys.stdin)['info']['version'])")
           fi
+
+          # The nightly tag emitted by create-nightly-tag (used when
+          # nightly_build.yml chains into this workflow) carries a `v` prefix,
+          # but docker-nightly-build.yml strips that `v` before publishing —
+          # so on Docker Hub the tag is `1.10.0.devNN`, not `v1.10.0.devNN`.
+          # Normalise the tag here so the pull, the docker-run scenario, and
+          # the docker-compose scenario all reference a tag that actually
+          # exists on the registry. db-migration-validation.yml does the same
+          # strip in its install step.
+          IMAGE_NAME="${NIGHTLY_TAG%%:*}"
+          TAG_PART="${NIGHTLY_TAG##*:}"
+          NIGHTLY_TAG="${IMAGE_NAME}:${TAG_PART#v}"
+
           docker pull "$NIGHTLY_TAG" >/dev/null
           IMG_VER=$(docker run --rm --entrypoint sh "$NIGHTLY_TAG" \
             -c "pip show langflow-nightly | awk '/^Version:/ {print \$2}'")
@@ -169,13 +182,26 @@ jobs:
           echo "Installed version: $INSTALLED"
           echo "INSTALLED_VERSION=$INSTALLED" >> "$GITHUB_ENV"
 
-      - name: Assert unpinned install resolved to PyPI latest
+      - name: Assert unpinned install did not silently backtrack
         run: |
+          set -euo pipefail
+          # The signal we care about is "the unpinned resolver picked a version
+          # OLDER than what PyPI currently advertises as latest" — the
+          # broken-pins backtrack we want to catch loudly. The opposite case
+          # (installed > snapshot) happens naturally if a fresh nightly lands
+          # on PyPI between resolve-versions and this step, and shouldn't fail
+          # an otherwise healthy release.
           EXPECTED="${{ needs.resolve-versions.outputs.pypi_version }}"
-          if [ "$INSTALLED_VERSION" != "$EXPECTED" ]; then
-            echo "::error::Unpinned 'uv pip install langflow-nightly' silently resolved to $INSTALLED_VERSION (expected PyPI latest $EXPECTED). This usually means the latest release has unsatisfiable dependency pins and the resolver backtracked to an older nightly."
-            exit 1
+          if [ "$INSTALLED_VERSION" = "$EXPECTED" ]; then
+            exit 0
           fi
+          NEWER=$(printf '%s\n%s\n' "$INSTALLED_VERSION" "$EXPECTED" | sort -V | tail -1)
+          if [ "$NEWER" = "$INSTALLED_VERSION" ]; then
+            echo "::warning::Unpinned install resolved to $INSTALLED_VERSION, which is newer than the snapshot taken at the start of the run ($EXPECTED). A new nightly likely landed mid-run; not a backtrack."
+            exit 0
+          fi
+          echo "::error::Unpinned 'uv pip install langflow-nightly' silently resolved to $INSTALLED_VERSION (older than PyPI latest $EXPECTED). This usually means the latest release has unsatisfiable dependency pins and the resolver backtracked to an older nightly."
+          exit 1
 
       - name: Start Langflow
         working-directory: ${{ runner.temp }}/fresh

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -42,6 +42,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.13"
   POSTGRES_DB: langflow_test
@@ -62,10 +65,31 @@ jobs:
     steps:
       - name: Resolve PyPI and image versions
         id: resolve
+        # Inputs are passed via env (not expanded directly into the script) and
+        # validated against strict regexes before any shell or docker command
+        # consumes them, so a workflow_dispatch caller can't inject shell
+        # metacharacters through `nightly_tag` or `pypi_version`.
+        env:
+          INPUT_NIGHTLY_TAG: ${{ inputs.nightly_tag }}
+          INPUT_PYPI_VERSION: ${{ inputs.pypi_version }}
         run: |
           set -euo pipefail
-          NIGHTLY_TAG="${{ inputs.nightly_tag || 'langflowai/langflow-nightly:latest' }}"
-          PYPI_VER="${{ inputs.pypi_version }}"
+
+          NIGHTLY_TAG="${INPUT_NIGHTLY_TAG:-langflowai/langflow-nightly:latest}"
+          PYPI_VER="${INPUT_PYPI_VERSION:-}"
+
+          # Docker image reference: lowercase alnum + . _ - / and exactly one ":" before the tag.
+          if ! printf '%s' "$NIGHTLY_TAG" | grep -Eq '^[a-z0-9][a-z0-9._/-]*:[a-z0-9._-]+$'; then
+            echo "::error::Invalid nightly_tag format: '$NIGHTLY_TAG' (expected '<image>:<tag>')"
+            exit 1
+          fi
+
+          # PEP 440-ish: blank, or M.m.p[.devN][.rcN]; deliberately conservative.
+          if [ -n "$PYPI_VER" ] && ! printf '%s' "$PYPI_VER" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.(dev|rc|a|b)[0-9]+)?$'; then
+            echo "::error::Invalid pypi_version format: '$PYPI_VER'"
+            exit 1
+          fi
+
           if [ -z "$PYPI_VER" ]; then
             PYPI_VER=$(curl -fsSL https://pypi.org/pypi/langflow-nightly/json \
               | python3 -c "import json,sys;print(json.load(sys.stdin)['info']['version'])")

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -387,12 +387,12 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.database }}" = "postgres" ]; then
-            docker run -d --name lf --network lftest -p ${LANGFLOW_PORT}:7860 \
+            docker run -d --name lf --network lftest -p "${LANGFLOW_PORT}:7860" \
               -e LANGFLOW_DATABASE_URL=postgresql://langflow:langflow_test_pass@lf-pg:5432/langflow_test \
               -e LANGFLOW_AUTO_LOGIN=true \
               "${NIGHTLY_TAG}"
           else
-            docker run -d --name lf -p ${LANGFLOW_PORT}:7860 \
+            docker run -d --name lf -p "${LANGFLOW_PORT}:7860" \
               -e LANGFLOW_AUTO_LOGIN=true \
               "${NIGHTLY_TAG}"
           fi

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -482,6 +482,8 @@ jobs:
 
       - name: docker compose up
         working-directory: compose-test
+        env:
+          LANGFLOW_PORT: ${{ env.LANGFLOW_PORT }}
         run: docker compose up -d
 
       - name: Wait for health check
@@ -492,7 +494,10 @@ jobs:
             if curl -fsS -m 2 "http://127.0.0.1:${LANGFLOW_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
               echo "ready"; exit 0
             fi
-            STATE=$(docker compose ps --format json langflow | python3 -c "import json,sys;d=json.loads(sys.stdin.read() or '{}'); print(d.get('State','missing'))" 2>/dev/null || echo missing)
+            # `docker compose ps --format json` returns an array on most compose v2
+            # versions even when a single service name is passed, but older releases
+            # have returned an object — accept both shapes.
+            STATE=$(docker compose ps --format json langflow | python3 -c "import json,sys; raw=sys.stdin.read().strip() or '[]'; d=json.loads(raw); d=(d[0] if d else {}) if isinstance(d, list) else d; print(d.get('State','missing'))" 2>/dev/null || echo missing)
             if [ "$STATE" != "running" ]; then
               echo "::error::langflow service state: $STATE"
               docker compose logs langflow 2>&1 | tail -200

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -1,0 +1,526 @@
+name: Nightly Fresh Install
+
+# Smoke-test that a freshly published nightly is actually installable end-to-end
+# from all the channels users consume it through:
+#
+#   Scenario 1 — uv pip install langflow-nightly                  (unpinned, latest)
+#   Scenario 2 — uv pip install langflow-nightly==<PyPI latest>   (explicit pin)
+#   Scenario 3 — docker run langflowai/langflow-nightly:latest    (image)
+#   Scenario 4 — docker compose up                                (compose)
+#
+# Each scenario is exercised twice: once against SQLite (default) and once
+# against a fresh PostgreSQL. The job fails if:
+#   * the install/resolver fails,
+#   * the process/container does not become healthy,
+#   * /api/v1/version disagrees with what was installed, or
+#   * (Scenario 1) an unpinned install silently backtracks away from the
+#     PyPI latest — this catches broken releases whose dependency pins are
+#     unsatisfiable from public indexes.
+
+on:
+  workflow_call:
+    inputs:
+      nightly_tag:
+        description: "Nightly Docker tag under test (e.g. langflowai/langflow-nightly:v1.10.0.devNN)"
+        required: true
+        type: string
+      pypi_version:
+        description: "PyPI version of langflow-nightly under test (e.g. 1.10.0.devNN). Blank = resolve from PyPI."
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      nightly_tag:
+        description: "Nightly Docker tag under test"
+        required: false
+        type: string
+        default: "langflowai/langflow-nightly:latest"
+      pypi_version:
+        description: "PyPI version to pin (blank = current latest on PyPI)"
+        required: false
+        type: string
+        default: ""
+
+env:
+  PYTHON_VERSION: "3.13"
+  POSTGRES_DB: langflow_test
+  POSTGRES_USER: langflow
+  POSTGRES_PASSWORD: langflow_test_pass  # pragma: allowlist secret
+  HEALTH_PATH: /health_check
+  LANGFLOW_PORT: "7860"
+
+jobs:
+  resolve-versions:
+    name: Resolve versions under test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pypi_version: ${{ steps.resolve.outputs.pypi_version }}
+      image_version: ${{ steps.resolve.outputs.image_version }}
+      nightly_tag: ${{ steps.resolve.outputs.nightly_tag }}
+    steps:
+      - name: Resolve PyPI and image versions
+        id: resolve
+        run: |
+          set -euo pipefail
+          NIGHTLY_TAG="${{ inputs.nightly_tag || 'langflowai/langflow-nightly:latest' }}"
+          PYPI_VER="${{ inputs.pypi_version }}"
+          if [ -z "$PYPI_VER" ]; then
+            PYPI_VER=$(curl -fsSL https://pypi.org/pypi/langflow-nightly/json \
+              | python3 -c "import json,sys;print(json.load(sys.stdin)['info']['version'])")
+          fi
+          docker pull "$NIGHTLY_TAG" >/dev/null
+          IMG_VER=$(docker run --rm --entrypoint sh "$NIGHTLY_TAG" \
+            -c "pip show langflow-nightly | awk '/^Version:/ {print \$2}'")
+
+          echo "PyPI latest:   $PYPI_VER"
+          echo "Image version: $IMG_VER"
+          echo "Image tag:     $NIGHTLY_TAG"
+
+          {
+            echo "pypi_version=$PYPI_VER"
+            echo "image_version=$IMG_VER"
+            echo "nightly_tag=$NIGHTLY_TAG"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Warn if PyPI and image versions disagree
+        run: |
+          if [ "${{ steps.resolve.outputs.pypi_version }}" != "${{ steps.resolve.outputs.image_version }}" ]; then
+            echo "::warning::PyPI latest (${{ steps.resolve.outputs.pypi_version }}) and image (${{ steps.resolve.outputs.image_version }}) advertise different langflow-nightly versions. This is expected briefly during a release, but a persistent gap means one of the publish steps failed."
+          fi
+
+  uv-unpinned:
+    name: "Scenario 1 — uv unpinned (${{ matrix.database }})"
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [sqlite, postgres]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: langflow_test
+          POSTGRES_USER: langflow
+          POSTGRES_PASSWORD: langflow_test_pass  # pragma: allowlist secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+
+      - name: Fresh install (unpinned)
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          mkdir -p fresh && cd fresh
+          uv venv
+          source .venv/bin/activate
+          if [ "${{ matrix.database }}" = "postgres" ]; then
+            uv pip install "langflow-nightly[postgresql]"
+          else
+            uv pip install "langflow-nightly"
+          fi
+          INSTALLED=$(pip show langflow-nightly | awk '/^Version:/ {print $2}')
+          echo "Installed version: $INSTALLED"
+          echo "INSTALLED_VERSION=$INSTALLED" >> "$GITHUB_ENV"
+
+      - name: Assert unpinned install resolved to PyPI latest
+        run: |
+          EXPECTED="${{ needs.resolve-versions.outputs.pypi_version }}"
+          if [ "$INSTALLED_VERSION" != "$EXPECTED" ]; then
+            echo "::error::Unpinned 'uv pip install langflow-nightly' silently resolved to $INSTALLED_VERSION (expected PyPI latest $EXPECTED). This usually means the latest release has unsatisfiable dependency pins and the resolver backtracked to an older nightly."
+            exit 1
+          fi
+
+      - name: Start Langflow
+        working-directory: ${{ runner.temp }}/fresh
+        env:
+          LANGFLOW_AUTO_LOGIN: "true"
+          LANGFLOW_DATABASE_URL: ${{ matrix.database == 'postgres' && 'postgresql://langflow:langflow_test_pass@localhost:5432/langflow_test' || 'sqlite:///./langflow.db' }}
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          nohup python -m langflow run \
+            --host 127.0.0.1 --port "${LANGFLOW_PORT}" --backend-only \
+            > langflow.log 2>&1 &
+          echo $! > langflow.pid
+
+      - name: Wait for health check
+        working-directory: ${{ runner.temp }}/fresh
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 90); do
+            if curl -fsS -m 2 "http://127.0.0.1:${LANGFLOW_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+              echo "ready after ${i} attempts"
+              exit 0
+            fi
+            if ! kill -0 "$(cat langflow.pid)" 2>/dev/null; then
+              echo "::error::Process died during startup"
+              tail -200 langflow.log
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for ${HEALTH_PATH}"
+          tail -200 langflow.log
+          exit 1
+
+      - name: Assert /api/v1/version matches installed
+        run: |
+          set -euo pipefail
+          REPORTED=$(curl -fsS "http://127.0.0.1:${LANGFLOW_PORT}/api/v1/version" \
+            | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])")
+          echo "reported=$REPORTED installed=$INSTALLED_VERSION"
+          if [ "$REPORTED" != "$INSTALLED_VERSION" ]; then
+            echo "::error::API reports $REPORTED but pip installed $INSTALLED_VERSION"
+            exit 1
+          fi
+
+      - name: Stop Langflow
+        if: always()
+        working-directory: ${{ runner.temp }}/fresh
+        run: |
+          if [ -f langflow.pid ]; then kill "$(cat langflow.pid)" 2>/dev/null || true; fi
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scenario1-${{ matrix.database }}-log
+          path: ${{ runner.temp }}/fresh/langflow.log
+          if-no-files-found: ignore
+
+  uv-pinned:
+    name: "Scenario 2 — uv pinned (${{ matrix.database }})"
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [sqlite, postgres]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: langflow_test
+          POSTGRES_USER: langflow
+          POSTGRES_PASSWORD: langflow_test_pass  # pragma: allowlist secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+
+      - name: Fresh install (pinned to PyPI latest)
+        working-directory: ${{ runner.temp }}
+        env:
+          PIN: ${{ needs.resolve-versions.outputs.pypi_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p fresh && cd fresh
+          uv venv
+          source .venv/bin/activate
+          if [ "${{ matrix.database }}" = "postgres" ]; then
+            uv pip install "langflow-nightly[postgresql]==${PIN}"
+          else
+            uv pip install "langflow-nightly==${PIN}"
+          fi
+          INSTALLED=$(pip show langflow-nightly | awk '/^Version:/ {print $2}')
+          if [ "$INSTALLED" != "$PIN" ]; then
+            echo "::error::Pinned install resolved to $INSTALLED instead of $PIN"
+            exit 1
+          fi
+          echo "INSTALLED_VERSION=$INSTALLED" >> "$GITHUB_ENV"
+
+      - name: Start Langflow
+        working-directory: ${{ runner.temp }}/fresh
+        env:
+          LANGFLOW_AUTO_LOGIN: "true"
+          LANGFLOW_DATABASE_URL: ${{ matrix.database == 'postgres' && 'postgresql://langflow:langflow_test_pass@localhost:5432/langflow_test' || 'sqlite:///./langflow.db' }}
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          nohup python -m langflow run \
+            --host 127.0.0.1 --port "${LANGFLOW_PORT}" --backend-only \
+            > langflow.log 2>&1 &
+          echo $! > langflow.pid
+
+      - name: Wait for health check
+        working-directory: ${{ runner.temp }}/fresh
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 90); do
+            if curl -fsS -m 2 "http://127.0.0.1:${LANGFLOW_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+              echo "ready after ${i} attempts"; exit 0
+            fi
+            if ! kill -0 "$(cat langflow.pid)" 2>/dev/null; then
+              echo "::error::Process died during startup"
+              tail -200 langflow.log
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for ${HEALTH_PATH}"
+          tail -200 langflow.log
+          exit 1
+
+      - name: Assert /api/v1/version matches installed
+        run: |
+          set -euo pipefail
+          REPORTED=$(curl -fsS "http://127.0.0.1:${LANGFLOW_PORT}/api/v1/version" \
+            | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])")
+          if [ "$REPORTED" != "$INSTALLED_VERSION" ]; then
+            echo "::error::API reports $REPORTED but pip installed $INSTALLED_VERSION"
+            exit 1
+          fi
+
+      - name: Stop Langflow
+        if: always()
+        working-directory: ${{ runner.temp }}/fresh
+        run: |
+          if [ -f langflow.pid ]; then kill "$(cat langflow.pid)" 2>/dev/null || true; fi
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scenario2-${{ matrix.database }}-log
+          path: ${{ runner.temp }}/fresh/langflow.log
+          if-no-files-found: ignore
+
+  docker-run:
+    name: "Scenario 3 — docker run (${{ matrix.database }})"
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [sqlite, postgres]
+    steps:
+      - name: Provision Postgres (if needed)
+        if: matrix.database == 'postgres'
+        run: |
+          set -euo pipefail
+          docker network create lftest
+          docker run -d --name lf-pg --network lftest \
+            -e POSTGRES_DB=langflow_test \
+            -e POSTGRES_USER=langflow \
+            -e POSTGRES_PASSWORD=langflow_test_pass \
+            postgres:16
+          for i in $(seq 1 30); do
+            if docker exec lf-pg pg_isready -U langflow >/dev/null 2>&1; then break; fi
+            sleep 2
+          done
+
+      - name: docker run langflow-nightly
+        env:
+          NIGHTLY_TAG: ${{ needs.resolve-versions.outputs.nightly_tag }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.database }}" = "postgres" ]; then
+            docker run -d --name lf --network lftest -p ${LANGFLOW_PORT}:7860 \
+              -e LANGFLOW_DATABASE_URL=postgresql://langflow:langflow_test_pass@lf-pg:5432/langflow_test \
+              -e LANGFLOW_AUTO_LOGIN=true \
+              "${NIGHTLY_TAG}"
+          else
+            docker run -d --name lf -p ${LANGFLOW_PORT}:7860 \
+              -e LANGFLOW_AUTO_LOGIN=true \
+              "${NIGHTLY_TAG}"
+          fi
+
+      - name: Wait for health check
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            if curl -fsS -m 2 "http://127.0.0.1:${LANGFLOW_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+              echo "ready"; exit 0
+            fi
+            STATE=$(docker inspect -f '{{.State.Status}}' lf 2>/dev/null || echo missing)
+            if [ "$STATE" != "running" ]; then
+              echo "::error::Container state: $STATE"
+              docker logs lf 2>&1 | tail -200
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for ${HEALTH_PATH}"
+          docker logs lf 2>&1 | tail -200
+          exit 1
+
+      - name: Assert /api/v1/version matches image
+        env:
+          IMG_VER: ${{ needs.resolve-versions.outputs.image_version }}
+        run: |
+          set -euo pipefail
+          REPORTED=$(curl -fsS "http://127.0.0.1:${LANGFLOW_PORT}/api/v1/version" \
+            | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])")
+          if [ "$REPORTED" != "$IMG_VER" ]; then
+            echo "::error::API reports $REPORTED but image has $IMG_VER installed"
+            exit 1
+          fi
+
+      - name: Container logs (on failure)
+        if: failure()
+        run: |
+          docker logs lf 2>&1 | tail -300 || true
+          if [ "${{ matrix.database }}" = "postgres" ]; then docker logs lf-pg 2>&1 | tail -200 || true; fi
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f lf 2>/dev/null || true
+          docker rm -f lf-pg 2>/dev/null || true
+          docker network rm lftest 2>/dev/null || true
+
+  docker-compose:
+    name: "Scenario 4 — docker compose (${{ matrix.database }})"
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [sqlite, postgres]
+    steps:
+      - name: Write compose file
+        env:
+          NIGHTLY_TAG: ${{ needs.resolve-versions.outputs.nightly_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p compose-test && cd compose-test
+          if [ "${{ matrix.database }}" = "postgres" ]; then
+            cat > compose.yaml <<EOF
+          services:
+            postgres:
+              image: postgres:16
+              environment:
+                POSTGRES_DB: langflow_test
+                POSTGRES_USER: langflow
+                POSTGRES_PASSWORD: langflow_test_pass
+              healthcheck:
+                test: ["CMD", "pg_isready", "-U", "langflow"]
+                interval: 5s
+                timeout: 5s
+                retries: 10
+            langflow:
+              image: ${NIGHTLY_TAG}
+              depends_on:
+                postgres:
+                  condition: service_healthy
+              ports:
+                - "${LANGFLOW_PORT}:7860"
+              environment:
+                LANGFLOW_DATABASE_URL: postgresql://langflow:langflow_test_pass@postgres:5432/langflow_test
+                LANGFLOW_AUTO_LOGIN: "true"
+          EOF
+          else
+            cat > compose.yaml <<EOF
+          services:
+            langflow:
+              image: ${NIGHTLY_TAG}
+              ports:
+                - "${LANGFLOW_PORT}:7860"
+              environment:
+                LANGFLOW_AUTO_LOGIN: "true"
+          EOF
+          fi
+          cat compose.yaml
+
+      - name: docker compose up
+        working-directory: compose-test
+        run: docker compose up -d
+
+      - name: Wait for health check
+        working-directory: compose-test
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            if curl -fsS -m 2 "http://127.0.0.1:${LANGFLOW_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+              echo "ready"; exit 0
+            fi
+            STATE=$(docker compose ps --format json langflow | python3 -c "import json,sys;d=json.loads(sys.stdin.read() or '{}'); print(d.get('State','missing'))" 2>/dev/null || echo missing)
+            if [ "$STATE" != "running" ]; then
+              echo "::error::langflow service state: $STATE"
+              docker compose logs langflow 2>&1 | tail -200
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "::error::Timed out waiting for ${HEALTH_PATH}"
+          docker compose logs 2>&1 | tail -300
+          exit 1
+
+      - name: Assert /api/v1/version matches image
+        env:
+          IMG_VER: ${{ needs.resolve-versions.outputs.image_version }}
+        run: |
+          set -euo pipefail
+          REPORTED=$(curl -fsS "http://127.0.0.1:${LANGFLOW_PORT}/api/v1/version" \
+            | python3 -c "import json,sys;print(json.load(sys.stdin)['version'])")
+          if [ "$REPORTED" != "$IMG_VER" ]; then
+            echo "::error::API reports $REPORTED but image has $IMG_VER installed"
+            exit 1
+          fi
+
+      - name: Compose logs (on failure)
+        if: failure()
+        working-directory: compose-test
+        run: docker compose logs 2>&1 | tail -300 || true
+
+      - name: Tear down
+        if: always()
+        working-directory: compose-test
+        run: docker compose down -v 2>/dev/null || true
+
+  summary:
+    name: Fresh install summary
+    if: always()
+    needs: [resolve-versions, uv-unpinned, uv-pinned, docker-run, docker-compose]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          echo "PyPI version under test:  ${{ needs.resolve-versions.outputs.pypi_version }}"
+          echo "Image version under test: ${{ needs.resolve-versions.outputs.image_version }}"
+          echo "Image tag:                ${{ needs.resolve-versions.outputs.nightly_tag }}"
+          echo "scenario1 (uv unpinned):  ${{ needs.uv-unpinned.result }}"
+          echo "scenario2 (uv pinned):    ${{ needs.uv-pinned.result }}"
+          echo "scenario3 (docker run):   ${{ needs.docker-run.result }}"
+          echo "scenario4 (docker compose): ${{ needs.docker-compose.result }}"
+          if [ "${{ needs.uv-unpinned.result }}" != "success" ] \
+             || [ "${{ needs.uv-pinned.result }}" != "success" ] \
+             || [ "${{ needs.docker-run.result }}" != "success" ] \
+             || [ "${{ needs.docker-compose.result }}" != "success" ]; then
+            echo "::error::One or more fresh-install scenarios failed — see job logs"
+            exit 1
+          fi

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -183,6 +183,9 @@ jobs:
           echo "INSTALLED_VERSION=$INSTALLED" >> "$GITHUB_ENV"
 
       - name: Assert unpinned install did not silently backtrack
+        working-directory: ${{ runner.temp }}/fresh
+        env:
+          EXPECTED: ${{ needs.resolve-versions.outputs.pypi_version }}
         run: |
           set -euo pipefail
           # The signal we care about is "the unpinned resolver picked a version
@@ -191,17 +194,25 @@ jobs:
           # (installed > snapshot) happens naturally if a fresh nightly lands
           # on PyPI between resolve-versions and this step, and shouldn't fail
           # an otherwise healthy release.
-          EXPECTED="${{ needs.resolve-versions.outputs.pypi_version }}"
-          if [ "$INSTALLED_VERSION" = "$EXPECTED" ]; then
-            exit 0
-          fi
-          NEWER=$(printf '%s\n%s\n' "$INSTALLED_VERSION" "$EXPECTED" | sort -V | tail -1)
-          if [ "$NEWER" = "$INSTALLED_VERSION" ]; then
-            echo "::warning::Unpinned install resolved to $INSTALLED_VERSION, which is newer than the snapshot taken at the start of the run ($EXPECTED). A new nightly likely landed mid-run; not a backtrack."
-            exit 0
-          fi
-          echo "::error::Unpinned 'uv pip install langflow-nightly' silently resolved to $INSTALLED_VERSION (older than PyPI latest $EXPECTED). This usually means the latest release has unsatisfiable dependency pins and the resolver backtracked to an older nightly."
-          exit 1
+          #
+          # Uses packaging.version (PEP 440) via the venv's python — the langflow
+          # install in the previous step pulls packaging as a transitive dep, and
+          # PEP 440 ordering is portable (GNU sort -V handles X.Y.Z.devNN but BSD
+          # sort -V does not, so a shell-only check fails on macOS).
+          source .venv/bin/activate
+          python3 - <<'PY'
+          import os, sys
+          from packaging.version import Version
+          installed = Version(os.environ["INSTALLED_VERSION"])
+          expected  = Version(os.environ["EXPECTED"])
+          if installed == expected:
+              sys.exit(0)
+          if installed > expected:
+              print(f"::warning::Unpinned install resolved to {installed}, which is newer than the snapshot taken at the start of the run ({expected}). A new nightly likely landed mid-run; not a backtrack.")
+              sys.exit(0)
+          print(f"::error::Unpinned 'uv pip install langflow-nightly' silently resolved to {installed} (older than PyPI latest {expected}). This usually means the latest release has unsatisfiable dependency pins and the resolver backtracked to an older nightly.")
+          sys.exit(1)
+          PY
 
       - name: Start Langflow
         working-directory: ${{ runner.temp }}/fresh

--- a/.github/workflows/nightly_fresh_install.yml
+++ b/.github/workflows/nightly_fresh_install.yml
@@ -160,7 +160,12 @@ jobs:
           else
             uv pip install "langflow-nightly"
           fi
-          INSTALLED=$(pip show langflow-nightly | awk '/^Version:/ {print $2}')
+          # `uv venv` without --seed doesn't install pip in the venv, so a bare
+          # `pip show ...` here would resolve via PATH to setup-python's base pip
+          # (which can't see what uv installed in the venv). Reading the version
+          # through python -m + importlib.metadata uses the venv's interpreter
+          # and its site-packages — same pattern as db-migration-validation.yml.
+          INSTALLED=$(python -c 'from importlib.metadata import version; print(version("langflow-nightly"))')
           echo "Installed version: $INSTALLED"
           echo "INSTALLED_VERSION=$INSTALLED" >> "$GITHUB_ENV"
 
@@ -278,7 +283,10 @@ jobs:
           else
             uv pip install "langflow-nightly==${PIN}"
           fi
-          INSTALLED=$(pip show langflow-nightly | awk '/^Version:/ {print $2}')
+          # See note in the unpinned job: read the installed version through the
+          # venv's interpreter rather than `pip show`, since `uv venv` doesn't
+          # seed pip and the bare `pip` falls through to setup-python's base pip.
+          INSTALLED=$(python -c 'from importlib.metadata import version; print(version("langflow-nightly"))')
           if [ "$INSTALLED" != "$PIN" ]; then
             echo "::error::Pinned install resolved to $INSTALLED instead of $PIN"
             exit 1
@@ -355,16 +363,23 @@ jobs:
         if: matrix.database == 'postgres'
         run: |
           set -euo pipefail
+          PG_PASS=langflow_test_pass  # pragma: allowlist secret
           docker network create lftest
           docker run -d --name lf-pg --network lftest \
             -e POSTGRES_DB=langflow_test \
             -e POSTGRES_USER=langflow \
-            -e POSTGRES_PASSWORD=langflow_test_pass \
+            -e POSTGRES_PASSWORD="$PG_PASS" \
             postgres:16
           for i in $(seq 1 30); do
-            if docker exec lf-pg pg_isready -U langflow >/dev/null 2>&1; then break; fi
+            if docker exec lf-pg pg_isready -U langflow >/dev/null 2>&1; then
+              echo "postgres ready after $((i*2))s"
+              exit 0
+            fi
             sleep 2
           done
+          echo "::error::Postgres did not become ready in 60s"
+          docker logs lf-pg 2>&1 | tail -100
+          exit 1
 
       - name: docker run langflow-nightly
         env:
@@ -450,7 +465,7 @@ jobs:
               environment:
                 POSTGRES_DB: langflow_test
                 POSTGRES_USER: langflow
-                POSTGRES_PASSWORD: langflow_test_pass
+                POSTGRES_PASSWORD: langflow_test_pass  # pragma: allowlist secret
               healthcheck:
                 test: ["CMD", "pg_isready", "-U", "langflow"]
                 interval: 5s


### PR DESCRIPTION
## Summary

Adds a new CI workflow — `.github/workflows/nightly_fresh_install.yml` — that smoke-tests a freshly published nightly through every channel users consume it from. Complements [#13249](https://github.com/langflow-ai/langflow/pull/13249) (migration validation): that PR exercises *upgrade* paths; this one exercises *fresh installs*.

### Scenarios

Each scenario is exercised twice in a `[sqlite, postgres]` matrix:

| # | Channel | What's tested |
|---|---|---|
| 1 | `uv pip install langflow-nightly` (unpinned) | Resolver picks the PyPI latest, install succeeds, server boots, `/api/v1/version` matches what pip installed. |
| 2 | `uv pip install langflow-nightly==<PyPI latest>` (pinned) | Explicit pin resolves and installs the exact version published to PyPI. |
| 3 | `docker run langflowai/langflow-nightly:latest` | The Docker image labeled `:latest` boots and reports the version it actually ships. |
| 4 | `docker compose up` | Same image, exercised through compose, with optional Postgres service. |

### Failure modes the workflow catches

* **Install/resolver failure** — e.g. a nightly whose deps are unsatisfiable from public indexes (`uv pip install langflow-nightly==<X>` returns `No solution found`).
* **Silent backtrack** — `uv pip install langflow-nightly` (unpinned) resolves to an older nightly while the latest sits broken on PyPI. The job compares `pip show` against the PyPI `info.version` and fails if they disagree.
* **Container fails to boot** — `/health_check` never goes 200, or the container exits during startup.
* **Version drift** — `/api/v1/version` reports a different version than the one actually installed inside the venv/image.
* **PyPI ↔ image desync** — emits a workflow `::warning::` when the image's installed version doesn't match the PyPI latest (expected briefly during a release; a persistent gap means one of the publish steps failed).

### Integration

The workflow exposes both `workflow_call` and `workflow_dispatch`. It is chained into `nightly_build.yml` so every successful nightly release is automatically smoke-tested through all four channels (same pattern as [#13249](https://github.com/langflow-ai/langflow/pull/13249)). The Slack notification job consolidates results from both validation workflows: a failure in either turns the nightly run red and names the failing job.

## Test plan

- [ ] CI on this PR exercises the workflow against the current `langflow-nightly:latest`.
- [ ] Manual `workflow_dispatch` against a known-good and a known-broken nightly tag to confirm both outcomes.
- [ ] First scheduled nightly after merge runs `nightly-fresh-install` end-to-end alongside `db-migration-validation`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests & Chores**
  * Added comprehensive automated testing for fresh nightly releases, verifying installation and functionality across multiple installation methods and database configurations to ensure quality and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
