### PR TITLE
fix: slider value lost when adjusting before the node is selected

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
@@ -78,7 +78,7 @@ describe("SliderComponent — node-selection isolation", () => {
 
     const sliderRoot = screen.getByTestId("slider_track").parentElement;
 
-    expect(sliderRoot).toHaveClass("nodrag", "nopan", "noflow", "nowheel");
+    expect(sliderRoot).toHaveClass("nodrag", "nopan", "noflow", "nowheel", "nodelete");
   });
 
   it("does not let a pointer-down on the slider bubble to the node wrapper", () => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import SliderComponent from "../index";
+
+/**
+ * Regression guard for the "Depth slider value lost on node selection" bug.
+ *
+ * Sliders live inside React Flow nodes. React Flow selects a node on `click`
+ * and pans/drags it on `pointerdown`, while Radix drives the slider with the
+ * same pointer events. When the interactive slider root does not isolate those
+ * events, the first interaction on an *unselected* node is consumed by node
+ * selection: the slider reacts visually but the value the user set is never
+ * committed (it reverts or snaps to wherever the pointer landed).
+ *
+ * The fix stops pointer/click propagation on `SliderPrimitive.Root` and adds
+ * React Flow's opt-out classes. These tests use a parent that stands in for the
+ * node wrapper and assert that slider interactions never reach it, while
+ * unrelated children still bubble normally.
+ */
+
+beforeAll(() => {
+  // Radix Slider uses the Pointer Events API + pointer capture, which jsdom
+  // does not fully implement. Polyfill them so the Radix handlers can run
+  // during the test without throwing. MouseEvent is a constructible, bubbling
+  // stand-in for PointerEvent; the handlers only read event.pointerId, which is
+  // harmlessly undefined here.
+  if (!("PointerEvent" in window)) {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = jest.fn();
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = jest.fn();
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = jest.fn(() => false);
+  }
+});
+
+const renderSliderInNode = () => {
+  const parentPointerDown = jest.fn();
+  const parentClick = jest.fn();
+
+  const sliderProps: ComponentProps<typeof SliderComponent> = {
+    id: "slider_test",
+    // The value prop type collapses to `never` (legacy generic: both
+    // BaseInputProps and SliderComponentType declare `value`). The component
+    // coerces it with Number() at runtime, so a scalar is what it expects.
+    value: 1 as never,
+    editNode: false,
+    disabled: false,
+    rangeSpec: { min: 1, max: 5, step: 1 },
+    handleOnNewValue: jest.fn(),
+  };
+
+  render(
+    // Stand-in for the React Flow node wrapper: it selects the node on click
+    // and would drag it on pointer down.
+    <div
+      data-testid="rf-node"
+      onPointerDown={parentPointerDown}
+      onClick={parentClick}
+    >
+      <SliderComponent {...sliderProps} />
+      <button type="button" data-testid="bubbling-control">
+        control
+      </button>
+    </div>,
+  );
+
+  return { parentPointerDown, parentClick };
+};
+
+describe("SliderComponent — node-selection isolation", () => {
+  it("applies React Flow opt-out classes to the interactive slider root", () => {
+    renderSliderInNode();
+
+    const sliderRoot = screen.getByTestId("slider_track").parentElement;
+
+    expect(sliderRoot).toHaveClass("nodrag", "nopan", "noflow", "nowheel");
+  });
+
+  it("does not let a pointer-down on the slider bubble to the node wrapper", () => {
+    const { parentPointerDown } = renderSliderInNode();
+
+    fireEvent.pointerDown(screen.getByTestId("slider_thumb"));
+
+    expect(parentPointerDown).not.toHaveBeenCalled();
+  });
+
+  it("does not let a click on the slider bubble to the node wrapper (which would select the node)", () => {
+    const { parentClick } = renderSliderInNode();
+
+    fireEvent.click(screen.getByTestId("slider_thumb"));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("still lets unrelated children bubble to the node wrapper (isolation is scoped to the slider)", () => {
+    const { parentClick } = renderSliderInNode();
+
+    fireEvent.click(screen.getByTestId("bubbling-control"));
+
+    expect(parentClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/__tests__/slider-node-selection.test.tsx
@@ -78,7 +78,13 @@ describe("SliderComponent — node-selection isolation", () => {
 
     const sliderRoot = screen.getByTestId("slider_track").parentElement;
 
-    expect(sliderRoot).toHaveClass("nodrag", "nopan", "noflow", "nowheel", "nodelete");
+    expect(sliderRoot).toHaveClass(
+      "nodrag",
+      "nopan",
+      "noflow",
+      "nowheel",
+      "nodelete",
+    );
   });
 
   it("does not let a pointer-down on the slider bubble to the node wrapper", () => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx
@@ -269,10 +269,19 @@ export default function SliderComponent({
       </Case>
 
       <div className="flex cursor-default items-center justify-center">
+        {/*
+          Isolate the slider from React Flow's node interactions. Radix drives the
+          slider with pointer events, while the node selects on click and pans/drags
+          on pointer down. Without stopping propagation (and the nodrag/nopan opt-out
+          classes), the first interaction on an unselected node is consumed by node
+          selection and the value the user set is silently lost or mis-registered.
+        */}
         <SliderPrimitive.Root
-          className="relative flex h-5 w-full touch-none select-none items-center"
+          className="noflow nowheel nopan nodelete nodrag relative flex h-5 w-full touch-none select-none items-center"
           value={[valueAsNumber]}
           onValueChange={handleChange}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
           min={min}
           max={max}
           step={step}


### PR DESCRIPTION
## Bug

When configuring a slider field inside a node that is **not yet selected** on the canvas — e.g. the **Depth** field on the **URL** component — the first interaction is silently lost. The slider reacts visually to the click/drag, giving the impression the value changed, but the field reverts to its previous value (or snaps to wherever the pointer happened to land) rather than the value the user intended. The user then saves the flow or runs the agent and only later discovers the crawl depth (or any slider value) is wrong.

## Root cause

Sliders live inside React Flow nodes. React Flow (v12) selects a node on **`click`** and pans/drags it on **`pointerdown`**, while Radix UI drives the slider with those **same pointer events**.

The interactive `SliderPrimitive.Root` had **no React Flow isolation**:

- The node wrapper in `GenericNode` only stops `onMouseDown` — not the pointer/click events React Flow and Radix actually use.
- The slider's value-text input already carried the `noflow nowheel nopan nodelete nodrag` opt-out classes, but the **slider track/thumb itself carried none**, and nothing stopped pointer/click propagation.

So on an unselected node, the first slider interaction was shared with React Flow's node-selection `onClick` handler. Selection fires a competing `setNodes` update that races the slider's value write, and the value the user set is dropped.

## Fix

Isolate the interactive slider root from React Flow:

- Stop `onPointerDown` / `onClick` propagation on `SliderPrimitive.Root`.
- Add the `nodrag nopan noflow nowheel` opt-out classes (matching the slider's value-text input).

Radix composes incoming handlers via `composeEventHandlers`, and we only call `stopPropagation()` (never `preventDefault()`), so the slider's own value setting is completely unaffected — the interaction is simply no longer hijacked by node selection/drag.

The change is scoped to the slider component only (minimal blast radius), so all slider fields benefit (temperature, depth, etc.) without touching shared node-wrapper behavior.

## Test plan

- [x] New unit test `slider-node-selection.test.tsx` asserts that pointer-down and click on the slider do **not** bubble to a stand-in node wrapper, that the opt-out classes are applied, and that unrelated children still bubble normally. Verified it **fails without the fix** (3/4 fail) and **passes with it** (4/4).
- [x] Full `parameterRenderComponent` Jest suite green (21 suites / 225 tests).
- [x] `biome check` clean on changed files (no new lint, no `any`).

### Manual verification
1. Add a **URL** component to a blank flow (do **not** click it first).
2. Without selecting the node, drag/click the **Depth** slider to a new value.
3. The value now registers on the first interaction (previously it reverted / mis-registered).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the slider value would be lost when selecting nodes, improving overall interaction stability and user experience during parameter adjustments.

* **Tests**
  * Added regression tests to verify slider functionality remains stable across node selection and interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->