### PR TITLE
fix: standardize playground code block + container backgrounds on shadcn tokens

### DIFF
--- a/src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
+++ b/src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
@@ -147,7 +147,7 @@ export function ContentBlockDisplay({
                     <AccordionItem
                       key={toolKey}
                       value={toolKey}
-                      className="overflow-hidden rounded-xl border border-border/70 bg-primary-foreground shadow-sm"
+                      className="overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
                     >
                       <AccordionTrigger className="rounded-lg px-4 py-3 hover:bg-background/30 hover:no-underline">
                         <div className="flex items-center justify-between w-full pr-2">

--- a/src/frontend/src/components/core/codeTabsComponent/index.tsx
+++ b/src/frontend/src/components/core/codeTabsComponent/index.tsx
@@ -41,7 +41,7 @@ export default function SimplifiedCodeTabComponent({
       className="mt-2 flex w-full flex-col overflow-hidden rounded-md text-left"
       data-testid="chat-code-tab"
     >
-      <div className="flex w-full items-center justify-between rounded-t-md border border-b-0 border-border bg-primary-foreground px-4 py-2">
+      <div className="flex w-full items-center justify-between rounded-t-md border border-b-0 border-border bg-canvas px-4 py-2">
         <span className="text-sm font-semibold text-foreground">
           {language}
         </span>
@@ -62,7 +62,7 @@ export default function SimplifiedCodeTabComponent({
       <SyntaxHighlighter
         language={language.toLowerCase()}
         style={dark ? oneDark : oneLight}
-        className="!mt-0 h-full w-full overflow-auto !bg-primary-foreground [&_code]:!bg-primary-foreground !rounded-b-md !rounded-t-none border border-border text-left custom-scroll"
+        className="!mt-0 h-full w-full overflow-auto !bg-canvas [&_code]:!bg-canvas !rounded-b-md !rounded-t-none border border-border text-left custom-scroll"
         customStyle={maxHeight ? { maxHeight } : undefined}
       >
         {code}


### PR DESCRIPTION
## Problem

Follow-up to #13470. In the playground, tool-call ("Called tool") cards and their code blocks used `bg-primary-foreground`, which inverts to **solid black in dark mode**. Result:

- The container card and the code blocks were both black in dark mode, so the whole section rendered as one black block with no contrast.
- Light mode happened to look fine only because `primary-foreground` resolves to white there.

Product (Sean) asked for the standard shadcn treatment: code blocks on the `canvas` color that swaps by mode (light grey / dark black), and the container matching the chat background so the code blocks stand out.

## Fix

Two semantic-token swaps (no hardcoded hex, both theme-reactive):

| Element | Before | After | Light | Dark |
|---|---|---|---|---|
| Code blocks (`SimplifiedCodeTabComponent`) | `bg-primary-foreground` | `bg-canvas` | `#F4F4F5` grey | `#000` black |
| "Called tool" container (`ContentBlockDisplay`) | `bg-primary-foreground` | `bg-background` | white (chat bg) | `#19191c` (chat bg) |

Now the container blends with the chat background in both themes and the `bg-canvas` code blocks stand out against it. Syntax text colors continue to swap via `oneDark`/`oneLight` (`useDarkStore`).

## Notes / scope

- Dark `--canvas` is pure `#000` (the existing token). Matches Sean's "dark mode black"; if product later wants `#0A0A0A` specifically, that would mean changing the global `--canvas` var, which also recolors the flow-editor dot grid — out of scope here.
- `error-message.tsx` uses the same `bg-primary-foreground` pattern for the error card. Left as-is to keep this PR scoped to the reviewed tool-call surfaces; can be aligned in a follow-up.

## Testing

- Manual: playground tool-call message, toggle Dark↔Light — container matches chat bg, code blocks stand out, both themes.
- `chat-message`, `ContentBlockDisplay`, `ContentDisplay` suites pass (28/28).
- Biome (CI mode, `--diagnostic-level=error`) clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined background color styling across components for improved visual consistency and theme alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->