### PR TITLE
fix: prevent UnboundLocalError in lifespan cleanup when startup fails early (#13634)

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -164,6 +164,10 @@ def get_lifespan(*, fix_migration=False, version=None):
         sync_flows_from_fs_task = None
         mcp_init_task = None
         models_dev_refresh_task = None
+        # Pre-initialize so the shutdown cleanup in the `finally` block is safe even
+        # when startup fails before bundle loading assigns it. Otherwise that cleanup
+        # raises UnboundLocalError, masking the real startup error.
+        temp_dirs: list[tempfile.TemporaryDirectory] = []
 
         try:
             start_time = asyncio.get_event_loop().time()


### PR DESCRIPTION
## Summary

Fixes #13634.

`temp_dirs` is only assigned during the **bundle-loading** step of `lifespan()`
(`get_owned_temp_dirs()` / `load_bundles_with_error_handling()`), but the
shutdown cleanup in the `finally` block iterates it unconditionally:

```python
temp_dir_cleanups = [asyncio.to_thread(temp_dir.cleanup) for temp_dir in temp_dirs]
```

When startup fails **before** that step — e.g. `initialize_services()` raising
`RuntimeError: Error creating DB and tables` on a misresolved
`LANGFLOW_DATABASE_URL` — the `finally` runs with `temp_dirs` never bound and
raises:

```
UnboundLocalError: cannot access local variable 'temp_dirs' where it is not associated with a value
```

This second exception **masks the real startup error** in a chained traceback,
so users have to dig past it to find the actual cause.

## Fix

Pre-initialize `temp_dirs` next to the other `lifespan()` task variables
(`sync_flows_from_fs_task`, `mcp_init_task`, `models_dev_refresh_task`) that are
already defined before the `try` for exactly this reason:

```python
temp_dirs: list[tempfile.TemporaryDirectory] = []
```

Now the `finally` cleanup is always safe (it iterates an empty list when bundles
never loaded), and the original startup exception surfaces uncovered. No
behavior change on the success path — `temp_dirs` is still reassigned by the
bundle-loading step. `tempfile` is already imported; the annotation matches
`Preload`'s `temp_dirs: list[tempfile.TemporaryDirectory]`.

This intentionally addresses only the **error-masking** half of #13634 (the
`UnboundLocalError`). The relative-`LANGFLOW_DATABASE_URL` path-resolution
behavior is a separate concern and left out of scope.

## Validation

- `python -m py_compile` on the changed module: passes.
- `ruff check` with the repo config: **All checks passed!**
- (The full pytest suite requires the complete backend dependency install; this
  change is a defensive, behavior-preserving variable initialization.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where application startup errors could be masked by cleanup failures, ensuring startup exceptions are properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->