### PR TITLE
fix(conditional-router): route Text Input when Case True/False are blank

### DIFF
--- a/src/backend/tests/unit/components/flow_controls/test_conditional_router.py
+++ b/src/backend/tests/unit/components/flow_controls/test_conditional_router.py
@@ -252,7 +252,7 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
             result = component.true_response()
 
             assert isinstance(result, Message)
-            assert result.content == ""
+            assert result.text == ""
             mock_iterate.assert_called_once_with("true_result")
 
     async def test_false_response_condition_false(self, component_class, default_kwargs):
@@ -283,7 +283,7 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
             result = component.false_response()
 
             assert isinstance(result, Message)
-            assert result.content == ""
+            assert result.text == ""
             mock_iterate.assert_called_once_with("false_result")
 
     async def test_true_response_blank_case_message_falls_back_to_input_text(self, component_class, default_kwargs):

--- a/src/backend/tests/unit/components/flow_controls/test_conditional_router.py
+++ b/src/backend/tests/unit/components/flow_controls/test_conditional_router.py
@@ -23,8 +23,8 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
             "operator": "equals",
             "match_text": "test input",
             "case_sensitive": True,
-            "true_case_message": Message(content="true result"),
-            "false_case_message": Message(content="false result"),
+            "true_case_message": Message(text="true result"),
+            "false_case_message": Message(text="false result"),
             "max_iterations": 10,
             "default_route": "true_result",
         }
@@ -223,7 +223,7 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
         component.match_text = "hello"
         component.operator = "equals"
         component.case_sensitive = True
-        component.true_case_message = Message(content="True case")
+        component.true_case_message = Message(text="True case")
 
         with (
             patch.object(component, "iterate_and_stop_once") as mock_iterate,
@@ -262,7 +262,7 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
         component.match_text = "world"
         component.operator = "equals"
         component.case_sensitive = True
-        component.false_case_message = Message(content="False case")
+        component.false_case_message = Message(text="False case")
 
         with patch.object(component, "iterate_and_stop_once") as mock_iterate:
             result = component.false_response()
@@ -285,6 +285,44 @@ class TestConditionalRouterComponent(ComponentTestBaseWithoutClient):
             assert isinstance(result, Message)
             assert result.content == ""
             mock_iterate.assert_called_once_with("false_result")
+
+    async def test_true_response_blank_case_message_falls_back_to_input_text(self, component_class, default_kwargs):
+        """Blank Case True should route the original Text Input on the true branch."""
+        component = await self.component_setup(component_class, default_kwargs)
+        component.input_text = "passthrough text"
+        component.match_text = "passthrough text"
+        component.operator = "equals"
+        component.case_sensitive = True
+        # Unset MessageInput resolves to an empty Message
+        component.true_case_message = Message(text="")
+
+        with (
+            patch.object(component, "iterate_and_stop_once") as mock_iterate,
+            patch.object(type(component), "ctx", new_callable=dict),
+            patch.object(component, "_id", "test_id"),
+        ):
+            result = component.true_response()
+
+            assert isinstance(result, Message)
+            assert result.text == "passthrough text"
+            mock_iterate.assert_called_once_with("false_result")
+
+    async def test_false_response_blank_case_message_falls_back_to_input_text(self, component_class, default_kwargs):
+        """Blank Case False should route the original Text Input on the false branch."""
+        component = await self.component_setup(component_class, default_kwargs)
+        component.input_text = "passthrough text"
+        component.match_text = "no match"
+        component.operator = "equals"
+        component.case_sensitive = True
+        # Unset MessageInput resolves to an empty Message
+        component.false_case_message = Message(text="")
+
+        with patch.object(component, "iterate_and_stop_once") as mock_iterate:
+            result = component.false_response()
+
+            assert isinstance(result, Message)
+            assert result.text == "passthrough text"
+            mock_iterate.assert_called_once_with("true_result")
 
     async def test_update_build_config_regex_operator(self, component_class, default_kwargs):
         """Test update_build_config when operator is regex."""

--- a/src/lfx/src/lfx/components/flow_controls/conditional_router.py
+++ b/src/lfx/src/lfx/components/flow_controls/conditional_router.py
@@ -165,6 +165,19 @@ class ConditionalRouterComponent(Component):
             # 2. Conditional exclusion for persistent routing (doesn't get reset except by this router)
             self.graph.exclude_branch_conditionally(self._id, output_name=route_to_stop)
 
+    def _resolve_case_message(self, case_message: Message | str | None) -> Message:
+        """Return the override case message, falling back to the input text when it is blank.
+
+        ``Case True`` and ``Case False`` are optional overrides. When left blank the
+        ``MessageInput`` resolves to an empty ``Message``, so the original ``Text Input``
+        is routed through instead of an empty message.
+        """
+        if isinstance(case_message, Message) and case_message.text:
+            return case_message
+        if isinstance(case_message, str) and case_message:
+            return Message(text=case_message)
+        return Message(text=self.input_text)
+
     def true_response(self) -> Message:
         result = self.evaluate_condition(
             self.input_text, self.match_text, self.operator, case_sensitive=self.case_sensitive
@@ -175,10 +188,11 @@ class ConditionalRouterComponent(Component):
         force_output = current_iteration >= self.max_iterations and self.default_route == "true_result"
 
         if result or force_output:
-            self.status = self.true_case_message
+            true_message = self._resolve_case_message(self.true_case_message)
+            self.status = true_message
             if not force_output:  # Only stop the other branch if not forcing due to max iterations
                 self.iterate_and_stop_once("false_result")
-            return self.true_case_message
+            return true_message
         self.iterate_and_stop_once("true_result")
         return Message(content="")
 
@@ -188,9 +202,10 @@ class ConditionalRouterComponent(Component):
         )
 
         if not result:
-            self.status = self.false_case_message
+            false_message = self._resolve_case_message(self.false_case_message)
+            self.status = false_message
             self.iterate_and_stop_once("true_result")
-            return self.false_case_message
+            return false_message
 
         self.iterate_and_stop_once("false_result")
         return Message(content="")

--- a/src/lfx/src/lfx/components/flow_controls/conditional_router.py
+++ b/src/lfx/src/lfx/components/flow_controls/conditional_router.py
@@ -194,7 +194,7 @@ class ConditionalRouterComponent(Component):
                 self.iterate_and_stop_once("false_result")
             return true_message
         self.iterate_and_stop_once("true_result")
-        return Message(content="")
+        return Message(text="")
 
     def false_response(self) -> Message:
         result = self.evaluate_condition(
@@ -208,7 +208,7 @@ class ConditionalRouterComponent(Component):
             return false_message
 
         self.iterate_and_stop_once("false_result")
-        return Message(content="")
+        return Message(text="")
 
     def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None) -> dict:
         if field_name == "operator":


### PR DESCRIPTION
## Fixes #13387

### Problem
The **If-Else** component (`ConditionalRouterComponent`) emits a **blank message** when the optional **Case True** / **Case False** fields are left empty.

These two fields are optional overrides — they're meant to *replace* the routed message only when filled in. But when blank, the `MessageInput` resolves to an empty `Message(text="")`, and the matched branch returned that empty message directly. The result: routing works (True/False is chosen correctly), but the output is blank instead of the original **Text Input** that entered the component.

### Fix
Added a small helper, `_resolve_case_message`, that returns the override message when it has content and otherwise falls back to routing `input_text` (the Text Input). Both `true_response()` and `false_response()` now use it on their matched branch.

```python
def _resolve_case_message(self, case_message: Message | str | None) -> Message:
    """Return the override case message, falling back to the input text when it is blank."""
    if isinstance(case_message, Message) and case_message.text:
        return case_message
    if isinstance(case_message, str) and case_message:
        return Message(text=case_message)
    return Message(text=self.input_text)
```

Behavior summary:
- **Case True / Case False filled in** → that message is routed (unchanged behavior).
- **Case True / Case False blank** → the original Text Input is routed to the True/False branch (the expected behavior described in the issue).

### Drive-by cleanup
The non-matched (stopped/excluded) branches returned `Message(content="")`, but `content` is not a `Message` field — it was silently stored as an arbitrary data key, leaving `.text` empty. Changed these to `Message(text="")` so the empty output is a proper empty `Message`.

### Tests
- Added `test_true_response_blank_case_message_falls_back_to_input_text` and `test_false_response_blank_case_message_falls_back_to_input_text` covering the regression.
- Updated existing fixtures to construct case messages with `Message(text=...)` (matching how `MessageInput` actually resolves user input) instead of `Message(content=...)`, and updated the stopped-branch assertions to check `.text`.

### Test plan
- [x] `uv run pytest src/backend/tests/unit/components/flow_controls/test_conditional_router.py` — all pass (54 passed, 4 skipped)
- [x] `ruff format` + `ruff check` clean
- [x] pre-commit hooks pass
