### PR TITLE
feat(auth): add external access ceiling for trusted auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2827,7 +2827,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 124,
+        "line_number": 123,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T20:12:13Z"
+  "generated_at": "2026-06-12T21:05:25Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2827,7 +2827,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 124,
         "is_secret": false
       }
     ],
@@ -4007,7 +4007,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 97,
         "is_secret": false
       },
       {
@@ -4015,7 +4015,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 113,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-10T08:36:23Z"
+  "generated_at": "2026-06-12T20:12:13Z"
 }

--- a/src/backend/base/langflow/api/v1/api_key.py
+++ b/src/backend/base/langflow/api/v1/api_key.py
@@ -36,6 +36,8 @@ async def create_api_key_route(
     try:
         user_id = current_user.id
         return await create_api_key(db, req, user_id=user_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/src/backend/base/langflow/api/v1/authz_me.py
+++ b/src/backend/base/langflow/api/v1/authz_me.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 
 from langflow.api.utils import CurrentActiveUser
+from langflow.services.auth.external import filter_actions_by_external_access_ceiling
 from langflow.services.deps import get_authorization_service
 
 router = APIRouter(prefix="/authz/me", tags=["Authorization"])
@@ -129,6 +130,10 @@ async def get_effective_permissions(
         domain=body.domain,
         context={"is_superuser": getattr(current_user, "is_superuser", False)},
     )
+    permissions = {
+        resource_id: filter_actions_by_external_access_ceiling(allowed_actions)
+        for resource_id, allowed_actions in permissions.items()
+    }
     return EffectivePermissionsResponse(
         resource_type=body.resource_type,
         permissions=permissions,

--- a/src/backend/base/langflow/services/auth/external.py
+++ b/src/backend/base/langflow/services/auth/external.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import json
 import time
 from collections.abc import Awaitable, Callable, Mapping
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypeVar, cast
@@ -35,6 +37,37 @@ JWKS_MIN_REFRESH_INTERVAL_SECONDS = 30
 _jwks_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 T = TypeVar("T")
 
+EXTERNAL_ACCESS_VIEWER = "viewer"
+EXTERNAL_ACCESS_EDITOR = "editor"
+EXTERNAL_ACCESS_ADMIN = "admin"
+_EXTERNAL_ACCESS_LEVELS = frozenset(
+    {
+        EXTERNAL_ACCESS_VIEWER,
+        EXTERNAL_ACCESS_EDITOR,
+        EXTERNAL_ACCESS_ADMIN,
+    }
+)
+_EXTERNAL_ACCESS_ALIASES = {
+    "view": EXTERNAL_ACCESS_VIEWER,
+    "viewer": EXTERNAL_ACCESS_VIEWER,
+    "read": EXTERNAL_ACCESS_VIEWER,
+    "readonly": EXTERNAL_ACCESS_VIEWER,
+    "read_only": EXTERNAL_ACCESS_VIEWER,
+    "read-only": EXTERNAL_ACCESS_VIEWER,
+    "edit": EXTERNAL_ACCESS_EDITOR,
+    "editor": EXTERNAL_ACCESS_EDITOR,
+    "write": EXTERNAL_ACCESS_EDITOR,
+    "developer": EXTERNAL_ACCESS_EDITOR,
+    "admin": EXTERNAL_ACCESS_ADMIN,
+    "administrator": EXTERNAL_ACCESS_ADMIN,
+}
+_VIEWER_ALLOWED_ACTIONS = frozenset({"read"})
+_EDITOR_ALLOWED_ACTIONS = frozenset({"read", "write", "create", "execute", "ingest"})
+_current_external_access = ContextVar["ExternalAccessContext | None"](
+    "langflow_external_access",
+    default=None,
+)
+
 
 @dataclass(frozen=True)
 class ExternalIdentity:
@@ -46,6 +79,17 @@ class ExternalIdentity:
     email: str | None = None
     name: str | None = None
     claims: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExternalAccessContext:
+    """Request-local access ceiling derived from an external identity claim."""
+
+    provider: str
+    subject: str
+    level: str
+    claim_name: str | None = None
+    claim_value: str | None = None
 
 
 class ExternalIdentityResolver(Protocol):
@@ -117,6 +161,115 @@ def identity_from_claims(claims: Mapping[str, Any], auth_settings: AuthSettings)
         name=name,
         claims=dict(claims),
     )
+
+
+def _normalize_access_level(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    return _EXTERNAL_ACCESS_ALIASES.get(normalized, normalized if normalized in _EXTERNAL_ACCESS_LEVELS else None)
+
+
+def _access_claim_mapping(auth_settings: AuthSettings) -> dict[str, str]:
+    raw_mapping = auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING
+    if not raw_mapping:
+        return {}
+
+    mapping: dict[str, str] = {}
+    try:
+        loaded = json.loads(raw_mapping)
+    except json.JSONDecodeError:
+        loaded = None
+
+    if isinstance(loaded, Mapping):
+        pairs = loaded.items()
+    else:
+        pairs = []
+        for item in raw_mapping.split(","):
+            key, separator, value = item.partition(":")
+            if not separator:
+                continue
+            pairs.append((key, value))
+
+    for key, value in pairs:
+        if not isinstance(key, str):
+            continue
+        normalized_level = _normalize_access_level(str(value))
+        if normalized_level is not None:
+            mapping[key.strip().lower()] = normalized_level
+    return mapping
+
+
+def access_context_from_identity(
+    identity: ExternalIdentity,
+    auth_settings: AuthSettings,
+) -> ExternalAccessContext | None:
+    """Return the request-local access ceiling for an external identity."""
+    if not auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED:
+        return None
+
+    claim_name = auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM
+    claim_value = _claim_as_str(identity.claims, claim_name)
+    mapped_level = None
+    if claim_value is not None:
+        mapped_level = _access_claim_mapping(auth_settings).get(claim_value.strip().lower())
+        if mapped_level is None:
+            mapped_level = _normalize_access_level(claim_value)
+    level = mapped_level or _normalize_access_level(auth_settings.EXTERNAL_AUTH_DEFAULT_ACCESS_LEVEL)
+    if level is None:
+        level = EXTERNAL_ACCESS_VIEWER
+
+    return ExternalAccessContext(
+        provider=identity.provider,
+        subject=identity.subject,
+        level=level,
+        claim_name=claim_name,
+        claim_value=claim_value,
+    )
+
+
+def set_current_external_access_context(context: ExternalAccessContext | None) -> None:
+    """Store the external access ceiling for the current request/task."""
+    _current_external_access.set(context)
+
+
+def clear_current_external_access_context() -> None:
+    """Clear any external access ceiling from the current request/task."""
+    _current_external_access.set(None)
+
+
+def get_current_external_access_context() -> ExternalAccessContext | None:
+    """Return the external access ceiling for the current request/task, if any."""
+    return _current_external_access.get()
+
+
+def external_access_allows(action: str, context: ExternalAccessContext | None = None) -> bool:
+    """Return whether the external access ceiling allows this action.
+
+    This is deliberately action-level and deny-only. It does not grant access to
+    resources; normal ownership, route guards, and enterprise authz plugins still
+    decide whether an otherwise allowed action may proceed.
+    """
+    context = context if context is not None else get_current_external_access_context()
+    if context is None:
+        return True
+
+    normalized_action = action.strip().lower()
+    if context.level == EXTERNAL_ACCESS_ADMIN:
+        return True
+    if context.level == EXTERNAL_ACCESS_EDITOR:
+        return normalized_action in _EDITOR_ALLOWED_ACTIONS
+    return normalized_action in _VIEWER_ALLOWED_ACTIONS
+
+
+def filter_actions_by_external_access_ceiling(actions: list[str] | tuple[str, ...]) -> list[str]:
+    """Filter an action list through the current external access ceiling."""
+    context = get_current_external_access_context()
+    if context is None:
+        return list(actions)
+    return [action for action in actions if external_access_allows(action, context)]
 
 
 def _validate_trusted_time_claims(claims: Mapping[str, Any]) -> None:

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -274,9 +274,8 @@ class AuthService(BaseAuthService):
 
     async def _external_access_ceiling_blocks_api_key_user(self, user: User, db: AsyncSession) -> bool:
         auth_settings = self.settings.auth_settings
-        if (
-            not auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED
-            or not auth_settings.EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS
+        if not getattr(auth_settings, "EXTERNAL_AUTH_ACCESS_CEILING_ENABLED", False) or not getattr(
+            auth_settings, "EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS", True
         ):
             return False
 

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -28,8 +28,11 @@ from langflow.services.auth.exceptions import (
 )
 from langflow.services.auth.external import (
     ExternalIdentity,
+    access_context_from_identity,
+    clear_current_external_access_context,
     identity_from_claims,
     resolve_external_identity,
+    set_current_external_access_context,
 )
 from langflow.services.database.models.api_key.crud import check_key
 from langflow.services.database.models.user.crud import (
@@ -89,6 +92,8 @@ class AuthService(BaseAuthService):
             TokenExpiredError: If token has expired
             InactiveUserError: If user account is inactive
         """
+        clear_current_external_access_context()
+
         # Try token authentication first (if token provided)
         if token:
             try:
@@ -245,6 +250,7 @@ class AuthService(BaseAuthService):
         except AuthInvalidTokenError as exc:
             logger.debug(f"External credential rejected: {exc}")
             return None
+        set_current_external_access_context(access_context_from_identity(identity, self.settings.auth_settings))
         return await self._materialize_external_user(identity, db)
 
     async def _authenticate_with_api_key(self, api_key: str, db: AsyncSession) -> UserRead | None:
@@ -254,6 +260,10 @@ class AuthService(BaseAuthService):
             return None
 
         if isinstance(result, User):
+            if await self._external_access_ceiling_blocks_api_key_user(result, db):
+                logger.info("API key rejected for externally managed user while external access ceiling is enabled")
+                msg = "API key authentication is disabled for externally managed users"
+                raise InvalidCredentialsError(msg)
             user_read = UserRead.model_validate(result, from_attributes=True)
             if not user_read.is_active:
                 msg = "User account is inactive"
@@ -261,6 +271,24 @@ class AuthService(BaseAuthService):
             return user_read
 
         return None
+
+    async def _external_access_ceiling_blocks_api_key_user(self, user: User, db: AsyncSession) -> bool:
+        auth_settings = self.settings.auth_settings
+        if (
+            not auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED
+            or not auth_settings.EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS
+        ):
+            return False
+
+        from sqlmodel import select
+
+        from langflow.services.database.models.auth import SSOUserProfile
+
+        profile_stmt = select(SSOUserProfile).where(
+            SSOUserProfile.user_id == user.id,
+            SSOUserProfile.sso_provider == auth_settings.EXTERNAL_AUTH_PROVIDER,
+        )
+        return (await db.exec(profile_stmt)).first() is not None
 
     # ------------------------------------------------------------------
     # JIT user provisioning via BaseAuthService hook

--- a/src/backend/base/langflow/services/authorization/guards.py
+++ b/src/backend/base/langflow/services/authorization/guards.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from lfx.log.logger import logger
 
+from langflow.services.auth.external import external_access_allows, get_current_external_access_context
 from langflow.services.authorization import audit as _audit
 from langflow.services.authorization.actions import (
     DeploymentAction,
@@ -168,6 +169,24 @@ async def _ensure_resource_permission(
 ) -> None:
     """Build object key, apply owner override, else delegate to ensure_permission."""
     obj = f"{resource_type}:{resource_id}" if resource_id else f"{resource_type}:*"
+
+    external_context = get_current_external_access_context()
+    if external_context is not None and not external_access_allows(act_str, external_context):
+        await _audit.audit_decision(
+            user_id=user.id,
+            action=f"{resource_type}:{act_str}",
+            obj=obj,
+            result=_audit.AUDIT_DENY,
+            details={
+                "domain": resolved_domain,
+                "external_auth_provider": external_context.provider,
+                "external_access_level": external_context.level,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="External credentials do not allow this action",
+        )
 
     if owner_id is not None and getattr(user, "id", None) == owner_id:
         await _audit.audit_decision(

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -64,6 +64,18 @@ async def get_api_keys(session: AsyncSession, user_id: UUID) -> list[ApiKeyRead]
 
 async def create_api_key(session: AsyncSession, api_key_create: ApiKeyCreate, user_id: UUID) -> UnmaskedApiKeyRead:
     """Create a new API key, storing an encrypted value and a SHA-256 hash for fast lookup."""
+    settings_service = get_settings_service()
+    auth_settings = settings_service.auth_settings
+    if (
+        auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED
+        and auth_settings.EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS
+    ):
+        from langflow.services.auth.external import get_current_external_access_context
+
+        if get_current_external_access_context() is not None:
+            msg = "API key creation is disabled for externally authenticated users"
+            raise PermissionError(msg)
+
     # Generate a random API key with 32 bytes of randomness
     generated_api_key = f"sk-{secrets.token_urlsafe(32)}"
 

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -66,9 +66,8 @@ async def create_api_key(session: AsyncSession, api_key_create: ApiKeyCreate, us
     """Create a new API key, storing an encrypted value and a SHA-256 hash for fast lookup."""
     settings_service = get_settings_service()
     auth_settings = settings_service.auth_settings
-    if (
-        auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED
-        and auth_settings.EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS
+    if getattr(auth_settings, "EXTERNAL_AUTH_ACCESS_CEILING_ENABLED", False) and getattr(
+        auth_settings, "EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS", True
     ):
         from langflow.services.auth.external import get_current_external_access_context
 

--- a/src/backend/tests/unit/services/auth/test_external_auth.py
+++ b/src/backend/tests/unit/services/auth/test_external_auth.py
@@ -11,11 +11,16 @@ import pytest
 from langflow.services.auth import external
 from langflow.services.auth.exceptions import InvalidTokenError
 from langflow.services.auth.external import (
+    access_context_from_identity,
     decode_external_jwt,
+    external_access_allows,
     extract_bearer_or_raw_token,
     extract_external_token,
+    filter_actions_by_external_access_ceiling,
+    get_current_external_access_context,
     identity_from_claims,
     resolve_external_identity,
+    set_current_external_access_context,
 )
 from lfx.services.settings.auth import AuthSettings
 
@@ -278,6 +283,51 @@ def test_identity_from_claims_falls_back_to_synthesized_username(tmp_path):
     assert identity.username.startswith("test-provider-")
     assert identity.email is None
     assert identity.name is None
+
+
+def test_external_access_context_uses_configured_claim_mapping(tmp_path):
+    settings = _auth_settings(
+        tmp_path,
+        EXTERNAL_AUTH_ACCESS_CEILING_ENABLED=True,
+        EXTERNAL_AUTH_ACCESS_CLAIM="openrag_mode",
+        EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING='{"can_view":"viewer","can_edit":"editor"}',
+    )
+    identity = identity_from_claims({"sub": "subject-1", "openrag_mode": "can_edit"}, settings)
+
+    context = access_context_from_identity(identity, settings)
+
+    assert context is not None
+    assert context.level == "editor"
+    assert external_access_allows("write", context)
+    assert external_access_allows("execute", context)
+    assert not external_access_allows("delete", context)
+
+
+def test_external_access_context_defaults_to_viewer_for_missing_claim(tmp_path):
+    settings = _auth_settings(
+        tmp_path,
+        EXTERNAL_AUTH_ACCESS_CEILING_ENABLED=True,
+        EXTERNAL_AUTH_ACCESS_CLAIM="openrag_mode",
+    )
+    identity = identity_from_claims({"sub": "subject-1"}, settings)
+
+    context = access_context_from_identity(identity, settings)
+
+    assert context is not None
+    assert context.level == "viewer"
+    assert external_access_allows("read", context)
+    assert not external_access_allows("write", context)
+
+
+def test_filter_actions_by_external_access_ceiling_uses_request_context():
+    set_current_external_access_context(
+        external.ExternalAccessContext(provider="test-provider", subject="subject-1", level="viewer")
+    )
+    try:
+        assert filter_actions_by_external_access_ceiling(["read", "write", "delete"]) == ["read"]
+        assert get_current_external_access_context() is not None
+    finally:
+        set_current_external_access_context(None)
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/authorization/test_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_guards.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from langflow.services.auth.external import ExternalAccessContext, set_current_external_access_context
 from langflow.services.authorization import guards as authz_guards
 from langflow.services.authorization.actions import (
     DeploymentAction,
@@ -291,6 +292,56 @@ async def test_owner_override_skips_enforce(monkeypatch, fake_user):
 
     assert service.calls == []
     assert len(audit_calls) == 1
+    assert audit_calls[0]["result"] == "owner_override"
+
+
+@pytest.mark.anyio
+async def test_external_viewer_ceiling_denies_before_owner_override(monkeypatch, fake_user):
+    """A viewer claim is a deny-only ceiling even when the user owns the flow."""
+    install_settings(monkeypatch, authz_enabled=False, audit_enabled=True)
+    service = _StubAuthorizationService(allow=True)
+    install_authz(monkeypatch, service)
+    audit_calls = install_audit_recorder(monkeypatch)
+    set_current_external_access_context(ExternalAccessContext(provider="openrag", subject="subject-1", level="viewer"))
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await authz_guards.ensure_flow_permission(
+                fake_user,
+                FlowAction.WRITE,
+                flow_id=uuid4(),
+                flow_user_id=fake_user.id,
+            )
+    finally:
+        set_current_external_access_context(None)
+
+    assert exc_info.value.status_code == 403
+    assert "External credentials" in exc_info.value.detail
+    assert service.calls == []
+    assert audit_calls[0]["result"] == "deny"
+    assert audit_calls[0]["details"]["external_access_level"] == "viewer"
+
+
+@pytest.mark.anyio
+async def test_external_editor_ceiling_allows_write_then_owner_override(monkeypatch, fake_user):
+    """Editor is still only a ceiling; normal owner/plugin logic continues after it passes."""
+    install_settings(monkeypatch, authz_enabled=True, audit_enabled=True)
+    service = _StubAuthorizationService(allow=False)
+    install_authz(monkeypatch, service)
+    audit_calls = install_audit_recorder(monkeypatch)
+    set_current_external_access_context(ExternalAccessContext(provider="openrag", subject="subject-1", level="editor"))
+
+    try:
+        await authz_guards.ensure_flow_permission(
+            fake_user,
+            FlowAction.WRITE,
+            flow_id=uuid4(),
+            flow_user_id=fake_user.id,
+        )
+    finally:
+        set_current_external_access_context(None)
+
+    assert service.calls == []
     assert audit_calls[0]["result"] == "owner_override"
 
 

--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -36,6 +36,11 @@ _EXTERNAL_FIELDS = (
     "EXTERNAL_AUTH_USERNAME_CLAIM",
     "EXTERNAL_AUTH_EMAIL_CLAIM",
     "EXTERNAL_AUTH_NAME_CLAIM",
+    "EXTERNAL_AUTH_ACCESS_CEILING_ENABLED",
+    "EXTERNAL_AUTH_ACCESS_CLAIM",
+    "EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING",
+    "EXTERNAL_AUTH_DEFAULT_ACCESS_LEVEL",
+    "EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS",
 )
 
 
@@ -58,6 +63,11 @@ async def external_auth_settings(client):  # noqa: ARG001
     auth_settings.EXTERNAL_AUTH_USERNAME_CLAIM = "preferred_username"
     auth_settings.EXTERNAL_AUTH_EMAIL_CLAIM = "email"
     auth_settings.EXTERNAL_AUTH_NAME_CLAIM = "name"
+    auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED = False
+    auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM = None
+    auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING = None
+    auth_settings.EXTERNAL_AUTH_DEFAULT_ACCESS_LEVEL = "viewer"
+    auth_settings.EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS = True
 
     yield auth_settings
 
@@ -218,3 +228,47 @@ async def test_session_endpoint_rejects_expired_external_token(client, external_
 
     assert response.status_code == 200
     assert response.json()["authenticated"] is False
+
+
+async def test_external_access_ceiling_filters_effective_permissions(client, external_auth_settings):
+    external_auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED = True
+    external_auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM = "openrag_mode"
+    external_auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING = '{"view":"viewer","edit":"editor"}'
+    token = _external_token(
+        sub="viewer-subject",
+        preferred_username="viewer-user",
+        openrag_mode="view",
+    )
+
+    response = await client.post(
+        "api/v1/authz/me/permissions",
+        headers={_EXTERNAL_AUTH_HEADER: f"Bearer {token}"},
+        json={
+            "resource_type": "flow",
+            "resource_ids": ["00000000-0000-0000-0000-000000000001"],
+            "actions": ["read", "write", "delete"],
+        },
+    )
+
+    assert response.status_code == 200
+    permissions = response.json()["permissions"]
+    assert permissions["00000000-0000-0000-0000-000000000001"] == ["read"]
+
+
+async def test_external_access_ceiling_blocks_api_key_creation(client, external_auth_settings):
+    external_auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED = True
+    external_auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM = "openrag_mode"
+    token = _external_token(
+        sub="viewer-api-key-subject",
+        preferred_username="viewer-api-key-user",
+        openrag_mode="viewer",
+    )
+
+    response = await client.post(
+        "api/v1/api_key/",
+        headers={_EXTERNAL_AUTH_HEADER: f"Bearer {token}"},
+        json={"name": "should-not-work"},
+    )
+
+    assert response.status_code == 403
+    assert "API key creation is disabled" in response.json()["detail"]

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -202,6 +202,38 @@ class AuthSettings(BaseSettings):
         default="name",
         description="JWT claim containing the user's display name.",
     )
+    EXTERNAL_AUTH_ACCESS_CEILING_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable a coarse deny-only action ceiling for users authenticated by external trusted identity. "
+            "This is not an RBAC engine; it only caps actions above a mapped access level."
+        ),
+    )
+    EXTERNAL_AUTH_ACCESS_CLAIM: str | None = Field(
+        default=None,
+        description=(
+            "JWT claim used to derive the external access ceiling. Claim values are mapped through "
+            "EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING."
+        ),
+    )
+    EXTERNAL_AUTH_ACCESS_CLAIM_MAPPING: str | None = Field(
+        default=None,
+        description=(
+            "JSON object or comma-separated value map from external claim values to one of: viewer, editor, admin. "
+            'Example: \'{"view":"viewer","edit":"editor"}\'. Built-in aliases cover common values.'
+        ),
+    )
+    EXTERNAL_AUTH_DEFAULT_ACCESS_LEVEL: str = Field(
+        default="viewer",
+        description="Fallback access level used when the access claim is missing or unmapped.",
+    )
+    EXTERNAL_AUTH_DISABLE_API_KEYS_FOR_EXTERNAL_USERS: bool = Field(
+        default=True,
+        description=(
+            "When the external access ceiling is enabled, reject Langflow API-key authentication for users mapped "
+            "through the configured external provider so API keys cannot bypass the JWT claim ceiling."
+        ),
+    )
 
     # Authorization (RBAC) feature flags — enforcement via authorization_service plugin
     AUTHZ_ENABLED: bool = Field(


### PR DESCRIPTION
## Summary
- add opt-in EXTERNAL_AUTH_ACCESS_* settings to derive a coarse viewer/editor/admin access ceiling from trusted external JWT claims
- enforce the ceiling as a deny-only guard before owner override, without making OSS a policy engine
- filter /authz/me effective permissions and block Langflow API-key creation/auth for externally managed users while the ceiling is active

## Test plan
- uv run ruff check src/lfx/src/lfx/services/settings/auth.py src/backend/base/langflow/services/auth/external.py src/backend/base/langflow/services/auth/service.py src/backend/base/langflow/services/authorization/guards.py src/backend/base/langflow/api/v1/authz_me.py src/backend/base/langflow/api/v1/api_key.py src/backend/base/langflow/services/database/models/api_key/crud.py src/backend/tests/unit/services/auth/test_external_auth.py src/backend/tests/unit/services/authorization/test_guards.py src/backend/tests/unit/test_login.py
- uv run pytest src/backend/tests/unit/services/auth/test_external_auth.py src/backend/tests/unit/services/authorization/test_guards.py src/backend/tests/unit/test_login.py