### PR TITLE
docs: clarify local CLAUDE.md hard-rules import behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # CLAUDE.md
 
 @AGENTS.md
+@.claude/CLAUDE.md
 
-This project uses [AGENTS.md](https://agents.md/) as the standard for providing context to AI coding agents. The `@AGENTS.md` import above tells Claude Code to load `AGENTS.md` automatically; other tools that natively support `AGENTS.md` will pick it up directly.
+This project uses [AGENTS.md](https://agents.md/) as the standard for providing context to AI coding agents. The `@AGENTS.md` import above tells Claude Code to load `AGENTS.md` automatically; other tools that natively support `AGENTS.md` will pick it up directly. The `@.claude/CLAUDE.md` import loads the local hard-rules file (gitignored) that mirrors the PostToolUse hook policy.


### PR DESCRIPTION
This pull request updates the `CLAUDE.md` documentation to clarify how context files are imported for AI coding agents. The main change is the addition of an explanation for the `@.claude/CLAUDE.md` import.

Documentation improvements:

* Added `@.claude/CLAUDE.md` to the list of imports in `CLAUDE.md` and explained that it loads a local, gitignored hard-rules file mirroring the PostToolUse hook policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration documentation with an additional import directive and clarified documentation on how the policy file is loaded and utilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->