### PR TITLE
fix: Resolve API keys from global variable before .env

### DIFF
--- a/src/backend/tests/unit/test_credential_resolution.py
+++ b/src/backend/tests/unit/test_credential_resolution.py
@@ -168,6 +168,56 @@ class TestGetApiKeyForProviderDbFallback:
         assert result is None
 
 
+class TestExplicitVarNameDbPrecedence:
+    """A var-name api_key must resolve the user's DB global variable before env.
+
+    Production bug (P2): .env held an old/revoked OPENAI_API_KEY; the user added
+    a valid key as a DB global variable via Settings → Global Variables. A flow's
+    Agent (which resolves via load_from_db) used the valid DB key, but the
+    Assistant resolved the api_key NAME env-first and authenticated with the
+    revoked .env key → 401. Global variables are per-user and encrypted; the
+    env read silently bypassed that boundary.
+    """
+
+    @patch("lfx.base.models.unified_models.credentials.run_until_complete")
+    def test_should_prefer_db_global_variable_over_env_for_explicit_var_name(self, mock_run, monkeypatch):
+        user_id = str(uuid4())
+        # The user's valid key, stored as a DB global variable (SecretStr).
+        mock_run.return_value = SecretStr("sk-db-valid")
+        # The stale/revoked key in .env that must NOT win.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-revoked")
+
+        from lfx.base.models.unified_models.credentials import get_api_key_for_provider
+
+        result = get_api_key_for_provider(user_id, "OpenAI", "OPENAI_API_KEY")
+
+        assert result == "sk-db-valid"
+
+    @patch("lfx.base.models.unified_models.credentials.run_until_complete")
+    def test_should_fallback_to_env_for_var_name_when_db_has_no_value(self, mock_run, monkeypatch):
+        # Regression guard: DB-first must still fall back to env when the user
+        # has no such DB variable (the value the .env provides is the only one).
+        user_id = str(uuid4())
+        mock_run.return_value = None
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-fallback")
+
+        from lfx.base.models.unified_models.credentials import get_api_key_for_provider
+
+        result = get_api_key_for_provider(user_id, "OpenAI", "OPENAI_API_KEY")
+
+        assert result == "sk-env-fallback"
+
+    def test_should_use_env_for_var_name_when_no_user_id(self, monkeypatch):
+        # lfx run (no user): no DB to consult, so the env var is the source.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-only")
+
+        from lfx.base.models.unified_models.credentials import get_api_key_for_provider
+
+        result = get_api_key_for_provider(None, "OpenAI", "OPENAI_API_KEY")
+
+        assert result == "sk-env-only"
+
+
 class TestGetAllVariablesForProviderDbFallback:
     """Tests for get_all_variables_for_provider when DB lookup yields nothing.
 

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -31,11 +31,14 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
     # stringification. Unwrap here because provider clients need the raw value.
     api_key = secret_value_to_str(api_key, strip=True)
 
-    # Resolve variable name (canonical or custom e.g. MY_OPENAI_API_KEY) from env or global vars
+    # Resolve variable name (canonical or custom e.g. MY_OPENAI_API_KEY) from
+    # global vars or env. The user's per-user, encrypted DB global variable is
+    # the source of truth (it's what the Agent component resolves via
+    # load_from_db) and MUST win over a process-wide ``.env`` value — otherwise
+    # a stale/revoked .env key silently shadows the key the user configured in
+    # the UI (and, in multi-tenant deploys, every user shares a server-wide env
+    # key). Env is the fallback for the no-user (lfx run) / no-DB-value case.
     def _resolve_var_name(var_name: str) -> str | None:
-        env_value = os.environ.get(var_name)
-        if env_value and env_value.strip():
-            return env_value.strip()
         if user_id and not (isinstance(user_id, str) and user_id == "None"):
 
             async def _get_by_var_name():
@@ -57,6 +60,9 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
             value = secret_value_to_str(value, strip=True)
             if value:
                 return value
+        env_value = os.environ.get(var_name)
+        if env_value and env_value.strip():
+            return env_value.strip()
         return None
 
     if api_key and api_key.strip():


### PR DESCRIPTION
## Objective
Make the Assistant resolve a provider API key from the user's encrypted global variable before falling back to .env — the same source the Agent component uses — so a stale/revoked .env key no longer shadows it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added comprehensive test coverage for credential resolution with explicit variable names, verifying proper precedence of user database variables over environment variables and correct fallback behavior.

* **Refactor**
  - Enhanced clarity of credential resolution logic with improved documentation describing the precedence order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->