### PR TITLE
[DO NOT MERGE] chore(bundles): rc bundles (0.1.1rc0) for RC QA pip-install

### DIFF
--- a/src/bundles/arxiv/pyproject.toml
+++ b/src/bundles/arxiv/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-arxiv"
-version = "0.1.1"
+version = "0.1.1rc0"
 description = "arXiv search component as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -15,7 +15,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "arxiv", "search"]
 # but we list it here as a direct runtime dep so the bundle keeps building
 # even if lfx drops it later.
 dependencies = [
-    "lfx>=1.10.0,<2.0.0",
+    "lfx>=1.10.0rc0,<2.0.0",
     "defusedxml>=0.7.1,<1.0.0",
 ]
 

--- a/src/bundles/docling/pyproject.toml
+++ b/src/bundles/docling/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-docling"
-version = "0.1.1"
+version = "0.1.1rc0"
 description = "Docling document processing components as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -14,7 +14,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "docling", "documents"]
 # base dependency because the bundle exchanges DoclingDocument objects even when
 # conversion happens remotely.
 dependencies = [
-    "lfx>=1.10.0,<2.0.0",
+    "lfx>=1.10.0rc0,<2.0.0",
     "httpx>=0.28.1,<1.0.0",
     "docling-core>=2.36.1,<3.0.0",
 ]

--- a/src/bundles/duckduckgo/pyproject.toml
+++ b/src/bundles/duckduckgo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-duckduckgo"
-version = "0.1.1"
+version = "0.1.1rc0"
 description = "DuckDuckGo Search component as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -18,7 +18,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "duckduckgo", "search"]
 # "lfx": {"compat": [...]} contract.  langchain-community uses the same
 # range the lfx tree does to keep co-installation lockstep.
 dependencies = [
-    "lfx>=1.10.0,<2.0.0",
+    "lfx>=1.10.0rc0,<2.0.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ddgs>=9.0.0",
 ]

--- a/src/bundles/ibm/pyproject.toml
+++ b/src/bundles/ibm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-ibm"
-version = "0.1.1"
+version = "0.1.1rc0"
 description = "IBM components (Db2 Vector Store + watsonx.ai LLM and embeddings) as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -26,7 +26,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "ibm", "db2", "watsonx", "
 #   3.10-compatible build elsewhere.  Kept in lockstep with langflow-base.
 # * ``langchain-community`` provides the helpers DB2VS leans on.
 dependencies = [
-    "lfx>=1.10.0,<2.0.0",
+    "lfx>=1.10.0rc0,<2.0.0",
     "langchain-community>=0.4.1,<1.0.0",
     "ibm-db>=3.2.9,<4.0.0; sys_platform != 'linux' or platform_machine != 'aarch64'",
     "ibm-watsonx-ai>=1.3.1,<2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9040,7 +9040,7 @@ integration = [
 
 [[package]]
 name = "lfx-arxiv"
-version = "0.1.1"
+version = "0.1.1rc0"
 source = { editable = "src/bundles/arxiv" }
 dependencies = [
     { name = "defusedxml" },
@@ -9055,7 +9055,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-docling"
-version = "0.1.1"
+version = "0.1.1rc0"
 source = { editable = "src/bundles/docling" }
 dependencies = [
     { name = "docling-core" },
@@ -9124,7 +9124,7 @@ provides-extras = ["local", "chunking", "image-description", "all"]
 
 [[package]]
 name = "lfx-duckduckgo"
-version = "0.1.1"
+version = "0.1.1rc0"
 source = { editable = "src/bundles/duckduckgo" }
 dependencies = [
     { name = "ddgs" },
@@ -9141,7 +9141,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-ibm"
-version = "0.1.1"
+version = "0.1.1rc0"
 source = { editable = "src/bundles/ibm" }
 dependencies = [
     { name = "ibm-db", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },


### PR DESCRIPTION
> **⚠️ DO NOT MERGE.** This is a **staging branch** whose only purpose is to be the dispatch source for `release_bundles.yml`, publishing pre-release bundle wheels so QA can `pip install` the RC from PyPI. The stable bundle source on `release-1.10.0` must stay at `0.1.1` / `lfx>=1.10.0` (#13542). Close this once the RC window is over.

## Why

`pip install --pre "langflow==1.10.0rc0"` can't resolve from PyPI today: `langflow` depends on `lfx-arxiv>=0.1.0` (core dep), and the only published `lfx-arxiv` (`0.1.0`) pins `lfx>=0.5.0,<0.6.0`, which conflicts with `lfx 1.10.0rc0`. Publishing rc-versioned bundles closes that gap for QA.

## Changes (all 4 bundles)

| | from | to | why |
|---|---|---|---|
| version | `0.1.1` | `0.1.1rc0` | sorts **above** published `0.1.0` (so `--pre` prefers it) and **below** stable `0.1.1` (so tomorrow's final still publishes — no immutability collision) |
| lfx floor | `>=1.10.0,<2.0.0` | `>=1.10.0rc0,<2.0.0` | resolves against the published `lfx 1.10.0rc0` |

`uv.lock` regenerated (4 version stamps). `lfx-docling[...]` self-refs untouched.

## How to publish (when ready)

**Prerequisite:** the RC run must have published the full stack to PyPI — `langflow`/`langflow-base`/`lfx`/`langflow-sdk` all as `…rc0`. As of opening this, `lfx 1.10.0rc0` is **not yet on PyPI** (latest is `0.4.6`).

```
gh workflow run release_bundles.yml --ref chore/rc-bundles-0.1.1rc0
```

(`dry_run` defaults to false → it builds, smoke-tests against a locally-built lfx 1.10.0, and publishes `0.1.1rc0` to PyPI.)

Then QA: `pip install --pre "langflow==1.10.0rc0"`.

## After the RC

Stable path is unchanged: publish `lfx 1.10.0` + bundles `0.1.1` (clean `>=1.10.0`) via `release_bundles.yml` from `release-1.10.0`. `0.1.1 > 0.1.1rc0`, so it supersedes cleanly.