### PR TITLE
Fix: resolve Pydantic V2.11 model_fields deprecation warnings

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -488,7 +488,7 @@ class DatabaseService(Service):
         legacy_tables = ["flowstyle"]
 
         for table, model in model_mapping.items():
-            expected_columns = list(model.model_fields.keys())
+            expected_columns = list(model.model_fields.keys()) if hasattr(model, "model_fields") else list(model.__fields__.keys())
 
             try:
                 available_columns = [col["name"] for col in inspector.get_columns(table)]

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -618,7 +618,7 @@ class DatabaseService(Service):
         results = []
         inspector = inspect(connection)
         table_name = model.__tablename__
-        expected_columns = list(model.__fields__.keys())
+        expected_columns = list(model.model_fields.keys()) if hasattr(model, "model_fields") else list(model.__fields__.keys())
         available_columns = []
         try:
             available_columns = [col["name"] for col in inspector.get_columns(table_name)]

--- a/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/base_model.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/base_model.py
@@ -117,8 +117,9 @@ def _resolve_secret_value(secret_value: Any) -> Any:
 def _handle_special_pydantic_types(obj: Any, serialized: dict[str, Any]) -> dict[str, Any]:
     """Handle SecretStr and other special Pydantic types during serialization."""
     try:
-        if hasattr(obj, "model_fields"):
-            fields = obj.model_fields
+        cls = type(obj)
+        if hasattr(cls, "model_fields"):
+            fields = cls.model_fields
             for field_name, field_info in fields.items():
                 if hasattr(field_info, "annotation"):
                     field_type = field_info.annotation
@@ -130,8 +131,8 @@ def _handle_special_pydantic_types(obj: Any, serialized: dict[str, Any]) -> dict
                                 serialized[field_name] = _resolve_secret_value(secret_value)
                             except Exception:
                                 pass
-        elif hasattr(obj, "__fields__"):
-            fields = obj.__fields__
+        elif hasattr(cls, "__fields__"):
+            fields = cls.__fields__
             for field_name, field_info in fields.items():
                 field_type = field_info.type_
                 if _is_secret_str_type(field_type):

--- a/src/lfx/src/lfx/base/agents/altk_tool_wrappers.py
+++ b/src/lfx/src/lfx/base/agents/altk_tool_wrappers.py
@@ -225,10 +225,10 @@ class ValidatedTool(ALTKBaseTool):
             try:
                 schema = self.wrapped_tool.args_schema
                 field_source = None
-                if hasattr(schema, "__fields__"):
-                    field_source = schema.__fields__
-                elif hasattr(schema, "model_fields"):
+                if hasattr(schema, "model_fields"):
                     field_source = schema.model_fields
+                elif hasattr(schema, "__fields__"):
+                    field_source = schema.__fields__
                 if field_source:
                     field_names = list(field_source.keys())
                     for i, arg in enumerate(args):


### PR DESCRIPTION
Accessing `model_fields` directly on a model instance triggers a `PydanticDeprecatedSince20` warning in Pydantic V2.11+. This PR addresses this by dynamically deriving the class type and reordering `__fields__` checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal model field detection to support a broader range of model definition formats, enhancing compatibility across different configuration types and increasing system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->