### PR TITLE
fix: Remove long comments for bundle deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,20 +19,8 @@ maintainers = [
 dependencies = [
     "langflow-base[complete]>=0.10.0",
     # langflow-extensions:bundle-deps-start
-    # Bundle pilot: lfx-duckduckgo ships the DuckDuckGoSearchComponent
-    # as a standalone Extension distribution.  Listed as a regular dep so
-    # ``pip install langflow`` still pulls the component in -- there must
-    # be no user-visible change at install time.
     "lfx-duckduckgo>=0.1.0",
-    # Second pilot port (validates src/bundles/PORTING.md): lfx-arxiv ships
-    # ArXivComponent as a standalone Bundle.  Same regular-dep rationale --
-    # ``pip install langflow`` keeps shipping the arxiv component as before.
     "lfx-arxiv>=0.1.0",
-    # Third pilot port: lfx-ibm ships the three IBM components --
-    # DB2VectorStoreComponent (with its DB2VS LangChain-compatible vector
-    # store), WatsonxAIComponent, and WatsonxEmbeddingsComponent -- as a
-    # single standalone Bundle.  Same regular-dep rationale --
-    # ``pip install langflow`` keeps shipping the IBM components as before.
     "lfx-ibm>=0.1.0",
     # langflow-extensions:bundle-deps-end
 ]


### PR DESCRIPTION
This pull request makes a minor change to the `pyproject.toml` file by removing explanatory comments about bundled extension dependencies. The dependencies themselves remain unchanged, so there is no impact on installation or functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal dependency bundling configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->