### PR TITLE
feat: add MongoDB client metadata

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": "1.0.26"
+                    "version": null
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": null
+                    "version": "1.0.26"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
+++ b/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
@@ -274,8 +274,10 @@ def test_mongodb_overwrite_insert_mode_clears_collection(mocker):
     mock_store_cls.from_documents.assert_called_once()
 
 
-def test_mongodb_client_passes_driver_info(mocker):
-    """The MongoClient is constructed with DriverInfo identifying Langflow in the handshake."""
+@pytest.mark.parametrize("enable_mtls", [False, True])
+def test_mongodb_client_passes_driver_info(mocker, enable_mtls):
+    """Both the plain and mTLS paths construct MongoClient with DriverInfo identifying Langflow."""
+    from lfx.components.mongodb.mongodb_atlas import _DRIVER_VERSION
     from pymongo.driver_info import DriverInfo
 
     mock_client_cls = mocker.patch("pymongo.MongoClient", return_value=MagicMock())
@@ -285,7 +287,9 @@ def test_mongodb_client_passes_driver_info(mocker):
         db_name="test_db",
         collection_name="test_collection",
         index_name="test_index",
-        enable_mtls=False,
+        enable_mtls=enable_mtls,
+        # The mTLS branch reads/transforms this cert before constructing the client.
+        mongodb_atlas_client_cert="-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----",
     )
     component.embedding = MagicMock()
 
@@ -295,3 +299,4 @@ def test_mongodb_client_passes_driver_info(mocker):
     assert "driver" in kwargs
     assert isinstance(kwargs["driver"], DriverInfo)
     assert kwargs["driver"].name == "Langflow"
+    assert kwargs["driver"].version == _DRIVER_VERSION

--- a/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
+++ b/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
@@ -277,9 +277,11 @@ def test_mongodb_overwrite_insert_mode_clears_collection(mocker):
 @pytest.mark.parametrize("enable_mtls", [False, True])
 def test_mongodb_client_passes_driver_info(mocker, enable_mtls):
     """Both the plain and mTLS paths construct MongoClient with DriverInfo identifying Langflow."""
-    from lfx.components.mongodb.mongodb_atlas import _DRIVER_VERSION
+    from lfx.components.mongodb import mongodb_atlas
     from pymongo.driver_info import DriverInfo
 
+    expected_driver_version = "1.2.3-test"
+    mocker.patch.object(mongodb_atlas, "_DRIVER_VERSION", expected_driver_version)
     mock_client_cls = mocker.patch("pymongo.MongoClient", return_value=MagicMock())
     mocker.patch("lfx.components.mongodb.mongodb_atlas.MongoDBAtlasVectorSearch")
     component = MongoVectorStoreComponent(
@@ -299,4 +301,4 @@ def test_mongodb_client_passes_driver_info(mocker, enable_mtls):
     assert "driver" in kwargs
     assert isinstance(kwargs["driver"], DriverInfo)
     assert kwargs["driver"].name == "Langflow"
-    assert kwargs["driver"].version == _DRIVER_VERSION
+    assert kwargs["driver"].version == expected_driver_version

--- a/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
+++ b/src/backend/tests/unit/components/vectorstores/test_mongodb_atlas.py
@@ -272,3 +272,26 @@ def test_mongodb_overwrite_insert_mode_clears_collection(mocker):
     collection = mock_client.__getitem__.return_value.__getitem__.return_value
     collection.delete_many.assert_called_once_with({})
     mock_store_cls.from_documents.assert_called_once()
+
+
+def test_mongodb_client_passes_driver_info(mocker):
+    """The MongoClient is constructed with DriverInfo identifying Langflow in the handshake."""
+    from pymongo.driver_info import DriverInfo
+
+    mock_client_cls = mocker.patch("pymongo.MongoClient", return_value=MagicMock())
+    mocker.patch("lfx.components.mongodb.mongodb_atlas.MongoDBAtlasVectorSearch")
+    component = MongoVectorStoreComponent(
+        mongodb_atlas_cluster_uri="mongodb://localhost:27017",
+        db_name="test_db",
+        collection_name="test_collection",
+        index_name="test_index",
+        enable_mtls=False,
+    )
+    component.embedding = MagicMock()
+
+    component.build_vector_store()
+
+    _, kwargs = mock_client_cls.call_args
+    assert "driver" in kwargs
+    assert isinstance(kwargs["driver"], DriverInfo)
+    assert kwargs["driver"].name == "Langflow"

--- a/src/lfx/src/lfx/components/mongodb/mongodb_atlas.py
+++ b/src/lfx/src/lfx/components/mongodb/mongodb_atlas.py
@@ -1,5 +1,8 @@
 import tempfile
 import time
+from contextlib import suppress
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _get_package_version
 
 import certifi
 from langchain_mongodb import MongoDBAtlasVectorSearch
@@ -10,6 +13,21 @@ from lfx.base.vectorstores.model import LCVectorStoreComponent, check_cached_vec
 from lfx.helpers.data import docs_to_data
 from lfx.io import BoolInput, DropdownInput, HandleInput, IntInput, SecretStrInput, StrInput
 from lfx.schema.data import Data
+
+# Identifies Langflow in the MongoDB driver handshake metadata so server-side
+# telemetry can attribute traffic to this library.
+_DRIVER_NAME = "Langflow"
+
+
+def _get_driver_version() -> str | None:
+    """Resolve the running Langflow/lfx version at runtime, or None if unavailable."""
+    for package_name in ("langflow", "langflow-base", "lfx"):
+        with suppress(PackageNotFoundError):
+            return _get_package_version(package_name)
+    return None
+
+
+_DRIVER_VERSION = _get_driver_version()
 
 
 class MongoVectorStoreComponent(LCVectorStoreComponent):
@@ -97,9 +115,12 @@ class MongoVectorStoreComponent(LCVectorStoreComponent):
     def build_vector_store(self) -> MongoDBAtlasVectorSearch:
         try:
             from pymongo import MongoClient
+            from pymongo.driver_info import DriverInfo
         except ImportError as e:
             msg = "Please install pymongo to use MongoDB Atlas Vector Store"
             raise ImportError(msg) from e
+
+        driver_info = DriverInfo(name=_DRIVER_NAME, version=_DRIVER_VERSION)
 
         # Create temporary files for the client certificate
         if self.enable_mtls:
@@ -127,9 +148,10 @@ class MongoVectorStoreComponent(LCVectorStoreComponent):
                     tls=True,
                     tlsCertificateKeyFile=client_cert_path,
                     tlsCAFile=certifi.where(),
+                    driver=driver_info,
                 )
                 if self.enable_mtls
-                else MongoClient(self.mongodb_atlas_cluster_uri)
+                else MongoClient(self.mongodb_atlas_cluster_uri, driver=driver_info)
             )
 
             collection = mongo_client[self.db_name][self.collection_name]


### PR DESCRIPTION
Pass DriverInfo identifying Langflow (with the runtime package version) to the MongoClient constructed by the MongoDB Atlas vector store component, so the library details are logged via the [MongoDB driver handshake](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) to the mongos/mongod log file.

This makes it easier to identify the source of a connection when troubleshooting or doing static analysis.

ex:
```json
 {
    "t": { "$date": "2026-06-12T14:32:10.123+00:00" },
    "s": "I",
    "c": "NETWORK",
    "id": 51800,
    "ctx": "conn42",
    "msg": "client metadata",
    "attr": {
      "remote": "192.0.2.10:54321",
      "client": "conn42",
      "doc": {
        "driver": {
          "name": "PyMongo|Langflow",
          "version": "4.16.0|1.10.0"
        },
        "os": {
          "type": "Darwin",
          "name": "macOS",
          "architecture": "arm64",
          "version": "25.4.0"
        },
        "platform": "CPython 3.12.4.final.0"
      }
    }
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MongoDB Atlas connections now include Langflow identification and runtime version information in the driver handshake metadata, enabling improved connection tracking and visibility for your MongoDB instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->