### PR TITLE
fix(ci): scope nightly migration-test pre-releases to the langflow stack

### DIFF
--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -178,20 +178,26 @@ jobs:
             VERSION="${VERSION#v}"
             echo "Version for PyPI: $VERSION"
 
+            # Scope pre-release resolution to the langflow stack only. uv accepts a
+            # pre-release for a package when its own requirement carries a pre-release
+            # marker, but NOT via transitive pins (langflow -> langflow-base -> lfx ->
+            # langflow-sdk are exact ==devN pins on nightlies), so each lockstep package
+            # must be requested directly. A global --prerelease=allow is NOT safe here:
+            # it lets unrelated dependencies resolve to alphas (pydantic 2.14.0a1 broke
+            # langchain-core imports on the first canonical-prerelease nightly).
+            # langflow-sdk has its own version line, so an explicit .dev0 floor marks it
+            # pre-release-eligible while the lfx pin selects the exact version.
             if [[ "$VERSION" == "latest" ]]; then
               # Install latest nightly (canonical pre-release) from PyPI
-              uv pip install --upgrade --prerelease=allow 'langflow[postgresql]'
+              uv pip install --upgrade 'langflow[postgresql]>=0.0.0.dev0' 'langflow-base>=0.0.0.dev0' 'lfx>=0.0.0.dev0' 'langflow-sdk>=0.0.0.dev0'
             else
-              # Install specific version. --prerelease=allow is required even for an
-              # exact ==X.Y.Z.devN pin: uv only implicitly allows the pre-release for
-              # the directly requested package, while langflow's metadata pins
-              # langflow-base==X.Y.Z.devN transitively, which uv rejects without it.
-              uv pip install --upgrade --prerelease=allow "langflow[postgresql]==$VERSION"
+              # Install specific version
+              uv pip install --upgrade "langflow[postgresql]==$VERSION" "langflow-base==$VERSION" "lfx==$VERSION" 'langflow-sdk>=0.0.0.dev0'
             fi
           else
             # Direct version string (strip 'v' prefix if present)
             VERSION="${NIGHTLY_TAG#v}"
-            uv pip install --upgrade --prerelease=allow "langflow[postgresql]==$VERSION"
+            uv pip install --upgrade "langflow[postgresql]==$VERSION" "langflow-base==$VERSION" "lfx==$VERSION" 'langflow-sdk>=0.0.0.dev0'
           fi
 
           # Verify upgrade


### PR DESCRIPTION
## Problem

#13599's global `--prerelease=allow` fixed the install but overshot: on nightly run 27274206250 the stable→nightly upgrade resolved **pydantic 2.14.0a1** and pydantic-yaml 1.6.1a1 (alphas), and the pydantic alpha breaks langchain-core at import (`RunnablePassthrough` ValidationError) — so the nightly failed to boot right after a successful install. Clean installs (cross-platform jobs) were unaffected; only this in-place-upgrade resolution produced the alpha combo.

## Fix

Scope pre-release eligibility to the langflow lockstep stack: uv accepts a pre-release when the package's **own requirement** carries a pre-release marker, but not via transitive pins — and the nightly chain is `langflow → langflow-base → lfx → langflow-sdk`, all exact `==devN` pins. Request each directly; `langflow-sdk` versions independently (`0.2.0.devN`), so an explicit `.dev0` floor marks it eligible while lfx's exact pin selects the version. Same treatment for the `latest` branch.

## Verification

Dry-run against PyPI:

```
+ langflow==1.11.0.dev2, langflow-base==1.11.0.dev2, lfx==1.11.0.dev2, langflow-sdk==0.2.0.dev2
+ pydantic==2.13.4  (stable — no alphas anywhere in the 639-package resolution)
```

## Test plan

- [x] Local dry-run resolution (above)
- [ ] Fresh nightly dispatch after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database migration validation workflow to use explicit package versioning constraints, improving consistency and predictability of pre-release package resolution in nightly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->