### PR TITLE
fix(test): raise spawn-child join timeout in test_multi_process_visibility (1.10.1)

### DIFF
--- a/src/backend/tests/unit/test_flow_events_service.py
+++ b/src/backend/tests/unit/test_flow_events_service.py
@@ -225,7 +225,13 @@ def test_multi_process_visibility(tmp_path):
         args=(str(shared_dir), "flow-mp", "component_added", "from-other-process"),
     )
     proc.start()
-    proc.join(timeout=10)
+    # Generous bound: a spawned child cold-imports the full langflow package
+    # (plus coverage's multiprocessing hooks in CI), which can take >10s on a
+    # loaded CI runner sharing 4 vCPUs with another xdist worker.
+    proc.join(timeout=60)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=5)
     assert proc.exitcode == 0, "Child process failed to append event"
 
     reader = FlowEventsService(cache_dir=shared_dir)


### PR DESCRIPTION
Port of #13588 to `release-1.10.1` (clean cherry-pick of 443f1fd3e0). See #13588 for details: the spawn-context child needs to cold-import the full langflow package and 10s is routinely exceeded on loaded CI runners; raised to 60s + kill-on-timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of multiprocessing test lifecycle handling with enhanced timeout and process termination logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->