### PR TITLE
fix(db): hold migration advisory lock for create_db_and_tables too

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -112,6 +112,22 @@ def _acquire_migration_lock_or_raise(conn, lock_id: int) -> None:
     raise RuntimeError(msg)
 
 
+def _normalize_sync_postgres_url(database_url: str) -> str:
+    """Return a sync-driver Postgres URL from a possibly async one.
+
+    Strips the ``+asyncpg`` / ``+aiosqlite`` suffix and upgrades the legacy
+    ``postgres://`` scheme to ``postgresql://`` so :func:`sa.create_engine`
+    picks the default sync driver. Centralised so the advisory-lock helper and
+    the table-creation lock path stay in sync with :func:`check_postgresql_version_sync`.
+    """
+    sync_url = database_url
+    if sync_url.startswith("postgres://"):
+        sync_url = "postgresql://" + sync_url.split("://", 1)[1]
+    for async_driver in ("+asyncpg", "+aiosqlite"):
+        sync_url = sync_url.replace(async_driver, "")
+    return sync_url
+
+
 @contextmanager
 def _postgres_migration_lock(database_url: str):
     """Hold a Postgres session-level advisory lock for the duration of the block.
@@ -131,15 +147,7 @@ def _postgres_migration_lock(database_url: str):
         yield
         return
 
-    # Normalise to a sync-compatible URL: strip async drivers so create_engine
-    # picks a sync driver, mirroring check_postgresql_version_sync above.
-    sync_url = database_url
-    if sync_url.startswith("postgres://"):
-        sync_url = "postgresql://" + sync_url.split("://", 1)[1]
-    for async_driver in ("+asyncpg", "+aiosqlite"):
-        sync_url = sync_url.replace(async_driver, "")
-
-    engine = sa.create_engine(sync_url)
+    engine = sa.create_engine(_normalize_sync_postgres_url(database_url))
     try:
         with engine.connect() as conn:
             logger.debug("Acquiring migration advisory lock %s", _MIGRATION_ADVISORY_LOCK_ID)
@@ -176,15 +184,7 @@ def check_postgresql_version_sync(database_url: str) -> None:
 
     from sqlalchemy import create_engine
 
-    # Normalise the async URL to a sync-compatible one.
-    url = database_url
-    if url.startswith("postgres://"):
-        url = "postgresql://" + url.split("://", 1)[1]
-    # Strip async driver suffixes so create_engine picks the default sync driver.
-    for async_driver in ("+asyncpg", "+aiosqlite"):
-        url = url.replace(async_driver, "")
-
-    engine = create_engine(url)
+    engine = create_engine(_normalize_sync_postgres_url(database_url))
     try:
         with engine.connect() as conn:
             row = conn.execute(_PG_VERSION_QUERY).fetchone()
@@ -686,8 +686,34 @@ class DatabaseService(Service):
         await self.create_db_and_tables()
 
     async def create_db_and_tables(self) -> None:
-        async with self.engine.begin() as conn:
-            await conn.run_sync(self._create_db_and_tables)
+        if not self.database_url.startswith(("postgresql", "postgres")):
+            # SQLite / non-PG: original async path; advisory lock does not apply.
+            async with self.engine.begin() as conn:
+                await conn.run_sync(self._create_db_and_tables)
+            return
+
+        # Postgres: serialise CREATE TYPE / CREATE TABLE across workers under
+        # the same advisory lock that protects run_migrations. Without this,
+        # concurrent workers booting against a fresh database race on
+        # ``table.create(checkfirst=True)`` and the losers fail with
+        # ``UniqueViolation`` on ``pg_type_typname_nsp_index``. The lock is
+        # acquired synchronously; run in a worker thread so a contended-lock
+        # poll does not block the event loop.
+        await asyncio.to_thread(self._create_db_and_tables_with_lock)
+
+    def _create_db_and_tables_with_lock(self) -> None:
+        """Postgres path: hold the migration advisory lock for the DDL.
+
+        Opens its own sync engine so the DDL runs on the same driver the lock
+        uses; the application's async engine is unaffected.
+        """
+        with _postgres_migration_lock(self.database_url):
+            sync_engine = sa.create_engine(_normalize_sync_postgres_url(self.database_url))
+            try:
+                with sync_engine.begin() as conn:
+                    self._create_db_and_tables(conn)
+            finally:
+                sync_engine.dispose()
 
     async def teardown(self) -> None:
         await logger.adebug("Tearing down database")

--- a/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
+++ b/src/backend/tests/unit/services/database/test_migration_advisory_lock.py
@@ -158,3 +158,89 @@ def test_postgres_url_normalised_to_sync_driver(raw_url: str, expected_url: str)
         pass
 
     create_engine_mock.assert_called_once_with(expected_url)
+
+
+def test_create_db_and_tables_with_lock_holds_advisory_lock_for_postgres():
+    """The locked sync DDL path acquires the lock, runs the DDL, then releases.
+
+    Concurrent workers booting against a fresh PG raced on ``CREATE TYPE``
+    inside ``create_db_and_tables`` because the advisory lock previously only
+    covered ``run_migrations``. This verifies the new path holds the lock
+    around the DDL.
+    """
+    from langflow.services.database.service import DatabaseService
+
+    lock_engine_mock, lock_conn_mock = _engine_with_conn(scalar_returns=True)
+    ddl_engine_mock = MagicMock()
+    ddl_conn_mock = MagicMock()
+    ddl_engine_mock.begin.return_value.__enter__.return_value = ddl_conn_mock
+
+    service = DatabaseService.__new__(DatabaseService)
+    service.database_url = _PG_URL
+
+    create_db_mock = MagicMock()
+    with (
+        patch(_CREATE_ENGINE_PATH, side_effect=[lock_engine_mock, ddl_engine_mock]) as create_engine_mock,
+        patch.object(DatabaseService, "_create_db_and_tables", staticmethod(create_db_mock)),
+    ):
+        service._create_db_and_tables_with_lock()
+
+    # Two sync engines created: one for the lock, one for the DDL.
+    assert create_engine_mock.call_count == 2
+    # The DDL ran while the lock was held: unlock is the last call on the lock conn.
+    lock_sql = _executed_sql(lock_conn_mock)
+    assert lock_sql[0] == f"SELECT pg_try_advisory_lock({_MIGRATION_ADVISORY_LOCK_ID})"
+    assert lock_sql[-1] == f"SELECT pg_advisory_unlock({_MIGRATION_ADVISORY_LOCK_ID})"
+    # The DDL was passed the DDL engine's connection, not the lock connection.
+    create_db_mock.assert_called_once_with(ddl_conn_mock)
+    # Both engines disposed even on the happy path.
+    lock_engine_mock.dispose.assert_called_once()
+    ddl_engine_mock.dispose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_db_and_tables_uses_lock_on_postgres():
+    """``create_db_and_tables`` dispatches to the locked sync path on Postgres."""
+    from langflow.services.database.service import DatabaseService
+
+    service = DatabaseService.__new__(DatabaseService)
+    service.database_url = _PG_URL
+
+    with patch.object(DatabaseService, "_create_db_and_tables_with_lock") as locked_mock:
+        await service.create_db_and_tables()
+
+    locked_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_db_and_tables_skips_lock_on_sqlite():
+    """SQLite preserves the original async path; the lock helper is never invoked."""
+    from langflow.services.database.service import DatabaseService
+
+    service = DatabaseService.__new__(DatabaseService)
+    service.database_url = _SQLITE_URL
+
+    async_engine = MagicMock()
+    async_conn = MagicMock()
+
+    class _AsyncCM:
+        async def __aenter__(self):
+            return async_conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    async_engine.begin.return_value = _AsyncCM()
+    async_conn.run_sync = MagicMock(return_value=None)
+
+    async def _await_none(*_a, **_kw):
+        return None
+
+    async_conn.run_sync = _await_none  # awaited inside create_db_and_tables
+    service.engine = async_engine
+
+    with patch.object(DatabaseService, "_create_db_and_tables_with_lock") as locked_mock:
+        await service.create_db_and_tables()
+
+    locked_mock.assert_not_called()
+    async_engine.begin.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #13204. The advisory lock added there only wrapped `run_migrations`, but `initialize_database` calls `create_db_and_tables` first. That path runs `table.create(checkfirst=True)` for every SQLModel table, which is a SELECT-then-CREATE that's not atomic. Concurrent workers booting against a fresh Postgres still race here, and the losers crash with `UniqueViolation` on `pg_type_typname_nsp_index` before alembic ever runs.

## Reproduction (without this PR)

Against `postgres:16-alpine` with a fresh volume, N=3 concurrent processes each calling `initialize_database()`:

```
exit codes: [3, 3, 0]

psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
DETAIL:  Key (typname, typnamespace)=(job_status_enum, 2200) already exists.
sqlalchemy.exc.IntegrityError: (psycopg.errors.UniqueViolation) ...
RuntimeError: Error creating table job
RuntimeError: Error creating DB and tables
```

This matches the bug report: 2 of 3 workers exit with code 3, gunicorn halts with `HaltServer`, schema ends up partial. The `\"already exists\"` swallow in `utils.py:31` never matches because `_create_db_and_tables` rewraps the `IntegrityError` as `RuntimeError(\"Error creating table {table}\")` before the guard sees it.

## Fix

Wrap `create_db_and_tables` in the same `_postgres_migration_lock`. On Postgres the DDL now runs in a worker thread so the contended-lock poll does not block the event loop; SQLite preserves the original async path (no advisory locks).

Also extracts `_normalize_sync_postgres_url` so the lock helper, the new locked DDL path, and `check_postgresql_version_sync` stop duplicating the same async-to-sync URL normalisation.

## Verification

Against `postgres:16-alpine` with a fresh volume (volume reset between each run):

```
N=3 -> exit codes: [0, 0, 0]
N=4 -> exit codes: [0, 0, 0, 0]
N=6 -> exit codes: [0, 0, 0, 0, 0, 0]
N=8 -> exit codes: [0, 0, 0, 0, 0, 0, 0, 0]

alembic_version: mb01b2c3d4e5
public tables:   26
```

All workers complete cleanly and converge on the same schema head.

Unit tests: 11 passing (`test_migration_advisory_lock.py`), 3 new covering the locked DDL path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL database initialization reliability through enhanced synchronization during table creation to prevent concurrent access issues.

* **Improvements**
  * Streamlined database connection URL handling and standardized PostgreSQL configuration processing.

* **Tests**
  * Added unit tests for PostgreSQL table creation synchronization behavior and database initialization workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->