### PR TITLE
fix(memories): return 422 instead of 500 when request body is missing

### DIFF
--- a/src/backend/base/langflow/api/v1/memories.py
+++ b/src/backend/base/langflow/api/v1/memories.py
@@ -92,7 +92,7 @@ class RegenerateResponse(BaseModel):
 @router.post("/", status_code=HTTPStatus.CREATED)
 async def create_memory_base(
     current_user: CurrentActiveUser,
-    payload: Annotated[MemoryBaseCreate, Body(embed=False)] = ...,
+    payload: Annotated[MemoryBaseCreate, Body(embed=False)],
 ) -> MemoryBaseRead:
     """Create a new Memory Base.
 
@@ -258,7 +258,7 @@ async def list_memory_base_messages(
 async def update_memory_base(
     memory_base_id: uuid.UUID,
     current_user: CurrentActiveUser,
-    patch: Annotated[MemoryBaseUpdate, Body(embed=False)] = ...,
+    patch: Annotated[MemoryBaseUpdate, Body(embed=False)],
 ) -> MemoryBaseRead:
     """Update mutable parameters (name, threshold, auto_capture).
 
@@ -301,7 +301,7 @@ async def delete_memory_base(
 async def flush_memory_base(
     memory_base_id: uuid.UUID,
     current_user: CurrentActiveUser,
-    body: Annotated[FlushRequest, Body(embed=False)] = ...,
+    body: Annotated[FlushRequest, Body(embed=False)],
 ) -> dict:
     """Manually trigger an ingestion / sync job regardless of the threshold.
 

--- a/src/backend/tests/unit/test_memory_bases.py
+++ b/src/backend/tests/unit/test_memory_bases.py
@@ -2268,3 +2268,36 @@ class TestMemoryBaseSecurityAdversarial:
         compiled = str(stmt)
         assert "user_id" in compiled
         assert "memory_base" in compiled.lower()
+
+
+class TestMemoryBaseBodyValidation:
+    """HTTP-level validation for endpoints that require a JSON request body.
+
+    Regression for: a *missing* request body must be rejected with 422
+    (the same as an empty JSON object), never a 500.  Previously the body
+    parameters were declared as ``Annotated[Model, Body(embed=False)] = ...``;
+    the Ellipsis default leaked through FastAPI's body solver when no body was
+    sent, so the handler received ``...`` and raised
+    ``'ellipsis' object has no attribute '...'`` (HTTP 500).
+    """
+
+    @pytest.mark.asyncio
+    async def test_flush_missing_body_returns_422(self, client, logged_in_headers):
+        """POST /memories/{id}/flush with no body -> 422 (not 500)."""
+        mb_id = uuid.uuid4()
+        response = await client.post(f"api/v1/memories/{mb_id}/flush", headers=logged_in_headers)
+        assert response.status_code == 422, response.text
+
+    @pytest.mark.asyncio
+    async def test_flush_empty_json_returns_422(self, client, logged_in_headers):
+        """POST /memories/{id}/flush with {} -> 422 flagging the missing session_id."""
+        mb_id = uuid.uuid4()
+        response = await client.post(f"api/v1/memories/{mb_id}/flush", headers=logged_in_headers, json={})
+        assert response.status_code == 422, response.text
+        assert "session_id" in response.text
+
+    @pytest.mark.asyncio
+    async def test_create_missing_body_returns_422(self, client, logged_in_headers):
+        """POST /memories with no body -> 422 (not 500); same root cause as flush."""
+        response = await client.post("api/v1/memories", headers=logged_in_headers)
+        assert response.status_code == 422, response.text


### PR DESCRIPTION
## Summary

`POST /api/v1/memories/{id}/flush` returned **HTTP 500** with
`{"message":"'ellipsis' object has no attribute 'session_id'"}` when called
with **no request body**, instead of the **422** it already returns for an
empty JSON object (`{}`). A missing body should be a clean client-side
validation error, not a server error.

| Request | Before | After |
|---|---|---|
| no body | ❌ 500 `'ellipsis' object has no attribute 'session_id'` | ✅ 422 |
| `{}` (empty JSON) | ✅ 422 (field required: `session_id`) | ✅ 422 |
| `{"session_id":"..."}` | ✅ 202 | ✅ 202 |

## Root cause

The body parameters were declared as:

```python
body: Annotated[FlushRequest, Body(embed=False)] = ...,
```

When **no body** is sent at all, FastAPI's body solver leaks the `...`
(Ellipsis) default through as the parameter value, so the handler runs with
`body = ...` and `body.session_id` raises
`'ellipsis' object has no attribute 'session_id'` → 500. (With `{}`, the body
*is* present, so the model validates normally and the missing `session_id`
correctly produces 422.)

Per [FastAPI's documented practice](https://fastapi.tiangolo.com/tutorial/body/#__tabbed_2_1),
a required body declared with `Annotated` must **omit** the default rather
than set `= ...`. Dropping the Ellipsis default makes a missing body fail
validation cleanly with 422.

## Changes

- `src/backend/base/langflow/api/v1/memories.py` — removed the `= ...`
  default from the three handlers sharing this pattern: `create_memory_base`
  (`payload`), `update_memory_base` (`patch`), and `flush_memory_base`
  (`body`). All three would have returned 500 on a missing body; QA only
  exercised `/flush`.
- `src/backend/tests/unit/test_memory_bases.py` — added `TestMemoryBaseBodyValidation`
  with HTTP-level regression tests (a function-level call can't reproduce
  this; it lives in FastAPI's request parsing).

No behavior change for the happy path or the `{}` case — only the
missing-body path is corrected (500 → 422).

## Secondary observation (not addressed — intentional)

The QA note that `/flush` doesn't *clear* the Memory Base (it triggers an
ingestion/sync job; clearing is `DELETE /api/v1/memories/{id}`) is a naming
nit, not a defect. Renaming a shipped endpoint would be a breaking API change,
so it's left as-is.

## Test plan

- [x] New tests fail on the base commit (reproduce the 500) and pass after the fix
- [x] `uv run pytest src/backend/tests/unit/test_memory_bases.py` — 97 passed
- [x] `ruff format` / `ruff check` clean; pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request validation for memory management API endpoints to ensure proper error handling and response codes.

* **Tests**
  * Added comprehensive test coverage for memory API request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->