### PR TITLE
fix(stepflow): route multi-output fan-out to the correct step per connection

### DIFF
--- a/src/langflow-stepflow/src/langflow_stepflow/translation/node_processor.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/translation/node_processor.py
@@ -51,20 +51,26 @@ class NodeProcessor:
         builder: FlowBuilder,
         node_output_refs: dict[str, Any],
         field_mapping: dict[str, dict[str, str]],
-        output_mapping: dict[str, str],
+        output_mapping: dict[tuple[str, str], str],
+        source_outputs: dict[str, list[str]],
+        output_refs_by_handle: dict[tuple[str, str], Any],
     ) -> Any | None:
         """Process a Langflow node using flow builder architecture.
 
         Args:
             node: Langflow node object
             dependencies: Dependency graph for all nodes
-            all_nodes: All nodes in the workflow
             builder: FlowBuilder instance
-            node_output_refs: Mapping of node IDs to their output references
+            node_output_refs: Mapping of node IDs to their primary output references
             field_mapping: Mapping of target nodes to their input field names
                 from edges
-            output_mapping: Mapping of source node IDs to their selected output names
+            output_mapping: Mapping of (source_id, target_id) -> selected output name
                 from edges
+            source_outputs: Mapping of source node IDs to the distinct outputs they
+                fan out, in first-seen edge order
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref;
+                populated as steps are materialized so downstream nodes can wire to
+                the correct step when a source fans out multiple outputs
 
         Returns:
             Output reference for this node, or None if node should be skipped
@@ -100,14 +106,18 @@ class NodeProcessor:
                 # ChatInput returns a reference to workflow input directly
                 return Value.input.add_path("message")
             elif component_type == "ChatOutput":
-                # ChatOutput depends on another node - return that node's output
-                # reference
+                # ChatOutput passes through its upstream node's output. Resolve the
+                # specific fanned-out output it consumes so a multi-output source
+                # feeding ChatOutput routes the correct branch (see issue #12308).
                 dependency_node_ids = dependencies.get(node_id, [])
-                if dependency_node_ids and dependency_node_ids[0] in node_output_refs:
-                    return node_output_refs[dependency_node_ids[0]]
-                else:
-                    # ChatOutput with no dependencies - return input passthrough
-                    return Value.input.add_path("message")
+                if dependency_node_ids:
+                    dep_ref = self._resolve_dependency_ref(
+                        dependency_node_ids[0], node_id, node_output_refs, output_mapping, output_refs_by_handle
+                    )
+                    if dep_ref is not None:
+                        return dep_ref
+                # ChatOutput with no dependencies - return input passthrough
+                return Value.input.add_path("message")
 
             # Component is a tool if it has tool_mode=True at the component level
             is_tool_component = node_info.get("tool_mode", False)
@@ -120,6 +130,8 @@ class NodeProcessor:
                     dependencies,
                     node_output_refs,
                     field_mapping,
+                    output_mapping,
+                    output_refs_by_handle,
                 )
 
             # For regular components, determine routing based on component type
@@ -134,62 +146,17 @@ class NodeProcessor:
             if code_hash and module:
                 known_component = lookup_known_component(code_hash, module)
 
-            # Determine component path and inputs based on routing
+            outputs = node_info.get("outputs", [])
+
+            # Determine routing (core executor vs custom code executor)
             if known_component:
                 # Known core component - use core executor (no blob needed)
                 component_path = f"/langflow/core/{module_to_path(known_component.module)}"
                 logger.debug(f"Routing {component_type} to core executor: {component_path}")
-
-                # Extract outputs and selected_output for core executor
-                outputs = node_info.get("outputs", [])
-                selected_output = output_mapping.get(node_id)
-                if not selected_output and outputs:
-                    selected_output = outputs[0].get("name")
-
-                # Prepare template without code field
-                raw_template = {k: v for k, v in template.items() if k != "code"}
-                template_without_code = _sanitize_for_stepflow(raw_template)
-
-                step_input = {
-                    "template": template_without_code,
-                    "outputs": outputs,
-                    "selected_output": selected_output,
-                    "input": self._extract_runtime_inputs_for_builder(
-                        node,
-                        dependencies.get(node_id, []),
-                        node_output_refs,
-                        field_mapping,
-                    ),
-                }
             elif custom_code:
                 # Component with custom code - use custom code executor
                 component_path = "/langflow/custom_code"
                 logger.debug(f"Routing {component_type} to custom_code executor")
-
-                # First create a blob step for the code
-                blob_data = self._prepare_udf_blob(node, component_type, output_mapping)
-
-                blob_step_id = f"{step_id}_blob"
-                blob_step_handle = builder.add_step(
-                    id=blob_step_id,
-                    component="/builtin/put_blob",
-                    input_data={
-                        "data": _sanitize_for_stepflow(blob_data),
-                        "blob_type": "data",
-                    },
-                    must_execute=True,
-                )
-
-                # Create the custom code executor step that uses the blob
-                step_input = {
-                    "blob_id": Value.step(blob_step_handle.id, "blob_id"),
-                    "input": self._extract_runtime_inputs_for_builder(
-                        node,
-                        dependencies.get(node_id, []),
-                        node_output_refs,
-                        field_mapping,
-                    ),
-                }
             else:
                 # All executable components should have custom code or be known
                 raise ConversionError(
@@ -197,20 +164,188 @@ class NodeProcessor:
                     f"and is not a known core component."
                 )
 
-            # Add step to builder with proper ID and component path
-            step_id = self._generate_step_id(node_id, component_type)
-            step_handle = builder.add_step(
-                id=step_id,
-                component=component_path,
-                input_data=step_input,
-                must_execute=True,
+            # Runtime inputs are identical across this node's outputs, so resolve
+            # them once and reuse for every materialized step.
+            runtime_input = self._extract_runtime_inputs_for_builder(
+                node,
+                dependencies.get(node_id, []),
+                node_output_refs,
+                field_mapping,
+                output_mapping,
+                output_refs_by_handle,
             )
 
-            # Return a reference to this step's output
-            return Value.step(step_handle.id, "result")
+            # The core executor reads the template (sans code) directly; it does not
+            # vary per output, so build it once (only the core path needs it).
+            template_without_code = (
+                _sanitize_for_stepflow({k: v for k, v in template.items() if k != "code"}) if known_component else None
+            )
+
+            # Materialize one step per distinct output this node fans out. A step
+            # produces a single "result" (its selected output's method), so a node
+            # feeding different outputs to different targets needs one step apiece.
+            # NOTE: a component that fans out N distinct outputs is therefore
+            # instantiated and executed N times (once per output). Components with
+            # side effects will run their selected method once for each branch.
+            emitted_outputs = self._resolve_emitted_outputs(node_id, outputs, source_outputs)
+            if len(emitted_outputs) > 1:
+                logger.debug(
+                    "Node %s (%s) fans out %d distinct outputs %s; materializing one step each "
+                    "(component executes once per output).",
+                    node_id,
+                    component_type,
+                    len(emitted_outputs),
+                    emitted_outputs,
+                )
+
+            primary_ref = None
+            used_step_ids: set[str] = {step_id}
+            for index, output_name in enumerate(emitted_outputs):
+                # Keep the first output on the unsuffixed step id for stability;
+                # additional outputs get a unique, suffixed step id.
+                out_step_id = (
+                    step_id if index == 0 else self._unique_output_step_id(step_id, output_name, used_step_ids)
+                )
+
+                if known_component:
+                    step_input: dict[str, Any] = {
+                        "template": template_without_code,
+                        "outputs": outputs,
+                        "selected_output": output_name,
+                        "input": runtime_input,
+                    }
+                else:
+                    # Custom code: the executor reads selected_output from the blob,
+                    # so each output gets its own blob with the selection baked in.
+                    blob_data = self._prepare_udf_blob(node, component_type, output_name)
+
+                    blob_step_handle = builder.add_step(
+                        id=f"{out_step_id}_blob",
+                        component="/builtin/put_blob",
+                        input_data={
+                            "data": _sanitize_for_stepflow(blob_data),
+                            "blob_type": "data",
+                        },
+                        must_execute=True,
+                    )
+
+                    step_input = {
+                        "blob_id": Value.step(blob_step_handle.id, "blob_id"),
+                        "input": runtime_input,
+                    }
+
+                step_handle = builder.add_step(
+                    id=out_step_id,
+                    component=component_path,
+                    input_data=step_input,
+                    must_execute=True,
+                )
+
+                output_ref = Value.step(step_handle.id, "result")
+                if output_name is not None:
+                    output_refs_by_handle[(node_id, output_name)] = output_ref
+                if index == 0:
+                    primary_ref = output_ref
+
+            # Return the primary (first) output's reference as this node's default
+            return primary_ref
 
         except Exception as e:
             raise ConversionError(f"Error processing node {node.get('id', 'unknown')}: {e}") from e
+
+    def _resolve_emitted_outputs(
+        self,
+        node_id: str,
+        outputs: list[dict[str, Any]],
+        source_outputs: dict[str, list[str]],
+    ) -> list[str | None]:
+        """Determine which outputs a node must materialize as steps.
+
+        Returns one entry per distinct output the node fans out (so each downstream
+        branch can wire to the correct step). When the node has no outgoing edges
+        with a resolvable output, falls back to a single default step using the
+        component's first declared output, mirroring the prior single-step behavior.
+
+        Args:
+            node_id: The source node ID
+            outputs: The component's declared outputs
+            source_outputs: Mapping of source node IDs to their fanned-out outputs
+
+        Returns:
+            Non-empty list of output names (or a single None when no output is known)
+        """
+        emitted = source_outputs.get(node_id)
+        if emitted:
+            return list(emitted)
+
+        # No outgoing edges with a known output (e.g. a leaf feeding the workflow
+        # output) - emit a single step using the first declared output, if any.
+        default_output = outputs[0].get("name") if outputs else None
+        return [default_output]
+
+    def _sanitize_output_suffix(self, output_name: str | None) -> str:
+        """Sanitize an output name for use in a Stepflow step id suffix."""
+        if not output_name:
+            return "output"
+        return "".join(ch if ch.isalnum() else "_" for ch in output_name)
+
+    def _unique_output_step_id(self, base_step_id: str, output_name: str | None, used: set[str]) -> str:
+        """Build a unique, readable step id for a secondary fanned-out output.
+
+        Distinct output names can sanitize to the same suffix (e.g. "out-a" and
+        "out.a" both become "out_a"); a numeric disambiguator keeps each step id
+        unique so no branch silently overwrites another.
+
+        Args:
+            base_step_id: The node's primary (unsuffixed) step id
+            output_name: The output this step emits
+            used: Step ids already assigned for this node (mutated in place)
+
+        Returns:
+            A step id unique among ``used``
+        """
+        suffix = self._sanitize_output_suffix(output_name)
+        candidate = f"{base_step_id}__{suffix}"
+        disambiguator = 1
+        while candidate in used:
+            candidate = f"{base_step_id}__{suffix}_{disambiguator}"
+            disambiguator += 1
+        used.add(candidate)
+        return candidate
+
+    def _resolve_dependency_ref(
+        self,
+        dep_id: str,
+        target_id: str | None,
+        node_output_refs: dict[str, Any],
+        output_mapping: dict[tuple[str, str], str],
+        output_refs_by_handle: dict[tuple[str, str], Any],
+    ) -> Any | None:
+        """Resolve the output ref a dependency feeds into a specific target.
+
+        Prefers the step matching the exact output named on the (dep -> target)
+        edge so multi-output fan-out routes correctly; falls back to the
+        dependency's primary output ref when the edge's output is unknown or the
+        source materialized only a single (default) step.
+
+        Args:
+            dep_id: The dependency (source) node ID
+            target_id: The target node ID consuming the dependency
+            node_output_refs: Mapping of node IDs to their primary output refs
+            output_mapping: Mapping of (source_id, target_id) -> output name
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref
+
+        Returns:
+            The resolved output reference, or None if the dependency has no ref
+        """
+        if target_id is not None:
+            edge_output = output_mapping.get((dep_id, target_id))
+            if edge_output is not None:
+                handle_ref = output_refs_by_handle.get((dep_id, edge_output))
+                if handle_ref is not None:
+                    return handle_ref
+
+        return node_output_refs.get(dep_id)
 
     def _generate_step_id(self, node_id: str, component_type: str) -> str:
         """Generate a clean step ID from node ID and type.
@@ -234,14 +369,15 @@ class NodeProcessor:
         self,
         node: dict[str, Any],
         component_type: str,
-        output_mapping: dict[str, str],
+        selected_output: str | None,
     ) -> dict[str, Any]:
         """Prepare enhanced UDF blob data for component execution.
 
         Args:
             node: Langflow node object
             component_type: Component type name
-            output_mapping: Mapping of node IDs to their selected output names
+            selected_output: The output this blob should execute. When None, falls
+                back to the component's first declared output.
 
         Returns:
             Enhanced UDF blob data with complete component information
@@ -263,14 +399,8 @@ class NodeProcessor:
         # Use node outputs if available (more complete), fallback to data outputs
         final_outputs = node_outputs if node_outputs else outputs
 
-        # Determine selected output - use output mapping from edges if available
-        selected_output = None
-        node_id = node.get("id")
-        if output_mapping and node_id in output_mapping:
-            # Use the output specified in the edge
-            selected_output = output_mapping[node_id]
-        elif final_outputs:
-            # Fallback to the first output if no edge mapping found
+        # Fall back to the first declared output when the caller didn't specify one
+        if selected_output is None and final_outputs:
             selected_output = final_outputs[0].get("name")
 
         # Extract additional component metadata from node_info
@@ -338,15 +468,19 @@ class NodeProcessor:
         dependency_node_ids: list[str],
         node_output_refs: dict[str, Any],
         field_mapping: dict[str, dict[str, str]],
+        output_mapping: dict[tuple[str, str], str],
+        output_refs_by_handle: dict[tuple[str, str], Any],
     ) -> dict[str, Any]:
         """Extract runtime inputs for UDF components using flow builder architecture.
 
         Args:
             node: Langflow node object
             dependency_node_ids: IDs of nodes this node depends on
-            node_output_refs: Mapping of node IDs to their output references
+            node_output_refs: Mapping of node IDs to their primary output references
             field_mapping: Mapping of target nodes to their input field names
                 from edges
+            output_mapping: Mapping of (source_id, target_id) -> output name
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref
 
         Returns:
             Dict of runtime inputs
@@ -361,16 +495,21 @@ class NodeProcessor:
             field_inputs: dict[str, Any] = {}
 
             for dep_id in dependency_node_ids:
-                if dep_id in node_field_map and dep_id in node_output_refs:
+                # Resolve the specific output this dependency feeds into this node so
+                # multi-output fan-out routes to the right step (see issue #12308).
+                dep_ref = self._resolve_dependency_ref(
+                    dep_id, node_id, node_output_refs, output_mapping, output_refs_by_handle
+                )
+                if dep_id in node_field_map and dep_ref is not None:
                     field_name = node_field_map[dep_id]
 
                     # Handle list fields by collecting multiple inputs
                     if field_name not in field_inputs:
                         field_inputs[field_name] = []
-                    field_inputs[field_name].append(node_output_refs[dep_id])
-                elif dep_id in node_output_refs:
+                    field_inputs[field_name].append(dep_ref)
+                elif dep_ref is not None:
                     # Fallback to generic name if no field mapping
-                    runtime_inputs[f"input_{len(runtime_inputs)}"] = node_output_refs[dep_id]
+                    runtime_inputs[f"input_{len(runtime_inputs)}"] = dep_ref
 
             # Convert to runtime inputs format
             for field_name, inputs in field_inputs.items():
@@ -383,8 +522,11 @@ class NodeProcessor:
         else:
             # Fallback to old behavior for backwards compatibility
             for i, dep_id in enumerate(dependency_node_ids):
-                if dep_id in node_output_refs:
-                    runtime_inputs[f"input_{i}"] = node_output_refs[dep_id]
+                dep_ref = self._resolve_dependency_ref(
+                    dep_id, node_id, node_output_refs, output_mapping, output_refs_by_handle
+                )
+                if dep_ref is not None:
+                    runtime_inputs[f"input_{i}"] = dep_ref
                 else:
                     # Fallback to workflow input if dependency not found
                     runtime_inputs[f"input_{i}"] = Value.input("$.message")
@@ -434,6 +576,8 @@ class NodeProcessor:
         dependencies: dict[str, list[str]],
         node_output_refs: dict[str, Any],
         field_mapping: dict[str, dict[str, str]],
+        output_mapping: dict[tuple[str, str], str],
+        output_refs_by_handle: dict[tuple[str, str], Any],
     ) -> Any:
         """Create a component_tool step for tool-mode components.
 
@@ -444,6 +588,8 @@ class NodeProcessor:
             dependencies: Dependency graph
             node_output_refs: Node output references
             field_mapping: Field mapping from edges
+            output_mapping: Mapping of (source_id, target_id) -> output name
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref
 
         Returns:
             Output reference for the tool wrapper step
@@ -455,7 +601,9 @@ class NodeProcessor:
             node_info = node_data.get("node", {})
 
             # Extract component inputs from dependencies and field mapping
-            component_inputs = self._build_component_inputs(node_id, dependencies, node_output_refs, field_mapping)
+            component_inputs = self._build_component_inputs(
+                node_id, dependencies, node_output_refs, field_mapping, output_mapping, output_refs_by_handle
+            )
 
             # Create step that calls component_tool to create tool wrapper
             step_handle = builder.add_step(
@@ -482,6 +630,8 @@ class NodeProcessor:
         dependencies: dict[str, list[str]],
         node_output_refs: dict[str, Any],
         field_mapping: dict[str, dict[str, str]],
+        output_mapping: dict[tuple[str, str], str],
+        output_refs_by_handle: dict[tuple[str, str], Any],
     ) -> dict[str, Any]:
         """Build input dict for a component from its dependencies.
 
@@ -490,6 +640,8 @@ class NodeProcessor:
             dependencies: Dependency graph
             node_output_refs: Output references from other nodes
             field_mapping: Field name mapping from edges
+            output_mapping: Mapping of (source_id, target_id) -> output name
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref
 
         Returns:
             Dict mapping input field names to their values/references
@@ -501,7 +653,12 @@ class NodeProcessor:
         field_map = field_mapping.get(node_id, {})
 
         for dep_node_id in deps:
-            if dep_node_id in node_output_refs:
+            # Resolve the specific output this dependency feeds into this node so
+            # multi-output fan-out routes to the right step (see issue #12308).
+            dep_ref = self._resolve_dependency_ref(
+                dep_node_id, node_id, node_output_refs, output_mapping, output_refs_by_handle
+            )
+            if dep_ref is not None:
                 field_name = field_map.get(dep_node_id)
                 if field_name is None:
                     logger.warning(
@@ -511,6 +668,6 @@ class NodeProcessor:
                     )
                     continue
                 # Map dependency output to input field
-                inputs[field_name] = node_output_refs[dep_node_id]
+                inputs[field_name] = dep_ref
 
         return inputs

--- a/src/langflow-stepflow/src/langflow_stepflow/translation/translator.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/translation/translator.py
@@ -97,9 +97,15 @@ class LangflowConverter:
             # Create field mapping from edges for proper UDF input handling
             field_mapping = self._build_field_mapping_from_edges(edges)
 
-            # Create output mapping from edges to track which output is used from
-            # each component
+            # Create output mapping from edges to track which output is used by
+            # each connection. Keyed per (source, target) so that a component
+            # fanning out different outputs to different targets routes correctly.
             output_mapping = self._build_output_mapping_from_edges(edges)
+
+            # Derive, per source node, the distinct outputs it actually fans out.
+            # A node with two or more distinct outputs must materialize one step
+            # per output so each downstream branch receives the correct value.
+            source_outputs = self._build_source_outputs(output_mapping)
 
             # Create node lookup for efficient processing
             node_lookup = {node["id"]: node for node in nodes}
@@ -113,8 +119,12 @@ class LangflowConverter:
             # if input_schema:
             #     builder.set_input_schema(input_schema)
 
-            # Process nodes and collect output references
+            # Process nodes and collect output references.
+            # node_output_refs maps node_id -> its primary (default) output ref.
+            # output_refs_by_handle maps (node_id, output_name) -> output ref so
+            # multi-output fan-out can be wired to the right step per connection.
             node_output_refs: dict[str, Any] = {}  # node_id -> output reference
+            output_refs_by_handle: dict[tuple[str, str], Any] = {}
             processed_nodes = set()
 
             # First, process nodes in execution order
@@ -127,6 +137,8 @@ class LangflowConverter:
                         node_output_refs,
                         field_mapping,
                         output_mapping,
+                        source_outputs,
+                        output_refs_by_handle,
                     )
                     if output_ref is not None:
                         node_output_refs[node_id] = output_ref
@@ -143,12 +155,16 @@ class LangflowConverter:
                         node_output_refs,
                         field_mapping,
                         output_mapping,
+                        source_outputs,
+                        output_refs_by_handle,
                     )
                     if output_ref is not None:
                         node_output_refs[node_id] = output_ref
 
             # Set workflow output using incremental output building
-            self._build_flow_output(builder, nodes, dependencies, node_output_refs)
+            self._build_flow_output(
+                builder, nodes, dependencies, node_output_refs, output_mapping, output_refs_by_handle
+            )
 
             # Set variable schema
             if self.node_processor.variables:
@@ -298,21 +314,28 @@ class LangflowConverter:
 
         return field_mapping
 
-    def _build_output_mapping_from_edges(self, edges: list[dict[str, Any]]) -> dict[str, str]:
-        """Build output mapping from edges to track output usage per component.
+    def _build_output_mapping_from_edges(self, edges: list[dict[str, Any]]) -> dict[tuple[str, str], str]:
+        """Build output mapping from edges to track output usage per connection.
+
+        The mapping is keyed per (source_node_id, target_node_id) rather than per
+        source node alone. Keying only by source node is lossy: when a component
+        fans out *different* outputs to *different* targets, all but the first
+        connection would silently inherit the wrong output. Per-connection keys
+        preserve the output selected by each individual edge.
 
         Args:
             edges: List of Langflow edges
 
         Returns:
-            Dict mapping source_node_id -> output_name
+            Dict mapping (source_node_id, target_node_id) -> output_name
         """
-        output_mapping: dict[str, str] = {}
+        output_mapping: dict[tuple[str, str], str] = {}
 
         for edge in edges:
             source_id = edge.get("source")
+            target_id = edge.get("target")
 
-            if not source_id:
+            if not source_id or not target_id:
                 continue
 
             # Get source output name from edge data
@@ -325,20 +348,35 @@ class LangflowConverter:
             elif isinstance(source_handle, str):
                 # Sometimes sourceHandle is a JSON string - handle this case
                 try:
-                    import json
-
                     source_info = json.loads(source_handle.replace("œ", '"'))
                     output_name = source_info.get("name")
                 except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
                     output_name = None
 
-            # Only store if we found an output name and don't have one already
-            # (first edge wins if component has multiple outgoing edges with
-            # different outputs)
-            if output_name and source_id not in output_mapping:
-                output_mapping[source_id] = output_name
+            if output_name:
+                output_mapping[(source_id, target_id)] = output_name
 
         return output_mapping
+
+    def _build_source_outputs(self, output_mapping: dict[tuple[str, str], str]) -> dict[str, list[str]]:
+        """Group the edge-scoped output mapping by source node.
+
+        Args:
+            output_mapping: Mapping of (source_id, target_id) -> output_name
+
+        Returns:
+            Dict mapping source_node_id -> list of distinct output names it fans
+            out, in first-seen edge order. Used to decide how many steps a node
+            must materialize (one per distinct output).
+        """
+        source_outputs: dict[str, list[str]] = {}
+
+        for (source_id, _target_id), output_name in output_mapping.items():
+            names = source_outputs.setdefault(source_id, [])
+            if output_name not in names:
+                names.append(output_name)
+
+        return source_outputs
 
     def _build_flow_output(
         self,
@@ -346,6 +384,8 @@ class LangflowConverter:
         nodes: list[dict[str, Any]],
         dependencies: dict[str, list[str]],
         node_output_refs: dict[str, Any],
+        output_mapping: dict[tuple[str, str], str],
+        output_refs_by_handle: dict[tuple[str, str], Any],
     ) -> None:
         """Build workflow output using incremental output building API.
 
@@ -353,7 +393,9 @@ class LangflowConverter:
             builder: FlowBuilder instance to add output fields to
             nodes: Original Langflow nodes
             dependencies: Dependency graph
-            node_output_refs: Mapping of node IDs to their output references
+            node_output_refs: Mapping of node IDs to their primary output references
+            output_mapping: Mapping of (source_id, target_id) -> output name
+            output_refs_by_handle: Mapping of (source_id, output_name) -> output ref
         """
         # Look for ChatOutput nodes first
         chat_output_nodes = [n for n in nodes if n.get("data", {}).get("type") == "ChatOutput"]
@@ -365,10 +407,14 @@ class LangflowConverter:
 
             # Check if ChatOutput has dependencies
             if node_id in dependencies and dependencies[node_id]:
-                # ChatOutput depends on another node - use that node's output
+                # ChatOutput depends on another node - use that node's output,
+                # resolved to the specific fanned-out output ChatOutput consumes.
                 dep_node_id = dependencies[node_id][0]
-                if dep_node_id in node_output_refs:
-                    builder.set_output(node_output_refs[dep_node_id])
+                dep_ref = self.node_processor._resolve_dependency_ref(
+                    dep_node_id, node_id, node_output_refs, output_mapping, output_refs_by_handle
+                )
+                if dep_ref is not None:
+                    builder.set_output(dep_ref)
                     return
 
             # ChatOutput has no dependencies or dependencies not found - check if

--- a/src/langflow-stepflow/tests/unit/test_translator.py
+++ b/src/langflow-stepflow/tests/unit/test_translator.py
@@ -22,6 +22,197 @@ def get_step_input_dict(step) -> dict:
     return msgspec.to_builtins(step.input)
 
 
+def find_step(workflow, step_id):
+    """Return the step with the given id, or None."""
+    return next((s for s in workflow.steps if s.id == step_id), None)
+
+
+def ref_step_id(value) -> str | None:
+    """Return the step id a serialized step reference points to, or None.
+
+    A Stepflow step reference serializes to ``{"$step": <step_id>, "path": ...}``.
+    """
+    if isinstance(value, dict):
+        return value.get("$step")
+    return None
+
+
+def flow_output(workflow) -> Any:
+    """Return the workflow's output as a plain (msgspec-decoded) value."""
+    if workflow.output is None:
+        return None
+    import msgspec
+
+    return msgspec.to_builtins(workflow.output)
+
+
+# A known core component (hash/module taken from known_components.KNOWN_COMPONENTS).
+# Conversion only checks the hash/module tables, so any matching pair routes the
+# node through the core executor without importing the module.
+_KNOWN_CODE_HASH = "bb5f8714781b"  # pragma: allowlist secret
+_KNOWN_MODULE = "lfx.components.models.language_model.LanguageModelComponent"
+
+
+# Minimal custom-component code; only its truthiness matters to the translator,
+# which routes any component carrying code to the custom_code executor.
+_COMPONENT_CODE = """
+from langflow.custom.custom_component.component import Component
+from langflow.io import Output
+
+class TrivialComponent(Component):
+    outputs = [Output(display_name="Output", name="output", method="build")]
+
+    def build(self) -> str:
+        return "trivial result"
+"""
+
+
+def _custom_node(node_id: str, component_type: str, outputs: list[dict[str, str]]) -> dict[str, Any]:
+    """Build a custom-code Langflow node with the given outputs."""
+    return {
+        "id": node_id,
+        "type": "genericNode",
+        "data": {
+            "type": component_type,
+            "node": {
+                "template": {"code": {"value": _COMPONENT_CODE}},
+                "outputs": outputs,
+            },
+        },
+    }
+
+
+def _edge(source: str, target: str, source_output: str, target_field: str) -> dict[str, Any]:
+    """Build a Langflow edge carrying explicit source-output and target-field handles."""
+    return {
+        "source": source,
+        "target": target,
+        "data": {
+            "sourceHandle": {"name": source_output},
+            "targetHandle": {"fieldName": target_field},
+        },
+    }
+
+
+def _multi_output_fanout_workflow() -> dict[str, Any]:
+    """A single source whose two distinct outputs each feed a different consumer."""
+    return {
+        "data": {
+            "nodes": [
+                _custom_node(
+                    "splitter",
+                    "Splitter",
+                    [
+                        {"name": "output_a", "method": "build_a"},
+                        {"name": "output_b", "method": "build_b"},
+                    ],
+                ),
+                _custom_node("consumer-a", "ConsumerA", [{"name": "output", "method": "build"}]),
+                _custom_node("consumer-b", "ConsumerB", [{"name": "output", "method": "build"}]),
+            ],
+            "edges": [
+                _edge("splitter", "consumer-a", "output_a", "input_0"),
+                _edge("splitter", "consumer-b", "output_b", "input_0"),
+            ],
+        }
+    }
+
+
+def _single_output_fanout_workflow() -> dict[str, Any]:
+    """A single source whose one output feeds two different consumers."""
+    return {
+        "data": {
+            "nodes": [
+                _custom_node("source", "Source", [{"name": "output", "method": "build"}]),
+                _custom_node("consumer-a", "ConsumerA", [{"name": "output", "method": "build"}]),
+                _custom_node("consumer-b", "ConsumerB", [{"name": "output", "method": "build"}]),
+            ],
+            "edges": [
+                _edge("source", "consumer-a", "output", "input_0"),
+                _edge("source", "consumer-b", "output", "input_0"),
+            ],
+        }
+    }
+
+
+def _known_core_node(node_id: str, component_type: str, outputs: list[dict[str, str]]) -> dict[str, Any]:
+    """Build a Langflow node that routes through the core executor (no blob)."""
+    return {
+        "id": node_id,
+        "type": "genericNode",
+        "data": {
+            "type": component_type,
+            "node": {
+                "template": {"param": {"type": "str", "value": "x"}},
+                "outputs": outputs,
+                "metadata": {"code_hash": _KNOWN_CODE_HASH, "module": _KNOWN_MODULE},
+            },
+        },
+    }
+
+
+def _multi_output_fanout_core_workflow() -> dict[str, Any]:
+    """Multi-output fan-out where the source routes through the core executor."""
+    return {
+        "data": {
+            "nodes": [
+                _known_core_node(
+                    "splitter-core",
+                    "Splitter",
+                    [
+                        {"name": "output_a", "method": "build_a"},
+                        {"name": "output_b", "method": "build_b"},
+                    ],
+                ),
+                _known_core_node("consumer-a", "ConsumerA", [{"name": "output", "method": "build"}]),
+                _known_core_node("consumer-b", "ConsumerB", [{"name": "output", "method": "build"}]),
+            ],
+            "edges": [
+                _edge("splitter-core", "consumer-a", "output_a", "input_0"),
+                _edge("splitter-core", "consumer-b", "output_b", "input_0"),
+            ],
+        }
+    }
+
+
+def _fanout_to_chat_output_workflow() -> dict[str, Any]:
+    """A source whose *non-primary* output feeds ChatOutput (the workflow output).
+
+    The first edge (to a plain consumer) makes ``output_a`` primary, so ChatOutput,
+    wired to ``output_b``, must resolve to the secondary step.
+    """
+    return {
+        "data": {
+            "nodes": [
+                _custom_node(
+                    "splitter",
+                    "Splitter",
+                    [
+                        {"name": "output_a", "method": "build_a"},
+                        {"name": "output_b", "method": "build_b"},
+                    ],
+                ),
+                _custom_node("consumer", "Consumer", [{"name": "output", "method": "build"}]),
+                {
+                    "id": "ChatOutput-1",
+                    "type": "genericNode",
+                    "data": {
+                        "type": "ChatOutput",
+                        "node": {
+                            "template": {},
+                            "outputs": [{"name": "message", "method": "message_response"}],
+                        },
+                    },
+                },
+            ],
+            "edges": [
+                _edge("splitter", "consumer", "output_a", "input_0"),
+                _edge("splitter", "ChatOutput-1", "output_b", "input_value"),
+            ],
+        }
+    }
+
+
 class TestLangflowConverter:
     """Test LangflowConverter functionality."""
 
@@ -409,3 +600,121 @@ class CustomComponent(Component):
         # Should raise ConversionError for components without custom code
         with pytest.raises(ConversionError, match="has no custom code"):
             converter.convert(workflow_data)
+
+    def test_build_output_mapping_is_edge_scoped(self, converter: LangflowConverter):
+        """Output mapping is keyed per (source, target), not collapsed per source.
+
+        Regression guard for issue #12308: a node fanning out different outputs
+        must retain a distinct output per outgoing connection.
+        """
+        edges = [
+            {"source": "x", "target": "t1", "data": {"sourceHandle": {"name": "out_a"}}},
+            {"source": "x", "target": "t2", "data": {"sourceHandle": {"name": "out_b"}}},
+        ]
+
+        mapping = converter._build_output_mapping_from_edges(edges)
+
+        assert mapping == {("x", "t1"): "out_a", ("x", "t2"): "out_b"}
+
+    def test_build_source_outputs_collects_distinct_outputs(self, converter: LangflowConverter):
+        """Distinct outputs per source are collected in first-seen edge order."""
+        mapping = {
+            ("x", "t1"): "out_a",
+            ("x", "t2"): "out_b",
+            ("x", "t3"): "out_a",  # repeat of out_a to a third target
+            ("y", "t4"): "only",
+        }
+
+        source_outputs = converter._build_source_outputs(mapping)
+
+        assert source_outputs == {"x": ["out_a", "out_b"], "y": ["only"]}
+
+    def test_multi_output_fanout_routes_each_branch_to_its_own_output(self, converter: LangflowConverter):
+        """Multi-output fan-out wires each consumer to the correct output (issue #12308).
+
+        Before the fix, a single source step was created with a "first-edge-wins"
+        selected output, so every consumer received the same (wrong) output.
+        """
+        workflow = converter.convert(_multi_output_fanout_workflow())
+        step_ids = {step.id for step in workflow.steps}
+
+        # The source materializes one executor step per distinct fanned-out output.
+        assert "langflow_splitter" in step_ids
+        assert "langflow_splitter__output_b" in step_ids
+
+        # Each materialized source step selects the output its branch needs.
+        primary_blob = get_step_input_dict(find_step(workflow, "langflow_splitter_blob"))
+        secondary_blob = get_step_input_dict(find_step(workflow, "langflow_splitter__output_b_blob"))
+        assert primary_blob["data"]["selected_output"] == "output_a"
+        assert secondary_blob["data"]["selected_output"] == "output_b"
+
+        # The crux: each consumer references the step matching its edge's output,
+        # and the two consumers reference *different* steps.
+        consumer_a_inputs = get_step_input_dict(find_step(workflow, "langflow_consumer-a"))["input"]
+        consumer_b_inputs = get_step_input_dict(find_step(workflow, "langflow_consumer-b"))["input"]
+        a_ref = ref_step_id(consumer_a_inputs["input_0"])
+        b_ref = ref_step_id(consumer_b_inputs["input_0"])
+
+        assert a_ref == "langflow_splitter"
+        assert b_ref == "langflow_splitter__output_b"
+        assert a_ref != b_ref
+
+    def test_single_output_fanout_reuses_one_source_step(self, converter: LangflowConverter):
+        """A node fanning out the *same* output to many targets stays a single step.
+
+        Guards against over-materialization: per-output steps are only created when
+        the outputs actually differ.
+        """
+        workflow = converter.convert(_single_output_fanout_workflow())
+        step_ids = [step.id for step in workflow.steps]
+
+        # Only one executor step for the source (no per-output duplication).
+        source_executor_steps = [
+            sid for sid in step_ids if sid == "langflow_source" or sid.startswith("langflow_source__")
+        ]
+        assert source_executor_steps == ["langflow_source"]
+
+        # Both consumers reference that single source step.
+        for consumer in ("langflow_consumer-a", "langflow_consumer-b"):
+            consumer_inputs = get_step_input_dict(find_step(workflow, consumer))["input"]
+            assert ref_step_id(consumer_inputs["input_0"]) == "langflow_source"
+
+    def test_multi_output_fanout_core_executor_path(self, converter: LangflowConverter):
+        """Fan-out routing also works for the core-executor path (no blob steps).
+
+        The core path embeds ``selected_output`` directly in the step input rather
+        than in a blob, so it needs its own coverage.
+        """
+        workflow = converter.convert(_multi_output_fanout_core_workflow())
+        step_ids = {step.id for step in workflow.steps}
+
+        assert "langflow_splitter-core" in step_ids
+        assert "langflow_splitter-core__output_b" in step_ids
+
+        # Each core step carries the correct selected_output inline.
+        primary = get_step_input_dict(find_step(workflow, "langflow_splitter-core"))
+        secondary = get_step_input_dict(find_step(workflow, "langflow_splitter-core__output_b"))
+        assert primary["selected_output"] == "output_a"
+        assert secondary["selected_output"] == "output_b"
+
+        # Each consumer is wired to the step matching its edge's output.
+        a_ref = ref_step_id(get_step_input_dict(find_step(workflow, "langflow_consumer-a"))["input"]["input_0"])
+        b_ref = ref_step_id(get_step_input_dict(find_step(workflow, "langflow_consumer-b"))["input"]["input_0"])
+        assert a_ref == "langflow_splitter-core"
+        assert b_ref == "langflow_splitter-core__output_b"
+
+    def test_chat_output_resolves_non_primary_fanout_output(self, converter: LangflowConverter):
+        """ChatOutput wired to a source's non-primary output gets that output.
+
+        Regression guard: the ChatOutput / workflow-output paths previously used the
+        source's primary ref, so connecting ChatOutput to a secondary output silently
+        returned the wrong result.
+        """
+        workflow = converter.convert(_fanout_to_chat_output_workflow())
+
+        # The plain consumer takes the primary output (output_a)...
+        consumer_inputs = get_step_input_dict(find_step(workflow, "langflow_consumer"))["input"]
+        assert ref_step_id(consumer_inputs["input_0"]) == "langflow_splitter"
+
+        # ...and the workflow output (driven by ChatOutput) takes output_b.
+        assert ref_step_id(flow_output(workflow)) == "langflow_splitter__output_b"


### PR DESCRIPTION
## Summary

Fixes #12308. In `langflow-stepflow`, a single component whose **multiple outputs fan out to different downstream nodes** routed the *same* output to every consumer, silently corrupting at least one branch.

`LangflowConverter._build_output_mapping_from_edges` keyed the selected output by **source node id only**, with an explicit "first-edge-wins" comment — so the first outgoing edge's output name was stored and every subsequent edge from that source was discarded. Every consumer of that node then received the same (wrong) `selected_output`.

## Root cause & why the fix looks the way it does

Each Langflow node is translated to **one Stepflow step**, and each executor (`core_executor`, `custom_code_executor`) runs **exactly one method** — the one named by `selected_output` — and returns a single `{"result": ...}`. So edge-scoping the mapping alone is not enough: a single step can only ever compute one output. Correct fan-out requires **materializing one step per distinct output** a source actually fans out, then wiring each consumer to the step matching its edge.

## Changes

- **`translator.py`**
  - `_build_output_mapping_from_edges` is now keyed per **`(source_id, target_id)`** connection (no more first-edge-wins).
  - New `_build_source_outputs` derives, per source node, the distinct outputs it fans out (first-seen edge order).
  - `_build_flow_output` resolves the ChatOutput → workflow-output edge to its specific output.
- **`node_processor.py`**
  - `process_node` materializes **one step per distinct fanned-out output**. The first output keeps the stable unsuffixed step id (`langflow_<node>`); additional outputs get unique suffixed ids (`langflow_<node>__<output>`), with a numeric disambiguator if two output names sanitize to the same suffix.
  - New `output_refs_by_handle` registry maps `(source, output_name) -> step ref`; new `_resolve_dependency_ref` wires every consumer edge (regular inputs, tool inputs, and `ChatOutput`) to the correct step, falling back to the source's primary ref for single-output nodes.
  - `_prepare_udf_blob` now takes an explicit `selected_output` instead of the mapping.

## Behavior & compatibility

- **Single-output flows are unchanged** — one step per node, same step ids, same refs (verified by the existing suite + a dedicated reuse test).
- **Known trade-off (documented in code):** a component that fans out *N distinct* outputs is now instantiated and executed N times (once per output), because the executor returns a single result. A `logger.debug` notes this when N > 1.

## Test plan

- [x] `make unit_tests` for `langflow-stepflow` — **216 passed, 12 skipped** (skips are pre-existing missing-fixture/optional-dep cases).
- [x] New regression tests in `test_translator.py`:
  - [x] multi-output fan-out (custom-code path) routes each branch to its own output + correct `selected_output` per blob
  - [x] multi-output fan-out (core-executor path) carries correct inline `selected_output`
  - [x] `ChatOutput` wired to a **non-primary** output resolves to the right step (workflow output)
  - [x] single-output fan-out reuses one source step (no over-materialization)
  - [x] `_build_output_mapping_from_edges` is edge-scoped; `_build_source_outputs` collects distinct outputs
- [x] Confirmed the new tests **fail on the pre-fix code** (both consumers previously referenced the same step).
- [x] `ruff check`, `ruff format --check`, and `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-output node routing to ensure each downstream connection receives the correct output rather than always using the first output.
  * Improved output resolution for nodes with multiple outputs across different execution paths.
  * Enhanced workflow output handling to properly resolve non-primary outputs.

* **Tests**
  * Added comprehensive test coverage for multi-output fan-out behavior.
  * Added regression tests validating correct output selection per downstream connection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->