### PR TITLE
test(e2e): Replace non-terminal waits to fix flaky Windows specs

### DIFF
--- a/src/frontend/tests/core/integrations/assistant-panel-integration.spec.ts
+++ b/src/frontend/tests/core/integrations/assistant-panel-integration.spec.ts
@@ -58,20 +58,25 @@ test.describe("Assistant Panel Integration", { tag: ["@release"] }, () => {
       page.getByTestId("assistant-message-user").first(),
     ).toContainText("uppercase");
 
-    // Wait for component result OR for an assistant message wrapper to mount.
-    // page.waitForFunction is capped at actionTimeout=20s (PLAYWRIGHT_RULE #4),
-    // so we use locator.waitFor which respects its own timeout.
-    await Promise.race([
-      page
-        .getByTestId("assistant-component-result")
-        .waitFor({ state: "visible", timeout: 150000 }),
-      page
-        .getByTestId("assistant-message-assistant")
-        .last()
-        .waitFor({ state: "visible", timeout: 150000 }),
+    // Wait for a TERMINAL generation state before branching. With a real LLM
+    // the run is non-deterministic: it either builds a component (the
+    // component-result card renders) or answers with plain text (the input
+    // re-enables). Both are terminal. We must NOT race on
+    // `assistant-message-assistant` — that wrapper mounts MID-STREAM, before the
+    // component card renders and before the input re-enables, so branching on it
+    // checks `componentResult.count()` too early and trips on the still-disabled
+    // "Generating component..." textarea.
+    //
+    // `Promise.any` resolves on the FIRST terminal signal and only rejects if
+    // BOTH time out (a truly hung generation). `locator.waitFor` /
+    // `expect().toBeEnabled()` respect their own timeouts (page.waitForFunction
+    // would be capped at actionTimeout=20s per PLAYWRIGHT_RULE #4).
+    const componentResult = page.getByTestId("assistant-component-result");
+    await Promise.any([
+      componentResult.waitFor({ state: "visible", timeout: 150000 }),
+      expect(textarea).toBeEnabled({ timeout: 150000 }),
     ]);
 
-    const componentResult = page.getByTestId("assistant-component-result");
     const hasComponentResult = (await componentResult.count()) > 0;
 
     if (hasComponentResult) {

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -76,6 +76,17 @@ test(
     expect(cleanCode).not.toEqual(newCode);
     await setAceEditorValue(page, newCode);
     await page.locator('//*[@id="checkAndSaveBtn"]').click();
+
+    // Wait for the code modal to CLOSE before validating the node. The modal
+    // only closes on a successful save (processDynamicField → setOpen(false));
+    // if validation fails it stays open showing an error. Asserting the close
+    // first (a) confirms the new code actually committed, and (b) makes a save
+    // failure surface here with a clear signal instead of downstream as a
+    // confusing stale-slider value. On a slow Windows runner the node re-render
+    // also lags the click, so this doubles as the settle wait.
+    await expect(page.locator('//*[@id="checkAndSaveBtn"]')).toBeHidden({
+      timeout: 15000,
+    });
     await adjustScreenView(page);
 
     await mutualValidation(page);
@@ -121,16 +132,21 @@ test(
 // and fires the `change` event that react-ace listens to — which is what
 // updates the React `code` state that gets POSTed on save.
 async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
-  const expectedNewlines = (newCode.match(/\n/g) || []).length;
+  // Normalize to LF before filling. A Windows checkout (autocrlf) or the
+  // extract→replace round-trip can introduce CRLF; feeding mixed line endings
+  // through Ace's hidden textarea has produced a saved buffer that diverges
+  // from the asserted code on Windows. LF round-trips identically everywhere.
+  const normalizedCode = newCode.replace(/\r\n/g, "\n");
+  const expectedNewlines = (normalizedCode.match(/\n/g) || []).length;
   if (expectedNewlines < 10) {
     throw new Error(
-      `setAceEditorValue: newCode has only ${expectedNewlines} newlines (length ${newCode.length}); upstream extractAndCleanCode likely lost newlines.`,
+      `setAceEditorValue: newCode has only ${expectedNewlines} newlines (length ${normalizedCode.length}); upstream extractAndCleanCode likely lost newlines.`,
     );
   }
 
   await page.locator("textarea").last().press("ControlOrMeta+a");
   await page.keyboard.press("Backspace");
-  await page.locator("textarea").last().fill(newCode);
+  await page.locator("textarea").last().fill(normalizedCode);
 
   // Wait for the change to propagate into the controlled React state. The
   // `#codeValue` mirror is rendered by `<Input>` (single-line), so browsers
@@ -143,8 +159,13 @@ async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
 }
 
 async function mutualValidation(page: Page) {
+  // Longer timeout on the first post-save assertion: the slider only reflects
+  // the new range_spec (min=3, which clamps the preserved value to 3.00) once
+  // the node has fully re-rendered with the saved code. That re-render lags on
+  // a slow Windows runner; the default 5s poll can read the pre-save value.
   await expect(page.getByTestId("default_slider_display_value")).toHaveText(
     "3.00",
+    { timeout: 15000 },
   );
   await expect(page.getByTestId("min_label")).toHaveText("test");
   await expect(page.getByTestId("max_label")).toHaveText("test2");

--- a/src/frontend/tests/utils/clean-all-flows.ts
+++ b/src/frontend/tests/utils/clean-all-flows.ts
@@ -1,9 +1,39 @@
 import { Page } from "playwright/test";
 
 export const cleanAllFlows = async (page: Page) => {
-  let emptyPageDescription = page.getByTestId("empty_page_description");
-  while ((await emptyPageDescription.count()) === 0) {
-    await page.getByTestId("home-dropdown-menu").first().click();
+  const emptyPageDescription = page.getByTestId("empty_page_description");
+  const dropdownMenu = page.getByTestId("home-dropdown-menu");
+
+  // Delete every flow until the global empty state renders. Each iteration
+  // first waits for the projects list to settle into a KNOWN terminal state —
+  // the empty marker OR at least one flow card — before acting.
+  //
+  // Why: on a slow runner the list can still be mounting when the loop runs.
+  // The previous version blindly clicked `home-dropdown-menu`; with no card
+  // present yet that click hung for the full 20s action timeout (the observed
+  // CI deadlock). Waiting for a terminal state first removes the race; the
+  // iteration cap makes a genuinely stuck view fail fast with a clear
+  // downstream assertion instead of looping forever.
+  const MAX_DELETIONS = 50;
+  for (let i = 0; i < MAX_DELETIONS; i++) {
+    if ((await emptyPageDescription.count()) > 0) return;
+
+    try {
+      await Promise.any([
+        emptyPageDescription.waitFor({ state: "visible", timeout: 15000 }),
+        dropdownMenu.first().waitFor({ state: "visible", timeout: 15000 }),
+      ]);
+    } catch {
+      // Neither the empty marker nor a flow card appeared — the page is in an
+      // unexpected view (not the projects home). Stop here and let the
+      // caller's own assertions surface the real problem.
+      return;
+    }
+
+    // The settle wait may have resolved because the empty state arrived.
+    if ((await emptyPageDescription.count()) > 0) return;
+
+    await dropdownMenu.first().click();
     await page.getByTestId("btn_delete_dropdown_menu").first().click();
     await page
       .getByTestId("btn_delete_delete_confirmation_modal")


### PR DESCRIPTION
## Objective
Stop two assistant-suite Playwright specs from flaking on Windows/CI by waiting on real terminal states instead of transient ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability for component generation and approval workflows by refining waiting logic to handle asynchronous streaming behavior more effectively and prevent premature assertions during mid-stream operations.
  * Enhanced test cleanup utility with bounded deletion constraints and improved page state detection, providing explicit failure-fast behavior to reduce timeout-related race condition flakiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->