### PR TITLE
fix(ci): re-enable migration-pip-venv now that nightly bundles resolve

### DIFF
--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -25,17 +25,6 @@ env:
 jobs:
   migration-pip-venv:
     name: "Migration Test: pip/venv (stable → nightly)"
-    # TEMPORARILY DISABLED (2026-05-28): the PyPI `langflow-nightly` is currently
-    # pip-uninstallable. Its core bundle deps (lfx-arxiv, lfx-duckduckgo) are
-    # published pinning stable `lfx>=0.5.0,<0.6.0`, but stable `lfx` tops out at
-    # 0.4.4 — the 0.5.0 line ships only as the separately-named `lfx-nightly`,
-    # which cannot satisfy an `lfx` pin. So this job fails at the install step.
-    # The Docker Compose job below is unaffected (it runs the prebuilt nightly
-    # image, whose environment is already resolved). Re-enable once EITHER a
-    # stable lfx 0.5.x is published to PyPI OR nightly bundle variants (e.g.
-    # lfx-arxiv-nightly pinning lfx-nightly) are published and langflow-nightly
-    # depends on them.
-    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## What

Re-enables the `migration-pip-venv` job in the **DB Migration Validation** workflow by removing the temporary `if: false` guard (and its explanatory comment) added on 2026-05-28.

## Why

The job was disabled because the published `langflow-nightly` was pip-uninstallable: its bundle deps (`lfx-arxiv`, `lfx-duckduckgo`) pinned stable `lfx>=0.5.0,<0.6.0`, but stable `lfx` topped out at `0.4.4` — the `0.5.x` line shipped only as the separately-named `lfx-nightly`, which cannot satisfy an `lfx` pin. The job failed at the install step.

That root cause is now resolved. #13418 (this branch) and its forward-port #13419 (main) gave the extension bundles their own nightly track, so the published `langflow-nightly` now depends on `lfx-arxiv-nightly` / `lfx-duckduckgo-nightly` / `lfx-ibm-nightly`, which pin `lfx-nightly` instead of stable `lfx`.

## Verification

A dry-run resolve of `langflow-nightly[postgresql]` against the published `dev57` wheels now succeeds (`549 packages, exit 0`), pulling the nightly variants:

```
+ lfx-arxiv-nightly==0.1.0.dev57
+ lfx-duckduckgo-nightly==0.1.0.dev57
+ lfx-ibm-nightly==0.1.0.dev57
+ lfx-nightly==0.5.0.dev57
```

— exactly the install step that previously failed.

## Test plan

- [ ] CI green on this PR
- [ ] Next nightly run executes `migration-pip-venv` (pip/venv stable → nightly) and passes

## Note

`main` carries the same disable. A sibling forward-port PR re-enables it there too (mirroring #13418 → #13419).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled database migration validation in the CI/CD pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->