### PR TITLE
fix(ci): create GitHub release on the source tag, not main HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1188,6 +1188,7 @@ jobs:
           draft: false
           generateReleaseNotes: true
           prerelease: ${{ inputs.pre_release }}
-          tag: ${{ needs.determine-main-version.outputs.version }}
+          tag: ${{ inputs.release_tag }}
+          commit: ${{ inputs.release_tag }}
           allowUpdates: true
           updateOnlyUnreleased: false


### PR DESCRIPTION
The release notes for 1.10.0 only listed 2 PRs because the release got tagged on the wrong commit.

The `create_release` job tagged the release with `determine-main-version.outputs.version`, which strips the `v` prefix (line 260, `sed 's/^v//'`), and passed no `commit`. So ncipollo created a brand new bare tag `1.10.0` at the default branch (main) HEAD instead of using the validated source tag `v1.10.0`.

You can see it on the live release: `1.10.0` has `tagName: 1.10.0`, `targetCommitish: main`, and the bare tag resolves to main HEAD (`e26dff2`), while `v1.10.0` points at the actual release commit. GitHub's `generateReleaseNotes` then compared the bare `1.10.0` against the previous bare tag `1.9.6`, so the changelog only picked up the handful of PRs merged directly to main and missed everything that shipped through the release branch.

This is the same vless-duplicate-tag failure the `validate-tag-format` job already warns about, except the workflow itself was creating the duplicate tag.

Fix: tag the release on `inputs.release_tag` (already validated to be `vX.Y.Z`) and pin the commit to it. GitHub then generates the notes against `v1.9.6` like it does for the rest of the 1.9.x line. `create-release.yml` already tags this way.

One manual follow-up this PR cannot do: the stray bare tags `1.9.6` and `1.10.0` are still on origin and could be picked as a comparison base on a future run. They should be deleted:

```
git push origin :refs/tags/1.9.6 :refs/tags/1.10.0
```

And the already-published 1.10.0 release needs to be re-created on `v1.10.0` to get the correct notes.