### PR TITLE
docs: update flow_utils.py comment after ON DELETE CASCADE migration

### DIFF
--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -105,9 +105,9 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # by default (requires PRAGMA foreign_keys = ON), and this function follows
         # the existing pattern of explicitly deleting all child records.
         await session.exec(delete(FlowVersion).where(FlowVersion.flow_id == flow_id))
-        # span.trace_id FK lacks ON DELETE CASCADE in the DDL, so spans must
-        # be removed before traces to avoid an FK violation under
-        # PRAGMA foreign_keys=ON.
+        # Explicit span deletion for clarity and SQLite compatibility.
+        # Database-level CASCADE exists, but explicit deletion ensures
+        # consistent behavior across all database backends.
         trace_ids = (await session.exec(select(TraceTable.id).where(TraceTable.flow_id == flow_id))).all()
         if trace_ids:
             await session.exec(delete(SpanTable).where(col(SpanTable.trace_id).in_(trace_ids)))


### PR DESCRIPTION
Updates the comment in `src/backend/base/langflow/api/utils/flow_utils.py` to reflect that the `span.trace_id` FK now has ON DELETE CASCADE in the DDL (via PR #13475).

The explicit span deletion is kept for SQLite compatibility and clarity, but the comment now correctly notes that DB-level CASCADE exists.

Fixes #12732 (follow-up nitpick from CodeRabbit review on PR #13475).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code clarity improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->