### PR TITLE
fix(a11y): label icon-only controls

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -469,6 +469,9 @@ function GenericNode({
                 ? "node-save-name-description-button"
                 : "node-edit-name-description-button"
             }
+            aria-label={
+              editedNameDescription ? "Save node details" : "Edit node details"
+            }
           >
             <ForwardedIconComponent
               name={editedNameDescription ? "Check" : "PencilLine"}

--- a/src/frontend/src/components/common/GradientWrapper/index.tsx
+++ b/src/frontend/src/components/common/GradientWrapper/index.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 export function GradientWrapper({ children }: { children: ReactNode }) {
   return (
     <>
-      <svg width="0" height="0" className="absolute">
+      <svg
+        width="0"
+        height="0"
+        className="absolute"
+        aria-hidden="true"
+        focusable="false"
+      >
         <defs>
           <linearGradient id="x-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
             <stop offset="-35.61%" stopColor="#e6b1e1" />

--- a/src/frontend/src/components/common/modelProviderCountComponent/index.tsx
+++ b/src/frontend/src/components/common/modelProviderCountComponent/index.tsx
@@ -27,6 +27,7 @@ export const ModelProviderCount = () => {
         className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
         onClick={() => setOpen((cur) => !cur)}
         data-testid="model-provider-count-button"
+        aria-label="Model providers"
       >
         <ForwardedIconComponent name="BrainCog" className="w-5 h-5" />
         <div className="text-sm">Models</div>

--- a/src/frontend/src/components/common/pageLayout/index.tsx
+++ b/src/frontend/src/components/common/pageLayout/index.tsx
@@ -37,6 +37,7 @@ export default function PageLayout({
                       navigate(backTo);
                     }}
                     data-testid="back_page_button"
+                    aria-label="Back"
                   >
                     <ForwardedIconComponent
                       name="ChevronLeft"

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -136,7 +136,7 @@ export const AccountMenu = () => {
                 id="menu_github_button"
                 className="flex items-center gap-2"
               >
-                <FaGithub className="h-4 w-4" />
+                <FaGithub className="h-4 w-4" aria-hidden="true" />
                 {t("account.github")}
               </span>
             </HeaderMenuItemLink>
@@ -146,7 +146,10 @@ export const AccountMenu = () => {
                 id="menu_discord_button"
                 className="flex items-center gap-2"
               >
-                <FaDiscord className="h-4 w-4 text-[#5865F2]" />
+                <FaDiscord
+                  className="h-4 w-4 text-[#5865F2]"
+                  aria-hidden="true"
+                />
                 {t("account.discord")}
               </span>
             </HeaderMenuItemLink>

--- a/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
@@ -26,9 +26,10 @@ export const LangflowCounts = () => {
           unstyled
           onClick={() => window.open(GITHUB_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
+          aria-label={`GitHub ${formattedStars}`.trim()}
         >
           <div className="relative items-center rounded-md px-2 py-1 flex">
-            <FaGithub className="h-4 w-4" />
+            <FaGithub className="h-4 w-4" aria-hidden="true" />
             <Case condition={Boolean(formattedStars) && formattedStars !== "0"}>
               <span className="text-xs font-semibold pl-2">
                 {formattedStars}
@@ -47,9 +48,10 @@ export const LangflowCounts = () => {
           unstyled
           onClick={() => window.open(DISCORD_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
+          aria-label={`Discord ${formattedDiscordCount}`.trim()}
         >
           <div className="relative items-center rounded-md px-2 py-1 flex">
-            <FaDiscord className="h-4 w-4" />
+            <FaDiscord className="h-4 w-4" aria-hidden="true" />
             <Case
               condition={
                 Boolean(formattedDiscordCount) && formattedDiscordCount !== "0"

--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -64,8 +64,9 @@ export default function AppHeader(): JSX.Element {
           onClick={() => navigate("/")}
           className="mr-1 flex h-8 w-8 items-center"
           data-testid="icon-ChevronLeft"
+          aria-label={t("common.langflowLogo")}
         >
-          <LangflowLogo className="h-5 w-5" />
+          <LangflowLogo className="h-5 w-5" aria-hidden="true" />
         </Button>
         <CustomOrgSelector />
       </div>

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/add-folder-button.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/add-folder-button.tsx
@@ -23,6 +23,7 @@ export const AddFolderButton = ({
         data-testid="add-project-button"
         disabled={disabled}
         loading={loading}
+        aria-label={t("folder.createNewProject")}
       >
         <IconComponent name="Plus" className="h-4 w-4" />
       </Button>

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -108,6 +108,7 @@ export const GetStartedProgress: FC<{
           onClick={() => handleUserTrack("dialog_dismissed")}
           className="text-muted-foreground hover:text-foreground"
           data-testid="close_get_started_dialog"
+          aria-label={t("toolsModal.close")}
         >
           <IconComponent name="X" className="h-4 w-4" />
         </button>
@@ -158,7 +159,7 @@ export const GetStartedProgress: FC<{
                 />
               </span>
             ) : (
-              <FaGithub className="h-4 w-4 shrink-0" />
+              <FaGithub className="h-4 w-4 shrink-0" aria-hidden="true" />
             )}
             <ShadTooltip content={t("sidebar.starRepo")} side="right">
               <span
@@ -202,7 +203,10 @@ export const GetStartedProgress: FC<{
                 />
               </span>
             ) : (
-              <FaDiscord className="h-4 w-4 shrink-0 text-[#5865F2]" />
+              <FaDiscord
+                className="h-4 w-4 shrink-0 text-[#5865F2]"
+                aria-hidden="true"
+              />
             )}
             <ShadTooltip content={t("sidebar.joinCommunity")} side="right">
               <span

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -49,6 +49,7 @@ export const SelectOptions = ({
           <SelectTrigger
             className="w-fit"
             id={`options-trigger-${item.name}`}
+            aria-label={`${t("folder.options")} ${item.name}`}
             data-testid={
               "more-options-button" + `_${convertTestName(item?.name ?? "")}`
             }

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/upload-folder-button.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/upload-folder-button.tsx
@@ -14,6 +14,7 @@ export const UploadFolderButton = ({ onClick, disabled }) => {
         onClick={onClick}
         data-testid="upload-project-button"
         disabled={disabled}
+        aria-label={t("folder.uploadFlow")}
       >
         <IconComponent name="Upload" className="h-4 w-4" />
       </Button>

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
@@ -282,6 +282,7 @@ export default function InputComponent({
                   : "text-placeholder-foreground",
                 !disabled && "hover:text-foreground",
               )}
+              aria-label="Select input option"
             >
               <ForwardedIconComponent
                 name={

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -316,6 +316,7 @@ export default function InputFileComponent({
                   readOnly
                   disabled={isDisabled}
                   onClick={handleButtonClick}
+                  aria-label={t("fileManager.selectFile")}
                 />
               </div>
               <div>
@@ -332,6 +333,7 @@ export default function InputFileComponent({
                   disabled={isDisabled}
                   size="icon"
                   data-testid="button_upload_file"
+                  aria-label={value ? t("files.remove") : t("files.uploadFile")}
                 >
                   <IconComponent
                     name={value ? "CircleCheckBig" : "Upload"}

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx
@@ -126,6 +126,7 @@ export function ChatSidebar({
               variant="ghost"
               className="flex h-8 w-8 items-center justify-center !p-0 hover:bg-secondary-hover"
               onClick={onNewChat}
+              aria-label={t("chat.newChat")}
             >
               <ForwardedIconComponent
                 name="Plus"

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message-logo.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message-logo.tsx
@@ -1,14 +1,12 @@
-import { useTranslation } from "react-i18next";
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 
 export default function LogoIcon() {
-  const { t } = useTranslation();
   return (
     <div className="relative flex h-8 w-8 items-center justify-center rounded-md bg-muted">
       <div className="flex h-8 w-8 items-center justify-center">
         <LangflowLogo
-          title={t("common.langflowLogo")}
           className="absolute h-[18px] w-[18px]"
+          aria-hidden="true"
         />
       </div>
     </div>

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message.tsx
@@ -148,7 +148,10 @@ export const BotMessage = memo(
                   }
                 >
                   <div className="flex h-5 w-5 items-center justify-center">
-                    <LangflowLogo className="h-4 w-4 text-black" />
+                    <LangflowLogo
+                      className="h-4 w-4 text-black"
+                      aria-hidden="true"
+                    />
                   </div>
                 </div>
               )}

--- a/src/frontend/src/components/ui/loading.tsx
+++ b/src/frontend/src/components/ui/loading.tsx
@@ -17,6 +17,8 @@ export const Loading = ({ size = 24, ...props }: LoadingProps) => (
     strokeLinecap="round"
     strokeLinejoin="round"
     className="feather feather-circle"
+    aria-hidden={props["aria-label"] ? undefined : true}
+    focusable={props["aria-label"] ? undefined : false}
     {...props}
     data-testid="loading-icon"
   >

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/chat-logo-icon.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/chat-logo-icon.tsx
@@ -1,14 +1,12 @@
-import { useTranslation } from "react-i18next";
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 
 export default function LogoIcon() {
-  const { t } = useTranslation();
   return (
     <div className="relative flex h-8 w-8 items-center justify-center rounded-md bg-muted">
       <div className="flex h-8 w-8 items-center justify-center">
         <LangflowLogo
-          title={t("common.langflowLogo")}
           className="absolute h-[18px] w-[18px]"
+          aria-hidden="true"
         />
       </div>
     </div>

--- a/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
@@ -196,8 +196,8 @@ export default function ChatView({
               <div className="flex flex-grow w-full flex-col items-center justify-center">
                 <div className="flex flex-col items-center justify-center gap-4 p-8">
                   <LangflowLogo
-                    title={t("common.langflowLogo")}
                     className="h-10 w-10 scale-[1.5]"
+                    aria-hidden="true"
                   />
                   <div className="flex flex-col items-center justify-center">
                     <h3 className="mt-2 pb-2 text-2xl font-semibold text-primary">

--- a/src/frontend/src/modals/IOModal/components/sidebar-open-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/sidebar-open-view.tsx
@@ -47,6 +47,7 @@ export const SidebarOpenView = ({
                   data-testid="new-chat"
                   variant="ghost"
                   className="flex h-8 w-8 items-center justify-center !p-0 hover:bg-secondary-hover"
+                  aria-label={t("chat.newChat")}
                   onClick={(_) => {
                     setvisibleSession(undefined);
                     setSelectedViewField(undefined);

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelEditField.tsx
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelEditField.tsx
@@ -87,6 +87,7 @@ export default function InspectionPanelEditField({
           data-testid={`show${name}`}
           id={`show${name}`}
           aria-checked={isOnCanvas}
+          aria-label={`${isOnCanvas ? t("common.hide") : t("common.show")} ${title}`}
           role="checkbox"
         >
           <IconComponent

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelHeader.tsx
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelHeader.tsx
@@ -138,6 +138,9 @@ export default function InspectionPanelHeader({
                   ? "save-name-description-button"
                   : "edit-name-description-button"
               }
+              aria-label={
+                editMode ? t("settings.saveButton") : t("admin.editTitle")
+              }
             >
               <ForwardedIconComponent
                 name={editMode ? "Check" : "PencilLine"}
@@ -181,6 +184,7 @@ export default function InspectionPanelHeader({
                 )}
                 className="!text-muted-foreground"
                 dataTestId="docs-button-modal"
+                label={t("nodeToolbar.docs")}
               />
             )}
             {hasCode && (

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/searchConfigTrigger.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/searchConfigTrigger.tsx
@@ -23,6 +23,7 @@ export const SearchConfigTrigger = ({
           onClick={() => setShowConfig(!showConfig)}
           className="hover:text-primary text-muted-foreground"
           style={{ padding: "0px" }}
+          aria-label={t("sidebar.componentSettings")}
         >
           <ForwardedIconComponent name="Settings2" className="h-4 w-4" />
         </Button>

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx
@@ -221,7 +221,10 @@ export const SidebarDraggableComponent = forwardRef(
                     name="GripVertical"
                     className="h-4 w-4 shrink-0 text-muted-foreground group-hover/draggable:text-primary"
                   />
-                  <SelectTrigger tabIndex={-1}></SelectTrigger>
+                  <SelectTrigger
+                    tabIndex={-1}
+                    aria-label={t("folder.options")}
+                  ></SelectTrigger>
                   <SelectContent
                     position="popper"
                     side="bottom"

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader.tsx
@@ -54,6 +54,7 @@ export const SidebarHeaderComponent = memo(function SidebarHeaderComponent({
                     variant={showConfig ? "ghostActive" : "ghost"}
                     size="iconMd"
                     data-testid="sidebar-options-trigger"
+                    aria-label={t("sidebar.componentSettings")}
                   >
                     <ForwardedIconComponent
                       name="SlidersHorizontal"

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/components/toolbar-button.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/components/toolbar-button.tsx
@@ -5,6 +5,13 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/utils";
 import ShortcutDisplay from "../shortcutDisplay";
 
+type ToolbarShortcut = {
+  display_name?: string;
+  name?: string;
+  shortcut: string;
+  sidebar?: boolean;
+};
+
 export const ToolbarButton = memo(
   ({
     onClick,
@@ -17,12 +24,12 @@ export const ToolbarButton = memo(
     onClick: () => void;
     icon: string;
     label?: string;
-    shortcut?: any;
+    shortcut?: ToolbarShortcut;
     className?: string;
     dataTestId?: string;
   }) => (
     <ShadTooltip
-      content={<ShortcutDisplay {...shortcut} />}
+      content={shortcut ? <ShortcutDisplay {...shortcut} /> : (label ?? icon)}
       side="top"
       avoidCollisions={true}
     >
@@ -32,6 +39,7 @@ export const ToolbarButton = memo(
         onClick={onClick}
         size="node-toolbar"
         data-testid={dataTestId}
+        aria-label={label ?? shortcut?.name ?? icon}
       >
         <ForwardedIconComponent name={icon} className="h-4 w-4" />
         {label && <span className="text-mmd font-medium">{label}</span>}

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -632,7 +632,10 @@ const NodeToolbarComponent = memo(
               onOpenChange={handleOpenChange}
               open={dropdownOpen}
             >
-              <SelectTrigger className="w-62">
+              <SelectTrigger
+                className="w-62"
+                aria-label={t("nodeToolbar.showMore")}
+              >
                 <ShadTooltip content={t("nodeToolbar.showMore")} side="top">
                   <div data-testid="more-options-modal">
                     <Button

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -227,6 +227,9 @@ const HeaderComponent = ({
                           : "text-muted-foreground hover:bg-muted"
                       }`}
                       onClick={() => setView(viewType as "list" | "grid")}
+                      aria-label={
+                        viewType === "list" ? "List view" : "Grid view"
+                      }
                     >
                       <ForwardedIconComponent
                         name={viewType === "list" ? "Menu" : "LayoutGrid"}
@@ -252,6 +255,7 @@ const HeaderComponent = ({
                     onClick={handleDownload}
                     loading={isDownloading}
                     tabIndex={hasSelection ? 0 : -1}
+                    aria-label={t("shortcuts.name.download")}
                   >
                     <ForwardedIconComponent name="Download" />
                   </Button>

--- a/src/frontend/src/pages/MainPage/pages/empty-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/empty-page.tsx
@@ -106,7 +106,7 @@ export const EmptyPageCommunity = ({
                 <div className="relative flex flex-col rounded-lg border-[1px] bg-background p-4 transition-all duration-300 hover:border-accent-pink-foreground">
                   <div className="grid w-full items-center justify-between gap-2">
                     <div className="flex gap-3">
-                      <FaGithub className="h-6 w-6" />
+                      <FaGithub className="h-6 w-6" aria-hidden="true" />
                       <div>
                         <span className="font-semibold">GitHub</span>
                         <span className="ml-2 font-mono text-muted-foreground">
@@ -136,7 +136,10 @@ export const EmptyPageCommunity = ({
                 <div className="relative flex flex-col rounded-lg border-[1px] bg-background p-4 transition-all duration-300 hover:border-discord-color">
                   <div className="grid w-full items-center justify-between gap-2">
                     <div className="flex gap-3">
-                      <FaDiscord className="h-6 w-6 text-discord-color" />
+                      <FaDiscord
+                        className="h-6 w-6 text-discord-color"
+                        aria-hidden="true"
+                      />
                       <div>
                         <span className="font-semibold">Discord</span>
                         <span className="ml-2 font-mono text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add accessible names to icon-only controls across header, folder/sidebar actions, node toolbars, playground, file upload, and main page actions.
- Hide decorative SVG/icon content where parent controls already provide the accessible name.
- Keep React Flow/background SVG handling out of scope to avoid DOM patch risk.

## Validation
- make test_frontend_a11y_e2e
- cd src/frontend && npm run a11y:report --silent -- --json
- cd src/frontend && npx jest src/components/core/appHeaderComponent/__tests__/appHeader.a11y.test.tsx src/pages/FlowPage/components/InspectionPanel/__tests__/InspectionPanelHeader.test.tsx --runInBand

## Notes
- This overlaps with PR #13666 in a few call sites. Leaving this draft until #13664/#13666 merge so we can rebase and reconcile i18n/test choices.

Refs LE-1516