### PR TITLE
fix: add ON DELETE CASCADE to span.trace_id FK + migration

### DIFF
--- a/src/backend/base/langflow/alembic/versions/b1c2d3e4f5a6_add_ondelete_cascade_to_span_trace_id_fk.py
+++ b/src/backend/base/langflow/alembic/versions/b1c2d3e4f5a6_add_ondelete_cascade_to_span_trace_id_fk.py
@@ -1,0 +1,62 @@
+"""Add ondelete CASCADE to span.trace_id FK
+
+Revision ID: b1c2d3e4f5a6
+Revises: fc7f696a57bf
+Create Date: 2026-06-03 03:00:00.000000
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"  # pragma: allowlist secret
+down_revision: str | None = "fc7f696a57bf"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_fk_constraint_name(conn, table_name: str, column_name: str) -> str | None:
+    """Find the foreign key constraint name for a given column."""
+    inspector = sa.inspect(conn)
+    for fk in inspector.get_foreign_keys(table_name):
+        if column_name in fk["constrained_columns"]:
+            return fk["name"]
+    return None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.create_foreign_key("fk_span_trace_id_trace", "trace", ["trace_id"], ["id"], ondelete="CASCADE")
+    else:
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+            batch_op.create_foreign_key("fk_span_trace_id_trace", "trace", ["trace_id"], ["id"], ondelete="CASCADE")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        return
+
+    with op.batch_alter_table("span", schema=None) as batch_op:
+        batch_op.drop_constraint(fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(fk_name, "trace", ["trace_id"], ["id"])

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -106,9 +106,9 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # by default (requires PRAGMA foreign_keys = ON), and this function follows
         # the existing pattern of explicitly deleting all child records.
         await session.exec(delete(FlowVersion).where(FlowVersion.flow_id == flow_id))
-        # span.trace_id FK lacks ON DELETE CASCADE in the DDL, so spans must
-        # be removed before traces to avoid an FK violation under
-        # PRAGMA foreign_keys=ON.
+        # Explicit span deletion for clarity and SQLite compatibility.
+        # Database-level CASCADE exists, but explicit deletion ensures
+        # consistent behavior across all database backends.
         trace_ids = (await session.exec(select(TraceTable.id).where(TraceTable.flow_id == flow_id))).all()
         if trace_ids:
             await session.exec(delete(SpanTable).where(col(SpanTable.trace_id).in_(trace_ids)))

--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -351,7 +351,7 @@ class SpanTable(SpanBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "span"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    trace_id: UUID = Field(foreign_key="trace.id", index=True, description="Parent trace ID")
+    trace_id: UUID = Field(foreign_key="trace.id", index=True, ondelete="CASCADE", description="Parent trace ID")
     parent_span_id: UUID | None = Field(
         default=None,
         foreign_key="span.id",


### PR DESCRIPTION
## Summary

When deleting a flow, trace rows get deleted (flow_id -> trace ON DELETE CASCADE).
But span.trace_id -> trace.id did NOT have ON DELETE CASCADE,
causing FK violation when trace rows are deleted:

```
psycopg.errors.ForeignKeyViolation: update or delete on table "trace" violates foreign key constraint "span_trace_id_fkey" on table "span"
```

## Fix

Two-part fix:
1. **Model change**: Add ondelete=CASCADE to SpanTable.trace_id field
2. **Alembic migration**: Add migration a1b2c3d4e5f6_add_ondelete_cascade_to_span_trace_id_fk.py following the same pattern as 0e6138e7a0c2

## Files Changed

- src/backend/base/langflow/services/database/models/traces/model.py: +ondelete=CASCADE on trace_id field
- src/backend/base/langflow/alembic/versions/a1b2c3d4e5f6_add_ondelete_cascade_to_span_trace_id_fk.py: New migration

Closes #12732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database data integrity by enabling cascade deletion for span records when their parent trace is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->