### PR TITLE
fix(ci): resolve validate-version output in release-lfx changelog link

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -276,7 +276,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [release-lfx, build-docker]
+    needs: [validate-version, release-lfx, build-docker]
     if: always() && github.event.inputs.create_github_release == 'true' && needs.release-lfx.result == 'success'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

The `create-release` job in `release-lfx.yml` references `needs.validate-version.outputs.current_version` in its generated release notes (the **Full Changelog** compare link), but `validate-version` was not in that job's `needs` array. The expression therefore evaluates to an empty string and the changelog link renders with a broken base:

```
https://github.com/.../compare/v...lfx-vX.Y.Z
```

Flagged by actionlint:

```
release-lfx.yml:294:866: property "validate-version" is not defined in object type
{build-docker: {outputs: {}; result: string}; release-lfx: {outputs: {version: string}; result: string}} [expression]
```

## Fix

Add `validate-version` to the `create-release` job's `needs` array.

- **No added serialization:** `create-release` already waits on `release-lfx`, which transitively requires `validate-version` (via `run-tests`).
- **No behavior change to run conditions:** the job's `if` uses `always() && ... && needs.release-lfx.result == 'success'`, so the extra dependency cannot introduce new skips, and `release-lfx` succeeding implies `validate-version` succeeded.

## Verification

`actionlint .github/workflows/release-lfx.yml` no longer reports the `validate-version is not defined` error; only pre-existing shellcheck style notes remain.

## Ports

`release-lfx.yml` is byte-identical on `release-1.10.1` and `release-1.11.0`, and release-branch workflow runs use the dispatched branch's definition, so this is cherry-picked there as well (same pattern as #13607/#13609).