### PR TITLE
chore: unconstrained lfx version for bundles

### DIFF
--- a/.github/workflows/release_bundles.yml
+++ b/.github/workflows/release_bundles.yml
@@ -65,9 +65,9 @@ jobs:
           done
           echo "bundles-found=1" >> $GITHUB_OUTPUT
           ls -la bundles-dist/
-      # Bundles pin lfx (e.g. lfx>=0.5.0,<0.6.0). The smoke test below
+      # Bundles floor lfx at >=0.5.0 (no upper bound). The smoke test below
       # installs the bundles in a fresh venv, so it needs an lfx wheel that
-      # satisfies the pin available locally — PyPI may not yet have a
+      # satisfies the floor available locally — PyPI may not yet have a
       # matching lfx published when bundles are released ahead of a main
       # release. We build the lfx wheel from the current ref so the smoke
       # test resolves against it; this artifact is not published.

--- a/scripts/ci/update_bundle_versions.py
+++ b/scripts/ci/update_bundle_versions.py
@@ -23,15 +23,15 @@ from pathlib import Path
 BASE_DIR = Path(__file__).parent.parent.parent
 
 # Matches the lfx dep specifier inside a bundle pyproject's dependencies list.
-# Accepts the bundle default ("lfx>=X.Y.Z,<A.B.C"), legacy ~=/==, and the
-# already-rewritten "lfx-nightly==X.Y.Z" form (idempotent).
+# Accepts the bundle default ("lfx>=X.Y.Z" with an optional upper bound),
+# legacy ~=/==, and the already-rewritten "lfx-nightly==X.Y.Z" form (idempotent).
 _LFX_DEP_PATTERN = re.compile(
     r'"lfx(?:-nightly)?'
     r"(?:"
     r"(?:~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*"
     r"|"
     r">=[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*"
-    r",\s*<[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*"
+    r"(?:,\s*<[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*)?"
     r')"'
 )
 

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -60,8 +60,8 @@ _BUNDLE_LFX_DEP_PATTERN = re.compile(r'"lfx(?:-nightly)?(?=[<>=!~])[^"]*"')
 def update_lfx_dep_in_bundles(lfx_version: str) -> None:
     """Pin every bundle's `lfx` dep to the renamed `lfx-nightly==<version>`.
 
-    Each `src/bundles/*/pyproject.toml` declares an `lfx>=X.Y,<Z` style pin
-    against the published `lfx` package. During nightly builds the
+    Each `src/bundles/*/pyproject.toml` floors its `lfx` dep at `>=X.Y`
+    (no upper bound) against the published `lfx` package. During nightly builds the
     workspace `lfx` package gets renamed to `lfx-nightly`, so those pins
     no longer resolve against the workspace member — and PyPI may not yet
     ship a matching `lfx` either. Rewrite each bundle's pin to

--- a/scripts/migrate/port_bundle.py
+++ b/scripts/migrate/port_bundle.py
@@ -86,8 +86,11 @@ keywords = ["langflow", "lfx", "extension", "bundle", "{bundle}"]
 # Runtime deps: lfx (the BUNDLE_API surface) plus any third-party imports
 # the bundle's components rely on.  REVIEW THIS LIST -- the script ports
 # only ``lfx``; add any other deps the moved component(s) import.
+# lfx is floored at >=0.5.0 (the release that introduced extension bundles)
+# with no upper bound so bundles track the latest lfx; BUNDLE_API compat is
+# enforced via extension.json's lfx.compat list, not an upper version cap.
 dependencies = [
-    "lfx>=0.5.0,<0.6.0",
+    "lfx>=0.5.0",
 ]
 
 [project.urls]

--- a/src/bundles/PORTING.md
+++ b/src/bundles/PORTING.md
@@ -67,9 +67,13 @@ src/bundles/<bundle>/
 Copy [`src/bundles/duckduckgo/pyproject.toml`](duckduckgo/pyproject.toml) and
 substitute names + the runtime-dep block. The non-obvious bits:
 
-- `dependencies` lists every runtime dep the component imports. Pin `lfx`
-  to a range that covers the `BUNDLE_API_VERSION` you target
-  (currently `>=0.5.0,<0.6.0`).
+- `dependencies` lists every runtime dep the component imports. Floor `lfx`
+  at `>=0.5.0` (the release that introduced extension bundles) with **no
+  upper bound**, so the bundle always resolves the latest available `lfx` —
+  BUNDLE_API compatibility is enforced separately via `extension.json`'s
+  `"lfx": {"compat": [...]}` contract, not an upper version cap. A bundle
+  author *may* tighten this if a component needs a specific newer `lfx`, but
+  the default carries no ceiling.
 - **Platform-gated deps:** if a runtime dep has no wheel on some platform
   (e.g. `ibm-db` ships none for linux/aarch64), gate it with a PEP 508 marker
   so `pip install langflow` still succeeds there, e.g.

--- a/src/bundles/arxiv/pyproject.toml
+++ b/src/bundles/arxiv/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "arxiv", "search"]
 # but we list it here as a direct runtime dep so the bundle keeps building
 # even if lfx drops it later.
 dependencies = [
-    "lfx>=0.5.0,<0.6.0",
+    "lfx>=0.5.0",
     "defusedxml>=0.7.1,<1.0.0",
 ]
 

--- a/src/bundles/duckduckgo/pyproject.toml
+++ b/src/bundles/duckduckgo/pyproject.toml
@@ -11,11 +11,14 @@ authors = [
 keywords = ["langflow", "lfx", "extension", "bundle", "duckduckgo", "search"]
 
 # Runtime deps: lfx (the BUNDLE_API surface) and the langchain-community
-# binding that wraps the duckduckgo-search Python client.  We pin lfx to a
-# range that includes the BUNDLE_API_VERSION=1 contract; langchain-community
-# is the same range the lfx tree uses to keep co-installation lockstep.
+# binding that wraps the duckduckgo-search Python client.  lfx is floored
+# at >=0.5.0 -- the release that introduced extension bundles -- with no
+# upper bound, so the bundle resolves the latest available lfx; BUNDLE_API
+# compatibility is enforced separately via extension.json's
+# "lfx": {"compat": [...]} contract.  langchain-community uses the same
+# range the lfx tree does to keep co-installation lockstep.
 dependencies = [
-    "lfx>=0.5.0,<0.6.0",
+    "lfx>=0.5.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ddgs>=9.0.0",
 ]

--- a/src/bundles/ibm/pyproject.toml
+++ b/src/bundles/ibm/pyproject.toml
@@ -22,7 +22,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "ibm", "db2", "watsonx", "
 #   the marker stays in lockstep with the langflow-base dep block.
 # * ``langchain-community`` provides the helpers DB2VS leans on.
 dependencies = [
-    "lfx>=0.5.0,<0.6.0",
+    "lfx>=0.5.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ibm-db>=3.2.9,<4.0.0; sys_platform != 'linux' or platform_machine != 'aarch64'",
     "ibm-watsonx-ai>=1.3.1,<2.0.0; python_version < '3.14'",


### PR DESCRIPTION
This pull request updates how bundles specify their dependency on the `lfx` package. Previously, bundles pinned `lfx` to a version range with both a lower and upper bound (e.g., `lfx>=0.5.0,<0.6.0`). Now, bundles will floor `lfx` at `>=0.5.0` with **no upper bound** by default, so they always resolve the latest compatible `lfx`. Compatibility is enforced by each bundle’s `extension.json` contract, not by an upper version cap. Documentation, scripts, and bundle configs have been updated to reflect this policy.

**Dependency specification changes:**

* Updated all bundle `pyproject.toml` files (e.g., `arxiv`, `duckduckgo`, `ibm`) to specify `lfx>=0.5.0` with no upper bound, instead of a pinned range. [[1]](diffhunk://#diff-304465848c05b1d5ae61b0655fc52ae71dbe46b3ba2e5903fea377049a8eb9e7L18-R18) [[2]](diffhunk://#diff-551f1defad949f2a72e53cc9c1142d54ef72abab171f256f4ef027aeb61551aeL14-R21) [[3]](diffhunk://#diff-402b90e601ac6bb4fdc63c53076c2281c7671d49528d538ffd0a7eafa98fd9deL25-R25) [[4]](diffhunk://#diff-a36361dedd69405bb24e20555a341f4d76f6192ae51dd67fab085ba9939ad4f0R89-R93)
* Updated migration and porting scripts/documentation (`port_bundle.py`, `PORTING.md`) to describe and implement the new floored `lfx` dependency policy. [[1]](diffhunk://#diff-a36361dedd69405bb24e20555a341f4d76f6192ae51dd67fab085ba9939ad4f0R89-R93) [[2]](diffhunk://#diff-6d30650ea15b03a03182e18978ba8dd8123d49badf68dd5e1ead0a2bf7b9f9ccL70-R76)

**CI and automation updates:**

* Modified workflow and automation scripts (`release_bundles.yml`, `update_bundle_versions.py`, `update_lfx_version.py`) to handle and document the new floored `lfx` dependency, including regex and explanatory comments. [[1]](diffhunk://#diff-040151fcc9df38c879af340e383668e9d539db3dfa7726df6034ff68822b6cffL68-R70) [[2]](diffhunk://#diff-3ab0b44b98bdbfc24da5b2b707c478efe54a68c0ff6eb6d7846de4b81b1d38adL26-R34) [[3]](diffhunk://#diff-426a90fbb15f074c431851ddc296a851f5340f9b872e8c560fdb1cf085510b15L63-R64)

This ensures bundles always use the latest compatible `lfx` and centralizes compatibility management in `extension.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Loosened the `lfx` dependency constraint from a bounded range to a lower-bounded specification across all bundles, removing upper version limits.

* **Documentation**
  * Updated porting guide and related documentation to reflect the new `lfx` dependency versioning approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->