### PR TITLE
fix(ci): create GitHub releases on the dispatched v-prefixed tag

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -337,6 +337,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: lfx-v${{ github.event.inputs.version }}
+          # Pin the minted tag to the commit this release was built from;
+          # without it GitHub creates the tag at the default-branch HEAD.
+          target_commitish: ${{ github.sha }}
           name: LFX ${{ github.event.inputs.version }}
           body_path: release_notes.md
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1216,6 +1216,20 @@ jobs:
         with:
           name: dist-main
           path: dist
+      # The release must attach to the dispatched v-prefixed tag. Passing the
+      # bare version as `tag` made GitHub mint a new lightweight tag at the
+      # default-branch HEAD — the wrong commit, still carrying the previous
+      # version (main only adopts the new version via the post-release
+      # back-merge). Pre-releases keep their computed tag (e.g. 1.10.0rc1),
+      # but `commit` pins any newly minted tag to the release commit.
+      - name: Resolve release commit
+        id: release_commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.release_tag }}" --jq '.sha')
+          echo "Release tag '${{ inputs.release_tag }}' resolves to commit $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -1224,6 +1238,8 @@ jobs:
           draft: false
           generateReleaseNotes: true
           prerelease: ${{ inputs.pre_release }}
-          tag: ${{ needs.determine-main-version.outputs.version }}
+          tag: ${{ inputs.pre_release && needs.determine-main-version.outputs.version || inputs.release_tag }}
+          name: ${{ needs.determine-main-version.outputs.version }}
+          commit: ${{ steps.release_commit.outputs.sha }}
           allowUpdates: true
           updateOnlyUnreleased: false


### PR DESCRIPTION
## Problem

Every stable release since 1.8.2 has shipped a **stray, un-prefixed git tag pointing at the wrong commit**. Checking out tag `1.10.0` shows `version = "1.9.6"` in `pyproject.toml`, `uv.lock`, and `src/frontend/package.json`.

Root cause: the `create_release` job in `release.yml` calls `ncipollo/release-action` with `tag: ${{ needs.determine-main-version.outputs.version }}` — the bare version with the `v` stripped — and no `commit:` input. The workflow is dispatched with the v-prefixed `release_tag` (e.g. `v1.10.0`), so the bare tag doesn't exist, and GitHub auto-creates a lightweight tag at the **default-branch HEAD at publish time**. Since `main` only adopts a release's version via the post-release back-merge, that commit always carries the *previous* version:

| stray tag | points at | version there |
|---|---|---|
| `1.8.2` | `cacb54d601` (main) | 1.8.1 |
| `1.8.3` | `08bf98404c` (main) | 1.8.1 |
| `1.9.5` | `30b89779b7` (main) | 1.9.4 |
| `1.9.6` | `110bea8281` (main) | 1.9.5 |
| `1.10.0` | `e26dff25be` (main) | 1.9.6 |

The GitHub release row also gets created on the bare tag, which is why every release from 1.9.0 onward had to be manually re-pointed to its `vX.Y.Z` tag afterward. The `validate-tag-format` guard (#12847) only blocks at *dispatch* time — `create_release` was re-creating the very duplicates the guard exists to catch.

## Fix

**`release.yml` — `create_release`:**
- Stable releases now attach to `${{ inputs.release_tag }}` (the validated, existing `vX.Y.Z` tag), matching what the standalone `create-release.yml` already does.
- Pre-releases keep their computed tag (e.g. `1.10.0rc1`), but a new `Resolve release commit` step resolves `release_tag` to a SHA and passes it as `commit:`, so any newly minted tag lands on the release commit instead of main HEAD.
- `name:` is set explicitly to the bare version so release display names stay as before (`1.10.1`, not `v1.10.1`).

**`release-lfx.yml` — `create-release`:**
- Adds `target_commitish: ${{ github.sha }}` so a minted `lfx-v*` tag points at the commit the release was built from, not the default branch (same bug class, latent since no `lfx-v*` tag has been minted via this path yet).

## Already remediated (no action needed)

The GitHub releases for 1.8.2, 1.8.3, 1.9.5, and 1.9.6 were re-pointed to their correct `vX.Y.Z` tags via the API on 2026-06-10; 1.9.0–1.9.4 and 1.10.0 had already been fixed manually.

## Remaining cleanup (deliberately not in this PR)

The stray bare tags (`1.8.2`, `1.8.3`, `1.9.0`, `1.9.2`–`1.9.6`, `1.10.0`) still exist and should be deleted once everyone agrees (`git push origin :refs/tags/<tag>`); `validate-tag-format` will block a re-dispatch of an affected version until its duplicate is removed.

> [!IMPORTANT]
> Release runs are dispatched on release branches and use that branch's workflow definition, so this fix should be cherry-picked to `release-1.10.1` and `release-1.11.0` to take effect for upcoming releases.

## Test plan

- [x] `actionlint` passes on both workflows (no new findings; pre-existing shellcheck style notes untouched)
- [x] YAML parses cleanly
- [ ] Next release dry-run/dispatch confirms the release attaches to the `vX.Y.Z` tag and no bare tag is created


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process reliability by ensuring GitHub releases are properly anchored to their corresponding commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->