### PR TITLE
fix(test): raise spawn-child join timeout in test_multi_process_visibility

### DIFF
--- a/src/backend/tests/unit/test_flow_events_service.py
+++ b/src/backend/tests/unit/test_flow_events_service.py
@@ -225,7 +225,13 @@ def test_multi_process_visibility(tmp_path):
         args=(str(shared_dir), "flow-mp", "component_added", "from-other-process"),
     )
     proc.start()
-    proc.join(timeout=10)
+    # Generous bound: a spawned child cold-imports the full langflow package
+    # (plus coverage's multiprocessing hooks in CI), which can take >10s on a
+    # loaded CI runner sharing 4 vCPUs with another xdist worker.
+    proc.join(timeout=60)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=5)
     assert proc.exitcode == 0, "Child process failed to append event"
 
     reader = FlowEventsService(cache_dir=shared_dir)


### PR DESCRIPTION
## Problem

Nightly run 27253229568 failed on `Unit Tests - Python 3.12 - Group 5`: `test_flow_events_service.py::test_multi_process_visibility` failed **all 12 executions** (5 pytest reruns × 2 step attempts) with `AssertionError: Child process failed to append event`.

The reruns failed exactly 10s apart — the `proc.join(timeout=10)` deadline, not a product bug. The test spawns a child via the multiprocessing **spawn** context, which cold-imports the full langflow package (plus coverage's multiprocessing hooks in CI) before appending a single event. On a loaded runner sharing 4 vCPUs with a second xdist worker that routinely exceeds 10s. This is a latent flake exposed by the test-group rebalance in #13583 (the test now runs alongside heavier neighbors).

## Fix

- Raise the liveness bound to 60s — `join` returns as soon as the child exits, so the passing case is unaffected
- Kill the child if it's still alive at the deadline so a hung spawn can't leak into later tests

## Test plan

- [x] `uv run pytest src/backend/tests/unit/test_flow_events_service.py` — 16 passed in 5.3s locally
- [ ] Re-run nightly failed job after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of process shutdown handling in tests with enhanced timeout management and force-termination logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->