### PR TITLE
fix(playground): optimize canvas performance by limiting chat history fetch

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -227,6 +227,8 @@ async def get_messages(
     sender: Annotated[str | None, Query()] = None,
     sender_name: Annotated[str | None, Query()] = None,
     order_by: Annotated[str | None, Query()] = "timestamp",
+    order: Annotated[str | None, Query()] = "ASC",
+    limit: Annotated[int | None, Query()] = None,
 ) -> list[MessageResponse]:
     try:
         # When a flow_id is provided, gate on flow READ permission first; the
@@ -255,8 +257,14 @@ async def get_messages(
         if sender_name:
             stmt = stmt.where(MessageTable.sender_name == sender_name)
         if order_by:
-            order_col = getattr(MessageTable, order_by).asc()
+            order_col = getattr(MessageTable, order_by)
+            if order and order.upper() == "DESC":
+                order_col = order_col.desc()
+            else:
+                order_col = order_col.asc()
             stmt = stmt.order_by(order_col)
+        if limit is not None:
+            stmt = stmt.limit(limit)
         messages = await session.exec(stmt)
         return [MessageResponse.model_validate(d, from_attributes=True) for d in messages]
     except Exception as e:

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -230,6 +230,13 @@ async def get_messages(
     order: Annotated[str | None, Query()] = "ASC",
     limit: Annotated[int | None, Query()] = None,
 ) -> list[MessageResponse]:
+    if order_by and order_by not in {"id", "timestamp", "sender", "sender_name", "session_id", "text", "flow_id"}:
+        raise HTTPException(status_code=400, detail=f"Invalid order_by field: {order_by}")
+    if order and order.upper() not in {"ASC", "DESC"}:
+        raise HTTPException(status_code=400, detail=f"Invalid order direction: {order}")
+    if limit is not None and (limit < 1 or limit > 1000):
+        raise HTTPException(status_code=400, detail="Limit must be between 1 and 1000")
+
     try:
         # When a flow_id is provided, gate on flow READ permission first; the
         # share-aware path lets a non-owner with a read grant see the flow's

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-chat-history.ts
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-chat-history.ts
@@ -15,8 +15,14 @@ export const useChatHistory = (visibleSession: string | null) => {
   const messageQueryParams: Parameters<typeof useGetMessagesQuery>[0] = {
     id: currentFlowId,
     mode: "union",
+    params: {
+      limit: 30,
+      order: "DESC"
+    }
   };
-  const { data: queryData } = useGetMessagesQuery(messageQueryParams);
+  const { data: queryData } = useGetMessagesQuery(messageQueryParams, {
+    enabled: !!visibleSession,
+  });
 
   // Session cache key - this is the single source of truth for messages
   const sessionCacheKey = useMemo(


### PR DESCRIPTION
Fixes #13460

### Description
Resolves canvas performance degradation after repeated Playground runs by limiting the number of messages fetched initially and only enabling the fetch when the playground is visible.

### Changes
- **Backend**: Added `limit` and `order` query parameters to `GET /monitor/messages` to allow retrieving the latest N messages efficiently.
- **Frontend**: Updated `useChatHistory` to conditionally enable the message fetch only when `visibleSession` is true, preventing unnecessary background fetches on canvas changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Messages endpoint now supports controlling sort direction (ascending or descending)
  * Messages endpoint now supports limiting the number of results returned

<!-- end of auto-generated comment: release notes by coderabbit.ai -->