### PR TITLE
fix: declare kb_allowed_folder_roots on Settings so KB folder ingestion works

### DIFF
--- a/src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py
+++ b/src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py
@@ -242,6 +242,47 @@ class TestFolderIngest:
         assert "outside the configured allow-list" in response.json()["detail"]
         mock_job_service.assert_not_called()
 
+    @patch("langflow.api.v1.knowledge_bases.KBAnalysisHelper.get_metadata")
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_folder_ingest_with_real_settings_returns_400_not_500(
+        self,
+        mock_root,
+        mock_meta,
+        client: AsyncClient,
+        logged_in_headers,
+        active_user,
+        tmp_path,
+    ):
+        """Regression: the route must read a *declared* Settings field.
+
+        The other folder-ingest tests inject ``SimpleNamespace(kb_allowed_folder_roots=...)``
+        so they never touch the real ``Settings`` model. In 1.10.0 the field was not
+        declared, so the route raised ``AttributeError`` → HTTP 500 on every call. This
+        test deliberately does NOT mock ``get_settings_service``: with the field present
+        and defaulting to an empty allow-list, the route reaches
+        ``FolderSource.validate_config()`` and returns an actionable 400 — exactly like
+        the sibling ``/ingest/connector`` route — instead of a 500.
+        """
+        mock_root.return_value = tmp_path
+        kb_dir = tmp_path / active_user.username / "folder_kb_real_settings"
+        kb_dir.mkdir(parents=True)
+        mock_meta.return_value = {
+            "id": "00000000-0000-0000-0000-000000000006",
+            "embedding_provider": "OpenAI",
+            "embedding_model": "text-embedding-3-small",
+        }
+
+        # ``tmp_path`` exists and is a directory, so validation advances past the
+        # path checks to the allow-list gate (empty by default → actionable 400).
+        response = await client.post(
+            "api/v1/knowledge_bases/folder_kb_real_settings/ingest/folder",
+            headers=logged_in_headers,
+            json={"path": str(tmp_path)},
+        )
+
+        assert response.status_code == 400, response.text
+        assert "allow-list" in response.json()["detail"]
+
     async def test_folder_ingest_rejects_unbounded_chunk_parameters(self, client: AsyncClient, logged_in_headers):
         response = await client.post(
             "api/v1/knowledge_bases/folder_kb/ingest/folder",

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -69,6 +69,16 @@ class Settings(BaseSettings):
     knowledge_bases_dir: str | None = "~/.langflow/knowledge_bases"
     """The directory to store knowledge bases."""
 
+    kb_allowed_folder_roots: list[str] = []
+    """Allow-list of directories the folder-ingestion endpoint may read from.
+
+    Comma-separated when set via env (``LANGFLOW_KB_ALLOWED_FOLDER_ROOTS``),
+    e.g. ``/srv/docs,/data/shared``. Empty by default — operators must opt in.
+    ``POST /api/v1/knowledge_bases/{kb_name}/ingest/folder`` refuses to walk any
+    directory that is not equal to or inside one of these roots; symlink escapes
+    are blocked because the path is resolved before the containment check. Leave
+    empty in multi-tenant cloud deployments to refuse arbitrary-path access."""
+
     dev: bool = False
     """If True, Langflow will run in development mode."""
     database_url: str | None = None

--- a/src/lfx/tests/unit/services/settings/test_kb_allowed_folder_roots.py
+++ b/src/lfx/tests/unit/services/settings/test_kb_allowed_folder_roots.py
@@ -1,0 +1,44 @@
+"""Tests for the ``kb_allowed_folder_roots`` setting.
+
+The folder-ingestion route (``POST /{kb_name}/ingest/folder``) gates which
+server-side directories it may read via ``settings.kb_allowed_folder_roots``.
+Before this field was declared on the model, the attribute did not exist:
+reading it raised ``AttributeError`` (re-raised by the route as a generic
+HTTP 500), and ``LANGFLOW_KB_ALLOWED_FOLDER_ROOTS`` bound to nothing because
+``model_config`` uses ``extra="ignore"`` — so the allow-list could never be
+configured and the endpoint was unusable.
+
+These tests exercise the *real* Settings model (the endpoint unit tests inject
+a mocked settings object, so they never caught the missing field).
+"""
+
+from lfx.services.settings.base import Settings
+
+
+def test_kb_allowed_folder_roots_field_is_declared(monkeypatch):
+    """The field must exist on the model — guards against the 1.10.0 regression."""
+    monkeypatch.delenv("LANGFLOW_KB_ALLOWED_FOLDER_ROOTS", raising=False)
+    settings = Settings()
+    # Accessing the attribute must not raise AttributeError.
+    assert hasattr(settings, "kb_allowed_folder_roots")
+
+
+def test_kb_allowed_folder_roots_defaults_to_empty_list(monkeypatch):
+    """With no env var configured the allow-list is empty (operators opt in)."""
+    monkeypatch.delenv("LANGFLOW_KB_ALLOWED_FOLDER_ROOTS", raising=False)
+    settings = Settings()
+    assert settings.kb_allowed_folder_roots == []
+
+
+def test_kb_allowed_folder_roots_binds_single_value_from_env(monkeypatch):
+    """A single directory binds from the LANGFLOW_-prefixed env var."""
+    monkeypatch.setenv("LANGFLOW_KB_ALLOWED_FOLDER_ROOTS", "/srv/docs")
+    settings = Settings()
+    assert settings.kb_allowed_folder_roots == ["/srv/docs"]
+
+
+def test_kb_allowed_folder_roots_parses_comma_separated_env(monkeypatch):
+    """Multiple roots are comma-separated, like the other list settings."""
+    monkeypatch.setenv("LANGFLOW_KB_ALLOWED_FOLDER_ROOTS", "/srv/docs,/data/shared")
+    settings = Settings()
+    assert settings.kb_allowed_folder_roots == ["/srv/docs", "/data/shared"]


### PR DESCRIPTION
## Summary

`POST /api/v1/knowledge_bases/{kb_name}/ingest/folder` returns **HTTP 500 on every call** (both Chroma and OpenSearch backends), making the dedicated "Folder" ingestion source completely non-functional in 1.10.0.

The route reads `settings.kb_allowed_folder_roots`, but **that field is never declared on the `Settings` model** — only `knowledge_bases_dir` exists among the KB fields. Because `Settings.model_config` uses `extra="ignore"`:

- Accessing `settings.kb_allowed_folder_roots` raises `AttributeError`, which the route's generic `except Exception` re-raises as `HTTPException(500)`.
- The env var `LANGFLOW_KB_ALLOWED_FOLDER_ROOTS` binds to nothing and is silently dropped — so the allow-list **cannot be configured at all**.

The `AttributeError` fires before `FolderSource.validate_config()`, so the empty-allow-list case never produces its actionable 400 either.

Deterministic repro (in the app venv):
```python
from lfx.services.settings.base import Settings
Settings().kb_allowed_folder_roots   # AttributeError: 'Settings' object has no attribute 'kb_allowed_folder_roots'
```

The sibling generic route `POST /{kb_name}/ingest/connector` (same machinery, same `FolderSource`) does **not** read this setting and behaves correctly — confirming the defect is isolated to the dedicated `/ingest/folder` route reading an undeclared field.

## Fix

Declare the field on `Settings` (next to `knowledge_bases_dir`):

```python
kb_allowed_folder_roots: list[str] = []
```

The existing `CustomSource` (the model's sole settings source) already parses comma-separated values for any list-typed field, so `LANGFLOW_KB_ALLOWED_FOLDER_ROOTS=/srv/docs,/data/shared` now binds correctly.

After the fix:
- **No allow-list configured** → `400` with `"FolderSource refuses to walk without an allow-list. Configure LANGFLOW_KB_ALLOWED_FOLDER_ROOTS …"` (matches the sibling connector route) instead of a `500`.
- **Allow-list configured, path inside a root** → folder ingestion works (KB → ready, chunks created).
- **Allow-list configured, path outside** → `400` `"outside the configured allow-list"`.

## Why CI didn't catch it

The existing endpoint tests inject a mocked settings object — `SimpleNamespace(kb_allowed_folder_roots=[...])` — so they never exercise the real `Settings` model and passed despite the missing field. This PR adds tests that hit the real model.

## Test plan

- [x] `src/lfx/tests/unit/services/settings/test_kb_allowed_folder_roots.py` (new) — exercises the **real** `Settings` model: field is declared, defaults to `[]`, binds single + comma-separated values from `LANGFLOW_KB_ALLOWED_FOLDER_ROOTS`. (4 passed)
- [x] `test_connector_endpoints.py::TestFolderIngest::test_folder_ingest_with_real_settings_returns_400_not_500` (new) — does **not** mock `get_settings_service`; asserts the route returns `400` (not `500`) with an actionable allow-list message. Would fail (500) before the fix.
- [x] Full `test_connector_endpoints.py` suite green (13 passed), including the pre-existing tests that mock settings.
- [x] `ruff check` + `ruff format --check` clean.

Affects: release-1.10.0 (Langflow 1.10.0). Found by QA — F4 Knowledge Base, checklist item KB-N6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable allow-list setting to restrict which directories can be used for knowledge-base folder ingestion. Administrators can specify permitted directories via environment variable (comma-separated paths).

* **Bug Fixes**
  * Improved error messaging on the folder ingestion endpoint—now returns a clear 400 error referencing the allow-list when configuration is missing, instead of an unclear server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->