### PR TITLE
fix(bundles): sync lfx pin to the 1.10.0 line after version realignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,6 +579,9 @@ patch: ## Update version across all projects. Usage: make patch v=1.5.0
 	echo "$(GREEN)Updating lfx pyproject.toml...$(NC)"; \
 	python -c "import re; fname='src/lfx/pyproject.toml'; txt=open(fname).read(); txt=re.sub(r'^version = \".*\"', 'version = \"$$LANGFLOW_VERSION\"', txt, flags=re.MULTILINE); open(fname, 'w').write(txt)"; \
 	\
+	echo "$(GREEN)Syncing bundle lfx pins (src/bundles/*) -> $$LANGFLOW_VERSION...$(NC)"; \
+	python scripts/ci/sync_bundle_lfx_pin.py "$$LANGFLOW_VERSION"; \
+	\
 	echo "$(GREEN)Updating frontend package.json...$(NC)"; \
 	python -c "import re; fname='src/frontend/package.json'; txt=open(fname).read(); txt=re.sub(r'\"version\": \".*\"', '\"version\": \"$$LANGFLOW_VERSION\"', txt); open(fname, 'w').write(txt)"; \
 	\

--- a/scripts/ci/sync_bundle_lfx_pin.py
+++ b/scripts/ci/sync_bundle_lfx_pin.py
@@ -1,0 +1,121 @@
+"""Sync the ``lfx`` runtime-dependency floor in every ``src/bundles/*`` package.
+
+After a ``make patch v=X.Y.Z`` version bump, each bundle's ``lfx`` dependency
+floor must track Langflow/LFX's ``major.minor`` line: a bundle published from
+the X.Y release is built against that lfx's BUNDLE_API surface, so it must be
+guaranteed to resolve an lfx new enough to carry it.  Before the LFX 0.5.x ->
+1.10.0 realignment (#13176) the generated floor was a flat ``lfx>=0.5.0`` with
+no upper bound, which silently permitted resolving against the now-dead 0.5.x
+line -- and neither pip nor uv flags the cross-line jump.
+
+Pin form: ``lfx>=X.Y.0,<(X+1).0.0`` -- floored at the current minor line,
+capped below the next lfx major.  The cap is a coarse install-time guard
+against an untested lfx major; fine-grained BUNDLE_API compatibility is still
+enforced at load time by each ``extension.json``'s ``lfx.compat`` list against
+the running lfx's ``BUNDLE_API_VERSION`` (see
+``src/lfx/src/lfx/extension/manifest.py``).
+
+Idempotent: re-running with the same version is a no-op (so it is safe to call
+unconditionally from ``make patch``, including patch releases within a minor
+line where the floor does not move).  Only the bundle's ``"lfx<op>..."``
+runtime dependency is rewritten -- self-references such as
+``"lfx-docling[local]"`` and the nightly ``"lfx-nightly=="`` form are left
+untouched (neither has a bare version operator immediately after ``lfx``).
+
+Stdlib only, so it runs in any CI checkout (same constraint as the sibling
+``scripts/ci/update_bundle_versions.py`` and ``scripts/migrate/port_bundle.py``).
+
+Usage:
+    python scripts/ci/sync_bundle_lfx_pin.py 1.10.0
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+# Matches a bundle's ``"lfx<op>VERSION[,<UPPER]"`` runtime dependency. The
+# version operator immediately after ``lfx`` is what distinguishes the runtime
+# dep from self-refs like ``"lfx-docling[local]"`` (a ``-`` follows ``lfx``)
+# and the nightly ``"lfx-nightly=="`` rename produced by update_bundle_versions.
+_LFX_DEP_PATTERN = re.compile(
+    r'"lfx(?:>=|~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*'
+    r'(?:,\s*<[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*)?"'
+)
+
+# Parses the leading ``X.Y`` out of an ``X.Y.Z`` (optionally ``vX.Y.Z``) version.
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.\d+")
+
+
+def lfx_floor_spec(version: str) -> str:
+    """Return the bundle ``lfx`` dependency spec for a Langflow/LFX version.
+
+    ``"1.10.0"`` -> ``"lfx>=1.10.0,<2.0.0"`` (floor at the minor line start,
+    cap below the next lfx major). A leading ``v`` is tolerated.
+
+    NOTE: this floor format is duplicated in ``scripts/migrate/port_bundle.py``
+    (``_current_lfx_floor``) so each script stays standalone; keep them in step.
+    """
+    match = _VERSION_RE.match(version.lstrip("v"))
+    if not match:
+        msg = f"Unparseable version {version!r}; expected X.Y.Z"
+        raise ValueError(msg)
+    major, minor = int(match.group(1)), int(match.group(2))
+    return f"lfx>={major}.{minor}.0,<{major + 1}.0.0"
+
+
+def rewrite_lfx_dep(content: str, floor_spec: str) -> str:
+    """Rewrite the bundle's ``lfx`` runtime dep to ``floor_spec``. Idempotent.
+
+    Only the first (runtime) ``"lfx<op>..."`` specifier is touched; self-refs
+    and the nightly form do not match ``_LFX_DEP_PATTERN``.
+    """
+    return _LFX_DEP_PATTERN.sub(f'"{floor_spec}"', content, count=1)
+
+
+def sync_bundles(version: str, bundles_dir: Path) -> list[tuple[str, bool]]:
+    """Rewrite the ``lfx`` floor in every ``src/bundles/*/pyproject.toml``.
+
+    Returns ``(bundle_name, changed)`` tuples, sorted by bundle name.
+    """
+    floor_spec = lfx_floor_spec(version)
+    results: list[tuple[str, bool]] = []
+    for pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
+        original = pyproject.read_text(encoding="utf-8")
+        updated = rewrite_lfx_dep(original, floor_spec)
+        if updated != original:
+            pyproject.write_text(updated, encoding="utf-8")
+        results.append((pyproject.parent.name, updated != original))
+    return results
+
+
+def main() -> None:
+    """Entry point.
+
+    Usage:
+        sync_bundle_lfx_pin.py <version>
+
+    ``version`` is the Langflow/LFX release version (e.g. ``1.10.0``).
+    """
+    expected_args = 2
+    if len(sys.argv) != expected_args:
+        print("Usage: sync_bundle_lfx_pin.py <version>")
+        sys.exit(1)
+
+    version = sys.argv[1]
+    floor_spec = lfx_floor_spec(version)  # validates early
+    bundles_dir = BASE_DIR / "src" / "bundles"
+    if not bundles_dir.is_dir():
+        print("No src/bundles directory; nothing to sync.")
+        return
+
+    print(f'Syncing bundle lfx pin -> "{floor_spec}"')
+    for name, changed in sync_bundles(version, bundles_dir):
+        print(f"  {'updated' if changed else 'unchanged'}: {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate/port_bundle.py
+++ b/scripts/migrate/port_bundle.py
@@ -65,6 +65,25 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _current_lfx_floor() -> str:
+    """Return the ``lfx`` dependency floor for a freshly-ported bundle.
+
+    Reads the workspace lfx version from ``src/lfx/pyproject.toml`` and pins
+    ``lfx>=X.Y.0,<(X+1).0.0`` -- floored at the current major.minor line,
+    capped below the next lfx major.  Mirrors ``lfx_floor_spec`` in
+    ``scripts/ci/sync_bundle_lfx_pin.py`` (each script is kept standalone, so
+    keep the two in step); that script re-syncs every existing bundle on
+    ``make patch``.
+    """
+    lfx_pyproject = (REPO_ROOT / "src" / "lfx" / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "(\d+)\.(\d+)\.\d+', lfx_pyproject, re.MULTILINE)
+    if not match:
+        msg = "Could not read lfx version from src/lfx/pyproject.toml"
+        raise ValueError(msg)
+    major, minor = int(match.group(1)), int(match.group(2))
+    return f"lfx>={major}.{minor}.0,<{major + 1}.0.0"
+
+
 # ---------------------------------------------------------------------------
 # Templates
 # ---------------------------------------------------------------------------
@@ -86,11 +105,13 @@ keywords = ["langflow", "lfx", "extension", "bundle", "{bundle}"]
 # Runtime deps: lfx (the BUNDLE_API surface) plus any third-party imports
 # the bundle's components rely on.  REVIEW THIS LIST -- the script ports
 # only ``lfx``; add any other deps the moved component(s) import.
-# lfx is floored at >=0.5.0 (the release that introduced extension bundles)
-# with no upper bound so bundles track the latest lfx; BUNDLE_API compat is
-# enforced via extension.json's lfx.compat list, not an upper version cap.
+# lfx is floored at the current major.minor line and capped below the next
+# lfx major (e.g. "lfx>=1.10.0,<2.0.0"); the floor is read from
+# src/lfx/pyproject.toml at port time and re-synced on ``make patch`` via
+# scripts/ci/sync_bundle_lfx_pin.py.  Fine-grained BUNDLE_API compatibility
+# is enforced via extension.json's lfx.compat list against BUNDLE_API_VERSION.
 dependencies = [
-    "lfx>=0.5.0",
+    "{lfx_floor}",
 ]
 
 [project.urls]
@@ -357,7 +378,7 @@ def _layout_bundle(plan: PortPlan, *, apply: bool) -> list[str]:
     package_reexports, component_reexports = _render_reexports(plan)
     files = {
         plan.bundle_dir / "pyproject.toml": PYPROJECT_TEMPLATE.format(
-            bundle=plan.bundle, display_name=plan.display_name
+            bundle=plan.bundle, display_name=plan.display_name, lfx_floor=_current_lfx_floor()
         ),
         plan.bundle_dir / "README.md": README_TEMPLATE.format(bundle=plan.bundle, display_name=plan.display_name),
         package_dir / "__init__.py": PACKAGE_INIT_TEMPLATE.format(

--- a/src/backend/tests/unit/test_bundle_lfx_pin.py
+++ b/src/backend/tests/unit/test_bundle_lfx_pin.py
@@ -1,0 +1,135 @@
+"""Tests for ``scripts/ci/sync_bundle_lfx_pin.py``.
+
+The ``make patch`` target calls this script to keep every ``src/bundles/*``
+package's ``lfx`` runtime-dependency floor in step with the Langflow/LFX
+``major.minor`` line. These tests exercise the real script module so a
+regression in the floor format or the dependency regex is caught without
+running ``make``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPT = REPO_ROOT / "scripts" / "ci" / "sync_bundle_lfx_pin.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sync_bundle_lfx_pin", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_bundle_lfx_pin"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# lfx_floor_spec
+# ---------------------------------------------------------------------------
+
+
+class TestLfxFloorSpec:
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.10.0", "lfx>=1.10.0,<2.0.0"),
+            ("1.10.3", "lfx>=1.10.0,<2.0.0"),  # patch within a minor -> same floor
+            ("1.11.0", "lfx>=1.11.0,<2.0.0"),
+            ("2.0.0", "lfx>=2.0.0,<3.0.0"),
+            ("v1.10.0", "lfx>=1.10.0,<2.0.0"),  # leading v tolerated
+            ("10.4.2", "lfx>=10.4.0,<11.0.0"),  # multi-digit major
+        ],
+    )
+    def test_floor(self, version, expected):
+        assert mod.lfx_floor_spec(version) == expected
+
+    @pytest.mark.parametrize("bad", ["", "1.10", "abc", "1", "x.y.z"])
+    def test_rejects_unparseable(self, bad):
+        with pytest.raises(ValueError, match="Unparseable version"):
+            mod.lfx_floor_spec(bad)
+
+
+# ---------------------------------------------------------------------------
+# rewrite_lfx_dep
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteLfxDep:
+    FLOOR = "lfx>=1.10.0,<2.0.0"
+
+    def test_rewrites_bare_floor(self):
+        assert mod.rewrite_lfx_dep('    "lfx>=0.5.0",', self.FLOOR) == f'    "{self.FLOOR}",'
+
+    def test_rewrites_existing_range(self):
+        assert mod.rewrite_lfx_dep('    "lfx>=1.9.0,<2.0.0",', self.FLOOR) == f'    "{self.FLOOR}",'
+
+    def test_rewrites_compatible_release_and_equality(self):
+        assert mod.rewrite_lfx_dep('"lfx~=0.5.0"', self.FLOOR) == f'"{self.FLOOR}"'
+        assert mod.rewrite_lfx_dep('"lfx==0.5.0"', self.FLOOR) == f'"{self.FLOOR}"'
+
+    def test_idempotent(self):
+        once = mod.rewrite_lfx_dep('"lfx>=0.5.0"', self.FLOOR)
+        assert mod.rewrite_lfx_dep(once, self.FLOOR) == once
+
+    def test_leaves_self_reference_untouched(self):
+        # docling's optional-deps self-ref must NOT be treated as the lfx dep.
+        for self_ref in ('"lfx-docling[local]"', '"lfx-docling[local,chunking,image-description]"'):
+            assert mod.rewrite_lfx_dep(self_ref, self.FLOOR) == self_ref
+
+    def test_leaves_nightly_form_untouched(self):
+        # update_bundle_versions.py rewrites to this; sync must not clobber it.
+        assert mod.rewrite_lfx_dep('"lfx-nightly==1.10.0.dev38"', self.FLOOR) == '"lfx-nightly==1.10.0.dev38"'
+
+    def test_only_rewrites_runtime_dep_in_full_block(self):
+        content = (
+            "dependencies = [\n"
+            '    "lfx>=0.5.0",\n'
+            '    "langchain-community>=0.4.1,<1.0.0",\n'
+            "]\n"
+            "[project.optional-dependencies]\n"
+            "all = [\n"
+            '    "lfx-docling[local,chunking,image-description]",\n'
+            "]\n"
+        )
+        out = mod.rewrite_lfx_dep(content, self.FLOOR)
+        assert f'    "{self.FLOOR}",' in out
+        assert '    "langchain-community>=0.4.1,<1.0.0",' in out  # untouched
+        assert '    "lfx-docling[local,chunking,image-description]",' in out  # untouched
+
+
+# ---------------------------------------------------------------------------
+# sync_bundles (filesystem-level, on a temp tree)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBundles:
+    def _make_bundle(self, bundles_dir: Path, name: str, lfx_line: str) -> Path:
+        d = bundles_dir / name
+        d.mkdir(parents=True)
+        pyproject = d / "pyproject.toml"
+        content = f'[project]\nname = "lfx-{name}"\ndependencies = [\n    "{lfx_line}",\n]\n'
+        pyproject.write_text(content, encoding="utf-8")
+        return pyproject
+
+    def test_sync_updates_and_reports(self, tmp_path):
+        bundles = tmp_path / "bundles"
+        self._make_bundle(bundles, "arxiv", "lfx>=0.5.0")
+        self._make_bundle(bundles, "ibm", "lfx>=1.10.0,<2.0.0")  # already correct
+
+        results = dict(mod.sync_bundles("1.10.0", bundles))
+        assert results == {"arxiv": True, "ibm": False}  # arxiv changed, ibm no-op
+        assert '"lfx>=1.10.0,<2.0.0"' in (bundles / "arxiv" / "pyproject.toml").read_text()
+
+    def test_sync_idempotent(self, tmp_path):
+        bundles = tmp_path / "bundles"
+        self._make_bundle(bundles, "arxiv", "lfx>=0.5.0")
+        mod.sync_bundles("1.10.0", bundles)
+        second = dict(mod.sync_bundles("1.10.0", bundles))
+        assert second == {"arxiv": False}

--- a/src/bundles/PORTING.md
+++ b/src/bundles/PORTING.md
@@ -68,12 +68,14 @@ Copy [`src/bundles/duckduckgo/pyproject.toml`](duckduckgo/pyproject.toml) and
 substitute names + the runtime-dep block. The non-obvious bits:
 
 - `dependencies` lists every runtime dep the component imports. Floor `lfx`
-  at `>=0.5.0` (the release that introduced extension bundles) with **no
-  upper bound**, so the bundle always resolves the latest available `lfx` —
-  BUNDLE_API compatibility is enforced separately via `extension.json`'s
-  `"lfx": {"compat": [...]}` contract, not an upper version cap. A bundle
-  author *may* tighten this if a component needs a specific newer `lfx`, but
-  the default carries no ceiling.
+  at the current Langflow/LFX `major.minor` line and cap below the next `lfx`
+  major — e.g. `"lfx>=1.10.0,<2.0.0"`. You normally don't hand-write this:
+  `port_bundle.py` fills it in from `src/lfx/pyproject.toml` at port time, and
+  `make patch` re-syncs every existing bundle via
+  [`scripts/ci/sync_bundle_lfx_pin.py`](../../scripts/ci/sync_bundle_lfx_pin.py).
+  Fine-grained BUNDLE_API compatibility is enforced separately via
+  `extension.json`'s `"lfx": {"compat": [...]}` contract against the running
+  lfx's `BUNDLE_API_VERSION`, not the version cap.
 - **Platform-gated deps:** if a runtime dep has no wheel on some platform
   (e.g. `ibm-db` ships none for linux/aarch64), gate it with a PEP 508 marker
   so `pip install langflow` still succeeds there, e.g.

--- a/src/bundles/arxiv/pyproject.toml
+++ b/src/bundles/arxiv/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "arxiv", "search"]
 # but we list it here as a direct runtime dep so the bundle keeps building
 # even if lfx drops it later.
 dependencies = [
-    "lfx>=0.5.0",
+    "lfx>=1.10.0,<2.0.0",
     "defusedxml>=0.7.1,<1.0.0",
 ]
 

--- a/src/bundles/docling/pyproject.toml
+++ b/src/bundles/docling/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "docling", "documents"]
 # base dependency because the bundle exchanges DoclingDocument objects even when
 # conversion happens remotely.
 dependencies = [
-    "lfx>=0.5.0",
+    "lfx>=1.10.0,<2.0.0",
     "httpx>=0.28.1,<1.0.0",
     "docling-core>=2.36.1,<3.0.0",
 ]

--- a/src/bundles/duckduckgo/pyproject.toml
+++ b/src/bundles/duckduckgo/pyproject.toml
@@ -11,14 +11,14 @@ authors = [
 keywords = ["langflow", "lfx", "extension", "bundle", "duckduckgo", "search"]
 
 # Runtime deps: lfx (the BUNDLE_API surface) and the langchain-community
-# binding that wraps the duckduckgo-search Python client.  lfx is floored
-# at >=0.5.0 -- the release that introduced extension bundles -- with no
-# upper bound, so the bundle resolves the latest available lfx; BUNDLE_API
+# binding that wraps the duckduckgo-search Python client.  lfx is floored at
+# the current major.minor line (>=1.10.0) and capped below the next lfx major
+# (<2.0.0) so the bundle resolves a compatible lfx; fine-grained BUNDLE_API
 # compatibility is enforced separately via extension.json's
 # "lfx": {"compat": [...]} contract.  langchain-community uses the same
 # range the lfx tree does to keep co-installation lockstep.
 dependencies = [
-    "lfx>=0.5.0",
+    "lfx>=1.10.0,<2.0.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ddgs>=9.0.0",
 ]

--- a/src/bundles/ibm/pyproject.toml
+++ b/src/bundles/ibm/pyproject.toml
@@ -26,7 +26,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "ibm", "db2", "watsonx", "
 #   3.10-compatible build elsewhere.  Kept in lockstep with langflow-base.
 # * ``langchain-community`` provides the helpers DB2VS leans on.
 dependencies = [
-    "lfx>=0.5.0",
+    "lfx>=1.10.0,<2.0.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ibm-db>=3.2.9,<4.0.0; sys_platform != 'linux' or platform_machine != 'aarch64'",
     "ibm-watsonx-ai>=1.3.1,<2.0.0",


### PR DESCRIPTION
## Problem

[#13176](https://github.com/langflow-ai/langflow/pull/13176) realigned LFX from its standalone `0.5.x` line onto Langflow's `major.minor` line (`0.5.0 → 1.10.0`). But every `src/bundles/*` package — and the `port_bundle.py` generator that scaffolds new ones — still floored its runtime dep at **`lfx>=0.5.0`**.

After the jump, that floor is stale and latently unsafe:

- It silently permits resolving against the now-dead `0.5.x` line (`0.5.0` is the only sub-`1.10` version that satisfies it).
- These bundles are built against lfx **1.10.0**'s `BUNDLE_API` surface; installed against `0.5.0` a component can `ImportError` at load, and the `BUNDLE_API_VERSION` gate (both `"1"`) would **not** catch it.
- `RELEASE.md` (added by #13176) flags exactly this: the jump *"affects downstream pins, and neither pip nor uv will flag it."* Bundles are downstream pins, and nothing in the release tooling kept them in step.

Note the API-compat contract itself is unaffected: `extension.json`'s `lfx.compat: ["1"]` is validated against `BUNDLE_API_VERSION` (`=1`, unchanged), so those manifests need no change. This PR only fixes the **install-time version floor**.

## Changes

- **Bump the 4 bundles** (`arxiv`, `docling`, `duckduckgo`, `ibm`) to **`lfx>=1.10.0,<2.0.0`** — floored at the current `major.minor` line, capped below the next lfx major. Fine-grained API compat stays enforced via `extension.json`'s `lfx.compat`, not the cap.
- **`scripts/ci/sync_bundle_lfx_pin.py`** (new) — rewrites every `src/bundles/*` lfx floor for a given version. Idempotent; leaves docling's `lfx-docling[...]` self-refs and the nightly `lfx-nightly==` form untouched.
- **`make patch`** now calls the sync script, so future releases keep bundle floors in step automatically (a no-op on patch releases, moves the floor on minor/major bumps).
- **`port_bundle.py`** derives the floor from `src/lfx/pyproject.toml`, so newly-ported bundles are born at the current line instead of a hardcoded `0.5.0`.
- Docs (`src/bundles/PORTING.md`) updated; **`test_bundle_lfx_pin.py`** added.

## Test plan

- [x] `make patch` parses and includes the sync step (`make -n patch v=1.10.0`)
- [x] Sync is idempotent (re-run at `1.10.0` → all unchanged); `v=1.11.0` → `lfx>=1.11.0,<2.0.0`; `v=2.0.0` → `lfx>=2.0.0,<3.0.0`
- [x] docling self-refs and the nightly `lfx-nightly==` rename are not clobbered (verified `update_bundle_versions.py` still matches the new floor)
- [x] `uv lock --check` passes (workspace lfx is `1.10.0`; lock unchanged)
- [x] `ruff check` + `ruff format` clean; 20/20 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated LFX dependency constraints across all bundles from `>=0.5.0` to `>=1.10.0,<2.0.0` to ensure compatibility within a specific LFX version range.
  * Added automated CI workflow to synchronize bundle dependency versions during release cycles.

* **Documentation**
  * Updated bundle porting guide to specify explicit version bounds for LFX dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->