### PR TITLE
fix: preserve NVIDIA model selections

### DIFF
--- a/src/lfx/src/lfx/components/nvidia/nvidia_embedding.py
+++ b/src/lfx/src/lfx/components/nvidia/nvidia_embedding.py
@@ -51,8 +51,12 @@ class NVIDIAEmbeddingsComponent(LCEmbeddingsModel):
             try:
                 build_model = self.build_embeddings()
                 ids = [model.id for model in build_model.available_models]
+                current_model = build_config["model"].get("value")
                 build_config["model"]["options"] = ids
-                build_config["model"]["value"] = ids[0]
+                if current_model in ids:
+                    build_config["model"]["value"] = current_model
+                else:
+                    build_config["model"]["value"] = ids[0] if ids else None
             except Exception as e:
                 msg = f"Error getting model names: {e}"
                 raise ValueError(msg) from e

--- a/src/lfx/src/lfx/components/nvidia/nvidia_rerank.py
+++ b/src/lfx/src/lfx/components/nvidia/nvidia_rerank.py
@@ -47,8 +47,12 @@ class NvidiaRerankComponent(LCCompressorComponent):
             try:
                 build_model = self.build_compressor()
                 ids = [model.id for model in build_model.available_models]
+                current_model = build_config["model"].get("value")
                 build_config["model"]["options"] = ids
-                build_config["model"]["value"] = ids[0]
+                if current_model in ids:
+                    build_config["model"]["value"] = current_model
+                else:
+                    build_config["model"]["value"] = ids[0] if ids else None
             except Exception as e:
                 msg = f"Error getting model names: {e}"
                 raise ValueError(msg) from e

--- a/src/lfx/tests/unit/components/test_nvidia_component.py
+++ b/src/lfx/tests/unit/components/test_nvidia_component.py
@@ -8,6 +8,12 @@ import contextlib
 from unittest.mock import MagicMock, patch
 
 
+def _mock_model(model_id: str):
+    model = MagicMock()
+    model.id = model_id
+    return model
+
+
 class TestNVIDIAModelComponentLazyLoading:
     """Ensure NVIDIA model list is fetched lazily, not at import time."""
 
@@ -111,3 +117,85 @@ class TestNVIDIAModelComponentLazyLoading:
 
         assert build_config["model_name"]["options"] == []
         assert build_config["model_name"]["value"] is None
+
+
+class TestNVIDIAComponentModelSelection:
+    def test_rerank_update_preserves_selected_model(self):
+        from lfx.components.nvidia.nvidia_rerank import NvidiaRerankComponent
+        from lfx.schema.dotdict import dotdict
+
+        component = NvidiaRerankComponent()
+        build_config = dotdict(
+            {
+                "model": {
+                    "options": ["nv-rerank-qa-mistral-4b:1"],
+                    "value": "nv-rerank-qa-mistral-4b:1",
+                }
+            }
+        )
+        compressor = MagicMock()
+        compressor.available_models = [
+            _mock_model("nvidia/llama-3.2-nv-rerankqa-1b-v1"),
+            _mock_model("nv-rerank-qa-mistral-4b:1"),
+        ]
+
+        with patch.object(component, "build_compressor", return_value=compressor):
+            result = component.update_build_config(
+                build_config,
+                "https://integrate.api.nvidia.com/v1",
+                field_name="base_url",
+            )
+
+        assert result["model"]["options"] == [
+            "nvidia/llama-3.2-nv-rerankqa-1b-v1",
+            "nv-rerank-qa-mistral-4b:1",
+        ]
+        assert result["model"]["value"] == "nv-rerank-qa-mistral-4b:1"
+
+    def test_embedding_update_preserves_selected_model(self):
+        from lfx.components.nvidia.nvidia_embedding import NVIDIAEmbeddingsComponent
+        from lfx.schema.dotdict import dotdict
+
+        component = NVIDIAEmbeddingsComponent()
+        build_config = dotdict(
+            {
+                "model": {
+                    "options": ["snowflake/arctic-embed-I"],
+                    "value": "snowflake/arctic-embed-I",
+                }
+            }
+        )
+        embeddings = MagicMock()
+        embeddings.available_models = [
+            _mock_model("nvidia/nv-embed-v1"),
+            _mock_model("snowflake/arctic-embed-I"),
+        ]
+
+        with patch.object(component, "build_embeddings", return_value=embeddings):
+            result = component.update_build_config(
+                build_config,
+                "https://integrate.api.nvidia.com/v1",
+                field_name="base_url",
+            )
+
+        assert result["model"]["options"] == ["nvidia/nv-embed-v1", "snowflake/arctic-embed-I"]
+        assert result["model"]["value"] == "snowflake/arctic-embed-I"
+
+    def test_rerank_update_falls_back_when_selected_model_is_unavailable(self):
+        from lfx.components.nvidia.nvidia_rerank import NvidiaRerankComponent
+        from lfx.schema.dotdict import dotdict
+
+        component = NvidiaRerankComponent()
+        build_config = dotdict({"model": {"options": ["removed-model"], "value": "removed-model"}})
+        compressor = MagicMock()
+        compressor.available_models = [_mock_model("model-a"), _mock_model("model-b")]
+
+        with patch.object(component, "build_compressor", return_value=compressor):
+            result = component.update_build_config(
+                build_config,
+                "https://integrate.api.nvidia.com/v1",
+                field_name="base_url",
+            )
+
+        assert result["model"]["options"] == ["model-a", "model-b"]
+        assert result["model"]["value"] == "model-a"


### PR DESCRIPTION
## Summary
- Preserve the selected NVIDIA Rerank and Embeddings model when refreshed model options still include it.
- Fall back to the first available model, or `None` when no models are returned.
- Add unit coverage for rerank preservation, embedding preservation, and unavailable-model fallback.

## Validation
- `uv run ruff check src/lfx/src/lfx/components/nvidia/nvidia_embedding.py src/lfx/src/lfx/components/nvidia/nvidia_rerank.py src/lfx/tests/unit/components/test_nvidia_component.py`
- `cd src/lfx && LFX_TEST_ALLOW_LANGFLOW=1 uv run pytest tests/unit/components/test_nvidia_component.py`

Fixes #13406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NVIDIA embedding and reranking components now preserve your selected model when refreshing available options. If your selection is no longer available, the system automatically falls back to the first available model.

* **Tests**
  * Added unit tests validating model selection preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->