### PR TITLE
fix(security): block code-execution components on unauthenticated public flow builds

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -17,6 +17,7 @@ from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
     CustomComponentValidationError,
     validate_flow_for_current_settings,
+    validate_public_flow_no_code_execution,
 )
 from sqlmodel import select
 
@@ -837,6 +838,12 @@ async def build_public_tmp(
             flow = await session.get(Flow, flow_id)
             if flow and flow.data:
                 validate_flow_for_current_settings(flow.data)
+                # Block unauthenticated builds of flows that run arbitrary code
+                # (Python interpreter/REPL, legacy Python Code Structured tool,
+                # Smart Transform lambda). Without this, any public flow
+                # containing such a component is an unauthenticated server-side
+                # code-execution primitive (report H1-3754930).
+                validate_public_flow_no_code_execution(flow.data)
 
         # flow_id=new_flow_id for tracking/sessions/messages (virtual, per-user isolation).
         # source_flow_id=flow_id to load the actual flow data from the database.

--- a/src/backend/tests/unit/components/tools/test_python_code_structured_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_code_structured_tool.py
@@ -1,6 +1,7 @@
-from unittest.mock import patch
+import os
 
 import pytest
+from langchain_core.tools import ToolException
 from langflow.components.tools.python_code_structured_tool import PythonCodeStructuredTool
 
 from tests.base import ComponentTestBaseWithoutClient
@@ -85,24 +86,38 @@ class TestPythonCodeStructuredTool(ComponentTestBaseWithoutClient):
         assert hasattr(component, "outputs")
         assert len(component.outputs) > 0
 
-    @pytest.mark.asyncio
-    async def test_build_tool_method_exists(self, component_class, default_kwargs):
-        """Test that build_tool method exists and can be called."""
+    async def test_build_tool_returns_non_executable_stub(self, component_class, default_kwargs):
+        """build_tool returns a tool that refuses to run instead of exec()'ing tool_code.
+
+        Security regression for report H1-3754930: this legacy component used to
+        ``exec()`` the ``tool_code`` field at build time, which was reachable as
+        an unauthenticated RCE through public flows.
+        """
         component = await self.component_setup(component_class, default_kwargs)
-        # Set up required attributes for build_tool
-        component.tool_code = "def test_func(): return 42"
-        component.tool_name = "test_tool"
-        component.tool_description = "Test description"
-        component.return_direct = False
-        component.tool_function = "test_func"
-        component.global_variables = []
+        tool = await component.build_tool()
 
-        # Mock the internal parsing methods
-        with patch.object(component, "_parse_code") as mock_parse:
-            mock_parse.return_value = ({}, [{"name": "test_func", "args": []}])
+        # The tool exists but is inert: invoking it raises a clear deprecation error.
+        with pytest.raises(ToolException) as exc_info:
+            tool.func()
 
-            # The method should exist and be callable
-            assert hasattr(component, "build_tool")
-            assert callable(component.build_tool)
+        message = str(exc_info.value)
+        assert "disabled" in message.lower()
+        assert "PythonREPLComponent" in message
 
-            # We won't test the full execution due to complex setup requirements
+    async def test_build_tool_does_not_execute_tool_code(self, component_class, default_kwargs):
+        """Neither building nor invoking the tool may execute attacker-supplied tool_code."""
+        sentinel = "PCT_SHOULD_NEVER_RUN"
+        assert sentinel not in os.environ
+
+        component = await self.component_setup(component_class, default_kwargs)
+        # Code that would set an env var if it were ever exec()'d.
+        component.tool_code = f"import os\nos.environ['{sentinel}'] = 'pwned'\ndef test_func():\n    return 42"
+
+        tool = await component.build_tool()
+        # Building must not have executed the payload.
+        assert sentinel not in os.environ
+
+        # Invoking must refuse rather than execute the payload.
+        with pytest.raises(ToolException):
+            tool.func()
+        assert sentinel not in os.environ

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -703,6 +703,54 @@ async def test_build_public_tmp_rejects_code_execution_components(
 
 @pytest.mark.benchmark
 @pytest.mark.security
+async def test_build_public_tmp_rejects_flow_invoking_components(client, json_memory_chatbot_no_llm, logged_in_headers):
+    """Report H1-3754930 (transitive case): public builds must reject flow-invoking components.
+
+    A public wrapper flow with no directly-blocked nodes could otherwise embed a
+    Run Flow / Sub Flow / Flow as Tool node that loads and executes another saved
+    owner flow by id/name at runtime — a private flow which may itself contain a
+    code-execution component that is never re-validated on the run path. Blocking
+    the flow-invoking node type on the public path closes that indirection.
+    """
+    flow_dict = json.loads(json_memory_chatbot_no_llm)
+    flow_dict["data"]["nodes"].append(
+        {
+            "id": "RunFlow-pub1",
+            "type": "genericNode",
+            "position": {"x": 0, "y": 0},
+            "data": {
+                "id": "RunFlow-pub1",
+                "type": "RunFlow",
+                "display_name": "Run Flow",
+                "node": {
+                    "display_name": "Run Flow",
+                    "template": {"flow_id_selected": {"value": str(uuid.uuid4())}},
+                },
+            },
+        }
+    )
+    flow_id = await create_flow(client, json.dumps(flow_dict), logged_in_headers)
+
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+
+    client.cookies.set("client_id", "test-flow-invoke-client")
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": "test_session"}},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"] == "This flow cannot be executed."
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
 async def test_build_flow_cross_user_blocked(client, json_memory_chatbot_no_llm, logged_in_headers, user_two):
     """Security (GHSA-qj98-rhf8-v93f): authenticated user cannot build another user's private flow.
 

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -658,6 +658,51 @@ async def test_build_public_tmp_checks_public_access_before_validation(
 
 @pytest.mark.benchmark
 @pytest.mark.security
+async def test_build_public_tmp_rejects_code_execution_components(
+    client, json_memory_chatbot_no_llm, logged_in_headers
+):
+    """Report H1-3754930: unauthenticated public builds must reject code-execution components.
+
+    A public flow containing a Python interpreter/REPL (or the legacy Python Code
+    Structured tool) would otherwise let any anonymous visitor trigger
+    server-side code execution through /build_public_tmp.
+    """
+    flow_dict = json.loads(json_memory_chatbot_no_llm)
+    flow_dict["data"]["nodes"].append(
+        {
+            "id": "PythonREPLComponent-pub1",
+            "type": "genericNode",
+            "position": {"x": 0, "y": 0},
+            "data": {
+                "id": "PythonREPLComponent-pub1",
+                "type": "PythonREPLComponent",
+                "display_name": "Python Interpreter",
+                "node": {"display_name": "Python Interpreter", "template": {}},
+            },
+        }
+    )
+    flow_id = await create_flow(client, json.dumps(flow_dict), logged_in_headers)
+
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+
+    client.cookies.set("client_id", "test-code-exec-client")
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": "test_session"}},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"] == "This flow cannot be executed."
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
 async def test_build_flow_cross_user_blocked(client, json_memory_chatbot_no_llm, logged_in_headers, user_two):
     """Security (GHSA-qj98-rhf8-v93f): authenticated user cannot build another user's private flow.
 

--- a/src/lfx/src/lfx/components/tools/python_code_structured_tool.py
+++ b/src/lfx/src/lfx/components/tools/python_code_structured_tool.py
@@ -1,19 +1,31 @@
-import ast
-import json
-from typing import Any
+"""Non-executable compatibility stub for the legacy Python Code Structured tool.
+
+SECURITY (report H1-3754930): this component historically ``exec()``'d the
+user-supplied ``tool_code`` template field at flow-build time. Because a flow
+can be built without authentication once it is marked PUBLIC
+(``/api/v1/build_public_tmp/{flow_id}/flow``), that sink was reachable as an
+unauthenticated server-side RCE.
+
+The component is deprecated (``legacy=True``, replaced by
+``PythonREPLComponent``). Rather than delete it outright — which would break
+saved flows that still reference it — it is kept as a non-executable
+compatibility stub for one release/patch cycle: existing flows continue to
+load, but the component can no longer run arbitrary code. It will be removed in
+a future release.
+"""
 
 from langchain_classic.agents import Tool
-from langchain_core.tools import StructuredTool
-from pydantic.v1 import Field, create_model
-from pydantic.v1.fields import Undefined
-from typing_extensions import override
+from langchain_core.tools import StructuredTool, ToolException
 
 from lfx.base.langchain_utilities.model import LCToolComponent
 from lfx.inputs.inputs import BoolInput, DropdownInput, FieldTypes, HandleInput, MessageTextInput, MultilineInput
 from lfx.io import Output
-from lfx.log.logger import logger
-from lfx.schema.data import Data
-from lfx.schema.dotdict import dotdict
+
+DISABLED_MESSAGE = (
+    "The 'Python Code Structured' tool has been disabled for security reasons: it executed "
+    "arbitrary Python code, which was remotely exploitable through public flows. Rebuild this "
+    "step with the 'Python Interpreter' component (PythonREPLComponent) instead."
+)
 
 
 class PythonCodeStructuredTool(LCToolComponent):
@@ -31,6 +43,10 @@ class PythonCodeStructuredTool(LCToolComponent):
         "_functions",
     ]
     display_name = "Python Code Structured"
+    # NOTE: display_name/description/input strings are intentionally kept identical to the
+    # pre-stub component so the i18n locale keys (locales/*.json) do not change. The
+    # deprecation is signalled via legacy=True, the replacement below, and the runtime
+    # ToolException raised by build_tool.
     description = "structuredtool dataclass code to tool"
     documentation = "https://python.langchain.com/docs/modules/tools/custom_tools/#structuredtool-dataclass"
     name = "PythonCodeStructuredTool"
@@ -91,238 +107,23 @@ class PythonCodeStructuredTool(LCToolComponent):
         Output(display_name="Tool", name="result_tool", method="build_tool"),
     ]
 
-    @override
-    async def update_build_config(
-        self, build_config: dotdict, field_value: Any, field_name: str | None = None
-    ) -> dotdict:
-        if field_name is None:
-            return build_config
-
-        if field_name not in {"tool_code", "tool_function"}:
-            return build_config
-
-        try:
-            named_functions = {}
-            [classes, functions] = self._parse_code(build_config["tool_code"]["value"])
-            existing_fields = {}
-            if len(build_config) > len(self.DEFAULT_KEYS):
-                for key in build_config.copy():
-                    if key not in self.DEFAULT_KEYS:
-                        existing_fields[key] = build_config.pop(key)
-
-            names = []
-            for func in functions:
-                named_functions[func["name"]] = func
-                names.append(func["name"])
-
-                for arg in func["args"]:
-                    field_name = f"{func['name']}|{arg['name']}"
-                    if field_name in existing_fields:
-                        build_config[field_name] = existing_fields[field_name]
-                        continue
-
-                    field = MessageTextInput(
-                        display_name=f"{arg['name']}: Description",
-                        name=field_name,
-                        info=f"Enter the description for {arg['name']}",
-                        required=True,
-                    )
-                    build_config[field_name] = field.to_dict()
-            build_config["_functions"]["value"] = json.dumps(named_functions)
-            build_config["_classes"]["value"] = json.dumps(classes)
-            build_config["tool_function"]["options"] = names
-        except Exception as e:  # noqa: BLE001
-            self.status = f"Failed to extract names: {e}"
-            logger.debug(self.status, exc_info=True)
-            build_config["tool_function"]["options"] = ["Failed to parse", str(e)]
-        return build_config
-
     async def build_tool(self) -> Tool:
-        local_namespace = {}  # type: ignore[var-annotated]
-        modules = self._find_imports(self.tool_code)
-        import_code = ""
-        for module in modules["imports"]:
-            import_code += f"global {module}\nimport {module}\n"
-        for from_module in modules["from_imports"]:
-            for alias in from_module.names:
-                import_code += f"global {alias.name}\n"
-            import_code += (
-                f"from {from_module.module} import {', '.join([alias.name for alias in from_module.names])}\n"
-            )
-        exec(import_code, globals())
-        exec(self.tool_code, globals(), local_namespace)
+        """Return a non-executable placeholder tool.
 
-        class PythonCodeToolFunc:
-            params: dict = {}
+        The previous implementation ``exec()``'d the ``tool_code`` field, which
+        allowed arbitrary code execution at build time (reachable
+        unauthenticated through public flows — report H1-3754930). It now
+        returns a tool that refuses to run, so saved flows still load but no
+        code is executed. Use ``PythonREPLComponent`` instead.
+        """
 
-            def run(**kwargs):
-                for key, arg in kwargs.items():
-                    if key not in PythonCodeToolFunc.params:
-                        PythonCodeToolFunc.params[key] = arg
-                return local_namespace[self.tool_function](**PythonCodeToolFunc.params)
+        def _disabled(*_args, **_kwargs) -> str:
+            raise ToolException(DISABLED_MESSAGE)
 
-        globals_ = globals()
-        local = {}
-        local[self.tool_function] = PythonCodeToolFunc
-        globals_.update(local)
-
-        if isinstance(self.global_variables, list):
-            for data in self.global_variables:
-                if isinstance(data, Data):
-                    globals_.update(data.data)
-        elif isinstance(self.global_variables, dict):
-            globals_.update(self.global_variables)
-
-        classes = json.loads(self._attributes["_classes"])
-        for class_dict in classes:
-            exec("\n".join(class_dict["code"]), globals_)
-
-        named_functions = json.loads(self._attributes["_functions"])
-        schema_fields = {}
-
-        for attr in self._attributes:
-            if attr in self.DEFAULT_KEYS:
-                continue
-
-            func_name = attr.split("|")[0]
-            field_name = attr.split("|")[1]
-            func_arg = self._find_arg(named_functions, func_name, field_name)
-            if func_arg is None:
-                msg = f"Failed to find arg: {field_name}"
-                raise ValueError(msg)
-
-            field_annotation = func_arg["annotation"]
-            field_description = self._get_value(self._attributes[attr], str)
-
-            if field_annotation:
-                exec(f"temp_annotation_type = {field_annotation}", globals_)
-                schema_annotation = globals_["temp_annotation_type"]
-            else:
-                schema_annotation = Any
-            schema_fields[field_name] = (
-                schema_annotation,
-                Field(
-                    default=func_arg.get("default", Undefined),
-                    description=field_description,
-                ),
-            )
-
-        if "temp_annotation_type" in globals_:
-            globals_.pop("temp_annotation_type")
-
-        python_code_tool_schema = None
-        if schema_fields:
-            python_code_tool_schema = create_model("PythonCodeToolSchema", **schema_fields)
-
+        self.status = DISABLED_MESSAGE
         return StructuredTool.from_function(
-            func=local[self.tool_function].run,
-            args_schema=python_code_tool_schema,
-            name=self.tool_name,
-            description=self.tool_description,
-            return_direct=self.return_direct,
+            func=_disabled,
+            name=self.tool_name or "python_code_structured_tool",
+            description=self.tool_description or DISABLED_MESSAGE,
+            return_direct=bool(self.return_direct),
         )
-
-    async def update_frontend_node(self, new_frontend_node: dict, current_frontend_node: dict):
-        """This function is called after the code validation is done."""
-        frontend_node = await super().update_frontend_node(new_frontend_node, current_frontend_node)
-        frontend_node["template"] = await self.update_build_config(
-            frontend_node["template"],
-            frontend_node["template"]["tool_code"]["value"],
-            "tool_code",
-        )
-        frontend_node = await super().update_frontend_node(new_frontend_node, current_frontend_node)
-        for key in frontend_node["template"]:
-            if key in self.DEFAULT_KEYS:
-                continue
-            frontend_node["template"] = await self.update_build_config(
-                frontend_node["template"], frontend_node["template"][key]["value"], key
-            )
-            frontend_node = await super().update_frontend_node(new_frontend_node, current_frontend_node)
-        return frontend_node
-
-    def _parse_code(self, code: str) -> tuple[list[dict], list[dict]]:
-        parsed_code = ast.parse(code)
-        lines = code.split("\n")
-        classes = []
-        functions = []
-        for node in parsed_code.body:
-            if isinstance(node, ast.ClassDef):
-                class_lines = lines[node.lineno - 1 : node.end_lineno]
-                class_lines[-1] = class_lines[-1][: node.end_col_offset]
-                class_lines[0] = class_lines[0][node.col_offset :]
-                classes.append(
-                    {
-                        "name": node.name,
-                        "code": class_lines,
-                    }
-                )
-                continue
-
-            if not isinstance(node, ast.FunctionDef):
-                continue
-
-            func = {"name": node.name, "args": []}
-            for arg in node.args.args:
-                if arg.lineno != arg.end_lineno:
-                    msg = "Multiline arguments are not supported"
-                    raise ValueError(msg)
-
-                func_arg = {
-                    "name": arg.arg,
-                    "annotation": None,
-                }
-
-                for default in node.args.defaults:
-                    if (
-                        arg.lineno > default.lineno
-                        or arg.col_offset > default.col_offset
-                        or (
-                            arg.end_lineno is not None
-                            and default.end_lineno is not None
-                            and arg.end_lineno < default.end_lineno
-                        )
-                        or (
-                            arg.end_col_offset is not None
-                            and default.end_col_offset is not None
-                            and arg.end_col_offset < default.end_col_offset
-                        )
-                    ):
-                        continue
-
-                    if isinstance(default, ast.Name):
-                        func_arg["default"] = default.id
-                    elif isinstance(default, ast.Constant):
-                        func_arg["default"] = str(default.value) if default.value is not None else None
-
-                if arg.annotation:
-                    annotation_line = lines[arg.annotation.lineno - 1]
-                    annotation_line = annotation_line[: arg.annotation.end_col_offset]
-                    annotation_line = annotation_line[arg.annotation.col_offset :]
-                    func_arg["annotation"] = annotation_line
-                    if isinstance(func_arg["annotation"], str) and func_arg["annotation"].count("=") > 0:
-                        func_arg["annotation"] = "=".join(func_arg["annotation"].split("=")[:-1]).strip()
-                if isinstance(func["args"], list):
-                    func["args"].append(func_arg)
-            functions.append(func)
-
-        return classes, functions
-
-    def _find_imports(self, code: str) -> dotdict:
-        imports: list[str] = []
-        from_imports = []
-        parsed_code = ast.parse(code)
-        for node in parsed_code.body:
-            if isinstance(node, ast.Import):
-                imports.extend(alias.name for alias in node.names)
-            elif isinstance(node, ast.ImportFrom):
-                from_imports.append(node)
-        return dotdict({"imports": imports, "from_imports": from_imports})
-
-    def _get_value(self, value: Any, annotation: Any) -> Any:
-        return value if isinstance(value, annotation) else value["value"]
-
-    def _find_arg(self, named_functions: dict, func_name: str, arg_name: str) -> dict | None:
-        for arg in named_functions[func_name]["args"]:
-            if arg["name"] == arg_name:
-                return arg
-        return None

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -47,6 +47,23 @@ CODE_EXECUTION_COMPONENT_TYPES: frozenset[str] = frozenset(
     }
 )
 
+# Component node ``type`` values that load and execute *another* saved flow by
+# id or name at build/run time. On the unauthenticated public path these are an
+# indirect code-execution primitive: a public wrapper flow with none of the
+# blocked types above can invoke a private owner flow that itself contains a
+# code-execution component. The referenced flow is read straight from the
+# database and never re-validated, so blocking it via CODE_EXECUTION_COMPONENT_TYPES
+# alone is bypassable (report H1-3754930, transitive case). The flow-invoking
+# node types are blocked outright on the public path rather than recursively
+# resolved, which is fail-closed. Authenticated builds are unaffected.
+FLOW_REFERENCE_COMPONENT_TYPES: frozenset[str] = frozenset(
+    {
+        "RunFlow",  # "Run Flow" — runs a selected flow by id/name
+        "SubFlow",  # "Sub Flow" (legacy) — runs a selected flow by name
+        "FlowTool",  # "Flow as Tool" (legacy) — exposes a selected flow as a tool
+    }
+)
+
 
 def _compute_code_hash(code: str) -> str:
     """Compute the 12-char SHA256 prefix used by the component index."""
@@ -257,11 +274,62 @@ def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -
     )
 
 
-def _collect_code_execution_components(nodes: list[dict]) -> list[str]:
-    """Return ``display_name (id)`` labels for code-execution components in ``nodes``.
+def _node_code_hash(node_info: Any) -> str | None:
+    """Return the code-hash of a node's ``code`` field, mirroring the hash gate.
 
-    Recurses into nested flow definitions so a code-execution component cannot
-    be hidden inside a sub-flow / group node.
+    The build executes ``eval_custom_component_code(node.code)`` regardless of the
+    node's declared ``type``, so the code-hash is the authoritative identity of
+    what will actually run.
+    """
+    if not isinstance(node_info, Mapping):
+        return None
+    template = node_info.get("template", {})
+    if not isinstance(template, Mapping):
+        return None
+    code_field = template.get("code", {})
+    code = code_field.get("value") if isinstance(code_field, Mapping) else None
+    if isinstance(code, str) and code:
+        return _compute_code_hash(code)
+    return None
+
+
+def _blocked_code_hashes(canonical_types: frozenset[str]) -> frozenset[str]:
+    """Best-effort set of server template code-hashes for ``canonical_types``.
+
+    A component's canonical name is always one of its own alias keys in the
+    hash lookup, so ``type_to_current_hash[name]`` yields that component's known
+    code-hash(es). Returns an empty set when the lookup is unavailable (e.g.
+    custom components are allowed and the hash gate is inactive) — type-name
+    matching still applies in that case.
+    """
+    type_to_current_hash = get_component_hash_lookups_for_validation()
+    if not type_to_current_hash:
+        return frozenset()
+    hashes: set[str] = set()
+    for component_type in canonical_types:
+        hashes |= type_to_current_hash.get(component_type, set())
+    return frozenset(hashes)
+
+
+def _collect_blocked_components(
+    nodes: list[dict],
+    *,
+    blocked_types: frozenset[str],
+    blocked_hashes: frozenset[str],
+) -> list[str]:
+    """Return ``display_name (id)`` labels for nodes matching a blocked component.
+
+    A node matches if its declared ``type`` is in ``blocked_types`` OR its
+    ``code`` field hashes to a blocked component's known template hash. The
+    code-hash check closes an aliasing bypass: in the hardened
+    ``allow_custom_components=false`` mode a node can declare an alias ``type``
+    (e.g. a display name) that still passes the custom-component hash gate and
+    builds, yet whose executed code is a blocked component's.
+
+    Recurses into *inlined* nested flow definitions (group / sub-flow nodes) so a
+    blocked component cannot be hidden inside one. This follows only inlined
+    nested flow data, not flows referenced by id/name from the database — those
+    referencing components are themselves blocked via ``FLOW_REFERENCE_COMPONENT_TYPES``.
     """
     found: list[str] = []
     for node in nodes:
@@ -271,19 +339,26 @@ def _collect_code_execution_components(nodes: list[dict]) -> list[str]:
         if not isinstance(node_data, dict):
             continue
 
-        if node_data.get("type") in CODE_EXECUTION_COMPONENT_TYPES:
-            node_info = node_data.get("node", {})
-            display_name = (node_info.get("display_name") if isinstance(node_info, dict) else None) or node_data["type"]
+        node_info = node_data.get("node", {})
+        matched_by_type = node_data.get("type") in blocked_types
+        matched_by_hash = bool(blocked_hashes) and _node_code_hash(node_info) in blocked_hashes
+        if matched_by_type or matched_by_hash:
+            display_name = (node_info.get("display_name") if isinstance(node_info, dict) else None) or node_data.get(
+                "type", "unknown"
+            )
             node_id = node_data.get("id") or node.get("id", "unknown")
             found.append(f"{display_name} ({node_id})")
 
         # Recurse into nested flows (group / sub-flow nodes).
-        node_info = node_data.get("node", {})
         if isinstance(node_info, dict):
             nested_flow = node_info.get("flow", {})
             nested_nodes = nested_flow.get("data", {}).get("nodes", []) if isinstance(nested_flow, dict) else []
             if isinstance(nested_nodes, list) and nested_nodes:
-                found.extend(_collect_code_execution_components(nested_nodes))
+                found.extend(
+                    _collect_blocked_components(
+                        nested_nodes, blocked_types=blocked_types, blocked_hashes=blocked_hashes
+                    )
+                )
     return found
 
 
@@ -291,18 +366,32 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
     """Reject unauthenticated public-flow builds that would run arbitrary code.
 
     Public flows are reachable without authentication through
-    ``/api/v1/build_public_tmp/{flow_id}/flow``. Components that execute user-
-    or model-supplied code (the Python interpreter/REPL components, the legacy
-    Python Code Structured tool, the Smart Transform lambda) must not run on
-    that path — otherwise any anonymous visitor can trigger server-side code
-    execution through a public flow that contains one (report H1-3754930).
+    ``/api/v1/build_public_tmp/{flow_id}/flow`` and build as the flow owner.
+    Two classes of component are rejected on that path:
+
+    * Direct code execution (``CODE_EXECUTION_COMPONENT_TYPES``) — the Python
+      interpreter/REPL components, the legacy Python Code Structured tool and
+      the Smart Transform lambda — which run user- or model-supplied code
+      (report H1-3754930).
+    * Flow invocation (``FLOW_REFERENCE_COMPONENT_TYPES``) — Run Flow, Sub Flow
+      and Flow as Tool — which load and execute *another* saved owner flow by
+      id/name at runtime. That referenced flow is read straight from the
+      database and never re-validated, so a public wrapper flow with no blocked
+      nodes could otherwise invoke a private flow containing a code-execution
+      component, bypassing the check above (the transitive case).
+
+    Each class is matched both by the node's declared ``type`` and by its
+    ``code``-hash, so relabelling a node's ``type`` to an alias cannot smuggle a
+    blocked component past the check (the build runs the stored ``code``, not the
+    ``type`` label).
 
     This is enforced only on the unauthenticated public build path; authenticated
-    builds (``/api/v1/build/{flow_id}/flow``) are unaffected and may still run
+    builds (``/api/v1/build/{flow_id}/flow``) are unaffected and may still use
     these components.
 
     Raises:
-        PublicFlowValidationError: if the flow contains a code-execution component.
+        PublicFlowValidationError: if the flow contains a code-execution or
+            flow-invoking component.
     """
     normalized_flow_data = _extract_flow_data(target)
     if not normalized_flow_data:
@@ -312,13 +401,31 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
     if not isinstance(nodes, list) or not nodes:
         return
 
-    blocked = _collect_code_execution_components(nodes)
-    if blocked:
-        blocked_names = ", ".join(blocked)
+    code_execution = _collect_blocked_components(
+        nodes,
+        blocked_types=CODE_EXECUTION_COMPONENT_TYPES,
+        blocked_hashes=_blocked_code_hashes(CODE_EXECUTION_COMPONENT_TYPES),
+    )
+    if code_execution:
+        blocked_names = ", ".join(code_execution)
         logger.warning(f"Public flow build blocked: code-execution components are not allowed: {blocked_names}")
         message = (
             "Public flows cannot be built without authentication when they contain "
             f"code-execution components: {blocked_names}"
+        )
+        raise PublicFlowValidationError(message)
+
+    flow_references = _collect_blocked_components(
+        nodes,
+        blocked_types=FLOW_REFERENCE_COMPONENT_TYPES,
+        blocked_hashes=_blocked_code_hashes(FLOW_REFERENCE_COMPONENT_TYPES),
+    )
+    if flow_references:
+        blocked_names = ", ".join(flow_references)
+        logger.warning(f"Public flow build blocked: flow-invoking components are not allowed: {blocked_names}")
+        message = (
+            "Public flows cannot be built without authentication when they contain "
+            f"components that can execute other flows: {blocked_names}"
         )
         raise PublicFlowValidationError(message)
 

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -24,6 +24,30 @@ class CustomComponentValidationError(ValueError):
     """
 
 
+class PublicFlowValidationError(CustomComponentValidationError):
+    """Raised when a public (unauthenticated) flow build is disallowed.
+
+    Subclasses CustomComponentValidationError so the existing public-build
+    handlers (which already map that error to a safe 400) catch it too.
+    """
+
+
+# Component node ``type`` values that execute user- or model-supplied code when
+# a flow is built or run. Public flows are buildable without authentication via
+# ``/api/v1/build_public_tmp/{flow_id}/flow``; allowing these components on that
+# path turns any public flow into an unauthenticated server-side code-execution
+# primitive (report H1-3754930). The restriction is enforced ONLY on the
+# unauthenticated public path — authenticated builds are unaffected.
+CODE_EXECUTION_COMPONENT_TYPES: frozenset[str] = frozenset(
+    {
+        "PythonCodeStructuredTool",  # legacy raw exec() (now a disabled stub)
+        "PythonREPLComponent",  # "Python Interpreter"
+        "PythonREPLTool",  # legacy "Python REPL" tool
+        "Smart Transform",  # LambdaFilterComponent — eval()s a generated lambda
+    }
+)
+
+
 def _compute_code_hash(code: str) -> str:
     """Compute the 12-char SHA256 prefix used by the component index."""
     return hashlib.sha256(code.encode("utf-8")).hexdigest()[:12]
@@ -231,6 +255,72 @@ def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -
         allow_custom_components=allow_custom_components,
         type_to_current_hash=type_to_current_hash,
     )
+
+
+def _collect_code_execution_components(nodes: list[dict]) -> list[str]:
+    """Return ``display_name (id)`` labels for code-execution components in ``nodes``.
+
+    Recurses into nested flow definitions so a code-execution component cannot
+    be hidden inside a sub-flow / group node.
+    """
+    found: list[str] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_data = node.get("data", {})
+        if not isinstance(node_data, dict):
+            continue
+
+        if node_data.get("type") in CODE_EXECUTION_COMPONENT_TYPES:
+            node_info = node_data.get("node", {})
+            display_name = (node_info.get("display_name") if isinstance(node_info, dict) else None) or node_data["type"]
+            node_id = node_data.get("id") or node.get("id", "unknown")
+            found.append(f"{display_name} ({node_id})")
+
+        # Recurse into nested flows (group / sub-flow nodes).
+        node_info = node_data.get("node", {})
+        if isinstance(node_info, dict):
+            nested_flow = node_info.get("flow", {})
+            nested_nodes = nested_flow.get("data", {}).get("nodes", []) if isinstance(nested_flow, dict) else []
+            if isinstance(nested_nodes, list) and nested_nodes:
+                found.extend(_collect_code_execution_components(nested_nodes))
+    return found
+
+
+def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | None) -> None:
+    """Reject unauthenticated public-flow builds that would run arbitrary code.
+
+    Public flows are reachable without authentication through
+    ``/api/v1/build_public_tmp/{flow_id}/flow``. Components that execute user-
+    or model-supplied code (the Python interpreter/REPL components, the legacy
+    Python Code Structured tool, the Smart Transform lambda) must not run on
+    that path — otherwise any anonymous visitor can trigger server-side code
+    execution through a public flow that contains one (report H1-3754930).
+
+    This is enforced only on the unauthenticated public build path; authenticated
+    builds (``/api/v1/build/{flow_id}/flow``) are unaffected and may still run
+    these components.
+
+    Raises:
+        PublicFlowValidationError: if the flow contains a code-execution component.
+    """
+    normalized_flow_data = _extract_flow_data(target)
+    if not normalized_flow_data:
+        return
+
+    nodes = normalized_flow_data.get("nodes", [])
+    if not isinstance(nodes, list) or not nodes:
+        return
+
+    blocked = _collect_code_execution_components(nodes)
+    if blocked:
+        blocked_names = ", ".join(blocked)
+        logger.warning(f"Public flow build blocked: code-execution components are not allowed: {blocked_names}")
+        message = (
+            "Public flows cannot be built without authentication when they contain "
+            f"code-execution components: {blocked_names}"
+        )
+        raise PublicFlowValidationError(message)
 
 
 async def ensure_component_hash_lookups_loaded() -> dict[str, str] | None:

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from lfx.utils.flow_validation import (
     CODE_EXECUTION_COMPONENT_TYPES,
+    FLOW_REFERENCE_COMPONENT_TYPES,
     CustomComponentValidationError,
     PublicFlowValidationError,
     ensure_component_hash_lookups_loaded,
@@ -149,3 +150,135 @@ def test_public_flow_noop_on_empty(empty):
 def test_public_flow_validation_error_is_custom_component_error():
     """Subclassing keeps the existing public-build handler (CustomComponentValidationError -> 400)."""
     assert issubclass(PublicFlowValidationError, CustomComponentValidationError)
+
+
+# --- transitive flow execution (report H1-3754930, transitive case) ---------------
+
+
+@pytest.mark.parametrize("component_type", sorted(FLOW_REFERENCE_COMPONENT_TYPES))
+def test_public_flow_blocks_flow_invoking_components(component_type):
+    """Flow-invoking components (Run Flow / Sub Flow / Flow as Tool) must be rejected.
+
+    They load and execute another saved owner flow by id/name at runtime; that
+    referenced flow is never re-validated, so a public wrapper flow could use one
+    to reach a private flow containing a code-execution component.
+    """
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(_flow_with_component(component_type))
+    assert component_type in str(exc_info.value)
+    assert "execute other flows" in str(exc_info.value)
+
+
+def test_public_flow_blocks_wrapper_with_runflow_and_safe_nodes():
+    """The real attack shape — a wrapper of otherwise-safe nodes plus a Run Flow — is blocked."""
+    wrapper = {
+        "nodes": [
+            {"id": "ChatInput-1", "data": {"id": "ChatInput-1", "type": "ChatInput", "node": {"template": {}}}},
+            {
+                "id": "RunFlow-1",
+                "data": {"id": "RunFlow-1", "type": "RunFlow", "node": {"display_name": "Run Flow", "template": {}}},
+            },
+            {"id": "ChatOutput-1", "data": {"id": "ChatOutput-1", "type": "ChatOutput", "node": {"template": {}}}},
+        ],
+        "edges": [],
+    }
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(wrapper)
+    assert "RunFlow-1" in str(exc_info.value)
+
+
+def test_public_flow_blocks_nested_flow_invoking_component():
+    """A flow-invoking component hidden inside an inlined sub-flow must still be caught."""
+    nested = {
+        "nodes": [
+            {
+                "id": "group-1",
+                "data": {
+                    "id": "group-1",
+                    "type": "GroupNode",
+                    "node": {"flow": {"data": _flow_with_component("SubFlow")}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+    with pytest.raises(PublicFlowValidationError):
+        validate_public_flow_no_code_execution(nested)
+
+
+def test_code_execution_and_flow_reference_sets_are_disjoint():
+    """The two blocklists describe different failure modes and must not overlap."""
+    assert CODE_EXECUTION_COMPONENT_TYPES.isdisjoint(FLOW_REFERENCE_COMPONENT_TYPES)
+
+
+# --- aliasing bypass: match by code-hash, not just declared type ------------------
+
+
+def _flow_with_typed_code(component_type: str, code: str) -> dict:
+    """Build raw graph data for a single node carrying ``code`` under ``component_type``."""
+    return {
+        "nodes": [
+            {
+                "id": "evasive-1",
+                "data": {
+                    "id": "evasive-1",
+                    "type": component_type,
+                    "node": {"display_name": component_type, "template": {"code": {"value": code}}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+
+def test_public_flow_blocks_flow_invoking_component_relabelled_via_code_hash(monkeypatch):
+    """A flow-invoking node that relabels its ``type`` to dodge the type block is still caught.
+
+    In the hardened ``allow_custom_components=false`` mode the build runs the node's
+    stored ``code`` regardless of its declared ``type``, so the code-hash of a
+    blocked component is the authoritative signal.
+    """
+    from lfx.utils import flow_validation as fv
+
+    run_flow_code = "class RunFlowComponent(Component):\n    name = 'RunFlow'\n"
+    code_hash = fv._compute_code_hash(run_flow_code)
+    # Pretend the server's known RunFlow template hashes to this code.
+    monkeypatch.setattr(fv, "get_component_hash_lookups_for_validation", lambda: {"RunFlow": {code_hash}})
+
+    # Declared type is innocuous and in NEITHER blocklist, but the code is RunFlow's.
+    evasive = _flow_with_typed_code("Totally Innocent", run_flow_code)
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(evasive)
+    assert "execute other flows" in str(exc_info.value)
+
+
+def test_public_flow_blocks_code_execution_component_relabelled_via_code_hash(monkeypatch):
+    """The same aliasing defense applies to code-execution components."""
+    from lfx.utils import flow_validation as fv
+
+    repl_code = "class PythonREPLComponent(Component):\n    pass\n"
+    code_hash = fv._compute_code_hash(repl_code)
+    monkeypatch.setattr(fv, "get_component_hash_lookups_for_validation", lambda: {"PythonREPLComponent": {code_hash}})
+
+    evasive = _flow_with_typed_code("Harmless Label", repl_code)
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(evasive)
+    assert "code-execution" in str(exc_info.value)
+
+
+def test_public_flow_code_hash_allows_unrelated_code(monkeypatch):
+    """A node whose code does not match any blocked template hash must still build."""
+    from lfx.utils import flow_validation as fv
+
+    monkeypatch.setattr(fv, "get_component_hash_lookups_for_validation", lambda: {"RunFlow": {"deadbeefcafe"}})
+    safe = _flow_with_typed_code("ChatInput", "class ChatInput(Component):\n    pass\n")
+    validate_public_flow_no_code_execution(safe)  # must not raise
+
+
+def test_public_flow_type_block_works_without_hash_lookups(monkeypatch):
+    """When the hash lookup is unavailable, canonical type-name matching still blocks."""
+    from lfx.utils import flow_validation as fv
+
+    monkeypatch.setattr(fv, "get_component_hash_lookups_for_validation", lambda: None)
+    with pytest.raises(PublicFlowValidationError):
+        validate_public_flow_no_code_execution(_flow_with_component("RunFlow"))

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -4,7 +4,14 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from lfx.utils.flow_validation import ensure_component_hash_lookups_loaded, validate_flow_for_current_settings
+from lfx.utils.flow_validation import (
+    CODE_EXECUTION_COMPONENT_TYPES,
+    CustomComponentValidationError,
+    PublicFlowValidationError,
+    ensure_component_hash_lookups_loaded,
+    validate_flow_for_current_settings,
+    validate_public_flow_no_code_execution,
+)
 
 
 def _blocked_raw_graph() -> dict:
@@ -65,3 +72,80 @@ def test_validate_flow_for_current_settings_requires_settings_service(monkeypatc
 
     with pytest.raises(RuntimeError, match="Settings service must be initialized"):
         validate_flow_for_current_settings(graph)
+
+
+# --- validate_public_flow_no_code_execution (report H1-3754930) -------------------
+
+
+def _flow_with_component(component_type: str) -> dict:
+    """Build minimal raw graph data containing a single node of ``component_type``."""
+    node_id = f"{component_type}-1"
+    return {
+        "nodes": [
+            {
+                "id": node_id,
+                "data": {
+                    "id": node_id,
+                    "type": component_type,
+                    "node": {"display_name": component_type, "template": {}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+
+@pytest.mark.parametrize("component_type", sorted(CODE_EXECUTION_COMPONENT_TYPES))
+def test_public_flow_blocks_code_execution_components(component_type):
+    """Every code-execution component must be rejected on the unauthenticated public path."""
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(_flow_with_component(component_type))
+    assert component_type in str(exc_info.value)
+
+
+def test_public_flow_allows_safe_components():
+    """A flow without code-execution components must build on the public path."""
+    safe = {
+        "nodes": [
+            {"id": "ChatInput-1", "data": {"id": "ChatInput-1", "type": "ChatInput", "node": {"template": {}}}},
+        ],
+        "edges": [],
+    }
+    validate_public_flow_no_code_execution(safe)  # must not raise
+
+
+def test_public_flow_blocks_nested_code_execution_component():
+    """A code-execution component hidden inside a sub-flow must still be caught."""
+    nested = {
+        "nodes": [
+            {
+                "id": "group-1",
+                "data": {
+                    "id": "group-1",
+                    "type": "GroupNode",
+                    "node": {"flow": {"data": _flow_with_component("PythonREPLComponent")}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+    with pytest.raises(PublicFlowValidationError):
+        validate_public_flow_no_code_execution(nested)
+
+
+def test_public_flow_unwraps_data_envelope():
+    """The {"data": {...}} envelope must be unwrapped before validation."""
+    wrapped = {"data": _flow_with_component("PythonREPLTool")}
+    with pytest.raises(PublicFlowValidationError):
+        validate_public_flow_no_code_execution(wrapped)
+
+
+@pytest.mark.parametrize("empty", [None, {}, {"nodes": []}, {"nodes": "not-a-list"}])
+def test_public_flow_noop_on_empty(empty):
+    """Missing/empty/malformed node lists are a no-op, not an error."""
+    validate_public_flow_no_code_execution(empty)  # must not raise
+
+
+def test_public_flow_validation_error_is_custom_component_error():
+    """Subclassing keeps the existing public-build handler (CustomComponentValidationError -> 400)."""
+    assert issubclass(PublicFlowValidationError, CustomComponentValidationError)


### PR DESCRIPTION
## Summary

`PythonCodeStructuredTool` executes attacker-controlled Python via `exec(self.tool_code)` at flow-build time. Because a flow can be built **without authentication** once it is marked `PUBLIC` — `POST /api/v1/build_public_tmp/{flow_id}/flow` — that sink is reachable as an **unauthenticated server-side RCE**.

The gap is not specific to one component: `Python Interpreter` / `Python REPL` (`PythonREPLComponent`, `PythonREPLTool`) and the `Smart Transform` lambda (`LambdaFilterComponent`) also execute code on the same path, so removing a single component would leave the unauthenticated path open via the others.

This PR does two complementary things, matching the team decision (harden the endpoint + retire the legacy component as a non-executable stub for one release cycle, full removal later):

### 1. Harden the unauthenticated public build path — the actual fix

`build_public_tmp` now rejects any stored flow that contains a code-execution component, via a new `validate_public_flow_no_code_execution()` in `lfx.utils.flow_validation`:

- The block keys on the node **`type`** (`PythonCodeStructuredTool`, `PythonREPLComponent`, `PythonREPLTool`, `Smart Transform`), so it holds **regardless of the stored component `code`** — `instantiate_class` execs the node's stored `code` field, so a code/hash-based check alone would not be sufficient.
- It recurses into nested sub-flows so a code component can't be smuggled inside a group node.
- It is enforced **only** on the unauthenticated public path; authenticated `/build` is unchanged.
- `PublicFlowValidationError` subclasses the existing `CustomComponentValidationError`, so the public-build handler already maps it to a safe `400 "This flow cannot be executed."` (no component details leaked to the caller).

### 2. Neuter `PythonCodeStructuredTool` to a non-executable compatibility stub

- All `exec()`/`eval()` sinks are removed (AST-verified). `build_tool` now returns a tool that raises a clear `ToolException` deprecation message pointing to `PythonREPLComponent`.
- The component stays **registered with identical `display_name`/`inputs`**, so existing saved flows still load and **no locale keys change** (`locales/*.json` untouched).
- `legacy=True` + `replacement=["processing.PythonREPLComponent"]` continue to surface the deprecation in the UI.

**Scope note on the stub (for reviewers):** `instantiate_class` (`loading.py`) execs the `code` field stored in each flow node, not the imported class. So the stub fully covers (a) the unauthenticated public path — closed by #1, type-based, independent of stored code; (b) newly created flows — the palette now serves the stub; and (c) `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` deployments — the hash gate now rejects the old code since the trusted server copy is the stub. Under the default `allow_custom_components=true`, an existing/crafted flow that still carries the *old* code could exec it on the **authenticated** path — but that mode already permits authenticated arbitrary code execution by design (Custom Component, Python Interpreter), so this is not a new vector. The endpoint hardening in #1 is what closes the unauthenticated RCE.

## Test plan

- `src/lfx/tests/unit/utils/test_flow_validation.py` — unit tests for `validate_public_flow_no_code_execution`: every code-exec type blocked, safe flows allowed, nested sub-flows caught, `{"data": …}` envelope unwrapped, empty/malformed no-op, error subclassing.
- `src/backend/tests/unit/components/tools/test_python_code_structured_tool.py` — the stub returns a tool that raises, and a malicious `tool_code` payload **never executes** (no env side effect) on build or invocation.
- `src/backend/tests/unit/test_chat_endpoint.py::test_build_public_tmp_rejects_code_execution_components` — end-to-end: a PUBLIC flow containing a Python Interpreter is rejected `400` on the unauthenticated path; the rest of the `build_public_tmp` suite still passes (normal public builds still `200`).

```bash
uv run pytest src/backend/tests/unit/components/tools/test_python_code_structured_tool.py
uv run pytest src/backend/tests/unit/test_chat_endpoint.py -k public_tmp
LFX_TEST_ALLOW_LANGFLOW=1 uv run pytest src/lfx/tests/unit/utils/test_flow_validation.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Disabled Python Code Structured tool due to a server-side remote code execution vulnerability.
  * Added validation to restrict code-execution components in public flows to prevent unauthorized access.

* **Bug Fixes**
  * Public flow build endpoint now validates and rejects flows containing code-execution primitives before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->