### PR TITLE
fix(load): bound remote flow fetches

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3356,7 +3356,7 @@
         "filename": "src/backend/tests/unit/base/load/test_load.py",
         "hashed_secret": "7aa10ce5d31e8d4bc6f0b5cf997173ff307e9172",
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 52,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T22:46:30Z"
+  "generated_at": "2026-06-17T18:03:47Z"
 }

--- a/src/backend/base/langflow/load/utils.py
+++ b/src/backend/base/langflow/load/utils.py
@@ -4,6 +4,9 @@ from lfx.load.utils import UploadError, replace_tweaks_with_env, upload, upload_
 from langflow.services.database.models.flow.model import FlowBase
 
 GET_FLOW_TIMEOUT = 30.0
+# Cap how much of an error response body is embedded in the raised UploadError
+# so a large upstream error page (e.g. an HTML 500) can't bloat logs/messages.
+GET_FLOW_ERROR_BODY_LIMIT = 500
 
 
 def get_flow(url: str, flow_id: str):
@@ -26,10 +29,13 @@ def get_flow(url: str, flow_id: str):
         if response.status_code == httpx.codes.OK:
             json_response = response.json()
             return FlowBase(**json_response).model_dump()
-        response_text = getattr(response, "text", "")
+        response_text = response.text or ""
         msg = f"Error retrieving flow: {response.status_code}"
         if response_text:
-            msg = f"{msg} - {response_text}"
+            truncated = response_text[:GET_FLOW_ERROR_BODY_LIMIT]
+            if len(response_text) > GET_FLOW_ERROR_BODY_LIMIT:
+                truncated = f"{truncated}... (truncated)"
+            msg = f"{msg} - {truncated}"
         raise UploadError(msg)
     except UploadError:
         raise

--- a/src/backend/base/langflow/load/utils.py
+++ b/src/backend/base/langflow/load/utils.py
@@ -3,6 +3,8 @@ from lfx.load.utils import UploadError, replace_tweaks_with_env, upload, upload_
 
 from langflow.services.database.models.flow.model import FlowBase
 
+GET_FLOW_TIMEOUT = 30.0
+
 
 def get_flow(url: str, flow_id: str):
     """Get the details of a flow from Langflow.
@@ -20,10 +22,20 @@ def get_flow(url: str, flow_id: str):
     """
     try:
         flow_url = f"{url}/api/v1/flows/{flow_id}"
-        response = httpx.get(flow_url)
+        response = httpx.get(flow_url, timeout=GET_FLOW_TIMEOUT)
         if response.status_code == httpx.codes.OK:
             json_response = response.json()
             return FlowBase(**json_response).model_dump()
+        response_text = getattr(response, "text", "")
+        msg = f"Error retrieving flow: {response.status_code}"
+        if response_text:
+            msg = f"{msg} - {response_text}"
+        raise UploadError(msg)
+    except UploadError:
+        raise
+    except httpx.TimeoutException as e:
+        msg = f"Error retrieving flow: request timed out after {GET_FLOW_TIMEOUT}s"
+        raise UploadError(msg) from e
     except Exception as e:
         msg = f"Error retrieving flow: {e}"
         raise UploadError(msg) from e

--- a/src/backend/tests/unit/base/load/test_load.py
+++ b/src/backend/tests/unit/base/load/test_load.py
@@ -1,9 +1,13 @@
 import inspect
 import os
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from dotenv import load_dotenv
 from langflow.load import run_flow_from_json
+from langflow.load.utils import get_flow
+from lfx.load.utils import UploadError
 
 
 def test_run_flow_from_json_params():
@@ -79,3 +83,29 @@ def test_run_flow_with_fake_env_tweaks(fake_env_file):
     # Extract and check the output data
     output_data = result[0].outputs[0].results["message"].data["text"]
     assert output_data == "**********"
+
+
+def test_get_flow_uses_bounded_http_timeout():
+    response = MagicMock()
+    response.status_code = httpx.codes.OK
+    response.json.return_value = {"name": "Remote Flow"}
+
+    with patch("langflow.load.utils.httpx.get", return_value=response) as mock_get:
+        result = get_flow("http://host", "flow-1")
+
+    assert result["name"] == "Remote Flow"
+    _args, kwargs = mock_get.call_args
+    assert kwargs["timeout"] == 30.0
+
+
+def test_get_flow_raises_upload_error_with_response_body_on_http_error():
+    response = MagicMock()
+    response.status_code = httpx.codes.INTERNAL_SERVER_ERROR
+    response.text = "database unavailable"
+
+    with patch("langflow.load.utils.httpx.get", return_value=response), pytest.raises(UploadError) as exc_info:
+        get_flow("http://host", "flow-1")
+
+    message = str(exc_info.value)
+    assert "500" in message
+    assert "database unavailable" in message

--- a/src/backend/tests/unit/base/load/test_load.py
+++ b/src/backend/tests/unit/base/load/test_load.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 from dotenv import load_dotenv
 from langflow.load import run_flow_from_json
-from langflow.load.utils import get_flow
+from langflow.load.utils import GET_FLOW_ERROR_BODY_LIMIT, GET_FLOW_TIMEOUT, get_flow
 from lfx.load.utils import UploadError
 
 
@@ -95,7 +95,7 @@ def test_get_flow_uses_bounded_http_timeout():
 
     assert result["name"] == "Remote Flow"
     _args, kwargs = mock_get.call_args
-    assert kwargs["timeout"] == 30.0
+    assert kwargs["timeout"] == GET_FLOW_TIMEOUT
 
 
 def test_get_flow_raises_upload_error_with_response_body_on_http_error():
@@ -109,3 +109,27 @@ def test_get_flow_raises_upload_error_with_response_body_on_http_error():
     message = str(exc_info.value)
     assert "500" in message
     assert "database unavailable" in message
+
+
+def test_get_flow_raises_upload_error_on_timeout():
+    with (
+        patch("langflow.load.utils.httpx.get", side_effect=httpx.ReadTimeout("slow host")),
+        pytest.raises(UploadError) as exc_info,
+    ):
+        get_flow("http://host", "flow-1")
+
+    assert "timed out" in str(exc_info.value)
+
+
+def test_get_flow_truncates_large_response_body_in_error():
+    response = MagicMock()
+    response.status_code = httpx.codes.INTERNAL_SERVER_ERROR
+    response.text = "x" * (GET_FLOW_ERROR_BODY_LIMIT * 10)
+
+    with patch("langflow.load.utils.httpx.get", return_value=response), pytest.raises(UploadError) as exc_info:
+        get_flow("http://host", "flow-1")
+
+    message = str(exc_info.value)
+    assert "truncated" in message
+    # Body portion is capped; the full 5000-char payload is not embedded verbatim.
+    assert len(message) < len(response.text)


### PR DESCRIPTION
## Summary

Fixes #13653.

`langflow.load.utils.get_flow()` fetched remote flows with `httpx.get(flow_url)` and no explicit timeout. Slow or stalled Langflow hosts could keep the import path waiting on httpx defaults, and non-200 responses returned `None` without a clear `UploadError`.

This change adds a bounded 30s timeout, wraps timeout failures as `UploadError`, and raises `UploadError` for non-200 responses with the status code and response text when available.

## Testing

- Red first: `uv run pytest src/backend/tests/unit/base/load/test_load.py::test_get_flow_uses_bounded_http_timeout src/backend/tests/unit/base/load/test_load.py::test_get_flow_raises_upload_error_with_response_body_on_http_error -q` failed because `httpx.get()` received no `timeout` and 500 responses did not raise.
- `uv run pytest src/backend/tests/unit/base/load/test_load.py -q`
- `uv run python -m py_compile src/backend/base/langflow/load/utils.py src/backend/tests/unit/base/load/test_load.py`
- `uv run ruff check src/backend/base/langflow/load/utils.py src/backend/tests/unit/base/load/test_load.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Flow retrieval operations now enforce a 30-second timeout to prevent indefinite hangs
* Enhanced error messages when flow retrieval fails to display HTTP status codes and response body details
* Implemented dedicated error handling for timeout scenarios with clearer user-facing messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->