### PR TITLE
fix(ci): attach GitHub releases to the dispatched v-prefixed tag, not an auto-created bare tag

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -337,6 +337,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: lfx-v${{ github.event.inputs.version }}
+          # The lfx-v* tag does not pre-exist, so the action creates it. Pin it
+          # to the dispatched commit; otherwise GitHub tags the default-branch
+          # HEAD, which is the wrong commit when releasing from a release branch.
+          target_commitish: ${{ github.sha }}
           name: LFX ${{ github.event.inputs.version }}
           body_path: release_notes.md
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1212,6 +1212,16 @@ jobs:
       needs.publish-main.result == 'success' &&
       needs.validate-tag-format.result == 'success'
     steps:
+      # Checkout must come first: resolve the commit the dispatched tag points
+      # at so the release can never attach to an auto-created tag on the
+      # default branch (see validate-tag-format for the duplicate-tag history).
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag }}
+      - name: Resolve release commit
+        id: release_commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         with:
           name: dist-main
@@ -1224,6 +1234,8 @@ jobs:
           draft: false
           generateReleaseNotes: true
           prerelease: ${{ inputs.pre_release }}
-          tag: ${{ needs.determine-main-version.outputs.version }}
+          tag: ${{ inputs.release_tag }}
+          commit: ${{ steps.release_commit.outputs.sha }}
+          name: ${{ needs.determine-main-version.outputs.version }}
           allowUpdates: true
           updateOnlyUnreleased: false


### PR DESCRIPTION
## Problem

`create_release` in `release.yml` creates the GitHub Release via `ncipollo/release-action@v1` with `tag: ${{ needs.determine-main-version.outputs.version }}` — the **bare** version (`determine-main-version` strips the `v` with `sed 's/^v//'`) and no `commit:` input.

The workflow is dispatched with a v-prefixed `release_tag` (e.g. `v1.10.0`), so the bare tag (`1.10.0`) doesn't exist. ncipollo then asks GitHub to create it, and with no commit specified GitHub mints a lightweight tag at the **default branch (main) HEAD at publish time** — the wrong commit, still carrying the *previous* version, since main only adopts the new version after the post-release back-merge.

This is the source of the existing stray tags:

| stray tag | points at | which is |
|---|---|---|
| `1.9.5` | `30b89779b74b` | a version-1.9.4 commit on main |
| `1.9.6` | `110bea828104` | the *Merge release-1.9.5 into main* commit |
| `1.10.0` | `e26dff25be2a` | a version-1.9.6 commit on main |

The `validate-tag-format` guard (#12847) only blocks at **dispatch** time — it cannot prevent `create_release` from minting the next stray at run end. It guards against the very duplicates this job creates.

## Fix

**`release.yml` (`create_release`):**
- `tag: ${{ inputs.release_tag }}` — the dispatched v-prefixed tag, already validated to exist by `validate-tag`.
- Belt-and-braces `commit:` resolved by checking out the tag and `git rev-parse HEAD`, so even if the tag were somehow missing, it could never be auto-created on the default branch.
- `name: ${{ needs.determine-main-version.outputs.version }}` keeps the release title as the bare version, matching all existing releases (e.g. release "1.10.0" on tag `v1.10.0`).

**`release-lfx.yml` (`create-release`):** same latent bug — no `lfx-v*` tag exists on the remote, so `softprops/action-gh-release` creates it, and without `target_commitish` GitHub tags the default-branch HEAD, which is wrong when the workflow is dispatched from a release branch. Pinned to `github.sha` (the commit the workflow validated and built).

**`create-release.yml`** already passes an explicit `commit: ${{ inputs.ref }}` and a v-prefixed tag — no change needed.

## Cleanup of existing stray tags (maintainer action after merge)

All three GitHub releases are now attached to the v-prefixed tags (`gh api repos/langflow-ai/langflow/releases/tags/v1.9.5|v1.9.6|v1.10.0` all resolve; the bare-tag lookups 404), so deleting the bare tags will **not** orphan any release assets or notes:

```bash
git push origin :refs/tags/1.10.0 :refs/tags/1.9.6 :refs/tags/1.9.5
```

This also fixes `generateReleaseNotes` base-comparison selection for future releases (the reason #12847 added the duplicate check).

## Ports

Release runs are dispatched on release branches and use that branch's workflow definition, so this needs to land on `release-1.10.1` and `release-1.11.0` as well — port PRs are stacked on this one. (`release.yml` and `release-lfx.yml` are currently byte-identical across all three branches, so the cherry-picks are clean.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process to ensure GitHub releases are correctly associated with their intended commits, enhancing reliability of release creation and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->