### PR TITLE
fix: point file manager empty-state link to the files page route

### DIFF
--- a/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/__tests__/recent-files-component.test.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/__tests__/recent-files-component.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import type { FileType } from "@/types/file_management";
 import { setRelativePathForServerPath } from "@/utils/file-relative-path-map";
 import RecentFilesComponent from "../index";
@@ -165,5 +166,25 @@ describe("RecentFilesComponent", () => {
     });
 
     expect(screen.getByTestId("files-renderer")).toBeInTheDocument();
+  });
+
+  it("links the empty-state 'My Files' shortcut to the /assets/files route", () => {
+    // Regression: the empty-state link pointed at the non-existent top-level
+    // "/files" route (a dead end). The files page is nested under "assets",
+    // so the link must target "/assets/files" — matching the sidebar's
+    // navigation in sideBarFolderButtons.
+    render(
+      <MemoryRouter>
+        <RecentFilesComponent
+          files={[]}
+          selectedFiles={[]}
+          setSelectedFiles={jest.fn()}
+          types={["txt"]}
+          isList={true}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/assets/files");
   });
 });

--- a/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
@@ -427,7 +427,7 @@ export default function RecentFilesComponent({
               {t("fileManager.orVisit")}{" "}
               <CustomLink
                 className="text-accent-pink-foreground underline"
-                to="/files"
+                to="/assets/files"
               >
                 {t("files.myFiles")}.
               </CustomLink>


### PR DESCRIPTION
## Bug

In the file manager empty state (e.g. when attaching files to a flow with no files uploaded yet), the message reads:

> Upload or import files, or visit **My Files**.

Clicking the **"My Files"** link navigated to the wrong route — it pointed at a top-level `/files` path that does not exist in the router, so the link dead-ended instead of opening the My Files page.

## Root cause

The files page is registered as a **nested** route under `assets` (`src/frontend/src/routes.tsx`):

```tsx
<Route path="assets">
  <Route index element={<CustomNavigate replace to="files" />} />
  <Route path="files" element={<FilesPage />} />
  ...
</Route>
```

So the real path is `/assets/files` (and `/assets` redirects to it). There is no top-level `/files` route. The empty-state link in `recentFilesComponent` used `to="/files"`, while every other navigation to this page uses `/assets/files` — e.g. the folder sidebar (`sideBarFolderButtons/index.tsx`):

```tsx
_navigate("/assets/files");
```

## Fix

Point the empty-state `CustomLink` at `/assets/files`, matching the route definition and the sidebar's navigation. One-line change.

## Tests

Added a regression test in `recent-files-component.test.tsx` that renders the empty state and asserts the link `href` is `/assets/files`. Confirmed it **fails** on the old `/files` value and **passes** with the fix.

## Test plan

- [x] `npx jest src/modals/fileManagerModal/components/recentFilesComponent/__tests__/recent-files-component.test.tsx` — 3 passed
- [x] New test fails on the pre-fix `/files` route (verifies it actually catches the regression)
- [x] `biome check` clean on both changed files
- [ ] Manual: open the file manager with no files → click "My Files" → lands on the My Files page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the navigation link for the "My Files" shortcut in the empty state of the file manager to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->