### PR TITLE
fix: prevent KeyError in Composio Gmail Send Mail component

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -145,7 +145,7 @@ class TestSafeLangchainProviderRegression:
 
     def test_file_helper_downloads_no_keyerror_on_untyped_property(self):
         """End-to-end guard against the original KeyError site for downloads.
-        
+
         Drives Composio's download walker with a params dict whose property has no
         ``type`` key. The wrapper should inject "type": "object" into the param.
         """

--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -143,6 +143,36 @@ class TestSafeLangchainProviderRegression:
         result = helper._substitute_file_uploads_recursively(None, schema, request)
         assert result == request
 
+    def test_file_helper_downloads_no_keyerror_on_untyped_property(self):
+        """End-to-end guard against the original KeyError site for downloads.
+        
+        Drives Composio's download walker with a params dict whose property has no
+        ``type`` key. The wrapper should inject "type": "object" into the param.
+        """
+        from composio.core.models._files import FileHelper
+
+        helper = FileHelper.__new__(FileHelper)
+
+        request = {"payload": {"foo": "bar"}}
+        params = {"payload": {"description": "blob"}}
+
+        result = helper._substitute_file_downloads_recursively(request=request, params=params)
+        assert result == request
+        assert params["payload"]["type"] == "object"
+
+    def test_file_helper_downloads_accepts_positional_args(self):
+        """Forward-compat guard: wrapper must tolerate positional invocation for downloads."""
+        from composio.core.models._files import FileHelper
+
+        helper = FileHelper.__new__(FileHelper)
+
+        request = {"payload": {"foo": "bar"}}
+        params = {"payload": {"description": "blob"}}
+
+        result = helper._substitute_file_downloads_recursively(request, params)
+        assert result == request
+        assert params["payload"]["type"] == "object"
+
     def test_pydantic_builder_patched(self):
         """``pydantic_model_from_param_schema`` must be wrapped on import.
 

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -159,6 +159,16 @@ def _patch_file_helper_once() -> None:
         return original_uploads(self, *args, **kwargs)
 
     def safe_downloads(self, *args, **kwargs):
+        # Extract params based on expected signature: (self, request, params, param=None)
+        params = kwargs.get("params") if "params" in kwargs else (args[1] if len(args) > 1 else None)
+
+        # Apply the targeted fix for missing 'type' keys in parameter schemas
+        if isinstance(params, dict):
+            for value in params.values():
+                if isinstance(value, dict) and "type" not in value:
+                    value["type"] = "object"
+
+        # Still run the original sanitize fallback just in case
         _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
         return original_downloads(self, *args, **kwargs)
 


### PR DESCRIPTION
## Description
Fixes a KeyError when the 'type' key is missing in the parameters dictionary of the Composio Gmail Send Mail component.

## Changes
- Extended the existing safe_provider monkey‑patch to ensure every parameter dictionary has a 'type' key before it reaches the Composio library.
- Prevents crash in `_substitute_file_downloads_recursively` when `"type"` is absent.

Closes #13476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter schema validation to ensure robust handling of parameter definitions across file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->