### PR TITLE
fix: nest root LLM runs under the flow trace in Langfuse (#13429)

### DIFF
--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import threading
 from collections import OrderedDict
+from functools import cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -160,6 +161,95 @@ def delete_feedback_score(*, message_id: UUID | str) -> None:
     """
     client = _get_langfuse_client()
     client.api.score.delete(score_id=feedback_score_id(message_id))
+
+
+def _build_otel_parent_span(trace_id: str | None, parent_span_id: str | None):
+    """Build a non-recording OpenTelemetry span pointing at an existing Langfuse span.
+
+    Mirrors the SDK's private ``Langfuse._create_remote_parent_span`` using only
+    public values we already hold — the flow ``trace_id`` and the parent span id.
+    The returned span is suitable for ``opentelemetry.trace.use_span(...)`` so a
+    subsequently created span nests under it and inherits the same trace id.
+
+    Returns ``None`` when either id is missing or not valid hex (e.g. under unit
+    tests that use mock span ids) so callers degrade to the SDK's default behavior
+    instead of raising.
+    """
+    if not trace_id or not parent_span_id:
+        return None
+
+    from opentelemetry import trace as otel_trace_api
+
+    try:
+        int_trace_id = int(trace_id, 16)
+        int_span_id = int(parent_span_id, 16)
+    except (TypeError, ValueError):
+        return None
+
+    span_context = otel_trace_api.SpanContext(
+        trace_id=int_trace_id,
+        span_id=int_span_id,
+        is_remote=False,
+        trace_flags=otel_trace_api.TraceFlags(0x01),  # mark span as sampled
+    )
+    return otel_trace_api.NonRecordingSpan(span_context)
+
+
+@cache
+def _root_run_reparenting_handler_cls(base_cls: type) -> type:
+    """Build a langfuse ``CallbackHandler`` subclass that re-parents root LLM runs.
+
+    Why this exists
+    ---------------
+    The langfuse v3 LangChain ``CallbackHandler`` only applies its constructor
+    ``trace_context`` on the chain path (``on_chain_start``). When a model runs as
+    the *root* LangChain run — e.g. a bare Ollama / chat-model call with no wrapping
+    chain — the generation path calls ``start_observation`` without that
+    ``trace_context``. With no active OpenTelemetry span in context, the generation
+    starts a brand-new root trace, orphaned from the flow trace and therefore
+    missing ``userId`` / ``sessionId`` and its token-usage metrics.
+    See https://github.com/langflow-ai/langflow/issues/13429.
+
+    The fix
+    -------
+    For root LLM runs we activate the flow's component (or root) span as the current
+    OpenTelemetry span while the SDK creates the generation span. The generation then
+    inherits the flow ``trace_id`` and nests under that span, restoring user/session
+    attribution. The handler sets ``run_inline = True``, so these callbacks execute
+    synchronously inside the model invocation and the activation reliably wraps span
+    creation. Non-root runs (wrapping chain/agent present) are left untouched — the
+    SDK already nests those correctly under the chain span.
+
+    Cached per ``base_cls`` so repeated callbacks reuse a single class object.
+    """
+    from opentelemetry import trace as otel_trace_api
+
+    class _RootRunReparentingCallbackHandler(base_cls):  # type: ignore[misc, valid-type]
+        def __init__(self, *, otel_parent: Any = None, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self._otel_parent = otel_parent
+
+        def _reparent(self, method_name: str, args: tuple, kwargs: dict, parent_run_id: UUID | None):
+            bound = getattr(super(), method_name)
+            if parent_run_id is None and self._otel_parent is not None:
+                # end_on_exit/record_exception False so the parent span is never
+                # mutated or closed by activating it as the current context.
+                with otel_trace_api.use_span(
+                    self._otel_parent,
+                    end_on_exit=False,
+                    record_exception=False,
+                    set_status_on_exception=False,
+                ):
+                    return bound(*args, parent_run_id=parent_run_id, **kwargs)
+            return bound(*args, parent_run_id=parent_run_id, **kwargs)
+
+        def on_chat_model_start(self, *args: Any, parent_run_id: UUID | None = None, **kwargs: Any) -> Any:
+            return self._reparent("on_chat_model_start", args, kwargs, parent_run_id)
+
+        def on_llm_start(self, *args: Any, parent_run_id: UUID | None = None, **kwargs: Any) -> Any:
+            return self._reparent("on_llm_start", args, kwargs, parent_run_id)
+
+    return _RootRunReparentingCallbackHandler
 
 
 class LangFuseTracer(BaseTracer):
@@ -375,19 +465,23 @@ class LangFuseTracer(BaseTracer):
         try:
             from langfuse.langchain import CallbackHandler
 
-            # Get the current span's context for proper nesting
-            if self.spans:
-                # Use the most recent span as parent
-                current_span = next(reversed(self.spans.values()))
-                # Create callback with parent context
-                trace_ctx: TraceContext = {
-                    "trace_id": self._trace_context["trace_id"],
-                    "parent_span_id": current_span.id,
-                }
-                handler = CallbackHandler(trace_context=trace_ctx)
-            else:
-                # Fall back to root trace context
-                handler = CallbackHandler(trace_context=self._trace_context)
+            # Nest LangChain work under the most recent open component span when
+            # there is one, else under the flow root span. Both share the flow
+            # trace_id, so generations stay attributed to the flow's user/session.
+            parent_span = next(reversed(self.spans.values())) if self.spans else self._root_span
+            trace_ctx: TraceContext = {
+                "trace_id": self._trace_context["trace_id"],
+                "parent_span_id": parent_span.id,
+            }
+
+            # ``trace_context`` alone keeps chain/agent runs nested (the SDK honors
+            # it on the chain path). ``otel_parent`` additionally re-parents *root*
+            # LLM runs (a bare model with no wrapping chain), which the SDK would
+            # otherwise emit as an orphan trace with no user/session and detached
+            # token usage. See https://github.com/langflow-ai/langflow/issues/13429.
+            otel_parent = _build_otel_parent_span(self._trace_context["trace_id"], parent_span.id)
+            handler_cls = _root_run_reparenting_handler_cls(CallbackHandler)
+            handler = handler_cls(trace_context=trace_ctx, otel_parent=otel_parent)
 
         except (ImportError, ValueError, TypeError) as e:
             logger.debug(f"Error creating LangChain callback handler: {e}")

--- a/src/backend/tests/unit/services/tracing/test_langfuse_orphan_generation.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_orphan_generation.py
@@ -1,0 +1,276 @@
+"""Regression tests for the Langfuse orphan-generation fix (issue #13429).
+
+When a model runs as the *root* LangChain run — i.e. invoked directly with no
+wrapping chain, as reproduced with Ollama — the langfuse v3 ``CallbackHandler``
+emitted the LLM generation as a separate, orphan trace: ``parent = None``,
+``userId = None``, ``sessionId = None``, and the token usage detached from the
+flow trace. The langfuse SDK only applies the constructor ``trace_context`` on
+the chain path, so a bare model's generation started a brand-new trace.
+
+``LangFuseTracer.get_langchain_callback`` now returns a handler that re-parents
+root LLM runs under the flow's component (or root) span, so the generation
+shares the flow ``trace_id`` and stays attributed to the user/session.
+
+The end-to-end test exercises the real langfuse SDK with an in-memory
+OpenTelemetry exporter — a pure mock cannot catch this bug because the orphaning
+happens inside the SDK's generation path.
+"""
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def langfuse_env_vars():
+    """Set fake langfuse credentials for testing."""
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_SECRET_KEY": "sk-lf-test",  # pragma: allowlist secret
+            "LANGFUSE_PUBLIC_KEY": "pk-lf-test",
+            "LANGFUSE_HOST": "http://localhost:3000",
+        },
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_langfuse_shared_client():
+    """Clear the cached Langfuse client between tests so mocks don't leak."""
+    from langflow.services.tracing.langfuse import _reset_shared_client_for_tests
+
+    _reset_shared_client_for_tests()
+    yield
+    _reset_shared_client_for_tests()
+
+
+class TestOtelParentSpanBuilder:
+    """``_build_otel_parent_span`` turns the flow ids into an OTel parent span."""
+
+    def test_returns_none_when_ids_missing(self):
+        from langflow.services.tracing.langfuse import _build_otel_parent_span
+
+        assert _build_otel_parent_span(None, "b" * 16) is None
+        assert _build_otel_parent_span("a" * 32, None) is None
+        assert _build_otel_parent_span("", "") is None
+
+    def test_returns_none_for_non_hex_ids(self):
+        """Mock span ids (non-hex) degrade gracefully instead of raising."""
+        from langflow.services.tracing.langfuse import _build_otel_parent_span
+
+        assert _build_otel_parent_span("not-hex", "child-span-id") is None
+
+    def test_builds_span_context_from_hex_ids(self):
+        from langflow.services.tracing.langfuse import _build_otel_parent_span
+
+        trace_id = "a" * 32
+        span_id = "b" * 16
+        parent = _build_otel_parent_span(trace_id, span_id)
+
+        assert parent is not None
+        ctx = parent.get_span_context()
+        assert ctx.trace_id == int(trace_id, 16)
+        assert ctx.span_id == int(span_id, 16)
+        # Sampled so downstream generations are recorded under the flow trace.
+        assert ctx.trace_flags.sampled
+
+
+class _RecordingBase:
+    """Stand-in for langfuse's ``CallbackHandler`` that records OTel context.
+
+    Each LLM-start callback records the span context that is *current* at the
+    moment the SDK would create the generation span. The re-parenting subclass
+    is expected to make the flow's parent span current for root runs only.
+    """
+
+    def __init__(self, *, trace_context=None, **kwargs):  # noqa: ARG002
+        self.trace_context = trace_context
+        self.captured = []
+
+    def _record(self):
+        from opentelemetry import trace as otel_trace_api
+
+        self.captured.append(otel_trace_api.get_current_span().get_span_context())
+
+    def on_chat_model_start(self, *args, **kwargs):  # noqa: ARG002
+        self._record()
+
+    def on_llm_start(self, *args, **kwargs):  # noqa: ARG002
+        self._record()
+
+
+class TestRootRunReparentingHandler:
+    """The subclass activates the parent span for root LLM runs only."""
+
+    def _make_handler(self, trace_id="a" * 32, span_id="b" * 16, *, with_parent=True):
+        from langflow.services.tracing.langfuse import (
+            _build_otel_parent_span,
+            _root_run_reparenting_handler_cls,
+        )
+
+        handler_cls = _root_run_reparenting_handler_cls(_RecordingBase)
+        otel_parent = _build_otel_parent_span(trace_id, span_id) if with_parent else None
+        handler = handler_cls(
+            trace_context={"trace_id": trace_id, "parent_span_id": span_id},
+            otel_parent=otel_parent,
+        )
+        return handler, trace_id, span_id
+
+    def test_activates_parent_for_root_chat_model_run(self):
+        handler, trace_id, span_id = self._make_handler()
+
+        handler.on_chat_model_start({}, [], run_id=uuid.uuid4(), parent_run_id=None)
+
+        ctx = handler.captured[-1]
+        assert ctx.is_valid
+        assert ctx.trace_id == int(trace_id, 16)
+        assert ctx.span_id == int(span_id, 16)
+
+    def test_activates_parent_for_root_llm_run(self):
+        handler, trace_id, span_id = self._make_handler()
+
+        handler.on_llm_start({}, [], run_id=uuid.uuid4(), parent_run_id=None)
+
+        ctx = handler.captured[-1]
+        assert ctx.is_valid
+        assert ctx.trace_id == int(trace_id, 16)
+        assert ctx.span_id == int(span_id, 16)
+
+    def test_does_not_activate_for_non_root_run(self):
+        """A wrapping chain/agent is present (parent_run_id set) → leave untouched.
+
+        The SDK already nests these correctly under the chain span, so the
+        handler must not force the flow parent into the OTel context.
+        """
+        handler, _, _ = self._make_handler()
+
+        handler.on_chat_model_start({}, [], run_id=uuid.uuid4(), parent_run_id=uuid.uuid4())
+
+        ctx = handler.captured[-1]
+        # No span was activated → ambient context is the invalid root span.
+        assert not ctx.is_valid
+
+    def test_missing_parent_is_safe(self):
+        """When the parent span id is not resolvable, root runs simply no-op."""
+        handler, _, _ = self._make_handler(with_parent=False)
+
+        handler.on_chat_model_start({}, [], run_id=uuid.uuid4(), parent_run_id=None)
+
+        ctx = handler.captured[-1]
+        assert not ctx.is_valid
+
+
+def _build_real_langfuse_client_or_skip(tracer_provider):
+    """Construct a real Langfuse client wired to ``tracer_provider``.
+
+    Its network OTLP exporter is replaced with a no-op so the test stays local
+    and fast (no connection to a Langfuse server). Skips if the SDK cannot be
+    imported on this interpreter (e.g. pydantic/python version mismatch).
+    """
+    try:
+        from langfuse import Langfuse
+        from opentelemetry.sdk.trace.export import SpanExportResult
+    except Exception as exc:
+        pytest.skip(f"langfuse SDK is not importable: {exc}")
+
+    class _NoopOtlpExporter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def export(self, spans):  # noqa: ARG002
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            pass
+
+        def force_flush(self, timeout_millis=30000):  # noqa: ARG002
+            return True
+
+    with patch("langfuse._client.span_processor.OTLPSpanExporter", _NoopOtlpExporter):
+        client = Langfuse(
+            public_key="pk-lf-test",
+            secret_key="sk-lf-test",  # noqa: S106  # pragma: allowlist secret
+            host="http://localhost:3000",
+            tracer_provider=tracer_provider,
+            tracing_enabled=True,
+        )
+    # Avoid a network round-trip during tracer setup's health check.
+    client.auth_check = lambda: True
+    return client
+
+
+class TestRootGenerationNestsUnderFlowTrace:
+    """End-to-end: a root LLM generation shares the flow trace (issue #13429)."""
+
+    def test_root_llm_generation_shares_flow_trace_and_nests_under_component(self):
+        pytest.importorskip("langfuse")
+        pytest.importorskip("langchain_core")
+        import langflow.services.tracing.langfuse as langfuse_module
+        from langchain_core.messages import AIMessage, HumanMessage
+        from langchain_core.outputs import ChatGeneration, LLMResult
+        from langflow.services.tracing.langfuse import LangFuseTracer
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        client = _build_real_langfuse_client_or_skip(provider)
+
+        with patch.object(langfuse_module, "_get_or_create_shared_client", lambda config: client):  # noqa: ARG005
+            try:
+                tracer = LangFuseTracer(
+                    trace_name="repro - flow-xyz",
+                    trace_type="chain",
+                    project_name="proj",
+                    trace_id=uuid.uuid4(),
+                    user_id="demo-user-13429",
+                    session_id="demo-session-13429",
+                )
+                assert tracer.ready
+
+                # Open a component span, then run a bare chat model as the root
+                # LangChain run (parent_run_id=None) — the orphan-trace condition.
+                tracer.add_trace("comp-ollama", "Ollama (comp-ollama)", "llm", {"input": "hi"})
+                handler = tracer.get_langchain_callback()
+                assert handler is not None
+
+                run_id = uuid.uuid4()
+                handler.on_chat_model_start(
+                    {"id": ["langchain", "chat_models", "ollama", "ChatOllama"]},
+                    [[HumanMessage(content="hi")]],
+                    run_id=run_id,
+                    parent_run_id=None,
+                    invocation_params={},
+                )
+                handler.on_llm_end(
+                    LLMResult(generations=[[ChatGeneration(message=AIMessage(content="ok"), generation_info={})]]),
+                    run_id=run_id,
+                    parent_run_id=None,
+                )
+                tracer.end_trace("comp-ollama", "Ollama", outputs={"output": "ok"})
+                tracer.end(inputs={"in": "hi"}, outputs={"out": "ok"})
+            finally:
+                client.shutdown()
+
+        spans = {s.name: s for s in exporter.get_finished_spans()}
+        assert "flow-xyz" in spans, f"missing flow root span; got {list(spans)}"
+        assert "Ollama" in spans, f"missing component span; got {list(spans)}"
+        assert "ChatOllama" in spans, f"missing generation span; got {list(spans)}"
+
+        root_span = spans["flow-xyz"]
+        component_span = spans["Ollama"]
+        generation_span = spans["ChatOllama"]
+
+        # The generation is recorded as a langfuse generation (carries token usage).
+        assert generation_span.attributes.get("langfuse.observation.type") == "generation"
+
+        # Core of #13429: the generation must live in the flow trace, not orphan.
+        assert generation_span.context.trace_id == root_span.context.trace_id
+        # And nest under the component span (not be a root of its own trace).
+        assert generation_span.parent is not None
+        assert generation_span.parent.span_id == component_span.context.span_id

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
@@ -65,6 +65,28 @@ def _import_callback_handler_or_skip():
     return CallbackHandler
 
 
+class _FakeLangchainCallbackHandler:
+    """Real (subclassable) stand-in for langfuse's ``CallbackHandler`` base.
+
+    ``get_langchain_callback`` now subclasses the imported ``CallbackHandler`` to
+    re-parent root LLM runs, so tests must patch the import with an actual class
+    (a bare ``MagicMock`` instance cannot be used as a base class). This mirrors
+    the relevant part of the real constructor signature.
+    """
+
+    def __init__(self, *, public_key=None, update_trace=False, trace_context=None):
+        self.run_inline = True
+        self.public_key = public_key
+        self.update_trace = update_trace
+        self.trace_context = trace_context
+
+    def on_chat_model_start(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+    def on_llm_start(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
 class TestLangfuseV3ApiExists:
     """Verify that the langfuse v3 API methods we need actually exist."""
 
@@ -334,14 +356,12 @@ class TestLangfuseTracerFunctionality:
         tracer.add_trace("comp-1", "Test", "llm", {})
         assert mock_langfuse["root_span"].start_span.called
 
-        with patch("langfuse.langchain.CallbackHandler") as mock_handler:
-            mock_handler.return_value = MagicMock()
-            tracer.get_langchain_callback()
+        with patch("langfuse.langchain.CallbackHandler", _FakeLangchainCallbackHandler):
+            handler = tracer.get_langchain_callback()
 
-            mock_handler.assert_called_once()
-            call_kwargs = mock_handler.call_args[1]
-            assert "trace_context" in call_kwargs
-            assert "trace_id" in call_kwargs["trace_context"]
+        assert handler is not None
+        assert isinstance(handler, _FakeLangchainCallbackHandler)
+        assert "trace_id" in handler.trace_context
 
     def test_get_langchain_callback_includes_parent_span_id(self, mock_langfuse):
         """Test that callback handler gets parent span ID for proper nesting."""
@@ -358,14 +378,10 @@ class TestLangfuseTracerFunctionality:
         tracer.add_trace("comp-1", "Test", "llm", {})
         assert mock_langfuse["child_span"].id == "child-span-id"
 
-        with patch("langfuse.langchain.CallbackHandler") as mock_handler:
-            mock_handler.return_value = MagicMock()
-            tracer.get_langchain_callback()
+        with patch("langfuse.langchain.CallbackHandler", _FakeLangchainCallbackHandler):
+            handler = tracer.get_langchain_callback()
 
-            call_kwargs = mock_handler.call_args[1]
-            trace_context = call_kwargs["trace_context"]
-            assert "parent_span_id" in trace_context
-            assert trace_context["parent_span_id"] == "child-span-id"
+        assert handler.trace_context["parent_span_id"] == "child-span-id"
 
 
 class TestLangfuseClientSingleton:


### PR DESCRIPTION
## Summary

Fixes #13429 (follow-up to #13319).

When a flow runs a model as the **root LangChain run** — no wrapping chain, reproduced with **Ollama** — the langfuse v3 `CallbackHandler` emitted the LLM generation as a **separate, orphan trace** instead of nesting it under the flow trace:

| Trace | `userId` / `sessionId` | Contents |
|-------|------------------------|----------|
| Flow trace (`<flow_id>`) | set correctly | root span + component spans (Chat Input, Ollama, Chat Output) — **no generation** |
| Orphan trace (`"Ollama"`) | `None` / `None` | the real **generation** (`model=llama3.2`, `parent=None`, tokens 32→2) with metadata `is_langchain_root: true` |

Because the orphan trace has no `userId`/`sessionId`, the token-usage metrics could not be attributed to a session or user, and the generation was invisible inside the flow trace.

## Root cause

The langfuse v3 LangChain `CallbackHandler` only applies its constructor `trace_context` on the **chain** path (`on_chain_start` → `start_observation(trace_context=...)`). The **generation** path (`__on_llm_action`, used by `on_chat_model_start` / `on_llm_start`) calls `start_observation(as_type="generation", ...)` **without** `trace_context`. When the model is the root run (`parent_run_id is None`) there is no active OpenTelemetry span in context, so the SDK starts a **brand-new root trace** for the generation — the `is_langchain_root: true` condition the issue identified.

This is purely an SDK behavior; the prior tracing fixes (#13266, #13341, #13344) do not address it.

## The fix

`LangFuseTracer.get_langchain_callback` now returns a small `CallbackHandler` subclass that, **for root LLM runs only** (`parent_run_id is None`), activates the flow's component (or root) span as the current OpenTelemetry span while the SDK creates the generation span. The generation then:

- inherits the flow `trace_id` (no longer orphaned), and
- nests under the corresponding component span,

so it shares the parent trace's `userId` / `sessionId` and its token usage is attributed correctly.

Mechanics:
- `_build_otel_parent_span(trace_id, parent_span_id)` builds a non-recording OTel parent from values we already hold — mirroring the SDK's own `_create_remote_parent_span` used on the chain path — using only public OTel API (no langfuse private attributes). It degrades to `None` (default SDK behavior) if the ids aren't valid hex.
- The subclass wraps `super().on_chat_model_start` / `super().on_llm_start` in `opentelemetry.trace.use_span(...)`. The handler sets `run_inline = True`, so these callbacks run synchronously inside the model invocation and the activation reliably wraps span creation. `end_on_exit=False` / `record_exception=False` ensure the parent span is never closed or mutated.

**Non-root runs are untouched** — when a wrapping chain/agent is present the LLM fires with a non-`None` `parent_run_id`, and the SDK already nests it correctly under the chain span. Only the bare-model case changes.

## Test plan

- [x] `test_langfuse_orphan_generation.py` — **end-to-end** test driving the **real** langfuse SDK with an in-memory OpenTelemetry exporter (a pure mock cannot catch this — the orphaning happens inside the SDK). Asserts the root LLM generation:
  - shares the flow `trace_id` (the core of #13429), and
  - parents under the component span (not a root of its own trace), and
  - is recorded as a `generation` (carries token usage).
  - Manually verified this test **fails on the pre-fix behavior** (`SAME TRACE: False`, `gen.parent: None`) and passes with the fix.
- [x] Unit tests for `_build_otel_parent_span` (hex / non-hex / missing ids) and the re-parenting handler (activates parent for root chat-model & llm runs; **does not** activate for non-root runs; safe when the parent is unresolvable).
- [x] Updated the two existing `get_langchain_callback` tests to subclass a real fake base (the handler is now subclassed, so a bare `MagicMock` base no longer works).
- [x] Full tracing suite green: `298 passed, 5 skipped`.
- [x] `ruff check` / `ruff format` clean; pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed orphan span generation preventing proper trace attribution in distributed tracing systems.
  * Improved trace nesting to ensure language model operations are correctly attributed to parent flow spans.

* **Tests**
  * Added comprehensive regression test suite for trace hierarchy and span parenting validation.
  * Enhanced distributed tracing system compatibility test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->