### PR TITLE
docs: fix multi-worker docs links

### DIFF
--- a/docs/docs/Deployment/deployment-multi-worker.mdx
+++ b/docs/docs/Deployment/deployment-multi-worker.mdx
@@ -254,7 +254,7 @@ To verify that cancellation works across workers, trigger a build with the API t
 
 ## Troubleshoot
 
-See [Troubleshoot multi-worker deployments](./troubleshoot#multi-worker-deployments).
+See [Troubleshoot multi-worker deployments](../Support/troubleshooting.mdx#multi-worker-deployments).
 
 ## Configuration reference
 

--- a/docs/docs/Develop/environment-variables.mdx
+++ b/docs/docs/Develop/environment-variables.mdx
@@ -395,7 +395,7 @@ See [Use Langflow as an MCP server](/mcp-server).
 
 ### Multi-worker deployments
 
-For multi-worker tuning—including the Redis job queue and Gunicorn worker settings—see [Deploy Langflow with multiple workers](./deployment-multi-worker).
+For multi-worker tuning—including the Redis job queue and Gunicorn worker settings—see [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx).
 
 ### Monitoring and metrics
 
@@ -413,10 +413,10 @@ The following environment variables set base Langflow server configuration, such
 | `LANGFLOW_DEV` | Boolean | `False` | Whether to run Langflow in development mode (may contain bugs). |
 | `LANGFLOW_OPEN_BROWSER` | Boolean | `False` | Open the system web browser on startup. |
 | `LANGFLOW_HEALTH_CHECK_MAX_RETRIES` | Integer | `5` | Set the maximum number of retries for Langflow's server status health checks. |
-| `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_GUNICORN_PRELOAD` | Boolean | `False` | Enables Gunicorn `preload_app`. Non-Windows only. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_JOB_QUEUE_TYPE` | String | `asyncio` | Job queue backend. Use `redis` for multi-worker deployments. See [Deploy Langflow with multiple workers](./deployment-multi-worker#configuration-reference). |
+| `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx#recommended-gunicorn-settings). |
+| `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx#recommended-gunicorn-settings). |
+| `LANGFLOW_GUNICORN_PRELOAD` | Boolean | `False` | Enables Gunicorn `preload_app`. Non-Windows only. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx#recommended-gunicorn-settings). |
+| `LANGFLOW_JOB_QUEUE_TYPE` | String | `asyncio` | Job queue backend. Use `redis` for multi-worker deployments. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx#configuration-reference). |
 | `LANGFLOW_SSL_CERT_FILE` | String | Not set | Path to the SSL certificate file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_SSL_KEY_FILE` | String | Not set | Path to the SSL key file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_DEACTIVATE_TRACING` | Boolean | `False` | Deactivate tracing functionality. |

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -81,7 +81,7 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
 
     Single-process deployments are unaffected. The default `asyncio` in-memory queue is unchanged.
 
-    For setup instructions and configuration details, see [Deploy Langflow with multiple workers](./deployment-multi-worker).
+    For setup instructions and configuration details, see [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx).
 
 - Memory bases
 

--- a/docs/docs/Support/troubleshooting.mdx
+++ b/docs/docs/Support/troubleshooting.mdx
@@ -682,7 +682,7 @@ To resolve this issue:
 - Ensure `LANGFLOW_JOB_QUEUE_TYPE=redis` is set on **all** workers, not just some. Mixed-mode deployments (some workers using `asyncio`, others using `redis`) are not supported.
 - Verify all workers can reach the same Redis instance.
 
-For setup instructions, see [Deploy Langflow with multiple workers](./deployment-multi-worker).
+For setup instructions, see [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker.mdx).
 
 ### Redis connection refused or auth errors
 


### PR DESCRIPTION
## Summary

- Fix multi-worker documentation links that pointed to missing sibling pages.
- Use Docusaurus source-relative `.mdx` links so current docs resolve to the `/next` routes correctly.

## Verification

- `gh search prs --repo langflow-ai/langflow --state open 'deployment-multi-worker environment-variables'`
- `gh search issues --repo langflow-ai/langflow --state open 'deployment-multi-worker environment-variables'`
- `gh search prs --repo langflow-ai/langflow --state open 'troubleshoot multi-worker deployments'`
- `gh search issues --repo langflow-ai/langflow --state open 'troubleshoot multi-worker deployments'`
- `npm run build`

Notes: `npm run build` completed successfully. It emitted existing OpenAPI bundling warnings and existing broken-anchor warnings unrelated to these edited links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected internal documentation cross-references across deployment guides, environment variables, and support articles to ensure consistent navigation to multi-worker deployment setup and configuration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->