### PR TITLE
feat(ci): nightly Approach A — canonical pre-releases, drop nightly bundles [DRAFT/gated]

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -172,13 +172,9 @@ jobs:
           cd src/lfx && uv lock && cd ../..
 
           git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml src/sdk/pyproject.toml uv.lock
-          # update_lfx_version.py re-pins each bundle's `lfx` dep to
-          # lfx-nightly==<dev>, so any modified bundle pyprojects need to
-          # ride the same commit/tag as the rest of the version bumps.
-          if compgen -G "src/bundles/*/pyproject.toml" > /dev/null; then
-            git add src/bundles/*/pyproject.toml
-          fi
-          git commit -m "Update version and project name"
+          # Approach A: the nightly keeps canonical package names and the stable `lfx-*` bundles
+          # are not modified (see src/bundles/NIGHTLY.md), so no bundle pyprojects ride this commit.
+          git commit -m "Update version for nightly"
 
           echo "Tagging main with $RELEASE_TAG"
           if ! git tag -a $RELEASE_TAG -m "Langflow nightly $RELEASE_TAG"; then

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -81,8 +81,8 @@ jobs:
         run: |
           name=$(grep '^name = "' src/sdk/pyproject.toml | head -n 1 | sed 's/.*"\(.*\)".*/\1/')
           version=$(grep '^version = "' src/sdk/pyproject.toml | head -n 1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ "$name" != "langflow-sdk-nightly" ]; then
-            echo "Name $name does not match langflow-sdk-nightly. Exiting the workflow."
+          if [ "$name" != "langflow-sdk" ]; then
+            echo "Name $name does not match langflow-sdk. Exiting the workflow."
             exit 1
           fi
           if [ "v$version" != "${{ inputs.nightly_tag_sdk }}" ]; then
@@ -96,8 +96,8 @@ jobs:
           cd src/lfx
           name=$(uv tree | grep 'lfx' | head -n 1 | awk '{print $1}')
           version=$(uv tree | grep 'lfx' | head -n 1 | awk '{print $2}')
-          if [ "$name" != "lfx-nightly" ]; then
-            echo "Name $name does not match lfx-nightly. Exiting the workflow."
+          if [ "$name" != "lfx" ]; then
+            echo "Name $name does not match lfx. Exiting the workflow."
             exit 1
           fi
           if [ "$version" != "${{ inputs.nightly_tag_lfx }}" ]; then
@@ -192,8 +192,8 @@ jobs:
           version=$(uv tree | grep 'langflow-base' | awk '{print $3}' | head -n 1)
           # Strip extras from package name (e.g., "langflow-base-nightly[complete]" -> "langflow-base-nightly")
           name_without_extras=$(echo $name | sed 's/\[.*\]//')
-          if [ "$name_without_extras" != "langflow-base-nightly" ]; then
-            echo "Name $name_without_extras does not match langflow-base-nightly. Exiting the workflow."
+          if [ "$name_without_extras" != "langflow-base" ]; then
+            echo "Name $name_without_extras does not match langflow-base. Exiting the workflow."
             echo "skipped=true" >> $GITHUB_OUTPUT
             exit 1
           fi
@@ -297,10 +297,10 @@ jobs:
       - name: Verify Nightly Name and Version
         id: verify
         run: |
-          name=$(uv tree | grep -E '^langflow(-nightly)?[[:space:]]' | awk '{print $1}')
-          version=$(uv tree | grep -E '^langflow(-nightly)?[[:space:]]' | awk '{print $2}')
-          if [ "$name" != "langflow-nightly" ]; then
-            echo "Name $name does not match langflow-nightly. Exiting the workflow."
+          name=$(uv tree | grep -E '^langflow[[:space:]]' | awk '{print $1}')
+          version=$(uv tree | grep -E '^langflow[[:space:]]' | awk '{print $2}')
+          if [ "$name" != "langflow" ]; then
+            echo "Name $name does not match langflow. Exiting the workflow."
             exit 1
           fi
           if [ "$version" != "${{ inputs.nightly_tag_release }}" ]; then
@@ -337,9 +337,9 @@ jobs:
       - name: Prepare Langflow Main artifact
         run: |
           shopt -s nullglob
-          MAIN_WHEELS=(dist/langflow_nightly-*.whl)
+          MAIN_WHEELS=(dist/langflow-*.whl)
           if [ ${#MAIN_WHEELS[@]} -ne 1 ]; then
-            echo "Expected exactly one langflow-nightly wheel in dist/, found ${#MAIN_WHEELS[@]}"
+            echo "Expected exactly one langflow wheel in dist/, found ${#MAIN_WHEELS[@]}"
             ls -la dist/
             exit 1
           fi
@@ -347,23 +347,9 @@ jobs:
           mkdir -p main-dist
           cp "${MAIN_WHEELS[0]}" main-dist/
 
-      - name: Build bundle wheels for cross-platform test
-        run: |
-          shopt -s nullglob
-          bundles=(src/bundles/*/pyproject.toml)
-          if [ ${#bundles[@]} -eq 0 ]; then
-            echo "No bundles found under src/bundles/*/"
-            exit 1
-          fi
-          rm -rf bundles-dist
-          mkdir -p bundles-dist
-          BUNDLES_DIST="$PWD/bundles-dist"
-          for bundle_pyproject in "${bundles[@]}"; do
-            bundle_dir=$(dirname "$bundle_pyproject")
-            echo "Building wheel for $bundle_dir"
-            (cd "$bundle_dir" && uv build --wheel --out-dir "$BUNDLES_DIST")
-          done
-          ls -la bundles-dist/
+      # Approach A: bundles are NOT rebuilt/republished for nightly. The stable `lfx-*` bundles on
+      # PyPI work as-is against the canonical `lfx` pre-release (see src/bundles/NIGHTLY.md). The
+      # cross-platform test self-builds the bundles from src/bundles for install coverage.
 
       # PyPI publishing moved to after cross-platform testing
 
@@ -372,12 +358,6 @@ jobs:
         with:
           name: dist-nightly-main
           path: main-dist
-
-      - name: Upload bundles artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: dist-nightly-bundles
-          path: bundles-dist
 
   test-cross-platform:
     name: Test Cross-Platform Installation
@@ -388,7 +368,6 @@ jobs:
       main-artifact-name: "dist-nightly-main"
       lfx-artifact-name: "dist-nightly-lfx"
       sdk-artifact-name: "dist-nightly-sdk"
-      bundles-artifact-name: "dist-nightly-bundles"
 
   publish-nightly-lfx:
     name: Publish LFX Nightly to PyPI
@@ -475,60 +454,10 @@ jobs:
         run: |
           make publish base=true
 
-  publish-nightly-bundles:
-    name: Publish Langflow Bundles Nightly to PyPI
-    # langflow-nightly pins each `lfx-<name>-nightly==<dev>` exactly, so the
-    # bundles must be on PyPI before main is published (publish-nightly-main
-    # gates on this job). They depend on `lfx-nightly`, so gate on the lfx
-    # publish too (or skip it when lfx isn't being rebuilt).
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-lfx]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && (needs.publish-nightly-lfx.result == 'success' || inputs.build_lfx == false) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download bundles artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-bundles
-          path: bundles-dist
-      - name: Setup Environment
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: false
-          python-version: "3.13"
-      - name: Publish bundles to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          shopt -s nullglob
-          wheels=(bundles-dist/*.whl)
-          if [ ${#wheels[@]} -eq 0 ]; then
-            echo "No bundle wheels to publish."
-            exit 1
-          fi
-          failed=0
-          for wheel in "${wheels[@]}"; do
-            echo "Publishing $wheel"
-            # Capture stderr so a re-run without a version bump is a no-op for
-            # an already-published bundle instead of failing the whole job.
-            if ! err=$(uv publish "$wheel" 2>&1); then
-              echo "$err"
-              if echo "$err" | grep -qiE 'already exists|file already exists|HTTP 400|duplicate'; then
-                echo "Skipping $wheel: already published."
-              else
-                echo "Publish failed for $wheel"
-                failed=1
-              fi
-            fi
-          done
-          if [ "$failed" = "1" ]; then
-            exit 1
-          fi
-
   publish-nightly-main:
     name: Publish Langflow Main Nightly to PyPI
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-base, publish-nightly-bundles]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' && needs.publish-nightly-bundles.result == 'success' }}
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-base]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 304,
+        "line_number": 308,
         "is_secret": false
       }
     ],
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 494,
         "is_secret": false
       }
     ],
@@ -2327,29 +2327,6 @@
         "hashed_secret": "b8205f6293ceac2bf593580250e865708c8a9aeb",
         "is_verified": false,
         "line_number": 2157
-      }
-    ],
-    "src/backend/base/langflow/initial_setup/starter_projects/Pok\u00e9dex Agent.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Pok\u00e9dex Agent.json",
-        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
-        "is_verified": false,
-        "line_number": 115
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Pok\u00e9dex Agent.json",
-        "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
-        "is_verified": false,
-        "line_number": 394
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Pok\u00e9dex Agent.json",
-        "hashed_secret": "ecdbe30d19e36761df3620b37270f23c8e3eaa4c",
-        "is_verified": false,
-        "line_number": 774
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Pok\u00e9dex Agent.json": [
@@ -9310,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T18:07:39Z"
+  "generated_at": "2026-06-07T19:17:32Z"
 }

--- a/scripts/ci/lfx_nightly_tag.py
+++ b/scripts/ci/lfx_nightly_tag.py
@@ -1,70 +1,75 @@
-"""Script to generate nightly tags for LFX package."""
+"""Generate the nightly tag for the canonical ``lfx`` package.
+
+Approach A (canonical pre-releases): the nightly publishes ``lfx==<base>.devN`` to the canonical
+``lfx`` PyPI project (not a separate ``lfx-nightly`` distribution), so the dev counter is computed
+against ``lfx``'s own release history. ``<base>`` is the in-development version from
+``src/lfx/pyproject.toml`` (the latest ``release-*`` branch the nightly builds from) and ``N`` is
+``max(existing same-base devN) + 1``.
+
+Only ``.devN`` releases whose ``base_version`` matches contribute; stable finals (e.g. ``1.10.0``)
+are ignored. A 404 (no releases yet) yields ``dev0``; any other lookup failure is fatal (fail
+closed) so a transient error cannot regenerate an already-published version. See
+``src/bundles/NIGHTLY.md``.
+"""
+
+from pathlib import Path
 
 import packaging.version
 import requests
+import tomllib
 from packaging.version import Version
 
 PYPI_LFX_URL = "https://pypi.org/pypi/lfx/json"
-PYPI_LFX_NIGHTLY_URL = "https://pypi.org/pypi/lfx-nightly/json"
 
 
-def get_latest_published_version(*, is_nightly: bool) -> Version:
-    url = PYPI_LFX_NIGHTLY_URL if is_nightly else PYPI_LFX_URL
-
-    res = requests.get(url, timeout=10)
-    if res.status_code == requests.codes.not_found:
-        msg = "Package not found on PyPI"
-        raise requests.RequestException(msg)
-
-    try:
-        version_str = res.json()["info"]["version"]
-    except (KeyError, ValueError) as e:
-        msg = "Got unexpected response from PyPI"
-        raise requests.RequestException(msg) from e
-    return Version(version_str)
-
-
-def create_lfx_tag():
-    # Since LFX has never been released, we'll use the version from pyproject.toml as base
-    from pathlib import Path
-
-    import tomllib
-
-    # Read version from pyproject.toml
+def _lfx_base_version() -> str:
+    """Return the base_version (e.g. "1.11.0") from src/lfx/pyproject.toml."""
     lfx_pyproject_path = Path(__file__).parent.parent.parent / "src" / "lfx" / "pyproject.toml"
     pyproject_data = tomllib.loads(lfx_pyproject_path.read_text())
+    return Version(pyproject_data["project"]["version"]).base_version
 
-    current_version_str = pyproject_data["project"]["version"]
-    current_version = Version(current_version_str)
 
+def _dev_numbers(url: str, base_version: str) -> list[int]:
+    """Dev numbers of every release at ``url`` whose base_version matches ``base_version``.
+
+    A 404 means the package has no releases yet and returns an empty list. Every other failure --
+    a network error, a non-404 HTTP status, or a malformed 200 -- is fatal and raises, so the
+    nightly job aborts BEFORE mutating tags rather than regenerating an already-published version.
+    """
+    res = requests.get(url, timeout=10)
+    if res.status_code == requests.codes.not_found:
+        return []
+    res.raise_for_status()
     try:
-        current_nightly_version = get_latest_published_version(is_nightly=True)
-        nightly_base_version = current_nightly_version.base_version
-    except (requests.RequestException, KeyError, ValueError):
-        # If LFX nightly doesn't exist on PyPI yet, this is the first nightly
-        current_nightly_version = None
-        nightly_base_version = None
+        releases = res.json()["releases"]
+    except (ValueError, KeyError) as e:
+        msg = f"Unexpected response from {url!r}: missing 'releases' mapping"
+        raise RuntimeError(msg) from e
 
-    build_number = "0"
-    latest_base_version = current_version.base_version
+    dev_numbers: list[int] = []
+    for version_str in releases:
+        try:
+            version = Version(version_str)
+        except packaging.version.InvalidVersion:
+            continue
+        if version.base_version == base_version and version.dev is not None:
+            dev_numbers.append(version.dev)
+    return dev_numbers
 
-    if current_nightly_version and latest_base_version == nightly_base_version:
-        # If the latest version is the same as the nightly version, increment the build number
-        build_number = str(current_nightly_version.dev + 1)
 
-    new_nightly_version = latest_base_version + ".dev" + build_number
+def create_lfx_tag() -> str:
+    """Return the next ``lfx`` nightly tag (with a leading ``v``)."""
+    base_version = _lfx_base_version()
+    dev_numbers = _dev_numbers(PYPI_LFX_URL, base_version)
+    next_dev = max(dev_numbers) + 1 if dev_numbers else 0
 
-    # Prepend "v" to the version, if DNE.
-    # This is an update to the nightly version format.
-    if not new_nightly_version.startswith("v"):
-        new_nightly_version = "v" + new_nightly_version
+    new_nightly_version = f"v{base_version}.dev{next_dev}"
 
-    # Verify if version is PEP440 compliant.
+    # Verify the version is PEP 440 compliant.
     packaging.version.Version(new_nightly_version)
 
     return new_nightly_version
 
 
 if __name__ == "__main__":
-    tag = create_lfx_tag()
-    print(tag)
+    print(create_lfx_tag())

--- a/scripts/ci/pypi_nightly_tag.py
+++ b/scripts/ci/pypi_nightly_tag.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 """Idea from https://github.com/streamlit/streamlit/blob/4841cf91f1c820a392441092390c4c04907f9944/scripts/pypi_nightly_create_tag.py.
 
-`langflow-nightly` pins an EXACT dependency on `langflow-base-nightly[complete]==X.Y.Z.devN`.
-For the latest published `langflow-nightly` to be installable, the base version it pins must
+Approach A publishes the nightly as canonical `.devN` pre-releases (e.g. `langflow==X.Y.Z.devN`),
+NOT separate `*-nightly` distributions, so the dev counter is computed against the canonical
+`langflow` / `langflow-base` PyPI histories (their `.devN` pre-releases; stable finals never
+contribute). See `src/bundles/NIGHTLY.md`.
+
+`langflow` (the nightly pre-release) pins an EXACT dependency on `langflow-base[complete]==X.Y.Z.devN`.
+For the latest published nightly `langflow` to be installable, the base version it pins must
 exist on PyPI. The two packages are therefore versioned in lockstep: they share a single dev
 number so that, in a single nightly run (publish order base -> main, gated), main's `devN` pin
 always references the base `devN` built and published in the same run.
@@ -20,11 +25,13 @@ import packaging.version
 import requests
 from packaging.version import Version
 
-PYPI_LANGFLOW_NIGHTLY_URL = "https://pypi.org/pypi/langflow-nightly/json"
-PYPI_LANGFLOW_BASE_NIGHTLY_URL = "https://pypi.org/pypi/langflow-base-nightly/json"
+# Approach A: count dev releases against the CANONICAL projects (not `*-nightly`), since the
+# nightly is published as canonical `.devN` pre-releases of `langflow` / `langflow-base`.
+PYPI_LANGFLOW_URL = "https://pypi.org/pypi/langflow/json"
+PYPI_LANGFLOW_BASE_URL = "https://pypi.org/pypi/langflow-base/json"
 
 # main and base MUST share one dev number, so the shared number is derived from both packages.
-PYPI_NIGHTLY_URLS = (PYPI_LANGFLOW_NIGHTLY_URL, PYPI_LANGFLOW_BASE_NIGHTLY_URL)
+PYPI_CANONICAL_URLS = (PYPI_LANGFLOW_URL, PYPI_LANGFLOW_BASE_URL)
 
 ARGUMENT_NUMBER = 2
 VALID_BUILD_TYPES = ("main", "base", "both")
@@ -80,7 +87,7 @@ def _shared_nightly_version() -> str:
     """Compute the single dev number shared by langflow-nightly and langflow-base-nightly."""
     base_version = _root_base_version()
 
-    dev_numbers = [dev for url in PYPI_NIGHTLY_URLS for dev in _all_dev_numbers(url, base_version)]
+    dev_numbers = [dev for url in PYPI_CANONICAL_URLS for dev in _all_dev_numbers(url, base_version)]
 
     # First-ever nightly for this base_version -> dev0. Otherwise max+1, so the result is
     # strictly ahead of BOTH packages' newest same-series dev release.

--- a/scripts/ci/sdk_nightly_tag.py
+++ b/scripts/ci/sdk_nightly_tag.py
@@ -1,63 +1,69 @@
-"""Script to generate nightly tags for the SDK package."""
+"""Generate the nightly tag for the canonical ``langflow-sdk`` package.
+
+Approach A (canonical pre-releases): mirrors ``lfx_nightly_tag.py`` but for the SDK -- the nightly
+publishes ``langflow-sdk==<base>.devN`` to the canonical ``langflow-sdk`` PyPI project, so the dev
+counter is computed against that project's ``.devN`` history (stable finals never contribute).
+``<base>`` comes from ``src/sdk/pyproject.toml``. See ``src/bundles/NIGHTLY.md``.
+"""
+
+from pathlib import Path
 
 import packaging.version
 import requests
+import tomllib
 from packaging.version import Version
 
 PYPI_SDK_URL = "https://pypi.org/pypi/langflow-sdk/json"
-PYPI_SDK_NIGHTLY_URL = "https://pypi.org/pypi/langflow-sdk-nightly/json"
 
 
-def get_latest_published_version(*, is_nightly: bool) -> Version:
-    url = PYPI_SDK_NIGHTLY_URL if is_nightly else PYPI_SDK_URL
-
-    res = requests.get(url, timeout=10)
-    if res.status_code == requests.codes.not_found:
-        msg = "Package not found on PyPI"
-        raise requests.RequestException(msg)
-
-    try:
-        version_str = res.json()["info"]["version"]
-    except (KeyError, ValueError) as e:
-        msg = "Got unexpected response from PyPI"
-        raise requests.RequestException(msg) from e
-    return Version(version_str)
-
-
-def create_sdk_tag():
-    from pathlib import Path
-
-    import tomllib
-
+def _sdk_base_version() -> str:
+    """Return the base_version (e.g. "0.1.0") from src/sdk/pyproject.toml."""
     sdk_pyproject_path = Path(__file__).parent.parent.parent / "src" / "sdk" / "pyproject.toml"
     pyproject_data = tomllib.loads(sdk_pyproject_path.read_text())
+    return Version(pyproject_data["project"]["version"]).base_version
 
-    current_version_str = pyproject_data["project"]["version"]
-    current_version = Version(current_version_str)
 
+def _dev_numbers(url: str, base_version: str) -> list[int]:
+    """Dev numbers of every release at ``url`` whose base_version matches ``base_version``.
+
+    A 404 means the package has no releases yet and returns an empty list. Every other failure --
+    a network error, a non-404 HTTP status, or a malformed 200 -- is fatal and raises, so the
+    nightly job aborts BEFORE mutating tags rather than regenerating an already-published version.
+    """
+    res = requests.get(url, timeout=10)
+    if res.status_code == requests.codes.not_found:
+        return []
+    res.raise_for_status()
     try:
-        current_nightly_version = get_latest_published_version(is_nightly=True)
-        nightly_base_version = current_nightly_version.base_version
-    except (requests.RequestException, KeyError, ValueError):
-        current_nightly_version = None
-        nightly_base_version = None
+        releases = res.json()["releases"]
+    except (ValueError, KeyError) as e:
+        msg = f"Unexpected response from {url!r}: missing 'releases' mapping"
+        raise RuntimeError(msg) from e
 
-    build_number = "0"
-    latest_base_version = current_version.base_version
+    dev_numbers: list[int] = []
+    for version_str in releases:
+        try:
+            version = Version(version_str)
+        except packaging.version.InvalidVersion:
+            continue
+        if version.base_version == base_version and version.dev is not None:
+            dev_numbers.append(version.dev)
+    return dev_numbers
 
-    if current_nightly_version and latest_base_version == nightly_base_version:
-        build_number = str(current_nightly_version.dev + 1)
 
-    new_nightly_version = latest_base_version + ".dev" + build_number
+def create_sdk_tag() -> str:
+    """Return the next ``langflow-sdk`` nightly tag (with a leading ``v``)."""
+    base_version = _sdk_base_version()
+    dev_numbers = _dev_numbers(PYPI_SDK_URL, base_version)
+    next_dev = max(dev_numbers) + 1 if dev_numbers else 0
 
-    if not new_nightly_version.startswith("v"):
-        new_nightly_version = "v" + new_nightly_version
+    new_nightly_version = f"v{base_version}.dev{next_dev}"
 
+    # Verify the version is PEP 440 compliant.
     packaging.version.Version(new_nightly_version)
 
     return new_nightly_version
 
 
 if __name__ == "__main__":
-    tag = create_sdk_tag()
-    print(tag)
+    print(create_sdk_tag())

--- a/scripts/ci/test_pypi_nightly_tag.py
+++ b/scripts/ci/test_pypi_nightly_tag.py
@@ -20,8 +20,8 @@ import requests
 sys.path.insert(0, str(Path(__file__).parent))
 import pypi_nightly_tag as nt
 
-MAIN_URL = nt.PYPI_LANGFLOW_NIGHTLY_URL
-BASE_URL = nt.PYPI_LANGFLOW_BASE_NIGHTLY_URL
+MAIN_URL = nt.PYPI_LANGFLOW_URL
+BASE_URL = nt.PYPI_LANGFLOW_BASE_URL
 
 
 class _FakeResponse:

--- a/scripts/ci/update_lf_base_dependency.py
+++ b/scripts/ci/update_lf_base_dependency.py
@@ -28,7 +28,9 @@ def update_base_dep(pyproject_path: str, new_version: str) -> None:
 
     # Extract extras if present (e.g., "[complete]")
     extras = match.group(2) if match.group(2) else ""
-    replacement = f'"langflow-base-nightly{extras}=={new_version}"'
+    # Approach A: keep the canonical `langflow-base` name; the exact `==<dev>` pin enables
+    # pre-release resolution down the tree and keeps base in lockstep with the run.
+    replacement = f'"langflow-base{extras}=={new_version}"'
 
     # Replace the matched pattern with the new one
     content = pattern.sub(replacement, content)
@@ -43,7 +45,9 @@ def update_lfx_dep_in_base(pyproject_path: str, lfx_version: str) -> None:
     # Updated pattern to handle PEP 440 version suffixes, both ~= and == version specifiers,
     # and both lfx and lfx-nightly names
     pattern = re.compile(r'("lfx(?:-nightly)?(?:~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*")')
-    replacement = f'"lfx-nightly=={lfx_version}"'
+    # Approach A: pin base's lfx dep to the exact canonical dev version (single `lfx` distribution,
+    # no `lfx-nightly`), so there is no `lfx` vs `lfx-nightly` install collision with the bundles.
+    replacement = f'"lfx=={lfx_version}"'
 
     # Check if the pattern is found
     if not pattern.search(content):

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -1,12 +1,20 @@
-"""Script to update LFX version for nightly builds."""
+"""Update the canonical ``lfx`` package (and its SDK dep) for nightly builds.
+
+Approach A (canonical pre-releases): the nightly publishes ``lfx`` and ``langflow-sdk`` under their
+CANONICAL names as ``.devN`` pre-releases -- it does NOT rename them to ``lfx-nightly`` /
+``langflow-sdk-nightly``, and it does NOT give the ``src/bundles/*`` packages their own nightly
+track. The stable ``lfx-*`` bundles (pinning ``lfx>=X.Y.0,<(X+1).0.0``) then resolve against the
+single canonical ``lfx`` distribution, so there is no ``lfx`` vs ``lfx-nightly`` install collision.
+See ``src/bundles/NIGHTLY.md``.
+
+This script therefore only (a) sets ``lfx``'s version to the nightly ``.devN`` and (b) re-pins
+lfx's ``langflow-sdk`` dependency to the exact canonical dev version.
+"""
 
 import re
 import sys
 from pathlib import Path
 
-import tomllib
-from packaging.version import Version
-from update_pyproject_name import update_pyproject_name
 from update_pyproject_version import update_pyproject_version
 
 # Add the current directory to the path so we can import the other scripts
@@ -14,36 +22,20 @@ current_dir = Path(__file__).resolve().parent
 sys.path.append(str(current_dir))
 
 BASE_DIR = Path(__file__).parent.parent.parent
-ROOT_PYPROJECT = BASE_DIR / "pyproject.toml"
-
-
-def update_lfx_workspace_dep(pyproject_path: str, new_project_name: str) -> None:
-    """Update the LFX workspace dependency in pyproject.toml."""
-    filepath = BASE_DIR / pyproject_path
-    content = filepath.read_text(encoding="utf-8")
-
-    if new_project_name == "lfx-nightly":
-        pattern = re.compile(r"lfx = \{ workspace = true \}")
-        replacement = "lfx-nightly = { workspace = true }"
-    else:
-        msg = f"Invalid LFX project name: {new_project_name}"
-        raise ValueError(msg)
-
-    # Updates the dependency name for uv
-    if not pattern.search(content):
-        msg = f"lfx workspace dependency not found in {filepath}"
-        raise ValueError(msg)
-    content = pattern.sub(replacement, content)
-    filepath.write_text(content, encoding="utf-8")
 
 
 def update_sdk_dependency_in_lfx(pyproject_path: str, sdk_version: str) -> None:
-    """Update the SDK dependency in the LFX pyproject for nightly builds."""
+    """Pin lfx's ``langflow-sdk`` dependency to the exact canonical dev version.
+
+    An exact ``==<dev>`` pin keeps the SDK in lockstep with the lfx built in the same run and,
+    because it names a pre-release explicitly, enables pre-release resolution for ``langflow-sdk``
+    down the dependency tree without requiring ``--pre``.
+    """
     filepath = BASE_DIR / pyproject_path
     content = filepath.read_text(encoding="utf-8")
 
     pattern = re.compile(r'"langflow-sdk(?:-nightly)?(?:==|~=|>=)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*"')
-    replacement = f'"langflow-sdk-nightly=={sdk_version}"'
+    replacement = f'"langflow-sdk=={sdk_version}"'
 
     if not pattern.search(content):
         msg = f"SDK dependency not found in {filepath}"
@@ -53,169 +45,24 @@ def update_sdk_dependency_in_lfx(pyproject_path: str, sdk_version: str) -> None:
     filepath.write_text(content, encoding="utf-8")
 
 
-# Match an `lfx` (or `lfx-nightly`) dependency specifier inside a quoted
-# string. The lookahead enforces a version operator immediately after the
-# name so we don't accidentally match sibling packages like `lfx-arxiv` or
-# `lfx-duckduckgo`.
-_BUNDLE_LFX_DEP_PATTERN = re.compile(r'"lfx(?:-nightly)?(?=[<>=!~])[^"]*"')
-
-
-def update_lfx_dep_in_bundles(lfx_version: str) -> None:
-    """Pin every bundle's `lfx` dep to the renamed `lfx-nightly==<version>`.
-
-    Each `src/bundles/*/pyproject.toml` floors its `lfx` dep at
-    `>=X.Y.0,<(X+1).0.0` against the published `lfx` package. During nightly
-    builds the workspace `lfx` package gets renamed to `lfx-nightly`, so those
-    pins no longer resolve against the workspace member — and PyPI may not yet
-    ship a matching `lfx` either. Rewrite each bundle's pin to
-    `lfx-nightly==<exact dev version>` so `uv lock` resolves cleanly.
-
-    This is also why `langflow-nightly` cannot simply depend on the *stable*
-    bundles: `lfx-nightly` and stable `lfx` are different distributions that both
-    ship the same `lfx/` import package, so co-installing them collides on disk —
-    an install-time conflict, not just a resolution failure. Repinning each
-    bundle to `lfx-nightly` keeps a single `lfx/` in the environment. See
-    `src/bundles/NIGHTLY.md` for the planned cutover that removes this step.
-
-    No-op when no bundles exist (e.g. on a branch that hasn't picked up
-    the bundle extraction) or when a bundle has no `lfx` dep.
-    """
-    bundles_dir = BASE_DIR / "src" / "bundles"
-    if not bundles_dir.is_dir():
-        return
-
-    replacement = f'"lfx-nightly=={lfx_version}"'
-    for bundle_pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
-        content = bundle_pyproject.read_text(encoding="utf-8")
-        if not _BUNDLE_LFX_DEP_PATTERN.search(content):
-            continue
-        new_content = _BUNDLE_LFX_DEP_PATTERN.sub(replacement, content)
-        if new_content == content:
-            continue
-        bundle_pyproject.write_text(new_content, encoding="utf-8")
-        print(f"Updated lfx dep in {bundle_pyproject.relative_to(BASE_DIR)} -> lfx-nightly=={lfx_version}")
-
-
-def _bundle_nightly_version(bundle_base_version: str, lfx_version: str) -> str:
-    """Derive a bundle's nightly version: `<bundle base>.dev<N>`.
-
-    The dev build number `N` is shared with `lfx-nightly` (the same value the
-    nightly tagger already pins each bundle's `lfx` dep to), so a bundle's
-    nightly version moves in lockstep with the lfx it was built against while
-    keeping the bundle's own base version (e.g. `0.1.0`) truthful.
-    """
-    lfx_parsed = Version(lfx_version)
-    if lfx_parsed.dev is None:
-        msg = f"Expected a .devN nightly lfx version, got {lfx_version!r}"
-        raise ValueError(msg)
-    base = Version(bundle_base_version).base_version
-    return f"{base}.dev{lfx_parsed.dev}"
-
-
-def rename_bundles_for_nightly(lfx_version: str) -> None:
-    """Rename each `src/bundles/*` package to its `-nightly` distribution.
-
-    The stable bundles publish as `lfx-<name>` and pin `lfx>=X.Y`. During a
-    nightly build the workspace `lfx` becomes `lfx-nightly` (no stable `lfx`
-    matching the pin may exist on PyPI yet), so a `langflow-nightly` that still
-    depended on the stable `lfx-<name>` would drag in `lfx>=X.Y` and fail to
-    resolve. And even once stable `lfx` IS on PyPI, that stable `lfx` would be
-    co-installed alongside `lfx-nightly` — both ship the same `lfx/` import
-    package — colliding at install time, not just at resolution. Give the
-    bundles their own nightly track instead, mirroring how lfx/base/main are
-    renamed (see `src/bundles/NIGHTLY.md` for the planned cutover). For every
-    bundle this:
-
-      * rewrites its `[project] name`     `lfx-<name>` -> `lfx-<name>-nightly`
-      * rewrites its `[project] version`  `0.1.0`      -> `0.1.0.dev<N>`
-      * repoints the root `[tool.uv.sources]` workspace entry to the new name
-      * repoints the root `langflow` dependencies to `lfx-<name>-nightly==<dev>`,
-        including extras forms like `lfx-docling[local]>=...` in
-        `[project.optional-dependencies]` (the `[extra]` selector is preserved)
-
-    The bundle's own `lfx` dep is repinned separately by
-    `update_lfx_dep_in_bundles`. No-op when no bundles are present, and
-    idempotent for bundles already carrying a `-nightly` name.
-    """
-    bundles_dir = BASE_DIR / "src" / "bundles"
-    if not bundles_dir.is_dir():
-        return
-
-    root_content = ROOT_PYPROJECT.read_text(encoding="utf-8")
-
-    for bundle_pyproject in sorted(bundles_dir.glob("*/pyproject.toml")):
-        data = tomllib.loads(bundle_pyproject.read_text(encoding="utf-8"))
-        old_name = data["project"]["name"]
-        if old_name.endswith("-nightly"):
-            continue
-        new_name = f"{old_name}-nightly"
-        new_version = _bundle_nightly_version(data["project"]["version"], lfx_version)
-
-        rel_path = str(bundle_pyproject.relative_to(BASE_DIR))
-        update_pyproject_name(rel_path, new_name)
-        update_pyproject_version(rel_path, new_version)
-
-        # Repoint the workspace source: `lfx-<name> = { workspace = true }`.
-        source_pattern = re.compile(rf"^{re.escape(old_name)}(\s*=\s*\{{ workspace = true \}})", re.MULTILINE)
-        if not source_pattern.search(root_content):
-            msg = f"Workspace source entry for {old_name} not found in {ROOT_PYPROJECT}"
-            raise ValueError(msg)
-        root_content = source_pattern.sub(rf"{new_name}\1", root_content)
-
-        # Repoint the root dependencies to the exact nightly pin. This covers
-        # both the bare main dep `"lfx-<name>>=0.1.0"` and any extras form in
-        # `[project.optional-dependencies]` such as `"lfx-docling[local]>=0.1.0"`.
-        # The optional `[extra]` is captured and re-emitted so the selector
-        # survives the rewrite (-> `"lfx-docling-nightly[local]==<dev>"`); a
-        # missed extras ref would stay `lfx-<name>` and leak to PyPI, where no
-        # `>=0.1.0` is published, breaking `uv lock`. The lookahead still
-        # requires a version operator right after the name+optional-extra so we
-        # match `lfx-arxiv>=...` / `lfx-docling[local]>=...` without also
-        # matching an already-renamed `lfx-arxiv-nightly`.
-        dep_pattern = re.compile(rf'"{re.escape(old_name)}(\[[^\]]+\])?(?=[<>=!~])[^"]*"')
-        if not dep_pattern.search(root_content):
-            msg = f"Root dependency on {old_name} not found in {ROOT_PYPROJECT}"
-            raise ValueError(msg)
-        root_content = dep_pattern.sub(rf'"{new_name}\g<1>=={new_version}"', root_content)
-
-        print(f"Renamed bundle {old_name} -> {new_name}=={new_version}")
-
-    ROOT_PYPROJECT.write_text(root_content, encoding="utf-8")
-
-
 def update_lfx_for_nightly(lfx_tag: str, sdk_tag: str):
-    """Update LFX package for nightly build.
+    """Update the canonical ``lfx`` package for a nightly build.
 
     Args:
-        lfx_tag: The nightly tag for LFX (e.g., "v0.1.0.dev0")
-        sdk_tag: The nightly tag for the SDK (e.g., "v0.1.0.dev0")
+        lfx_tag: The nightly tag for LFX (e.g., "v1.11.0.dev0").
+        sdk_tag: The nightly tag for the SDK (e.g., "v0.1.0.dev0").
     """
     lfx_pyproject_path = "src/lfx/pyproject.toml"
 
-    # Update name to lfx-nightly
-    update_pyproject_name(lfx_pyproject_path, "lfx-nightly")
-
-    # Update version (strip 'v' prefix if present)
+    # Set the version (strip 'v' prefix if present); the package keeps its canonical `lfx` name.
     version = lfx_tag.lstrip("v")
     update_pyproject_version(lfx_pyproject_path, version)
 
-    # Update workspace dependency in root pyproject.toml
-    update_lfx_workspace_dep("pyproject.toml", "lfx-nightly")
-
+    # Re-pin lfx's SDK dependency to the exact canonical dev version.
     sdk_version = sdk_tag.lstrip("v")
     update_sdk_dependency_in_lfx(lfx_pyproject_path, sdk_version)
 
-    # Re-pin every bundle's lfx dep to the renamed workspace package so
-    # `uv lock` resolves cleanly. No-op when no bundles are present.
-    update_lfx_dep_in_bundles(version)
-
-    # Give each bundle its own `-nightly` distribution and repoint the root
-    # `langflow` deps + workspace sources at it, so `langflow-nightly` pulls
-    # `lfx-<name>-nightly` (which pins `lfx-nightly`) instead of the stable
-    # `lfx-<name>` (which pins an as-yet-unpublished stable `lfx`).
-    rename_bundles_for_nightly(version)
-
-    print(f"Updated LFX package to lfx-nightly version {version}")
+    print(f"Updated lfx to nightly version {version}")
 
 
 def main():

--- a/scripts/ci/update_pyproject_combined.py
+++ b/scripts/ci/update_pyproject_combined.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 
 from update_lf_base_dependency import update_lfx_dep_in_base
-from update_pyproject_name import update_pyproject_name
-from update_pyproject_name import update_uv_dep as update_name_uv_dep
 from update_pyproject_version import update_pyproject_version
 from update_uv_dependency import update_uv_dep as update_version_uv_dep
 
@@ -16,6 +14,11 @@ sys.path.append(str(current_dir))
 
 def main():
     """Universal update script that handles both base and main updates in a single run.
+
+    Approach A (canonical pre-releases): the packages keep their CANONICAL names (``langflow``,
+    ``langflow-base``) -- they are NOT renamed to ``*-nightly``. This script only sets the nightly
+    ``.devN`` versions and re-pins the inter-package dependencies to exact canonical dev versions.
+    See ``src/bundles/NIGHTLY.md``.
 
     Usage:
     update_pyproject_combined.py main <main_tag> <base_tag> <lfx_tag>
@@ -36,26 +39,22 @@ def main():
     base_tag = sys.argv[3]
     lfx_tag = sys.argv[4]
 
-    # Lockstep invariant: langflow-base-nightly's published version (set here from `base_tag`)
-    # and langflow-nightly's exact `==` pin on it (set below from the same `base_tag`) MUST come
-    # from the same value, so the latest langflow-nightly always pins a base version published in
-    # the same run. `pypi_nightly_tag.py` makes the main and base tags identical; keep both writes
-    # sourced from `base_tag` or the pin can reference a version that was never published.
+    # Lockstep invariant: langflow-base's published dev version (set here from `base_tag`) and
+    # langflow's exact `==` pin on it (set below from the same `base_tag`) MUST come from the same
+    # value, so the latest nightly `langflow` always pins a base version published in the same run.
+    # `pypi_nightly_tag.py` makes the main and base tags identical; keep both writes sourced from
+    # `base_tag` or the pin can reference a version that was never published.
 
-    # First handle base package updates
-    update_pyproject_name("src/backend/base/pyproject.toml", "langflow-base-nightly")
-    update_name_uv_dep("pyproject.toml", "langflow-base-nightly")
+    # First handle base package updates (canonical name kept).
     update_pyproject_version("src/backend/base/pyproject.toml", base_tag)
 
-    # Update LFX dependency in langflow-base
+    # Update LFX dependency in langflow-base (exact canonical dev pin).
     lfx_version = lfx_tag.lstrip("v")
     update_lfx_dep_in_base("src/backend/base/pyproject.toml", lfx_version)
 
-    # Then handle main package updates
-    update_pyproject_name("pyproject.toml", "langflow-nightly")
-    update_name_uv_dep("pyproject.toml", "langflow-nightly")
+    # Then handle main package updates (canonical name kept).
     update_pyproject_version("pyproject.toml", main_tag)
-    # Update dependency version (strip 'v' prefix if present)
+    # Update langflow-base dependency version (strip 'v' prefix if present).
     base_version = base_tag.lstrip("v")
     update_version_uv_dep(base_version)
 

--- a/scripts/ci/update_sdk_version.py
+++ b/scripts/ci/update_sdk_version.py
@@ -1,10 +1,13 @@
-"""Script to update SDK version for nightly builds."""
+"""Update the canonical ``langflow-sdk`` version for nightly builds.
+
+Approach A (canonical pre-releases): the SDK keeps its canonical ``langflow-sdk`` name -- it is NOT
+renamed to ``langflow-sdk-nightly`` -- and is published as a ``.devN`` pre-release. This script only
+sets the nightly version. See ``src/bundles/NIGHTLY.md``.
+"""
 
 import sys
 from pathlib import Path
 
-from update_pyproject_name import update_pyproject_name
-from update_pyproject_name import update_uv_dep as update_workspace_dep
 from update_pyproject_version import update_pyproject_version
 
 # Add the current directory to the path so we can import the other scripts
@@ -13,17 +16,13 @@ sys.path.append(str(current_dir))
 
 
 def update_sdk_for_nightly(sdk_tag: str):
-    """Update SDK package for nightly build."""
+    """Set the canonical ``langflow-sdk`` package version for a nightly build."""
     sdk_pyproject_path = "src/sdk/pyproject.toml"
-
-    update_pyproject_name(sdk_pyproject_path, "langflow-sdk-nightly")
 
     version = sdk_tag.lstrip("v")
     update_pyproject_version(sdk_pyproject_path, version)
 
-    update_workspace_dep("pyproject.toml", "langflow-sdk-nightly")
-
-    print(f"Updated SDK package to langflow-sdk-nightly version {version}")
+    print(f"Updated langflow-sdk to nightly version {version}")
 
 
 def main():

--- a/scripts/ci/update_uv_dependency.py
+++ b/scripts/ci/update_uv_dependency.py
@@ -32,7 +32,8 @@ def update_uv_dep(base_version: str) -> None:
 
     # Extract extras if present (e.g., "[complete]")
     extras = match.group(3) if match.group(3) else ""
-    replacement = rf'\1"langflow-base-nightly{extras}=={base_version}"'
+    # Approach A: keep the canonical `langflow-base` name with an exact `==<dev>` pin.
+    replacement = rf'\1"langflow-base{extras}=={base_version}"'
 
     # Replace the matched pattern with the new one
     content = pattern.sub(replacement, content)

--- a/src/bundles/NIGHTLY.md
+++ b/src/bundles/NIGHTLY.md
@@ -1,10 +1,9 @@
 # Bundles & the nightly build
 
-> **Status:** decision record + runbook. The cutover described in
-> [Cutover runbook](#cutover-runbook-gated) is **deferred** and **gated on stable `lfx 1.10.0`
-> being published to PyPI**. Until then the nightly keeps its current behavior (it renames the
-> bundles — see [Why the nightly renames the bundles](#why-the-nightly-renames-the-bundles)).
-> Sibling docs: [PORTING.md](./PORTING.md).
+> **Status:** Approach A (canonical pre-releases) is **implemented in this PR** (stacked on the
+> prep PR #13528). It is held as a **draft** and must **NOT** be merged/activated until the
+> [activation gate](#activation-gate-must-read) below is met (stable `lfx 1.10.0` published **and**
+> the nightly's base version moved to the next minor). Sibling docs: [PORTING.md](./PORTING.md).
 
 ## Goal
 
@@ -24,89 +23,94 @@ Four bundles are extracted as standalone PyPI packages (the only dirs here with 
 | `lfx-ibm`        | `src/bundles/ibm`         | `0.1.0` | ✅ live |
 
 Each pins `lfx>=1.10.0,<2.0.0` and is wired into the root `pyproject.toml` as a direct dependency
-(`lfx-*>=0.1.0`), a `[tool.uv.sources]` workspace entry, and a `[tool.uv.workspace]` member. (The
-other dirs under `src/bundles/` are placeholders for future extraction and ship nothing.)
+(`lfx-*>=0.1.0`), a `[tool.uv.sources]` workspace entry, and a `[tool.uv.workspace]` member. **The
+bundles are unchanged by this PR.**
 
 ## The normal release already meets the goal
 
 Stable `langflow 1.10.0` → `lfx-*>=0.1.0` → `lfx>=1.10.0,<2.0.0` → stable `lfx`. One consistent,
-canonical `lfx`. **No change needed.** (These published bundles only become *installable* once the
-release ships stable `lfx 1.10.0`; PyPI's stable `lfx` is otherwise behind the bundles' floor.)
+canonical `lfx`. No change needed there.
 
-## Why the nightly renames the bundles
+## Background: why the nightly renamed the bundles (removed by this PR)
 
-The nightly stack publishes the core as a **separate distribution**, `lfx-nightly` — but the
-rename only rewrites `[project].name`; the wheel still ships the **same `lfx/` import package**
-(`[tool.hatch.build.targets.wheel] packages = ["src/lfx"]` is untouched).
+The old nightly published the core as a **separate distribution**, `lfx-nightly` — but the rename
+only rewrote `[project].name`; the wheel still shipped the **same `lfx/` import package**. So a
+`langflow-nightly` depending on a *stable* bundle would drag in **stable `lfx` alongside
+`lfx-nightly`** — two distributions both owning `site-packages/lfx/` → an install-time collision.
+To avoid that, the nightly gave the bundles their own `-nightly` track (`update_lfx_dep_in_bundles`
++ `rename_bundles_for_nightly` in `update_lfx_version.py`). Approach A removes the dual-distribution
+design entirely, so that bundle renaming is no longer needed.
 
-So if `langflow-nightly` depended on a **stable** bundle, that bundle's transitive
-`lfx>=1.10.0,<2.0.0` would pull in **stable `lfx` alongside `lfx-nightly`**. Two distributions, both
-owning `site-packages/lfx/` → an install-time file collision / clobber.
+## What this PR changes (Approach A — canonical pre-releases)
 
-This is the real blocker, and it is **not** removed by publishing stable `lfx 1.10.0`: shipping it
-fixes the *resolve* step, but the dual-`lfx` *install* conflict remains as long as the nightly core
-is a separately-named distribution. That is why
-[`scripts/ci/update_lfx_version.py`](../../scripts/ci/update_lfx_version.py) gives the bundles their
-own nightly track via `update_lfx_dep_in_bundles()` (repins each bundle to `lfx-nightly==<dev>`) and
-`rename_bundles_for_nightly()` (renames `lfx-<name>` → `lfx-<name>-nightly` and repoints the root
-deps + workspace sources).
+Publish the nightly under the **canonical** package names as `.devN` pre-releases (`lfx==X.Y.Z.devN`,
+`langflow==…`, `langflow-base==…`, `langflow-sdk==…`) instead of separate `*-nightly` distributions.
+A single canonical `lfx` then exists, so the stable bundles resolve cleanly — **no bundle changes**.
 
-## Cutover runbook (gated)
+- **Stop renaming the core.** `update_lfx_version.py`, `update_pyproject_combined.py`,
+  `update_sdk_version.py` no longer rename to `*-nightly`; they only set the `.devN` version and
+  re-pin inter-package deps to **exact canonical dev versions** (`langflow-base[complete]==<dev>`,
+  `lfx==<dev>`, `langflow-sdk==<dev>` — via `update_uv_dependency.py` / `update_lf_base_dependency.py`).
+  The exact dev pins also enable pre-release resolution down the tree, so the bundles' `lfx>=…`
+  range latches onto the dev `lfx`.
+- **Drop the bundle nightly track.** `update_lfx_dep_in_bundles()` and `rename_bundles_for_nightly()`
+  are deleted; bundles keep their stable names + `lfx>=1.10.0,<2.0.0` pins.
+- **Version math.** `pypi_nightly_tag.py` / `lfx_nightly_tag.py` / `sdk_nightly_tag.py` count `.devN`
+  against the **canonical** PyPI histories (`langflow` / `langflow-base` / `lfx` / `langflow-sdk`),
+  not the `*-nightly` projects. The base version is still read from the pyproject of the latest
+  `release-*` branch the nightly builds from (see `nightly_build.yml`'s `resolve-release-branch`),
+  so it tracks the release cadence automatically.
+- **Publish workflow.** `release_nightly.yml` publishes canonical pre-releases; the bundle build
+  step, the `dist-nightly-bundles` artifact, the `publish-nightly-bundles` job, and its gate in
+  `publish-nightly-main` are removed. Verify steps now expect canonical names; the main wheel glob
+  is `dist/langflow-*.whl`.
 
-> **Gate:** do **not** activate any of the following until stable `lfx 1.10.0` is published to PyPI.
-> The nightly runs daily (`cron "0 0 * * *"`) from **main's** workflow definition, so anything
-> merged that flips this behavior goes live on the next run.
+## Activation gate (MUST READ)
 
-### Approach A — canonical pre-releases (recommended)
+Do **not** merge/activate until **both**:
 
-Publish the nightly under the **real** package names as `.devN` pre-releases (`lfx==1.10.x.devN`,
-`langflow==…`, `langflow-base==…`, `langflow-sdk==…`); users install with `pip install --pre langflow`.
-Then a single canonical `lfx` distribution exists, so the stable bundles resolve cleanly with **no
-changes to the bundles at all**.
+1. **Stable `lfx 1.10.0` is published to PyPI** (the bundles' `lfx>=1.10.0` floor must be satisfiable
+   by a real release), **and**
+2. **The nightly's base version is the next minor** (i.e. the latest `release-*` branch is
+   `release-1.11.0`, so nightlies are `1.11.0.devN`).
 
-1. **Stop renaming the core** in `scripts/ci/update_lfx_version.py`: drop
-   `update_pyproject_name(..., "lfx-nightly")` and `update_lfx_workspace_dep(..., "lfx-nightly")`;
-   version-bump `lfx` under its canonical name. Mirror for base/main/sdk in
-   `update_pyproject_combined.py` / `update_pyproject_name.py` / `update_uv_dependency.py`.
-2. **Remove the bundle nightly handling**: delete the `update_lfx_dep_in_bundles()` and
-   `rename_bundles_for_nightly()` calls in `update_lfx_for_nightly()`.
-3. **Version math** — nightlies must sort *above* the latest stable. Post-1.10.0 they become
-   `1.10.1.devN` (or the next minor). Update `pypi_nightly_tag.py` / `lfx_nightly_tag.py` /
-   `sdk_nightly_tag.py` to read the next-version base and count `dev` against the **canonical** PyPI
-   histories (`lfx`, `langflow`, `langflow-base`) instead of the `*-nightly` ones.
-4. **Publish workflow** `.github/workflows/release_nightly.yml`: publish canonical pre-releases and
-   remove the bundle build step, the `dist-nightly-bundles` artifact, the `publish-nightly-bundles`
-   job, and its entry in `publish-nightly-main`'s `needs` / `if`.
-5. **Install UX / docs / docker**: `pip install langflow-nightly` → `pip install --pre langflow`;
-   update docs + docker nightly tags; deprecate/freeze `langflow-nightly`, `langflow-base-nightly`,
-   `lfx-nightly`, and the `lfx-*-nightly` bundles (optionally keep a thin alias during a transition).
+Why (2) is not optional: a bundle pins `lfx>=1.10.0,<2.0.0`, and PEP 440 sorts `1.10.0.devN`
+**below** `1.10.0`. So a `1.10.0.devN` nightly is **not** `>= 1.10.0` — `langflow-base`'s exact
+`lfx==1.10.0.devN` pin would directly conflict with the bundle's `lfx>=1.10.0` floor and resolution
+**fails**. Only a next-minor dev (`1.11.0.devN`, which *is* `>= 1.10.0`) resolves. The nightly runs
+daily from **main's** workflow definition, so merging this before the gate would break the live
+nightly on the next run.
 
-### Approach B — `lfx` as a bundle extra (contained alternative)
+## A1 vs A2 + remaining follow-ups (decide before un-drafting)
 
-Move each bundle's `lfx` dependency into an extra (e.g. `lfx-<name>[standalone]`) so the **same
-wheel** is safe inside a `lfx-nightly` environment (it no longer drags in a second `lfx`). Keep the
-`-nightly` core and the `pip install langflow-nightly` UX; remove only the bundle rename and the
-`publish-nightly-bundles` job.
+This PR implements the **A1** publish behavior: the separate `langflow-nightly` / `langflow-base-nightly`
+/ `lfx-nightly` distributions go away; the nightly is installed via `pip install --pre langflow`.
+Still open (intentionally not done here — they depend on the A1-vs-A2 call):
 
-- **Downside:** standalone `pip install lfx-arxiv` no longer auto-installs `lfx` (a runtime
-  `ImportError` footgun unless users install the extra or already have `lfx`).
-- Bundles re-publish as `0.1.1`. Finalize A-vs-B before cutover.
+- **Install UX / docs.** Update install instructions `pip install langflow-nightly` →
+  `pip install --pre langflow` (only one doc reference today: `docs/.../integrations-langwatch.mdx`).
+- **Docker nightly image.** `langflowai/langflow-nightly` (Docker Hub) is independent of the PyPI
+  name and is left as-is; decide whether to keep or rename.
+- **Runtime nightly detection.** `get_version_info` keys off the `langflow-nightly` package *name*
+  (`src/backend/.../utils/version.py`, `test_version.py`). Under A1 the installed package is
+  `langflow` with a `.dev` version, so detection should key off the `.dev` marker instead.
+- **A2 alternative (preserve the install name).** Instead of dropping `langflow-nightly`, keep it as
+  a thin meta-package pinning `langflow==X.Y.Z.devN`. The scripts above already produce exact dev
+  pins, so A2 only adds a meta-package publish step and leaves the UX/docs untouched.
 
-## Why prepping now is safe (but activating is gated)
+## Approach B (alternative, not taken)
 
-The cutover can be authored and **CI-validated now**: PR CI resolves `lfx` from the uv **workspace**
-(editable local `lfx 1.10.0`), not PyPI — proven by the fact that the bundles already pin
-`lfx>=1.10.0,<2.0.0`, no PR-triggered workflow installs a bundle from PyPI, and the branch is green.
-Only **merging/activating** the cutover must wait for stable `lfx 1.10.0`, because that is when
-published nightly artifacts and end-user installs resolve `lfx>=1.10.0` from PyPI and the dual-`lfx`
-conflict would re-appear on the live nightly.
+Move each bundle's `lfx` dependency into an extra (e.g. `lfx-<name>[standalone]`) so the same wheel
+is safe inside a `lfx-nightly` env; keep the `-nightly` core and the `pip install langflow-nightly`
+UX. Downside: standalone `pip install lfx-arxiv` no longer auto-installs `lfx`, and bundles must
+re-publish as `0.1.1`.
 
-## Verification (at cutover time)
+## Verification (run against this branch)
 
-- `uv lock` resolves `lfx` to the workspace editable (`grep -A2 'name = "lfx"' uv.lock` →
-  `editable = "src/lfx"`).
-- Dry-run the updater:
-  `uv run --no-sync ./scripts/ci/update_lfx_version.py v1.10.1.dev0 v0.1.0.dev0`, then
-  `git diff src/bundles src/lfx/pyproject.toml` shows **no** bundle renamed to `-nightly` and **no**
-  `lfx` → `lfx-nightly` rename of the core.
-- No `lfx-*-nightly` wheels are produced (the `publish-nightly-bundles` job is gone).
+- `scripts/ci/test_pypi_nightly_tag.py` passes (15/15) with canonical URLs.
+- Tag scripts run live against canonical PyPI and emit `vX.Y.Z.dev0` (no `*-nightly` counted).
+- Dry-run `update_sdk_version.py` / `update_lfx_version.py` / `update_pyproject_combined.py` with
+  `v1.11.0.dev0` tags → all packages keep canonical names; versions set; pins become
+  `langflow-base[complete]==1.11.0.dev0`, `lfx==1.11.0.dev0`, `langflow-sdk==…`; **no** `src/bundles/*`
+  file is touched.
+- Both workflows are valid YAML; no `publish-nightly-bundles` job remains.


### PR DESCRIPTION
> **DRAFT — do not merge.** Reference implementation of the nightly→stable-bundle cutover
> (Approach A). Stacked on #13528 (base = `nightly-bundle-stable-cutover` for a clean diff).
> Gated — see [Activation gate](#activation-gate) below.

## Summary

Publish the nightly under **canonical** package names as `.devN` pre-releases (`lfx==X.Y.Z.devN`,
`langflow==…`, `langflow-base==…`, `langflow-sdk==…`) instead of separate `*-nightly` distributions.
A single canonical `lfx` then exists, so the **stable `lfx-*` bundles resolve as-is** (no `lfx` vs
`lfx-nightly` dual-distribution install collision) and **no nightly bundle packages are produced**.
This is the cutover whose plan/runbook lives in `src/bundles/NIGHTLY.md`.

## What changed

- **Tag scripts** (`pypi_nightly_tag.py`, `lfx_nightly_tag.py`, `sdk_nightly_tag.py`): count `.devN`
  against the **canonical** PyPI histories (`langflow`/`langflow-base`/`lfx`/`langflow-sdk`) instead
  of the `*-nightly` projects. `lfx`/`sdk` rewritten to a robust max-dev count (the old
  "latest.dev+1" breaks on canonical *finals*).
- **Update scripts** (`update_lfx_version.py`, `update_pyproject_combined.py`, `update_sdk_version.py`,
  `update_lf_base_dependency.py`, `update_uv_dependency.py`): stop renaming to `*-nightly`; keep
  canonical names; set `.devN` versions; re-pin inter-package deps to **exact canonical dev versions**
  (`langflow-base[complete]==`, `lfx==`, `langflow-sdk==` — exact dev pins also enable pre-release
  resolution down the tree). **Deleted** the bundle nightly track (`update_lfx_dep_in_bundles`,
  `rename_bundles_for_nightly`).
- **`release_nightly.yml`**: publish canonical pre-releases; remove the bundle build step, the
  `dist-nightly-bundles` artifact, the `publish-nightly-bundles` job + its gate in
  `publish-nightly-main`; verify steps expect canonical names; main wheel glob `dist/langflow-*.whl`.
- **`nightly_build.yml`**: drop the bundle `git add` in the tag commit.
- **`NIGHTLY.md`**: Approach A marked implemented + activation gate + A1/A2 follow-ups.
- Bundles (`src/bundles/*`) and `pyproject.toml`/`uv.lock` are **unchanged**.

## Activation gate

Do **not** un-draft/merge until **both**:
1. **Stable `lfx 1.10.0` is on PyPI** (the bundles' `lfx>=1.10.0` floor must be satisfiable), and
2. **The nightly base is the next minor** (latest `release-*` branch is `release-1.11.0`, so nightlies
   are `1.11.0.devN`).

Why (2) is mandatory: a bundle pins `lfx>=1.10.0,<2.0.0`, and PEP 440 sorts `1.10.0.devN` **below**
`1.10.0`. So a `1.10.0.devN` core is **not** `>= 1.10.0` and `langflow-base`'s exact pin would
conflict with the bundle floor → resolution fails. Only a next-minor dev (`1.11.0.devN`) resolves.
The nightly runs daily from main's workflow def, so merging before the gate breaks the live nightly.

## Open decision (A1 vs A2)

Implements **A1**: the `*-nightly` distributions go away; install via `pip install --pre langflow`.
Intentionally NOT done here (depends on the A1-vs-A2 call): install-UX/docs (`--pre`), docker nightly
image naming, and runtime nightly-detection (`get_version_info` keys off the `langflow-nightly`
*name*; under A1 it should key off `.dev`). **A2** (keep a thin `langflow-nightly` meta-package
pinning the exact dev versions → no `--pre`, no breaking UX) is a small delta on top of this. See
`NIGHTLY.md`.

## Validation

- `scripts/ci/test_pypi_nightly_tag.py` 15/15; ruff + py_compile clean on all changed scripts.
- Tag scripts run live → `vX.Y.Z.dev0` (canonical counting; no `*-nightly`).
- Dry-run updaters with `v1.11.0.dev0` → canonical names kept, exact dev pins set, **no `src/bundles/*`
  touched**, reverted clean.
- Both workflows valid YAML; no `publish-nightly-bundles` job remains.

## Note on the diff

A prior commit on the prep branch documented the bundle-rename functions; this PR deletes them — the
expected progression (prep documents the status quo + plan; cutover executes it). `.secrets.baseline`
has incidental line-number shifts (workflow edits) + a prune of pre-existing stale entries.