### PR TITLE
fix(database): resolve Alembic log to writable config dir, never crash on read-only filesystems

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -240,14 +240,32 @@ class DatabaseService(Service):
         elif Path(alembic_log_file).is_absolute():
             self.alembic_log_path = Path(alembic_log_file)
         else:
-            self.alembic_log_path = Path(langflow_dir) / alembic_log_file
+            # Resolve relative log paths against the writable runtime config
+            # directory, not the installed package directory. The package dir is
+            # read-only in hardened deployments (non-root containers, read-only
+            # root filesystems, Kubernetes), where writing into it raises OSError
+            # and crashes startup. config_dir is always writable (it defaults to
+            # platformdirs' user cache dir and is created on startup).
+            config_dir = getattr(self.settings_service.settings, "config_dir", None)
+            base_dir = Path(config_dir) if config_dir else langflow_dir
+            self.alembic_log_path = base_dir / alembic_log_file
 
     async def initialize_alembic_log_file(self):
-        if self.alembic_log_to_stdout:
+        log_path = self.alembic_log_path
+        if self.alembic_log_to_stdout or log_path is None:
             return
-        # Ensure the directory and file for the alembic log file exists
-        await anyio.Path(self.alembic_log_path.parent).mkdir(parents=True, exist_ok=True)
-        await anyio.Path(self.alembic_log_path).touch(exist_ok=True)
+        # Ensure the directory and file for the alembic log file exists. The
+        # migration log is diagnostic-only, so a read-only filesystem (hardened
+        # containers / Kubernetes) must never abort startup: warn and move on.
+        try:
+            await anyio.Path(log_path.parent).mkdir(parents=True, exist_ok=True)
+            await anyio.Path(log_path).touch(exist_ok=True)
+        except OSError as exc:
+            await logger.awarning(
+                f"Could not initialize the Alembic migration log at '{log_path}' ({exc}). "
+                "Migration output falls back to stdout. Set LANGFLOW_ALEMBIC_LOG_FILE to a writable path "
+                "or LANGFLOW_ALEMBIC_LOG_TO_STDOUT=true to silence this warning."
+            )
 
     def reload_engine(self) -> None:
         self._sanitize_database_url()
@@ -518,6 +536,33 @@ class DatabaseService(Service):
         # alembic_cfg.attributes["connection"].commit()
         command.upgrade(alembic_cfg, "head")
 
+    def _open_alembic_log_buffer(self):
+        """Open the Alembic migration log for writing, falling back to stdout.
+
+        The migration log is diagnostic-only output. If the target path cannot
+        be written -- e.g. the installed package directory or the root
+        filesystem is read-only, as in hardened container/Kubernetes deployments
+        (non-root user or read-only root filesystem) -- startup must not abort.
+        Fall back to stdout rather than letting OSError propagate through the
+        FastAPI lifespan. Returns a context manager yielding the buffer Alembic
+        writes its output to.
+        """
+        log_path = self.alembic_log_path
+        if self.alembic_log_to_stdout or log_path is None:
+            return nullcontext(sys.stdout)
+        try:
+            # _run_migrations can run before initialize_alembic_log_file(), so
+            # make sure the parent directory exists before opening for writing.
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            return log_path.open("w", encoding="utf-8")
+        except OSError as exc:
+            logger.warning(
+                f"Could not open the Alembic migration log at '{log_path}' ({exc}). "
+                "Falling back to stdout. Set LANGFLOW_ALEMBIC_LOG_FILE to a writable path "
+                "or LANGFLOW_ALEMBIC_LOG_TO_STDOUT=true to silence this warning."
+            )
+            return nullcontext(sys.stdout)
+
     def _run_migrations(self, should_initialize_alembic, fix) -> None:
         # First we need to check if alembic has been initialized
         # If not, we need to initialize it
@@ -528,9 +573,7 @@ class DatabaseService(Service):
         # which is a buffer
         # I don't want to output anything
         # subprocess.DEVNULL is an int
-        buffer_context = (
-            nullcontext(sys.stdout) if self.alembic_log_to_stdout else self.alembic_log_path.open("w", encoding="utf-8")  # type: ignore[union-attr]
-        )
+        buffer_context = self._open_alembic_log_buffer()
         # The advisory lock serialises concurrent migration runs across workers
         # so they do not race on CREATE TYPE / CREATE TABLE against a fresh PG.
         with _postgres_migration_lock(self.database_url), buffer_context as buffer:

--- a/src/backend/tests/unit/services/database/test_alembic_log_path.py
+++ b/src/backend/tests/unit/services/database/test_alembic_log_path.py
@@ -1,0 +1,166 @@
+"""Tests for Alembic migration-log path resolution and read-only resilience.
+
+Regression coverage for https://github.com/langflow-ai/langflow/issues/11143:
+the default Alembic log path resolved into the installed package directory,
+which is read-only in hardened container/Kubernetes deployments (non-root user
+or read-only root filesystem). Opening it for writing raised an unhandled
+``OSError: [Errno 30] Read-only file system`` and crashed startup
+(CrashLoopBackOff).
+
+The fix:
+1. Relative log paths resolve against the writable ``config_dir`` instead of the
+   package directory (root cause).
+2. Opening the log and initializing it both degrade gracefully to stdout when
+   the target is not writable, since the migration log is diagnostic-only and
+   must never abort startup (defense in depth).
+"""
+
+import errno
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langflow.services.database.service import DatabaseService
+
+
+def _make_service(
+    *,
+    config_dir: str,
+    alembic_log_file: str = "alembic/alembic.log",
+    alembic_log_to_stdout: bool = False,
+) -> DatabaseService:
+    """Construct a DatabaseService with a mocked settings service.
+
+    The engine is patched out (mirrors the existing Windows/Postgres tests);
+    only the settings relevant to log-path resolution are populated.
+    """
+    mock_settings_service = MagicMock()
+    settings = mock_settings_service.settings
+    settings.database_url = "sqlite:///test.db"
+    settings.database_connection_retry = False
+    settings.sqlite_pragmas = {}
+    settings.db_driver_connection_settings = None
+    settings.db_connection_settings = {}
+    settings.alembic_log_file = alembic_log_file
+    settings.alembic_log_to_stdout = alembic_log_to_stdout
+    settings.config_dir = config_dir
+
+    with patch("langflow.services.database.service.create_async_engine", return_value=MagicMock()):
+        return DatabaseService(mock_settings_service)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution (root cause)
+# ---------------------------------------------------------------------------
+
+
+class TestAlembicLogPathResolution:
+    def test_relative_path_resolves_under_config_dir_not_package(self, tmp_path):
+        """A relative log path must resolve under the writable config_dir.
+
+        It must NOT resolve into the installed langflow package directory, which
+        is the read-only location that caused the crash.
+        """
+        import langflow
+
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file="alembic/alembic.log")
+
+        assert service.alembic_log_path == tmp_path / "alembic" / "alembic.log"
+        # Guard against regressing to the package directory.
+        package_dir = Path(langflow.__file__).parent.resolve()
+        assert package_dir not in service.alembic_log_path.resolve().parents
+
+    def test_absolute_path_is_preserved(self, tmp_path):
+        """An absolute LANGFLOW_ALEMBIC_LOG_FILE is used verbatim."""
+        absolute = tmp_path / "custom" / "alembic.log"
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file=str(absolute))
+        assert service.alembic_log_path == absolute
+
+    def test_stdout_mode_yields_no_path(self, tmp_path):
+        """When logging to stdout, no file path is resolved."""
+        service = _make_service(config_dir=str(tmp_path), alembic_log_to_stdout=True)
+        assert service.alembic_log_path is None
+
+
+# ---------------------------------------------------------------------------
+# _open_alembic_log_buffer (the actual crash point)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAlembicLogBuffer:
+    def test_writable_path_opens_real_file(self, tmp_path):
+        """On a writable filesystem the buffer is the real log file, not stdout."""
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file="alembic/alembic.log")
+        with service._open_alembic_log_buffer() as buffer:
+            assert buffer is not sys.stdout
+            buffer.write("hello\n")
+        assert service.alembic_log_path.exists()
+        assert service.alembic_log_path.read_text(encoding="utf-8") == "hello\n"
+
+    def test_stdout_mode_returns_stdout(self, tmp_path):
+        service = _make_service(config_dir=str(tmp_path), alembic_log_to_stdout=True)
+        with service._open_alembic_log_buffer() as buffer:
+            assert buffer is sys.stdout
+
+    def test_oserror_falls_back_to_stdout(self, tmp_path):
+        """A read-only filesystem (EROFS) must fall back to stdout, not raise.
+
+        This is the deterministic regression test for issue #11143: it does not
+        depend on real filesystem permissions (which root bypasses in CI).
+        """
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file="alembic.log")
+        path_type = type(service.alembic_log_path)
+        with (
+            patch.object(path_type, "mkdir", return_value=None),
+            patch.object(path_type, "open", side_effect=OSError(errno.EROFS, "Read-only file system")),
+        ):
+            ctx = service._open_alembic_log_buffer()
+        with ctx as buffer:
+            assert buffer is sys.stdout
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits do not restrict directory writes on Windows")
+    def test_readonly_directory_falls_back_to_stdout(self, tmp_path):
+        """End-to-end repro: a real read-only directory must not crash startup."""
+        readonly_dir = tmp_path / "ro"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            if os.access(readonly_dir, os.W_OK):
+                pytest.skip("Filesystem does not enforce write permission (likely running as root)")
+            service = _make_service(config_dir=str(readonly_dir), alembic_log_file="alembic.log")
+            # Must not raise OSError: [Errno 30] Read-only file system.
+            with service._open_alembic_log_buffer() as buffer:
+                assert buffer is sys.stdout
+        finally:
+            readonly_dir.chmod(stat.S_IRWXU)
+
+
+# ---------------------------------------------------------------------------
+# initialize_alembic_log_file resilience
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeAlembicLogFile:
+    async def test_creates_log_file_when_writable(self, tmp_path):
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file="alembic/alembic.log")
+        await service.initialize_alembic_log_file()
+        assert service.alembic_log_path.exists()
+
+    async def test_stdout_mode_is_noop(self, tmp_path):
+        service = _make_service(config_dir=str(tmp_path), alembic_log_to_stdout=True)
+        # Should return immediately without touching the filesystem.
+        await service.initialize_alembic_log_file()
+
+    async def test_oserror_is_swallowed(self, tmp_path):
+        """A read-only filesystem during init must not abort startup."""
+        service = _make_service(config_dir=str(tmp_path), alembic_log_file="alembic.log")
+        with patch("langflow.services.database.service.anyio.Path") as mock_anyio_path:
+            instance = mock_anyio_path.return_value
+            instance.mkdir = AsyncMock(side_effect=OSError(errno.EROFS, "Read-only file system"))
+            instance.touch = AsyncMock()
+            # Must not raise.
+            await service.initialize_alembic_log_file()
+            instance.mkdir.assert_awaited()


### PR DESCRIPTION
## Problem

Deploying Langflow on Kubernetes (official image) with a minimal Helm `values.yaml` — or any read-only-rootfs / non-root container posture — crashes the backend pod into `CrashLoopBackOff` during startup:

```
[error] [Errno 30] Read-only file system: '/app/.venv/lib/python3.12/site-packages/langflow/alembic/alembic.log'
  File ".../langflow/services/database/service.py", line ..., in _run_migrations
    nullcontext(sys.stdout) if self.alembic_log_to_stdout else self.alembic_log_path.open("w", encoding="utf-8")
OSError: [Errno 30] Read-only file system: '.../site-packages/langflow/alembic/alembic.log'
[error] Application startup failed. Exiting.
```

`DO_NOT_TRACK=true` (cited in the original report) is a **red herring** — with a writable config dir + database, the only failing write is the Alembic log inside the read-only package directory.

Fixes #11143

## Root cause

The default `alembic_log_file = "alembic/alembic.log"` is a **relative** path that was resolved against the installed **package directory** (`<site-packages>/langflow`), then opened for writing with no error handling. Package install locations are expected to be immutable/read-only; writing mutable runtime state there is an anti-pattern. Every other writable Langflow artifact already resolves to `config_dir`/`cache_dir` (via `platformdirs.user_cache_dir`) — only the Alembic log resolved into `site-packages`.

The crash surfaces in `_run_migrations` (the unguarded `.open("w")`), which runs **before** `initialize_alembic_log_file()` in the startup sequence — so guarding/relocating only the `touch()` would not have fixed it.

## Fix

1. **Relocate the default (root cause):** relative `alembic_log_file` paths now resolve against the writable `config_dir` instead of the read-only package directory. Absolute paths and `alembic_log_to_stdout` mode are unchanged.
2. **Guard the open (defense in depth):** new `_open_alembic_log_buffer()` creates the parent directory, then falls back to `stdout` with a warning if opening the log raises `OSError`. This is the actual crash point.
3. **Guard init:** `initialize_alembic_log_file()` now swallows `OSError` for the same reason.

The migration log is diagnostic-only output and must never abort startup. On any filesystem that *can* write it, behavior is the new (writable) location; on one that can't, output degrades to stdout — identical to the already-supported `LANGFLOW_ALEMBIC_LOG_TO_STDOUT=true` path.

### Note (out of scope)
A fully read-only root filesystem also needs writable mounts for the data/control-server dir (`/app/data`) — a separate path. The official Helm chart provides such volumes (and sets an explicit `LANGFLOW_ALEMBIC_LOG_FILE`), which is why it doesn't crash. This PR makes the **out-of-the-box** default safe.

## Backward compatibility

- Deployments setting `LANGFLOW_ALEMBIC_LOG_FILE` (absolute) or `LANGFLOW_ALEMBIC_LOG_TO_STDOUT=true` are unaffected.
- For default installs the log moves from `<site-packages>/langflow/alembic/alembic.log` to `<config_dir>/alembic/alembic.log` (the conventional, writable location). Nothing reads the log back from the old path.

## Test plan

New `src/backend/tests/unit/services/database/test_alembic_log_path.py` (10 tests, all passing):

- [x] Relative path resolves under `config_dir`, **not** the package dir (regression guard)
- [x] Absolute path preserved; stdout mode yields no path
- [x] Writable path opens a real file and writes land in it
- [x] `OSError`/EROFS on open → falls back to stdout, no raise (deterministic, root-independent)
- [x] Real read-only directory → falls back to stdout (skipped on Windows / when running as root)
- [x] `initialize_alembic_log_file()` creates the file when writable, no-ops in stdout mode, swallows `OSError`
- [x] Existing DB tests green: `140 passed` across `tests/unit/services/database/` + path-resolution + Windows/Postgres integration
- [x] `ruff check`/`ruff format` clean; no new mypy errors on the changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration logging reliability by gracefully falling back to console output when log file creation fails in restricted filesystem environments
  * Migration log paths now resolve from a writable configuration directory instead of the package installation directory

* **Tests**
  * Added comprehensive test coverage for migration log path resolution and fallback behavior in read-only filesystem scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->