### PR TITLE
fix(logger): log message key fallback

### DIFF
--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -717,6 +717,18 @@ class TestSizedLogBufferIntegration:
         entries = buffer.get_last_n(1)
         assert "Test msg message" in entries.values()
 
+    def test_write_with_message_field_fallback(self):
+        """Test write() falls back to message field when other content fields are absent."""
+        buffer = SizedLogBuffer()
+        buffer.max = 5
+
+        message = json.dumps({"message": "Test message fallback", "timestamp": "2021-07-01T12:00:00Z"})
+
+        buffer.write(message)
+        assert len(buffer) == 1
+        entries = buffer.get_last_n(1)
+        assert "Test message fallback" in entries.values()
+
     def test_write_with_numeric_timestamp(self):
         """Test write() with numeric timestamp."""
         buffer = SizedLogBuffer()

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -56,7 +56,7 @@ class SizedLogBuffer:
     def write(self, message: str) -> None:
         """Write a message to the buffer."""
         record = json.loads(message)
-        log_entry = record.get("event", record.get("msg", record.get("text", "")))
+        log_entry = record.get("event", record.get("msg", record.get("text", record.get("message", ""))))
 
         # Extract timestamp - support both direct timestamp and nested record.time.timestamp
         timestamp = record.get("timestamp", 0)


### PR DESCRIPTION
The `add_serialized` function in logger.py stores "message" key. But the SizedLogBuffer.write method only outputs `msg` key. This change fixes the logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced log entry extraction to recognize additional field formats, improving compatibility with different JSON record structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->