### PR TITLE
fix(lfx): bound upload helper http requests

### DIFF
--- a/src/lfx/src/lfx/load/utils.py
+++ b/src/lfx/src/lfx/load/utils.py
@@ -8,6 +8,9 @@ class UploadError(Exception):
     """Raised when an error occurs during the upload process."""
 
 
+UPLOAD_TIMEOUT = 30.0
+
+
 def upload(file_path: str, host: str, flow_id: str, api_key: str | None = None):
     """Upload a file to Langflow and return the file path.
 
@@ -34,14 +37,20 @@ def upload(file_path: str, host: str, flow_id: str, api_key: str | None = None):
         resolved_api_key = api_key if api_key is not None else os.environ.get("LANGFLOW_API_KEY")
         headers = {"x-api-key": resolved_api_key} if resolved_api_key else {}
         with Path(file_path).open("rb") as file:
-            response = httpx.post(url, files={"file": file}, headers=headers)
+            response = httpx.post(url, files={"file": file}, headers=headers, timeout=UPLOAD_TIMEOUT)
             if response.status_code in {httpx.codes.OK, httpx.codes.CREATED}:
                 return response.json()
+    except httpx.TimeoutException as e:
+        msg = f"Error uploading file: request timed out after {UPLOAD_TIMEOUT}s"
+        raise UploadError(msg) from e
     except Exception as e:
         msg = f"Error uploading file: {e}"
         raise UploadError(msg) from e
 
+    response_text = getattr(response, "text", "")
     msg = f"Error uploading file: {response.status_code}"
+    if response_text:
+        msg = f"{msg} - {response_text}"
     raise UploadError(msg)
 
 

--- a/src/lfx/tests/unit/load/test_upload.py
+++ b/src/lfx/tests/unit/load/test_upload.py
@@ -75,6 +75,30 @@ def test_upload_sends_no_headers_when_no_api_key(tmp_path, monkeypatch):
     assert kwargs["headers"] == {}
 
 
+def test_upload_uses_bounded_http_timeout(tmp_path):
+    file_path = tmp_path / "x.txt"
+    file_path.write_bytes(b"contents")
+
+    with patch("lfx.load.utils.httpx.post", return_value=_ok_response()) as mock_post:
+        upload(str(file_path), "http://host", "flow-1")
+
+    _args, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == 30.0
+
+
+def test_upload_wraps_timeout_as_upload_error(tmp_path):
+    file_path = tmp_path / "x.txt"
+    file_path.write_bytes(b"contents")
+
+    with (
+        patch("lfx.load.utils.httpx.post", side_effect=httpx.TimeoutException("connect stalled")),
+        pytest.raises(UploadError) as exc_info,
+    ):
+        upload(str(file_path), "http://host", "flow-1")
+
+    assert "timed out after 30.0s" in str(exc_info.value)
+
+
 def test_upload_file_forwards_api_key(tmp_path):
     """``upload_file`` must pass the api_key through to ``upload``."""
     file_path = tmp_path / "x.txt"
@@ -106,5 +130,10 @@ def test_upload_raises_upload_error_on_auth_failure(tmp_path, monkeypatch):
 
     response = MagicMock()
     response.status_code = httpx.codes.UNAUTHORIZED
-    with patch("lfx.load.utils.httpx.post", return_value=response), pytest.raises(UploadError):
+    response.text = "missing api key"
+    with patch("lfx.load.utils.httpx.post", return_value=response), pytest.raises(UploadError) as exc_info:
         upload(str(file_path), "http://host", "flow-1")
+
+    message = str(exc_info.value)
+    assert "401" in message
+    assert "missing api key" in message


### PR DESCRIPTION
## Summary

Fixes #13654.

`lfx.load.utils.upload()` posted files to `/api/v1/upload/{flow_id}` without an explicit timeout, so slow or stalled hosts could leave callers waiting on httpx defaults. Non-success responses also only reported the status code, which hid useful server details such as auth failure bodies.

This change adds a bounded 30s timeout to the upload request, wraps timeout failures as `UploadError`, and includes response text in non-success `UploadError` messages when available.

## Testing

- Red first: `uv run pytest tests/unit/load/test_upload.py -q` failed because `httpx.post()` received no `timeout`, timeout exceptions were not normalized, and 401 response text was omitted.
- `uv run pytest tests/unit/load/test_upload.py -q`
- `uv run python -m py_compile src/lfx/load/utils.py tests/unit/load/test_upload.py`
- `uv run ruff check src/lfx/load/utils.py tests/unit/load/test_upload.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads now enforce a 30-second timeout to prevent requests from hanging indefinitely during long operations.
  * Enhanced error reporting for upload failures, including detailed HTTP status codes and server response information when available.

* **Tests**
  * Added comprehensive test coverage for upload timeout handling and various error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->