### PR TITLE
fix: bootstrap env variables for superusers

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -52,7 +52,6 @@ from langflow.services.deps import (
     get_auth_service,
     get_settings_service,
     get_storage_service,
-    get_variable_service,
     session_scope,
 )
 
@@ -1326,8 +1325,10 @@ async def initialize_auto_login_default_superuser() -> None:
     password = DEFAULT_SUPERUSER_PASSWORD.get_secret_value()
 
     async with session_scope() as async_session:
+        from langflow.services.utils import try_initialize_superuser_variables
+
         super_user = await get_auth_service().create_super_user(username, password, db=async_session)
-        await get_variable_service().initialize_user_variables(super_user.id, async_session)
+        await try_initialize_superuser_variables(async_session, username)
         # Initialize agentic variables if agentic experience is enabled
         from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_user_variables
 

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -38,6 +38,7 @@ class SetupSuperuserResult(str, Enum):
 
 
 async def get_or_create_super_user(session: AsyncSession, username, password, is_default):
+    """Return an existing matching superuser or create one with the supplied credentials."""
     from langflow.services.database.models.user.model import User
 
     stmt = select(User).where(User.username == username)
@@ -82,6 +83,7 @@ async def get_or_create_super_user(session: AsyncSession, username, password, is
 
 
 async def initialize_superuser_variables(session: AsyncSession, username: str) -> None:
+    """Initialize environment-backed variables for the configured superuser."""
     from langflow.services.database.models.user.model import User
     from langflow.services.deps import get_variable_service
 
@@ -95,6 +97,12 @@ async def initialize_superuser_variables(session: AsyncSession, username: str) -
 
 
 async def try_initialize_superuser_variables(session: AsyncSession, username: str) -> None:
+    """Best-effort wrapper for superuser variable initialization.
+
+    Variable bootstrap failures should not prevent Langflow from creating or
+    reusing the superuser account, so this runs inside a nested transaction and
+    logs failures without propagating them.
+    """
     try:
         async with session.begin_nested():
             await initialize_superuser_variables(session, username)
@@ -103,6 +111,7 @@ async def try_initialize_superuser_variables(session: AsyncSession, username: st
 
 
 async def setup_superuser(settings_service: SettingsService, session: AsyncSession) -> SetupSuperuserResult:
+    """Create or verify the configured superuser and bootstrap its startup resources."""
     if settings_service.auth_settings.AUTO_LOGIN:
         await logger.adebug("AUTO_LOGIN is set to True. Creating default superuser with full initialization.")
         # Use file lock to prevent race conditions in multi-worker environments
@@ -286,6 +295,7 @@ async def migrate_orphaned_mcp_servers_config(
             return True
 
         def _find_orphans() -> list[tuple[float, Path]]:
+            """Find orphaned MCP config files from previous default-superuser IDs."""
             orphans: list[tuple[float, Path]] = []
             for entry in config_dir.iterdir():
                 if not entry.is_dir() or entry.name == current_user_dir:

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -81,6 +81,27 @@ async def get_or_create_super_user(session: AsyncSession, username, password, is
     return await auth.create_super_user(username, password, db=session)
 
 
+async def initialize_superuser_variables(session: AsyncSession, username: str) -> None:
+    from langflow.services.database.models.user.model import User
+    from langflow.services.deps import get_variable_service
+
+    stmt = select(User).where(User.username == username, User.is_superuser == True)  # noqa: E712
+    super_user = (await session.exec(stmt)).first()
+    if super_user is None:
+        await logger.awarning("Could not initialize environment variables: configured superuser was not found.")
+        return
+
+    await get_variable_service().initialize_user_variables(super_user.id, session)
+
+
+async def try_initialize_superuser_variables(session: AsyncSession, username: str) -> None:
+    try:
+        async with session.begin_nested():
+            await initialize_superuser_variables(session, username)
+    except Exception as exc:  # noqa: BLE001
+        await logger.aexception(f"Failed to initialize environment variables for configured superuser: {exc}")
+
+
 async def setup_superuser(settings_service: SettingsService, session: AsyncSession) -> SetupSuperuserResult:
     if settings_service.auth_settings.AUTO_LOGIN:
         await logger.adebug("AUTO_LOGIN is set to True. Creating default superuser with full initialization.")
@@ -102,12 +123,11 @@ async def setup_superuser(settings_service: SettingsService, session: AsyncSessi
                 super_user = await get_or_create_super_user(session, username, password, is_default=True)
                 if super_user:  # Only initialize if user was created
                     from langflow.initial_setup.setup import get_or_create_default_folder
-                    from langflow.services.deps import get_variable_service
 
                     # Recover MCP server config files orphaned when DB was reset but LANGFLOW_CONFIG_DIR was kept.
                     await migrate_orphaned_mcp_servers_config(session, settings_service, super_user)
 
-                    await get_variable_service().initialize_user_variables(super_user.id, session)
+                    await try_initialize_superuser_variables(session, username)
 
                     # NOTE: Agentic variables are initialized separately in preload or main lifespan
                     # via initialize_agentic_global_variables() which handles all users at once.
@@ -116,6 +136,7 @@ async def setup_superuser(settings_service: SettingsService, session: AsyncSessi
                     _ = await get_or_create_default_folder(session, super_user.id)
                     await logger.adebug("Auto-login superuser initialized successfully")
                     return SetupSuperuserResult.AUTO_LOGIN_INITIALIZED
+                await try_initialize_superuser_variables(session, username)
                 return SetupSuperuserResult.AUTO_LOGIN_ALREADY_SATISFIED
         except TimeoutError as exc:
             # Another worker may be handling it - but a stale/abandoned lock or dead holder
@@ -140,6 +161,7 @@ async def setup_superuser(settings_service: SettingsService, session: AsyncSessi
                 )
                 await logger.aerror(msg)
                 raise RuntimeError(msg) from exc
+            await try_initialize_superuser_variables(session, username)
             return SetupSuperuserResult.AUTO_LOGIN_LOCK_TIMEOUT_SUPERUSER_PRESENT
     # Remove the default superuser if it exists
     await teardown_superuser(settings_service, session)
@@ -173,6 +195,7 @@ async def setup_superuser(settings_service: SettingsService, session: AsyncSessi
                 await migrate_orphaned_mcp_servers_config(session, settings_service, user)
         else:
             outcome = SetupSuperuserResult.SUPERUSER_UNCHANGED
+        await try_initialize_superuser_variables(session, username)
     except Exception as exc:
         await logger.aexception(f"Failed to create superuser: {exc}")
         msg = "Could not create superuser. Please create a superuser manually."

--- a/src/backend/tests/unit/services/test_utils_superuser_variables.py
+++ b/src/backend/tests/unit/services/test_utils_superuser_variables.py
@@ -23,6 +23,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture(name="db_engine")
 def db_engine_fixture():
+    """Create an in-memory SQLite engine for superuser bootstrap tests."""
     engine = create_async_engine(
         "sqlite+aiosqlite://",
         connect_args={"check_same_thread": False},
@@ -31,6 +32,7 @@ def db_engine_fixture():
 
     @event.listens_for(engine.sync_engine, "connect")
     def _enable_fk(dbapi_connection, connection_record):  # noqa: ARG001
+        """Enable foreign-key checks for the SQLite test database."""
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
         cursor.close()
@@ -40,6 +42,7 @@ def db_engine_fixture():
 
 @pytest.fixture(name="db")
 async def db_fixture(db_engine):
+    """Provide a clean async database session for each test."""
     async with db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
     async with AsyncSession(db_engine, expire_on_commit=False) as session:
@@ -50,10 +53,14 @@ async def db_fixture(db_engine):
 
 
 class _FakeAuthService:
+    """Small auth-service stand-in used by setup_superuser tests."""
+
     def verify_password(self, password: str, hashed_password: str) -> bool:
+        """Treat stored test passwords as already comparable plain text."""
         return password == hashed_password
 
     async def create_super_user(self, username: str, password: str, db: AsyncSession) -> User:
+        """Create a superuser row through the provided async session."""
         super_user = User(username=username, password=password, is_superuser=True, is_active=True)
         db.add(super_user)
         await db.flush()
@@ -63,6 +70,7 @@ class _FakeAuthService:
 
 @pytest.fixture
 def settings_service(monkeypatch):
+    """Build settings and variable-service stubs shared by the tests."""
     auth_settings = SimpleNamespace(
         AUTO_LOGIN=False,
         SUPERUSER="configured-admin",
@@ -94,6 +102,7 @@ def settings_service(monkeypatch):
 
 
 async def _get_variable(db: AsyncSession, user_id, name: str) -> Variable:
+    """Fetch a single variable for a user by name."""
     return (await db.exec(select(Variable).where(Variable.user_id == user_id, Variable.name == name))).one()
 
 
@@ -103,6 +112,7 @@ async def test_auto_login_false_fresh_superuser_gets_env_variables_during_setup(
     monkeypatch,
     settings_service,
 ) -> None:
+    """Create configured superuser variables during non-AUTO_LOGIN setup."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
 
     result = await service_utils.setup_superuser(settings_service, db)
@@ -120,6 +130,7 @@ async def test_auto_login_false_setup_does_not_overwrite_user_modified_env_varia
     monkeypatch,
     settings_service,
 ) -> None:
+    """Preserve a user-edited environment variable on repeated setup."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "new-env-secret")
     super_user = User(
         username="configured-admin",
@@ -157,6 +168,7 @@ async def test_auto_login_false_existing_superuser_gets_missing_env_variable(
     monkeypatch,
     settings_service,
 ) -> None:
+    """Backfill missing environment variables for an existing superuser."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
     super_user = User(
         username="configured-admin",
@@ -181,8 +193,12 @@ async def test_auto_login_false_variable_initialization_failure_does_not_fail_su
     monkeypatch,
     settings_service,
 ) -> None:
+    """Keep superuser setup successful when variable bootstrap raises."""
     class FailingVariableService:
+        """Variable service that fails before writing anything."""
+
         async def initialize_user_variables(self, *_, **__) -> None:
+            """Raise a synthetic bootstrap failure."""
             msg = "variable bootstrap failed"
             raise RuntimeError(msg)
 
@@ -201,8 +217,12 @@ async def test_auto_login_false_variable_initialization_db_failure_rolls_back_on
     monkeypatch,
     settings_service,
 ) -> None:
+    """Rollback only partial variable writes when bootstrap fails after flush."""
     class FailingAfterFlushVariableService:
+        """Variable service that writes a row and then fails."""
+
         async def initialize_user_variables(self, user_id, session: AsyncSession) -> None:
+            """Insert a partial variable before raising a bootstrap failure."""
             session.add(
                 Variable(
                     user_id=user_id,
@@ -235,6 +255,7 @@ async def test_auto_login_true_fresh_default_superuser_gets_env_variables_during
     monkeypatch,
     settings_service,
 ) -> None:
+    """Initialize default superuser variables during AUTO_LOGIN setup."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
     settings_service.auth_settings.AUTO_LOGIN = True
 
@@ -252,11 +273,13 @@ async def test_initialize_auto_login_default_superuser_gets_env_variables(
     monkeypatch,
     settings_service,
 ) -> None:
+    """Initialize variables through the standalone AUTO_LOGIN helper."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
     settings_service.auth_settings.AUTO_LOGIN = True
 
     @asynccontextmanager
     async def test_session_scope():
+        """Yield the test session in place of the app session scope."""
         yield db
 
     monkeypatch.setattr(initial_setup, "session_scope", test_session_scope)
@@ -276,8 +299,12 @@ async def test_auto_login_true_fresh_variable_initialization_db_failure_keeps_su
     monkeypatch,
     settings_service,
 ) -> None:
+    """Keep AUTO_LOGIN superuser creation when variable bootstrap rolls back."""
     class FailingAfterFlushVariableService:
+        """Variable service that writes a row and then fails."""
+
         async def initialize_user_variables(self, user_id, session: AsyncSession) -> None:
+            """Insert a partial variable before raising a bootstrap failure."""
             session.add(
                 Variable(
                     user_id=user_id,
@@ -311,6 +338,7 @@ async def test_auto_login_true_existing_default_superuser_gets_missing_env_varia
     monkeypatch,
     settings_service,
 ) -> None:
+    """Backfill missing variables for an existing AUTO_LOGIN superuser."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
     settings_service.auth_settings.AUTO_LOGIN = True
     super_user = User(
@@ -336,6 +364,7 @@ async def test_auto_login_lock_timeout_existing_default_superuser_gets_missing_e
     monkeypatch,
     settings_service,
 ) -> None:
+    """Backfill variables after a lock timeout when the superuser exists."""
     monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
     settings_service.auth_settings.AUTO_LOGIN = True
     super_user = User(
@@ -349,14 +378,18 @@ async def test_auto_login_lock_timeout_existing_default_superuser_gets_missing_e
     await db.refresh(super_user)
 
     class FailingLock:
+        """FileLock replacement that always times out on enter."""
+
         def __init__(self, *_, **__) -> None:
-            pass
+            """Accept the same construction shape as FileLock."""
 
         def __enter__(self):
+            """Raise a timeout to exercise the lock-timeout recovery path."""
             msg = "mock lock timeout"
             raise TimeoutError(msg)
 
         def __exit__(self, *_) -> bool:
+            """Do not suppress exceptions from the context manager."""
             return False
 
     monkeypatch.setattr(filelock, "FileLock", FailingLock)

--- a/src/backend/tests/unit/services/test_utils_superuser_variables.py
+++ b/src/backend/tests/unit/services/test_utils_superuser_variables.py
@@ -194,6 +194,7 @@ async def test_auto_login_false_variable_initialization_failure_does_not_fail_su
     settings_service,
 ) -> None:
     """Keep superuser setup successful when variable bootstrap raises."""
+
     class FailingVariableService:
         """Variable service that fails before writing anything."""
 
@@ -218,6 +219,7 @@ async def test_auto_login_false_variable_initialization_db_failure_rolls_back_on
     settings_service,
 ) -> None:
     """Rollback only partial variable writes when bootstrap fails after flush."""
+
     class FailingAfterFlushVariableService:
         """Variable service that writes a row and then fails."""
 
@@ -300,6 +302,7 @@ async def test_auto_login_true_fresh_variable_initialization_db_failure_keeps_su
     settings_service,
 ) -> None:
     """Keep AUTO_LOGIN superuser creation when variable bootstrap rolls back."""
+
     class FailingAfterFlushVariableService:
         """Variable service that writes a row and then fails."""
 

--- a/src/backend/tests/unit/services/test_utils_superuser_variables.py
+++ b/src/backend/tests/unit/services/test_utils_superuser_variables.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import filelock
+import pytest
+from langflow.initial_setup import setup as initial_setup
+from langflow.services import utils as service_utils
+from langflow.services.database.models import User, Variable
+from langflow.services.variable import service as variable_service_module
+from langflow.services.variable.constants import CREDENTIAL_TYPE
+from langflow.services.variable.service import DatabaseVariableService
+from lfx.services.settings.constants import DEFAULT_SUPERUSER, DEFAULT_SUPERUSER_PASSWORD
+from pydantic import SecretStr
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture(name="db_engine")
+def db_engine_fixture():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_fk(dbapi_connection, connection_record):  # noqa: ARG001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+@pytest.fixture(name="db")
+async def db_fixture(db_engine):
+    async with db_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(db_engine, expire_on_commit=False) as session:
+        yield session
+    async with db_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await db_engine.dispose()
+
+
+class _FakeAuthService:
+    def verify_password(self, password: str, hashed_password: str) -> bool:
+        return password == hashed_password
+
+    async def create_super_user(self, username: str, password: str, db: AsyncSession) -> User:
+        super_user = User(username=username, password=password, is_superuser=True, is_active=True)
+        db.add(super_user)
+        await db.flush()
+        await db.refresh(super_user)
+        return super_user
+
+
+@pytest.fixture
+def settings_service(monkeypatch):
+    auth_settings = SimpleNamespace(
+        AUTO_LOGIN=False,
+        SUPERUSER="configured-admin",
+        SUPERUSER_PASSWORD=SecretStr("configured-password"),
+        reset_credentials=lambda: None,
+    )
+    settings = SimpleNamespace(
+        agentic_experience=False,
+        store_environment_variables=True,
+        variables_to_get_from_environment=["BOOTSTRAP_API_KEY"],
+    )
+    settings_service = SimpleNamespace(auth_settings=auth_settings, settings=settings)
+
+    variable_service = DatabaseVariableService(settings_service)
+
+    monkeypatch.setattr(service_utils, "get_auth_service", lambda: _FakeAuthService())
+    monkeypatch.setattr("langflow.services.deps.get_variable_service", lambda: variable_service)
+    monkeypatch.setattr(
+        variable_service_module.auth_utils,
+        "encrypt_api_key",
+        lambda value, _settings_service=None: f"encrypted:{value}",
+    )
+    monkeypatch.setattr(
+        variable_service_module.auth_utils,
+        "decrypt_api_key",
+        lambda value, _settings_service=None: value.removeprefix("encrypted:"),
+    )
+    return settings_service
+
+
+async def _get_variable(db: AsyncSession, user_id, name: str) -> Variable:
+    return (await db.exec(select(Variable).where(Variable.user_id == user_id, Variable.name == name))).one()
+
+
+@pytest.mark.asyncio
+async def test_auto_login_false_fresh_superuser_gets_env_variables_during_setup(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.SUPERUSER_CREATED
+    super_user = (await db.exec(select(User).where(User.username == "configured-admin"))).one()
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.type == CREDENTIAL_TYPE
+    assert variable.value == "encrypted:env-secret"
+
+
+@pytest.mark.asyncio
+async def test_auto_login_false_setup_does_not_overwrite_user_modified_env_variable(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "new-env-secret")
+    super_user = User(
+        username="configured-admin",
+        password="configured-password",  # noqa: S106
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(super_user)
+    await db.flush()
+    await db.refresh(super_user)
+
+    created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    variable = Variable(
+        user_id=super_user.id,
+        name="BOOTSTRAP_API_KEY",
+        value="encrypted:user-secret",
+        type=CREDENTIAL_TYPE,
+        default_fields=[],
+        created_at=created_at,
+        updated_at=created_at + timedelta(hours=1),
+    )
+    db.add(variable)
+    await db.flush()
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.SUPERUSER_UNCHANGED
+    preserved = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert preserved.value == "encrypted:user-secret"
+
+
+@pytest.mark.asyncio
+async def test_auto_login_false_existing_superuser_gets_missing_env_variable(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+    super_user = User(
+        username="configured-admin",
+        password="configured-password",  # noqa: S106
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(super_user)
+    await db.flush()
+    await db.refresh(super_user)
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.SUPERUSER_UNCHANGED
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.value == "encrypted:env-secret"
+
+
+@pytest.mark.asyncio
+async def test_auto_login_false_variable_initialization_failure_does_not_fail_superuser_setup(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    class FailingVariableService:
+        async def initialize_user_variables(self, *_, **__) -> None:
+            msg = "variable bootstrap failed"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr("langflow.services.deps.get_variable_service", lambda: FailingVariableService())
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.SUPERUSER_CREATED
+    super_user = (await db.exec(select(User).where(User.username == "configured-admin"))).one()
+    assert super_user.is_superuser is True
+
+
+@pytest.mark.asyncio
+async def test_auto_login_false_variable_initialization_db_failure_rolls_back_only_variables(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    class FailingAfterFlushVariableService:
+        async def initialize_user_variables(self, user_id, session: AsyncSession) -> None:
+            session.add(
+                Variable(
+                    user_id=user_id,
+                    name="BOOTSTRAP_API_KEY",
+                    value="encrypted:partial",
+                    type=CREDENTIAL_TYPE,
+                    default_fields=[],
+                )
+            )
+            await session.flush()
+            msg = "variable bootstrap failed after flush"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr("langflow.services.deps.get_variable_service", lambda: FailingAfterFlushVariableService())
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.SUPERUSER_CREATED
+    super_user = (await db.exec(select(User).where(User.username == "configured-admin"))).one()
+    assert super_user.is_superuser is True
+    variables = (
+        await db.exec(select(Variable).where(Variable.user_id == super_user.id, Variable.name == "BOOTSTRAP_API_KEY"))
+    ).all()
+    assert variables == []
+
+
+@pytest.mark.asyncio
+async def test_auto_login_true_fresh_default_superuser_gets_env_variables_during_setup(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+    settings_service.auth_settings.AUTO_LOGIN = True
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.AUTO_LOGIN_INITIALIZED
+    super_user = (await db.exec(select(User).where(User.username == DEFAULT_SUPERUSER))).one()
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.value == "encrypted:env-secret"
+
+
+@pytest.mark.asyncio
+async def test_initialize_auto_login_default_superuser_gets_env_variables(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+    settings_service.auth_settings.AUTO_LOGIN = True
+
+    @asynccontextmanager
+    async def test_session_scope():
+        yield db
+
+    monkeypatch.setattr(initial_setup, "session_scope", test_session_scope)
+    monkeypatch.setattr(initial_setup, "get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(initial_setup, "get_auth_service", lambda: _FakeAuthService())
+
+    await initial_setup.initialize_auto_login_default_superuser()
+
+    super_user = (await db.exec(select(User).where(User.username == DEFAULT_SUPERUSER))).one()
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.value == "encrypted:env-secret"
+
+
+@pytest.mark.asyncio
+async def test_auto_login_true_fresh_variable_initialization_db_failure_keeps_superuser(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    class FailingAfterFlushVariableService:
+        async def initialize_user_variables(self, user_id, session: AsyncSession) -> None:
+            session.add(
+                Variable(
+                    user_id=user_id,
+                    name="BOOTSTRAP_API_KEY",
+                    value="encrypted:partial",
+                    type=CREDENTIAL_TYPE,
+                    default_fields=[],
+                )
+            )
+            await session.flush()
+            msg = "variable bootstrap failed after flush"
+            raise RuntimeError(msg)
+
+    settings_service.auth_settings.AUTO_LOGIN = True
+    monkeypatch.setattr("langflow.services.deps.get_variable_service", lambda: FailingAfterFlushVariableService())
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.AUTO_LOGIN_INITIALIZED
+    super_user = (await db.exec(select(User).where(User.username == DEFAULT_SUPERUSER))).one()
+    assert super_user.is_superuser is True
+    variables = (
+        await db.exec(select(Variable).where(Variable.user_id == super_user.id, Variable.name == "BOOTSTRAP_API_KEY"))
+    ).all()
+    assert variables == []
+
+
+@pytest.mark.asyncio
+async def test_auto_login_true_existing_default_superuser_gets_missing_env_variable(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+    settings_service.auth_settings.AUTO_LOGIN = True
+    super_user = User(
+        username=DEFAULT_SUPERUSER,
+        password=DEFAULT_SUPERUSER_PASSWORD.get_secret_value(),
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(super_user)
+    await db.flush()
+    await db.refresh(super_user)
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.AUTO_LOGIN_ALREADY_SATISFIED
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.value == "encrypted:env-secret"
+
+
+@pytest.mark.asyncio
+async def test_auto_login_lock_timeout_existing_default_superuser_gets_missing_env_variable(
+    db: AsyncSession,
+    monkeypatch,
+    settings_service,
+) -> None:
+    monkeypatch.setenv("BOOTSTRAP_API_KEY", "env-secret")
+    settings_service.auth_settings.AUTO_LOGIN = True
+    super_user = User(
+        username=DEFAULT_SUPERUSER,
+        password=DEFAULT_SUPERUSER_PASSWORD.get_secret_value(),
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(super_user)
+    await db.flush()
+    await db.refresh(super_user)
+
+    class FailingLock:
+        def __init__(self, *_, **__) -> None:
+            pass
+
+        def __enter__(self):
+            msg = "mock lock timeout"
+            raise TimeoutError(msg)
+
+        def __exit__(self, *_) -> bool:
+            return False
+
+    monkeypatch.setattr(filelock, "FileLock", FailingLock)
+
+    result = await service_utils.setup_superuser(settings_service, db)
+
+    assert result == service_utils.SetupSuperuserResult.AUTO_LOGIN_LOCK_TIMEOUT_SUPERUSER_PRESENT
+    variable = await _get_variable(db, super_user.id, "BOOTSTRAP_API_KEY")
+    assert variable.value == "encrypted:env-secret"


### PR DESCRIPTION
## What changed
Initializes environment-backed variables for startup-created or already-existing superusers, including both configured `AUTO_LOGIN=false` superusers and the default `AUTO_LOGIN=true` superuser.

The bootstrap reuses the existing variable service, so user-modified variables are preserved. Variable initialization runs inside a nested transaction so a partial variable failure does not break the surrounding superuser setup.

Fixes #11119

## Testing
- PYTHONPATH=src/backend/base:src/lfx/src python -m pytest -q src/backend/tests/unit/services/test_utils_superuser_variables.py
- PYTHONPATH=src/backend/base:src/lfx/src python -m pytest -q src/backend/tests/unit/test_setup_superuser_flow.py src/backend/tests/unit/services/test_utils_superuser_variables.py
- python -m ruff check src/backend/base/langflow/services/utils.py src/backend/base/langflow/initial_setup/setup.py src/backend/tests/unit/services/test_utils_superuser_variables.py
- python -m ruff format --check src/backend/base/langflow/services/utils.py src/backend/base/langflow/initial_setup/setup.py src/backend/tests/unit/services/test_utils_superuser_variables.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced superuser environment variable initialization with improved resilience during setup—variables are now reliably populated from environment configuration across all startup modes.

* **Tests**
  * Added comprehensive test coverage for superuser setup and variable initialization, validating behavior in various scenarios including failure cases and different configuration modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->