### PR TITLE
fix(bundles): republish lfx-* at 0.1.1 with corrected pin + relax lfx floor for RC builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -888,6 +888,23 @@ jobs:
           prune-cache: false
       - name: Install the project
         run: uv sync
+      - name: Relax bundle lfx floor for pre-release
+        if: ${{ inputs.pre_release }}
+        run: |
+          # Bundles floor lfx at the release line (e.g. lfx>=1.10.0). A pre-release
+          # such as 1.10.0rc0 sorts BELOW 1.10.0 under PEP 440, so it fails that
+          # floor and the cross-platform install test cannot resolve. Mirror what
+          # build-base / build-main / build-lfx already do for pre-release: rewrite
+          # the floor to the exact pre-release lfx version, preserving the bundle's
+          # wide <2.0.0 BUNDLE_API cap. Stable source stays at >=1.10.0 -- only the
+          # RC wheels are relaxed, at build time.
+          LFX_VERSION="${{ needs.determine-lfx-version.outputs.version }}"
+          echo "Relaxing bundle lfx floor to pre-release version: $LFX_VERSION"
+          for pyproject in src/bundles/*/pyproject.toml; do
+            sed -i.bak -E "s|\"lfx>=[^\"]*\"|\"lfx>=${LFX_VERSION},<2.0.0\"|" "$pyproject"
+            rm -f "${pyproject}.bak"
+            grep -E '"lfx>=' "$pyproject" | sed "s|^|  ${pyproject}: |"
+          done
       - name: Build bundle wheels
         id: build
         run: |
@@ -995,10 +1012,25 @@ jobs:
             echo "No bundle wheels to publish."
             exit 0
           fi
+          failed=0
           for wheel in "${wheels[@]}"; do
             echo "Publishing $wheel"
-            uv publish "$wheel"
+            # Tolerate "already exists" so reruns -- or a bundle whose version is
+            # unchanged and already on PyPI -- do not fail the job. Matches the
+            # duplicate-tolerant publish in release_bundles.yml.
+            if ! err=$(uv publish "$wheel" 2>&1); then
+              echo "$err"
+              if echo "$err" | grep -qiE 'already exists|file already exists|HTTP 400|duplicate'; then
+                echo "Skipping $wheel: already published."
+              else
+                echo "Publish failed for $wheel"
+                failed=1
+              fi
+            fi
           done
+          if [ "$failed" = "1" ]; then
+            exit 1
+          fi
 
   publish-main:
     name: Publish Langflow Main to PyPI

--- a/src/bundles/arxiv/pyproject.toml
+++ b/src/bundles/arxiv/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-arxiv"
-version = "0.1.0"
+version = "0.1.1"
 description = "arXiv search component as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/docling/pyproject.toml
+++ b/src/bundles/docling/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-docling"
-version = "0.1.0"
+version = "0.1.1"
 description = "Docling document processing components as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/duckduckgo/pyproject.toml
+++ b/src/bundles/duckduckgo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-duckduckgo"
-version = "0.1.0"
+version = "0.1.1"
 description = "DuckDuckGo Search component as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/ibm/pyproject.toml
+++ b/src/bundles/ibm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-ibm"
-version = "0.1.0"
+version = "0.1.1"
 description = "IBM components (Db2 Vector Store + watsonx.ai LLM and embeddings) as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9040,7 +9040,7 @@ integration = [
 
 [[package]]
 name = "lfx-arxiv"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "src/bundles/arxiv" }
 dependencies = [
     { name = "defusedxml" },
@@ -9055,7 +9055,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-docling"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "src/bundles/docling" }
 dependencies = [
     { name = "docling-core" },
@@ -9124,7 +9124,7 @@ provides-extras = ["local", "chunking", "image-description", "all"]
 
 [[package]]
 name = "lfx-duckduckgo"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "src/bundles/duckduckgo" }
 dependencies = [
     { name = "ddgs" },
@@ -9141,7 +9141,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-ibm"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "src/bundles/ibm" }
 dependencies = [
     { name = "ibm-db", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },


### PR DESCRIPTION
This PR addresses two related problems with the `lfx-*` bundle pins, both stemming from the `lfx` 0.5.0 → 1.10.0 version realignment.

## Part 1 — Republish stable bundles with the corrected pin (version bump)

The published `lfx-*` 0.1.0 artifacts on PyPI carry stale `lfx` pins from **before** the realignment:

| Bundle | PyPI 0.1.0 pin | Severity |
|---|---|---|
| `lfx-arxiv` | `lfx>=0.5.0,<0.6.0` | **Hard-broken** — `<0.6.0` can never resolve `lfx` 1.10.0 |
| `lfx-duckduckgo` | `lfx>=0.5.0,<0.6.0` | **Hard-broken** — same |
| `lfx-docling` | `lfx>=0.5.0` | Uncapped floor/cap mismatch |
| `lfx-ibm` | `lfx>=0.5.0` | Uncapped floor/cap mismatch |

The **source** pin was already corrected to `lfx>=1.10.0,<2.0.0` in #13516, but PyPI is immutable and `release_bundles.yml` no-ops on "already exists" — so republishing the fix requires a version bump. This bumps all four **0.1.0 → 0.1.1** (`pyproject.toml` + `uv.lock`). Root `pyproject.toml` keeps its `>=0.1.0` floors (still satisfied).

## Part 2 — Fix RC pre-release resolution in `release.yml`

A `pre_release=true` run builds `lfx` as `1.10.0rc0`. Under PEP 440 a pre-release sorts **below** the final, so `1.10.0rc0` fails the bundle floor `>=1.10.0`, and the cross-platform install test (`cross-platform-test.yml`, which runs *before* publish) can't resolve the bundle wheels against the RC `lfx` wheel:

```
Because only lfx<=1.10.0rc0 is available and lfx-arxiv==0.1.0 depends on
lfx>=1.10.0,<2.0.0, we can conclude that lfx-arxiv==0.1.0 cannot be used.
```

Root cause: `build-base` / `build-main` / `build-lfx` already rewrite their inter-package deps to the pre-release version when `pre_release=true`; **`build-bundles` was the only release artifact missing that step.**

This adds it: when `pre_release=true`, `build-bundles` rewrites each bundle's `lfx` floor to the exact pre-release version (`lfx>=<LFX_VERSION>,<2.0.0`), preserving the wide `<2.0.0` BUNDLE_API cap. **Stable source stays at `>=1.10.0`** — only RC wheels are relaxed, at build time, so there's no source churn and no re-tag of `v1.10.0`.

Also makes `publish-bundles` tolerate "already exists" duplicate wheels on rerun, matching `release_bundles.yml` (independent hardening; protects reruns where a bundle version is unchanged).

## Why floor-rewrite-at-build-time (not a source floor change)

- Keeps published **stable** bundle metadata clean at `>=1.10.0` (no permanent "allow lfx pre-releases" looseness).
- Matches the existing pre-release dep-rewrite pattern for every other package.
- No re-tag: the rewrite applies to whatever `v1.10.0` points at.

## Verification

- [x] PEP 440: `1.10.0rc0` ∉ `>=1.10.0` but ∈ `>=1.10.0rc0,<2.0.0`; `0.5.0` still excluded
- [x] Build-time `sed` rewrites only the `lfx>=…` floor; leaves `lfx-docling[local]` and other `lfx-*` deps untouched
- [x] `uv.lock` diff limited to the four bundle version stamps
- [x] `release.yml` YAML validated
- [ ] RC re-run (`release.yml`, `pre_release=true`, dispatched from `release-1.10.0`) — cross-platform bundle install resolves