### PR TITLE
fix: Respect OpenAI embeddings API base for Knowledge Base

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4169,7 +4169,7 @@
         "filename": "src/backend/tests/unit/test_unified_models.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 494
+        "line_number": 517
       }
     ],
     "src/backend/tests/unit/test_user.py": [
@@ -9535,5 +9535,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T16:55:05Z"
+  "generated_at": "2026-05-28T15:17:56Z"
 }

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -536,6 +536,62 @@ def test_get_embeddings_openai_basic(mock_get_class, mock_get_api_key):
     assert kwargs["api_key"] == "sk-test"  # pragma: allowlist secret
 
 
+@pytest.mark.parametrize(
+    ("env_values", "expected_base_url"),
+    [
+        ({"OPENAI_EMBEDDINGS_API_BASE": "http://embeddings.example/v1"}, "http://embeddings.example/v1"),
+        ({"OPENAI_API_BASE": "http://openai-compatible.example/v1"}, "http://openai-compatible.example/v1"),
+        (
+            {
+                "OPENAI_EMBEDDINGS_API_BASE": "http://embeddings.example/v1",
+                "OPENAI_API_BASE": "http://openai-compatible.example/v1",
+            },
+            "http://embeddings.example/v1",
+        ),
+    ],
+)
+@patch("lfx.base.models.unified_models.get_api_key_for_provider")
+@patch("lfx.base.models.unified_models.get_embedding_class")
+def test_get_embeddings_openai_api_base_env_fallback(
+    mock_get_class,
+    mock_get_api_key,
+    monkeypatch,
+    env_values,
+    expected_base_url,
+):
+    mock_get_api_key.return_value = "sk-test"
+    mock_embedding_class = MagicMock()
+    mock_get_class.return_value = mock_embedding_class
+    monkeypatch.delenv("OPENAI_EMBEDDINGS_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    for name, value in env_values.items():
+        monkeypatch.setenv(name, value)
+
+    get_embeddings([_make_openai_embedding_model()], api_key="sk-test")
+
+    kwargs = mock_embedding_class.call_args.kwargs
+    assert kwargs["base_url"] == expected_base_url
+
+
+@patch("lfx.base.models.unified_models.get_api_key_for_provider")
+@patch("lfx.base.models.unified_models.get_embedding_class")
+def test_get_embeddings_openai_explicit_api_base_overrides_env(mock_get_class, mock_get_api_key, monkeypatch):
+    mock_get_api_key.return_value = "sk-test"
+    mock_embedding_class = MagicMock()
+    mock_get_class.return_value = mock_embedding_class
+    monkeypatch.setenv("OPENAI_EMBEDDINGS_API_BASE", "http://embeddings.example/v1")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://openai-compatible.example/v1")
+
+    get_embeddings(
+        [_make_openai_embedding_model()],
+        api_key="sk-test",  # pragma: allowlist secret
+        api_base="http://component.example/v1",
+    )
+
+    kwargs = mock_embedding_class.call_args.kwargs
+    assert kwargs["base_url"] == "http://component.example/v1"
+
+
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 def test_get_embeddings_optional_params_only_added_when_mapped(mock_get_class, mock_get_api_key):

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -271,6 +271,11 @@ def get_embeddings(
     model_name = model_dict.get("name")
     provider = model_dict.get("provider")
     metadata = model_dict.get("metadata", {})
+    api_base_value = _to_str(api_base)
+    if provider == "OpenAI" and not api_base_value:
+        api_base_value = _to_str(os.environ.get("OPENAI_EMBEDDINGS_API_BASE")) or _to_str(
+            os.environ.get("OPENAI_API_BASE")
+        )
 
     # --- resolve API key -----------------------------------------------------
     api_key = unified_models_module.get_api_key_for_provider(user_id, provider, api_key)
@@ -326,7 +331,7 @@ def get_embeddings(
     # Optional parameters - only add when both a value is supplied *and* the
     # provider's param_mapping declares the corresponding key.
     optional_params: dict[str, Any] = {
-        "api_base": _to_str(api_base) or None,
+        "api_base": api_base_value or None,
         "dimensions": int(dimensions) if dimensions else None,
         "chunk_size": int(chunk_size) if chunk_size else None,
         "request_timeout": float(request_timeout) if request_timeout else None,


### PR DESCRIPTION
## Summary

- Resolve OpenAI embeddings `base_url` in the shared `get_embeddings()` helper from an explicit `api_base`, then `OPENAI_EMBEDDINGS_API_BASE`, then `OPENAI_API_BASE`.
- Keep the fallback OpenAI-only so other embedding providers keep their existing endpoint behavior.
- Add regression coverage for embeddings-specific env priority, `OPENAI_API_BASE` fallback, and explicit API base override.

## Root Cause

Knowledge Base ingestion and retrieval call `get_embeddings()` without `api_base`, and the helper only passed `base_url` to `OpenAIEmbeddings` when a caller supplied `api_base` directly. That meant KB query embeddings fell through to the OpenAI SDK default endpoint instead of honoring `OPENAI_EMBEDDINGS_API_BASE`.

Refs #13264.

## Validation

- Confirmed with the attached Jira reproduction log that the current Knowledge Base call path constructs `OpenAIEmbeddings` with no `base_url` when only `OPENAI_EMBEDDINGS_API_BASE` is configured.
- `uv run ruff format src/lfx/src/lfx/base/models/unified_models/instantiation.py src/backend/tests/unit/test_unified_models.py`
- `uv run ruff check src/lfx/src/lfx/base/models/unified_models/instantiation.py src/backend/tests/unit/test_unified_models.py`
- `uv run pytest src/backend/tests/unit/test_unified_models.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenAI embeddings API configuration with support for explicit base URL overrides and environment variable fallbacks.

* **Tests**
  * Added comprehensive unit tests for embeddings configuration behavior.

* **Chores**
  * Updated dependencies and baseline metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->