### PR TITLE
fix(ci): give extension bundles a nightly track so langflow-nightly resolves

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -475,10 +475,60 @@ jobs:
         run: |
           make publish base=true
 
+  publish-nightly-bundles:
+    name: Publish Langflow Bundles Nightly to PyPI
+    # langflow-nightly pins each `lfx-<name>-nightly==<dev>` exactly, so the
+    # bundles must be on PyPI before main is published (publish-nightly-main
+    # gates on this job). They depend on `lfx-nightly`, so gate on the lfx
+    # publish too (or skip it when lfx isn't being rebuilt).
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-lfx]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && (needs.publish-nightly-lfx.result == 'success' || inputs.build_lfx == false) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download bundles artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-nightly-bundles
+          path: bundles-dist
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          python-version: "3.13"
+      - name: Publish bundles to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          shopt -s nullglob
+          wheels=(bundles-dist/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "No bundle wheels to publish."
+            exit 1
+          fi
+          failed=0
+          for wheel in "${wheels[@]}"; do
+            echo "Publishing $wheel"
+            # Capture stderr so a re-run without a version bump is a no-op for
+            # an already-published bundle instead of failing the whole job.
+            if ! err=$(uv publish "$wheel" 2>&1); then
+              echo "$err"
+              if echo "$err" | grep -qiE 'already exists|file already exists|HTTP 400|duplicate'; then
+                echo "Skipping $wheel: already published."
+              else
+                echo "Publish failed for $wheel"
+                failed=1
+              fi
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            exit 1
+          fi
+
   publish-nightly-main:
     name: Publish Langflow Main Nightly to PyPI
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-base]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' }}
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-base, publish-nightly-bundles]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' && needs.publish-nightly-bundles.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 565,
         "is_secret": false
       }
     ],
@@ -9281,5 +9281,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T15:59:28Z"
+  "generated_at": "2026-05-29T20:36:04Z"
 }

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -4,6 +4,8 @@ import re
 import sys
 from pathlib import Path
 
+import tomllib
+from packaging.version import Version
 from update_pyproject_name import update_pyproject_name
 from update_pyproject_version import update_pyproject_version
 
@@ -12,6 +14,7 @@ current_dir = Path(__file__).resolve().parent
 sys.path.append(str(current_dir))
 
 BASE_DIR = Path(__file__).parent.parent.parent
+ROOT_PYPROJECT = BASE_DIR / "pyproject.toml"
 
 
 def update_lfx_workspace_dep(pyproject_path: str, new_project_name: str) -> None:
@@ -86,6 +89,80 @@ def update_lfx_dep_in_bundles(lfx_version: str) -> None:
         print(f"Updated lfx dep in {bundle_pyproject.relative_to(BASE_DIR)} -> lfx-nightly=={lfx_version}")
 
 
+def _bundle_nightly_version(bundle_base_version: str, lfx_version: str) -> str:
+    """Derive a bundle's nightly version: `<bundle base>.dev<N>`.
+
+    The dev build number `N` is shared with `lfx-nightly` (the same value the
+    nightly tagger already pins each bundle's `lfx` dep to), so a bundle's
+    nightly version moves in lockstep with the lfx it was built against while
+    keeping the bundle's own base version (e.g. `0.1.0`) truthful.
+    """
+    lfx_parsed = Version(lfx_version)
+    if lfx_parsed.dev is None:
+        msg = f"Expected a .devN nightly lfx version, got {lfx_version!r}"
+        raise ValueError(msg)
+    base = Version(bundle_base_version).base_version
+    return f"{base}.dev{lfx_parsed.dev}"
+
+
+def rename_bundles_for_nightly(lfx_version: str) -> None:
+    """Rename each `src/bundles/*` package to its `-nightly` distribution.
+
+    The stable bundles publish as `lfx-<name>` and pin `lfx>=X.Y`. During a
+    nightly build the workspace `lfx` becomes `lfx-nightly` (no stable `lfx`
+    matching the pin may exist on PyPI yet), so a `langflow-nightly` that still
+    depended on the stable `lfx-<name>` would drag in `lfx>=X.Y` and fail to
+    resolve. Give the bundles their own nightly track instead, mirroring how
+    lfx/base/main are renamed. For every bundle this:
+
+      * rewrites its `[project] name`     `lfx-<name>` -> `lfx-<name>-nightly`
+      * rewrites its `[project] version`  `0.1.0`      -> `0.1.0.dev<N>`
+      * repoints the root `[tool.uv.sources]` workspace entry to the new name
+      * repoints the root `langflow` dependency to `lfx-<name>-nightly==<dev>`
+
+    The bundle's own `lfx` dep is repinned separately by
+    `update_lfx_dep_in_bundles`. No-op when no bundles are present, and
+    idempotent for bundles already carrying a `-nightly` name.
+    """
+    bundles_dir = BASE_DIR / "src" / "bundles"
+    if not bundles_dir.is_dir():
+        return
+
+    root_content = ROOT_PYPROJECT.read_text(encoding="utf-8")
+
+    for bundle_pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
+        data = tomllib.loads(bundle_pyproject.read_text(encoding="utf-8"))
+        old_name = data["project"]["name"]
+        if old_name.endswith("-nightly"):
+            continue
+        new_name = f"{old_name}-nightly"
+        new_version = _bundle_nightly_version(data["project"]["version"], lfx_version)
+
+        rel_path = str(bundle_pyproject.relative_to(BASE_DIR))
+        update_pyproject_name(rel_path, new_name)
+        update_pyproject_version(rel_path, new_version)
+
+        # Repoint the workspace source: `lfx-<name> = { workspace = true }`.
+        source_pattern = re.compile(rf"^{re.escape(old_name)}(\s*=\s*\{{ workspace = true \}})", re.MULTILINE)
+        if not source_pattern.search(root_content):
+            msg = f"Workspace source entry for {old_name} not found in {ROOT_PYPROJECT}"
+            raise ValueError(msg)
+        root_content = source_pattern.sub(rf"{new_name}\1", root_content)
+
+        # Repoint the root dependency: `"lfx-<name>>=0.1.0"` -> exact nightly pin.
+        # The lookahead requires a version operator right after the name so we
+        # match `lfx-arxiv>=...` without also matching `lfx-arxiv-nightly`.
+        dep_pattern = re.compile(rf'"{re.escape(old_name)}(?=[<>=!~])[^"]*"')
+        if not dep_pattern.search(root_content):
+            msg = f"Root dependency on {old_name} not found in {ROOT_PYPROJECT}"
+            raise ValueError(msg)
+        root_content = dep_pattern.sub(f'"{new_name}=={new_version}"', root_content)
+
+        print(f"Renamed bundle {old_name} -> {new_name}=={new_version}")
+
+    ROOT_PYPROJECT.write_text(root_content, encoding="utf-8")
+
+
 def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
     """Update LFX package for nightly build.
 
@@ -111,6 +188,12 @@ def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
     # Re-pin every bundle's lfx dep to the renamed workspace package so
     # `uv lock` resolves cleanly. No-op when no bundles are present.
     update_lfx_dep_in_bundles(version)
+
+    # Give each bundle its own `-nightly` distribution and repoint the root
+    # `langflow` deps + workspace sources at it, so `langflow-nightly` pulls
+    # `lfx-<name>-nightly` (which pins `lfx-nightly`) instead of the stable
+    # `lfx-<name>` (which pins an as-yet-unpublished stable `lfx`).
+    rename_bundles_for_nightly(version)
 
     print(f"Updated LFX package to lfx-nightly version {version}")
 


### PR DESCRIPTION
## Problem

`uv pip install langflow-nightly==1.10.0.devN` fails to resolve:

```
Because only lfx<=0.4.5 is available and lfx-arxiv==0.1.0 depends on
lfx>=0.5.0, we can conclude that lfx-arxiv==0.1.0 cannot be used.
And because langflow-nightly==1.10.0.dev56 depends on lfx-arxiv==0.1.0
... your requirements are unsatisfiable.
```

## Root cause

The nightly tagger renames `lfx` → `lfx-nightly` (no stable `lfx 0.5.0` is
published yet — only `lfx-nightly`). But the extension bundles are published
as **stable** `lfx-<name>` wheels pinning `lfx>=0.5.0`. `langflow-nightly`
depended on the stable `lfx-arxiv`/`lfx-ibm`/`lfx-duckduckgo`, which dragged
in `lfx>=0.5.0` under the stable name — unsatisfiable until stable `lfx 0.5.0`
ships. The bundles were the one part of the graph never given the nightly
treatment that `lfx`/`langflow-base`/`langflow` already get.

## Fix

Give the bundles their own nightly track, mirroring lfx/base/main.

**`scripts/ci/update_lfx_version.py`** — new `rename_bundles_for_nightly()`,
called from the existing tag step. For each `src/bundles/*`:

- `[project] name` → `lfx-<name>-nightly`
- `[project] version` → `<base>.dev<N>` (shares lfx's dev number `N`)
- root `[tool.uv.sources]` workspace entry → `-nightly`
- root `langflow` dependency → `lfx-<name>-nightly==<base>.dev<N>`

Only the `name`/`version` fields change — the entry points and import package
stay `lfx_<name>`, so extension discovery is unaffected (same pattern as
`lfx` → `lfx-nightly` keeping the `lfx` import). Each bundle's own `lfx` dep
was already repinned to `lfx-nightly==<dev>`.

**`.github/workflows/release_nightly.yml`** — new `publish-nightly-bundles`
job (tolerates "already exists"), and `publish-nightly-main` now waits on it
so `langflow-nightly`'s exact `==` pins always reference bundles published in
the same run.

No build/test/Docker changes: the bundles are already built and committed
under the nightly tag, the cross-platform test resolves them via
`--find-links`, and Docker builds from the regenerated workspace lock.

## Verification

- `uv lock` on the renamed workspace resolves cleanly (804 packages).
- The built wheel `lfx_arxiv_nightly-0.1.0.devN` declares
  `Requires-Dist: lfx-nightly==0.5.0.devN` (previously the unsatisfiable
  `lfx>=0.5.0`).
- Entry points / import dirs unchanged; `ruff check`/`format` clean;
  re-running the tagger is idempotent.

## Notes

- This fixes the **next** nightly — already-published `devN` builds remain
  broken on PyPI. Trigger the Nightly Build workflow after merge to cut a
  clean build.
- Pre-existing and out of scope: `langflow-stepflow` (a dev-only workspace
  member, never published) depends on bare `lfx`, so the existing rename
  already orphans it into a stray stable-`lfx` lock entry. Benign (not
  installed in Docker, not part of `langflow-nightly`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated nightly bundle publishing to the Python Package Index with intelligent duplicate detection and handling
  * Standardized nightly versioning system for bundle packages to ensure unique release identification

* **Chores**
  * Enhanced release workflow infrastructure with improved job dependency ordering
  * Extended automation support for coordinated multi-bundle nightly releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->