### PR TITLE
feat(lfx): add capability routing pluggability

### DIFF
--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -487,6 +487,7 @@ def register_all_service_factories() -> None:
     from lfx.services.schema import ServiceType
 
     service_manager = get_service_manager()
+    from lfx.services.capability import factory as capability_factory
     from lfx.services.executor import factory as executor_factory
     from lfx.services.mcp_composer import factory as mcp_composer_factory
     from lfx.services.settings import factory as settings_factory
@@ -543,6 +544,9 @@ def register_all_service_factories() -> None:
     )
     service_manager.register_factory(authorization_factory.AuthorizationServiceFactory())
     service_manager.register_factory(mcp_composer_factory.MCPComposerServiceFactory())
+    # ExecutorService depends on CAPABILITY_SERVICE, so its factory must be
+    # registered too or the manager can't resolve the dependency.
+    service_manager.register_factory(capability_factory.CapabilityServiceFactory())
     service_manager.register_factory(executor_factory.ExecutorServiceFactory())
     service_manager.set_factory_registered()
 

--- a/src/backend/tests/unit/services/test_executor_capability_registration.py
+++ b/src/backend/tests/unit/services/test_executor_capability_registration.py
@@ -1,0 +1,31 @@
+"""Regression test for the executor/capability service-factory wiring.
+
+``ExecutorService`` declares a hard dependency on ``CAPABILITY_SERVICE``. The
+langflow backend must register ``CapabilityServiceFactory`` alongside
+``ExecutorServiceFactory`` or the service manager cannot resolve the dependency
+when it builds ``ExecutorService`` -- which made every flow run 500 with
+``NoFactoryRegisteredError`` / "ExecutorService is not available".
+"""
+
+from __future__ import annotations
+
+from langflow.services.utils import register_all_service_factories
+from lfx.services.manager import get_service_manager
+from lfx.services.schema import ServiceType
+
+
+def test_executor_dependency_factories_are_registered():
+    register_all_service_factories()
+    service_manager = get_service_manager()
+
+    executor_factory = service_manager.factories.get(ServiceType.EXECUTOR_SERVICE.value)
+    assert executor_factory is not None, "ExecutorServiceFactory is not registered"
+
+    for dependency in executor_factory.dependencies:
+        assert dependency.value in service_manager.factories, (
+            f"ExecutorService depends on {dependency.value}, but no factory is registered for it; "
+            f"the service manager cannot build ExecutorService."
+        )
+
+    # The specific dependency that regressed.
+    assert ServiceType.CAPABILITY_SERVICE.value in service_manager.factories

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -15,20 +15,28 @@ Callers pick the view they want:
 - ``run_to_completion()``: drains the stream and returns ``RunComplete.outputs``.
   Practically useful only with the in-process executor's legacy passthrough; see
   the docstring on ``RunComplete.outputs`` for the full semantics.
+
+When a ``CapabilityService`` is wired in and not in passthrough mode, ``run()``
+asks it to route each run to an executor kind (e.g. an isolated sandbox for
+untrusted custom code) and strips capability-only metadata from the runtime
+options before they reach the executor.
 """
 
 from __future__ import annotations
 
 from contextlib import aclosing
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from lfx.execution.partitioner import identity_partition
 from lfx.execution.types import RunComplete, StepResult
+from lfx.services.capability.protocols import RESERVED_CAPABILITY_RUNTIME_OPTION_KEYS
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Sequence
 
     from lfx.execution.registry import ExecutorRegistry
+    from lfx.services.capability import CapabilityService
 
 
 class Coordinator:
@@ -39,9 +47,11 @@ class Coordinator:
         *,
         registry: ExecutorRegistry,
         executor_kind: str = "in-process",
+        capability_service: CapabilityService | None = None,
     ) -> None:
         self._registry = registry
         self._executor_kind = executor_kind
+        self._capability_service = capability_service
 
     async def run(
         self,
@@ -59,18 +69,44 @@ class Coordinator:
         ``runtime_options`` are forwarded as-is into ``Unit.runtime_options``;
         consult the active executor's documentation for which keys it honors.
 
+        If a ``CapabilityService`` is configured and active, each unit is routed
+        to the executor kind it selects, and capability-only metadata keys are
+        removed from the runtime options before dispatch.
+
         ``identity_partition`` currently yields exactly one ``Unit``, so this emits a
         single terminal ``RunComplete``. A future partitioner returning multiple units
         would emit one ``RunComplete`` per unit; consumers relying on a single terminal
         envelope (notably ``run_to_completion``) would need updating first.
         """
-        units = identity_partition(graph, inputs=inputs, runtime_options=runtime_options)
-        executor = self._registry.get(self._executor_kind)
+        options = self._without_capability_metadata(runtime_options)
+        units = identity_partition(graph, inputs=inputs, runtime_options=options)
+        if self._capability_service is not None and not self._capability_service.is_passthrough:
+            decision = self._capability_service.route(
+                graph,
+                user_id=self._context_value(graph, options, "user_id", "lfx_user_id"),
+                flow_id=self._context_value(graph, options, "flow_id", "lfx_flow_id"),
+                run_id=self._context_value(graph, options, "run_id", "lfx_run_id"),
+                default_executor_kind=self._executor_kind,
+                scopes=self._capability_scopes(options),
+                runtime_options=options,
+            )
+            units = [
+                replace(
+                    unit,
+                    executor_kind=decision.executor_kind,
+                    runtime_options={
+                        **self._without_capability_metadata(unit.runtime_options),
+                        **decision.runtime_options,
+                    },
+                )
+                for unit in units
+            ]
         for unit in units:
             # Cascade cleanup: if our consumer aclose()s us, we aclose the executor
             # stream, which lets InProcessExecutor's try/finally aclose the underlying
             # graph generator. Without this, the executor stream is abandoned on
             # consumer aclose and only finalizes when CPython gets around to GC.
+            executor = self._registry.get(unit.executor_kind or self._executor_kind)
             inner = executor.execute(unit)
             try:
                 async for item in inner:
@@ -126,3 +162,29 @@ class Coordinator:
             async for item in inner:
                 if isinstance(item, StepResult):
                     yield item.payload
+
+    @staticmethod
+    def _context_value(graph: Any, runtime_options: dict[str, Any], *names: str) -> str | None:
+        for name in names:
+            value = runtime_options.get(name)
+            if value is not None:
+                return str(value)
+            value = getattr(graph, name, None)
+            if value is not None:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _capability_scopes(runtime_options: dict[str, Any]) -> Sequence[str]:
+        scopes = runtime_options.get("capability_scopes", runtime_options.get("lfx_capability_scopes", ()))
+        if scopes is None:
+            return ()
+        if isinstance(scopes, str):
+            return (scopes,)
+        return tuple(scopes)
+
+    @staticmethod
+    def _without_capability_metadata(runtime_options: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value for key, value in runtime_options.items() if key not in RESERVED_CAPABILITY_RUNTIME_OPTION_KEYS
+        }

--- a/src/lfx/src/lfx/execution/types.py
+++ b/src/lfx/src/lfx/execution/types.py
@@ -43,6 +43,7 @@ class Unit:
     graph: Any
     inputs: list[dict[str, Any]] = field(default_factory=list)
     runtime_options: dict[str, Any] = field(default_factory=dict)
+    executor_kind: str | None = None
 
 
 @dataclass

--- a/src/lfx/src/lfx/services/capability/__init__.py
+++ b/src/lfx/src/lfx/services/capability/__init__.py
@@ -1,0 +1,27 @@
+"""Pluggable execution capability service."""
+
+from lfx.services.capability.defaults import AllTrustedClassifier, NoopCapabilityProvider, SingleTenantResolver
+from lfx.services.capability.protocols import (
+    CapabilityClaims,
+    CapabilityContext,
+    CapabilityProvider,
+    RoutingDecision,
+    TenantResolver,
+    Trust,
+    TrustClassifier,
+)
+from lfx.services.capability.service import CapabilityService
+
+__all__ = [
+    "AllTrustedClassifier",
+    "CapabilityClaims",
+    "CapabilityContext",
+    "CapabilityProvider",
+    "CapabilityService",
+    "NoopCapabilityProvider",
+    "RoutingDecision",
+    "SingleTenantResolver",
+    "TenantResolver",
+    "Trust",
+    "TrustClassifier",
+]

--- a/src/lfx/src/lfx/services/capability/__init__.py
+++ b/src/lfx/src/lfx/services/capability/__init__.py
@@ -2,6 +2,7 @@
 
 from lfx.services.capability.defaults import AllTrustedClassifier, NoopCapabilityProvider, SingleTenantResolver
 from lfx.services.capability.protocols import (
+    RESERVED_CAPABILITY_RUNTIME_OPTION_KEYS,
     CapabilityClaims,
     CapabilityContext,
     CapabilityProvider,
@@ -13,6 +14,7 @@ from lfx.services.capability.protocols import (
 from lfx.services.capability.service import CapabilityService
 
 __all__ = [
+    "RESERVED_CAPABILITY_RUNTIME_OPTION_KEYS",
     "AllTrustedClassifier",
     "CapabilityClaims",
     "CapabilityContext",

--- a/src/lfx/src/lfx/services/capability/defaults.py
+++ b/src/lfx/src/lfx/services/capability/defaults.py
@@ -40,9 +40,7 @@ class AllTrustedClassifier:
     def trust_of_flow(self, context: CapabilityContext) -> Trust:  # noqa: ARG002
         return Trust.TRUSTED
 
-    def is_untrusted_node(
-        self, _node: dict[str, object], _context: CapabilityContext | None = None
-    ) -> bool:
+    def is_untrusted_node(self, _node: dict[str, object], _context: CapabilityContext | None = None) -> bool:
         return False
 
 

--- a/src/lfx/src/lfx/services/capability/defaults.py
+++ b/src/lfx/src/lfx/services/capability/defaults.py
@@ -1,0 +1,55 @@
+"""Pass-through defaults for the capability service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lfx.services.capability.protocols import CapabilityClaims, CapabilityContext, Trust
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class NoopCapabilityProvider:
+    """No-op provider used when no capability plugin is installed."""
+
+    WILDCARD_SCOPE = "*"
+
+    def mint(
+        self,
+        *,
+        context: CapabilityContext,  # noqa: ARG002
+        tenant_id: str,  # noqa: ARG002
+        component_id: str | None,  # noqa: ARG002
+        scopes: Sequence[str],  # noqa: ARG002
+        ttl_seconds: int = 600,  # noqa: ARG002
+    ) -> str | None:
+        return None
+
+    def verify(self, token: str) -> CapabilityClaims:  # noqa: ARG002
+        return CapabilityClaims(
+            tenant_id=SingleTenantResolver.DEFAULT_TENANT,
+            user_id=SingleTenantResolver.DEFAULT_TENANT,
+            scopes=(self.WILDCARD_SCOPE,),
+        )
+
+
+class AllTrustedClassifier:
+    """Classifier that keeps every run on the default executor."""
+
+    def trust_of_flow(self, context: CapabilityContext) -> Trust:  # noqa: ARG002
+        return Trust.TRUSTED
+
+    def is_untrusted_node(
+        self, _node: dict[str, object], _context: CapabilityContext | None = None
+    ) -> bool:
+        return False
+
+
+class SingleTenantResolver:
+    """Resolver used by the pass-through default."""
+
+    DEFAULT_TENANT = "default"
+
+    def resolve(self, context: CapabilityContext) -> str:  # noqa: ARG002
+        return self.DEFAULT_TENANT

--- a/src/lfx/src/lfx/services/capability/factory.py
+++ b/src/lfx/src/lfx/services/capability/factory.py
@@ -1,0 +1,24 @@
+"""Factory for the capability service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lfx.services.capability.service import CapabilityService
+from lfx.services.factory import ServiceFactory
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from lfx.services.settings.service import SettingsService
+
+
+class CapabilityServiceFactory(ServiceFactory):
+    """Factory for creating CapabilityService instances."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.service_class = CapabilityService
+        self.dependencies = [ServiceType.SETTINGS_SERVICE]
+
+    def create(self, settings_service: SettingsService) -> CapabilityService:
+        return CapabilityService(settings_service=settings_service)

--- a/src/lfx/src/lfx/services/capability/protocols.py
+++ b/src/lfx/src/lfx/services/capability/protocols.py
@@ -1,0 +1,87 @@
+"""Protocols and value objects for pluggable execution capabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+class Trust(str, Enum):
+    """Trust classification used by execution policy plugins."""
+
+    TRUSTED = "trusted"
+    UNTRUSTED = "untrusted"
+
+
+@dataclass(frozen=True)
+class CapabilityContext:
+    """Context passed to capability plugins for one graph run."""
+
+    graph: Any
+    user_id: str | None = None
+    flow_id: str | None = None
+    run_id: str | None = None
+    runtime_options: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CapabilityClaims:
+    """Claims returned by a capability provider after token verification."""
+
+    tenant_id: str
+    user_id: str
+    flow_id: str | None = None
+    run_id: str | None = None
+    component_id: str | None = None
+    scopes: tuple[str, ...] = ()
+
+
+class CapabilityProvider(Protocol):
+    """Mints and verifies opaque capability tokens.
+
+    Core Langflow does not interpret token contents. Enterprise or other
+    extensions can install a provider that mints tokens for a remote executor,
+    worker gateway, or runtime API.
+    """
+
+    def mint(
+        self,
+        *,
+        context: CapabilityContext,
+        tenant_id: str,
+        component_id: str | None,
+        scopes: Sequence[str],
+        ttl_seconds: int = 600,
+    ) -> str | None: ...
+
+    def verify(self, token: str) -> CapabilityClaims: ...
+
+
+class TrustClassifier(Protocol):
+    """Decides whether a run can use the default executor or needs another one."""
+
+    def trust_of_flow(self, context: CapabilityContext) -> Trust: ...
+
+    def is_untrusted_node(self, node: dict[str, Any], context: CapabilityContext | None = None) -> bool: ...
+
+
+class TenantResolver(Protocol):
+    """Maps run context to the tenant id used by capability providers."""
+
+    def resolve(self, context: CapabilityContext) -> str: ...
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """The capability service's routing answer for one graph run."""
+
+    executor_kind: str
+    tenant_id: str
+    trust: Trust
+    capability_token: str | None = None
+    scopes: tuple[str, ...] = ()
+    runtime_options: dict[str, Any] = field(default_factory=dict)

--- a/src/lfx/src/lfx/services/capability/protocols.py
+++ b/src/lfx/src/lfx/services/capability/protocols.py
@@ -10,6 +10,15 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
 
+RESERVED_CAPABILITY_RUNTIME_OPTION_KEYS: frozenset[str] = frozenset(
+    {
+        "lfx_capability_token",
+        "lfx_tenant_id",
+        "lfx_trust",
+    }
+)
+
+
 class Trust(str, Enum):
     """Trust classification used by execution policy plugins."""
 

--- a/src/lfx/src/lfx/services/capability/service.py
+++ b/src/lfx/src/lfx/services/capability/service.py
@@ -102,7 +102,10 @@ class CapabilityService(Service):
         tenant_id = self._resolver.resolve(context)
         trust = self._classifier.trust_of_flow(context)
         executor_kind = default_executor_kind
-        if trust is Trust.UNTRUSTED and self._untrusted_executor_kind is not None:
+        if trust is Trust.UNTRUSTED:
+            if self._untrusted_executor_kind is None:
+                msg = "Cannot route untrusted flow because no untrusted executor is configured."
+                raise RuntimeError(msg)
             executor_kind = self._untrusted_executor_kind
 
         effective_scopes = tuple(scopes or ())

--- a/src/lfx/src/lfx/services/capability/service.py
+++ b/src/lfx/src/lfx/services/capability/service.py
@@ -1,0 +1,164 @@
+"""Capability service for pluggable execution policy."""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any
+
+from lfx.log.logger import logger
+from lfx.services.base import Service
+from lfx.services.capability.defaults import AllTrustedClassifier, NoopCapabilityProvider, SingleTenantResolver
+from lfx.services.capability.protocols import (
+    CapabilityContext,
+    CapabilityProvider,
+    RoutingDecision,
+    TenantResolver,
+    Trust,
+    TrustClassifier,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from lfx.services.settings.service import SettingsService
+
+
+ENTRY_POINT_GROUP = "lfx.capability_providers"
+
+
+class CapabilityService(Service):
+    """Holds the active capability provider, trust classifier, and tenant resolver."""
+
+    name = "capability_service"
+
+    def __init__(self, settings_service: SettingsService) -> None:
+        super().__init__()
+        self._settings_service = settings_service
+        self._provider: CapabilityProvider = NoopCapabilityProvider()
+        self._classifier: TrustClassifier = AllTrustedClassifier()
+        self._resolver: TenantResolver = SingleTenantResolver()
+        self._untrusted_executor_kind: str | None = None
+        self._discover_entry_points()
+
+    def install(
+        self,
+        *,
+        provider: CapabilityProvider | None = None,
+        classifier: TrustClassifier | None = None,
+        resolver: TenantResolver | None = None,
+        untrusted_executor_kind: str | None = None,
+    ) -> None:
+        """Replace one or more capability primitives."""
+        if provider is not None:
+            self._provider = provider
+        if classifier is not None:
+            self._classifier = classifier
+        if resolver is not None:
+            self._resolver = resolver
+        if untrusted_executor_kind is not None:
+            self._untrusted_executor_kind = untrusted_executor_kind
+
+    @property
+    def provider(self) -> CapabilityProvider:
+        return self._provider
+
+    @property
+    def classifier(self) -> TrustClassifier:
+        return self._classifier
+
+    @property
+    def resolver(self) -> TenantResolver:
+        return self._resolver
+
+    @property
+    def is_passthrough(self) -> bool:
+        """True when the service is still using inert defaults."""
+        return (
+            isinstance(self._provider, NoopCapabilityProvider)
+            and isinstance(self._classifier, AllTrustedClassifier)
+            and isinstance(self._resolver, SingleTenantResolver)
+            and self._untrusted_executor_kind is None
+        )
+
+    def route(
+        self,
+        graph: Any,
+        *,
+        user_id: str | None = None,
+        flow_id: str | None = None,
+        run_id: str | None = None,
+        default_executor_kind: str = "in-process",
+        scopes: Sequence[str] | None = None,
+        runtime_options: Mapping[str, Any] | None = None,
+    ) -> RoutingDecision:
+        """Return the executor and capability metadata for one graph run."""
+        context = CapabilityContext(
+            graph=graph,
+            user_id=user_id,
+            flow_id=flow_id,
+            run_id=run_id,
+            runtime_options=runtime_options or {},
+        )
+        tenant_id = self._resolver.resolve(context)
+        trust = self._classifier.trust_of_flow(context)
+        executor_kind = default_executor_kind
+        if trust is Trust.UNTRUSTED and self._untrusted_executor_kind is not None:
+            executor_kind = self._untrusted_executor_kind
+
+        effective_scopes = tuple(scopes or ())
+        token = self._provider.mint(
+            context=context,
+            tenant_id=tenant_id,
+            component_id=None,
+            scopes=effective_scopes,
+        )
+        options: dict[str, Any] = {}
+        if token:
+            options["lfx_capability_token"] = token
+        if not self.is_passthrough:
+            options["lfx_tenant_id"] = tenant_id
+            options["lfx_trust"] = trust.value
+
+        return RoutingDecision(
+            executor_kind=executor_kind,
+            tenant_id=tenant_id,
+            trust=trust,
+            capability_token=token,
+            scopes=effective_scopes,
+            runtime_options=options,
+        )
+
+    def _discover_entry_points(self) -> None:
+        """Discover capability primitives shipped by installed packages."""
+        try:
+            eps = entry_points(group=ENTRY_POINT_GROUP)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to enumerate entry points for group=%r. Capability discovery skipped.",
+                ENTRY_POINT_GROUP,
+            )
+            return
+
+        for ep in eps:
+            try:
+                obj = ep.load()
+                config = obj() if callable(obj) else obj
+                if not isinstance(config, dict):
+                    logger.warning(
+                        "Capability entry point %r did not return a dict; got %r",
+                        ep.name,
+                        type(config).__name__,
+                    )
+                    continue
+                self.install(**config)
+                logger.debug("Installed capability primitives from entry point: %s", ep.name)
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to load capability entry point %s", ep.name)
+
+    async def teardown(self) -> None:
+        """Reset to pass-through defaults and re-run plugin discovery."""
+        self._provider = NoopCapabilityProvider()
+        self._classifier = AllTrustedClassifier()
+        self._resolver = SingleTenantResolver()
+        self._untrusted_executor_kind = None
+        self._discover_entry_points()

--- a/src/lfx/src/lfx/services/deps.py
+++ b/src/lfx/src/lfx/services/deps.py
@@ -106,6 +106,13 @@ def get_variable_service() -> VariableServiceProtocol | None:
     return get_service(ServiceType.VARIABLE_SERVICE)
 
 
+def get_capability_service():
+    """Retrieves the capability service instance."""
+    from lfx.services.schema import ServiceType
+
+    return get_service(ServiceType.CAPABILITY_SERVICE)
+
+
 def get_shared_component_cache_service() -> CacheServiceProtocol | None:
     """Retrieves the shared component cache service instance."""
     from lfx.services.shared_component_cache.factory import SharedComponentCacheServiceFactory

--- a/src/lfx/src/lfx/services/executor/factory.py
+++ b/src/lfx/src/lfx/services/executor/factory.py
@@ -9,6 +9,7 @@ from lfx.services.factory import ServiceFactory
 from lfx.services.schema import ServiceType
 
 if TYPE_CHECKING:
+    from lfx.services.capability import CapabilityService
     from lfx.services.settings.service import SettingsService
 
 
@@ -18,7 +19,7 @@ class ExecutorServiceFactory(ServiceFactory):
     def __init__(self) -> None:
         super().__init__()
         self.service_class = ExecutorService
-        self.dependencies = [ServiceType.SETTINGS_SERVICE]
+        self.dependencies = [ServiceType.SETTINGS_SERVICE, ServiceType.CAPABILITY_SERVICE]
 
-    def create(self, settings_service: SettingsService) -> ExecutorService:
-        return ExecutorService(settings_service=settings_service)
+    def create(self, settings_service: SettingsService, capability_service: CapabilityService) -> ExecutorService:
+        return ExecutorService(settings_service=settings_service, capability_service=capability_service)

--- a/src/lfx/src/lfx/services/executor/service.py
+++ b/src/lfx/src/lfx/services/executor/service.py
@@ -13,6 +13,7 @@ from lfx.log.logger import logger
 from lfx.services.base import Service
 
 if TYPE_CHECKING:
+    from lfx.services.capability import CapabilityService
     from lfx.services.settings.service import SettingsService
 
 
@@ -24,9 +25,10 @@ class ExecutorService(Service):
 
     name = "executor_service"
 
-    def __init__(self, settings_service: SettingsService) -> None:
+    def __init__(self, settings_service: SettingsService, capability_service: CapabilityService | None = None) -> None:
         super().__init__()
         self._settings_service = settings_service
+        self._capability_service = capability_service
         self._registry = ExecutorRegistry()
         self._coordinator: Coordinator | None = None
         self._populate_registry()
@@ -63,7 +65,11 @@ class ExecutorService(Service):
     def coordinator(self) -> Coordinator:
         if self._coordinator is None:
             kind = self._settings_service.settings.executor_kind
-            self._coordinator = Coordinator(registry=self._registry, executor_kind=kind)
+            self._coordinator = Coordinator(
+                registry=self._registry,
+                executor_kind=kind,
+                capability_service=self._capability_service,
+            )
         return self._coordinator
 
     def set_coordinator(self, coordinator: Coordinator) -> None:

--- a/src/lfx/src/lfx/services/schema.py
+++ b/src/lfx/src/lfx/services/schema.py
@@ -28,3 +28,4 @@ class ServiceType(str, Enum):
     TELEMETRY_WRITER_SERVICE = "telemetry_writer_service"
     EXTENSION_EVENTS_SERVICE = "extension_events_service"
     EXECUTOR_SERVICE = "executor_service"
+    CAPABILITY_SERVICE = "capability_service"

--- a/src/lfx/tests/unit/execution/test_capability_routing.py
+++ b/src/lfx/tests/unit/execution/test_capability_routing.py
@@ -227,7 +227,7 @@ async def test_stream_close_finalizes_capability_selected_executor() -> None:
         capability_service=capability_service,
     )
 
-    stream = coordinator.stream(SimpleNamespace(), inputs=[{}])
+    stream = coordinator.stream(SimpleNamespace())
     assert await anext(stream) == "tick"
     await stream.aclose()
     await asyncio.sleep(0)

--- a/src/lfx/tests/unit/execution/test_capability_routing.py
+++ b/src/lfx/tests/unit/execution/test_capability_routing.py
@@ -118,6 +118,75 @@ async def test_coordinator_routes_untrusted_runs_to_capability_executor() -> Non
 
 
 @pytest.mark.asyncio
+async def test_coordinator_strips_spoofed_capability_metadata_when_provider_returns_no_token() -> None:
+    sandbox = _RecordingExecutor("sandbox", "sandbox-output")
+    registry = ExecutorRegistry()
+    registry.register(_RecordingExecutor("in-process", "in-process-output"))
+    registry.register(sandbox)
+
+    class _Classifier:
+        def trust_of_flow(self, context: CapabilityContext) -> Trust:
+            assert "lfx_capability_token" not in context.runtime_options
+            assert "lfx_tenant_id" not in context.runtime_options
+            assert "lfx_trust" not in context.runtime_options
+            return Trust.UNTRUSTED
+
+        def is_untrusted_node(self, _node: dict[str, Any], _context: CapabilityContext | None = None) -> bool:
+            return True
+
+    class _Resolver:
+        def resolve(self, context: CapabilityContext) -> str:  # noqa: ARG002
+            return "tenant:resolved"
+
+    class _Provider:
+        def mint(
+            self,
+            *,
+            context: CapabilityContext,  # noqa: ARG002
+            tenant_id: str,
+            component_id: str | None,
+            scopes: Sequence[str],
+            ttl_seconds: int = 600,  # noqa: ARG002
+        ) -> str | None:
+            assert tenant_id == "tenant:resolved"
+            assert component_id is None
+            assert tuple(scopes) == ("variables:read",)
+            return None
+
+        def verify(self, token: str) -> CapabilityClaims:  # noqa: ARG002
+            return CapabilityClaims(tenant_id="tenant:resolved", user_id="graph-user")
+
+    capability_service = CapabilityService(settings_service=_StubSettings())
+    capability_service.install(
+        provider=_Provider(),
+        classifier=_Classifier(),
+        resolver=_Resolver(),
+        untrusted_executor_kind="sandbox",
+    )
+    coordinator = Coordinator(
+        registry=registry,
+        executor_kind="in-process",
+        capability_service=capability_service,
+    )
+
+    outputs = await coordinator.run_to_completion(
+        SimpleNamespace(user_id="graph-user", flow_id="graph-flow"),
+        inputs=[{}],
+        capability_scopes=["variables:read"],
+        lfx_capability_token="spoofed",  # noqa: S106
+        lfx_tenant_id="tenant:spoofed",
+        lfx_trust="trusted",
+    )
+
+    assert outputs == ["sandbox-output"]
+    assert len(sandbox.units) == 1
+    assert sandbox.units[0].executor_kind == "sandbox"
+    assert "lfx_capability_token" not in sandbox.units[0].runtime_options
+    assert sandbox.units[0].runtime_options["lfx_tenant_id"] == "tenant:resolved"
+    assert sandbox.units[0].runtime_options["lfx_trust"] == "untrusted"
+
+
+@pytest.mark.asyncio
 async def test_coordinator_skips_capability_service_when_passthrough() -> None:
     default = _RecordingExecutor("in-process", "default-output")
     registry = ExecutorRegistry()

--- a/src/lfx/tests/unit/execution/test_capability_routing.py
+++ b/src/lfx/tests/unit/execution/test_capability_routing.py
@@ -1,0 +1,120 @@
+"""Tests for capability-driven coordinator routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.executor import Executor
+from lfx.execution.registry import ExecutorRegistry
+from lfx.execution.types import RunComplete, StepResult, Unit
+from lfx.services.capability import CapabilityClaims, CapabilityContext, CapabilityService, Trust
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+
+class _StubSettings:
+    settings = type("Settings", (), {})()
+
+
+class _RecordingExecutor(Executor):
+    def __init__(self, kind: str, output: str) -> None:
+        self.kind = kind
+        self.output = output
+        self.units: list[Unit] = []
+
+    async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
+        self.units.append(unit)
+        yield RunComplete(outputs=[self.output])
+
+
+@pytest.mark.asyncio
+async def test_coordinator_routes_untrusted_runs_to_capability_executor() -> None:
+    sandbox = _RecordingExecutor("sandbox", "sandbox-output")
+    registry = ExecutorRegistry()
+    registry.register(_RecordingExecutor("in-process", "in-process-output"))
+    registry.register(sandbox)
+
+    class _Classifier:
+        def trust_of_flow(self, context: CapabilityContext) -> Trust:
+            assert context.user_id == "graph-user"
+            assert context.flow_id == "graph-flow"
+            return Trust.UNTRUSTED
+
+        def is_untrusted_node(self, _node: dict[str, Any], _context: CapabilityContext | None = None) -> bool:
+            return True
+
+    class _Resolver:
+        def resolve(self, context: CapabilityContext) -> str:
+            assert context.run_id == "runtime-run"
+            return f"tenant:{context.user_id}"
+
+    class _Provider:
+        def mint(
+            self,
+            *,
+            context: CapabilityContext,
+            tenant_id: str,
+            component_id: str | None,
+            scopes: Sequence[str],
+            ttl_seconds: int = 600,  # noqa: ARG002
+        ) -> str:
+            assert context.runtime_options["run_id"] == "runtime-run"
+            assert tenant_id == "tenant:graph-user"
+            assert component_id is None
+            assert tuple(scopes) == ("variables:read",)
+            return f"token:{context.user_id}:{context.flow_id}"
+
+        def verify(self, token: str) -> CapabilityClaims:  # noqa: ARG002
+            return CapabilityClaims(tenant_id="tenant:graph-user", user_id="graph-user")
+
+    capability_service = CapabilityService(settings_service=_StubSettings())
+    capability_service.install(
+        provider=_Provider(),
+        classifier=_Classifier(),
+        resolver=_Resolver(),
+        untrusted_executor_kind="sandbox",
+    )
+    coordinator = Coordinator(
+        registry=registry,
+        executor_kind="in-process",
+        capability_service=capability_service,
+    )
+
+    graph = SimpleNamespace(user_id="graph-user", flow_id="graph-flow")
+    outputs = await coordinator.run_to_completion(
+        graph,
+        inputs=[{}],
+        run_id="runtime-run",
+        capability_scopes=["variables:read"],
+    )
+
+    assert outputs == ["sandbox-output"]
+    assert len(sandbox.units) == 1
+    assert sandbox.units[0].executor_kind == "sandbox"
+    expected_token = "token:graph-user:graph-flow"  # noqa: S105
+    assert sandbox.units[0].runtime_options["lfx_capability_token"] == expected_token
+    assert sandbox.units[0].runtime_options["lfx_tenant_id"] == "tenant:graph-user"
+    assert sandbox.units[0].runtime_options["lfx_trust"] == "untrusted"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_skips_capability_service_when_passthrough() -> None:
+    default = _RecordingExecutor("in-process", "default-output")
+    registry = ExecutorRegistry()
+    registry.register(default)
+    capability_service = CapabilityService(settings_service=_StubSettings())
+    coordinator = Coordinator(
+        registry=registry,
+        executor_kind="in-process",
+        capability_service=capability_service,
+    )
+
+    outputs = await coordinator.run_to_completion(SimpleNamespace(), inputs=[{}])
+
+    assert outputs == ["default-output"]
+    assert default.units[0].executor_kind is None
+    assert default.units[0].runtime_options == {}

--- a/src/lfx/tests/unit/execution/test_capability_routing.py
+++ b/src/lfx/tests/unit/execution/test_capability_routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -29,6 +30,21 @@ class _RecordingExecutor(Executor):
     async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
         self.units.append(unit)
         yield RunComplete(outputs=[self.output])
+
+
+class _NeverEndingExecutor(Executor):
+    kind = "sandbox"
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:  # noqa: ARG002
+        try:
+            while True:
+                yield StepResult(payload="tick")
+                await asyncio.sleep(0)
+        finally:
+            self.closed = True
 
 
 @pytest.mark.asyncio
@@ -118,3 +134,33 @@ async def test_coordinator_skips_capability_service_when_passthrough() -> None:
     assert outputs == ["default-output"]
     assert default.units[0].executor_kind is None
     assert default.units[0].runtime_options == {}
+
+
+@pytest.mark.asyncio
+async def test_stream_close_finalizes_capability_selected_executor() -> None:
+    sandbox = _NeverEndingExecutor()
+    registry = ExecutorRegistry()
+    registry.register(_RecordingExecutor("in-process", "in-process-output"))
+    registry.register(sandbox)
+
+    class _Classifier:
+        def trust_of_flow(self, _context: CapabilityContext) -> Trust:
+            return Trust.UNTRUSTED
+
+        def is_untrusted_node(self, _node: dict[str, Any], _context: CapabilityContext | None = None) -> bool:
+            return True
+
+    capability_service = CapabilityService(settings_service=_StubSettings())
+    capability_service.install(classifier=_Classifier(), untrusted_executor_kind="sandbox")
+    coordinator = Coordinator(
+        registry=registry,
+        executor_kind="in-process",
+        capability_service=capability_service,
+    )
+
+    stream = coordinator.stream(SimpleNamespace(), inputs=[{}])
+    assert await anext(stream) == "tick"
+    await stream.aclose()
+    await asyncio.sleep(0)
+
+    assert sandbox.closed is True

--- a/src/lfx/tests/unit/execution/test_executor_service.py
+++ b/src/lfx/tests/unit/execution/test_executor_service.py
@@ -219,10 +219,10 @@ def test_entry_point_returning_non_executor_is_skipped(monkeypatch):
     assert isinstance(fresh.get("in-process"), InProcessExecutor)
 
 
-def test_factory_declares_settings_dependency():
-    """Pin the factory contract: ExecutorService depends on settings_service only."""
+def test_factory_declares_settings_and_capability_dependencies():
+    """Pin the factory contract for ExecutorService dependencies."""
     from lfx.services.executor.factory import ExecutorServiceFactory
 
     factory = ExecutorServiceFactory()
     assert factory.service_class is ExecutorService
-    assert factory.dependencies == [ServiceType.SETTINGS_SERVICE]
+    assert factory.dependencies == [ServiceType.SETTINGS_SERVICE, ServiceType.CAPABILITY_SERVICE]

--- a/src/lfx/tests/unit/services/capability/test_capability_service.py
+++ b/src/lfx/tests/unit/services/capability/test_capability_service.py
@@ -1,0 +1,102 @@
+"""Unit tests for CapabilityService."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from lfx.services.capability import (
+    AllTrustedClassifier,
+    CapabilityClaims,
+    CapabilityContext,
+    CapabilityService,
+    NoopCapabilityProvider,
+    SingleTenantResolver,
+    Trust,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class _StubSettings:
+    settings = type("Settings", (), {})()
+
+
+@pytest.fixture
+def service() -> CapabilityService:
+    return CapabilityService(settings_service=_StubSettings())
+
+
+def test_defaults_are_passthrough(service: CapabilityService) -> None:
+    assert service.is_passthrough is True
+    assert isinstance(service.provider, NoopCapabilityProvider)
+    assert isinstance(service.classifier, AllTrustedClassifier)
+    assert isinstance(service.resolver, SingleTenantResolver)
+
+
+def test_passthrough_route_keeps_default_executor_without_runtime_metadata(service: CapabilityService) -> None:
+    decision = service.route(graph=None, user_id="u1", flow_id="f1", run_id="r1")
+
+    assert decision.executor_kind == "in-process"
+    assert decision.capability_token is None
+    assert decision.runtime_options == {}
+    assert decision.trust is Trust.TRUSTED
+
+
+def test_install_swaps_primitives(service: CapabilityService) -> None:
+    class _Classifier:
+        def trust_of_flow(self, context: CapabilityContext) -> Trust:  # noqa: ARG002
+            return Trust.UNTRUSTED
+
+        def is_untrusted_node(self, _node: dict[str, Any], _context: CapabilityContext | None = None) -> bool:
+            return True
+
+    class _Resolver:
+        def resolve(self, context: CapabilityContext) -> str:
+            assert context.user_id == "u1"
+            return "tenant-u1"
+
+    class _Provider:
+        def mint(
+            self,
+            *,
+            context: CapabilityContext,
+            tenant_id: str,
+            component_id: str | None,
+            scopes: Sequence[str],
+            ttl_seconds: int = 600,  # noqa: ARG002
+        ) -> str:
+            assert context.flow_id == "f1"
+            assert tenant_id == "tenant-u1"
+            assert component_id is None
+            assert tuple(scopes) == ("variables:read",)
+            return "cap-token"
+
+        def verify(self, token: str) -> CapabilityClaims:  # noqa: ARG002
+            return CapabilityClaims(tenant_id="tenant-u1", user_id="u1")
+
+    service.install(
+        provider=_Provider(),
+        classifier=_Classifier(),
+        resolver=_Resolver(),
+        untrusted_executor_kind="sandbox",
+    )
+
+    decision = service.route(
+        graph=None,
+        user_id="u1",
+        flow_id="f1",
+        run_id="r1",
+        default_executor_kind="in-process",
+        scopes=("variables:read",),
+    )
+
+    assert service.is_passthrough is False
+    assert decision.executor_kind == "sandbox"
+    assert decision.capability_token == "cap-token"  # noqa: S105
+    assert decision.runtime_options == {
+        "lfx_capability_token": "cap-token",
+        "lfx_tenant_id": "tenant-u1",
+        "lfx_trust": "untrusted",
+    }

--- a/src/lfx/tests/unit/services/capability/test_capability_service.py
+++ b/src/lfx/tests/unit/services/capability/test_capability_service.py
@@ -100,3 +100,17 @@ def test_install_swaps_primitives(service: CapabilityService) -> None:
         "lfx_tenant_id": "tenant-u1",
         "lfx_trust": "untrusted",
     }
+
+
+def test_untrusted_route_without_untrusted_executor_fails_closed(service: CapabilityService) -> None:
+    class _Classifier:
+        def trust_of_flow(self, context: CapabilityContext) -> Trust:  # noqa: ARG002
+            return Trust.UNTRUSTED
+
+        def is_untrusted_node(self, _node: dict[str, Any], _context: CapabilityContext | None = None) -> bool:
+            return True
+
+    service.install(classifier=_Classifier())
+
+    with pytest.raises(RuntimeError, match="no untrusted executor is configured"):
+        service.route(graph=None, user_id="u1", flow_id="f1", run_id="r1")


### PR DESCRIPTION
## Summary

Stacks on #13063. Adds the Langflow-side capability-routing contract needed for pluggable execution policy.

This keeps the scope intentionally narrow: Langflow can ask a pluggable capability provider how to route a run and which opaque per-run metadata to attach, while the provider implementation remains outside this PR.

## What changed

- Adds `lfx.services.capability`:
  - `CapabilityService`
  - provider/classifier/resolver protocols
  - noop/default implementations
  - entry-point installation hook
- Adds `ServiceType.CAPABILITY_SERVICE` and service dependency wiring.
- Lets `ExecutorService` create a `Coordinator` with a capability service.
- Extends `Coordinator` to request a routing decision before dispatch.
- Adds `Unit.executor_kind` so routing can select a non-default executor per unit.
- Adds generic opaque per-run metadata when a provider is active.

## Scope boundary

This PR is pluggability only. It defines the contract and default noop behavior, but it does not ship a concrete provider implementation.

The default provider is noop, so behavior remains unchanged unless a capability provider is installed/configured.

## How this fits the stack

- #12981 creates the generic executor seam.
- #13063 adds the Stepflow executor backend.
- This PR adds a capability-facing pluggability hook above that seam.
- Follow-up work can build on this contract in separate PRs.

## Verification

- Targeted Ruff passed.
- Targeted unit suite passed:
  - `src/lfx/tests/unit/services/capability/test_capability_service.py`
  - `src/lfx/tests/unit/execution/test_capability_routing.py`
  - existing executor/coordinator routing tests
- Service-manager probe passed.

## Review focus

- Is the capability contract generic enough for external providers?
- Does the default noop path preserve existing behavior?
- Is the opaque metadata handoff acceptable for this boundary?
- Is the scope tight enough for a contract-only extension point?
