### PR TITLE
fix: use Langflow logo on loading screen and remove size jump glitch

### DIFF
--- a/src/frontend/src/components/common/loadingComponent/index.tsx
+++ b/src/frontend/src/components/common/loadingComponent/index.tsx
@@ -12,7 +12,10 @@ export default function LoadingComponent({
         aria-hidden="true"
         title={t("common.langflowLogo")}
         className="animate-pulse text-primary"
-        style={{ width: `${remSize * 0.25}rem`, height: `${remSize * 0.25}rem` }}
+        style={{
+          width: `${remSize * 0.25}rem`,
+          height: `${remSize * 0.25}rem`,
+        }}
       />
       <br></br>
       <span className="animate-pulse text-lg text-primary">

--- a/src/frontend/src/components/common/loadingComponent/index.tsx
+++ b/src/frontend/src/components/common/loadingComponent/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 import type { LoadingComponentProps } from "../../../types/components";
 
 export default function LoadingComponent({
@@ -7,22 +8,12 @@ export default function LoadingComponent({
   const { t } = useTranslation();
   return (
     <div role="status" className="flex flex-col items-center justify-center">
-      <svg
+      <LangflowLogo
         aria-hidden="true"
-        className={`w-${remSize} h-${remSize} animate-spin fill-primary text-muted`}
-        viewBox="0 0 100 101"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-          fill="currentColor"
-        />
-        <path
-          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-          fill="currentFill"
-        />
-      </svg>
+        title={t("common.langflowLogo")}
+        className="animate-pulse text-primary"
+        style={{ width: `${remSize * 0.25}rem`, height: `${remSize * 0.25}rem` }}
+      />
       <br></br>
       <span className="animate-pulse text-lg text-primary">
         {t("loading.loading")}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -1066,7 +1066,7 @@ export default function Page({
         </>
       ) : (
         <div className="flex h-full w-full items-center justify-center">
-          <CustomLoader remSize={30} />
+          <CustomLoader remSize={20} />
         </div>
       )}
       <ExportModal open={openExportModal} setOpen={setOpenExportModal} />

--- a/src/frontend/src/pages/LoadingPage/index.tsx
+++ b/src/frontend/src/pages/LoadingPage/index.tsx
@@ -9,7 +9,7 @@ export function LoadingPage({ overlay = false }: { overlay?: boolean }) {
         overlay && "fixed left-0 top-0 z-[999]",
       )}
     >
-      <LoadingComponent remSize={50} />
+      <LoadingComponent remSize={20} />
     </div>
   );
 }

--- a/src/frontend/src/pages/MainPage/pages/main-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/main-page.tsx
@@ -87,7 +87,7 @@ export default function CollectionPage(): JSX.Element {
           </div>
         ) : (
           <div className="flex h-full w-full items-center justify-center">
-            <CustomLoader remSize={30} />
+            <CustomLoader remSize={20} />
           </div>
         )}
       </main>


### PR DESCRIPTION
Replaces the spinning circle on the loading screen with the Langflow logo mark and fixes a visual glitch where the logo jumped to a larger size mid-load.

<img width="993" height="812" alt="image" src="https://github.com/user-attachments/assets/17d93455-cd67-40f4-b88f-f46773b776a2" />
