### PR TITLE
fix: Improved styling of DatePicker icon in dark theme

### DIFF
--- a/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
+++ b/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
@@ -92,6 +92,7 @@ export const FormKeyRender = ({
             onChange={({ target: { value } }) => {
               setExpiresAt(value);
             }}
+            className="[color-scheme:light] dark:[&::-webkit-calendar-picker-indicator]:invert dark:[&::-webkit-calendar-picker-indicator]:opacity-80"
           />
         </Form.Control>
         <div className="mt-2 flex items-center gap-1.5">


### PR DESCRIPTION
In the API Key Creation modal, when the theme is dark, the icon is dark. This is bad visibility. Rectified the styling for the component to invert when the mode is dark.

<img width="1409" height="237" alt="Screenshot 2026-06-04 at 1 40 53 PM" src="https://github.com/user-attachments/assets/a3bfa784-d779-4bd6-b4ab-d7988da68b46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual appearance of the expiry date calendar picker to display properly in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->