### PR TITLE
fix(ci): allow pre-releases when pinning the nightly in migration validation

### DIFF
--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -182,13 +182,16 @@ jobs:
               # Install latest nightly (canonical pre-release) from PyPI
               uv pip install --upgrade --prerelease=allow 'langflow[postgresql]'
             else
-              # Install specific version
-              uv pip install --upgrade "langflow[postgresql]==$VERSION"
+              # Install specific version. --prerelease=allow is required even for an
+              # exact ==X.Y.Z.devN pin: uv only implicitly allows the pre-release for
+              # the directly requested package, while langflow's metadata pins
+              # langflow-base==X.Y.Z.devN transitively, which uv rejects without it.
+              uv pip install --upgrade --prerelease=allow "langflow[postgresql]==$VERSION"
             fi
           else
             # Direct version string (strip 'v' prefix if present)
             VERSION="${NIGHTLY_TAG#v}"
-            uv pip install --upgrade "langflow[postgresql]==$VERSION"
+            uv pip install --upgrade --prerelease=allow "langflow[postgresql]==$VERSION"
           fi
 
           # Verify upgrade


### PR DESCRIPTION
## Problem

`Migration Test: pip/venv (stable → nightly)` failed deterministically on nightly run 27260425158 (twice, including a re-run):

```
hint: `langflow-base` was requested with a pre-release marker (e.g., langflow-base==1.11.0.dev1),
but pre-releases weren't enabled (try: `--prerelease=allow`)
```

## Root cause

First nightly publishing as a **canonical `.devN` pre-release** of the `langflow` distribution (nightly → stable bundle cutover, #13528). The upgrade step's `latest` branch already passes `--prerelease=allow`, but the pinned-version branches don't. uv implicitly allows the pre-release for the **directly requested** `==X.Y.Z.devN` pin, yet langflow's metadata pins `langflow-base==X.Y.Z.devN` **transitively** — and uv rejects transitive pre-releases unless enabled. The install fails right after the stable uninstall, sinking the migration test.

## Fix

Add `--prerelease=allow` to both pinned-version install lines (no-op for stable `==X.Y.Z` pins, so release-channel validation is unaffected).

## Test plan

- [ ] Fresh nightly dispatch after merge (re-runs reuse the original run's workflow files, so the current run can't pick this up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database migration validation workflow to better support nightly release installations with enhanced prerelease version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->