### PR TITLE
fix(ci): resolve validate-version output in release-lfx changelog link (1.11.0)

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -276,7 +276,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [release-lfx, build-docker]
+    needs: [validate-version, release-lfx, build-docker]
     if: always() && github.event.inputs.create_github_release == 'true' && needs.release-lfx.result == 'success'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Port of #13610 to `release-1.11.0` (release-branch workflow runs use the dispatched branch's definition, same pattern as #13608).

The `create-release` job references `needs.validate-version.outputs.current_version` in the generated **Full Changelog** compare link, but `validate-version` was not in its `needs` array, so the link rendered with an empty base (`compare/v...lfx-vX.Y.Z`). Adding `validate-version` to `needs` fixes the expression with no added serialization (already required transitively via `release-lfx` → `run-tests`) and no run-condition change (the job's `if` uses `always()`).

Verified with actionlint: the `property "validate-version" is not defined` error is gone.