### PR TITLE
fix(ci): anchor langflow-base version extraction in nightly docker build

### DIFF
--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -72,7 +72,11 @@ jobs:
         id: version
         run: |
           echo "Extracting base version from pyproject.toml"
-          version=$(uv tree 2>/dev/null | grep 'langflow-base' | awk '{print $3}' | sed 's/^v//' | head -n 1)
+          # Anchor to the langflow-base workspace-root line (same pattern as the
+          # langflow extraction below): the unanchored grep used to match a
+          # dependency line whose version sat in field 3, but uv tree now lists
+          # the langflow-base root line first, which has no third field.
+          version=$(uv tree 2>/dev/null | grep -E '^langflow-base[[:space:]]' | cut -d' ' -f2 | sed 's/^v//' | head -n 1)
 
 
           # Verify nightly tag format
@@ -351,7 +355,7 @@ jobs:
         id: version
         run: |
           if [[ "${{ inputs.release_type }}" == "nightly-base" ]]; then
-            version=$(uv tree 2>/dev/null | grep 'langflow-base' | awk '{print $3}' | sed 's/^v//' | head -n 1)
+            version=$(uv tree 2>/dev/null | grep -E '^langflow-base[[:space:]]' | cut -d' ' -f2 | sed 's/^v//' | head -n 1)
           else
             version=$(uv tree 2>/dev/null | grep -E '^langflow(-nightly)?[[:space:]]' | cut -d' ' -f2 | sed 's/^v//')
           fi


### PR DESCRIPTION
## Problem

The first nightly on the 1.11 workspace (tag `v1.11.0.dev0`, run 27253229568) failed in **Build Nightly Base Package** within 2 seconds: `Base version format is incorrect. Must be in the format (e.g.) v1.5.1.dev36`.

## Root cause (reproduced locally against the tag)

The base-image version extraction is unanchored:

```bash
version=$(uv tree 2>/dev/null | grep 'langflow-base' | awk '{print $3}' | sed 's/^v//' | head -n 1)
```

On the 1.11 workspace, `uv tree` now prints the `langflow-base` **workspace-root** line first (`langflow-base v1.11.0.dev0` — two fields), before any dependency line (three fields). The first grep match therefore yields an empty `$3`, and the format check exits 1. With `uv tree` stderr discarded, the real cause was invisible in CI.

The langflow (main package) extraction in the same file is anchored to the root line (`grep -E '^langflow(-nightly)?[[:space:]]' | cut -d' ' -f2`) — which is why the main-package builds passed on the same tag.

## Fix

Use the same anchored root-line pattern for `langflow-base` (both occurrences: `build-nightly-base` and the combined `Get version` step). Verified locally against a checkout of `v1.11.0.dev0`: both extractions print `1.11.0.dev0`.

## Test plan

- [x] Local verification against the actual failing tag
- [ ] Fresh nightly dispatch after merge (re-runs reuse the original run's workflow files, so the current run cannot pick this up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build workflow extraction logic to improve version detection consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->