### PR TITLE
test: cover cross-user cache pollution on deprecated vertices endpoint (supplied-data path)

### DIFF
--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -386,6 +386,32 @@ async def test_get_vertices_returns_404_for_other_users_private_flow(
     assert response.status_code == 404, response.text
 
 
+async def test_get_vertices_with_supplied_data_returns_404_for_other_users_private_flow(
+    client, added_flow_webhook_test, second_user_headers
+):
+    """A non-owner cannot pollute another user's graph cache via the deprecated supplied-data path.
+
+    Regression for the reported cache-pollution scenario: a second user POSTs
+    attacker-controlled graph ``data`` for someone else's private flow UUID. The
+    owner-or-public ownership guard runs *before* the build-and-cache branch
+    (``build_and_cache_graph_from_data`` -> ``set_cache(str(flow_id), ...)``), so the
+    request fails closed with 404 and no graph is cached under the victim flow id.
+
+    Complements ``test_get_vertices_returns_404_for_other_users_private_flow`` (which
+    exercises the no-data branch) by covering the supplied-data branch specifically.
+    The payload is a schema-valid ``FlowDataRequest`` so the request clears body
+    validation and actually reaches the ownership guard.
+    """
+    flow_id = added_flow_webhook_test["id"]
+    attacker_data = {
+        "nodes": [{"id": "attacker-node", "data": {"type": "AttackerControlled"}}],
+        "edges": [],
+        "viewport": {"x": 1, "y": 2, "zoom": 0.75},
+    }
+    response = await client.post(f"/api/v1/build/{flow_id}/vertices", json=attacker_data, headers=second_user_headers)
+    assert response.status_code == 404, response.text
+
+
 async def test_build_vertex_returns_404_for_other_users_private_flow(
     client, added_flow_webhook_test, second_user_headers
 ):


### PR DESCRIPTION
## Summary

This adds **regression test coverage** for a reported cross-user graph cache pollution issue on the deprecated `POST /api/v1/build/{flow_id}/vertices` endpoint. The endpoint's handler (`retrieve_vertices_order`) accepts caller-supplied graph `data` and writes the resulting graph into the chat cache under `str(flow_id)`; the report showed that an authenticated non-owner could write attacker-controlled graph state under any flow UUID they did not own.

**The code is already remediated on this branch** — no production code change is needed. Both deprecated routes now run an ownership guard **before** the build-and-cache branch:

- `retrieve_vertices_order` (`/build/{flow_id}/vertices`) and `build_vertex` (`/build/{flow_id}/vertices/{vertex_id}`) take a `current_user` parameter, perform an owner-or-public `Flow` lookup, and call `ensure_flow_permission(FlowAction.EXECUTE, ...)` before reaching `build_and_cache_graph_from_data(...)` / `set_cache(str(flow_id), ...)`.
- A non-owner therefore fails closed with `404` (preserving UUID privacy) before any cache write occurs.
- The modern consumer path (`/build/{flow_id}/flow`) is `ensure_flow_permission`-gated as well.

This guard was introduced as part of the OSS authorization foundations work (#13153). Existing tests already cover the cross-user **no-data** path (`test_get_vertices_returns_404_for_other_users_private_flow`, `test_build_vertex_returns_404_for_other_users_private_flow`).

## What this PR adds

A single regression test, `test_get_vertices_with_supplied_data_returns_404_for_other_users_private_flow`, that exercises the **supplied-data branch specifically** — the exact reported vector. A second user POSTs a schema-valid `FlowDataRequest` (attacker-controlled nodes) for another user's private flow and must receive `404`, proving the ownership guard fires before `build_and_cache_graph_from_data` / the cache write and that the cache cannot be polluted under a flow the caller does not own.

This locks in the fix against regression of the precise cache-pollution path, which the existing suite did not explicitly cover.

## Test plan

```
uv run pytest src/backend/tests/unit/test_endpoints.py -k "vertices or build_vertex"
# 8 passed
```

- [x] new test: cross-user + supplied attacker `data` → 404 (no cache write)
- [x] existing cross-user no-data tests still pass (both deprecated routes)
- [x] owner happy path (`test_get_vertices`) still 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced security validation for private flow access controls to ensure unauthorized users receive proper access denial responses without exposing data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->