### PR TITLE
fix: resolve crash in DataOutputComponent when rows exceed maxItemsLength

### DIFF
--- a/src/frontend/src/components/core/dataOutputComponent/index.tsx
+++ b/src/frontend/src/components/core/dataOutputComponent/index.tsx
@@ -47,7 +47,9 @@ function DataOutputComponent({
       key={"dataOutputComponent"}
       overlayNoRowsTemplate="No data available"
       paginationInfo={
-        rows.length > maxItemsLength ? rows[maxItemsLength] : undefined
+        rows.length > maxItemsLength
+          ? `${rows.length - maxItemsLength} more items hidden`
+          : undefined
       }
       suppressRowClickSelection={true}
       pagination={pagination}


### PR DESCRIPTION
**Issue:** When inspecting outputs where the number of rows exceeds maxItemsLength, the application crashes with a React error: "Objects are not valid as a React child". This happened because DataOutputComponent passed the first hidden row object (rows[maxItemsLength]) to the paginationInfo prop, which is then rendered directly inside a <span> in TableOptions.

**Fix:** Updated paginationInfo to pass a formatted string indicating the number of hidden items ("{N} more items hidden") instead of the raw data object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination messaging in data output component to display a clearer notification when additional items are hidden beyond the display limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->