### PR TITLE
fix(ci): create GitHub releases on the dispatched v-prefixed tag (1.11.0)

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -337,6 +337,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: lfx-v${{ github.event.inputs.version }}
+          # Pin the minted tag to the commit this release was built from;
+          # without it GitHub creates the tag at the default-branch HEAD.
+          target_commitish: ${{ github.sha }}
           name: LFX ${{ github.event.inputs.version }}
           body_path: release_notes.md
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1216,6 +1216,20 @@ jobs:
         with:
           name: dist-main
           path: dist
+      # The release must attach to the dispatched v-prefixed tag. Passing the
+      # bare version as `tag` made GitHub mint a new lightweight tag at the
+      # default-branch HEAD — the wrong commit, still carrying the previous
+      # version (main only adopts the new version via the post-release
+      # back-merge). Pre-releases keep their computed tag (e.g. 1.10.0rc1),
+      # but `commit` pins any newly minted tag to the release commit.
+      - name: Resolve release commit
+        id: release_commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.release_tag }}" --jq '.sha')
+          echo "Release tag '${{ inputs.release_tag }}' resolves to commit $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -1224,6 +1238,8 @@ jobs:
           draft: false
           generateReleaseNotes: true
           prerelease: ${{ inputs.pre_release }}
-          tag: ${{ needs.determine-main-version.outputs.version }}
+          tag: ${{ inputs.pre_release && needs.determine-main-version.outputs.version || inputs.release_tag }}
+          name: ${{ needs.determine-main-version.outputs.version }}
+          commit: ${{ steps.release_commit.outputs.sha }}
           allowUpdates: true
           updateOnlyUnreleased: false


### PR DESCRIPTION
Port of #13608 to `release-1.11.0` — release runs are dispatched on release branches and use that branch's workflow definition, so the fix must exist here for the next release run (clean cherry-pick of 65aa85e16f; the workflow files are byte-identical across main and both release branches).

See #13608 for the full analysis: `create_release` tagged the GitHub Release with the bare version and no `commit:`, so GitHub minted a stray lightweight tag at main HEAD carrying the previous version (stray tags `1.8.2`–`1.10.0`). Stable releases now attach to the dispatched `inputs.release_tag`; pre-releases keep their computed tag but get `commit:` pinned to the resolved release SHA; `release-lfx.yml` pins `target_commitish` to `github.sha`.
