### PR TITLE
fix: convert timezone-aware datetimes to UTC during serialization

### DIFF
--- a/src/backend/base/langflow/serialization/serialization.py
+++ b/src/backend/base/langflow/serialization/serialization.py
@@ -67,8 +67,14 @@ def _serialize_bytes(obj: bytes, max_length: int | None, _) -> str:
 
 
 def _serialize_datetime(obj: datetime, *_) -> str:
-    """Convert datetime to UTC ISO format."""
-    return obj.replace(tzinfo=timezone.utc).isoformat()
+    """Convert datetime to UTC ISO format.
+
+    Naive datetimes are assumed to already be in UTC; timezone-aware datetimes
+    are converted to UTC so the encoded instant is preserved rather than
+    relabeled with a different offset.
+    """
+    obj = obj.replace(tzinfo=timezone.utc) if obj.tzinfo is None else obj.astimezone(timezone.utc)
+    return obj.isoformat()
 
 
 def _serialize_decimal(obj: Decimal, *_) -> float:

--- a/src/backend/tests/unit/serialization/test_serialization.py
+++ b/src/backend/tests/unit/serialization/test_serialization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import numpy as np
@@ -80,6 +80,26 @@ class TestSerializationHypothesis:
     def test_datetime_serialization(self, dt: datetime) -> None:
         result: str = serialize(dt)
         assert result == dt.replace(tzinfo=timezone.utc).isoformat()
+
+    def test_datetime_serialization_aware_non_utc_is_converted(self) -> None:
+        """Timezone-aware datetimes must be converted to UTC, not relabeled.
+
+        ``datetime.replace(tzinfo=utc)`` keeps the wall-clock time and only
+        swaps the offset, silently shifting the represented instant. Conversion
+        must use ``astimezone`` so the encoded instant is preserved.
+        """
+        # 12:00 at +05:00 is 07:00 UTC.
+        dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        assert serialize(dt) == "2023-01-01T07:00:00+00:00"
+
+        # 22:00 at -08:00 rolls over to 06:00 the next day in UTC.
+        dt = datetime(2023, 1, 1, 22, 0, 0, tzinfo=timezone(timedelta(hours=-8)))
+        assert serialize(dt) == "2023-01-02T06:00:00+00:00"
+
+    def test_datetime_serialization_naive_assumed_utc(self) -> None:
+        """Naive datetimes are assumed to already be in UTC."""
+        dt = datetime(2023, 1, 1, 12, 0, 0)  # noqa: DTZ001
+        assert serialize(dt) == "2023-01-01T12:00:00+00:00"
 
     @settings(max_examples=100)
     @given(dec=decimal_strategy)

--- a/src/lfx/src/lfx/serialization/serialization.py
+++ b/src/lfx/src/lfx/serialization/serialization.py
@@ -63,8 +63,14 @@ def _serialize_bytes(obj: bytes, max_length: int | None, _) -> str:
 
 
 def _serialize_datetime(obj: datetime, *_) -> str:
-    """Convert datetime to UTC ISO format."""
-    return obj.replace(tzinfo=timezone.utc).isoformat()
+    """Convert datetime to UTC ISO format.
+
+    Naive datetimes are assumed to already be in UTC; timezone-aware datetimes
+    are converted to UTC so the encoded instant is preserved rather than
+    relabeled with a different offset.
+    """
+    obj = obj.replace(tzinfo=timezone.utc) if obj.tzinfo is None else obj.astimezone(timezone.utc)
+    return obj.isoformat()
 
 
 def _serialize_decimal(obj: Decimal, *_) -> float:


### PR DESCRIPTION
## Bug

`serialize()` normalizes `datetime` values via `datetime.replace(tzinfo=timezone.utc)`. `replace()` only swaps the tzinfo label and keeps the wall-clock time, so for a timezone-aware datetime in a non-UTC zone it silently shifts the represented instant instead of converting it.

For example, `12:00` at `+05:00` (which is `07:00Z`) was serialized as `2023-01-01T12:00:00+00:00` rather than the correct `2023-01-01T07:00:00+00:00`. The docstring already says "Convert datetime to UTC", but the code relabels rather than converts.

The same `_serialize_datetime` helper is duplicated in `langflow.serialization.serialization` and `lfx.serialization.serialization`; both were affected.

## Fix

Use `astimezone(timezone.utc)` for timezone-aware datetimes so the encoded instant is preserved, while still treating naive datetimes as UTC (unchanged behavior):

```python
obj = obj.replace(tzinfo=timezone.utc) if obj.tzinfo is None else obj.astimezone(timezone.utc)
```

Applied to both copies of the serializer.

## Verification

Added regression tests in `test_serialization.py` covering non-UTC aware (`+05:00`, `-08:00` with day rollover) and naive datetimes. Running the focused tests against the serializer:

```
$ python -m pytest test_dt_serialize.py -q
# before fix: 2 failed (non-UTC offsets relabeled, not converted), 2 passed
# after fix:  4 passed
```

The existing `test_datetime_serialization` hypothesis test (which samples only UTC/naive) continues to pass, confirming no behavior change for those cases.

> Note: This PR was drafted with AI assistance and the fix and tests were reviewed and verified by a human before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime serialization to correctly handle timezone-aware datetimes by converting them to UTC while preserving the represented instant.
  * Naive datetimes are now consistently treated as UTC and serialized with the appropriate offset.

* **Tests**
  * Added test coverage for timezone-aware and naive datetime serialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->