### PR TITLE
fix(memory): show dashes for stat cards in All Sessions view

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetails.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/MemoryDetails.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/utils/utils";
 import { formatDate } from "../helpers";
+import { ALL_SESSIONS_VALUE } from "../hooks/useMemorySessionResolver";
 import { MemoryDetailsProps } from "../types";
 import { MemoryDetailsHeader } from "./MemoryDetailsHeader";
 import { MemoryKnowledgeBaseSection } from "./MemoryKnowledgeBaseSection";
@@ -33,6 +34,8 @@ export function MemoryDetails({
 }: MemoryDetailsProps) {
   const [configOpen, setConfigOpen] = useState(false);
   const { t } = useTranslation();
+  const isAllSessions =
+    !selectedSession || selectedSession === ALL_SESSIONS_VALUE;
   const pendingLabel =
     memory.batch_size > 1
       ? t("memory.pendingThisBatch")
@@ -61,13 +64,17 @@ export function MemoryDetails({
         <div className="mb-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
           <SummaryCard
             label={t("memory.processedMessages")}
-            value={memory.total_messages_processed}
+            value={isAllSessions ? "—" : memory.total_messages_processed}
             icon="MessageSquare"
           />
-          <SummaryCard label={pendingLabel} value={pendingValue} icon="Timer" />
+          <SummaryCard
+            label={pendingLabel}
+            value={isAllSessions ? "—" : pendingValue}
+            icon="Timer"
+          />
           <SummaryCard
             label={t("memory.lastGenerated")}
-            value={formatDate(memory.last_generated_at) || t("memory.never")}
+            value={isAllSessions ? "—" : formatDate(memory.last_generated_at)}
             icon="Clock"
           />
           <Popover open={configOpen} onOpenChange={setConfigOpen}>

--- a/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetails.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/MemoriesMainContent/components/__tests__/MemoryDetails.test.tsx
@@ -64,8 +64,17 @@ jest.mock("../MemoryKnowledgeBaseSection", () => ({
 }));
 
 jest.mock("../SummaryCard", () => ({
-  SummaryCard: ({ label }: { label: string }) => (
-    <div data-testid="summary-card">{label}</div>
+  SummaryCard: ({
+    label,
+    value,
+  }: {
+    label: string;
+    value: string | number;
+  }) => (
+    <div data-testid="summary-card">
+      <span data-testid="summary-card-label">{label}</span>
+      <span data-testid="summary-card-value">{value}</span>
+    </div>
   ),
 }));
 
@@ -254,5 +263,98 @@ describe("MemoryDetails — Config popover", () => {
     render(<MemoryDetails {...baseProps} />);
     const chevron = screen.getByTestId("icon-ChevronDown");
     expect(chevron.className).not.toContain("rotate-180");
+  });
+});
+
+describe("MemoryDetails — stat cards session filtering", () => {
+  const memoryWithStats: MemoryInfo = {
+    ...baseMemory,
+    total_messages_processed: 42,
+    pending_messages_count: 3,
+    last_generated_at: "2024-06-01T12:00:00Z",
+  };
+
+  function getValueByLabel(label: string) {
+    const cards = screen.getAllByTestId("summary-card");
+    const card = cards.find(
+      (c) =>
+        c.querySelector(`[data-testid="summary-card-label"]`)?.textContent ===
+        label,
+    );
+    return card?.querySelector(`[data-testid="summary-card-value"]`)
+      ?.textContent;
+  }
+
+  it("shows — for all stat cards when selectedSession is null (All Sessions default)", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={memoryWithStats}
+        selectedSession={null}
+      />,
+    );
+    expect(getValueByLabel("Processed Messages")).toBe("—");
+    expect(getValueByLabel("Pending Messages")).toBe("—");
+    expect(getValueByLabel("Last Generated")).toBe("—");
+  });
+
+  it("shows — for all stat cards when selectedSession is ALL_SESSIONS_VALUE", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={memoryWithStats}
+        selectedSession="__all__"
+      />,
+    );
+    expect(getValueByLabel("Processed Messages")).toBe("—");
+    expect(getValueByLabel("Pending Messages")).toBe("—");
+    expect(getValueByLabel("Last Generated")).toBe("—");
+  });
+
+  it("shows actual values when a specific session is selected", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={memoryWithStats}
+        selectedSession="session-abc"
+      />,
+    );
+    expect(getValueByLabel("Processed Messages")).toBe("42");
+    expect(getValueByLabel("Pending Messages")).toBe("3");
+    expect(getValueByLabel("Last Generated")).not.toBe("—");
+    expect(getValueByLabel("Last Generated")).not.toBe("");
+  });
+
+  it("shows 0 for Processed Messages when value is 0 and a session is selected", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={{ ...memoryWithStats, total_messages_processed: 0 }}
+        selectedSession="session-abc"
+      />,
+    );
+    expect(getValueByLabel("Processed Messages")).toBe("0");
+  });
+
+  it("shows 0 for Pending Messages when value is 0 and a session is selected", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={{ ...memoryWithStats, pending_messages_count: 0 }}
+        selectedSession="session-abc"
+      />,
+    );
+    expect(getValueByLabel("Pending Messages")).toBe("0");
+  });
+
+  it("shows Never for Last Generated when date is absent and session is selected", () => {
+    render(
+      <MemoryDetails
+        {...baseProps}
+        memory={{ ...memoryWithStats, last_generated_at: undefined }}
+        selectedSession="session-abc"
+      />,
+    );
+    expect(getValueByLabel("Last Generated")).toBe("Never");
   });
 });


### PR DESCRIPTION
## Summary

- In the Memory dashboard, the **Processed Messages**, **Pending Messages**, and **Last Generated** stat cards previously showed memory-wide totals regardless of which session was selected — this was misleading when "All Sessions" was active, as the numbers had no clear session context.
- Stat cards now show `—` when **All Sessions** is selected, and real session-specific values when a specific session is active.
- The **Config** card is unaffected and always shows the memory configuration.


## Test plan

- [ ] Open Memory dashboard → select a memory → confirm stat cards show `—` in All Sessions view
- [ ] Select a specific session from the dropdown → confirm Processed Messages, Pending Messages, and Last Generated show real session data
- [ ] Switch back to All Sessions → confirm cards revert to `—`
- [ ] Verify Config card is visible and unchanged in both views

## Screenhot
<img width="1550" height="288" alt="Screenshot 2026-06-01 at 12 54 42 PM" src="https://github.com/user-attachments/assets/6859d016-7b4d-4892-9511-0287662aa6db" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Summary stat cards now display placeholder values ("—") when viewing all sessions, and show actual session-specific values when filtering by a particular session.
  * Improved "Last Generated" field handling in memory details.

* **Tests**
  * Added tests to verify summary card behavior across different session filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->