### PR TITLE
feat(storage): support AWS_ENDPOINT_URL_S3 for S3 storage

### DIFF
--- a/docs/docs/Develop/concepts-file-management.mdx
+++ b/docs/docs/Develop/concepts-file-management.mdx
@@ -142,7 +142,7 @@ LANGFLOW_STORAGE_TYPE=s3
 LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
 LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS credentials and region (required for S3)
+# AWS credentials and region
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_DEFAULT_REGION=us-east-2

--- a/docs/docs/Develop/concepts-file-management.mdx
+++ b/docs/docs/Develop/concepts-file-management.mdx
@@ -139,22 +139,26 @@ To use S3 as your file storage backend, add the following configuration to your 
 ```text
 # S3 Storage Configuration
 LANGFLOW_STORAGE_TYPE=s3
-LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=S3_BUCKET_NAME
-LANGFLOW_OBJECT_STORAGE_PREFIX=S3_BUCKET_DIRECTORY
+LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
+LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS Credentials (required for S3)
-AWS_ACCESS_KEY_ID=S3_ACCESS_KEY
-AWS_SECRET_ACCESS_KEY=S3_ACCESS_SECRET_KEY
-AWS_DEFAULT_REGION=S3_REGION
+# AWS credentials and region (required for S3)
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_DEFAULT_REGION=us-east-2
+
+# Optional custom endpoint for S3-compatible storage
+AWS_ENDPOINT_URL_S3=https://your-s3-compatible-endpoint
 ```
 
-Replace the following placeholders with the actual values for your S3 instance:
+Replace the example values with the actual values for your S3 instance:
 
-* `S3_BUCKET_NAME`: The name of your S3 bucket.
-* `S3_BUCKET_DIRECTORY`: An optional folder path within the bucket where files are stored, such as `s3://S3_BUCKET_NAME/S3_BUCKET_DIRECTORY`.
-* `S3_ACCESS_KEY`: Your AWS Access Key ID.
-* `S3_ACCESS_SECRET_KEY`: Your AWS Secret Access Key.
-* `S3_REGION`: The AWS region where your bucket is located, such as `us-east-2`.
+* `your-bucket-name`: The name of your S3 bucket.
+* `your-folder-prefix`: An optional folder path within the bucket where files are stored, such as `s3://your-bucket-name/your-folder-prefix`.
+* `your-access-key-id`: Your AWS Access Key ID.
+* `your-secret-access-key`: Your AWS Secret Access Key.
+* `us-east-2`: The AWS region where your bucket is located.
+* `https://your-s3-compatible-endpoint`: Optional endpoint URL for S3-compatible storage services.
 
 Your AWS credentials must have the necessary permissions to perform the required S3 operations for your use case, such as reading, writing, and deleting files in S3.
 This example policy allows basic CRUD operations on S3 objects.
@@ -201,6 +205,10 @@ The following environment variables configure file storage backends for Langflow
 | `LANGFLOW_OBJECT_STORAGE_BUCKET_NAME` | String | Not set | The name of the S3 bucket to use for file storage. Required when `LANGFLOW_STORAGE_TYPE=s3`. |
 | `LANGFLOW_OBJECT_STORAGE_PREFIX` | String | Not set | Optional prefix/folder path within the S3 bucket where files will be stored. If not set, files are stored at the bucket root. |
 | `LANGFLOW_OBJECT_STORAGE_TAGS` | JSON object | Not set | Optional S3 object tags applied to stored files when `LANGFLOW_STORAGE_TYPE=s3`. Ignored for local storage. Provided as a JSON map of string keys to string values, such as `{"env": "prod", "owner": "data-team"}`. |
+| `AWS_ACCESS_KEY_ID` | String | Not set | The AWS access key ID used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_SECRET_ACCESS_KEY` | String | Not set | The AWS secret access key used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_DEFAULT_REGION` | String | Not set | The AWS region where your S3 bucket is located, such as `us-east-2`. |
+| `AWS_ENDPOINT_URL_S3` | URL | Not set | Optional custom endpoint URL for S3-compatible storage services. Leave unset when using AWS S3's standard regional endpoints. |
 
 ## See also
 

--- a/docs/versioned_docs/version-1.8.0/Develop/concepts-file-management.mdx
+++ b/docs/versioned_docs/version-1.8.0/Develop/concepts-file-management.mdx
@@ -142,7 +142,7 @@ LANGFLOW_STORAGE_TYPE=s3
 LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
 LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS credentials and region (required for S3)
+# AWS credentials and region
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_DEFAULT_REGION=us-east-2

--- a/docs/versioned_docs/version-1.8.0/Develop/concepts-file-management.mdx
+++ b/docs/versioned_docs/version-1.8.0/Develop/concepts-file-management.mdx
@@ -139,22 +139,26 @@ To use S3 as your file storage backend, add the following configuration to your 
 ```text
 # S3 Storage Configuration
 LANGFLOW_STORAGE_TYPE=s3
-LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=S3_BUCKET_NAME
-LANGFLOW_OBJECT_STORAGE_PREFIX=S3_BUCKET_DIRECTORY
+LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
+LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS Credentials (required for S3)
-AWS_ACCESS_KEY_ID=S3_ACCESS_KEY
-AWS_SECRET_ACCESS_KEY=S3_ACCESS_SECRET_KEY
-AWS_DEFAULT_REGION=S3_REGION
+# AWS credentials and region (required for S3)
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_DEFAULT_REGION=us-east-2
+
+# Optional custom endpoint for S3-compatible storage
+AWS_ENDPOINT_URL_S3=https://your-s3-compatible-endpoint
 ```
 
-Replace the following placeholders with the actual values for your S3 instance:
+Replace the example values with the actual values for your S3 instance:
 
-* `S3_BUCKET_NAME`: The name of your S3 bucket.
-* `S3_BUCKET_DIRECTORY`: An optional folder path within the bucket where files are stored, such as `s3://S3_BUCKET_NAME/S3_BUCKET_DIRECTORY`.
-* `S3_ACCESS_KEY`: Your AWS Access Key ID.
-* `S3_ACCESS_SECRET_KEY`: Your AWS Secret Access Key.
-* `S3_REGION`: The AWS region where your bucket is located, such as `us-east-2`.
+* `your-bucket-name`: The name of your S3 bucket.
+* `your-folder-prefix`: An optional folder path within the bucket where files are stored, such as `s3://your-bucket-name/your-folder-prefix`.
+* `your-access-key-id`: Your AWS Access Key ID.
+* `your-secret-access-key`: Your AWS Secret Access Key.
+* `us-east-2`: The AWS region where your bucket is located.
+* `https://your-s3-compatible-endpoint`: Optional endpoint URL for S3-compatible storage services.
 
 Your AWS credentials must have the necessary permissions to perform the required S3 operations for your use case, such as reading, writing, and deleting files in S3.
 This example policy allows basic CRUD operations on S3 objects.
@@ -201,6 +205,10 @@ The following environment variables configure file storage backends for Langflow
 | `LANGFLOW_OBJECT_STORAGE_BUCKET_NAME` | String | Not set | The name of the S3 bucket to use for file storage. Required when `LANGFLOW_STORAGE_TYPE=s3`. |
 | `LANGFLOW_OBJECT_STORAGE_PREFIX` | String | Not set | Optional prefix/folder path within the S3 bucket where files will be stored. If not set, files are stored at the bucket root. |
 | `LANGFLOW_OBJECT_STORAGE_TAGS` | JSON object | Not set | Optional S3 object tags applied to stored files when `LANGFLOW_STORAGE_TYPE=s3`. Ignored for local storage. Provided as a JSON map of string keys to string values, such as `{"env": "prod", "owner": "data-team"}`. |
+| `AWS_ACCESS_KEY_ID` | String | Not set | The AWS access key ID used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_SECRET_ACCESS_KEY` | String | Not set | The AWS secret access key used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_DEFAULT_REGION` | String | Not set | The AWS region where your S3 bucket is located, such as `us-east-2`. |
+| `AWS_ENDPOINT_URL_S3` | URL | Not set | Optional custom endpoint URL for S3-compatible storage services. Leave unset when using AWS S3's standard regional endpoints. |
 
 ## See also
 

--- a/docs/versioned_docs/version-1.9.0/Develop/concepts-file-management.mdx
+++ b/docs/versioned_docs/version-1.9.0/Develop/concepts-file-management.mdx
@@ -142,7 +142,7 @@ LANGFLOW_STORAGE_TYPE=s3
 LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
 LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS credentials and region (required for S3)
+# AWS credentials and region
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_DEFAULT_REGION=us-east-2

--- a/docs/versioned_docs/version-1.9.0/Develop/concepts-file-management.mdx
+++ b/docs/versioned_docs/version-1.9.0/Develop/concepts-file-management.mdx
@@ -139,22 +139,26 @@ To use S3 as your file storage backend, add the following configuration to your 
 ```text
 # S3 Storage Configuration
 LANGFLOW_STORAGE_TYPE=s3
-LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=S3_BUCKET_NAME
-LANGFLOW_OBJECT_STORAGE_PREFIX=S3_BUCKET_DIRECTORY
+LANGFLOW_OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
+LANGFLOW_OBJECT_STORAGE_PREFIX=your-folder-prefix
 
-# AWS Credentials (required for S3)
-AWS_ACCESS_KEY_ID=S3_ACCESS_KEY
-AWS_SECRET_ACCESS_KEY=S3_ACCESS_SECRET_KEY
-AWS_DEFAULT_REGION=S3_REGION
+# AWS credentials and region (required for S3)
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_DEFAULT_REGION=us-east-2
+
+# Optional custom endpoint for S3-compatible storage
+AWS_ENDPOINT_URL_S3=https://your-s3-compatible-endpoint
 ```
 
-Replace the following placeholders with the actual values for your S3 instance:
+Replace the example values with the actual values for your S3 instance:
 
-* `S3_BUCKET_NAME`: The name of your S3 bucket.
-* `S3_BUCKET_DIRECTORY`: An optional folder path within the bucket where files are stored, such as `s3://S3_BUCKET_NAME/S3_BUCKET_DIRECTORY`.
-* `S3_ACCESS_KEY`: Your AWS Access Key ID.
-* `S3_ACCESS_SECRET_KEY`: Your AWS Secret Access Key.
-* `S3_REGION`: The AWS region where your bucket is located, such as `us-east-2`.
+* `your-bucket-name`: The name of your S3 bucket.
+* `your-folder-prefix`: An optional folder path within the bucket where files are stored, such as `s3://your-bucket-name/your-folder-prefix`.
+* `your-access-key-id`: Your AWS Access Key ID.
+* `your-secret-access-key`: Your AWS Secret Access Key.
+* `us-east-2`: The AWS region where your bucket is located.
+* `https://your-s3-compatible-endpoint`: Optional endpoint URL for S3-compatible storage services.
 
 Your AWS credentials must have the necessary permissions to perform the required S3 operations for your use case, such as reading, writing, and deleting files in S3.
 This example policy allows basic CRUD operations on S3 objects.
@@ -201,6 +205,10 @@ The following environment variables configure file storage backends for Langflow
 | `LANGFLOW_OBJECT_STORAGE_BUCKET_NAME` | String | Not set | The name of the S3 bucket to use for file storage. Required when `LANGFLOW_STORAGE_TYPE=s3`. |
 | `LANGFLOW_OBJECT_STORAGE_PREFIX` | String | Not set | Optional prefix/folder path within the S3 bucket where files will be stored. If not set, files are stored at the bucket root. |
 | `LANGFLOW_OBJECT_STORAGE_TAGS` | JSON object | Not set | Optional S3 object tags applied to stored files when `LANGFLOW_STORAGE_TYPE=s3`. Ignored for local storage. Provided as a JSON map of string keys to string values, such as `{"env": "prod", "owner": "data-team"}`. |
+| `AWS_ACCESS_KEY_ID` | String | Not set | The AWS access key ID used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_SECRET_ACCESS_KEY` | String | Not set | The AWS secret access key used by boto3 for S3 authentication. Required when your AWS credential provider chain does not supply credentials another way. |
+| `AWS_DEFAULT_REGION` | String | Not set | The AWS region where your S3 bucket is located, such as `us-east-2`. |
+| `AWS_ENDPOINT_URL_S3` | URL | Not set | Optional custom endpoint URL for S3-compatible storage services. Leave unset when using AWS S3's standard regional endpoints. |
 
 ## See also
 

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -157,6 +157,9 @@ class S3StorageService(StorageService):
 
     def _get_client(self):
         """Get or create an S3 client using the async context manager."""
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL_S3")
+        if endpoint_url:
+            return self.session.client("s3", endpoint_url=endpoint_url)
         return self.session.client("s3")
 
     async def save_file(self, flow_id: str, file_name: str, data: bytes, *, append: bool = False) -> None:

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -156,7 +156,7 @@ class S3StorageService(StorageService):
         return logical_path
 
     def _get_client(self):
-        """Get or create an S3 client using the async context manager."""
+        """Create an S3 client using the async context manager."""
         endpoint_url = os.getenv("AWS_ENDPOINT_URL_S3")
         if endpoint_url:
             return self.session.client("s3", endpoint_url=endpoint_url)

--- a/src/backend/tests/unit/services/storage/test_s3_storage_service.py
+++ b/src/backend/tests/unit/services/storage/test_s3_storage_service.py
@@ -1,4 +1,4 @@
-"""Unit tests for S3StorageService input validation.
+"""Unit tests for S3StorageService input validation and client setup.
 
 These tests run offline. They assert that malformed flow_id / file_name values
 are rejected at the storage layer BEFORE any AWS call is attempted, so the
@@ -122,3 +122,49 @@ class TestS3StorageServicePathValidation:
         """
         with pytest.raises(ValueError, match="Invalid"):
             await s3_service_offline.get_file("/etc", "hosts")
+
+
+class FakeS3Session:
+    """Fake aioboto3 session that records S3 client calls."""
+
+    def __init__(self) -> None:
+        self.client_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def client(self, *args, **kwargs):
+        self.client_calls.append((args, kwargs))
+        return Mock()
+
+
+def test_get_client_uses_default_s3_client_when_endpoint_url_is_unset(
+    monkeypatch, mock_session_service, mock_settings_service
+):
+    """Verify S3StorageService keeps the default S3 client behavior without AWS_ENDPOINT_URL_S3."""
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    service = S3StorageService(mock_session_service, mock_settings_service)
+    fake_session = FakeS3Session()
+    service.session = fake_session
+
+    service._get_client()
+
+    assert fake_session.client_calls == [(("s3",), {})]
+
+
+def test_get_client_passes_service_endpoint_from_environment(monkeypatch, mock_session_service, mock_settings_service):
+    """Verify S3StorageService passes AWS_ENDPOINT_URL_S3 to the S3 client."""
+    monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "http://127.0.0.1:9000")
+    service = S3StorageService(mock_session_service, mock_settings_service)
+    fake_session = FakeS3Session()
+    service.session = fake_session
+
+    service._get_client()
+
+    assert fake_session.client_calls == [(("s3",), {"endpoint_url": "http://127.0.0.1:9000"})]
+
+
+def test_initialization_preserves_bucket_prefix_and_tags(mock_session_service, mock_settings_service):
+    """Verify S3StorageService keeps existing storage configuration behavior."""
+    service = S3StorageService(mock_session_service, mock_settings_service)
+
+    assert service.bucket_name == "langflow-unit-test-bucket"
+    assert service.prefix == "test-prefix/"
+    assert service.tags == {}


### PR DESCRIPTION
## Summary

This PR adds support for the AWS SDK-standard `AWS_ENDPOINT_URL_S3` environment variable in Langflow S3 file storage. When the variable is set, Langflow passes it to the S3 client as `endpoint_url`; when it is unset, the existing default AWS S3 client behavior is preserved.

It also updates the file management documentation to distinguish real Langflow and AWS environment variables from example placeholder values, including the new optional custom endpoint setting. The documentation now avoids implying that static AWS credential environment variables are always required when the AWS credential provider chain supplies credentials another way.

This update also addresses AI review feedback by clarifying the S3 credential guidance and aligning the S3 client helper docstring with its actual client creation behavior.

## Changes

* Pass `AWS_ENDPOINT_URL_S3` to `aioboto3.Session().client("s3", endpoint_url=...)` when the environment variable is configured.
* Preserve the current `client("s3")` behavior when `AWS_ENDPOINT_URL_S3` is not set.
* Add unit coverage for S3 client creation with and without `AWS_ENDPOINT_URL_S3`.
* Keep existing S3 bucket, prefix, object tag, and S3 path validation test coverage intact.
* Update current and versioned file management docs to use real environment variable names and example placeholder values.
* Document `AWS_ENDPOINT_URL_S3` as an optional endpoint URL for S3-compatible storage services.
* Clarify the docs example so AWS credentials and region are not described as universally required environment variables.
* Update the S3 client helper docstring to describe client creation rather than cached get-or-create behavior.

## Follow-up fixes

* The PR was retargeted to `release-1.10.0` and the unrelated starter-project dependency-version updates from the earlier `release-1.9.6`-based diff were removed.
* Addressed active Copilot review feedback for the AWS credential wording and the `_get_client` docstring.
* The AI comments about starter-project dependency bumps no longer apply to the current diff.
* The AI comment about unspecced test mocks is outdated and no longer applies to the current diff.
* The observed `Update Component Index` CI failure is unrelated to the S3 storage change. The job fails in the "Merge base branch" step with `merge: origin/release-1.10.0 - not something we can merge`, before any component-index generation logic runs.

## Validation

* `uv run pytest src/backend/tests/unit/services/storage/test_s3_storage_service.py`
* `uv run pytest src/backend/tests/unit/services/test_storage_parse_file_path.py`
* `uv run ruff check src/backend/base/langflow/services/storage/s3.py src/backend/tests/unit/services/storage/test_s3_storage_service.py`
* `git diff --check`
