### PR TITLE
fix: Warm circular imports to avoid deadlock

### DIFF
--- a/src/backend/tests/unit/components/test_all_modules_importable.py
+++ b/src/backend/tests/unit/components/test_all_modules_importable.py
@@ -14,12 +14,12 @@ system functionality AND the actual module code quality are validated.
 """
 
 import asyncio
-import contextlib
 import importlib
 import pkgutil
 
 import pytest
 from langflow import components
+from lfx.interface.components import _warm_circular_imports
 
 
 class TestAllModulesImportable:
@@ -419,30 +419,12 @@ class TestDirectModuleImports:
             else:
                 return ("success", modname, None)
 
-        # Pre-import third-party modules that contain an *internal* circular
-        # import, single-threaded, before the concurrent fan-out below.
-        #
-        # ``toolguard.runtime`` (package __init__) and its
-        # ``toolguard.runtime.runtime`` submodule import each other: the __init__
-        # does ``from .runtime import ...`` while runtime.py does
-        # ``from toolguard.runtime import IToolInvoker``. That cycle resolves
-        # cleanly when first imported from a single thread. The trouble is that
-        # the lfx policy modules reach it from two different entry points --
-        # ``...policies.tool_invoker`` enters at the ``toolguard.runtime`` package
-        # while ``...policies.guard_sync_utils`` enters at the
-        # ``toolguard.runtime.runtime`` submodule. When those two land on separate
-        # worker threads at the same time, one thread holds the package lock and
-        # waits for the submodule lock while the other holds the submodule lock and
-        # waits for the package lock, so CPython's import machinery raises
-        # ``_DeadlockError``. Warming these here populates ``sys.modules`` so the
-        # threaded fan-out only ever hits the cache and can never enter the cycle
-        # concurrently. This keeps the parallelism (and full coverage -- every
-        # module is still imported below) instead of skipping the module.
-        for circular_modname in ("toolguard.runtime", "toolguard.runtime.runtime"):
-            # Optional dependency: in environments without it, fall through to the
-            # fan-out below, which skips or reports the dependent modules as usual.
-            with contextlib.suppress(ImportError):
-                importlib.import_module(circular_modname)
+        # Pre-import third-party modules with internal circular imports single-threaded
+        # before the concurrent fan-out below. This reuses the exact warm-up the
+        # production loader (``_load_components_dynamically``) runs, so the test and
+        # production stay in lockstep -- see ``_warm_circular_imports`` for the full
+        # deadlock explanation.
+        _warm_circular_imports()
 
         # Import all modules in parallel
         results = await asyncio.gather(*[import_module_async(modname) for modname in module_names])

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import hashlib
 import importlib
 import inspect
@@ -37,6 +38,11 @@ if TYPE_CHECKING:
 MIN_MODULE_PARTS = 2
 MIN_MODULE_PARTS_WITH_FILENAME = 4  # Minimum parts needed to have a module filename (lfx.components.type.filename)
 EXPECTED_RESULT_LENGTH = 2  # Expected length of the tuple returned by _process_single_module
+
+# Third-party modules whose package __init__ and a submodule import each other.
+# These must be imported single-threaded before any concurrent import fan-out --
+# see ``_warm_circular_imports`` for the full deadlock explanation.
+MODULES_WITH_INTERNAL_CIRCULAR_IMPORTS = ("toolguard.runtime", "toolguard.runtime.runtime")
 
 
 # Create a class to manage component cache instead of using globals
@@ -357,6 +363,33 @@ async def _load_from_index_or_cache(
     return modules_dict, None
 
 
+def _warm_circular_imports() -> None:
+    """Pre-import third-party modules that contain an *internal* circular import.
+
+    ``toolguard.runtime`` (package __init__) and its ``toolguard.runtime.runtime``
+    submodule import each other: the __init__ does ``from .runtime import ...`` while
+    runtime.py does ``from toolguard.runtime import IToolInvoker``. That cycle resolves
+    cleanly when first imported from a single thread, but the lfx policy modules reach
+    it from two different entry points -- ``policies.tool_invoker`` enters at the
+    ``toolguard.runtime`` package while ``policies.guard_sync_utils`` enters at the
+    ``toolguard.runtime.runtime`` submodule. When those two land on separate worker
+    threads at the same time (the ``asyncio.to_thread`` fan-out in
+    ``_load_components_dynamically``), one thread holds the package lock and waits for
+    the submodule lock while the other holds the submodule lock and waits for the
+    package lock, so CPython's import machinery raises ``_DeadlockError``.
+
+    Warming these single-threaded populates ``sys.modules`` so the threaded fan-out
+    only ever hits the import cache and can never enter the cycle concurrently. Full
+    coverage is preserved -- every component module is still imported below; this only
+    front-loads the shared cycle instead of skipping any module.
+    """
+    for modname in MODULES_WITH_INTERNAL_CIRCULAR_IMPORTS:
+        # Optional dependency: when toolguard isn't installed, the dependent component
+        # modules are skipped/reported by the fan-out as usual.
+        with contextlib.suppress(ImportError):
+            importlib.import_module(modname)
+
+
 async def _load_components_dynamically(
     target_modules: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -405,6 +438,11 @@ async def _load_components_dynamically(
 
     if not module_names:
         return modules_dict
+
+    # Warm third-party modules with internal circular imports single-threaded before
+    # the concurrent fan-out below, otherwise two worker threads can each grab one half
+    # of the cycle and CPython raises an import ``_DeadlockError``.
+    _warm_circular_imports()
 
     # Create tasks for parallel module processing
     tasks = [asyncio.to_thread(_process_single_module, modname) for modname in module_names]


### PR DESCRIPTION
This pull request refactors how the codebase handles third-party modules with internal circular imports, specifically to prevent import deadlocks when loading components concurrently. The logic for pre-importing these modules is now centralized and reused between production and test code, ensuring consistency and reducing duplication.

**Improvements to handling circular imports:**

* Added a `_warm_circular_imports` function in `lfx/interface/components.py` that pre-imports third-party modules with known internal circular imports (currently `toolguard.runtime` and `toolguard.runtime.runtime`) in a single-threaded context to avoid CPython import deadlocks during parallel loading.
* Introduced the `MODULES_WITH_INTERNAL_CIRCULAR_IMPORTS` constant to list affected modules in one place.
* Updated the production loader (`_load_components_dynamically`) to call `_warm_circular_imports` before concurrent imports, ensuring the import cache is populated and deadlocks are avoided.

**Test code consistency:**

* Modified the test suite (`test_all_modules_importable.py`) to use the new `_warm_circular_imports` helper instead of duplicating the warm-up logic, keeping test and production behavior in sync. [[1]](diffhunk://#diff-158f7b049e655febc6c6d7747b424708c3806a0a2d8b85bad99a088c2fbbc75bL17-R22) [[2]](diffhunk://#diff-158f7b049e655febc6c6d7747b424708c3806a0a2d8b85bad99a088c2fbbc75bL422-R427)

**Code cleanup:**

* Removed unused `contextlib` import from the test file, as the context management is now handled in the shared helper.
* Added missing `contextlib` import in the production file for use in `_warm_circular_imports`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability and reliability during concurrent operations by optimizing how third-party packages are loaded before parallel processing begins. This prevents potential freeze or hang conditions that could occur when multiple concurrent operations attempt to load packages simultaneously, ensuring consistently smooth performance under demanding loads and high-volume usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->