### PR TITLE
fix: bound openai responses execution time

### DIFF
--- a/src/backend/base/langflow/api/v1/openai_responses.py
+++ b/src/backend/base/langflow/api/v1/openai_responses.py
@@ -3,6 +3,7 @@ import json
 import time
 import uuid
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 from typing import Annotated, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -27,11 +28,25 @@ from langflow.services.auth.utils import api_key_security
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.database.models.flow.model import FlowRead
 from langflow.services.database.models.user.model import UserRead
-from langflow.services.deps import get_telemetry_service
+from langflow.services.deps import get_settings_service, get_telemetry_service
 from langflow.services.telemetry.schema import RunPayload
 from langflow.services.telemetry.service import TelemetryService
 
 router = APIRouter(tags=["OpenAI Responses API"])
+DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS = 300
+
+
+def _get_openai_responses_timeout_seconds() -> float:
+    timeout = getattr(get_settings_service().settings, "worker_timeout", DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        return DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS
+    return timeout if timeout > 0 else DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS
+
+
+def _openai_responses_timeout_message(timeout_seconds: float) -> str:
+    return f"OpenAI Responses request exceeded {timeout_seconds:g} seconds"
 
 
 def has_chat_input(flow_data: dict | None) -> bool:
@@ -57,6 +72,7 @@ async def run_flow_for_openai_responses(
     *,
     stream: bool = False,
     variables: dict[str, str] | None = None,
+    timeout_seconds: float = DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS,
 ) -> OpenAIResponsesResponse | StreamingResponse:
     """Run a flow for OpenAI Responses API compatibility."""
     # Check if flow has chat input
@@ -114,6 +130,7 @@ async def run_flow_for_openai_responses(
                     context=context,
                 )
             )
+            stream_events: AsyncGenerator[Any, None] | None = None
 
             try:
                 await logger.adebug(
@@ -136,7 +153,17 @@ async def run_flow_for_openai_responses(
                 previous_content = ""  # Track content already sent to calculate deltas
                 stream_usage_data = None  # Track usage from completed message
 
-                async for event_data in consume_and_yield(asyncio_queue, asyncio_queue_client_consumed):
+                stream_events = consume_and_yield(asyncio_queue, asyncio_queue_client_consumed)
+                stream_deadline = asyncio.get_running_loop().time() + timeout_seconds
+                while True:
+                    remaining_timeout = stream_deadline - asyncio.get_running_loop().time()
+                    if remaining_timeout <= 0:
+                        raise TimeoutError
+                    try:
+                        event_data = await asyncio.wait_for(stream_events.__anext__(), timeout=remaining_timeout)
+                    except StopAsyncIteration:
+                        break
+
                     if event_data is None:
                         await logger.adebug("[OpenAIResponses][stream] received None event_data; breaking loop")
                         break
@@ -147,8 +174,6 @@ async def run_flow_for_openai_responses(
                     # Parse byte string events as JSON
                     if isinstance(event_data, bytes):
                         try:
-                            import json
-
                             event_str = event_data.decode("utf-8")
                             parsed_event = json.loads(event_str)
 
@@ -430,6 +455,17 @@ async def run_flow_for_openai_responses(
                     stream_usage_data,
                 )
 
+            except (TimeoutError, asyncio.TimeoutError):
+                timeout_message = _openai_responses_timeout_message(timeout_seconds)
+                logger.error(timeout_message)
+                error_chunk = create_openai_error_chunk(
+                    response_id=response_id,
+                    created_timestamp=created_timestamp,
+                    model=request.model,
+                    error_message=timeout_message,
+                )
+                yield f"data: {error_chunk.model_dump_json()}\n\n"
+                yield "data: [DONE]\n\n"
             except Exception as e:  # noqa: BLE001
                 logger.error(f"Error in stream generator: {e}")
                 # Send error as content chunk with finish_reason="error"
@@ -442,8 +478,19 @@ async def run_flow_for_openai_responses(
                 yield f"data: {error_chunk.model_dump_json()}\n\n"
                 yield "data: [DONE]\n\n"
             finally:
+                if stream_events is not None:
+                    with suppress(Exception):
+                        await stream_events.aclose()
                 if not main_task.done():
                     main_task.cancel()
+                    try:
+                        await asyncio.wait_for(main_task, timeout=1)
+                    except asyncio.CancelledError:
+                        pass
+                    except TimeoutError:
+                        await logger.awarning("[OpenAIResponses][stream] timed out waiting for cancelled flow task")
+                    except Exception as exc:  # noqa: BLE001
+                        await logger.awarning("[OpenAIResponses][stream] cancelled flow task failed: %s", exc)
 
         return StreamingResponse(
             openai_stream_generator(),
@@ -456,12 +503,15 @@ async def run_flow_for_openai_responses(
         )
 
     # Handle non-streaming response
-    result = await simple_run_flow(
-        flow=flow,
-        input_request=simplified_request,
-        stream=False,
-        api_key_user=api_key_user,
-        context=context,
+    result = await asyncio.wait_for(
+        simple_run_flow(
+            flow=flow,
+            input_request=simplified_request,
+            stream=False,
+            api_key_user=api_key_user,
+            context=context,
+        ),
+        timeout=timeout_seconds,
     )
 
     # Extract output text, tool calls, and usage from result
@@ -673,13 +723,37 @@ async def create_response(
 
     try:
         # Process the request
+        timeout_seconds = _get_openai_responses_timeout_seconds()
         result = await run_flow_for_openai_responses(
             flow=flow,
             request=request,
             api_key_user=api_key_user,
             stream=request.stream,
             variables=variables,
+            timeout_seconds=timeout_seconds,
         )
+
+    except (TimeoutError, asyncio.TimeoutError):
+        timeout_message = _openai_responses_timeout_message(timeout_seconds)
+        logger.error(timeout_message)
+
+        background_tasks.add_task(
+            telemetry_service.log_package_run,
+            RunPayload(
+                run_is_webhook=False,
+                run_seconds=int(time.perf_counter() - start_time),
+                run_success=False,
+                run_error_message=timeout_message,
+                run_id=None,
+            ),
+        )
+
+        error_response = create_openai_error(
+            message=timeout_message,
+            type_="request_timeout",
+            code="request_timeout",
+        )
+        return OpenAIErrorResponse(error=error_response["error"])
 
     except CustomComponentValidationError as exc:
         error_response = create_openai_error(

--- a/src/backend/base/langflow/api/v1/openai_responses.py
+++ b/src/backend/base/langflow/api/v1/openai_responses.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable
 from contextlib import suppress
 from typing import Annotated, Any
 
@@ -36,7 +36,16 @@ router = APIRouter(tags=["OpenAI Responses API"])
 DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS = 300
 
 
+class OpenAIResponsesRequestTimeoutError(TimeoutError):
+    """Raised when the Responses endpoint reaches its own deadline."""
+
+
+class OpenAIResponsesStreamTimeoutError(OpenAIResponsesRequestTimeoutError):
+    """Raised when the streaming Responses endpoint reaches its own deadline."""
+
+
 def _get_openai_responses_timeout_seconds() -> float:
+    """Return the Responses endpoint timeout, falling back to a safe default."""
     timeout = getattr(get_settings_service().settings, "worker_timeout", DEFAULT_OPENAI_RESPONSES_TIMEOUT_SECONDS)
     try:
         timeout = float(timeout)
@@ -46,7 +55,26 @@ def _get_openai_responses_timeout_seconds() -> float:
 
 
 def _openai_responses_timeout_message(timeout_seconds: float) -> str:
+    """Build a user-facing timeout message for OpenAI-compatible errors."""
     return f"OpenAI Responses request exceeded {timeout_seconds:g} seconds"
+
+
+async def _await_openai_responses_deadline(awaitable: Awaitable[Any], timeout_seconds: float) -> Any:
+    """Await work with an endpoint-owned deadline without masking provider TimeoutError."""
+    task = asyncio.create_task(awaitable)
+    try:
+        done, _ = await asyncio.wait({task}, timeout=timeout_seconds)
+        if not done:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            raise OpenAIResponsesRequestTimeoutError
+        return task.result()
+    finally:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
 
 
 def has_chat_input(flow_data: dict | None) -> bool:
@@ -131,6 +159,7 @@ async def run_flow_for_openai_responses(
                 )
             )
             stream_events: AsyncGenerator[Any, None] | None = None
+            event_task: asyncio.Task[Any] | None = None
 
             try:
                 await logger.adebug(
@@ -158,11 +187,22 @@ async def run_flow_for_openai_responses(
                 while True:
                     remaining_timeout = stream_deadline - asyncio.get_running_loop().time()
                     if remaining_timeout <= 0:
-                        raise TimeoutError
+                        raise OpenAIResponsesStreamTimeoutError
+
+                    event_task = asyncio.create_task(stream_events.__anext__())
+                    done, _ = await asyncio.wait({event_task}, timeout=remaining_timeout)
+                    if not done:
+                        event_task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await event_task
+                        raise OpenAIResponsesStreamTimeoutError
+
                     try:
-                        event_data = await asyncio.wait_for(stream_events.__anext__(), timeout=remaining_timeout)
+                        event_data = event_task.result()
                     except StopAsyncIteration:
                         break
+                    finally:
+                        event_task = None
 
                     if event_data is None:
                         await logger.adebug("[OpenAIResponses][stream] received None event_data; breaking loop")
@@ -455,7 +495,7 @@ async def run_flow_for_openai_responses(
                     stream_usage_data,
                 )
 
-            except (TimeoutError, asyncio.TimeoutError):
+            except OpenAIResponsesStreamTimeoutError:
                 timeout_message = _openai_responses_timeout_message(timeout_seconds)
                 logger.error(timeout_message)
                 error_chunk = create_openai_error_chunk(
@@ -478,6 +518,10 @@ async def run_flow_for_openai_responses(
                 yield f"data: {error_chunk.model_dump_json()}\n\n"
                 yield "data: [DONE]\n\n"
             finally:
+                if event_task is not None and not event_task.done():
+                    event_task.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await event_task
                 if stream_events is not None:
                     with suppress(Exception):
                         await stream_events.aclose()
@@ -503,7 +547,7 @@ async def run_flow_for_openai_responses(
         )
 
     # Handle non-streaming response
-    result = await asyncio.wait_for(
+    result = await _await_openai_responses_deadline(
         simple_run_flow(
             flow=flow,
             input_request=simplified_request,
@@ -511,7 +555,7 @@ async def run_flow_for_openai_responses(
             api_key_user=api_key_user,
             context=context,
         ),
-        timeout=timeout_seconds,
+        timeout_seconds,
     )
 
     # Extract output text, tool calls, and usage from result
@@ -733,7 +777,7 @@ async def create_response(
             timeout_seconds=timeout_seconds,
         )
 
-    except (TimeoutError, asyncio.TimeoutError):
+    except OpenAIResponsesRequestTimeoutError:
         timeout_message = _openai_responses_timeout_message(timeout_seconds)
         logger.error(timeout_message)
 

--- a/src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
+++ b/src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from langflow.main import create_app
+from langflow.schema import OpenAIResponsesRequest
 
 
 @pytest.fixture
@@ -61,58 +62,58 @@ async def test_openai_response_stream_error_handling(client):
 
     client.app.dependency_overrides[api_key_security] = _mock_api_key_security
 
-    # Mock the flow execution to simulate an error during streaming
-    with (
-        patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
-        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
-        patch("langflow.api.v1.openai_responses.run_flow_generator") as _,
-        patch("langflow.api.v1.openai_responses.consume_and_yield") as mock_consume,
-    ):
-        # Setup mock flow
-        mock_get_flow.return_value = _mock_responses_flow()
+    try:
+        # Mock the flow execution to simulate an error during streaming
+        with (
+            patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+            patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+            patch("langflow.api.v1.openai_responses.run_flow_generator") as _,
+            patch("langflow.api.v1.openai_responses.consume_and_yield") as mock_consume,
+        ):
+            # Setup mock flow
+            mock_get_flow.return_value = _mock_responses_flow()
 
-        # We need to simulate the event manager queue behavior
-        # The run_flow_generator in the actual code puts events into the event_manager
-        # which puts them into the queue.
+            # We need to simulate the event manager queue behavior
+            # The run_flow_generator in the actual code puts events into the event_manager
+            # which puts them into the queue.
 
-        # Instead of mocking the complex event manager interaction, we can mock
-        # consume_and_yield to yield our simulated error event
+            # Instead of mocking the complex event manager interaction, we can mock
+            # consume_and_yield to yield our simulated error event
 
-        # Simulate an error event from the queue
-        error_event = json.dumps({"event": "error", "data": {"error": "Simulated streaming error"}}).encode("utf-8")
+            # Simulate an error event from the queue
+            error_event = json.dumps({"event": "error", "data": {"error": "Simulated streaming error"}}).encode("utf-8")
 
-        # Yield error event then None to end stream
-        async def event_generator(*_, **__):
-            yield error_event
-            yield None
+            # Yield error event then None to end stream
+            async def event_generator(*_, **__):
+                yield error_event
+                yield None
 
-        mock_consume.side_effect = event_generator
+            mock_consume.side_effect = event_generator
 
-        # Make the request
-        response = client.post(
-            "/api/v1/responses",
-            json={"model": "test-flow-id", "input": "test input", "stream": True},
-            headers={"Authorization": "Bearer test-key"},
-        )
+            # Make the request
+            response = client.post(
+                "/api/v1/responses",
+                json={"model": "test-flow-id", "input": "test input", "stream": True},
+                headers={"Authorization": "Bearer test-key"},
+            )
 
-        # Check response
-        assert response.status_code == 200
-        content = response.content.decode("utf-8")
+            # Check response
+            assert response.status_code == 200
+            content = response.content.decode("utf-8")
 
-        # Verify we got the error event in the stream
-        assert (
-            "event: error" not in content
-        )  # OpenAI format doesn't use event: error for the data payload itself usually, but let's check the data
+            # Verify we got the error event in the stream
+            assert (
+                "event: error" not in content
+            )  # OpenAI format doesn't use event: error for the data payload itself usually, but let's check the data
 
-        # We expect a data line with the error JSON
-        # The fix implementation: yield f"data: {json.dumps(error_response)}\n\n"
+            # We expect a data line with the error JSON
+            # The fix implementation: yield f"data: {json.dumps(error_response)}\n\n"
 
-        assert '"content":"Simulated streaming error"' in content
-        assert '"status":"failed"' in content
-        assert '"finish_reason":"error"' in content
-
-    # Clean up overrides
-    client.app.dependency_overrides = {}
+            assert '"content":"Simulated streaming error"' in content
+            assert '"status":"failed"' in content
+            assert '"finish_reason":"error"' in content
+    finally:
+        client.app.dependency_overrides = {}
 
 
 def test_openai_response_timeout_setting_falls_back_for_none(monkeypatch):
@@ -131,34 +132,73 @@ def test_openai_response_non_streaming_execution_timeout(client):
 
     client.app.dependency_overrides[api_key_security] = _mock_api_key_security
 
-    async def slow_simple_run_flow(*_, **__):
-        await asyncio.sleep(0.2)
+    try:
 
-    with (
-        patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
-        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
-        patch("langflow.api.v1.openai_responses.simple_run_flow", side_effect=slow_simple_run_flow),
-        patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
-    ):
-        mock_get_flow.return_value = _mock_responses_flow()
-        mock_get_settings_service.return_value.settings.worker_timeout = 0.01
+        async def slow_simple_run_flow(*_, **__):
+            await asyncio.sleep(0.2)
 
-        start = time.perf_counter()
-        response = client.post(
-            "/api/v1/responses",
-            json={"model": "test-flow-id", "input": "test input", "stream": False},
-            headers={"Authorization": "Bearer test-key"},
-        )
-        elapsed = time.perf_counter() - start
+        with (
+            patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+            patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+            patch("langflow.api.v1.openai_responses.simple_run_flow", side_effect=slow_simple_run_flow),
+            patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+        ):
+            mock_get_flow.return_value = _mock_responses_flow()
+            mock_get_settings_service.return_value.settings.worker_timeout = 0.01
 
-        assert elapsed < 0.2
-        assert response.status_code == 200
-        content = response.json()
-        assert content["error"]["type"] == "request_timeout"
-        assert content["error"]["code"] == "request_timeout"
-        assert "exceeded 0.01 seconds" in content["error"]["message"]
+            start = time.perf_counter()
+            response = client.post(
+                "/api/v1/responses",
+                json={"model": "test-flow-id", "input": "test input", "stream": False},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            elapsed = time.perf_counter() - start
 
-    client.app.dependency_overrides = {}
+            assert elapsed < 0.2
+            assert response.status_code == 200
+            content = response.json()
+            assert content["error"]["type"] == "request_timeout"
+            assert content["error"]["code"] == "request_timeout"
+            assert "exceeded 0.01 seconds" in content["error"]["message"]
+    finally:
+        client.app.dependency_overrides = {}
+
+
+def test_openai_response_non_streaming_provider_timeout_is_reported_as_provider_error(client):
+    """Provider-raised TimeoutError should not be mislabeled as the non-streaming endpoint deadline."""
+    from langflow.services.auth.utils import api_key_security
+
+    client.app.dependency_overrides[api_key_security] = _mock_api_key_security
+
+    try:
+
+        async def provider_timeout_simple_run_flow(*_, **__):
+            msg = "provider timed out before returning"
+            raise TimeoutError(msg)
+
+        with (
+            patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+            patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+            patch("langflow.api.v1.openai_responses.simple_run_flow", side_effect=provider_timeout_simple_run_flow),
+            patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+        ):
+            mock_get_flow.return_value = _mock_responses_flow()
+            mock_get_settings_service.return_value.settings.worker_timeout = 30
+
+            response = client.post(
+                "/api/v1/responses",
+                json={"model": "test-flow-id", "input": "test input", "stream": False},
+                headers={"Authorization": "Bearer test-key"},
+            )
+
+            assert response.status_code == 200
+            content = response.json()
+            assert content["error"]["type"] == "processing_error"
+            assert content["error"]["message"] == "provider timed out before returning"
+            assert content["error"].get("code") != "request_timeout"
+            assert "OpenAI Responses request exceeded" not in content["error"]["message"]
+    finally:
+        client.app.dependency_overrides = {}
 
 
 def test_openai_response_streaming_execution_timeout_emits_error_chunk_and_cancels_flow(client):
@@ -166,45 +206,134 @@ def test_openai_response_streaming_execution_timeout_emits_error_chunk_and_cance
     from langflow.services.auth.utils import api_key_security
 
     client.app.dependency_overrides[api_key_security] = _mock_api_key_security
-    run_flow_cancelled = False
+    try:
+        run_flow_cancelled = False
+
+        async def slow_run_flow_generator(*_, **__):
+            nonlocal run_flow_cancelled
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                run_flow_cancelled = True
+                raise
+
+        async def stalled_stream_events(*_, **__):
+            await asyncio.sleep(0.2)
+            yield None
+
+        with (
+            patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+            patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+            patch("langflow.api.v1.openai_responses.run_flow_generator", side_effect=slow_run_flow_generator),
+            patch("langflow.api.v1.openai_responses.consume_and_yield", side_effect=stalled_stream_events),
+            patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+        ):
+            mock_get_flow.return_value = _mock_responses_flow()
+            mock_get_settings_service.return_value.settings.worker_timeout = 0.01
+
+            response = client.post(
+                "/api/v1/responses",
+                json={"model": "test-flow-id", "input": "test input", "stream": True},
+                headers={"Authorization": "Bearer test-key"},
+            )
+
+            assert response.status_code == 200
+            content = response.content.decode("utf-8")
+            timeout_chunk = json.loads(content.split("data: ")[2].split("\n\n")[0])
+            assert "event: response.failed" not in content
+            assert timeout_chunk["object"] == "response.chunk"
+            assert timeout_chunk["status"] == "failed"
+            assert timeout_chunk["finish_reason"] == "error"
+            assert timeout_chunk["delta"]["content"] == "OpenAI Responses request exceeded 0.01 seconds"
+            assert content.rstrip().endswith("data: [DONE]")
+            assert run_flow_cancelled is True
+    finally:
+        client.app.dependency_overrides = {}
+
+
+def test_openai_response_streaming_provider_timeout_is_reported_as_provider_error(client):
+    """Provider-raised TimeoutError should not be mislabeled as the endpoint deadline."""
+    from langflow.services.auth.utils import api_key_security
+
+    client.app.dependency_overrides[api_key_security] = _mock_api_key_security
+    try:
+
+        async def run_flow_generator_noop(*_, **__) -> None:
+            return None
+
+        async def provider_timeout_stream_events(*_, **__):
+            msg = "provider timed out while streaming"
+            raise TimeoutError(msg)
+            yield None
+
+        with (
+            patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+            patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+            patch("langflow.api.v1.openai_responses.run_flow_generator", side_effect=run_flow_generator_noop),
+            patch("langflow.api.v1.openai_responses.consume_and_yield", side_effect=provider_timeout_stream_events),
+            patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+        ):
+            mock_get_flow.return_value = _mock_responses_flow()
+            mock_get_settings_service.return_value.settings.worker_timeout = 30
+
+            response = client.post(
+                "/api/v1/responses",
+                json={"model": "test-flow-id", "input": "test input", "stream": True},
+                headers={"Authorization": "Bearer test-key"},
+            )
+
+            assert response.status_code == 200
+            content = response.content.decode("utf-8")
+            error_chunk = json.loads(content.split("data: ")[2].split("\n\n")[0])
+            assert error_chunk["status"] == "failed"
+            assert error_chunk["finish_reason"] == "error"
+            assert error_chunk["delta"]["content"] == "provider timed out while streaming"
+            assert "OpenAI Responses request exceeded" not in content
+    finally:
+        client.app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_openai_response_streaming_client_cancellation_cancels_pending_event_read():
+    """Client cancellation should not leave the pending stream event read running."""
+    from langflow.api.v1.openai_responses import run_flow_for_openai_responses
+
+    event_read_started = asyncio.Event()
+    event_read_cancelled = asyncio.Event()
 
     async def slow_run_flow_generator(*_, **__):
-        nonlocal run_flow_cancelled
+        await asyncio.sleep(10)
+
+    async def pending_stream_events(*_, **__):
         try:
+            event_read_started.set()
             await asyncio.sleep(10)
+            yield None
         except asyncio.CancelledError:
-            run_flow_cancelled = True
+            event_read_cancelled.set()
             raise
 
-    async def stalled_stream_events(*_, **__):
-        await asyncio.sleep(0.2)
-        yield None
-
     with (
-        patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
-        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
         patch("langflow.api.v1.openai_responses.run_flow_generator", side_effect=slow_run_flow_generator),
-        patch("langflow.api.v1.openai_responses.consume_and_yield", side_effect=stalled_stream_events),
-        patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+        patch("langflow.api.v1.openai_responses.consume_and_yield", side_effect=pending_stream_events),
     ):
-        mock_get_flow.return_value = _mock_responses_flow()
-        mock_get_settings_service.return_value.settings.worker_timeout = 0.01
-
-        response = client.post(
-            "/api/v1/responses",
-            json={"model": "test-flow-id", "input": "test input", "stream": True},
-            headers={"Authorization": "Bearer test-key"},
+        streaming_response = await run_flow_for_openai_responses(
+            flow=_mock_responses_flow(),
+            request=OpenAIResponsesRequest(model="test-flow-id", input="test input", stream=True),
+            api_key_user=_mock_api_key_user(),
+            stream=True,
+            timeout_seconds=30,
         )
 
-        assert response.status_code == 200
-        content = response.content.decode("utf-8")
-        timeout_chunk = json.loads(content.split("data: ")[2].split("\n\n")[0])
-        assert "event: response.failed" not in content
-        assert timeout_chunk["object"] == "response.chunk"
-        assert timeout_chunk["status"] == "failed"
-        assert timeout_chunk["finish_reason"] == "error"
-        assert timeout_chunk["delta"]["content"] == "OpenAI Responses request exceeded 0.01 seconds"
-        assert content.rstrip().endswith("data: [DONE]")
-        assert run_flow_cancelled is True
+        stream_iterator = streaming_response.body_iterator
+        first_chunk = await stream_iterator.__anext__()
+        assert first_chunk.startswith("data: ")
 
-    client.app.dependency_overrides = {}
+        next_chunk_task = asyncio.create_task(stream_iterator.__anext__())
+        await asyncio.wait_for(event_read_started.wait(), timeout=1)
+
+        next_chunk_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await next_chunk_task
+
+        await asyncio.wait_for(event_read_cancelled.wait(), timeout=1)

--- a/src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
+++ b/src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
@@ -1,6 +1,9 @@
 """Test OpenAI Responses Error Handling."""
 
+import asyncio
 import json
+import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,45 +17,59 @@ def client():
     return TestClient(app)
 
 
+def _mock_api_key_user():
+    from datetime import datetime, timezone
+
+    from langflow.services.database.models.user.model import UserRead
+
+    now = datetime.now(timezone.utc)
+    return UserRead(
+        id="00000000-0000-0000-0000-000000000000",
+        username="testuser",
+        is_active=True,
+        is_superuser=False,
+        create_at=now,
+        updated_at=now,
+        profile_image=None,
+        store_api_key=None,
+        last_login_at=None,
+        optins=None,
+    )
+
+
+def _mock_responses_flow():
+    mock_flow = MagicMock()
+    mock_flow.id = "11111111-1111-1111-1111-111111111111"
+    mock_flow.user_id = "00000000-0000-0000-0000-000000000000"
+    mock_flow.workspace_id = None
+    mock_flow.folder_id = None
+    mock_flow.data = {"nodes": [{"data": {"type": "ChatInput"}}, {"data": {"type": "ChatOutput"}}]}
+    return mock_flow
+
+
+async def _mock_api_key_security():
+    return _mock_api_key_user()
+
+
 @pytest.mark.asyncio
 async def test_openai_response_stream_error_handling(client):
     """Test that errors during streaming are correctly propagated to the client.
 
     Ensure errors are propagated as OpenAI-compatible error responses.
     """
-    # Mock api_key_security dependency
     from langflow.services.auth.utils import api_key_security
-    from langflow.services.database.models.user.model import UserRead
 
-    async def mock_api_key_security():
-        from datetime import datetime, timezone
-
-        now = datetime.now(timezone.utc)
-        return UserRead(
-            id="00000000-0000-0000-0000-000000000000",
-            username="testuser",
-            is_active=True,
-            is_superuser=False,
-            create_at=now,
-            updated_at=now,
-            profile_image=None,
-            store_api_key=None,
-            last_login_at=None,
-            optins=None,
-        )
-
-    client.app.dependency_overrides[api_key_security] = mock_api_key_security
+    client.app.dependency_overrides[api_key_security] = _mock_api_key_security
 
     # Mock the flow execution to simulate an error during streaming
     with (
         patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
         patch("langflow.api.v1.openai_responses.run_flow_generator") as _,
         patch("langflow.api.v1.openai_responses.consume_and_yield") as mock_consume,
     ):
         # Setup mock flow
-        mock_flow = MagicMock()
-        mock_flow.data = {"nodes": [{"data": {"type": "ChatInput"}}, {"data": {"type": "ChatOutput"}}]}
-        mock_get_flow.return_value = mock_flow
+        mock_get_flow.return_value = _mock_responses_flow()
 
         # We need to simulate the event manager queue behavior
         # The run_flow_generator in the actual code puts events into the event_manager
@@ -90,9 +107,104 @@ async def test_openai_response_stream_error_handling(client):
         # We expect a data line with the error JSON
         # The fix implementation: yield f"data: {json.dumps(error_response)}\n\n"
 
-        expected_error_part = '"message": "Simulated streaming error"'
-        assert expected_error_part in content
-        assert '"type": "processing_error"' in content
+        assert '"content":"Simulated streaming error"' in content
+        assert '"status":"failed"' in content
+        assert '"finish_reason":"error"' in content
 
     # Clean up overrides
+    client.app.dependency_overrides = {}
+
+
+def test_openai_response_timeout_setting_falls_back_for_none(monkeypatch):
+    """A missing/empty worker timeout should not crash Responses requests."""
+    from langflow.api.v1 import openai_responses
+
+    settings_service = SimpleNamespace(settings=SimpleNamespace(worker_timeout=None))
+    monkeypatch.setattr(openai_responses, "get_settings_service", lambda: settings_service)
+
+    assert openai_responses._get_openai_responses_timeout_seconds() == 300
+
+
+def test_openai_response_non_streaming_execution_timeout(client):
+    """Non-streaming Responses requests should stop at the configured worker timeout."""
+    from langflow.services.auth.utils import api_key_security
+
+    client.app.dependency_overrides[api_key_security] = _mock_api_key_security
+
+    async def slow_simple_run_flow(*_, **__):
+        await asyncio.sleep(0.2)
+
+    with (
+        patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+        patch("langflow.api.v1.openai_responses.simple_run_flow", side_effect=slow_simple_run_flow),
+        patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+    ):
+        mock_get_flow.return_value = _mock_responses_flow()
+        mock_get_settings_service.return_value.settings.worker_timeout = 0.01
+
+        start = time.perf_counter()
+        response = client.post(
+            "/api/v1/responses",
+            json={"model": "test-flow-id", "input": "test input", "stream": False},
+            headers={"Authorization": "Bearer test-key"},
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.2
+        assert response.status_code == 200
+        content = response.json()
+        assert content["error"]["type"] == "request_timeout"
+        assert content["error"]["code"] == "request_timeout"
+        assert "exceeded 0.01 seconds" in content["error"]["message"]
+
+    client.app.dependency_overrides = {}
+
+
+def test_openai_response_streaming_execution_timeout_emits_error_chunk_and_cancels_flow(client):
+    """Streaming Responses requests should fail with structured SSE and stop the producer task."""
+    from langflow.services.auth.utils import api_key_security
+
+    client.app.dependency_overrides[api_key_security] = _mock_api_key_security
+    run_flow_cancelled = False
+
+    async def slow_run_flow_generator(*_, **__):
+        nonlocal run_flow_cancelled
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            run_flow_cancelled = True
+            raise
+
+    async def stalled_stream_events(*_, **__):
+        await asyncio.sleep(0.2)
+        yield None
+
+    with (
+        patch("langflow.api.v1.openai_responses.get_flow_by_id_or_endpoint_name") as mock_get_flow,
+        patch("langflow.api.v1.openai_responses.ensure_flow_permission"),
+        patch("langflow.api.v1.openai_responses.run_flow_generator", side_effect=slow_run_flow_generator),
+        patch("langflow.api.v1.openai_responses.consume_and_yield", side_effect=stalled_stream_events),
+        patch("langflow.api.v1.openai_responses.get_settings_service") as mock_get_settings_service,
+    ):
+        mock_get_flow.return_value = _mock_responses_flow()
+        mock_get_settings_service.return_value.settings.worker_timeout = 0.01
+
+        response = client.post(
+            "/api/v1/responses",
+            json={"model": "test-flow-id", "input": "test input", "stream": True},
+            headers={"Authorization": "Bearer test-key"},
+        )
+
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        timeout_chunk = json.loads(content.split("data: ")[2].split("\n\n")[0])
+        assert "event: response.failed" not in content
+        assert timeout_chunk["object"] == "response.chunk"
+        assert timeout_chunk["status"] == "failed"
+        assert timeout_chunk["finish_reason"] == "error"
+        assert timeout_chunk["delta"]["content"] == "OpenAI Responses request exceeded 0.01 seconds"
+        assert content.rstrip().endswith("data: [DONE]")
+        assert run_flow_cancelled is True
+
     client.app.dependency_overrides = {}


### PR DESCRIPTION
## What changed
Adds an execution timeout around the OpenAI-compatible Responses endpoint so a hung flow returns a structured timeout error instead of holding the request indefinitely.

Non-streaming requests now use the existing worker timeout setting. Streaming requests share the same deadline, emit the existing OpenAI-compatible failed stream chunk shape, close with `[DONE]`, and cancel the producer task.

Fixes #13276

## Testing
- PYTHONPATH=src/backend/base:src/lfx/src python -m pytest -q src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
- PYTHONPATH=src/backend/base:src/lfx/src python -m pytest -q src/backend/tests/unit/test_endpoints.py -k openai_responses
- python -m ruff check src/backend/base/langflow/api/v1/openai_responses.py src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
- python -m ruff format --check src/backend/base/langflow/api/v1/openai_responses.py src/backend/base/langflow/tests/api/v1/test_openai_responses_error.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable timeout handling for OpenAI Responses (streaming and non-streaming) with proper timeout responses.

* **Bug Fixes**
  * Stronger streaming teardown and cancellation; emits structured timeout error chunks and ends streams cleanly.
  * Non-streaming requests now respect request deadlines and return proper timeout responses.

* **Tests**
  * Expanded tests for timeout fallbacks, streaming/non-streaming timeouts, provider timeouts, and client cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->