### PR TITLE
feat(assistant): Generate complete multi-node flows from natural language

### DIFF
--- a/src/backend/base/langflow/agentic/api/schemas.py
+++ b/src/backend/base/langflow/agentic/api/schemas.py
@@ -8,10 +8,14 @@ from pydantic import BaseModel, Field
 StepType = Literal[
     "generating",  # LLM is generating response
     "generating_component",  # LLM is generating component code
+    "generating_flow",  # LLM is generating a complete flow
     "generation_complete",  # LLM finished generating
     "extracting_code",  # Extracting Python code from response
+    "extracting_flow",  # Extracting compact flow JSON from response
     "validating",  # Validating component code
+    "validating_flow",  # Validating compact flow against registry
     "validated",  # Validation succeeded
+    "validated_flow",  # Flow validation passed
     "validation_failed",  # Validation failed
     "retrying",  # About to retry with error context
 ]

--- a/src/backend/base/langflow/agentic/flows/_model_config.py
+++ b/src/backend/base/langflow/agentic/flows/_model_config.py
@@ -1,0 +1,42 @@
+"""Shared model configuration builder for agentic flows.
+
+Extracted from translation_flow.py so that multiple flows (translation,
+flow generation, Q&A) can reuse the same model config construction logic
+without duplication.
+"""
+
+from __future__ import annotations
+
+
+def build_model_config(provider: str, model_name: str) -> list[dict]:
+    """Build model configuration for LanguageModelComponent.
+
+    Args:
+        provider: Model provider name (e.g., "OpenAI", "Anthropic").
+        model_name: Model name (e.g., "gpt-4o-mini", "claude-3-5-sonnet-20241022").
+
+    Returns:
+        List containing the model config dict expected by LanguageModelComponent.
+    """
+    from lfx.base.models.model_metadata import get_provider_param_mapping
+
+    param_mapping = get_provider_param_mapping(provider)
+    metadata: dict = {
+        "api_key_param": param_mapping.get("api_key_param", "api_key"),
+        "context_length": 128000,
+        "model_class": param_mapping.get("model_class", "ChatOpenAI"),
+        "model_name_param": param_mapping.get("model_name_param", "model"),
+    }
+    # Include extra params like base_url_param for providers like Ollama
+    for extra_param in ("url_param", "project_id_param", "base_url_param"):
+        if extra_param in param_mapping:
+            metadata[extra_param] = param_mapping[extra_param]
+
+    return [
+        {
+            "icon": provider,
+            "metadata": metadata,
+            "name": model_name,
+            "provider": provider,
+        }
+    ]

--- a/src/backend/base/langflow/agentic/flows/flow_generator.py
+++ b/src/backend/base/langflow/agentic/flows/flow_generator.py
@@ -1,0 +1,116 @@
+"""FlowGenerator — LLM graph that generates compact flow JSON from natural language.
+
+This flow takes a user prompt (with an injected component catalog) and produces
+a compact flow JSON object: {"nodes": [...], "edges": [...]}. The compact format
+is then validated and expanded into full ReactFlow format by the
+flow_generation_service.
+
+Usage:
+    from langflow.agentic.flows.flow_generator import get_graph
+    graph = get_graph(provider="OpenAI", model_name="gpt-4o-mini")
+"""
+
+from __future__ import annotations
+
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.components.models import LanguageModelComponent
+from lfx.graph import Graph
+
+from langflow.agentic.flows._model_config import build_model_config
+
+# ---------------------------------------------------------------------------
+# System prompt template — catalog and flow_context are injected at call time
+# via the user message (not via the system prompt template itself), so the
+# system prompt stays stable across retries while the user turn changes.
+# ---------------------------------------------------------------------------
+
+FLOW_GENERATION_SYSTEM_PROMPT = """\
+You are a Langflow Flow Generator. Your only job is to output a valid compact flow JSON object.
+
+## Compact Flow Format
+Output EXACTLY this JSON structure — nothing before, nothing after:
+{{
+  "nodes": [
+    {{"id": "node-1", "type": "ChatInput"}},
+    {{"id": "node-2", "type": "OpenAIModel", "values": {{"model_name": "gpt-4o"}}}},
+    {{"id": "node-3", "type": "ChatOutput"}}
+  ],
+  "edges": [
+    {{"source": "node-1", "source_output": "message", "target": "node-2", "target_input": "input_value"}},
+    {{"source": "node-2", "source_output": "text_output", "target": "node-3", "target_input": "input_value"}}
+  ]
+}}
+
+## Rules
+1. Use ONLY component types from the Available Components section in the user message
+2. Every node must have a unique "id" string (use "node-1", "node-2", etc.)
+3. "type" must EXACTLY match a component name from the catalog — no inventing names
+4. Only set "values" for fields the user explicitly mentioned or that differ from \
+obvious defaults
+5. "source_output" must match an output name listed for that component
+6. "target_input" must match an input name listed for that component
+7. Always include terminal nodes: ChatInput (or TextInput) for input, ChatOutput \
+(or TextOutput) for output — unless the user explicitly says otherwise
+8. For RAG pipelines: connect retriever output to LLM context/input, also connect \
+the user query directly to the LLM
+9. Output ONLY the JSON object — absolutely no explanation, no markdown, no preamble
+"""
+
+
+def get_graph(
+    provider: str | None = None,
+    model_name: str | None = None,
+    api_key_var: str | None = None,
+) -> Graph:
+    """Create and return the FlowGenerator graph.
+
+    The graph takes a user message containing the catalog + request and
+    produces compact flow JSON. session_id-based message storage is enabled
+    so multi-turn editing ("replace X with Y") retains context.
+
+    Args:
+        provider: Model provider (e.g., "OpenAI", "Anthropic"). Defaults to OpenAI.
+        model_name: Model name (e.g., "gpt-4o-mini"). Defaults to gpt-4o-mini.
+        api_key_var: Optional API key variable name.
+
+    Returns:
+        Graph: The configured flow generator graph.
+    """
+    provider = provider or "OpenAI"
+    model_name = model_name or "gpt-4o-mini"
+
+    # Chat input — stores messages so multi-turn edit sessions retain context
+    chat_input = ChatInput()
+    chat_input.set(
+        sender="User",
+        sender_name="User",
+        should_store_message=True,
+    )
+
+    # Language model component
+    llm = LanguageModelComponent()
+    llm.set_input_value("model", build_model_config(provider, model_name))
+
+    llm_config: dict = {
+        "input_value": chat_input.message_response,
+        "system_message": FLOW_GENERATION_SYSTEM_PROMPT,
+        "temperature": 0.3,  # Some creativity, but not too much
+    }
+
+    if api_key_var:
+        llm_config["api_key"] = api_key_var
+
+    llm.set(**llm_config)
+
+    # Chat output — stores model responses for session continuity
+    chat_output = ChatOutput()
+    chat_output.set(
+        input_value=llm.text_response,
+        sender="Machine",
+        sender_name="AI",
+        should_store_message=True,
+        clean_data=True,
+        data_template="{text}",
+    )
+
+    return Graph(start=chat_input, end=chat_output)

--- a/src/backend/base/langflow/agentic/flows/translation_flow.py
+++ b/src/backend/base/langflow/agentic/flows/translation_flow.py
@@ -1,17 +1,18 @@
 """TranslationFlow - Language Detection, Translation, and Intent Classification.
 
 This flow translates user input to English and classifies intent as either
-'generate_component' or 'question'.
+'generate_component', 'generate_flow', 'question', or 'off_topic'.
 
 Usage:
     from langflow.agentic.flows.translation_flow import get_graph
     graph = await get_graph(provider="OpenAI", model_name="gpt-4o-mini")
 """
 
-from lfx.base.models.model_metadata import get_provider_param_mapping
 from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.components.models import LanguageModelComponent
 from lfx.graph import Graph
+
+from langflow.agentic.flows._model_config import build_model_config
 
 TRANSLATION_PROMPT = """You are a Language Detection, Translation, and Intent Classification \
 Agent for Langflow Assistant.
@@ -21,11 +22,18 @@ Your responsibilities are:
 2. Classify the user's intent
 
 Intent Classification:
-- "generate_component": User wants you to CREATE/BUILD/GENERATE/MODIFY a custom Langflow component.
-  This includes both new component requests AND follow-up modifications to a previous component.
+- "generate_component": User wants you to CREATE/BUILD/GENERATE/MODIFY a single custom Langflow \
+component (a Python class). This includes new component requests AND follow-up modifications to a \
+previous component.
   Examples: "Create a component that calls an API", "Build me a custom component for...",
   "can you use dataframe output instead?", "add error handling", "make it also support CSV",
   "change the output to return a list", "use requests instead of urllib", "add a timeout parameter"
+- "generate_flow": User wants to CREATE/BUILD a complete FLOW or PIPELINE with multiple existing \
+Langflow components connected together. They describe a workflow, not a single custom component.
+  Examples: "build a RAG pipeline with OpenAI and Milvus", "create a chatbot flow with GPT-4",
+  "make a flow that takes user input and generates embeddings",
+  "connect ChatInput to an LLM to ChatOutput", "add a vector store retrieval step before the LLM",
+  "replace the OpenAI model with Claude in my flow", "wire up a summarization pipeline"
 - "question": User is ASKING A QUESTION about Langflow, seeking help with Langflow, or wants \
 information about Langflow features, components, flows, or how to use Langflow.
   Examples: "How do I create a component?", "What is a component?", "Can you explain flows?", \
@@ -37,15 +45,22 @@ knowledge, or anything unrelated to Langflow.
 
 IMPORTANT rules:
 - "How to create a component" = question (asking for Langflow guidance)
-- "Create a component that does X" = generate_component (requesting creation)
-- Short follow-up requests that imply changes to something previously generated = generate_component
-  (e.g., "use X instead", "add Y", "change Z", "make it do W", "can you also...", "what about using...")
+- "Create a component that does X" = generate_component (single custom Python class)
+- "Build a flow/pipeline that does X" = generate_flow (multiple connected components)
+- "Connect X to Y" or "wire up X with Y" = generate_flow
+- Keywords: pipeline/flow/chain/workflow/connect/wire = generate_flow
+- Keywords: component/class/custom/code = generate_component
+- Short follow-up requests implying changes to a previously generated component = generate_component
+  (e.g., "use X instead", "add Y", "change Z", "make it do W")
+- Short follow-up requests implying changes to a flow = generate_flow
+  (e.g., "replace OpenAI with Claude", "add a memory step", "remove the vector store")
+- If ambiguous between component and flow, prefer generate_flow (more capable)
 - Questions about OTHER tools or platforms (n8n, Make, Zapier, AutoGen, CrewAI, etc.) = off_topic
 - General knowledge questions NOT related to Langflow = off_topic
 - If unsure whether it's about Langflow, classify as "question" (not off_topic)
 
 Output format (JSON only, no markdown):
-{{"translation": "<english text>", "intent": "<generate_component|question|off_topic>"}}
+{{"translation": "<english text>", "intent": "<generate_component|generate_flow|question|off_topic>"}}
 
 Examples:
 Input: "como criar um componente no langflow"
@@ -77,30 +92,20 @@ Output: {{"translation": "explain how kubernetes works", "intent": "off_topic"}}
 
 Input: "write me a poem about cats"
 Output: {{"translation": "write me a poem about cats", "intent": "off_topic"}}
+
+Input: "build me a RAG pipeline with OpenAI and Milvus"
+Output: {{"translation": "build me a RAG pipeline with OpenAI and Milvus", "intent": "generate_flow"}}
+
+Input: "create a chatbot flow with input, GPT-4, and output"
+Output: {{"translation": "create a chatbot flow with input, GPT-4, and output", "intent": "generate_flow"}}
+
+Input: "replace the OpenAI model with Claude in my flow"
+Output: {{"translation": "replace the OpenAI model with Claude in my flow", "intent": "generate_flow"}}
 """
 
 
-def _build_model_config(provider: str, model_name: str) -> list[dict]:
-    """Build model configuration for LanguageModelComponent."""
-    param_mapping = get_provider_param_mapping(provider)
-    metadata: dict = {
-        "api_key_param": param_mapping.get("api_key_param", "api_key"),
-        "context_length": 128000,
-        "model_class": param_mapping.get("model_class", "ChatOpenAI"),
-        "model_name_param": param_mapping.get("model_name_param", "model"),
-    }
-    # Include extra params like base_url_param for providers like Ollama
-    for extra_param in ("url_param", "project_id_param", "base_url_param"):
-        if extra_param in param_mapping:
-            metadata[extra_param] = param_mapping[extra_param]
-    return [
-        {
-            "icon": provider,
-            "metadata": metadata,
-            "name": model_name,
-            "provider": provider,
-        }
-    ]
+# Keep the private alias for backward compatibility within this module
+_build_model_config = build_model_config
 
 
 def get_graph(

--- a/src/backend/base/langflow/agentic/helpers/component_catalog.py
+++ b/src/backend/base/langflow/agentic/helpers/component_catalog.py
@@ -1,0 +1,165 @@
+"""Component catalog builder for flow generation LLM prompts.
+
+Condenses the live Langflow component registry into a compact, token-efficient
+summary suitable for use in LLM prompts. The catalog is registry-aware:
+any custom components registered via LANGFLOW_COMPONENTS_PATH will automatically
+appear in the catalog with no code changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# Common flow patterns to show in the catalog preamble
+COMMON_PATTERNS = """\
+## Common Flow Patterns (compact format examples)
+
+### Simple Chatbot
+{"nodes": [{"id": "n1", "type": "ChatInput"}, {"id": "n2", "type": "OpenAIModel", "values": {"model_name": "gpt-4o"}}, {"id": "n3", "type": "ChatOutput"}], "edges": [{"source": "n1", "source_output": "message", "target": "n2", "target_input": "input_value"}, {"source": "n2", "source_output": "text_output", "target": "n3", "target_input": "input_value"}]}
+
+### RAG Pipeline (Retrieval-Augmented Generation)
+{"nodes": [{"id": "n1", "type": "ChatInput"}, {"id": "n2", "type": "Milvus", "values": {"collection_name": "docs"}}, {"id": "n3", "type": "OpenAIModel"}, {"id": "n4", "type": "ChatOutput"}], "edges": [{"source": "n1", "source_output": "message", "target": "n2", "target_input": "search_query"}, {"source": "n2", "source_output": "search_results", "target": "n3", "target_input": "context"}, {"source": "n1", "source_output": "message", "target": "n3", "target_input": "input_value"}, {"source": "n3", "source_output": "text_output", "target": "n4", "target_input": "input_value"}]}
+
+### Text Processing Pipeline
+{"nodes": [{"id": "n1", "type": "TextInput"}, {"id": "n2", "type": "Prompt", "values": {"template": "Summarize: {input}"}}, {"id": "n3", "type": "OpenAIModel"}, {"id": "n4", "type": "TextOutput"}], "edges": [{"source": "n1", "source_output": "text", "target": "n2", "target_input": "input"}, {"source": "n2", "source_output": "prompt", "target": "n3", "target_input": "input_value"}, {"source": "n3", "source_output": "text_output", "target": "n4", "target_input": "input_value"}]}
+"""
+
+
+def _get_visible_inputs(template: dict[str, Any], max_inputs: int = 8) -> list[tuple[str, str]]:
+    """Extract non-advanced, visible input fields from a component template."""
+    inputs = []
+    for field_name, field_data in template.items():
+        if not isinstance(field_data, dict):
+            continue
+        # Skip hidden, advanced, or special fields
+        if field_data.get("advanced", False):
+            continue
+        if not field_data.get("show", True):
+            continue
+        if field_name.startswith("_"):
+            continue
+        field_type = field_data.get("type", "str")
+        inputs.append((field_name, field_type))
+        if len(inputs) >= max_inputs:
+            break
+    return inputs
+
+
+def _get_output_names(outputs: list[dict[str, Any]]) -> list[str]:
+    """Extract output names from a component's outputs list."""
+    return [o.get("name", "") for o in outputs if isinstance(o, dict) and o.get("name")]
+
+
+def _truncate_description(description: str, max_chars: int = 80) -> str:
+    """Take the first sentence, capped at max_chars."""
+    if not description:
+        return ""
+    # Take up to the first period/newline
+    for sep in (".", "\n"):
+        idx = description.find(sep)
+        if 0 < idx < max_chars:
+            return description[: idx + 1].strip()
+    return description[:max_chars].strip()
+
+
+def _format_component_line(display_name: str, comp_data: dict[str, Any]) -> str:
+    """Format a single component as a compact catalog line."""
+    description = _truncate_description(comp_data.get("description", ""))
+    template = comp_data.get("template", {})
+    outputs = comp_data.get("outputs", [])
+
+    inputs = _get_visible_inputs(template)
+    output_names = _get_output_names(outputs)
+
+    parts = [f"- {display_name}"]
+    if description:
+        parts.append(f": {description}")
+
+    if inputs:
+        input_str = ", ".join(f"{name}({typ})" for name, typ in inputs)
+        parts.append(f" | Inputs: {input_str}")
+
+    if output_names:
+        parts.append(f" | Outputs: {', '.join(output_names)}")
+
+    return "".join(parts)
+
+
+async def build_component_catalog_prompt(
+    include_categories: list[str] | None = None,
+    exclude_categories: list[str] | None = None,
+    settings_service: Any | None = None,
+) -> str:
+    """Build a compact component catalog string for LLM prompts.
+
+    Condenses the live Langflow component registry (~100K+ tokens) into a
+    ~3-5K token summary. Categories and components are derived from the live
+    registry, so custom components (e.g., CosmosAI components) appear
+    automatically when registered.
+
+    Args:
+        include_categories: If set, only include these categories.
+        exclude_categories: Categories to skip entirely.
+        settings_service: Settings service for registry access. Auto-detected if None.
+
+    Returns:
+        A formatted string listing all components grouped by category,
+        prefixed with common flow patterns.
+    """
+    from lfx.interface.components import get_and_cache_all_types_dict
+
+    if settings_service is None:
+        from langflow.services.deps import get_settings_service
+
+        settings_service = get_settings_service()
+
+    all_types_dict = await get_and_cache_all_types_dict(settings_service)
+
+    exclude_set = set(exclude_categories or [])
+    include_set = set(include_categories or [])
+
+    lines: list[str] = [COMMON_PATTERNS, "## Available Components by Category\n"]
+
+    for category, components in sorted(all_types_dict.items()):
+        if not isinstance(components, dict) or not components:
+            continue
+        if exclude_set and category in exclude_set:
+            continue
+        if include_set and category not in include_set:
+            continue
+
+        # Collect component lines for this category
+        comp_lines = []
+        for comp_name, comp_data in components.items():
+            if not isinstance(comp_data, dict):
+                continue
+            display_name = comp_data.get("display_name", comp_name)
+            comp_lines.append(_format_component_line(display_name, comp_data))
+
+        if not comp_lines:
+            continue
+
+        # Format category header (title-case, replace underscores)
+        category_title = category.replace("_", " ").title()
+        lines.append(f"### {category_title}")
+        lines.extend(comp_lines)
+        lines.append("")  # blank line between categories
+
+    return "\n".join(lines)
+
+
+async def get_all_types_dict(settings_service: Any | None = None) -> dict[str, Any]:
+    """Get the full component registry dict (cached).
+
+    Convenience wrapper used by flow_generation_service and flow_validation
+    to share the same registry call.
+    """
+    from lfx.interface.components import get_and_cache_all_types_dict
+
+    if settings_service is None:
+        from langflow.services.deps import get_settings_service
+
+        settings_service = get_settings_service()
+
+    return await get_and_cache_all_types_dict(settings_service)

--- a/src/backend/base/langflow/agentic/helpers/component_catalog.py
+++ b/src/backend/base/langflow/agentic/helpers/component_catalog.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 # Common flow patterns to show in the catalog preamble
 COMMON_PATTERNS = """\
 ## Common Flow Patterns (compact format examples)

--- a/src/backend/base/langflow/agentic/helpers/flow_extraction.py
+++ b/src/backend/base/langflow/agentic/helpers/flow_extraction.py
@@ -1,0 +1,153 @@
+"""Flow JSON extraction from LLM markdown output.
+
+Extracts compact flow JSON from free-form LLM responses using a multi-fallback
+strategy. LLMs frequently wrap JSON in markdown code fences or surround it with
+explanatory text; this module handles all common output patterns robustly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+
+def _try_parse_json(text: str) -> dict | None:
+    """Attempt to parse text as JSON, returning None on failure."""
+    try:
+        result = json.loads(text)
+        if isinstance(result, dict):
+            return result
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return None
+
+
+def _fix_common_llm_json_errors(text: str) -> str:
+    """Apply heuristic fixes for common LLM JSON formatting mistakes."""
+    # Replace Python booleans with JSON booleans
+    text = re.sub(r"\bTrue\b", "true", text)
+    text = re.sub(r"\bFalse\b", "false", text)
+    text = re.sub(r"\bNone\b", "null", text)
+
+    # Remove trailing commas before ] or }
+    text = re.sub(r",\s*([}\]])", r"\1", text)
+
+    # Replace single-quoted strings with double-quoted (simple cases)
+    # Only when not inside a double-quoted string — use a simple heuristic
+    text = re.sub(r"'([^']*)'", r'"\1"', text)
+
+    return text
+
+
+def _is_valid_compact_flow(data: dict) -> bool:
+    """Check that a parsed dict has the minimum structure of a compact flow."""
+    if not isinstance(data.get("nodes"), list):
+        return False
+    if not isinstance(data.get("edges"), list):
+        return False
+    # Each node must have id and type
+    for node in data["nodes"]:
+        if not isinstance(node, dict):
+            return False
+        if not isinstance(node.get("id"), str) or not node["id"]:
+            return False
+        if not isinstance(node.get("type"), str) or not node["type"]:
+            return False
+    # Each edge must have the four required fields
+    for edge in data["edges"]:
+        if not isinstance(edge, dict):
+            return False
+        for field in ("source", "source_output", "target", "target_input"):
+            if not isinstance(edge.get(field), str):
+                return False
+    return True
+
+
+def extract_compact_flow(llm_output: str) -> dict | None:
+    """Extract compact flow JSON from LLM markdown output.
+
+    Tries multiple extraction strategies in order:
+    1. JSON code fence (```json ... ```)
+    2. Generic code fence (``` ... ```)
+    3. Raw JSON object (outermost { } containing "nodes" key)
+    4. Partial recovery (fix common LLM JSON errors, then retry above)
+
+    Args:
+        llm_output: Raw text output from the LLM.
+
+    Returns:
+        Parsed compact flow dict if extraction succeeds, None otherwise.
+    """
+    # Strategy 1: ```json ... ``` code fence
+    json_fence_pattern = re.compile(r"```json\s*\n(.*?)\n```", re.DOTALL)
+    for match in json_fence_pattern.finditer(llm_output):
+        candidate = match.group(1).strip()
+        parsed = _try_parse_json(candidate)
+        if parsed and _is_valid_compact_flow(parsed):
+            return parsed
+
+    # Strategy 2: generic ``` ... ``` code fence
+    generic_fence_pattern = re.compile(r"```\s*\n(.*?)\n```", re.DOTALL)
+    for match in generic_fence_pattern.finditer(llm_output):
+        candidate = match.group(1).strip()
+        parsed = _try_parse_json(candidate)
+        if parsed and _is_valid_compact_flow(parsed):
+            return parsed
+
+    # Strategy 3: find outermost { } block(s) containing "nodes"
+    # Walk through the string finding balanced { } pairs
+    for candidate in _extract_json_objects(llm_output):
+        parsed = _try_parse_json(candidate)
+        if parsed and _is_valid_compact_flow(parsed):
+            return parsed
+
+    # Strategy 4: apply heuristic fixes, then retry all strategies
+    fixed_output = _fix_common_llm_json_errors(llm_output)
+    if fixed_output != llm_output:
+        # Retry code fences on fixed output
+        for match in json_fence_pattern.finditer(fixed_output):
+            candidate = match.group(1).strip()
+            parsed = _try_parse_json(candidate)
+            if parsed and _is_valid_compact_flow(parsed):
+                return parsed
+
+        for match in generic_fence_pattern.finditer(fixed_output):
+            candidate = match.group(1).strip()
+            parsed = _try_parse_json(candidate)
+            if parsed and _is_valid_compact_flow(parsed):
+                return parsed
+
+        for candidate in _extract_json_objects(fixed_output):
+            parsed = _try_parse_json(candidate)
+            if parsed and _is_valid_compact_flow(parsed):
+                return parsed
+
+    return None
+
+
+def _extract_json_objects(text: str) -> list[str]:
+    """Extract all top-level JSON object strings from text using brace matching.
+
+    Returns candidates that contain the word "nodes" (to filter irrelevant objects).
+    Prefers longer (more complete) candidates first.
+    """
+    candidates: list[str] = []
+    depth = 0
+    start = -1
+
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start != -1:
+                candidate = text[start : i + 1]
+                if '"nodes"' in candidate or "'nodes'" in candidate:
+                    candidates.append(candidate)
+                start = -1
+
+    # Prefer longer candidates (more likely to be the complete flow JSON)
+    candidates.sort(key=len, reverse=True)
+    return candidates

--- a/src/backend/base/langflow/agentic/helpers/flow_validation.py
+++ b/src/backend/base/langflow/agentic/helpers/flow_validation.py
@@ -141,14 +141,11 @@ async def validate_compact_flow(
         if comp_type not in flat_components:
             suggestion = _closest_match(comp_type, all_comp_names)
             if suggestion:
-                warnings.append(
-                    f"Component '{comp_type}' not found — auto-corrected to '{suggestion}'."
-                )
+                warnings.append(f"Component '{comp_type}' not found — auto-corrected to '{suggestion}'.")
                 node["type"] = suggestion
             else:
                 errors.append(
-                    f"Component type '{comp_type}' not found in registry. "
-                    f"Check the available components list."
+                    f"Component type '{comp_type}' not found in registry. Check the available components list."
                 )
 
     # Bail early if unknown components remain (can't validate edges without templates)
@@ -197,15 +194,13 @@ async def validate_compact_flow(
             suggestion = _closest_match(src_output, src_outputs, cutoff=0.4)
             if suggestion:
                 warnings.append(
-                    f"Output '{src_output}' not found on '{src_node['type']}' — "
-                    f"auto-corrected to '{suggestion}'."
+                    f"Output '{src_output}' not found on '{src_node['type']}' — auto-corrected to '{suggestion}'."
                 )
                 edge["source_output"] = suggestion
                 src_output = suggestion
             else:
                 warnings.append(
-                    f"Output '{src_output}' not found on '{src_node['type']}'. "
-                    f"Available: {src_outputs or ['(none)']}"
+                    f"Output '{src_output}' not found on '{src_node['type']}'. Available: {src_outputs or ['(none)']}"
                 )
 
         # Check 6: Input name validity + auto-correct
@@ -214,15 +209,13 @@ async def validate_compact_flow(
             suggestion = _closest_match(tgt_input, tgt_inputs, cutoff=0.4)
             if suggestion:
                 warnings.append(
-                    f"Input '{tgt_input}' not found on '{tgt_node['type']}' — "
-                    f"auto-corrected to '{suggestion}'."
+                    f"Input '{tgt_input}' not found on '{tgt_node['type']}' — auto-corrected to '{suggestion}'."
                 )
                 edge["target_input"] = suggestion
                 tgt_input = suggestion
             else:
                 warnings.append(
-                    f"Input '{tgt_input}' not found on '{tgt_node['type']}'. "
-                    f"Available: {tgt_inputs or ['(none)']}"
+                    f"Input '{tgt_input}' not found on '{tgt_node['type']}'. Available: {tgt_inputs or ['(none)']}"
                 )
 
         # Check 7: Type compatibility (warning only)

--- a/src/backend/base/langflow/agentic/helpers/flow_validation.py
+++ b/src/backend/base/langflow/agentic/helpers/flow_validation.py
@@ -1,0 +1,243 @@
+"""Compact flow validation against the live Langflow component registry.
+
+Validates a compact flow JSON dict before it is expanded into full ReactFlow
+format. Provides 7 checks ranging from schema correctness to type compatibility,
+with auto-correction for close component/field name matches.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class FlowValidationResult:
+    """Result of compact flow validation."""
+
+    is_valid: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    compact_data: dict = field(default_factory=dict)  # possibly auto-corrected
+
+
+def _get_flat_components(all_types_dict: dict[str, Any]) -> dict[str, Any]:
+    """Flatten the component types dict for easy lookup by component name.
+
+    Reuses the same logic as expand_flow._get_flat_components so that
+    validation and expansion use identical component lookup semantics.
+    """
+    return {
+        comp_name: comp_data
+        for components in all_types_dict.values()
+        if isinstance(components, dict)
+        for comp_name, comp_data in components.items()
+    }
+
+
+def _closest_match(name: str, candidates: list[str], n: int = 1, cutoff: float = 0.6) -> str | None:
+    """Return the closest matching candidate name, or None if no good match."""
+    matches = difflib.get_close_matches(name, candidates, n=n, cutoff=cutoff)
+    return matches[0] if matches else None
+
+
+def _get_output_names(comp_data: dict[str, Any]) -> list[str]:
+    """Get output names from component data."""
+    outputs = comp_data.get("outputs", [])
+    return [o.get("name", "") for o in outputs if isinstance(o, dict) and o.get("name")]
+
+
+def _get_input_names(comp_data: dict[str, Any]) -> list[str]:
+    """Get template field names from component data."""
+    template = comp_data.get("template", {})
+    return [k for k in template if isinstance(template.get(k), dict)]
+
+
+def _get_output_types(comp_data: dict[str, Any], output_name: str) -> list[str]:
+    """Get output types for a named output."""
+    for output in comp_data.get("outputs", []):
+        if isinstance(output, dict) and output.get("name") == output_name:
+            return output.get("types", [])
+    return []
+
+
+def _get_input_types(comp_data: dict[str, Any], input_name: str) -> list[str]:
+    """Get accepted input types for a named template field."""
+    template = comp_data.get("template", {})
+    field_data = template.get(input_name, {})
+    if isinstance(field_data, dict):
+        types = field_data.get("input_types", [])
+        if not types:
+            types = [field_data.get("type", "str")]
+        return types
+    return []
+
+
+async def validate_compact_flow(
+    compact_data: dict,
+    all_types_dict: dict[str, Any] | None = None,
+    settings_service: Any | None = None,
+) -> FlowValidationResult:
+    """Validate a compact flow dict against the live component registry.
+
+    Performs 7 checks:
+    1. Schema: verifies nodes/edges structure via CompactFlowData parsing
+    2. Component existence: every node.type must be in the registry
+    3. Node ID uniqueness: no duplicate node IDs
+    4. Edge endpoint validity: edge source/target reference existing node IDs
+    5. Output name validity: edge.source_output exists on source component
+    6. Input name validity: edge.target_input exists on target component
+    7. Type compatibility: output types overlap with input types
+
+    Auto-corrects close name matches (edit distance ≤ 2) for components and
+    field names, adding warnings instead of errors when a correction was applied.
+
+    Args:
+        compact_data: Raw compact flow dict (nodes + edges).
+        all_types_dict: Component registry. Fetched automatically if None.
+        settings_service: Settings service for registry access. Auto-detected if None.
+
+    Returns:
+        FlowValidationResult with is_valid flag, errors, warnings, and
+        (possibly auto-corrected) compact_data.
+    """
+    from langflow.processing.expand_flow import CompactFlowData
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Fetch registry if not provided
+    if all_types_dict is None:
+        from langflow.agentic.helpers.component_catalog import get_all_types_dict
+
+        all_types_dict = await get_all_types_dict(settings_service)
+
+    flat_components = _get_flat_components(all_types_dict)
+    all_comp_names = list(flat_components.keys())
+
+    # Work on a mutable copy for auto-correction
+    import copy
+
+    data = copy.deepcopy(compact_data)
+
+    # --- Check 1: Schema validation ---
+    try:
+        flow = CompactFlowData(**data)
+    except Exception as exc:  # noqa: BLE001
+        return FlowValidationResult(
+            is_valid=False,
+            errors=[f"Schema error: {exc}"],
+            compact_data=data,
+        )
+
+    # Build a mutable node list for corrections
+    nodes = [n.model_dump() for n in flow.nodes]
+    edges = [e.model_dump() for e in flow.edges]
+
+    # --- Check 2: Component existence + auto-correct ---
+    for node in nodes:
+        comp_type = node["type"]
+        if comp_type not in flat_components:
+            suggestion = _closest_match(comp_type, all_comp_names)
+            if suggestion:
+                warnings.append(
+                    f"Component '{comp_type}' not found — auto-corrected to '{suggestion}'."
+                )
+                node["type"] = suggestion
+            else:
+                errors.append(
+                    f"Component type '{comp_type}' not found in registry. "
+                    f"Check the available components list."
+                )
+
+    # Bail early if unknown components remain (can't validate edges without templates)
+    if errors:
+        return FlowValidationResult(
+            is_valid=False,
+            errors=errors,
+            warnings=warnings,
+            compact_data={**data, "nodes": nodes, "edges": edges},
+        )
+
+    # --- Check 3: Node ID uniqueness ---
+    node_ids = [n["id"] for n in nodes]
+    seen: set[str] = set()
+    for nid in node_ids:
+        if nid in seen:
+            errors.append(f"Duplicate node ID: '{nid}'.")
+        seen.add(nid)
+
+    node_id_set = set(node_ids)
+
+    # --- Checks 4-7: Edge validation ---
+    for edge in edges:
+        src_id = edge["source"]
+        tgt_id = edge["target"]
+        src_output = edge["source_output"]
+        tgt_input = edge["target_input"]
+
+        # Check 4: Edge endpoint validity
+        if src_id not in node_id_set:
+            errors.append(f"Edge references unknown source node '{src_id}'.")
+            continue
+        if tgt_id not in node_id_set:
+            errors.append(f"Edge references unknown target node '{tgt_id}'.")
+            continue
+
+        # Get component data for source and target
+        src_node = next(n for n in nodes if n["id"] == src_id)
+        tgt_node = next(n for n in nodes if n["id"] == tgt_id)
+        src_comp = flat_components.get(src_node["type"], {})
+        tgt_comp = flat_components.get(tgt_node["type"], {})
+
+        # Check 5: Output name validity + auto-correct
+        src_outputs = _get_output_names(src_comp)
+        if src_outputs and src_output not in src_outputs:
+            suggestion = _closest_match(src_output, src_outputs, cutoff=0.4)
+            if suggestion:
+                warnings.append(
+                    f"Output '{src_output}' not found on '{src_node['type']}' — "
+                    f"auto-corrected to '{suggestion}'."
+                )
+                edge["source_output"] = suggestion
+                src_output = suggestion
+            else:
+                warnings.append(
+                    f"Output '{src_output}' not found on '{src_node['type']}'. "
+                    f"Available: {src_outputs or ['(none)']}"
+                )
+
+        # Check 6: Input name validity + auto-correct
+        tgt_inputs = _get_input_names(tgt_comp)
+        if tgt_inputs and tgt_input not in tgt_inputs:
+            suggestion = _closest_match(tgt_input, tgt_inputs, cutoff=0.4)
+            if suggestion:
+                warnings.append(
+                    f"Input '{tgt_input}' not found on '{tgt_node['type']}' — "
+                    f"auto-corrected to '{suggestion}'."
+                )
+                edge["target_input"] = suggestion
+                tgt_input = suggestion
+            else:
+                warnings.append(
+                    f"Input '{tgt_input}' not found on '{tgt_node['type']}'. "
+                    f"Available: {tgt_inputs or ['(none)']}"
+                )
+
+        # Check 7: Type compatibility (warning only)
+        src_types = set(_get_output_types(src_comp, src_output))
+        tgt_types = set(_get_input_types(tgt_comp, tgt_input))
+        if src_types and tgt_types and not src_types.intersection(tgt_types):
+            warnings.append(
+                f"Type mismatch on edge {src_id}→{tgt_id}: "
+                f"source outputs {sorted(src_types)}, target accepts {sorted(tgt_types)}."
+            )
+
+    corrected = {**data, "nodes": nodes, "edges": edges}
+    return FlowValidationResult(
+        is_valid=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        compact_data=corrected,
+    )

--- a/src/backend/base/langflow/agentic/helpers/sse.py
+++ b/src/backend/base/langflow/agentic/helpers/sse.py
@@ -14,6 +14,8 @@ def format_progress_event(
     error: str | None = None,
     class_name: str | None = None,
     component_code: str | None = None,
+    flow_data: dict | None = None,
+    expanded_flow: dict | None = None,
 ) -> str:
     """Format SSE progress event.
 
@@ -25,6 +27,8 @@ def format_progress_event(
         error: Optional error message (for validation_failed step)
         class_name: Optional class name (for validation_failed step)
         component_code: Optional component code (for validation_failed step)
+        flow_data: Optional compact flow JSON (for flow generation steps)
+        expanded_flow: Optional expanded ReactFlow JSON (for validated_flow step)
     """
     data: dict = {
         "event": "progress",
@@ -40,6 +44,10 @@ def format_progress_event(
         data["class_name"] = class_name
     if component_code:
         data["component_code"] = component_code
+    if flow_data:
+        data["flow_data"] = flow_data
+    if expanded_flow:
+        data["expanded_flow"] = expanded_flow
     return f"data: {json.dumps(data)}\n\n"
 
 

--- a/src/backend/base/langflow/agentic/services/assistant_service.py
+++ b/src/backend/base/langflow/agentic/services/assistant_service.py
@@ -202,6 +202,27 @@ async def execute_flow_with_validation_streaming(
         yield format_complete_event({"result": OFF_TOPIC_REFUSAL_MESSAGE})
         return
 
+    # Flow generation: build a complete multi-node flow from natural language
+    if intent_result.intent == "generate_flow":
+        logger.info("Flow generation request detected")
+        from langflow.agentic.services.flow_generation_service import generate_flow_streaming
+
+        flow_id = (global_variables or {}).get("FLOW_ID")
+        async for event in generate_flow_streaming(
+            intent_result.translation,
+            flow_id=flow_id,
+            user_id=user_id,
+            provider=provider,
+            model_name=model_name,
+            api_key_var=api_key_var,
+            global_variables=global_variables,
+            max_retries=max_retries,
+            session_id=session_id,
+            is_disconnected=is_disconnected,
+        ):
+            yield event
+        return
+
     # Check if this is a component generation request based on LLM classification
     is_component_request = intent_result.intent == "generate_component"
     logger.info(f"Intent classification: {intent_result.intent} (is_component_request={is_component_request})")

--- a/src/backend/base/langflow/agentic/services/flow_generation_service.py
+++ b/src/backend/base/langflow/agentic/services/flow_generation_service.py
@@ -279,8 +279,7 @@ async def generate_flow_streaming(
                     return
                 # Retry with explicit instruction to output JSON only
                 current_input = (
-                    base_message
-                    + "\n\n---\nIMPORTANT: Output ONLY the JSON object. "
+                    base_message + "\n\n---\nIMPORTANT: Output ONLY the JSON object. "
                     "No explanation, no markdown fences, no preamble."
                 )
                 yield format_progress_event(
@@ -309,9 +308,7 @@ async def generate_flow_streaming(
                     logger.info(f"Flow validation warning: {w}")
 
             if not validation.is_valid:
-                logger.warning(
-                    f"Flow validation failed (attempt {attempt + 1}): {validation.errors}"
-                )
+                logger.warning(f"Flow validation failed (attempt {attempt + 1}): {validation.errors}")
                 yield format_progress_event(
                     "validation_failed",
                     attempt + 1,

--- a/src/backend/base/langflow/agentic/services/flow_generation_service.py
+++ b/src/backend/base/langflow/agentic/services/flow_generation_service.py
@@ -1,0 +1,393 @@
+"""Flow generation service — SSE pipeline for natural-language → multi-node flow.
+
+Takes a user prompt, builds the component catalog, calls the FlowGenerator LLM
+graph, extracts compact JSON from the response, validates it against the live
+component registry, expands it to full ReactFlow format, and emits SSE events
+at each step.
+
+Usage:
+    from langflow.agentic.services.flow_generation_service import generate_flow_streaming
+    async for sse_event in generate_flow_streaming(...):
+        yield sse_event
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import aclosing
+from typing import TYPE_CHECKING, Any
+
+from lfx.log.logger import logger
+
+from langflow.agentic.helpers.component_catalog import (
+    build_component_catalog_prompt,
+    get_all_types_dict,
+)
+from langflow.agentic.helpers.flow_extraction import extract_compact_flow
+from langflow.agentic.helpers.flow_validation import validate_compact_flow
+from langflow.agentic.helpers.sse import (
+    format_cancelled_event,
+    format_complete_event,
+    format_error_event,
+    format_progress_event,
+    format_token_event,
+)
+from langflow.agentic.services.flow_executor import (
+    execute_flow_file_streaming,
+    extract_response_text,
+)
+from langflow.agentic.services.flow_types import FlowExecutionError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Coroutine
+    from uuid import UUID
+
+# Maximum characters of flow context to inject (prevents token overruns)
+_MAX_FLOW_CONTEXT_CHARS = 4000
+
+# Retry template when the LLM generates invalid flow JSON
+_FLOW_RETRY_TEMPLATE = """\
+{original_input}
+
+---
+The previous attempt produced invalid flow JSON. Errors found:
+{errors}
+
+Fix these issues and output ONLY the corrected compact flow JSON object.
+"""
+
+
+async def _get_flow_context(
+    flow_id: str | None,
+    user_id: Any,
+) -> str:
+    """Return a text representation of the user's current flow, or empty string."""
+    if not flow_id:
+        return ""
+    try:
+        from langflow.agentic.utils.flow_graph import get_flow_graph_representations
+
+        result = await get_flow_graph_representations(flow_id, user_id)
+        if "error" in result or not result.get("text_repr"):
+            return ""
+
+        text_repr: str = result["text_repr"]
+        vertex_count = result.get("vertex_count", 0)
+
+        # Skip injecting context for empty or near-empty flows
+        if vertex_count == 0:
+            return ""
+
+        # Truncate to avoid token overruns
+        if len(text_repr) > _MAX_FLOW_CONTEXT_CHARS:
+            text_repr = text_repr[:_MAX_FLOW_CONTEXT_CHARS] + "\n... (truncated)"
+
+        return (
+            f"\n## Current Flow\n"
+            f"The user's canvas currently has these components and connections:\n"
+            f"{text_repr}\n"
+            f"\nApply the user's requested changes to this existing flow structure. "
+            f"Preserve components and connections that the user did not mention changing.\n"
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _build_user_message(
+    user_input: str,
+    catalog: str,
+    flow_context: str,
+) -> str:
+    """Compose the full user message sent to the FlowGenerator LLM."""
+    parts = [
+        "## Available Components",
+        catalog,
+    ]
+    if flow_context:
+        parts.append(flow_context)
+    parts += [
+        "## User Request",
+        user_input,
+    ]
+    return "\n".join(parts)
+
+
+async def generate_flow_streaming(
+    user_input: str,
+    *,
+    flow_id: str | None = None,
+    user_id: str | UUID | None = None,
+    provider: str | None = None,
+    model_name: str | None = None,
+    api_key_var: str | None = None,
+    global_variables: dict[str, str] | None = None,
+    max_retries: int = 2,
+    session_id: str | None = None,
+    is_disconnected: Callable[[], Coroutine[Any, Any, bool]] | None = None,
+) -> AsyncGenerator[str, None]:
+    """Stream SSE events for natural-language → multi-node flow generation.
+
+    Pipeline:
+        1. Build component catalog from live registry
+        2. Inject current flow context (for edit requests)
+        3. Call FlowGenerator LLM (streaming tokens)
+        4. Extract compact JSON from LLM response
+        5. Validate against registry (retry with error context on failure)
+        6. Expand to full ReactFlow JSON
+        7. Emit complete event with flow_data + expanded_flow
+
+    Args:
+        user_input: Translated user request (from intent classifier).
+        flow_id: Current flow ID for edit context injection (optional).
+        user_id: User ID for flow lookup and graph session.
+        provider: LLM provider (e.g., "OpenAI").
+        model_name: LLM model name (e.g., "gpt-4o-mini").
+        api_key_var: API key variable name.
+        global_variables: Global variables dict for the graph execution context.
+        max_retries: Number of retry attempts on validation failure (default 2).
+        session_id: Session ID for multi-turn editing context.
+        is_disconnected: Async callable that returns True if client disconnected.
+
+    Yields:
+        SSE-formatted strings (data: {...}\\n\\n).
+    """
+    total_attempts = max_retries + 1
+    cancel_event = asyncio.Event()
+
+    async def check_cancelled() -> bool:
+        if cancel_event.is_set():
+            return True
+        if is_disconnected is not None:
+            return await is_disconnected()
+        return False
+
+    try:
+        # --- Step 1: Build catalog ---
+        yield format_progress_event(
+            "generating_flow",
+            1,
+            total_attempts,
+            message="Analyzing available components...",
+        )
+
+        try:
+            catalog, all_types_dict = await asyncio.gather(
+                build_component_catalog_prompt(),
+                get_all_types_dict(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Failed to build component catalog: {exc}")
+            yield format_error_event("Failed to load component catalog. Please try again.")
+            return
+
+        # --- Step 2: Get flow context (for edit requests) ---
+        flow_context = await _get_flow_context(flow_id, user_id)
+
+        # Base user message (catalog + context + request)
+        base_message = _build_user_message(user_input, catalog, flow_context)
+        current_input = base_message
+
+        for attempt in range(total_attempts):
+            if await check_cancelled():
+                yield format_cancelled_event()
+                return
+
+            # --- Step 3: Generate via LLM ---
+            yield format_progress_event(
+                "generating_flow",
+                attempt + 1,
+                total_attempts,
+                message="Designing your flow...",
+            )
+
+            result = None
+            cancelled = False
+            execution_error: str | None = None
+            full_response = ""
+
+            async with aclosing(
+                execute_flow_file_streaming(
+                    "flow_generator.py",
+                    input_value=current_input,
+                    global_variables=global_variables,
+                    user_id=str(user_id) if user_id else None,
+                    session_id=session_id,
+                    provider=provider,
+                    model_name=model_name,
+                    api_key_var=api_key_var,
+                    is_disconnected=is_disconnected,
+                    cancel_event=cancel_event,
+                )
+            ) as flow_gen:
+                try:
+                    async for event_type, event_data in flow_gen:
+                        if event_type == "token":
+                            full_response += event_data
+                            yield format_token_event(event_data)
+                        elif event_type == "end":
+                            result = event_data
+                        elif event_type == "cancelled":
+                            cancelled = True
+                            break
+                except GeneratorExit:
+                    cancel_event.set()
+                    yield format_cancelled_event()
+                    return
+                except FlowExecutionError as exc:
+                    execution_error = exc.original_error_message
+                except Exception as exc:  # noqa: BLE001
+                    execution_error = str(exc)
+
+            if cancelled:
+                yield format_cancelled_event()
+                return
+
+            if execution_error is not None:
+                logger.error(f"Flow generator execution error (attempt {attempt + 1}): {execution_error}")
+                yield format_error_event(f"Flow generation failed: {execution_error}")
+                return
+
+            # Use result text if tokens didn't accumulate (non-streaming fallback)
+            if not full_response and result is not None:
+                full_response = extract_response_text(result)
+
+            if not full_response:
+                logger.error("Flow generator returned empty response")
+                yield format_error_event("Flow generator returned an empty response.")
+                return
+
+            if await check_cancelled():
+                yield format_cancelled_event()
+                return
+
+            # --- Step 4: Extract compact JSON ---
+            yield format_progress_event(
+                "extracting_flow",
+                attempt + 1,
+                total_attempts,
+                message="Extracting flow structure...",
+            )
+
+            compact_data = extract_compact_flow(full_response)
+            if compact_data is None:
+                logger.warning(f"Failed to extract compact flow (attempt {attempt + 1})")
+                if attempt >= total_attempts - 1:
+                    yield format_error_event(
+                        "Could not extract a valid flow from the LLM response. "
+                        "The model did not produce JSON in the expected format."
+                    )
+                    return
+                # Retry with explicit instruction to output JSON only
+                current_input = (
+                    base_message
+                    + "\n\n---\nIMPORTANT: Output ONLY the JSON object. "
+                    "No explanation, no markdown fences, no preamble."
+                )
+                yield format_progress_event(
+                    "retrying",
+                    attempt + 1,
+                    total_attempts,
+                    message="Retrying — model must output JSON only...",
+                )
+                continue
+
+            # --- Step 5: Validate ---
+            yield format_progress_event(
+                "validating_flow",
+                attempt + 1,
+                total_attempts,
+                message="Validating components and connections...",
+            )
+
+            validation = await validate_compact_flow(
+                compact_data,
+                all_types_dict=all_types_dict,
+            )
+
+            if validation.warnings:
+                for w in validation.warnings:
+                    logger.info(f"Flow validation warning: {w}")
+
+            if not validation.is_valid:
+                logger.warning(
+                    f"Flow validation failed (attempt {attempt + 1}): {validation.errors}"
+                )
+                yield format_progress_event(
+                    "validation_failed",
+                    attempt + 1,
+                    total_attempts,
+                    message="Flow validation failed",
+                    error="; ".join(validation.errors),
+                )
+
+                if attempt >= total_attempts - 1:
+                    yield format_complete_event(
+                        {
+                            "result": full_response,
+                            "validated": False,
+                            "flow_validated": False,
+                            "validation_error": "; ".join(validation.errors),
+                            "validation_attempts": attempt + 1,
+                        }
+                    )
+                    return
+
+                errors_str = "\n".join(f"- {e}" for e in validation.errors)
+                current_input = _FLOW_RETRY_TEMPLATE.format(
+                    original_input=base_message,
+                    errors=errors_str,
+                )
+                yield format_progress_event(
+                    "retrying",
+                    attempt + 1,
+                    total_attempts,
+                    message=f"Retrying with validation feedback (attempt {attempt + 2}/{total_attempts})...",
+                    error="; ".join(validation.errors),
+                )
+                continue
+
+            # --- Step 6: Expand to full ReactFlow JSON ---
+            corrected_compact = validation.compact_data
+            yield format_progress_event(
+                "validated_flow",
+                attempt + 1,
+                total_attempts,
+                message="Flow validated! Preparing canvas data...",
+                flow_data=corrected_compact,  # sent here so the frontend can animate nodes
+            )
+
+            try:
+                from langflow.processing.expand_flow import expand_compact_flow
+
+                expanded_flow = expand_compact_flow(corrected_compact, all_types_dict)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(f"Failed to expand compact flow: {exc}")
+                yield format_error_event(f"Failed to expand flow to canvas format: {exc}")
+                return
+
+            # --- Step 7: Complete ---
+            node_count = len(corrected_compact.get("nodes", []))
+            edge_count = len(corrected_compact.get("edges", []))
+            logger.info(
+                f"Flow generation complete: {node_count} nodes, {edge_count} edges"
+                f" (attempt {attempt + 1}/{total_attempts})"
+            )
+
+            yield format_complete_event(
+                {
+                    "result": full_response,
+                    "validated": True,
+                    "flow_validated": True,
+                    "flow_data": corrected_compact,
+                    "expanded_flow": expanded_flow,
+                    "node_count": node_count,
+                    "edge_count": edge_count,
+                    "validation_attempts": attempt + 1,
+                    "warnings": validation.warnings if validation.warnings else None,
+                }
+            )
+            return
+
+    finally:
+        logger.debug("Flow generation generator exiting, setting cancel event")
+        cancel_event.set()

--- a/src/backend/base/langflow/agentic/utils/flow_graph.py
+++ b/src/backend/base/langflow/agentic/utils/flow_graph.py
@@ -91,7 +91,7 @@ async def get_flow_graph_representations(
         }
 
     except Exception as e:  # noqa: BLE001
-        await logger.aerror(f"Error getting flow graph representations for {flow_id_or_name}: {e}")
+        await logger.awarning(f"Could not read flow graph for context injection ({flow_id_or_name}): {e}")
         return {
             "error": str(e),
             "flow_id": flow_id_or_name,

--- a/src/frontend/src/components/core/assistantPanel/assistant-panel.tsx
+++ b/src/frontend/src/components/core/assistantPanel/assistant-panel.tsx
@@ -120,6 +120,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     currentStep,
     handleSend,
     handleApprove,
+    handleApproveFlow,
     handleRetry,
     handleStopGeneration,
     handleClearHistory,
@@ -273,6 +274,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                   key={msg.id}
                   message={msg}
                   onApprove={handleApproveAndClose}
+                  onApproveFlow={handleApproveFlow}
                   onRetry={hasEnabledModels ? handleRetry : undefined}
                 />
               ))}

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-flow-result.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-flow-result.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowRight, Check, GitBranch, RotateCcw } from "lucide-react";
-import type { AgenticResult, CompactFlowNode } from "@/controllers/API/queries/agentic";
+import type {
+  AgenticResult,
+  CompactFlowNode,
+} from "@/controllers/API/queries/agentic";
 import { cn } from "@/utils/utils";
 import CodeAreaModal from "@/modals/codeAreaModal";
 
@@ -60,13 +63,20 @@ function NodeValues({ nodes }: { nodes: CompactFlowNode[] }) {
   return (
     <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
       {configured.map((node) =>
-        Object.entries(node.values!).slice(0, 2).map(([k, v]) => (
-          <span key={`${node.id}-${k}`} className="text-[10px] text-muted-foreground">
-            <span className="font-medium text-muted-foreground/80">{node.type}</span>
-            {" · "}
-            {k}: <span className="text-foreground/70">{String(v)}</span>
-          </span>
-        )),
+        Object.entries(node.values!)
+          .slice(0, 2)
+          .map(([k, v]) => (
+            <span
+              key={`${node.id}-${k}`}
+              className="text-[10px] text-muted-foreground"
+            >
+              <span className="font-medium text-muted-foreground/80">
+                {node.type}
+              </span>
+              {" · "}
+              {k}: <span className="text-foreground/70">{String(v)}</span>
+            </span>
+          )),
       )}
     </div>
   );
@@ -122,7 +132,8 @@ export function AssistantFlowResult({
             Generated Flow
           </p>
           <p className="text-[10px] text-muted-foreground">
-            {nodeCount} node{nodeCount !== 1 ? "s" : ""} · {edgeCount} edge{edgeCount !== 1 ? "s" : ""}
+            {nodeCount} node{nodeCount !== 1 ? "s" : ""} · {edgeCount} edge
+            {edgeCount !== 1 ? "s" : ""}
           </p>
         </div>
       </div>

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-flow-result.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-flow-result.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowRight, Check, GitBranch, RotateCcw } from "lucide-react";
+import type { AgenticResult, CompactFlowNode } from "@/controllers/API/queries/agentic";
+import { cn } from "@/utils/utils";
+import CodeAreaModal from "@/modals/codeAreaModal";
+
+const APPROVED_DISPLAY_DURATION_MS = 3000;
+const MAX_VISIBLE_CHIPS = 6;
+
+interface AssistantFlowResultProps {
+  result: AgenticResult;
+  onApproveFlow: () => void;
+  onRegenerate?: () => void;
+}
+
+/** Colored chip for a single node type. */
+function NodeChip({ type }: { type: string }) {
+  return (
+    <span className="rounded-md border border-violet-400/30 bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-300">
+      {type}
+    </span>
+  );
+}
+
+/** Horizontal pipeline: NodeChip → NodeChip → ... → NodeChip */
+function FlowPipeline({ nodes }: { nodes: CompactFlowNode[] }) {
+  if (nodes.length === 0) return null;
+
+  const visible = nodes.slice(0, MAX_VISIBLE_CHIPS);
+  const truncated = nodes.length > MAX_VISIBLE_CHIPS;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {visible.map((node, idx) => (
+        <span key={node.id} className="flex items-center gap-1.5">
+          <NodeChip type={node.type} />
+          {(idx < visible.length - 1 || truncated) && (
+            <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+          )}
+        </span>
+      ))}
+      {truncated && (
+        <span className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            +{nodes.length - MAX_VISIBLE_CHIPS} more
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Key configured values per node, shown as small pills below the pipeline. */
+function NodeValues({ nodes }: { nodes: CompactFlowNode[] }) {
+  const configured = nodes.filter(
+    (n) => n.values && Object.keys(n.values).length > 0,
+  );
+  if (configured.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+      {configured.map((node) =>
+        Object.entries(node.values!).slice(0, 2).map(([k, v]) => (
+          <span key={`${node.id}-${k}`} className="text-[10px] text-muted-foreground">
+            <span className="font-medium text-muted-foreground/80">{node.type}</span>
+            {" · "}
+            {k}: <span className="text-foreground/70">{String(v)}</span>
+          </span>
+        )),
+      )}
+    </div>
+  );
+}
+
+export function AssistantFlowResult({
+  result,
+  onApproveFlow,
+  onRegenerate,
+}: AssistantFlowResultProps) {
+  const [showApproved, setShowApproved] = useState(false);
+  const [isViewJsonOpen, setIsViewJsonOpen] = useState(false);
+
+  const flowData = result.flowData;
+  const nodes = flowData?.nodes ?? [];
+  const edges = flowData?.edges ?? [];
+
+  const nodeCount = result.nodeCount ?? nodes.length;
+  const edgeCount = result.edgeCount ?? edges.length;
+
+  const compactJson = useMemo(
+    () => (flowData ? JSON.stringify(flowData, null, 2) : ""),
+    [flowData],
+  );
+
+  useEffect(() => {
+    if (showApproved) {
+      const timer = setTimeout(
+        () => setShowApproved(false),
+        APPROVED_DISPLAY_DURATION_MS,
+      );
+      return () => clearTimeout(timer);
+    }
+  }, [showApproved]);
+
+  const handleApprove = () => {
+    onApproveFlow();
+    setShowApproved(true);
+  };
+
+  return (
+    <div
+      data-testid="assistant-flow-result"
+      className="max-w-[85%] overflow-hidden rounded-xl border border-border bg-background"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2.5 border-b border-border px-4 py-3">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-violet-600">
+          <GitBranch className="h-3.5 w-3.5 text-white" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold leading-tight text-foreground">
+            Generated Flow
+          </p>
+          <p className="text-[10px] text-muted-foreground">
+            {nodeCount} node{nodeCount !== 1 ? "s" : ""} · {edgeCount} edge{edgeCount !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {/* Pipeline */}
+      {nodes.length > 0 && (
+        <div className="px-4 py-3">
+          <FlowPipeline nodes={nodes} />
+          <NodeValues nodes={nodes} />
+        </div>
+      )}
+
+      {/* Validation error (if any) */}
+      {result.validationError && (
+        <div className="mx-4 mb-3 rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {result.validationError}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 border-t border-border px-4 py-3">
+        {showApproved ? (
+          <div className="flex h-8 flex-1 items-center justify-center gap-1.5 rounded-lg bg-accent-emerald-foreground/10 text-sm font-medium text-accent-emerald-foreground">
+            <Check className="h-4 w-4" />
+            <span>Added to Canvas</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            data-testid="assistant-approve-flow-button"
+            className="h-8 flex-1 rounded-lg bg-violet-600 px-4 text-sm font-medium text-white transition-colors hover:bg-violet-500"
+            onClick={handleApprove}
+          >
+            Add to Canvas
+          </button>
+        )}
+        <button
+          type="button"
+          data-testid="assistant-view-json-button"
+          className="h-8 rounded-lg border border-border px-3 text-xs font-medium text-muted-foreground transition-colors hover:border-foreground/20 hover:text-foreground"
+          onClick={() => setIsViewJsonOpen(true)}
+        >
+          JSON
+        </button>
+        {onRegenerate && (
+          <button
+            type="button"
+            data-testid="assistant-regenerate-flow-button"
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:border-foreground/20 hover:text-foreground"
+            onClick={onRegenerate}
+            title="Regenerate"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {compactJson && (
+        <CodeAreaModal
+          value={compactJson}
+          setValue={() => {}}
+          nodeClass={undefined}
+          setNodeClass={() => {}}
+          dynamic={false}
+          readonly={true}
+          open={isViewJsonOpen}
+          setOpen={setIsViewJsonOpen}
+          size="medium"
+        >
+          <></>
+        </CodeAreaModal>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
@@ -7,12 +7,112 @@ import {
   Code2,
   Loader2,
 } from "lucide-react";
-import type { AgenticProgressState } from "@/controllers/API/queries/agentic";
+import type {
+  AgenticProgressState,
+  CompactFlowNode,
+} from "@/controllers/API/queries/agentic";
+import { cn } from "@/utils/utils";
 
 interface AssistantLoadingStateProps {
   progress: AgenticProgressState;
   streamingContent?: string;
   onValidationComplete?: () => void;
+}
+
+const FLOW_STEPS = [
+  "generating_flow",
+  "extracting_flow",
+  "validating_flow",
+  "validated_flow",
+] as const;
+
+const FLOW_STEP_LABELS: Record<string, string> = {
+  generating_flow: "Designing flow",
+  extracting_flow: "Extracting structure",
+  validating_flow: "Validating components",
+  validated_flow: "Flow ready",
+};
+
+/** Animated row of node chips that reveals one node at a time. */
+function FlowNodeTimeline({ nodes }: { nodes: CompactFlowNode[] }) {
+  const [visibleCount, setVisibleCount] = useState(0);
+
+  useEffect(() => {
+    if (nodes.length === 0) return;
+    setVisibleCount(0);
+    let i = 0;
+    const interval = setInterval(() => {
+      i += 1;
+      setVisibleCount(i);
+      if (i >= nodes.length) clearInterval(interval);
+    }, 220);
+    return () => clearInterval(interval);
+  }, [nodes]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 py-1">
+      {nodes.map((node, idx) => (
+        <span key={node.id} className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              "rounded-md border px-2 py-0.5 text-xs font-medium transition-all duration-300",
+              idx < visibleCount
+                ? "border-violet-400/40 bg-violet-500/10 text-violet-300 opacity-100 translate-y-0"
+                : "opacity-0 translate-y-1 pointer-events-none",
+            )}
+          >
+            {node.type}
+          </span>
+          {idx < nodes.length - 1 && idx < visibleCount - 1 && (
+            <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/60" />
+          )}
+          {idx < nodes.length - 1 && idx >= visibleCount - 1 && (
+            <span className="h-3 w-3" />
+          )}
+        </span>
+      ))}
+      {visibleCount < nodes.length && (
+        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground/50" />
+      )}
+    </div>
+  );
+}
+
+/** Step-by-step progress track for flow generation. */
+function FlowStepTrack({ currentStep }: { currentStep: string }) {
+  const steps = FLOW_STEPS.filter((s) => s !== "validated_flow");
+  const currentIdx = FLOW_STEPS.indexOf(currentStep as (typeof FLOW_STEPS)[number]);
+
+  return (
+    <div className="flex items-center gap-0">
+      {steps.map((step, idx) => {
+        const done = currentIdx > idx;
+        const active = currentIdx === idx;
+        return (
+          <span key={step} className="flex items-center gap-0">
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full transition-colors duration-300",
+                done
+                  ? "bg-violet-400"
+                  : active
+                    ? "bg-violet-400 animate-pulse"
+                    : "bg-muted-foreground/30",
+              )}
+            />
+            {idx < steps.length - 1 && (
+              <span
+                className={cn(
+                  "h-px w-6 transition-colors duration-500",
+                  done ? "bg-violet-400/60" : "bg-muted-foreground/20",
+                )}
+              />
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
 }
 
 function AssistantLoadingStateComponent({
@@ -24,10 +124,17 @@ function AssistantLoadingStateComponent({
   const streamingRef = useRef<HTMLPreElement>(null);
 
   const isValidated = progress.step === "validated";
-  const isReady = isValidated && !!progress.componentCode;
+  const isFlowValidated = progress.step === "validated_flow";
+  const isFlowStep = FLOW_STEPS.includes(
+    progress.step as (typeof FLOW_STEPS)[number],
+  );
+  const isReady = (isValidated && !!progress.componentCode) || isFlowValidated;
   const finalCode = progress.componentCode;
   const hasStreaming = !!streamingContent && streamingContent.length > 0;
-  const showStreamingPreview = !finalCode && hasStreaming;
+  const showStreamingPreview = !finalCode && hasStreaming && !isFlowStep;
+
+  const flowNodes = progress.flowData?.nodes ?? [];
+  const flowEdgeCount = progress.flowData?.edges?.length ?? 0;
 
   // Auto-scroll streaming preview
   useEffect(() => {
@@ -50,9 +157,23 @@ function AssistantLoadingStateComponent({
             isReady ? "text-accent-emerald-foreground" : "text-foreground"
           }
         >
-          {isReady ? "Component ready" : progress.message || "Working..."}
+          {isFlowValidated
+            ? "Flow ready"
+            : isFlowStep
+              ? (FLOW_STEP_LABELS[progress.step] ?? "Building flow...")
+              : isReady
+                ? "Component ready"
+                : (progress.message ?? "Working...")}
         </span>
-        {progress.className && (
+
+        {/* Step track dots for flow generation */}
+        {isFlowStep && !isFlowValidated && (
+          <span className="ml-auto">
+            <FlowStepTrack currentStep={progress.step} />
+          </span>
+        )}
+
+        {progress.className && !isFlowStep && (
           <span className="ml-auto rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
             {progress.className}
           </span>
@@ -60,75 +181,130 @@ function AssistantLoadingStateComponent({
       </div>
 
       <div
-        className={
+        className={cn(
           showStreamingPreview ||
-          progress.error ||
-          progress.attempt > 1 ||
-          finalCode ||
-          isReady
+            progress.error ||
+            progress.attempt > 1 ||
+            finalCode ||
+            isReady ||
+            (isFlowStep && flowNodes.length > 0)
             ? "px-4 pb-4"
-            : ""
-        }
+            : "",
+        )}
       >
-        {/* Live streaming — the main content while LLM generates */}
-        {showStreamingPreview && (
-          <pre
-            ref={streamingRef}
-            className="max-h-[300px] overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed"
-          >
-            <code className="whitespace-pre-wrap">{streamingContent}</code>
-          </pre>
-        )}
+        {/* ── Flow generation visual ── */}
+        {isFlowStep && (
+          <div className="space-y-3">
+            {/* Node-by-node reveal once we have flow data */}
+            {flowNodes.length > 0 ? (
+              <div>
+                <FlowNodeTimeline nodes={flowNodes} />
+                {flowEdgeCount > 0 && (
+                  <p className="mt-1 text-[10px] text-muted-foreground">
+                    {flowNodes.length} nodes · {flowEdgeCount} edges
+                  </p>
+                )}
+              </div>
+            ) : (
+              /* Skeleton shimmer while LLM is generating */
+              <div className="flex items-center gap-1.5">
+                {[48, 64, 56].map((w, i) => (
+                  <span key={i} className="flex items-center gap-1.5">
+                    <span
+                      className="h-6 animate-pulse rounded-md bg-muted"
+                      style={{ width: `${w}px`, animationDelay: `${i * 150}ms` }}
+                    />
+                    {i < 2 && (
+                      <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/30" />
+                    )}
+                  </span>
+                ))}
+                <span className="ml-1 text-xs text-muted-foreground/50">
+                  generating...
+                </span>
+              </div>
+            )}
 
-        {/* Validation error */}
-        {progress.error && (
-          <div className="mt-2 w-fit rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            {progress.error}
-          </div>
-        )}
+            {/* Retry counter */}
+            {progress.attempt > 1 && (
+              <div className="text-xs text-muted-foreground">
+                Attempt {progress.attempt} of {progress.maxAttempts}
+              </div>
+            )}
 
-        {/* Retry counter */}
-        {progress.attempt > 1 && (
-          <div className="mt-3 text-xs text-muted-foreground">
-            Attempt {progress.attempt} of {progress.maxAttempts}
-          </div>
-        )}
-
-        {/* Final extracted code — replaces streaming preview */}
-        {finalCode && (
-          <div className="mt-3">
-            <button
-              type="button"
-              onClick={() => setCodeOpen((prev) => !prev)}
-              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-            >
-              {codeOpen ? (
-                <ChevronDown className="h-3 w-3" />
-              ) : (
-                <ChevronRight className="h-3 w-3" />
-              )}
-              <Code2 className="h-3 w-3" />
-              <span>Code</span>
-            </button>
-            {codeOpen && (
-              <pre className="mt-2 max-h-[250px] overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed">
-                <code>{finalCode}</code>
-              </pre>
+            {/* Validation error */}
+            {progress.error && (
+              <div className="w-fit rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                {progress.error}
+              </div>
             )}
           </div>
         )}
 
-        {/* Continue — user controls transition */}
-        {isReady && (
-          <button
-            type="button"
-            data-testid="assistant-continue-button"
-            onClick={() => onValidationComplete?.()}
-            className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-accent-emerald-foreground/10 px-4 py-2.5 text-sm font-medium text-accent-emerald-foreground transition-colors hover:bg-accent-emerald-foreground/20"
-          >
-            <span>Continue</span>
-            <ArrowRight className="h-4 w-4" />
-          </button>
+        {/* ── Component generation ── */}
+        {!isFlowStep && (
+          <>
+            {/* Live streaming */}
+            {showStreamingPreview && (
+              <pre
+                ref={streamingRef}
+                className="max-h-[300px] overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed"
+              >
+                <code className="whitespace-pre-wrap">{streamingContent}</code>
+              </pre>
+            )}
+
+            {/* Validation error */}
+            {progress.error && (
+              <div className="mt-2 w-fit rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                {progress.error}
+              </div>
+            )}
+
+            {/* Retry counter */}
+            {progress.attempt > 1 && (
+              <div className="mt-3 text-xs text-muted-foreground">
+                Attempt {progress.attempt} of {progress.maxAttempts}
+              </div>
+            )}
+
+            {/* Final extracted code */}
+            {finalCode && (
+              <div className="mt-3">
+                <button
+                  type="button"
+                  onClick={() => setCodeOpen((prev) => !prev)}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  {codeOpen ? (
+                    <ChevronDown className="h-3 w-3" />
+                  ) : (
+                    <ChevronRight className="h-3 w-3" />
+                  )}
+                  <Code2 className="h-3 w-3" />
+                  <span>Code</span>
+                </button>
+                {codeOpen && (
+                  <pre className="mt-2 max-h-[250px] overflow-auto rounded-md bg-muted p-3 text-xs leading-relaxed">
+                    <code>{finalCode}</code>
+                  </pre>
+                )}
+              </div>
+            )}
+
+            {/* Continue — user controls transition */}
+            {isReady && (
+              <button
+                type="button"
+                data-testid="assistant-continue-button"
+                onClick={() => onValidationComplete?.()}
+                className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-accent-emerald-foreground/10 px-4 py-2.5 text-sm font-medium text-accent-emerald-foreground transition-colors hover:bg-accent-emerald-foreground/20"
+              >
+                <span>Continue</span>
+                <ArrowRight className="h-4 w-4" />
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
@@ -81,7 +81,9 @@ function FlowNodeTimeline({ nodes }: { nodes: CompactFlowNode[] }) {
 /** Step-by-step progress track for flow generation. */
 function FlowStepTrack({ currentStep }: { currentStep: string }) {
   const steps = FLOW_STEPS.filter((s) => s !== "validated_flow");
-  const currentIdx = FLOW_STEPS.indexOf(currentStep as (typeof FLOW_STEPS)[number]);
+  const currentIdx = FLOW_STEPS.indexOf(
+    currentStep as (typeof FLOW_STEPS)[number],
+  );
 
   return (
     <div className="flex items-center gap-0">
@@ -212,7 +214,10 @@ function AssistantLoadingStateComponent({
                   <span key={i} className="flex items-center gap-1.5">
                     <span
                       className="h-6 animate-pulse rounded-md bg-muted"
-                      style={{ width: `${w}px`, animationDelay: `${i * 150}ms` }}
+                      style={{
+                        width: `${w}px`,
+                        animationDelay: `${i * 150}ms`,
+                      }}
                     />
                     {i < 2 && (
                       <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/30" />

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-message.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-message.tsx
@@ -9,12 +9,14 @@ import { cn } from "@/utils/utils";
 import type { AssistantMessage } from "../assistant-panel.types";
 import { getRandomThinkingMessage } from "../helpers/messages";
 import { AssistantComponentResult } from "./assistant-component-result";
+import { AssistantFlowResult } from "./assistant-flow-result";
 import { AssistantLoadingState } from "./assistant-loading-state";
 import { AssistantValidationFailed } from "./assistant-validation-failed";
 
 interface AssistantMessageItemProps {
   message: AssistantMessage;
   onApprove?: (messageId: string, componentCode?: string) => void;
+  onApproveFlow?: (messageId: string) => void;
   onRetry?: (messageId: string) => void;
 }
 
@@ -40,6 +42,7 @@ function ThinkingIndicator({ message }: { message: string }) {
 export function AssistantMessageItem({
   message,
   onApprove,
+  onApproveFlow,
   onRetry,
 }: AssistantMessageItemProps) {
   const isUser = message.role === "user";
@@ -48,9 +51,23 @@ export function AssistantMessageItem({
     message.result?.validated && message.result?.componentCode;
   const hasValidationError =
     message.result?.validated === false && message.result?.validationError;
+  const hasFlowResult =
+    message.result?.flowValidated && message.result?.expandedFlow;
   // Skip animation if the message is already complete on mount (e.g. panel was closed and reopened)
   const [validationAnimationComplete, setValidationAnimationComplete] =
     useState(message.status === "complete");
+
+  // Auto-complete animation for flow results — no "Continue" button needed since
+  // there is no code to review; the flow result card is shown directly.
+  useEffect(() => {
+    if (
+      message.status === "complete" &&
+      hasFlowResult &&
+      !validationAnimationComplete
+    ) {
+      setValidationAnimationComplete(true);
+    }
+  }, [message.status, hasFlowResult, validationAnimationComplete]);
 
   // Timeout fallback: if message is complete but user hasn't clicked Continue,
   // force transition after 30s to prevent indefinitely stuck loading states
@@ -85,6 +102,14 @@ export function AssistantMessageItem({
     "validated",
   ];
 
+  // Steps that indicate flow generation mode
+  const flowGenerationSteps = [
+    "generating_flow",
+    "extracting_flow",
+    "validating_flow",
+    "validated_flow",
+  ];
+
   // Detect component code in streaming content (handles misclassified intent)
   const contentLooksLikeComponentCode =
     isStreaming &&
@@ -97,17 +122,23 @@ export function AssistantMessageItem({
       componentGenerationSteps.includes(message.progress.step)) ||
     contentLooksLikeComponentCode;
 
-  // Show loading state during component generation
-  const isGeneratingCode = isStreaming && isComponentGeneration;
+  // Check if we're in flow generation mode
+  const isFlowGeneration =
+    message.progress &&
+    flowGenerationSteps.includes(message.progress.step);
+
+  // Show loading state during component or flow generation
+  const isGeneratingCode = isStreaming && (isComponentGeneration || isFlowGeneration);
 
   const renderContent = () => {
-    // Show detailed loading state during component generation
+    // Show detailed loading state during component or flow generation
     // Keep showing it until validation animation completes
     const showLoadingState =
       (isGeneratingCode && message.progress) ||
       ((hasValidatedResult || hasValidationError) &&
         !validationAnimationComplete &&
-        message.progress);
+        message.progress) ||
+      (isFlowGeneration && message.progress && !validationAnimationComplete);
 
     if (showLoadingState && message.progress) {
       return (
@@ -143,6 +174,17 @@ export function AssistantMessageItem({
         <AssistantValidationFailed
           result={message.result}
           onRetry={onRetry ? () => onRetry(message.id) : undefined}
+        />
+      );
+    }
+
+    // Show successful flow result
+    if (hasFlowResult && message.result && canShowResult) {
+      return (
+        <AssistantFlowResult
+          result={message.result}
+          onApproveFlow={() => onApproveFlow?.(message.id)}
+          onRegenerate={onRetry ? () => onRetry(message.id) : undefined}
         />
       );
     }

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-message.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-message.tsx
@@ -124,11 +124,11 @@ export function AssistantMessageItem({
 
   // Check if we're in flow generation mode
   const isFlowGeneration =
-    message.progress &&
-    flowGenerationSteps.includes(message.progress.step);
+    message.progress && flowGenerationSteps.includes(message.progress.step);
 
   // Show loading state during component or flow generation
-  const isGeneratingCode = isStreaming && (isComponentGeneration || isFlowGeneration);
+  const isGeneratingCode =
+    isStreaming && (isComponentGeneration || isFlowGeneration);
 
   const renderContent = () => {
     // Show detailed loading state during component or flow generation

--- a/src/frontend/src/components/core/assistantPanel/hooks/use-assistant-chat.ts
+++ b/src/frontend/src/components/core/assistantPanel/hooks/use-assistant-chat.ts
@@ -7,6 +7,7 @@ import {
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
 import { useAddComponent } from "@/hooks/use-add-component";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
+import useFlowStore from "@/stores/flowStore";
 import type { APIClassType } from "@/types/api";
 import type {
   AssistantMessage,
@@ -23,6 +24,7 @@ interface UseAssistantChatReturn {
   currentStep: AgenticStepType | null;
   handleSend: (content: string, model: AssistantModel | null) => Promise<void>;
   handleApprove: (messageId: string, componentCode?: string) => Promise<void>;
+  handleApproveFlow: (messageId: string) => void;
   handleRetry: (messageId: string) => void;
   handleStopGeneration: () => void;
   handleClearHistory: () => void;
@@ -42,7 +44,14 @@ export function useAssistantChat(): UseAssistantChatReturn {
 
   const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
   const addComponent = useAddComponent();
+  const paste = useFlowStore((state) => state.paste);
+  const deleteNode = useFlowStore((state) => state.deleteNode);
   const { mutateAsync: validateComponent } = usePostValidateComponentCode();
+
+  // Tracks IDs of nodes that were pasted by the last "Add to Canvas" approval.
+  // On follow-up edits, these are removed before the new flow is pasted so the
+  // old flow doesn't accumulate on the canvas alongside the updated one.
+  const lastPastedNodeIdsRef = useRef<string[]>([]);
 
   const updateMessage = useCallback(
     (
@@ -123,6 +132,9 @@ export function useAssistantChat(): UseAssistantChatReturn {
                   className: event.class_name ?? msg.progress?.className,
                   componentCode:
                     event.component_code ?? msg.progress?.componentCode,
+                  flowData: event.flow_data ?? msg.progress?.flowData,
+                  expandedFlow:
+                    event.expanded_flow ?? msg.progress?.expandedFlow,
                 },
                 completedSteps: [...completedSteps],
               }));
@@ -143,6 +155,11 @@ export function useAssistantChat(): UseAssistantChatReturn {
                   componentCode: event.data.component_code,
                   validationAttempts: event.data.validation_attempts,
                   validationError: event.data.validation_error,
+                  flowValidated: event.data.flow_validated,
+                  flowData: event.data.flow_data,
+                  expandedFlow: event.data.expanded_flow,
+                  nodeCount: event.data.node_count,
+                  edgeCount: event.data.edge_count,
                 },
               }));
               setCurrentStep(null);
@@ -215,6 +232,69 @@ export function useAssistantChat(): UseAssistantChatReturn {
     [messages, validateComponent, addComponent, updateMessage],
   );
 
+  const handleApproveFlow = useCallback(
+    (messageId: string) => {
+      const message = messages.find((m) => m.id === messageId);
+      const expandedFlow = message?.result?.expandedFlow;
+      if (!expandedFlow) return;
+
+      const nodes = (expandedFlow as { nodes?: unknown[] }).nodes;
+      const edges = (expandedFlow as { edges?: unknown[] }).edges;
+      if (!nodes?.length) return;
+
+      try {
+        // Remove nodes from the previous flow approval so edits replace
+        // the old flow instead of stacking a second copy on top of it.
+        if (lastPastedNodeIdsRef.current.length > 0) {
+          deleteNode(lastPastedNodeIdsRef.current);
+          lastPastedNodeIdsRef.current = [];
+        }
+
+        // Capture the current node ID set so we can diff after paste.
+        const nodeIdsBefore = new Set(
+          useFlowStore.getState().nodes.map((n) => n.id),
+        );
+
+        // paste() requires each node to have a position field for its internal
+        // offset calculation. expand_compact_flow() doesn't set positions, so
+        // we assign a simple horizontal layout here. paste() will remap IDs
+        // and reposition relative to the canvas viewport anyway.
+        const nodesWithPositions = (nodes as any[]).map((node, index) => ({
+          ...node,
+          position: node.position ?? { x: index * 300, y: 100 },
+        }));
+        // paste() handles ID remapping, edge handle encoding, and canvas positioning
+        paste(
+          { nodes: nodesWithPositions, edges: edges ?? [] },
+          { x: 0, y: 0 },
+        );
+
+        // Record the newly added node IDs (paste remaps IDs, so we diff).
+        // We do this on the next tick after paste has updated the store.
+        setTimeout(() => {
+          const newIds = useFlowStore
+            .getState()
+            .nodes.map((n) => n.id)
+            .filter((id) => !nodeIdsBefore.has(id));
+          lastPastedNodeIdsRef.current = newIds;
+        }, 0);
+      } catch (error) {
+        console.error("Failed to add flow to canvas:", error);
+        updateMessage(messageId, (msg) => ({
+          result: msg.result
+            ? {
+                ...msg.result,
+                validationError: `Failed to add flow to canvas: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              }
+            : msg.result,
+        }));
+      }
+    },
+    [messages, paste, deleteNode, updateMessage],
+  );
+
   const handleRetry = useCallback(
     (messageId: string) => {
       // Find the failed assistant message and the user message before it
@@ -257,6 +337,7 @@ export function useAssistantChat(): UseAssistantChatReturn {
     setMessages([]);
     setCurrentStep(null);
     setIsProcessing(false);
+    lastPastedNodeIdsRef.current = [];
     const newId = `${AGENTIC_SESSION_PREFIX}${uid.randomUUID(16)}`;
     sessionIdRef.current = newId;
     setSessionId(newId);
@@ -267,6 +348,7 @@ export function useAssistantChat(): UseAssistantChatReturn {
     setMessages(msgs);
     setCurrentStep(null);
     setIsProcessing(false);
+    lastPastedNodeIdsRef.current = [];
     sessionIdRef.current = id;
     setSessionId(id);
   }, []);
@@ -278,6 +360,7 @@ export function useAssistantChat(): UseAssistantChatReturn {
     currentStep,
     handleSend,
     handleApprove,
+    handleApproveFlow,
     handleRetry,
     handleStopGeneration,
     handleClearHistory,

--- a/src/frontend/src/controllers/API/queries/agentic/types.ts
+++ b/src/frontend/src/controllers/API/queries/agentic/types.ts
@@ -1,12 +1,39 @@
 export type AgenticStepType =
   | "generating"
   | "generating_component"
+  | "generating_flow"
   | "generation_complete"
   | "extracting_code"
+  | "extracting_flow"
   | "validating"
+  | "validating_flow"
   | "validated"
+  | "validated_flow"
   | "validation_failed"
   | "retrying";
+
+export interface CompactFlowNode {
+  id: string;
+  type: string;
+  values?: Record<string, unknown>;
+}
+
+export interface CompactFlowEdge {
+  source: string;
+  source_output: string;
+  target: string;
+  target_input: string;
+}
+
+export interface CompactFlowData {
+  nodes: CompactFlowNode[];
+  edges: CompactFlowEdge[];
+}
+
+export interface ExpandedFlowData {
+  nodes: unknown[];
+  edges: unknown[];
+}
 
 export interface AgenticProgressEvent {
   event: "progress";
@@ -17,6 +44,8 @@ export interface AgenticProgressEvent {
   error?: string;
   class_name?: string;
   component_code?: string;
+  flow_data?: CompactFlowData;
+  expanded_flow?: ExpandedFlowData;
 }
 
 export interface AgenticTokenEvent {
@@ -31,6 +60,12 @@ export interface AgenticCompleteData {
   component_code?: string;
   validation_attempts?: number;
   validation_error?: string;
+  flow_validated?: boolean;
+  flow_data?: CompactFlowData;
+  expanded_flow?: ExpandedFlowData;
+  node_count?: number;
+  edge_count?: number;
+  warnings?: string[] | null;
 }
 
 export interface AgenticCompleteEvent {
@@ -72,6 +107,8 @@ export interface AgenticProgressState {
   error?: string;
   className?: string;
   componentCode?: string;
+  flowData?: CompactFlowData;
+  expandedFlow?: ExpandedFlowData;
 }
 
 export interface AgenticResult {
@@ -81,4 +118,9 @@ export interface AgenticResult {
   componentCode?: string;
   validationError?: string;
   validationAttempts?: number;
+  flowValidated?: boolean;
+  flowData?: CompactFlowData;
+  expandedFlow?: ExpandedFlowData;
+  nodeCount?: number;
+  edgeCount?: number;
 }


### PR DESCRIPTION
## Summary

Extends the Langflow Assistant to generate **complete, wired multi-node flows** from a single natural language prompt.

Previously the assistant could only generate individual custom components. Now users can say *\"build me a RAG pipeline with OpenAI and Milvus\"* and get a fully-connected flow dropped onto the canvas.

- **Catalog-aware:** The LLM receives a condensed summary of the live component registry (~5K tokens). Custom components auto-appear without any code changes.
- **Validated with auto-retry:** 7-point registry validation with fuzzy-match auto-correction. On failure the LLM retries with error feedback (up to 3 attempts).
- **Registry-to-canvas:** Uses the existing `expand_compact_flow()` to convert compact JSON to full ReactFlow format, then `paste()` to drop it on the canvas.
- **Edit support:** Follow-up prompts (\"replace OpenAI with Claude\") replace the previous canvas nodes via ID tracking — no stacking.

## What's included

### New backend files
- `agentic/flows/flow_generator.py` — LLM graph: user prompt + catalog → compact flow JSON
- `agentic/flows/_model_config.py` — Shared model config builder
- `agentic/helpers/component_catalog.py` — Condense live registry to ~5K-token LLM prompt
- `agentic/helpers/flow_extraction.py` — Multi-fallback JSON extractor from LLM markdown
- `agentic/helpers/flow_validation.py` — 7-point registry-aware validator with fuzzy auto-correction
- `agentic/services/flow_generation_service.py` — SSE streaming pipeline orchestrator

### Modified backend files
- `flows/translation_flow.py` — adds `generate_flow` intent with disambiguation rules
- `api/schemas.py` — adds 4 new SSE step types
- `helpers/sse.py` — adds `flow_data`/`expanded_flow` kwargs for real-time node animation
- `services/assistant_service.py` — routes `generate_flow` intent to the new pipeline

### Frontend
- New: `components/assistant-flow-result.tsx` — flow preview card with node chips and action buttons
- Modified: `assistant-loading-state.tsx`, `use-assistant-chat.ts`, `assistant-panel.tsx`, `assistant-message.tsx`, `types.ts`

## How it works

```
User prompt → Intent: generate_flow
  → Catalog (live registry ~5K tokens)
  → LLM → compact JSON {nodes, edges}
  → Extract JSON → Validate (retry on fail)
  → expand_compact_flow() → full ReactFlow JSON
  → paste() → wired flow on canvas
```

## Test plan

- [ ] "build a chatbot with GPT-4" → flow preview appears with ChatInput → OpenAI → ChatOutput
- [ ] "Add to Canvas" → all nodes appear wired correctly
- [ ] "replace GPT-4 with Claude" → previous nodes removed, updated flow appears
- [ ] "create a component that does X" → single component generation still works (no regression)
- [ ] Invalid component name → auto-corrected or retried with error feedback

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flow generation from natural language input with validation and error handling
  * Flow visualization UI with approval and add-to-canvas functionality
  * Enhanced progress tracking with flow-specific generation steps
  * Flow validation with automatic error correction and retry logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->