### PR TITLE
feat(lfx): fail-fast dependency preflight for `lfx run`

### DIFF
--- a/src/lfx/src/lfx/cli/_running_commands.py
+++ b/src/lfx/src/lfx/cli/_running_commands.py
@@ -41,6 +41,11 @@ def register(app: typer.Typer) -> None:
             show_default=True,
             help="Check global variables for environment compatibility",
         ),
+        check_dependencies: bool = typer.Option(
+            default=True,
+            show_default=True,
+            help="Preflight the flow's required packages; fail fast with install guidance when any are missing",
+        ),
         verbose: bool = typer.Option(
             False,
             "-v",
@@ -96,6 +101,7 @@ def register(app: typer.Typer) -> None:
             flow_json=flow_json,
             stdin=stdin,
             check_variables=check_variables,
+            check_dependencies=check_dependencies,
             verbose=verbose,
             verbose_detailed=verbose_detailed,
             verbose_full=verbose_full,

--- a/src/lfx/src/lfx/cli/run.py
+++ b/src/lfx/src/lfx/cli/run.py
@@ -81,6 +81,11 @@ async def run(
         show_default=True,
         help="Check global variables for environment compatibility",
     ),
+    check_dependencies: bool = typer.Option(
+        default=True,
+        show_default=True,
+        help="Preflight the flow's required packages; fail fast with install guidance when any are missing",
+    ),
     verbose: bool = typer.Option(
         False,  # noqa: FBT003
         "-v",
@@ -128,6 +133,7 @@ async def run(
         flow_json: Inline JSON flow content as a string
         stdin: Read JSON flow content from stdin
         check_variables: Check global variables for environment compatibility
+        check_dependencies: Preflight required packages and fail fast when any are missing
         timing: Include detailed timing information in output
         session_id: Optional session ID; auto-generated if not supplied
         upgrade_flow: Component compatibility mode ('check' or 'safe')
@@ -144,6 +150,7 @@ async def run(
             flow_json=flow_json,
             stdin=bool(stdin),
             check_variables=check_variables,
+            check_dependencies=check_dependencies,
             verbose=verbose,
             verbose_detailed=verbose_detailed,
             verbose_full=verbose_full,

--- a/src/lfx/src/lfx/run/base.py
+++ b/src/lfx/src/lfx/run/base.py
@@ -36,6 +36,57 @@ class RunError(Exception):
         self.original_exception = exception
 
 
+def _preflight_dependencies(
+    *,
+    flow_dict: dict | None,
+    script_path: Path | None,
+    verbose: bool,
+) -> None:
+    """Fail fast when a JSON flow needs packages that are not installed.
+
+    Runs before the graph load (and the component imports it triggers) so a
+    missing provider SDK surfaces as a single actionable ``pip install ...``
+    message instead of a deep ``ModuleNotFoundError`` mid-build.
+
+    Best-effort and conservative: it analyzes only JSON flows (``.py`` scripts
+    declare deps via PEP 723 inline metadata, handled elsewhere), and any
+    analysis error is logged and skipped so a runnable flow is never blocked by
+    the check itself. Disabled with ``--no-check-dependencies``.
+
+    Raises:
+        RunError: when one or more required packages are positively missing.
+    """
+    # Normalize to the ``{"data": {"nodes": [...]}}`` shape the analyzer expects.
+    if flow_dict is not None:
+        analysis_flow: dict = {"data": flow_dict}
+    elif script_path is not None and script_path.suffix.lower() == ".json":
+        try:
+            raw = json.loads(script_path.read_text(encoding="utf-8"))
+            _, inner = split_flow_envelope(raw)
+        except (OSError, json.JSONDecodeError, TypeError):
+            # Unreadable/invalid JSON: let the graph loader report it precisely.
+            return
+        analysis_flow = {"data": inner}
+    else:
+        # .py script or no JSON source: nothing to analyze here.
+        return
+
+    try:
+        from lfx.utils.flow_requirements import find_missing_dependencies
+
+        missing = find_missing_dependencies(analysis_flow)
+    except Exception as e:  # noqa: BLE001 - never let analysis crash a runnable flow
+        logger.debug(f"Dependency preflight skipped (analysis error: {e})")
+        return
+
+    if missing:
+        from lfx.utils.flow_requirements import format_missing_dependencies_error
+
+        error_msg = format_missing_dependencies_error(missing)
+        output_error(error_msg, verbose=verbose)
+        raise RunError(error_msg, None)
+
+
 def output_error(error_message: str, *, verbose: bool, exception: Exception | None = None) -> dict:
     """Create error response dict and optionally print to stderr when verbose."""
     if verbose:
@@ -152,6 +203,7 @@ async def run_flow(
     *,
     stdin: bool = False,
     check_variables: bool = True,
+    check_dependencies: bool = True,
     verbose: bool = False,
     verbose_detailed: bool = False,
     verbose_full: bool = False,
@@ -175,6 +227,8 @@ async def run_flow(
         flow_json: Inline JSON flow content as a string
         stdin: Read JSON flow content from stdin
         check_variables: Check global variables for environment compatibility
+        check_dependencies: Preflight the flow's required packages and fail fast
+            with install guidance when any are missing (JSON flows only)
         verbose: Show basic progress information
         verbose_detailed: Show detailed progress and debug information
         verbose_full: Show full debugging output including component logs
@@ -265,6 +319,11 @@ async def run_flow(
         if applied and verbose:
             sys.stderr.write(f"Applied {applied} safe component upgrade(s).\n")
     # --- end upgrade gate ---
+
+    # --- dependency preflight (fail fast before component imports) ---
+    if check_dependencies:
+        _preflight_dependencies(flow_dict=flow_dict, script_path=script_path, verbose=verbose)
+    # --- end dependency preflight ---
 
     try:
         # Handle direct JSON dict (from stdin or --flow-json)

--- a/src/lfx/src/lfx/utils/__init__.py
+++ b/src/lfx/src/lfx/utils/__init__.py
@@ -6,12 +6,16 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lfx.utils.flow_requirements import (
+        find_missing_dependencies,
+        format_missing_dependencies_error,
         generate_requirements_from_file,
         generate_requirements_from_flow,
         generate_requirements_txt,
     )
 
 __all__ = [
+    "find_missing_dependencies",
+    "format_missing_dependencies_error",
     "generate_requirements_from_file",
     "generate_requirements_from_flow",
     "generate_requirements_txt",

--- a/src/lfx/src/lfx/utils/flow_requirements.py
+++ b/src/lfx/src/lfx/utils/flow_requirements.py
@@ -609,3 +609,56 @@ def generate_requirements_from_file(
         include_lfx=include_lfx,
         pin_versions=pin_versions,
     )
+
+
+# ===================================================================
+# Dependency preflight (fail-fast for `lfx run` / `lfx serve`)
+# ===================================================================
+
+
+def _is_installed(package_name: str) -> bool:
+    """Return True if a distribution providing *package_name* is installed.
+
+    Mirrors the presence check used by the inline-script installer
+    (``cli.common._needs_install``): ``importlib.metadata`` normalizes the name
+    per PEP 503, so hyphen/underscore/case variants resolve to the same record.
+    """
+    try:
+        md.version(package_name)
+    except md.PackageNotFoundError:
+        return False
+    return True
+
+
+def find_missing_dependencies(flow: dict) -> list[str]:
+    """Return the sorted PyPI names a flow needs that are not installed.
+
+    Reuses :func:`generate_requirements_from_flow` to infer the flow's
+    third-party packages (excluding ``lfx`` itself and anything already provided
+    by lfx's transitive tree), then keeps only those with no installed
+    distribution.
+
+    Best-effort by design: it shares the analyzer's limitations (string-based
+    dynamic imports and ``PythonREPLTool.global_imports`` are invisible), so it
+    is a guard against the common "exported flow run on a bare ``pip install
+    lfx``" failure, not a complete dependency solver. Callers run it as a
+    fail-fast preflight before the graph load triggers the missing import deep
+    in a component.
+    """
+    required = generate_requirements_from_flow(flow, include_lfx=False, pin_versions=False)
+    return sorted(pkg for pkg in required if not _is_installed(pkg))
+
+
+def format_missing_dependencies_error(missing: list[str]) -> str:
+    """Build the actionable error message for a failed dependency preflight."""
+    bullets = "\n".join(f"  - {pkg}" for pkg in missing)
+    install_line = " ".join(missing)
+    return (
+        "This flow needs Python packages that are not installed in this environment:\n"
+        f"{bullets}\n\n"
+        "Install them and re-run:\n"
+        f"  pip install {install_line}\n\n"
+        "Provider components moved out of the lfx engine in the bundle split, so an "
+        "exported flow can require packages that a bare `pip install lfx` does not "
+        "include. Skip this preflight with --no-check-dependencies."
+    )

--- a/src/lfx/tests/unit/run/test_dependency_preflight.py
+++ b/src/lfx/tests/unit/run/test_dependency_preflight.py
@@ -1,0 +1,115 @@
+"""Tests for the fail-fast dependency preflight in `lfx run`.
+
+The preflight runs in :func:`lfx.run.base.run_flow` (and its helper
+:func:`lfx.run.base._preflight_dependencies`) *before* the graph load, so a
+flow that needs an uninstalled provider package surfaces as one actionable
+``pip install ...`` message instead of a deep ``ModuleNotFoundError`` mid-build.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from unittest.mock import patch
+
+import pytest
+from lfx.run.base import RunError, _preflight_dependencies, run_flow
+
+# A distribution / import name guaranteed to be absent from any environment.
+_MISSING_PKG = "totally-missing-pkg-xyz123"
+_MISSING_IMPORT = "totally_missing_pkg_xyz123"
+
+
+def _node_with_code(code: str) -> dict:
+    """Build a minimal flow node whose component `code` field is *code*."""
+    return {
+        "id": "node-1",
+        "type": "genericNode",
+        "data": {
+            "id": "node-1",
+            "type": "CustomComponent",
+            "node": {
+                "display_name": "Custom",
+                "template": {"_type": "Component", "code": {"type": "code", "value": code}},
+            },
+        },
+    }
+
+
+def _flow_inner(code: str) -> dict:
+    """Bare inner graph (no outer envelope)."""
+    return {"nodes": [_node_with_code(code)], "edges": []}
+
+
+def _flow_envelope_json(code: str) -> str:
+    """Exported-flow JSON string with the ``{"data": ...}`` envelope."""
+    return json.dumps({"name": "Test Flow", "data": _flow_inner(code)})
+
+
+class TestRunFlowPreflight:
+    @pytest.mark.asyncio
+    async def test_missing_dependency_fails_fast(self):
+        with pytest.raises(RunError) as exc_info:
+            await run_flow(flow_json=_flow_envelope_json(f"import {_MISSING_IMPORT}"))
+        message = str(exc_info.value)
+        assert _MISSING_PKG in message
+        assert "pip install" in message
+        assert "--no-check-dependencies" in message
+
+    @pytest.mark.asyncio
+    async def test_check_dependencies_false_skips_preflight(self):
+        # The flag must short-circuit the preflight entirely. The bogus flow may
+        # still fail to load afterwards — that is irrelevant to this assertion.
+        with patch("lfx.run.base._preflight_dependencies") as mock_preflight:
+            with contextlib.suppress(RunError):
+                await run_flow(
+                    flow_json=_flow_envelope_json(f"import {_MISSING_IMPORT}"),
+                    check_dependencies=False,
+                    check_variables=False,
+                )
+            mock_preflight.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_invokes_preflight(self):
+        # Preflight is on by default; assert run_flow routes through it.
+        with patch("lfx.run.base._preflight_dependencies") as mock_preflight:
+            with contextlib.suppress(RunError):
+                await run_flow(flow_json=_flow_envelope_json("import os"), check_variables=False)
+            mock_preflight.assert_called_once()
+
+
+class TestPreflightDependenciesHelper:
+    def test_raises_for_missing_dep_dict(self):
+        with pytest.raises(RunError) as exc_info:
+            _preflight_dependencies(
+                flow_dict=_flow_inner(f"import {_MISSING_IMPORT}"),
+                script_path=None,
+                verbose=False,
+            )
+        assert _MISSING_PKG in str(exc_info.value)
+
+    def test_noop_for_stdlib_dict(self):
+        # Should not raise for a stdlib-only flow.
+        _preflight_dependencies(flow_dict=_flow_inner("import os"), script_path=None, verbose=False)
+
+    def test_skips_python_script(self, tmp_path):
+        # .py scripts declare deps via PEP 723, not flow analysis — preflight is a no-op.
+        script = tmp_path / "flow.py"
+        script.write_text(f"import {_MISSING_IMPORT}\n", encoding="utf-8")
+        _preflight_dependencies(flow_dict=None, script_path=script, verbose=False)
+
+    def test_reads_json_file_path(self, tmp_path):
+        flow_file = tmp_path / "flow.json"
+        flow_file.write_text(_flow_envelope_json(f"import {_MISSING_IMPORT}"), encoding="utf-8")
+        with pytest.raises(RunError) as exc_info:
+            _preflight_dependencies(flow_dict=None, script_path=flow_file, verbose=False)
+        assert _MISSING_PKG in str(exc_info.value)
+
+    def test_skips_unreadable_json_file(self, tmp_path):
+        # Malformed JSON must fail open here (the graph loader reports it precisely later).
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ not valid json", encoding="utf-8")
+        _preflight_dependencies(flow_dict=None, script_path=bad, verbose=False)
+
+    def test_no_source_is_noop(self):
+        _preflight_dependencies(flow_dict=None, script_path=None, verbose=False)

--- a/src/lfx/tests/unit/test_flow_requirements.py
+++ b/src/lfx/tests/unit/test_flow_requirements.py
@@ -15,9 +15,12 @@ from lfx.utils.flow_requirements import (
     _get_lfx_provided_imports,
     _get_lfx_transitive_dists,
     _import_to_package,
+    _is_installed,
     _pin_version,
     _resolve_embedding_provider_packages,
     _resolve_provider_packages,
+    find_missing_dependencies,
+    format_missing_dependencies_error,
     generate_requirements_from_file,
     generate_requirements_from_flow,
     generate_requirements_txt,
@@ -1020,3 +1023,72 @@ class TestTyperRequirementsCommand:
         result = runner.invoke(app, ["requirements", str(bad)])
         assert result.exit_code == 1
         assert "Error" in result.output
+
+
+# ===================================================================
+# Unit tests: dependency preflight (find_missing_dependencies et al.)
+# ===================================================================
+
+# A distribution name that is guaranteed not to be installed anywhere.
+_DEFINITELY_MISSING_PKG = "totally-missing-pkg-xyz123"
+_DEFINITELY_MISSING_IMPORT = "totally_missing_pkg_xyz123"
+
+
+class TestIsInstalled:
+    def test_installed_core_dep(self):
+        # pandas is a core lfx dependency, so it is always present in the test env.
+        assert _is_installed("pandas") is True
+
+    def test_normalized_name_resolves(self):
+        # importlib.metadata normalizes per PEP 503, so the hyphen/underscore
+        # variants of an installed dist both resolve.
+        assert _is_installed("langchain-core") is True
+
+    def test_not_installed(self):
+        assert _is_installed(_DEFINITELY_MISSING_PKG) is False
+
+
+class TestFindMissingDependencies:
+    def test_missing_code_import_detected(self):
+        node = _make_node("Custom", code=f"import {_DEFINITELY_MISSING_IMPORT}")
+        missing = find_missing_dependencies(_make_flow(node))
+        assert _DEFINITELY_MISSING_PKG in missing
+
+    def test_installed_import_not_flagged(self):
+        # pandas is provided by lfx's tree; it must never be reported missing.
+        node = _make_node("Custom", code="import pandas")
+        assert "pandas" not in find_missing_dependencies(_make_flow(node))
+
+    def test_stdlib_only_is_empty(self):
+        node = _make_node("Custom", code="import os\nimport sys\nimport json")
+        assert find_missing_dependencies(_make_flow(node)) == []
+
+    def test_lfx_never_reported(self):
+        node = _make_node("Custom", code=f"import {_DEFINITELY_MISSING_IMPORT}")
+        assert "lfx" not in find_missing_dependencies(_make_flow(node))
+
+    def test_empty_flow_is_empty(self):
+        assert find_missing_dependencies(_make_flow()) == []
+
+    def test_result_is_sorted(self):
+        node = _make_node(
+            "Custom",
+            code=f"import {_DEFINITELY_MISSING_IMPORT}\nimport another_missing_zzz_pkg",
+        )
+        missing = find_missing_dependencies(_make_flow(node))
+        assert missing == sorted(missing)
+
+
+class TestFormatMissingDependenciesError:
+    def test_includes_pip_install_line(self):
+        msg = format_missing_dependencies_error(["langchain-openai", "chromadb"])
+        assert "pip install langchain-openai chromadb" in msg
+
+    def test_lists_each_package(self):
+        msg = format_missing_dependencies_error(["langchain-openai", "chromadb"])
+        assert "  - langchain-openai" in msg
+        assert "  - chromadb" in msg
+
+    def test_mentions_skip_flag(self):
+        msg = format_missing_dependencies_error(["chromadb"])
+        assert "--no-check-dependencies" in msg


### PR DESCRIPTION
## Context

Since the bundle metapackage split (#13563), `lfx` is engine-only — `pip install lfx` ships no provider components, and each provider's SDK lives in a separate bundle (`lfx-openai`, `lfx-bundles[chroma]`, …). A recurring confusion follows: a user authors a flow in Langflow, exports it, creates an environment with **only `lfx`**, runs it, and it fails deep inside a component import with an opaque `ModuleNotFoundError`.

This adds a **fail-fast dependency preflight** to `lfx run`: before the graph loads, it infers the packages the flow needs and, if any are missing, exits immediately with a single actionable message:

```
This flow needs Python packages that are not installed in this environment:
  - langchain-openai
  - chromadb

Install them and re-run:
  pip install langchain-openai chromadb

Provider components moved out of the lfx engine in the bundle split, so an
exported flow can require packages that a bare `pip install lfx` does not
include. Skip this preflight with --no-check-dependencies.
```

Addresses the **[Versioning] Move / Duplicate Optional Dependency Blocks in Langflow-Base to LFX** ticket's two follow-ups ("required check in lfx execution for reqs.txt?" / "run a check by default, fail fast?"). The dependency-relocation itself already shipped via the bundle split; this closes the runtime-check gap.

## What's in this PR

- **`utils/flow_requirements.py`** — `find_missing_dependencies()`, `_is_installed()`, `format_missing_dependencies_error()`. Reuses the existing flow analyzer (`generate_requirements_from_flow`) that already powers `lfx requirements`, then keeps only packages with no installed distribution.
- **`run/base.py`** — `_preflight_dependencies()` helper + a `check_dependencies` gate in `run_flow`, run after the `--upgrade-flow` gate and **before** the graph load (so the failure is caught before the component import explosion).
- **CLI** — `--check-dependencies / --no-check-dependencies` on `lfx run` (default **on**), mirroring the existing `--check-variables` flag.
- **Tests** — unit (`find_missing_dependencies`, `_is_installed`, message formatting) + integration (`run_flow` fail-fast, `--no-check-dependencies` bypass, `.json`/`.py`/dict/no-source paths).

## Design notes

- **Best-effort & conservative.** Shares the analyzer's documented limits (string-based dynamic imports, `PythonREPLTool.global_imports` are invisible). It is a guard for the common "exported flow on a bare lfx" case, not a full solver.
- **Fail-open on analysis errors.** Any error during analysis is logged at debug and skipped — a runnable flow is never blocked by the check itself. It only hard-fails when packages are *positively* identified as missing.
- **JSON flows only.** `.py` scripts declare deps via PEP 723 inline metadata (handled elsewhere), so the preflight no-ops for them.
- **No false positives from installed packages.** A package is flagged only when the import is unresolved by `packages_distributions()` *and* `importlib.metadata` finds no distribution — both agree precisely when something is genuinely absent.

## Scope / follow-up

This PR covers **`lfx run`**, the path that most directly matches the report ("author → export → run with only lfx"). The shared helper is serve-ready; wiring it into **`lfx serve`** is a deliberate fast-follow because serve has multiple entrypoints (direct, inline JSON, stdin, directory) and a worker-rebuild path, so the flag needs careful propagation. The seam is mapped: `_load_graph_and_meta` in `cli/commands.py`, right before `load_flow_from_json(raw_json)`, threading `check_dependencies` exactly like the existing `check_variables`.

## Test plan

- [x] `uv run --isolated --package lfx pytest src/lfx/tests/unit/run/test_dependency_preflight.py` — 13 passed
- [x] `... test_flow_requirements.py::{TestIsInstalled,TestFindMissingDependencies,TestFormatMissingDependenciesError}` — 8 passed
- [x] `... test_base.py` — 82 passed (no regression from default-on preflight)
- [x] starter-project run tests (`test_run_basic_starter_projects_detailed`, `test_run_starter_project_format_options`) — 34 passed
- [x] `test_run_command.py`, `test_cli_help_smoke.py`, `test_lazy_imports.py` — 49 passed
- [x] `lfx run --help` shows `--check-dependencies / --no-check-dependencies`

> Targets `bundles/foundation-discovery` (stacked on the metapackage-split work, #13563). Opened as a draft.
