### PR TITLE
ci: port safe workflow fixes from release-1.10.0 to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,20 @@ jobs:
       ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
+  lint-frontend:
+    needs: [path-filter, set-ci-condition]
+    name: Lint Frontend
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.set-ci-condition.outputs.should-run-ci == 'true' &&
+      (
+        inputs.run-all-tests ||
+        (needs.path-filter.result != 'skipped' &&
+        needs.path-filter.outputs.frontend == 'true')
+      )
+    uses: ./.github/workflows/lint-js.yml
+
   test-frontend-unit:
     needs: [path-filter, set-ci-condition]
     name: Run Frontend Unit Tests
@@ -431,16 +445,22 @@ jobs:
             --report-dir coverage/final
 
       - name: Upload Merged Frontend Coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: coverage/combined/total-frontend-coverage.json
           flags: frontend
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   # https://github.com/langchain-ai/langchain/blob/master/.github/workflows/check_diffs.yml
   ci_success:
     name: "CI Success"
+    # Note: `lint-frontend` is intentionally NOT in this list — the Biome
+    # check runs on every PR and shows up in the checks list, but its failure
+    # does NOT block merge (informational only).
     needs:
       [
         validate-pr-title,

--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -74,12 +74,11 @@ jobs:
         working-directory: migration-test
         env:
           LANGFLOW_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}  # pragma: allowlist secret
-          LANGFLOW_SUPERUSER: admin
-          LANGFLOW_SUPERUSER_PASSWORD: admin123  # pragma: allowlist secret
         run: |
           source .venv/bin/activate
 
           echo "Starting Langflow to initialize database..."
+          # shellcheck disable=SC2016
           timeout 120 bash -c '
             python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
             LANGFLOW_PID=$!
@@ -109,16 +108,25 @@ jobs:
           # Wait for startup
           timeout 60 bash -c 'until curl -f http://127.0.0.1:7860/health_check 2>/dev/null; do sleep 2; done'
 
-          # Create a simple flow via API
+          # Get auth token via auto_login (works under default AUTO_LOGIN=true, no credentials needed)
+          TOKEN=$(curl -fsS http://127.0.0.1:7860/api/v1/auto_login | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "❌ Failed to get authentication token"
+            kill $LANGFLOW_PID
+            exit 1
+          fi
+          echo "✅ Authentication token obtained"
+
+          # Create a witness flow (proves row persistence)
           curl -fsSL -X POST http://127.0.0.1:7860/api/v1/flows/ \
             -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
             -d '{
               "name": "Migration Witness Flow",
               "description": "Test flow to verify data persistence across migration",
               "data": {"nodes": [], "edges": []}
             }' > flow_response.json
 
-          # Verify flow was created
           if ! grep -q '"id"' flow_response.json; then
             echo "❌ Flow creation failed - no id in response"
             cat flow_response.json
@@ -126,11 +134,24 @@ jobs:
           fi
           echo "✅ Witness flow created successfully"
 
+          # Create a witness credential (type=Credential stores encrypted value, exercises encrypted-column migrations)
+          curl -fsSL -X POST http://127.0.0.1:7860/api/v1/variables/ \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"name": "migration_witness_secret", "value": "witness_value_12345", "type": "Credential", "default_fields": []}' > variable_response.json  # pragma: allowlist secret
+
+          if ! grep -q '"id"' variable_response.json; then
+            echo "❌ Credential creation failed - no id in response"
+            cat variable_response.json
+            exit 1
+          fi
+          echo "✅ Witness credential created successfully"
+
           # Stop Langflow
           kill $LANGFLOW_PID
           wait $LANGFLOW_PID 2>/dev/null || true
 
-          echo "Witness data created"
+          echo "Witness data created (flow + credential)"
 
       - name: Upgrade to nightly version
         working-directory: migration-test
@@ -139,6 +160,14 @@ jobs:
 
           NIGHTLY_TAG="${{ inputs.nightly_tag || 'langflowai/langflow-nightly:latest' }}"
           echo "Upgrading to nightly version: $NIGHTLY_TAG"
+
+          # Remove stable distributions before installing nightly.
+          # langflow and langflow-nightly share langflow-base which writes to the
+          # same site-packages/langflow/ namespace. If stable stays installed,
+          # python -m langflow still boots the stable version and no real
+          # nightly migration is exercised (false-positive test).
+          echo "Removing stable langflow to avoid namespace collision with nightly..."
+          uv pip uninstall -y langflow langflow-base || true
 
           # Extract version from Docker tag (format: langflowai/langflow-nightly:v1.10.0.dev20260522)
           if [[ "$NIGHTLY_TAG" == *":"* ]]; then
@@ -151,7 +180,7 @@ jobs:
 
             if [[ "$VERSION" == "latest" ]]; then
               # Install latest nightly from PyPI
-              uv pip install --upgrade langflow-nightly[postgresql]
+              uv pip install --upgrade 'langflow-nightly[postgresql]'
             else
               # Install specific version
               uv pip install --upgrade "langflow-nightly[postgresql]==$VERSION"
@@ -169,12 +198,11 @@ jobs:
         working-directory: migration-test
         env:
           LANGFLOW_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}  # pragma: allowlist secret
-          LANGFLOW_SUPERUSER: admin
-          LANGFLOW_SUPERUSER_PASSWORD: admin123  # pragma: allowlist secret
         run: |
           source .venv/bin/activate
 
           echo "Starting Langflow nightly to run migrations..."
+          # shellcheck disable=SC2016
           timeout 180 bash -c '
             python -m langflow run --host 127.0.0.1 --port 7860 --backend-only > langflow_nightly.log 2>&1 &
             LANGFLOW_PID=$!
@@ -210,14 +238,37 @@ jobs:
 
           timeout 60 bash -c 'until curl -f http://127.0.0.1:7860/health_check 2>/dev/null; do sleep 2; done'
 
-          # Verify witness flow exists
-          curl -f http://127.0.0.1:7860/api/v1/flows/ > flows_after_migration.json
+          # Get auth token via auto_login (works under default AUTO_LOGIN=true, no credentials needed)
+          TOKEN=$(curl -fsS http://127.0.0.1:7860/api/v1/auto_login | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "❌ Failed to get authentication token"
+            kill $LANGFLOW_PID
+            exit 1
+          fi
+          echo "✅ Authentication token obtained"
+
+          # Verify witness flow persisted
+          curl -fsSL --compressed http://127.0.0.1:7860/api/v1/flows/ \
+            -H "Authorization: Bearer $TOKEN" > flows_after_migration.json
 
           if grep -q "Migration Witness Flow" flows_after_migration.json; then
             echo "✅ Witness flow found after migration"
           else
             echo "❌ Witness flow NOT found after migration"
             cat flows_after_migration.json
+            kill $LANGFLOW_PID
+            exit 1
+          fi
+
+          # Verify witness credential persisted (confirms encrypted-column migration ran without data loss)
+          curl -fsSL --compressed http://127.0.0.1:7860/api/v1/variables/ \
+            -H "Authorization: Bearer $TOKEN" > variables_after_migration.json
+
+          if grep -q "migration_witness_secret" variables_after_migration.json; then
+            echo "✅ Witness credential found after migration"
+          else
+            echo "❌ Witness credential NOT found after migration"
+            cat variables_after_migration.json
             kill $LANGFLOW_PID
             exit 1
           fi
@@ -253,8 +304,6 @@ jobs:
         working-directory: docker-migration-test
         run: |  # pragma: allowlist secret
           cat > docker-compose.yml <<'EOF'
-          version: "3.8"
-
           services:
             langflow:
               image: langflowai/langflow:latest
@@ -262,8 +311,6 @@ jobs:
                 - "7860:7860"
               environment:  # pragma: allowlist secret
                 - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow  # pragma: allowlist secret
-                - LANGFLOW_SUPERUSER=admin
-                - LANGFLOW_SUPERUSER_PASSWORD=admin123  # pragma: allowlist secret
               depends_on:
                 postgres:
                   condition: service_healthy
@@ -309,22 +356,43 @@ jobs:
       - name: Create witness flow via API
         working-directory: docker-migration-test
         run: |
+          # Get auth token via auto_login (works under default AUTO_LOGIN=true, no credentials needed)
+          TOKEN=$(curl -fsS http://localhost:7860/api/v1/auto_login | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "❌ Failed to get authentication token"
+            exit 1
+          fi
+          echo "✅ Authentication token obtained"
+
           echo "Creating witness flow..."
           curl -fsSL -X POST http://localhost:7860/api/v1/flows/ \
             -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
             -d '{
               "name": "Docker Migration Witness Flow",
               "description": "Test flow for Docker Compose migration",
               "data": {"nodes": [], "edges": []}
             }' > flow_response.json
 
-          # Verify flow was created
           if ! grep -q '"id"' flow_response.json; then
             echo "❌ Flow creation failed - no id in response"
             cat flow_response.json
             exit 1
           fi
           echo "✅ Witness flow created successfully"
+
+          echo "Creating witness credential (exercises encrypted-column migrations)..."
+          curl -fsSL -X POST http://localhost:7860/api/v1/variables/ \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"name": "migration_witness_secret", "value": "witness_value_12345", "type": "Credential", "default_fields": []}' > variable_response.json  # pragma: allowlist secret
+
+          if ! grep -q '"id"' variable_response.json; then
+            echo "❌ Credential creation failed - no id in response"
+            cat variable_response.json
+            exit 1
+          fi
+          echo "✅ Witness credential created successfully"
 
       - name: Stop stable Langflow (keep PostgreSQL volume)
         working-directory: docker-migration-test
@@ -337,10 +405,15 @@ jobs:
         working-directory: docker-migration-test
         run: |
           NIGHTLY_TAG="${{ inputs.nightly_tag || 'langflowai/langflow-nightly:latest' }}"
-          echo "Updating to nightly: $NIGHTLY_TAG"
+          # Strip 'v' prefix from version part — Docker images are published without it
+          # e.g. langflowai/langflow-nightly:v1.10.0.dev20260522 → langflowai/langflow-nightly:1.10.0.dev20260522
+          VERSION_PART="${NIGHTLY_TAG##*:}"
+          IMAGE_NAME="${NIGHTLY_TAG%%:*}"
+          DOCKER_TAG="${IMAGE_NAME}:${VERSION_PART#v}"
+          echo "Updating to nightly: $DOCKER_TAG"
 
           # Update docker-compose.yml to use nightly image
-          sed -i "s|image: langflowai/langflow:latest|image: $NIGHTLY_TAG|" docker-compose.yml
+          sed -i "s|image: langflowai/langflow:latest|image: $DOCKER_TAG|" docker-compose.yml
 
           cat docker-compose.yml
 
@@ -362,14 +435,35 @@ jobs:
       - name: Verify witness data persisted
         working-directory: docker-migration-test
         run: |
-          echo "Verifying witness flow..."
-          curl -f http://localhost:7860/api/v1/flows/ > flows_after_migration.json
+          # Get auth token via auto_login (works under default AUTO_LOGIN=true, no credentials needed)
+          TOKEN=$(curl -fsS http://localhost:7860/api/v1/auto_login | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "❌ Failed to get authentication token"
+            exit 1
+          fi
+          echo "✅ Authentication token obtained"
+
+          echo "Verifying witness flow persisted..."
+          curl -fsSL --compressed http://localhost:7860/api/v1/flows/ \
+            -H "Authorization: Bearer $TOKEN" > flows_after_migration.json
 
           if grep -q "Docker Migration Witness Flow" flows_after_migration.json; then
             echo "✅ Witness flow found after Docker migration"
           else
             echo "❌ Witness flow NOT found after Docker migration"
             cat flows_after_migration.json
+            exit 1
+          fi
+
+          echo "Verifying witness credential persisted (confirms encrypted-column migration ran without data loss)..."
+          curl -fsSL --compressed http://localhost:7860/api/v1/variables/ \
+            -H "Authorization: Bearer $TOKEN" > variables_after_migration.json
+
+          if grep -q "migration_witness_secret" variables_after_migration.json; then
+            echo "✅ Witness credential found after Docker migration"
+          else
+            echo "❌ Witness credential NOT found after Docker migration"
+            cat variables_after_migration.json
             exit 1
           fi
 

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          # Need full history so biome can diff against the PR base
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -47,7 +49,41 @@ jobs:
           npm install
         if: ${{ steps.setup-node.outputs.cache-hit != 'true' }}
 
-      - name: Run Biome
+      - name: Run Biome on PR-changed files
         run: |
+          # Determine the branch this PR targets (falls back to `main` for
+          # workflow_dispatch / non-PR contexts).
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          echo "=== Debug ==="
+          echo "HEAD:          $(git rev-parse HEAD)"
+          echo "BASE_REF:      $BASE_REF"
+          echo "origin/$BASE_REF: $(git rev-parse "origin/$BASE_REF" 2>/dev/null || echo NOT_FOUND)"
+
+          # Merge-base = the commit where this branch forked off its target.
+          # Diffing against it yields ONLY the files this PR introduced,
+          # ignoring unrelated upstream changes merged into the base since.
+          MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF")
+          echo "MERGE_BASE:    $MERGE_BASE"
+
+          # Collect frontend files modified in this PR. Filter to file types
+          # biome can process (ts/tsx/js/jsx/json/jsonc and the like).
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR \
+            "$MERGE_BASE"...HEAD -- 'src/frontend/' \
+            | grep -E '\.(tsx?|jsx?|c(js|ts)|m(js|ts)|jsonc?)$' \
+            || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No frontend files changed in this PR — skipping biome."
+            exit 0
+          fi
+
+          echo "=== Files to lint ==="
+          echo "$CHANGED_FILES"
+
+          # Biome runs from src/frontend; strip that prefix from paths.
+          RELATIVE_FILES=$(echo "$CHANGED_FILES" | sed 's|^src/frontend/||')
+
           cd src/frontend
-          npx @biomejs/biome check --changed
+          echo "$RELATIVE_FILES" | xargs npx @biomejs/biome check \
+            --files-ignore-unknown=true \
+            --diagnostic-level=error

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -313,7 +313,6 @@ jobs:
       nightly_tag: langflowai/langflow-nightly:${{ needs.create-nightly-tag.outputs.release_tag }}
     secrets: inherit
 
-
   slack-notification:
     name: Send Slack Notification
     needs: [frontend-tests-linux, frontend-tests-windows, backend-unit-tests, release-nightly-build, db-migration-validation]

--- a/.github/workflows/py_autofix.yml
+++ b/.github/workflows/py_autofix.yml
@@ -63,7 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - name: Merge base branch
         run: |

--- a/.github/workflows/test-coverage-advisor.yml
+++ b/.github/workflows/test-coverage-advisor.yml
@@ -1,0 +1,175 @@
+# Advisory-only check: flags PRs that change source code (.py / .ts / .tsx)
+# without touching any test file. It NEVER fails and is NOT a required check,
+# so it cannot block other jobs or the merge — it only posts a sticky PR
+# comment + job summary so the author knows tests appear to be missing.
+name: Test Coverage Advisor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Dedicated concurrency group so this never cancels or queues behind CI.
+concurrency:
+  group: test-coverage-advisor-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  advise:
+    name: Test Coverage Advisor
+    # Skip drafts to avoid noise; they re-run on "ready_for_review".
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # Full history so merge-base against the PR target works.
+          fetch-depth: 0
+
+      - name: Detect missing tests
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch --no-tags --depth=50 origin "$BASE_REF" || true
+          MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF" || git rev-parse HEAD~1)
+
+          echo "BASE_REF=$BASE_REF"
+          echo "MERGE_BASE=$MERGE_BASE"
+
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE"...HEAD || true)
+          echo "=== Changed files ==="
+          echo "$CHANGED"
+
+          # --- Backend Python ---------------------------------------------
+          # Source: .py under src/backend or src/lfx, excluding tests,
+          # migrations and dunder/init plumbing.
+          PY_SRC=$(echo "$CHANGED" \
+            | grep -E '^(src/backend|src/lfx)/.*\.py$' \
+            | grep -Ev '(^|/)tests?/' \
+            | grep -Ev '(^|/)(test_[^/]+|conftest)\.py$' \
+            | grep -Ev '/alembic/versions/' \
+            | grep -Ev '/__init__\.py$' \
+            || true)
+          PY_TEST=$(echo "$CHANGED" \
+            | grep -E '\.py$' \
+            | grep -E '((^|/)tests?/|(^|/)test_[^/]+\.py$|(^|/)conftest\.py$)' \
+            || true)
+
+          # --- Frontend TS/TSX --------------------------------------------
+          # Source: .ts/.tsx under src/frontend/src, excluding *.test.* /
+          # *.spec.* / __tests__ and type declaration files.
+          FE_SRC=$(echo "$CHANGED" \
+            | grep -E '^src/frontend/src/.*\.(ts|tsx)$' \
+            | grep -Ev '\.(test|spec)\.(ts|tsx)$' \
+            | grep -Ev '(^|/)__tests__/' \
+            | grep -Ev '\.d\.ts$' \
+            || true)
+          FE_TEST=$(echo "$CHANGED" \
+            | grep -E '\.(ts|tsx)$' \
+            | grep -E '(^src/frontend/tests/|\.(test|spec)\.(ts|tsx)$|(^|/)__tests__/)' \
+            || true)
+
+          need_be=false
+          need_fe=false
+          [ -n "$PY_SRC" ] && [ -z "$PY_TEST" ] && need_be=true
+          [ -n "$FE_SRC" ] && [ -z "$FE_TEST" ] && need_fe=true
+
+          {
+            echo "need_be=$need_be"
+            echo "need_fe=$need_fe"
+          } >> "$GITHUB_OUTPUT"
+
+          # Multiline outputs for the comment body.
+          {
+            echo "py_src<<EOF"
+            echo "$PY_SRC"
+            echo "EOF"
+            echo "fe_src<<EOF"
+            echo "$FE_SRC"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build advisory message
+        id: msg
+        shell: bash
+        run: |
+          set -euo pipefail
+          NEED_BE="${{ steps.detect.outputs.need_be }}"
+          NEED_FE="${{ steps.detect.outputs.need_fe }}"
+
+          BODY_FILE="$(mktemp)"
+          echo '<!-- test-coverage-advisor -->' > "$BODY_FILE"
+
+          if [ "$NEED_BE" != "true" ] && [ "$NEED_FE" != "true" ]; then
+            {
+              echo '### ✅ Test Coverage Advisor'
+              echo
+              echo 'No source changes detected without accompanying tests. Thanks for keeping coverage up! 🎉'
+              echo
+              echo '> _Advisory check only — never blocks merge._'
+            } >> "$BODY_FILE"
+          else
+            {
+              echo '### ⚠️ Test Coverage Advisor — tests appear to be missing'
+              echo
+              echo 'This PR changes source code but does **not** add or modify any test files.'
+              echo 'This is an **advisory** check: it will **not** block this PR or any other job —'
+              echo 'please add tests if the change is testable.'
+              echo
+            } >> "$BODY_FILE"
+            if [ "$NEED_BE" = "true" ]; then
+              {
+                echo '#### Backend (Python) — no `test_*.py` / `tests/` change found'
+                echo '```'
+                echo '${{ steps.detect.outputs.py_src }}'
+                echo '```'
+              } >> "$BODY_FILE"
+            fi
+            if [ "$NEED_FE" = "true" ]; then
+              {
+                echo '#### Frontend (TS/TSX) — no `*.test.*` / `*.spec.*` / `tests/` change found'
+                echo '```'
+                echo '${{ steps.detect.outputs.fe_src }}'
+                echo '```'
+              } >> "$BODY_FILE"
+            fi
+            {
+              echo
+              echo '> _Advisory check only — it always passes and is never a required status._'
+            } >> "$BODY_FILE"
+          fi
+
+          # Mirror into the run's Job Summary (works even on fork PRs).
+          cat "$BODY_FILE" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing advisory comment
+        id: find
+        uses: peter-evans/find-comment@v3
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- test-coverage-advisor -->"
+
+      - name: Upsert advisory comment
+        uses: peter-evans/create-or-update-comment@v4
+        # Fork PRs get a read-only token — don't fail the run if so.
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: ${{ steps.msg.outputs.body_file }}
+          edit-mode: replace
+
+      - name: Always succeed
+        # Explicit: this job never blocks anything.
+        run: 'echo "Advisory check complete — this status is informational only."'

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -227,8 +227,22 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
 
       - name: Install Frontend Dependencies
         run: npm ci
@@ -298,8 +312,23 @@ jobs:
         id: setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: ./src/frontend/package-lock.json
+
+      # npm caching is decoupled from setup-node so a transient cache-service
+      # hiccup (frequent on Windows runners) never fails the job. See #25 / #1.
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ hashFiles('src/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
+
       - name: Install Frontend Dependencies
         run: npm ci
         working-directory: ./src/frontend
@@ -308,6 +337,7 @@ jobs:
       - name: Cache Playwright Browsers
         id: cache-playwright
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium-${{ runner.os }}
@@ -348,7 +378,12 @@ jobs:
       - name: Execute Playwright Tests
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 12
+          # Bumped from 12 → 18 minutes. Shard 38 carries all four
+          # starter-projects-shardN tests + the sentiment streaming test;
+          # iterating 8 templates per test under Linux nightly load
+          # consistently runs past 12 minutes once a single iteration
+          # triggers a per-test Playwright retry.
+          timeout_minutes: 18
           max_attempts: 2
           command: |
             cd src/frontend
@@ -361,6 +396,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: blob-report-${{ runner.os }}-${{ matrix.shardIndex }}
@@ -370,6 +406,7 @@ jobs:
 
       - name: Upload Playwright Coverage Artifact
         if: always() && hashFiles('src/frontend/coverage/playwright/**') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: playwright-coverage-${{ matrix.shardIndex }}

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -60,6 +60,7 @@ EXPECTED_FIELDS = {
     # CacheSettings
     "cache_type",
     "cache_expire",
+    "cache_dir",
     "langchain_cache",
     "redis_host",
     "redis_port",


### PR DESCRIPTION
## What

Reconciles the workflow/CI improvements that landed on `release-1.10.0` back into `main` — **excluding** workflows that depend on release-only features not yet present on `main`. Companion to the release-direction sync PR.

3-way merged from the common ancestor; verified this PR introduces **zero** references to release-only paths.

## Ported (no release-only dependencies)

- **`test-coverage-advisor.yml`** *(new)* — advisory-only check, fully self-contained
- **`db-migration-validation.yml`** — the #13249 enhancements
- **`ci.yml`, `nightly_build.yml`, `lint-js.yml`, `py_autofix.yml`, `typescript_test.yml`** — general CI fixes

(`cross-platform-test.yml` and `python_test.yml` reconciled to no-ops — main was already current.)

## Held back (depend on features that only exist on `release-1.10.0`)

These reference paths/scripts that **do not exist on `main`** yet, so they are intentionally **not** ported until `release-1.10.0` ships:

| Workflow | Release-only dependency |
|---|---|
| `extension-migration-checks.yml` | `src/lfx/.../extension/`, `src/bundles/`, `scripts/migrate/`, `BUNDLE_API.md` |
| `gp-backend-check.yml` | `scripts/gp/{bake_note_keys,extract_backend_strings}.py`, backend `locales/en.json` |
| `regression-stub.yml` | `regressions/` tracking dir |
| `gp-download.yml` / `gp-upload.yml` (backend-translation steps) | `scripts/gp/{download,upload}.py` |

These will converge with `main` once `release-1.10.0` merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test coverage advisor providing PR feedback on test coverage gaps.

* **Improvements**
  * Enhanced TypeScript test execution speed with npm dependency caching.
  * Strengthened CI/CD workflow resilience and error handling.
  * Improved frontend linting with better change detection.
  * Updated database migration validation with enhanced authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->