### PR TITLE
fix(ci): make Biome lint non-blocking for release workflow calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,10 @@ jobs:
   lint-frontend:
     needs: [path-filter, set-ci-condition]
     name: Lint Frontend
+    # Non-blocking for release workflow calls — Biome is informational there.
+    # For regular PRs (inputs.release is false/unset) failures still show as
+    # failed but are excluded from ci_success gating (see ci_success needs).
+    continue-on-error: ${{ inputs.release == true }}
     if: |
       always() &&
       !cancelled() &&


### PR DESCRIPTION
When ci.yml is called from release.yml (inputs.release == true), a Biome failure was blocking all downstream publish and docker jobs via needs.ci.result == 'success'. Biome was already excluded from the ci_success gate for PR merges, but the reusable CI workflow itself could still fail when the lint job errored.

Add continue-on-error: ${{ inputs.release == true }} to lint-frontend so Biome failures are informational-only during release runs, while remaining visible (and blocking ci_success) on regular PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved release processes.

**Note:** This release contains no user-facing changes. The update is an internal infrastructure improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->