### PR TITLE
fix(traces): full-height trace panel, and status badge position

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
@@ -438,7 +438,7 @@ export function FlowInsightsContent({
       >
         <DialogContent
           className={
-            "right-0 top-[3rem] h-[calc(100dvh-3rem)] w-full max-w-none rounded-l-xl rounded-r-none p-0 sm:w-[80vw] " +
+            "right-0 top-0 h-dvh w-full max-w-none rounded-none p-0 sm:w-[65vw] " +
             "data-[state=open]:animate-in data-[state=closed]:animate-out " +
             "data-[state=open]:slide-in-from-right-1/2 data-[state=closed]:slide-out-to-right-1/2"
           }

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
@@ -48,11 +48,11 @@ export function SpanDetail({ span }: SpanDetailProps) {
       {/* Header */}
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-center gap-2">
-          <h3 className="text-lg font-semibold">{span.name}</h3>
+          <h3 className="min-w-0 flex-1 truncate text-lg font-semibold">{span.name}</h3>
           <Badge
             variant={getStatusVariant(span.status)}
             size="sm"
-            className="h-auto gap-1 px-2 py-0.5"
+            className="h-auto shrink-0 gap-1 px-2 py-0.5"
           >
             <IconComponent
               name={iconName}

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
@@ -48,7 +48,9 @@ export function SpanDetail({ span }: SpanDetailProps) {
       {/* Header */}
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-center gap-2">
-          <h3 className="min-w-0 flex-1 truncate text-lg font-semibold">{span.name}</h3>
+          <h3 className="min-w-0 flex-1 truncate text-lg font-semibold">
+            {span.name}
+          </h3>
           <Badge
             variant={getStatusVariant(span.status)}
             size="sm"


### PR DESCRIPTION
Updated the trace detail panel to fill the full screen height, reduced its width slightly (80vw → 65vw), and removed rounded corners for a cleaner side-panel appearance
Fixed the status badge ("success" / "error") being pushed down when a long span name wrapped to multiple lines — the title now truncates and the badge stays on the same line

## Screenshot
Before
<img width="1550" height="955" alt="Screenshot 2026-05-28 at 1 20 49 PM" src="https://github.com/user-attachments/assets/ae86de78-adfd-421b-b045-a5ab12727e7a" />

After
<img width="1334" height="955" alt="Screenshot 2026-05-28 at 1 18 32 PM" src="https://github.com/user-attachments/assets/c2099fba-9a13-4ea3-80e5-af169f0464a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved trace panel layout with optimized viewport height calculations and responsive sizing adjustments
  * Enhanced span detail headers with better text truncation and layout refinement for improved readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->