### PR TITLE
fix(test): gate models.dev background refresh out of tests (main)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2837,7 +2837,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 490,
+        "line_number": 515,
         "is_secret": false
       },
       {
@@ -2845,7 +2845,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 700,
+        "line_number": 725,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T16:38:06Z"
+  "generated_at": "2026-06-10T08:36:23Z"
 }

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -479,7 +479,14 @@ def get_lifespan(*, fix_migration=False, version=None):
 
                     await asyncio.sleep(refresh_interval_seconds)
 
-            models_dev_refresh_task = asyncio.create_task(refresh_models_dev_periodically())
+            # LANGFLOW_MODELS_DEV_REFRESH=false disables the live models.dev
+            # fetch. Tests set this: the startup fetch otherwise fires from a
+            # background task during whatever test is running, hitting the
+            # network and tripping event-loop-block detectors (pyleak).
+            if os.getenv("LANGFLOW_MODELS_DEV_REFRESH", "true").lower() not in ("false", "0", "no"):
+                models_dev_refresh_task = asyncio.create_task(refresh_models_dev_periodically())
+            else:
+                await logger.adebug("models.dev refresh disabled via LANGFLOW_MODELS_DEV_REFRESH")
 
             # v1 and project MCP server context managers
             from langflow.api.v1.mcp import start_streamable_http_manager

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -50,6 +50,21 @@ def disable_rate_limiting():
     os.environ.pop("LANGFLOW_RATE_LIMIT_ENABLED", None)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def disable_models_dev_refresh():
+    """Keep the models.dev background refresh out of tests.
+
+    Every app boot otherwise launches a lifespan task that fetches
+    https://models.dev/api.json mid-test, which both hits the network and
+    trips event-loop-block detectors (pyleak) in whatever test happens to be
+    running when the request lands. The bundled static model lists are used
+    instead, which is also deterministic.
+    """
+    os.environ["LANGFLOW_MODELS_DEV_REFRESH"] = "false"
+    yield
+    os.environ.pop("LANGFLOW_MODELS_DEV_REFRESH", None)
+
+
 # TODO: Revert this to True once bb.functions[func].can_block_in("http/client.py", "_safe_read") is fixed
 @pytest.fixture(autouse=False)
 def blockbuster(request):


### PR DESCRIPTION
Forward-port of #13596 to `main` (cherry-pick of 0acfb3fcd1). See #13596: the unconditional models.dev startup fetch lands mid-test and trips pyleak's event-loop-block detector in random integration tests. Gated behind `LANGFLOW_MODELS_DEV_REFRESH` (default enabled) with a session-wide opt-out in the backend test conftest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable `LANGFLOW_MODELS_DEV_REFRESH` to control the models.dev background refresh task. Set to `false`, `0`, or `no` to disable the periodic refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->