### PR TITLE
fix: Fix timestamp rendering for expires_at in API Key model

### DIFF
--- a/src/backend/base/langflow/services/database/models/api_key/model.py
+++ b/src/backend/base/langflow/services/database/models/api_key/model.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from pydantic import field_validator
+from pydantic import field_serializer, field_validator
 from sqlmodel import Column, DateTime, Field, Relationship, SQLModel, func
 
 from langflow.schema.serialize import UUIDstr
@@ -16,12 +16,29 @@ def utc_now():
     return datetime.now(timezone.utc)
 
 
+def _as_utc_iso(v: datetime | None) -> str | None:
+    # SQLite (and pre-migration Postgres rows) return naive datetimes from a
+    # timezone=True column. Every writer in this codebase persists UTC, so
+    # treat naive values as UTC rather than letting Pydantic emit them without
+    # an offset — JS Date() parses an offset-less ISO string as local time,
+    # which shifts the displayed expiry by the viewer's UTC offset.
+    if v is None:
+        return None
+    if v.tzinfo is None:
+        v = v.replace(tzinfo=timezone.utc)
+    return v.replace(microsecond=0).isoformat()
+
+
 class ApiKeyBase(SQLModel):
     name: str | None = Field(index=True, nullable=True, default=None)
     last_used_at: datetime | None = Field(default=None, nullable=True)
     total_uses: int = Field(default=0)
     is_active: bool = Field(default=True)
     expires_at: datetime | None = Field(default=None, sa_column=Column(DateTime(timezone=True), nullable=True))
+
+    @field_serializer("expires_at", "last_used_at", when_used="always")
+    def _serialize_expires_last_used(self, v: datetime | None) -> str | None:
+        return _as_utc_iso(v)
 
 
 class ApiKey(ApiKeyBase, table=True):  # type: ignore[call-arg]
@@ -68,3 +85,7 @@ class ApiKeyRead(ApiKeyBase):
     def mask_api_key(cls, v) -> str:
         """Mask all but the first 8 characters of the API key."""
         return f"{v[:8]}{'*' * (len(v) - 8)}"
+
+    @field_serializer("created_at", when_used="always")
+    def _serialize_created_at(self, v: datetime) -> str | None:
+        return _as_utc_iso(v)

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -216,7 +216,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1082,7 +1081,6 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
       "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.1.2",
@@ -1094,7 +1092,6 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
       "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
@@ -1201,7 +1198,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1238,7 +1234,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1248,7 +1243,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
       "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1344,7 +1338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1368,7 +1361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6014,7 +6006,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -6421,7 +6412,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7133,7 +7123,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7144,7 +7133,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7160,8 +7148,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
       "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -7793,7 +7780,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8294,7 +8280,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8563,7 +8548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8956,7 +8940,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -9397,7 +9380,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9974,7 +9956,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10253,7 +10234,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11386,7 +11366,6 @@
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11539,7 +11518,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -12099,7 +12077,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -13686,7 +13663,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13736,7 +13712,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13776,7 +13751,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -16275,7 +16249,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16698,7 +16671,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16792,7 +16764,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16823,7 +16794,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17517,7 +17487,6 @@
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -18036,8 +18005,7 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
       "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -18216,7 +18184,6 @@
       "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -18591,7 +18558,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19188,7 +19154,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19702,7 +19667,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -20687,7 +20651,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/components/CreatedAtCellRender/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/components/CreatedAtCellRender/index.tsx
@@ -1,0 +1,16 @@
+import type { CustomCellRendererProps } from "ag-grid-react";
+import DateReader from "@/components/core/dateReaderComponent";
+
+export default function CreatedAtCellRender({
+  value,
+}: CustomCellRendererProps) {
+  if (value && typeof value === "string" && value.includes("T")) {
+    return (
+      <div className="flex h-full w-full items-center truncate">
+        <DateReader date={value} />
+      </div>
+    );
+  }
+
+  return <div className="flex h-full w-full items-center">—</div>;
+}

--- a/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/components/LastUsedAtCellRender/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/components/LastUsedAtCellRender/index.tsx
@@ -1,0 +1,20 @@
+import type { CustomCellRendererProps } from "ag-grid-react";
+import DateReader from "@/components/core/dateReaderComponent";
+
+export default function LastUsedAtCellRender({
+  value,
+}: CustomCellRendererProps) {
+  if (value && typeof value === "string" && value.includes("T")) {
+    return (
+      <div className="flex h-full w-full items-center truncate">
+        <DateReader date={value} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-center text-muted-foreground">
+      {value ? value : "Never"}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/helpers/column-defs.ts
+++ b/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/helpers/column-defs.ts
@@ -1,5 +1,7 @@
 import TableAutoCellRender from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender";
+import CreatedAtCellRender from "../components/CreatedAtCellRender";
 import ExpiryDateCellRender from "../components/ExpiryDateCellRender";
+import LastUsedAtCellRender from "../components/LastUsedAtCellRender";
 
 export const getColumnDefs = (t: (key: string) => string) => {
   return [
@@ -21,13 +23,13 @@ export const getColumnDefs = (t: (key: string) => string) => {
     {
       headerName: t("settings.apiKeys.columnCreated"),
       field: "created_at",
-      cellRenderer: TableAutoCellRender,
+      cellRenderer: CreatedAtCellRender,
       flex: 1,
     },
     {
       headerName: t("settings.apiKeys.columnLastUsed"),
       field: "last_used_at",
-      cellRenderer: TableAutoCellRender,
+      cellRenderer: LastUsedAtCellRender,
       flex: 1,
     },
     {

--- a/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ApiKeysPage/index.tsx
@@ -28,7 +28,6 @@ export default function ApiKeysPage() {
       const updatedKeysList = data["api_keys"].map((apikey) => ({
         ...apikey,
         name: apikey.name && apikey.name !== "" ? apikey.name : "Untitled",
-        last_used_at: apikey.last_used_at ?? "Never",
       }));
       setKeysList(updatedKeysList);
       setUserId(data["user_id"]);


### PR DESCRIPTION
# Fix API key timestamp timezone handling and display

## Summary
- Fixed backend serialization of datetime fields (created_at, expires_at, last_used_at) to always include UTC timezone offset and exclude milliseconds
- Frontend now correctly displays timestamps in user's local timezone instead of showing raw ISO strings with offset
- Added dedicated cell renderers (CreatedAtCellRender, LastUsedAtCellRender) for consistent date formatting across the table
- Moved "Never" label for unpopulated last_used_at from API query logic to the component layer

## Changes
**Backend:**
- Added `_as_utc_iso()` helper to normalize naive datetimes to UTC and strip milliseconds
- Added field serializers on ApiKeyBase and ApiKeyRead to ensure consistent datetime serialization

**Frontend:**
- Removed hardcoded "Never" mapping from API query, now handled in LastUsedAtCellRender
- Created CreatedAtCellRender component to format created_at using DateReader
- Updated LastUsedAtCellRender to validate ISO format before parsing and display "Never" for null values
- Updated column definitions to use new renderers

## Testing
✅ All backend API key tests pass
✅ All frontend component tests pass
✅ Formatting checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced API key management interface with improved date display, including custom rendering for creation date and last-accessed date columns with consistent timestamp formatting.

* **Bug Fixes**
  * Fixed datetime serialization inconsistencies for API key timestamps to ensure all times are represented in standardized UTC format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->