### PR TITLE
fix(ci): NUL-delimit biome file list so paths with spaces aren't split

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -84,6 +84,9 @@ jobs:
           RELATIVE_FILES=$(echo "$CHANGED_FILES" | sed 's|^src/frontend/||')
 
           cd src/frontend
-          echo "$RELATIVE_FILES" | xargs npx @biomejs/biome check \
-            --files-ignore-unknown=true \
-            --diagnostic-level=error
+          # NUL-delimit so paths containing spaces (e.g. starter-project
+          # specs like "Basic Prompting.spec.ts") aren't split by xargs.
+          printf '%s\n' "$RELATIVE_FILES" | tr '\n' '\0' \
+            | xargs -0 npx @biomejs/biome check \
+              --files-ignore-unknown=true \
+              --diagnostic-level=error


### PR DESCRIPTION
The Run Biome step pipes `$RELATIVE_FILES` into `xargs` unquoted, so any changed-file path containing a space (starter-project specs like `tests/core/integrations/Basic Prompting.spec.ts`) gets tokenised. Biome then errors with 'No such file or directory' on each fragment, and when there are enough such paths the job exits with code 123 from parse failures rather than from real lint output.

### Fix

Pipe NUL-delimited so each line becomes one argument regardless of internal whitespace:

```bash
printf '%s\\n' "$RELATIVE_FILES" | tr '\\n' '\\0' \\
  | xargs -0 npx @biomejs/biome check ...
```

### Repro

On a branch whose diff against the base touches any `tests/core/integrations/*.spec.ts` file (most playwright shards do), the current step prints hundreds of `internalError/io · No such file or directory (os error 2)` diagnostics for path fragments (`Basic`, `Prompting.spec.ts`, etc.) and exits 123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the linting workflow to properly handle file paths containing spaces during code quality checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->