### PR TITLE
fix: make playground code block background theme-reactive

### DIFF
--- a/src/frontend/src/components/core/codeTabsComponent/index.tsx
+++ b/src/frontend/src/components/core/codeTabsComponent/index.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { tomorrow } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { useDarkStore } from "@/stores/darkStore";
 import IconComponent from "../../common/genericIconComponent";
 import { Button } from "../../ui/button";
 
@@ -16,6 +20,7 @@ export default function SimplifiedCodeTabComponent({
   maxHeight,
 }: SimplifiedCodeTabProps) {
   const [isCopied, setIsCopied] = useState<boolean>(false);
+  const dark = useDarkStore((state) => state.dark);
 
   const copyToClipboard = () => {
     if (!navigator.clipboard || !navigator.clipboard.writeText) {
@@ -33,11 +38,13 @@ export default function SimplifiedCodeTabComponent({
 
   return (
     <div
-      className="mt-2 flex w-full flex-col overflow-hidden rounded-md text-left dark"
+      className="mt-2 flex w-full flex-col overflow-hidden rounded-md text-left"
       data-testid="chat-code-tab"
     >
       <div className="flex w-full items-center justify-between rounded-t-md border border-b-0 border-border bg-primary-foreground px-4 py-2">
-        <span className="dar text-sm font-semibold text-white">{language}</span>
+        <span className="text-sm font-semibold text-foreground">
+          {language}
+        </span>
         <Button
           variant="ghost"
           size="icon"
@@ -54,7 +61,7 @@ export default function SimplifiedCodeTabComponent({
       </div>
       <SyntaxHighlighter
         language={language.toLowerCase()}
-        style={tomorrow}
+        style={dark ? oneDark : oneLight}
         className="!mt-0 h-full w-full overflow-auto !bg-primary-foreground [&_code]:!bg-primary-foreground !rounded-b-md !rounded-t-none border border-border text-left custom-scroll"
         customStyle={maxHeight ? { maxHeight } : undefined}
       >


### PR DESCRIPTION
## Problem

In the playground, code / JSON / tool-output blocks (the "Called tool" Input/Output cards, tables, files, etc.) render with a **solid black background**. The black persists after switching from Dark to Light theme, making content hard to read and visually inconsistent.

## Root cause

`SimplifiedCodeTabComponent` (`src/components/core/codeTabsComponent/index.tsx`) was hardcoded to dark:

- The container carried a literal `dark` class, forcing the dark CSS variables locally regardless of the app theme.
- `--primary-foreground` is **white** in light theme and **black** in dark theme, so the forced `dark` class pinned `bg-primary-foreground` to black always.
- The language label used `text-white` (plus a stray `dar` typo) and the syntax highlighter used the dark-only `tomorrow` style.

Because the `dark` class was static, it never reacted to a theme switch.

## Fix

Make the component theme-reactive, matching the existing pattern in `apiModal/codeTabs/code-tabs.tsx` and `EmbedModal/embed-modal.tsx`:

- Read the active theme with `useDarkStore((state) => state.dark)` so the component re-renders on toggle.
- Remove the hardcoded `dark` class — `bg-primary-foreground` / `border-border` now follow the app theme (white block in light, black in dark).
- Label `text-white` (+ `dar` typo) → `text-foreground` (themed).
- Syntax style `tomorrow` → `dark ? oneDark : oneLight`.

Result: light theme → light block with dark text; dark theme → dark block with light text; updates live when the theme is switched.

## Scope

Tables/plain text route through the themed `Markdown` (`dark:prose-invert`); code/JSON/error/tool_use all funnel through this one component; `media` is a bare `<img>` with no forced background. So this single component is the regression source.

## Testing

- Manual: toggle Dark↔Light in the playground with a tool-call message — code blocks now adapt.
- `assistant-message`, `SpanDetail`, `TraceDetailView`, `edit-message-xss` suites pass (58/58).
- Biome (CI mode, `--diagnostic-level=error`) clean; tsc introduces no new errors.

## Screenshots

before
<img width="768" height="478" alt="image" src="https://github.com/user-attachments/assets/ebaa57e7-4d7e-424a-8d0b-85031157eade" />

After
<img width="950" height="812" alt="image" src="https://github.com/user-attachments/assets/0b9dac21-76f9-4b14-b47e-7b8e6e4c2b89" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code syntax highlighting now intelligently adapts to the active application theme, automatically applying appropriate color schemes for light and dark modes. This enhancement ensures optimal readability and maintains visual consistency across the interface, providing a seamless experience regardless of user theme preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->