### PR TITLE
fix: decouple Db2 vector store ingestion from search query

### DIFF
--- a/src/bundles/ibm/src/lfx_ibm/components/ibm/db2_vector.py
+++ b/src/bundles/ibm/src/lfx_ibm/components/ibm/db2_vector.py
@@ -410,8 +410,21 @@ class DB2VectorStoreComponent(LCVectorStoreComponent):
         return vector_store
 
     def search_documents(self) -> list[Data]:
-        """Perform similarity search and return results."""
+        """Perform similarity search and return results.
+
+        The vector store is built first so that any connected ingest data is
+        written to DB2 regardless of whether a search query is provided.
+        Ingestion and search are independent: an empty query simply skips the
+        search and returns no results -- it must not skip ingestion.
+        """
+        # Build (and ingest into) the vector store first. ``build_vector_store``
+        # is what writes ``self.ingest_data`` to DB2, so it has to run even when
+        # no search query is supplied -- otherwise ingestion would silently
+        # depend on a query being present. Mirrors LCVectorStoreComponent.
+        vector_store = self.build_vector_store()
+
         if not self.search_query:
+            self.status = ""
             return []
 
         # Extract text from search_query (handle Message, Data, or string)
@@ -441,9 +454,6 @@ class DB2VectorStoreComponent(LCVectorStoreComponent):
             # Convert any other type to string
             query_text = str(self.search_query)
 
-        # Build vector store
-        vector_store = self.build_vector_store()
-
         # Perform search based on search type
         if self.search_type == "Similarity":
             docs = vector_store.similarity_search(
@@ -456,7 +466,9 @@ class DB2VectorStoreComponent(LCVectorStoreComponent):
                 k=self.number_of_results,
             )
 
-        return [Data(text=doc.page_content, data={"text": doc.page_content}) for doc in docs]
+        results = [Data(text=doc.page_content, data={"text": doc.page_content}) for doc in docs]
+        self.status = results
+        return results
 
     def build(self):  # type: ignore[override]
         """Build the component based on the selected mode."""

--- a/src/bundles/ibm/tests/test_db2_vector.py
+++ b/src/bundles/ibm/tests/test_db2_vector.py
@@ -131,11 +131,53 @@ class TestDB2VectorStoreComponent:
     # Note: Integration tests requiring actual DB2 database removed
     # The component logic is tested through validation tests above
 
-    def test_search_documents_no_query(self, component):
-        """Test search with no query returns empty list."""
+    def test_search_documents_no_query(self, component, mock_embedding):
+        """Test search with no query returns an empty list but still builds the store.
+
+        Ingestion happens inside ``build_vector_store``; an empty search query
+        must not short-circuit that, so the store is still built (ingested)
+        and only the *search* is skipped.
+        """
+        component.embedding = mock_embedding
         component.search_query = None
-        results = component.search_documents()
-        assert results == []
+        with patch.object(component, "build_vector_store") as mock_build:
+            mock_build.return_value = MagicMock()
+            results = component.search_documents()
+            # Vector store is still built (ingestion runs) even without a query...
+            mock_build.assert_called_once()
+            # ...but no search is performed, so no results come back.
+            assert results == []
+
+    def test_ingestion_occurs_without_search_query(self, component, mock_embedding):
+        """Regression: ingestion must happen even when no search query is set.
+
+        Previously ``search_documents`` returned early on an empty query *before*
+        building the vector store, so connected ingest data was silently dropped
+        unless a search query was also provided. Ingestion and search are
+        independent.
+        """
+        component.embedding = mock_embedding
+        component.search_query = None
+        component.ingest_data = [Data(text="Doc to ingest")]
+
+        with patch("ibm_db_dbi.connect") as mock_connect:
+            mock_connect.return_value = MagicMock()
+
+            from lfx_ibm.components.ibm.db2vs import DB2VS
+
+            with (
+                patch.object(DB2VS, "__init__", return_value=None),
+                patch.object(DB2VS, "add_documents") as mock_add_docs,
+            ):
+                results = component.search_documents()
+
+                # No query -> no search results...
+                assert results == []
+                # ...but the document was still ingested into the store.
+                mock_add_docs.assert_called_once()
+                added_docs = mock_add_docs.call_args[0][0]
+                assert len(added_docs) == 1
+                assert added_docs[0].page_content == "Doc to ingest"
 
     def test_similarity_search(self, component, mock_embedding):
         """Test similarity search functionality through the component."""


### PR DESCRIPTION
## Summary

The **IBM Db2 Vector Store** component (`lfx-ibm`) only ingested `ingest_data` when a **search query** was *also* provided. Ingestion and search should be independent — connecting ingest data should write it to Db2 whether or not a query is set.

### Root cause

`DB2VectorStoreComponent.search_documents()` overrode the base-class method with the control flow reversed. It returned early on an empty query **before** calling `build_vector_store()` — and `build_vector_store()` is what runs `_add_documents_to_vector_store()` (the ingestion path):

```python
def search_documents(self):
    if not self.search_query:
        return []          # ← bailed out here...
    ...
    vector_store = self.build_vector_store()   # ← ...so ingestion never ran
```

The base `LCVectorStoreComponent.search_documents()` does the opposite: build/ingest first, then skip only the *search* when there's no query.

### Fix

Build (and ingest into) the vector store **first**, then return early for the search only when no query is present — mirroring `LCVectorStoreComponent`. `build_vector_store()` is decorated with `@check_cached_vector_store`, so it is not rebuilt across the component's output methods within a run.

### Note on the output column name (`text` vs `content`)

While investigating, the output key `"text"` was reviewed and **intentionally kept**. `"text"` is the Langflow-wide convention — `Data.text_key` defaults to `"text"`, `Data.from_document` / `docs_to_data` write `data["text"]`, and every other vector store (FAISS, Cassandra, Chroma, AstraDB, Couchbase, ClickHouse, …) returns results that way. It is **not** a Db2-specific quirk; switching to `"content"` would make this component inconsistent with the rest of Langflow and could break downstream nodes that read `.text`. (The Db2 *table* column is separately named `text`, and the store already auto-detects a `content`-named column on pre-existing tables.)

## Changes

- `src/bundles/ibm/src/lfx_ibm/components/ibm/db2_vector.py` — build the vector store before the empty-query check; set `self.status` on results.
- `src/bundles/ibm/tests/test_db2_vector.py` — update `test_search_documents_no_query` to assert the store is still built with no query; add `test_ingestion_occurs_without_search_query` regression test.

## Test plan

- [x] `uv run pytest src/bundles/ibm/tests/test_db2_vector.py` — **52 passed**
- [x] New regression test fails on the old code (early return) and passes with the fix
- [x] `ruff format` / `ruff check` clean; pre-commit hooks pass
- [ ] Manual: connect ingest data with **no** search query → rows land in the Db2 table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved the DB2 vector search component to ensure data ingestion into the vector store occurs before query processing, enhancing reliability.
- Enhanced handling of empty search queries to properly clear component status and return expected empty results.

## Tests
- Expanded test coverage to verify data ingestion behavior when no search query is provided, including regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->