### PR TITLE
fix(tracing): warn clearly when LangWatch is unavailable on Python 3.14 (Docker)

### DIFF
--- a/docs/docs/Develop/integrations-langwatch.mdx
+++ b/docs/docs/Develop/integrations-langwatch.mdx
@@ -7,6 +7,12 @@ slug: /integrations-langwatch
 
 ## Integrate LangWatch observability
 
+:::note LangWatch is unavailable in the default Docker images
+The official Langflow Docker images (`langflowai/langflow` and `langflowai/langflow-nightly`) run on Python 3.14, and the `langwatch` package doesn't yet support Python 3.14 (it requires Python `<3.14`). As a result, LangWatch tracing is **not available in the default Docker images** even when `LANGWATCH_API_KEY` is set. Langflow logs a warning on the first flow run and continues without LangWatch tracing.
+
+To use LangWatch, run Langflow on Python 3.10–3.13, such as the PyPI distribution (`pip install langflow`) or the Langflow desktop app. If you need a container, build a custom image on a Python 3.10–3.13 base.
+:::
+
 To integrate with Langflow, add your LangWatch API key as a Langflow environment variable:
 
 1. Get a LangWatch API key from your LangWatch account.

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 import nanoid
@@ -27,6 +28,9 @@ if TYPE_CHECKING:
 class LangWatchTracer(BaseTracer):
     flow_id: str
     tracer_provider = None
+    # Guards the missing-``langwatch``-package warning so it is logged once per process
+    # rather than on every flow run (a tracer instance is created per run).
+    _missing_dependency_warned = False
 
     def __init__(self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID):
         self.trace_name = trace_name
@@ -96,9 +100,39 @@ class LangWatchTracer(BaseTracer):
 
             get_http_instrumentation_manager().enable(self.tracer_provider)
         except ImportError as e:
-            logger.exception(f"{e}")
+            self._warn_langwatch_unavailable()
+            logger.debug(f"LangWatch tracing disabled; 'langwatch' import failed: {e}")
             return False
         return True
+
+    @classmethod
+    def _warn_langwatch_unavailable(cls) -> None:
+        """Log a single actionable warning when the optional ``langwatch`` package is missing.
+
+        ``LANGWATCH_API_KEY`` is set (so the user expects LangWatch), but ``langwatch`` could
+        not be imported. The most common cause is running on Python 3.14+, where ``langwatch``
+        is unavailable because it caps ``requires-python`` at ``<3.14`` -- which is the case for
+        the official Langflow Docker images. Warn only once to avoid log spam, since a tracer
+        instance is created on every flow run.
+        """
+        if cls._missing_dependency_warned:
+            return
+        cls._missing_dependency_warned = True
+        if sys.version_info >= (3, 14):
+            logger.warning(
+                "LANGWATCH_API_KEY is set but the 'langwatch' package is not installed, so "
+                "LangWatch tracing is disabled. 'langwatch' does not yet support Python "
+                f"{sys.version_info.major}.{sys.version_info.minor} (it requires Python <3.14), so "
+                "it is excluded from Python 3.14+ environments, including the official Langflow "
+                "Docker images. To enable LangWatch tracing, run Langflow on Python 3.10-3.13 "
+                "(for example via 'pip install langflow')."
+            )
+        else:
+            logger.warning(
+                "LANGWATCH_API_KEY is set but the 'langwatch' package is not installed, so "
+                "LangWatch tracing is disabled. Install it with 'pip install langwatch' or "
+                "'pip install \"langflow-base[langwatch]\"'."
+            )
 
     @override
     def add_trace(

--- a/src/backend/tests/unit/services/tracing/test_langwatch.py
+++ b/src/backend/tests/unit/services/tracing/test_langwatch.py
@@ -1,0 +1,72 @@
+"""Unit tests for the LangWatch tracer's handling of a missing ``langwatch`` package.
+
+``langwatch`` is an optional dependency that caps ``requires-python`` at ``<3.14`` upstream,
+so it is excluded from Python 3.14+ environments such as the official Langflow Docker images.
+When ``LANGWATCH_API_KEY`` is set but the package cannot be imported, the tracer must disable
+itself gracefully and emit a single actionable warning instead of failing silently.
+"""
+
+import sys
+import uuid
+from unittest.mock import patch
+
+import pytest
+from langflow.services.tracing import langwatch as langwatch_module
+from langflow.services.tracing.langwatch import LangWatchTracer
+
+
+@pytest.fixture(autouse=True)
+def _reset_langwatch_state():
+    """Reset the shared class-level state so tests don't leak into each other."""
+    original_warned = LangWatchTracer._missing_dependency_warned
+    original_provider = LangWatchTracer.tracer_provider
+    LangWatchTracer._missing_dependency_warned = False
+    LangWatchTracer.tracer_provider = None
+    yield
+    LangWatchTracer._missing_dependency_warned = original_warned
+    LangWatchTracer.tracer_provider = original_provider
+
+
+def _make_tracer() -> LangWatchTracer:
+    return LangWatchTracer(
+        trace_name="test flow - abc123",
+        trace_type="chain",
+        project_name="test",
+        trace_id=uuid.uuid4(),
+    )
+
+
+def test_tracer_disabled_and_warns_once_when_package_missing(monkeypatch):
+    """API key set + ``langwatch`` unimportable -> tracer not ready, warn exactly once.
+
+    Forcing ``import langwatch`` to fail mirrors the Python 3.14 Docker images, where the
+    package is absent. The warning must fire once even across multiple flow runs (each run
+    constructs a fresh tracer).
+    """
+    monkeypatch.setenv("LANGWATCH_API_KEY", "test-key")  # pragma: allowlist secret
+    # A ``None`` entry in ``sys.modules`` makes ``import langwatch`` raise ImportError,
+    # even when the package is genuinely installed in the local (Python <3.14) test env.
+    monkeypatch.setitem(sys.modules, "langwatch", None)
+
+    with patch.object(langwatch_module.logger, "warning") as mock_warning:
+        tracer1 = _make_tracer()
+        tracer2 = _make_tracer()
+
+    assert tracer1.ready is False
+    assert tracer2.ready is False
+
+    mock_warning.assert_called_once()
+    message = mock_warning.call_args.args[0]
+    assert "LANGWATCH_API_KEY" in message
+    assert "langwatch" in message
+
+
+def test_no_warning_when_api_key_not_set(monkeypatch):
+    """No API key -> tracer is a silent no-op and emits no missing-package warning."""
+    monkeypatch.delenv("LANGWATCH_API_KEY", raising=False)
+
+    with patch.object(langwatch_module.logger, "warning") as mock_warning:
+        tracer = _make_tracer()
+
+    assert tracer.ready is False
+    mock_warning.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the report that **LangWatch tracing does not work when Langflow runs in Docker** — setting `LANGWATCH_API_KEY` (and friends) as a container env var has no effect, while the same key works on the PyPI and desktop distributions. No error was surfaced in the container logs.

## Root cause

This is a side effect of moving the published Docker images to **Python 3.14** in #13085 (they previously ran Python 3.12).

- The `langwatch` package caps its own `requires-python` at **`<3.14`** in *every* released version (up to the current `0.23.0`).
- Because of that, #13085 added the marker `langwatch = ["langwatch~=0.10.0; python_version < '3.14'"]`, and `uv.lock` carries `marker = "python_full_version < '3.14'"`.
- The official images (`langflowai/langflow`, `-nightly`, `-ep`, `-all`, `-backend`) all build on `python:3.14-slim-trixie`, so `langwatch` is excluded from the install closure.
- At runtime, `LangWatchTracer.setup_langwatch()` does `import langwatch`, hits `ImportError`, and disables the tracer — but only logged a cryptic, per-flow-run `logger.exception(f"{e}")`, which read as noise rather than an actionable cause.

`pip install langflow` works because users run it on Python 3.10–3.13, where `langwatch` installs normally.

Removing the marker is **not** an option: `uv`/`pip` honor the upstream `requires-python` cap and would refuse to resolve `langwatch` on Python 3.14.

> Note for maintainers: the 3.12 → 3.14 image move also silently dropped other `<3.14`-capped integrations from the published images (`langchain-pinecone`, IBM watsonx, `altk`, `cuga`). Those are out of scope for this PR, which intentionally keeps Python 3.14 and improves the failure mode for LangWatch; they may warrant a separate follow-up.

## What changed

- **Actionable warning instead of silent failure** (`langwatch.py`): when `LANGWATCH_API_KEY` is set but `langwatch` can't be imported, log a single, version-aware `warning` explaining *why* (Python 3.14 has no `langwatch`; run on 3.10–3.13) and how to enable it. De-duplicated via a class flag so it fires once per process, not on every flow run. The raw `ImportError` is kept at `debug` level.
- **Docs** (`integrations-langwatch.mdx`): a `:::note` admonition documenting that LangWatch is unavailable in the default (Python 3.14) Docker images and how to use it (PyPI / desktop / custom 3.10–3.13 image).
- **Tests** (`test_langwatch.py`): cover that the tracer disables gracefully and warns exactly once when the package is missing with the key set, and stays silent when no key is set.

## Behavior

| | Before | After |
|---|---|---|
| `LANGWATCH_API_KEY` set, package missing (Docker / 3.14) | Silent disable; cryptic `logger.exception` per run | One clear `warning` with cause + remediation; disabled gracefully |
| Key set, package present (PyPI / 3.10–3.13) | Works | Works (unchanged) |
| No key set | No-op | No-op (no warning) |

## Test plan

- [x] `uv run pytest src/backend/tests/unit/services/tracing/test_langwatch.py` — new tests pass
- [x] `uv run pytest src/backend/tests/unit/services/tracing/test_http_context_propagation.py` — existing LangWatch tracer tests still pass
- [x] `uv run pytest src/backend/tests/unit/services/tracing/test_tracing_service.py` — 19 passed
- [x] `ruff format` + `ruff check` clean; pre-commit (incl. detect-secrets) passes
- [ ] Manual: run `langflowai/langflow:latest` with `LANGWATCH_API_KEY` set, execute a flow, confirm the new warning appears in container logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining LangWatch tracing availability in Docker images and Python version requirements (3.10–3.13 recommended for LangWatch support)

* **Bug Fixes**
  * Improved error handling for missing LangWatch dependency with clearer, non-repetitive warning messages

* **Tests**
  * Added comprehensive test coverage for LangWatch tracer behavior when the dependency is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->