### PR TITLE
docs: add Firecrawl bundle page

### DIFF
--- a/docs/docs/Components/bundles-firecrawl.mdx
+++ b/docs/docs/Components/bundles-firecrawl.mdx
@@ -1,0 +1,77 @@
+---
+title: Firecrawl
+slug: /bundles-firecrawl
+---
+
+import Icon from "@site/src/components/icon";
+
+<Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
+
+This page describes the components that are available in the **Firecrawl** bundle.
+
+For more information, see the [Firecrawl documentation](https://docs.firecrawl.dev).
+
+## Firecrawl Scrape API
+
+This component scrapes a single URL and returns its content.
+
+It outputs the API response as [`Data`](/data-types#data).
+
+### Firecrawl Scrape API parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| Firecrawl API Key (`api_key`) | SecretString | Input parameter. The API key to use Firecrawl API. |
+| URL (`url`) | String | Input parameter. The URL to scrape. |
+| Timeout (`timeout`) | Integer | Input parameter. Timeout in milliseconds for the request. |
+| Scrape Options (`scrapeOptions`) | Data | Input parameter. The page options to send with the request. |
+| Extractor Options (`extractorOptions`) | Data | Input parameter. The extractor options to send with the request. |
+
+## Firecrawl Crawl API
+
+This component crawls a URL and its accessible sub-pages, returning the results.
+
+It outputs the API response as [`Data`](/data-types#data).
+
+### Firecrawl Crawl API parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| Firecrawl API Key (`api_key`) | SecretString | Input parameter. The API key to use Firecrawl API. |
+| URL (`url`) | String | Input parameter. The URL to crawl. |
+| Timeout (`timeout`) | Integer | Input parameter. Timeout in milliseconds for the request. |
+| Idempotency Key (`idempotency_key`) | String | Input parameter. Optional idempotency key to ensure unique requests. |
+| Crawler Options (`crawlerOptions`) | Data | Input parameter. The crawler options to send with the request. |
+| Scrape Options (`scrapeOptions`) | Data | Input parameter. The page options to send with the request. |
+
+## Firecrawl Map API
+
+This component maps a URL and returns a list of related URLs.
+
+It outputs the API response as [`Data`](/data-types#data).
+
+### Firecrawl Map API parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| Firecrawl API Key (`api_key`) | SecretString | Input parameter. The API key to use Firecrawl API. |
+| URLs (`urls`) | String | Input parameter. List of URLs to create maps from (separated by commas or new lines). |
+| Ignore Sitemap (`ignore_sitemap`) | Boolean | Input parameter. When true, the `sitemap.xml` file is ignored during crawling. |
+| Sitemap Only (`sitemap_only`) | Boolean | Input parameter. When true, only links found in the sitemap are returned. |
+| Include Subdomains (`include_subdomains`) | Boolean | Input parameter. When true, subdomains of the provided URL are also scanned. |
+
+## Firecrawl Extract API
+
+This component extracts structured data from one or more URLs using a prompt or schema.
+
+It outputs the API response as [`Data`](/data-types#data).
+
+### Firecrawl Extract API parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| Firecrawl API Key (`api_key`) | SecretString | Input parameter. The API key to use Firecrawl API. |
+| URLs (`urls`) | String | Input parameter. List of URLs to extract data from (separated by commas or new lines). |
+| Prompt (`prompt`) | String | Input parameter. Prompt to guide the extraction process. |
+| Schema (`schema`) | Data | Input parameter. Schema to define the structure of the extracted data. |
+| Enable Web Search (`enable_web_search`) | Boolean | Input parameter. When true, the extraction uses web search to find additional data. |

--- a/docs/docs/Components/components-bundles.mdx
+++ b/docs/docs/Components/components-bundles.mdx
@@ -250,7 +250,6 @@ It accepts the following parameters:
 <!--
 * AgentQL
 * Confluence
-* Firecrawl
 * Git
 * Home Assistant
 * Jigsawstack

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -429,6 +429,7 @@ module.exports = {
             "Components/bundles-duckduckgo",
             "Components/bundles-elastic",
             "Components/bundles-exa",
+            "Components/bundles-firecrawl",
             "Components/bundles-faiss",
             "Components/bundles-glean",
             "Components/bundles-google",


### PR DESCRIPTION
## Summary

The Firecrawl bundle is available in Langflow (the Scrape, Crawl, Map, and Extract API components), but it currently has no documentation page. `docs.langflow.org/bundles-firecrawl` returns a 404, and Firecrawl is not present in the Bundles navigation. It is listed only in the commented-out "Not documented but in Langflow as of 1.5.11" block in `components-bundles.mdx`.

This PR adds the documentation page, following the structure and conventions of the existing bundle pages (modeled on `bundles-exa.mdx`).

## Changes

- Add `docs/docs/Components/bundles-firecrawl.mdx`, documenting the four components and their parameters (Firecrawl Scrape, Crawl, Map, and Extract API). Parameter details are sourced from the component definitions in `src/lfx/.../components/firecrawl/`.
- Register `Components/bundles-firecrawl` in the Bundles list in `docs/sidebars.js` (alphabetically, between `exa` and `faiss`).
- Remove Firecrawl from the "Not documented" comment block in `components-bundles.mdx`, as it is now documented.

## Notes

- Parameter names (`scrapeOptions`, `idempotency_key`, `enable_web_search`, etc.) are taken directly from the component inputs.
- Internal links (`/components-bundle-components`, `/data-types#data`) follow the conventions used by sibling bundle pages.
- This is a documentation-only change; no component or backend code is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation page for the Firecrawl components bundle
  * Documented four available APIs: Scrape, Crawl, Map, and Extract with parameter details
  * Updated navigation to include new Firecrawl bundle documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->