### PR TITLE
fix(frontend): duplicate tooltip + raw i18n key on collapsed sidebar nav (1.11.0)

### DIFF
--- a/src/frontend/src/components/core/canvasControlsComponent/CanvasControlButton.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/CanvasControlButton.tsx
@@ -28,7 +28,7 @@ export const CanvasControlButton = ({
       className="group !h-8 !w-8 rounded !p-0"
       onClick={onClick}
       disabled={disabled}
-      title={testId?.replace(/_/g, " ")}
+      aria-label={tooltipText}
     >
       <ShadTooltip content={tooltipText} side="right">
         <div

--- a/src/frontend/src/components/core/canvasControlsComponent/__tests__/CanvasControlButton.test.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/__tests__/CanvasControlButton.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import CanvasControlButton from "../CanvasControlButton";
+
+// ControlButton renders the real DOM <button> and spreads its props, so we can
+// assert exactly which attributes (title / aria-label) reach the element.
+jest.mock("@xyflow/react", () => ({
+  ControlButton: ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+// ShadTooltip is the single, styled tooltip — expose its content so we can
+// confirm the button's label is surfaced through it (and only it).
+jest.mock("@/components/common/shadTooltipComponent", () => ({
+  __esModule: true,
+  default: ({ content, children }: any) => (
+    <div data-testid="shad-tooltip" data-content={content}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name }: any) => <div data-testid={`icon-${name}`} />,
+}));
+
+// Regression coverage for the duplicate sidebar tooltip bug: the control nav
+// buttons rendered BOTH a native `title` attribute and a ShadTooltip, so
+// hovering surfaced two tooltips at once (one of them exposing a raw i18n key).
+describe("CanvasControlButton — single tooltip (no native title)", () => {
+  const setup = () =>
+    render(
+      <CanvasControlButton
+        iconName="blocks"
+        tooltipText="Bundles"
+        onClick={jest.fn()}
+        testId="bundles"
+      />,
+    );
+
+  it("does not render a native title attribute (would be a second tooltip)", () => {
+    setup();
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("title");
+  });
+
+  it("exposes the label via aria-label and the ShadTooltip, not a raw key", () => {
+    setup();
+    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Bundles");
+    expect(screen.getByTestId("shad-tooltip")).toHaveAttribute(
+      "data-content",
+      "Bundles",
+    );
+  });
+});

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/MemoizedComponents.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/MemoizedComponents.tsx
@@ -54,7 +54,7 @@ export const MemoizedSidebarTrigger = memo(() => {
             iconName={item.icon}
             iconClasses={item.id === "mcp" ? "h-8 w-8" : ""}
             key={item.id}
-            tooltipText={item.tooltip}
+            tooltipText={t(item.tooltip)}
             onClick={() => {
               setActiveSection(item.id);
               if (!open) {


### PR DESCRIPTION
## Summary

When the left navigation sidebar is collapsed, the floating canvas control nav showed **two tooltips at once** on every icon — one exposing the raw i18n key (e.g. `sidebar.nav.bundles`), the other the bare section id (e.g. `bundles`).

## Root Cause

The collapsed-sidebar rail is rendered by `MemoizedSidebarTrigger` → `CanvasControlButton`. Two issues stacked:

1. **`CanvasControlButton`** rendered a native `title` attribute on `ControlButton` **and** a styled `ShadTooltip` — two tooltips per button. (This also affected the zoom/fit/lock control buttons.)
2. **`MemoizedComponents`** passed `item.tooltip` (the raw i18n key) as the tooltip text without running it through `t()`, so the `ShadTooltip` displayed `sidebar.nav.bundles` instead of `Bundles`.

The native `title` showed `testId` (`bundles`); the ShadTooltip showed the untranslated key (`sidebar.nav.bundles`) — exactly the two tooltips in the report.

## Fix

- `CanvasControlButton.tsx` — drop the native `title` (the duplicate); preserve accessibility with `aria-label`. The `ShadTooltip` is now the single visual tooltip.
- `MemoizedComponents.tsx` — translate the nav tooltip: `tooltipText={t(item.tooltip)}` (`t` already in scope).

## Behavior

| | Before | After |
|---|---|---|
| Tooltips per icon | 2 (native + ShadTooltip) | 1 (ShadTooltip) |
| Text shown | `sidebar.nav.bundles` + `bundles` | `Bundles` |
| Accessible name | native `title` (raw id) | `aria-label` (translated) |

## Testing

- New isolated `CanvasControlButton.test.tsx`: asserts no native `title` and that the label is surfaced via `aria-label` + `ShadTooltip`.
- All touched suites green (109 tests), biome clean.
- Verified live against the running OSS app (collapsed sidebar): `title=null`, `aria-label="Bundles"` — single translated tooltip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for canvas control buttons by replacing native `title` attributes with proper `aria-label` attributes for improved screen reader support.
  * Fixed tooltip text to properly display translated content instead of raw translation keys.

* **Tests**
  * Added test coverage to verify canvas control buttons render with correct accessibility attributes and proper tooltip localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->