### PR TITLE
fix(authz): schedule periodic audit-log retention cleanup

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -215,6 +215,17 @@ def get_lifespan(*, fix_migration=False, version=None):
                     f"writes will use the legacy direct-write path: {exc}"
                 )
 
+            # Start the periodic authz audit-log retention sweep. No-op unless
+            # AUTHZ_AUDIT_ENABLED and AUTHZ_AUDIT_RETENTION_DAYS > 0. The startup
+            # sweep in initialize_services() already pruned at boot; this keeps a
+            # long-running instance bounded between restarts.
+            try:
+                from langflow.services.task.audit_cleanup import audit_log_cleanup_worker
+
+                await audit_log_cleanup_worker.start()
+            except Exception as exc:  # noqa: BLE001 — never block startup on cleanup scheduling
+                await logger.awarning(f"Failed to start authz audit-log cleanup worker: {exc}")
+
             current_time = asyncio.get_event_loop().time()
             await logger.adebug("Setting up LLM caching")
             setup_llm_caching()
@@ -547,6 +558,15 @@ def get_lifespan(*, fix_migration=False, version=None):
                         await stop_streamable_http_manager()
                     except Exception as e:  # noqa: BLE001
                         await logger.aerror(f"Failed to stop MCP server streamable-http session manager: {e}")
+                    # Stop the authz audit-log retention worker (best-effort;
+                    # no-op when it was never scheduled).
+                    try:
+                        from langflow.services.task.audit_cleanup import audit_log_cleanup_worker
+
+                        await audit_log_cleanup_worker.stop()
+                    except Exception as e:  # noqa: BLE001
+                        await logger.aerror(f"Failed to stop authz audit-log cleanup worker: {e}")
+
                     # Cancel background tasks
                     tasks_to_cancel = []
                     if sync_flows_from_fs_task:

--- a/src/backend/base/langflow/services/task/audit_cleanup.py
+++ b/src/backend/base/langflow/services/task/audit_cleanup.py
@@ -1,0 +1,154 @@
+"""Recurring retention sweep for the ``authz_audit_log`` table.
+
+The retention helper :func:`langflow.services.utils.clean_authz_audit_log` is
+invoked once at startup inside ``initialize_services``. That single boot-time
+sweep leaves a long-running instance to accumulate audit rows without bound
+between restarts. This module wires the same helper to a background worker that
+prunes on a fixed interval (daily by default), modelled on the sibling
+:class:`langflow.services.task.temp_flow_cleanup.CleanupWorker`.
+
+The worker is intentionally best-effort: every sweep opens its own
+``session_scope`` and the helper logs-and-swallows database errors, so a
+transient outage never kills the loop or blocks the event loop / request path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import TYPE_CHECKING
+
+from lfx.log.logger import logger
+
+from langflow.services.deps import get_settings_service, session_scope
+from langflow.services.utils import clean_authz_audit_log
+
+if TYPE_CHECKING:
+    from lfx.services.settings.auth import AuthSettings
+
+# Daily by default; mirrors AuthSettings.AUTHZ_AUDIT_CLEANUP_INTERVAL so the
+# worker still has a sane cadence if the setting is somehow unavailable.
+DEFAULT_CLEANUP_INTERVAL_SECONDS = 86400
+
+
+class AuditLogCleanupWorker:
+    """Periodically prune ``authz_audit_log`` rows past the retention window.
+
+    The worker is a no-op unless ``AUTHZ_AUDIT_ENABLED`` is True and
+    ``AUTHZ_AUDIT_RETENTION_DAYS`` is greater than 0 — both gates are evaluated
+    in :meth:`start`, so a disabled deployment never schedules a task. The
+    unconditional startup sweep in ``initialize_services`` still handles
+    boot-time pruning (including cleaning up leftover rows after auditing is
+    turned off), so this worker only has to cover the steady state.
+
+    Args:
+        interval: Optional override (seconds) for the sweep cadence. When None
+            the cadence is read from ``AUTHZ_AUDIT_CLEANUP_INTERVAL`` at start.
+            Primarily a testing seam so the schedule can be exercised quickly
+            without mutating global settings.
+    """
+
+    def __init__(self, *, interval: float | None = None) -> None:
+        self._interval_override = interval
+        self._interval: float = float(interval) if interval is not None else DEFAULT_CLEANUP_INTERVAL_SECONDS
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+    def _resolve_interval(self, auth_settings: AuthSettings) -> float:
+        """Resolve the sweep interval, preferring the constructor override."""
+        if self._interval_override is not None:
+            return float(self._interval_override)
+        try:
+            return float(getattr(auth_settings, "AUTHZ_AUDIT_CLEANUP_INTERVAL", DEFAULT_CLEANUP_INTERVAL_SECONDS))
+        except (TypeError, ValueError):
+            return float(DEFAULT_CLEANUP_INTERVAL_SECONDS)
+
+    async def start(self) -> None:
+        """Start the periodic cleanup task, honouring the audit/retention gates."""
+        if self._task is not None:
+            await logger.awarning("Audit-log cleanup worker is already running")
+            return
+
+        auth_settings = get_settings_service().auth_settings
+
+        if not getattr(auth_settings, "AUTHZ_AUDIT_ENABLED", False):
+            await logger.adebug("Audit-log cleanup worker not started: AUTHZ_AUDIT_ENABLED is False")
+            return
+
+        try:
+            retention_days = int(getattr(auth_settings, "AUTHZ_AUDIT_RETENTION_DAYS", 90))
+        except (TypeError, ValueError):
+            retention_days = 90
+        if retention_days <= 0:
+            await logger.adebug(
+                "Audit-log cleanup worker not started: retention disabled (AUTHZ_AUDIT_RETENTION_DAYS=%s)",
+                retention_days,
+            )
+            return
+
+        self._interval = self._resolve_interval(auth_settings)
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="authz-audit-cleanup")
+        await logger.adebug(
+            "Started authz_audit_log cleanup worker (interval=%ss, retention=%sd)",
+            self._interval,
+            retention_days,
+        )
+
+    async def stop(self) -> None:
+        """Stop the cleanup task gracefully, waiting for the current sweep to end."""
+        if self._task is None:
+            # Common path when auditing is disabled — nothing was ever scheduled.
+            await logger.adebug("Audit-log cleanup worker is not running")
+            return
+
+        await logger.adebug("Stopping authz_audit_log cleanup worker...")
+        self._stop_event.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        await logger.adebug("authz_audit_log cleanup worker stopped")
+
+    async def _run(self) -> None:
+        """Prune the audit log every interval until stopped.
+
+        Sleep-first: the unconditional startup sweep already pruned at boot, so
+        the first scheduled pass waits one interval to avoid an immediate,
+        redundant delete right after startup.
+        """
+        while not self._stop_event.is_set():
+            if await self._sleep_or_stop(self._interval):
+                break
+            await self._run_once()
+
+    async def _sleep_or_stop(self, delay: float) -> bool:
+        """Wait ``delay`` seconds or until stop is requested.
+
+        Returns True if a stop was requested during the wait (the caller should
+        break out of the loop), False if the full delay elapsed.
+        """
+        try:
+            await asyncio.wait_for(self._stop_event.wait(), timeout=delay)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    async def _run_once(self) -> int:
+        """Run a single retention sweep in its own session.
+
+        Best-effort: ``clean_authz_audit_log`` already swallows SQLAlchemy and
+        timeout errors; this outer guard additionally protects the loop from
+        session/connection failures so the worker survives a transient outage.
+        Returns the number of rows deleted (``-1`` when unavailable).
+        """
+        settings_service = get_settings_service()
+        try:
+            async with session_scope() as session:
+                return await clean_authz_audit_log(settings_service, session)
+        except Exception as exc:  # noqa: BLE001 — best-effort; never kill the loop
+            await logger.aerror(f"Scheduled authz_audit_log cleanup failed: {exc}")
+            return -1
+
+
+# Module-level singleton started/stopped by the application lifespan.
+audit_log_cleanup_worker = AuditLogCleanupWorker()

--- a/src/backend/base/langflow/services/task/audit_cleanup.py
+++ b/src/backend/base/langflow/services/task/audit_cleanup.py
@@ -26,8 +26,10 @@ from langflow.services.utils import clean_authz_audit_log
 if TYPE_CHECKING:
     from lfx.services.settings.auth import AuthSettings
 
-# Daily by default; mirrors AuthSettings.AUTHZ_AUDIT_CLEANUP_INTERVAL so the
-# worker still has a sane cadence if the setting is somehow unavailable.
+# Placeholder cadence used only until ``start()`` resolves the real value from
+# AUTHZ_AUDIT_CLEANUP_INTERVAL. Covers the window where a worker is constructed
+# but not yet started (the module-level singleton below, or a worker in tests),
+# so ``_interval`` is always a valid float. Daily, matching the setting default.
 DEFAULT_CLEANUP_INTERVAL_SECONDS = 86400
 
 
@@ -55,13 +57,15 @@ class AuditLogCleanupWorker:
         self._task: asyncio.Task | None = None
 
     def _resolve_interval(self, auth_settings: AuthSettings) -> float:
-        """Resolve the sweep interval, preferring the constructor override."""
+        """Resolve the sweep interval, preferring the constructor override.
+
+        Otherwise reads AUTHZ_AUDIT_CLEANUP_INTERVAL directly: it is a pydantic
+        field guaranteed present and ``>= 300`` (see AuthSettings), so no
+        defaulting or type-coercion guard is needed here.
+        """
         if self._interval_override is not None:
             return float(self._interval_override)
-        try:
-            return float(getattr(auth_settings, "AUTHZ_AUDIT_CLEANUP_INTERVAL", DEFAULT_CLEANUP_INTERVAL_SECONDS))
-        except (TypeError, ValueError):
-            return float(DEFAULT_CLEANUP_INTERVAL_SECONDS)
+        return float(auth_settings.AUTHZ_AUDIT_CLEANUP_INTERVAL)
 
     async def start(self) -> None:
         """Start the periodic cleanup task, honouring the audit/retention gates."""

--- a/src/backend/tests/unit/services/authorization/test_audit_cleanup_worker.py
+++ b/src/backend/tests/unit/services/authorization/test_audit_cleanup_worker.py
@@ -1,0 +1,241 @@
+"""Tests for the scheduled ``authz_audit_log`` retention worker.
+
+These cover the behaviour that the startup-only sweep lacked (gap C): the
+cleanup must run repeatedly on a recurring schedule, must be a no-op when
+retention is disabled (``AUTHZ_AUDIT_RETENTION_DAYS=0``) or auditing is off
+(``AUTHZ_AUDIT_ENABLED=False``), and must keep best-effort semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.auth import AuthzAuditLog
+from langflow.services.task import audit_cleanup
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+def _svc(*, enabled: bool, retention: int, interval: int = 86400) -> SimpleNamespace:
+    """A stand-in settings service exposing only the audit knobs the worker reads."""
+    return SimpleNamespace(
+        auth_settings=SimpleNamespace(
+            AUTHZ_AUDIT_ENABLED=enabled,
+            AUTHZ_AUDIT_RETENTION_DAYS=retention,
+            AUTHZ_AUDIT_CLEANUP_INTERVAL=interval,
+        )
+    )
+
+
+def _audit_row(*, days_old: int, resource_id=None) -> AuthzAuditLog:
+    timestamp = datetime.now(timezone.utc) - timedelta(days=days_old)
+    return AuthzAuditLog(
+        user_id=uuid4(),
+        action="flow:read",
+        resource_type="flow",
+        resource_id=resource_id or uuid4(),
+        result="allow",
+        details={"domain": "*"},
+        timestamp=timestamp,
+    )
+
+
+@contextlib.asynccontextmanager
+async def _fake_session_scope():
+    """No-op session scope for tests that patch out the cleanup helper."""
+    yield SimpleNamespace()
+
+
+# --------------------------------------------------------------------------- #
+# Scheduling behaviour (the core of gap C)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_cleanup_repeatedly_on_schedule(monkeypatch):
+    """The worker invokes the retention helper repeatedly, not just once."""
+    cleanup = AsyncMock(return_value=3)
+    monkeypatch.setattr(audit_cleanup, "clean_authz_audit_log", cleanup)
+    monkeypatch.setattr(audit_cleanup, "session_scope", _fake_session_scope)
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=True, retention=90))
+
+    worker = audit_cleanup.AuditLogCleanupWorker(interval=0.03)
+    await worker.start()
+    assert worker._task is not None
+    try:
+        # Several intervals worth of wall-clock; sleep-first means the first
+        # sweep lands one interval in, with more following.
+        await asyncio.sleep(0.25)
+    finally:
+        await worker.stop()
+
+    assert worker._task is None
+    assert cleanup.call_count >= 2, f"expected recurring sweeps, got {cleanup.call_count}"
+
+
+@pytest.mark.asyncio
+async def test_worker_is_noop_when_retention_disabled(monkeypatch):
+    """AUTHZ_AUDIT_RETENTION_DAYS=0 -> no task is scheduled and nothing is pruned."""
+    cleanup = AsyncMock()
+    monkeypatch.setattr(audit_cleanup, "clean_authz_audit_log", cleanup)
+    monkeypatch.setattr(audit_cleanup, "session_scope", _fake_session_scope)
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=True, retention=0))
+
+    worker = audit_cleanup.AuditLogCleanupWorker(interval=0.02)
+    await worker.start()
+    assert worker._task is None  # never scheduled
+    await asyncio.sleep(0.08)
+    cleanup.assert_not_called()
+    await worker.stop()  # safe no-op
+
+
+@pytest.mark.asyncio
+async def test_worker_is_noop_when_audit_disabled(monkeypatch):
+    """AUTHZ_AUDIT_ENABLED=False -> no task is scheduled and nothing is pruned."""
+    cleanup = AsyncMock()
+    monkeypatch.setattr(audit_cleanup, "clean_authz_audit_log", cleanup)
+    monkeypatch.setattr(audit_cleanup, "session_scope", _fake_session_scope)
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=False, retention=90))
+
+    worker = audit_cleanup.AuditLogCleanupWorker(interval=0.02)
+    await worker.start()
+    assert worker._task is None
+    await asyncio.sleep(0.08)
+    cleanup.assert_not_called()
+    await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_worker_start_stop_and_idempotency(monkeypatch):
+    """start()/stop() manage the task and tolerate double calls."""
+    cleanup = AsyncMock()
+    monkeypatch.setattr(audit_cleanup, "clean_authz_audit_log", cleanup)
+    monkeypatch.setattr(audit_cleanup, "session_scope", _fake_session_scope)
+    # interval read from settings (5s) so no sweep fires during the short test.
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=True, retention=90, interval=5))
+
+    worker = audit_cleanup.AuditLogCleanupWorker()
+    await worker.start()
+    assert worker._task is not None
+    assert not worker._stop_event.is_set()
+    assert worker._interval == 5  # resolved from AUTHZ_AUDIT_CLEANUP_INTERVAL
+
+    first_task = worker._task
+    await worker.start()  # already running -> no-op, same task
+    assert worker._task is first_task
+
+    await worker.stop()
+    assert worker._task is None
+    assert worker._stop_event.is_set()
+    await worker.stop()  # idempotent no-op
+
+
+@pytest.mark.asyncio
+async def test_worker_survives_cleanup_failure(monkeypatch):
+    """A failing sweep is swallowed and the loop keeps going."""
+    cleanup = AsyncMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(audit_cleanup, "clean_authz_audit_log", cleanup)
+    monkeypatch.setattr(audit_cleanup, "session_scope", _fake_session_scope)
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=True, retention=90))
+
+    worker = audit_cleanup.AuditLogCleanupWorker(interval=0.03)
+    await worker.start()
+    try:
+        await asyncio.sleep(0.2)
+    finally:
+        await worker.stop()
+
+    # Despite every sweep raising, the worker kept scheduling more.
+    assert cleanup.call_count >= 2
+
+
+def test_interval_resolution_prefers_override():
+    """The constructor override wins; otherwise the setting (then default) is used."""
+    overridden = audit_cleanup.AuditLogCleanupWorker(interval=1.5)
+    assert overridden._resolve_interval(SimpleNamespace(AUTHZ_AUDIT_CLEANUP_INTERVAL=99)) == 1.5
+
+    from_settings = audit_cleanup.AuditLogCleanupWorker()
+    assert from_settings._resolve_interval(SimpleNamespace(AUTHZ_AUDIT_CLEANUP_INTERVAL=99)) == 99.0
+    # Missing/garbage setting falls back to the module default.
+    assert from_settings._resolve_interval(SimpleNamespace()) == float(audit_cleanup.DEFAULT_CLEANUP_INTERVAL_SECONDS)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: real retention helper deletes real rows on the schedule
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(name="audit_engine")
+async def audit_engine():
+    """A shared in-memory SQLite engine (StaticPool so every session sees the same DB)."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+def _scope_factory(engine):
+    @contextlib.asynccontextmanager
+    async def _scope():
+        # Mirror the real session_scope: commit on clean exit, roll back on error.
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    return _scope
+
+
+async def _count(engine, resource_id) -> int:
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        rows = (await session.exec(select(AuthzAuditLog).where(AuthzAuditLog.resource_id == resource_id))).all()
+    return len(rows)
+
+
+@pytest.mark.asyncio
+async def test_worker_prunes_old_rows_on_schedule(audit_engine, monkeypatch):
+    """A row inserted after startup is pruned by the scheduled worker; fresh rows survive."""
+    old_id = uuid4()
+    fresh_id = uuid4()
+    async with AsyncSession(audit_engine, expire_on_commit=False) as session:
+        session.add(_audit_row(days_old=120, resource_id=old_id))  # outside 90-day window
+        session.add(_audit_row(days_old=2, resource_id=fresh_id))  # inside window
+        await session.commit()
+
+    monkeypatch.setattr(audit_cleanup, "session_scope", _scope_factory(audit_engine))
+    monkeypatch.setattr(audit_cleanup, "get_settings_service", lambda: _svc(enabled=True, retention=90))
+
+    worker = audit_cleanup.AuditLogCleanupWorker(interval=0.05)
+    await worker.start()
+    old_remaining = 1
+    try:
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + 5.0
+        while loop.time() < deadline:
+            await asyncio.sleep(0.1)
+            old_remaining = await _count(audit_engine, old_id)
+            if old_remaining == 0:
+                break
+    finally:
+        await worker.stop()
+
+    # The stale row was deleted by the recurring worker (the seed happened after
+    # any startup sweep would have run), and the fresh row was left intact.
+    assert old_remaining == 0
+    assert await _count(audit_engine, fresh_id) == 1

--- a/src/backend/tests/unit/services/authorization/test_audit_cleanup_worker.py
+++ b/src/backend/tests/unit/services/authorization/test_audit_cleanup_worker.py
@@ -158,14 +158,16 @@ async def test_worker_survives_cleanup_failure(monkeypatch):
 
 
 def test_interval_resolution_prefers_override():
-    """The constructor override wins; otherwise the setting (then default) is used."""
+    """The constructor override wins; otherwise the value comes from the setting.
+
+    AUTHZ_AUDIT_CLEANUP_INTERVAL is a pydantic field (default 86400, ge=300), so
+    the worker reads it directly without a missing/garbage fallback.
+    """
     overridden = audit_cleanup.AuditLogCleanupWorker(interval=1.5)
     assert overridden._resolve_interval(SimpleNamespace(AUTHZ_AUDIT_CLEANUP_INTERVAL=99)) == 1.5
 
     from_settings = audit_cleanup.AuditLogCleanupWorker()
     assert from_settings._resolve_interval(SimpleNamespace(AUTHZ_AUDIT_CLEANUP_INTERVAL=99)) == 99.0
-    # Missing/garbage setting falls back to the module default.
-    assert from_settings._resolve_interval(SimpleNamespace()) == float(audit_cleanup.DEFAULT_CLEANUP_INTERVAL_SECONDS)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -163,6 +163,17 @@ class AuthSettings(BaseSettings):
             "enterprise deployments."
         ),
     )
+    AUTHZ_AUDIT_CLEANUP_INTERVAL: int = Field(
+        default=86400,
+        ge=300,
+        description=(
+            "Seconds between scheduled ``authz_audit_log`` retention sweeps. A sweep runs once at "
+            "startup; thereafter a background worker prunes rows older than "
+            "AUTHZ_AUDIT_RETENTION_DAYS every interval so a long-running instance stays bounded "
+            "between restarts. The worker only runs when AUTHZ_AUDIT_ENABLED is True and "
+            "AUTHZ_AUDIT_RETENTION_DAYS > 0. Default 86400 (daily); minimum 300 (5 minutes)."
+        ),
+    )
 
     pwd_context: CryptContext = CryptContext(schemes=["bcrypt"], deprecated="auto")
 


### PR DESCRIPTION
## Problem

`clean_authz_audit_log()` ([`services/utils.py`](src/backend/base/langflow/services/utils.py)) is implemented and unit-tested, and bulk-deletes `authz_audit_log` rows older than `AUTHZ_AUDIT_RETENTION_DAYS` (default 90; `0` disables). But it was invoked **exactly once**, at startup inside `initialize_services()`. A long-running instance never pruned again after boot, so the table grew unbounded between restarts — even though the retention field's own docstring promised rows are "deleted on startup **and by the periodic cleanup task**." The periodic task did not exist; this PR adds it. (Closes gap **C** of the OSS RBAC rollout on `release-1.10.0`.)

## Change

Wire the existing helper to a recurring background worker, modelled on the sibling [`temp_flow_cleanup.CleanupWorker`](src/backend/base/langflow/services/task/temp_flow_cleanup.py):

- **`AuditLogCleanupWorker`** — new module [`services/task/audit_cleanup.py`](src/backend/base/langflow/services/task/audit_cleanup.py). A stop-event-driven `asyncio` task that prunes on a fixed interval, each sweep opening its **own `session_scope()`**. Best-effort: the helper already logs-and-swallows DB errors, and an outer guard keeps the loop alive across transient outages, so it never blocks the event loop or the request path.
- **Gating** — the worker only schedules when `AUTHZ_AUDIT_ENABLED` is `True` **and** `AUTHZ_AUDIT_RETENTION_DAYS > 0`. Otherwise `start()` is a quiet no-op (no task created). `retention=0` therefore stays a no-op end to end.
- **Sleep-first loop** — the unconditional startup sweep still prunes at boot, so the first scheduled pass waits one interval to avoid a redundant immediate delete. **The startup sweep is left unchanged.**
- **New setting** — `AUTHZ_AUDIT_CLEANUP_INTERVAL` (`AuthSettings`), default `86400` (daily), floor `300s`.
- **Lifespan wiring** — started right after the telemetry writer and stopped in the shutdown "Cancelling Background Tasks" step, both wrapped best-effort so cleanup scheduling can never block startup/shutdown.

## Why a worker (not a setting-only change)

The retention logic already existed and was correct — the only missing piece was *recurrence*. Reusing the helper verbatim (rather than reimplementing the delete) keeps the bounded-table guarantee in one place, and the `CleanupWorker` shape is already the established pattern in this package for periodic DB cleanup.

## Tests

New [`test_audit_cleanup_worker.py`](src/backend/tests/unit/services/authorization/test_audit_cleanup_worker.py) (7 tests):

- **`test_worker_runs_cleanup_repeatedly_on_schedule`** — the acceptance test: the helper is invoked ≥2× on a tiny interval, proving recurrence (not just a startup call).
- **`test_worker_is_noop_when_retention_disabled`** — `AUTHZ_AUDIT_RETENTION_DAYS=0` ⇒ no task scheduled, helper never called.
- **`test_worker_is_noop_when_audit_disabled`** — `AUTHZ_AUDIT_ENABLED=False` ⇒ no-op.
- **`test_worker_prunes_old_rows_on_schedule`** — end-to-end against a real SQLite engine: a row inserted *after* startup is pruned by the scheduled worker while an in-window row survives.
- Plus start/stop idempotency, interval resolution (override vs setting vs default), and resilience to a failing sweep.

```
26 passed   # new file + existing audit/retention/authorization-service suites
```

Backend `ruff check`/`ruff format` clean; all pre-commit hooks (incl. detect-secrets) pass.

## Notes / non-goals

- Like the existing startup sweep and `temp_flow_cleanup`, each uvicorn worker runs its own sweep. The delete is a single idempotent `WHERE timestamp < cutoff`, so concurrent sweeps after the first are no-ops; a distributed lock is intentionally out of scope (EE territory).
- Gates are read at `start()` (the env-configured common case). Runtime-toggling `AUTHZ_AUDIT_ENABLED` to `False` leaves a harmless pruner running until restart; the helper's internal `retention<=0` check is the per-tick defense for retention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic periodic cleanup of authorization audit logs to prevent indefinite database accumulation.
  * Background worker runs daily by default to remove expired audit entries.
  * Cleanup respects audit logging configuration and only activates when auditing and retention are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->