### PR TITLE
fix(observability): make grafana-loki reference stack instructions work end to end

### DIFF
--- a/deploy/observability/grafana-loki/README.md
+++ b/deploy/observability/grafana-loki/README.md
@@ -16,17 +16,23 @@ The dashboard expects Langflow to be running in JSON mode with service metadata 
 
 ```bash
 LANGFLOW_LOG_ENV=container
-LANGFLOW_LOG_FILE=/var/log/langflow/langflow.log
+LANGFLOW_LOG_FILE=/absolute/path/to/langflow/logs/langflow.log
 LANGFLOW_SERVICE_NAME=langflow
 LANGFLOW_VERSION=1.10.0
 LANGFLOW_ENVIRONMENT=production
 ```
 
+Promtail scrapes a directory of `*.log` files, so `LANGFLOW_LOG_FILE` must point at a file inside
+the directory you expose to Promtail as `LANGFLOW_LOG_DIR` (see [Run](#run)). Set both to the same
+directory, otherwise Promtail watches an empty folder and the dashboard stays blank. Use an
+absolute path: `LANGFLOW_LOG_FILE` is resolved against Langflow's working directory, not this one.
+
 In JSON mode the file is a single JSON stream: application logs and third-party stdlib loggers
 (`uvicorn`, `sqlalchemy`, `httpx`, `langchain`) are all rendered as JSON and run through PII
 redaction, so the `json` parse stage and the **Stdlib intercept routing** panel work against it
-directly. If you'd rather not write a file, drop `LANGFLOW_LOG_FILE` and scrape the container's
-stdout instead (same JSON, same labels).
+directly. This stack scrapes a file, so `LANGFLOW_LOG_FILE` is required. If you instead run
+Langflow as a container, you can drop the file and scrape its stdout by swapping Promtail's
+`static_configs` file target for `docker_sd_configs` (same JSON, same labels).
 
 See [Logs and observability](../../../docs/docs/Develop/observability-grafana-loki.mdx) for the full list of environment variables (per-logger overrides, extra PII redaction keys, trace correlation, etc.).
 
@@ -35,9 +41,10 @@ See [Logs and observability](../../../docs/docs/Develop/observability-grafana-lo
 From this directory:
 
 ```bash
-# Point Promtail at the directory containing your langflow*.log file(s).
-# Defaults to ./logs/ if unset (useful for a quick local smoke test).
-export LANGFLOW_LOG_DIR=/path/to/langflow/logs
+# Point Promtail at the directory that holds the file you set in
+# LANGFLOW_LOG_FILE above. Must be the same directory. Defaults to the
+# bundled ./logs (used by the quick smoke test below).
+export LANGFLOW_LOG_DIR=/absolute/path/to/langflow/logs
 
 docker compose up -d
 ```
@@ -48,6 +55,22 @@ To stop:
 
 ```bash
 docker compose down -v
+```
+
+### Quick smoke test (no Langflow required)
+
+To verify the stack end to end without running Langflow, write a sample record into the bundled
+`./logs` directory and query Loki directly:
+
+```bash
+mkdir -p logs
+echo '{"event":"smoke test","level":"info","logger":"langflow.api.run","timestamp":"2026-06-01T00:00:00Z","service":"langflow","environment":"production","version":"1.10.0"}' >> logs/langflow.log
+
+docker compose up -d
+
+# Give Promtail a few seconds to tail the file, then confirm the line reached Loki:
+sleep 5
+curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query={job="langflow"}' | grep -q "smoke test" && echo "OK: log reached Loki"
 ```
 
 ## What each dashboard panel proves


### PR DESCRIPTION
The reference stack README pointed `LANGFLOW_LOG_FILE` and `LANGFLOW_LOG_DIR` at different directories, so following it produced an empty Grafana dashboard: Langflow wrote to one path while Promtail scraped another. It also documented a stdout-scrape alternative the shipped Promtail config does not implement.

This makes the two paths consistent, requires an absolute log path, corrects the stdout note, and adds a no-Langflow smoke test that writes a sample record and confirms it reaches Loki.

Verified end to end against the shipped compose/Promtail: the sample line reaches Loki in ~5s with `level`, `service`, `environment`, `version`, and `logger` promoted to labels.

The docs PR #13251 builds on this stack and will need the same env-block correction (set `LANGFLOW_LOG_FILE` plus `LANGFLOW_LOG_DIR`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced Langflow+Grafana+Loki setup instructions with explicit environment variable examples and clearer configuration guidance for log file handling.
* Added a quick smoke test section to verify observability stack integration without requiring Langflow to be running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->