### PR TITLE
fix(qdrant): improve document ingestion using add_documents over from_documents

### DIFF
--- a/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
@@ -13,10 +13,9 @@ from unittest.mock import MagicMock, patch
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from qdrant_client.models import Distance
-
 from lfx.components.qdrant import QdrantVectorStoreComponent
 from lfx.schema.data import Data
+from qdrant_client.models import Distance
 
 
 def _make_component(documents: list[Document]) -> QdrantVectorStoreComponent:

--- a/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
@@ -13,29 +13,40 @@ from unittest.mock import MagicMock, patch
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
+from qdrant_client.models import Distance
+
 from lfx.components.qdrant import QdrantVectorStoreComponent
 from lfx.schema.data import Data
 
 
 def _make_component(documents: list[Document]) -> QdrantVectorStoreComponent:
+    embedding = MagicMock(spec=Embeddings)
+    embedding.embed_query.return_value = [0.1, 0.2, 0.3]
     return QdrantVectorStoreComponent().set(
         collection_name="test_collection",
-        embedding=MagicMock(spec=Embeddings),
+        embedding=embedding,
         ingest_data=[Data(text=doc.page_content, data=doc.metadata) for doc in documents],
     )
 
 
 def _captured_ids(documents: list[Document]) -> list[str]:
-    """Run build_vector_store with QdrantVectorStore.from_documents patched and return the ids passed in."""
+    """Run build_vector_store and return the ids passed to add_documents."""
     component = _make_component(documents)
 
     captured: dict[str, list[str]] = {}
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    qdrant = MagicMock()
 
-    def fake_from_documents(_docs, *, embedding, ids, **_kwargs):  # noqa: ARG001
+    def fake_add_documents(*, documents, ids):  # noqa: ARG001
         captured["ids"] = ids
-        return MagicMock()
 
-    with patch("lfx.components.qdrant.qdrant.QdrantVectorStore.from_documents", side_effect=fake_from_documents):
+    qdrant.add_documents.side_effect = fake_add_documents
+
+    with (
+        patch("lfx.components.qdrant.qdrant.QdrantClient", return_value=client),
+        patch("lfx.components.qdrant.qdrant.QdrantVectorStore", return_value=qdrant),
+    ):
         component.build_vector_store()
 
     return captured["ids"]
@@ -85,3 +96,23 @@ def test_qdrant_ids_handle_non_primitive_metadata() -> None:
 
     assert first == second
     uuid.UUID(first[0])  # raises if not a valid UUID
+
+
+def test_qdrant_creates_missing_collection_from_embedding_dimension() -> None:
+    component = _make_component([]).set(distance_func="Dot Product")
+    client = MagicMock()
+    client.collection_exists.return_value = False
+    qdrant = MagicMock()
+
+    with (
+        patch("lfx.components.qdrant.qdrant.QdrantClient", return_value=client),
+        patch("lfx.components.qdrant.qdrant.QdrantVectorStore", return_value=qdrant),
+    ):
+        vector_store = component.build_vector_store()
+
+    assert vector_store is qdrant
+    client.create_collection.assert_called_once()
+    create_kwargs = client.create_collection.call_args.kwargs
+    assert create_kwargs["collection_name"] == "test_collection"
+    assert create_kwargs["vectors_config"].size == 3
+    assert create_kwargs["vectors_config"].distance == Distance.DOT

--- a/src/lfx/src/lfx/components/qdrant/qdrant.py
+++ b/src/lfx/src/lfx/components/qdrant/qdrant.py
@@ -17,7 +17,6 @@ from lfx.io import (
 )
 from lfx.schema.data import Data, custom_serializer
 
-
 DISTANCE_MAP = {
     "Cosine": Distance.COSINE,
     "Euclidean": Distance.EUCLID,

--- a/src/lfx/src/lfx/components/qdrant/qdrant.py
+++ b/src/lfx/src/lfx/components/qdrant/qdrant.py
@@ -3,6 +3,8 @@ import uuid
 
 from langchain_core.embeddings import Embeddings
 from langchain_qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
 
 from lfx.base.vectorstores.model import LCVectorStoreComponent, check_cached_vector_store
 from lfx.helpers.data import docs_to_data
@@ -14,6 +16,13 @@ from lfx.io import (
     StrInput,
 )
 from lfx.schema.data import Data, custom_serializer
+
+
+DISTANCE_MAP = {
+    "Cosine": Distance.COSINE,
+    "Euclidean": Distance.EUCLID,
+    "Dot Product": Distance.DOT,
+}
 
 
 class QdrantVectorStoreComponent(LCVectorStoreComponent):
@@ -61,16 +70,14 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
 
         server_kwargs = {
             "host": self.host or None,
-            "port": int(self.port),  # Ensure port is an integer
-            "grpc_port": int(self.grpc_port),  # Ensure grpc_port is an integer
-            "api_key": self.api_key,
-            "prefix": self.prefix,
-            # Ensure timeout is an integer
+            "port": int(self.port) if self.port else 6333,
+            "grpc_port": int(self.grpc_port) if self.grpc_port else 6334,
+            "api_key": self.api_key or None,
+            "prefix": self.prefix or None,
             "timeout": int(self.timeout) if self.timeout else None,
             "path": self.path or None,
             "url": self.url or None,
         }
-
         server_kwargs = {k: v for k, v in server_kwargs.items() if v is not None}
 
         # Convert DataFrame to Data if needed using parent's method
@@ -87,6 +94,18 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
             msg = "Invalid embedding object"
             raise TypeError(msg)
 
+        client = QdrantClient(**server_kwargs)
+
+        if not client.collection_exists(self.collection_name):
+            vector_size = len(self.embedding.embed_query("test"))
+            distance = DISTANCE_MAP.get(self.distance_func, Distance.COSINE)
+            client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=vector_size, distance=distance),
+            )
+
+        qdrant = QdrantVectorStore(embedding=self.embedding, client=client, **qdrant_kwargs)
+
         if documents:
             ids = [
                 str(
@@ -97,14 +116,7 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
                 )
                 for doc in documents
             ]
-            qdrant = QdrantVectorStore.from_documents(
-                documents, embedding=self.embedding, ids=ids, **qdrant_kwargs, **server_kwargs
-            )
-        else:
-            from qdrant_client import QdrantClient
-
-            client = QdrantClient(**server_kwargs)
-            qdrant = QdrantVectorStore(embedding=self.embedding, client=client, **qdrant_kwargs)
+            qdrant.add_documents(documents=documents, ids=ids)
 
         return qdrant
 


### PR DESCRIPTION
### Overview 

- Switches from ``from_documents to add_documents`` so ingestion appends to an initialized Qdrant vector store instead of recreating the store during document insertion. Source: [Langchain_qdrant](https://docs.langchain.com/oss/python/integrations/vectorstores/qdrant#manage-vector-store)
  - Updates the Qdrant component to initialize a client-backed vector store before ingestion. distance_func was unused earlier. It was just defined but never used for initialized. 
  - Creates missing Qdrant collections using the embedding dimension and selected distance function.
 
> [tests] Also Updates Qdrant unit tests to cover deterministic IDs, add_documents, and collection creation.

Tests passed:
```bash
uv run pytest src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
```

<img width="1338" height="716" alt="Screenshot 2026-06-10 at 21 05 50" src="https://github.com/user-attachments/assets/3897cc57-f305-431b-b6de-46c3e8807ee7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Qdrant vector store automatically creates missing collections using embedding vector dimensions and configured distance metrics.

* **Bug Fixes**
  * Improved connection settings handling with fallback defaults for ports.
  * Search queries now return empty results consistently when no matches are found.
  * Distance metric configuration properly maps to Qdrant's supported distance functions.

* **Tests**
  * Added test coverage for automatic collection creation during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->