### PR TITLE
fix(security): derive Fernet key from short secrets with SHA-256 (GHSA-jxw3-mjmx-3pqm)

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-import random
+import hashlib
 from typing import TYPE_CHECKING, Annotated, Final
 
 from cryptography.fernet import Fernet
@@ -329,14 +329,25 @@ def add_base64_padding(value: str) -> str:
 def ensure_fernet_key(secret_key: str) -> bytes:
     """Derive a valid Fernet key from a secret key string.
 
-    For short keys (< 32 chars), uses the key as a random seed to generate
-    a deterministic 32-byte key. For longer keys, adds base64 padding.
+    For short keys (< 32 chars), the 32-byte key is derived with SHA-256, a
+    cryptographic hash. For longer keys, base64 padding is added.
+
+    Security note: short keys previously seeded Python's ``random`` module
+    (``random.seed(secret_key)``) to generate the key bytes. ``random`` is a
+    non-cryptographic Mersenne-Twister PRNG, so the resulting Fernet key was
+    fully predictable from the secret, and seeding it also mutated global PRNG
+    state. SHA-256 is deterministic (so the key stays stable for a given
+    secret) but is not predictable/reversible the way the PRNG output was.
+
+    Deployments that set a ``SECRET_KEY`` shorter than 32 characters will derive
+    a different key than before this fix and must re-enter encrypted secrets
+    (API keys, global variables) after upgrading. The default ``SECRET_KEY`` is
+    a 43-char ``secrets.token_urlsafe(32)`` value and is unaffected.
     """
     MINIMUM_KEY_LENGTH = 32  # noqa: N806
     if len(secret_key) < MINIMUM_KEY_LENGTH:
-        random.seed(secret_key)
-        key = bytes(random.getrandbits(8) for _ in range(32))
-        key = base64.urlsafe_b64encode(key)
+        digest = hashlib.sha256(secret_key.encode()).digest()  # 32 bytes
+        key = base64.urlsafe_b64encode(digest)
     else:
         key = add_base64_padding(secret_key).encode()
     return key

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -318,7 +318,7 @@ def test_encrypt_decrypt_roundtrip_with_base64_encoded_32_byte_key(tmp_path):
 
 
 def test_encrypt_decrypt_roundtrip_with_short_key(tmp_path):
-    """Keys shorter than 32 chars use the random.seed path and must work."""
+    """Keys shorter than 32 chars use the SHA-256 derivation and must work."""
     raw_key = "short-key"
 
     settings = AuthSettings(CONFIG_DIR=str(tmp_path))
@@ -365,6 +365,36 @@ def test_ensure_fernet_key_with_44_char_key():
     fernet = Fernet(ensure_fernet_key(raw_key))
     encrypted = fernet.encrypt(b"test-value")
     assert fernet.decrypt(encrypted) == b"test-value"
+
+
+def test_ensure_fernet_key_short_key_independent_of_random_state():
+    """Short-key derivation must not depend on the global ``random`` state.
+
+    Regression for GHSA-jxw3-mjmx-3pqm (LE-1250): the key was previously derived
+    with ``random.seed(secret_key)`` + ``random.getrandbits`` — a predictable,
+    non-cryptographic PRNG. The SHA-256 derivation must be deterministic for a
+    given secret regardless of the process-global PRNG state.
+    """
+    import random
+
+    from langflow.services.auth.utils import ensure_fernet_key
+
+    raw_key = "short-key"  # < 32 chars -> derivation branch
+
+    random.seed(0)
+    key_a = ensure_fernet_key(raw_key)
+    random.seed(123456789)
+    _ = [random.random() for _ in range(100)]  # noqa: S311  # perturb global PRNG state
+    key_b = ensure_fernet_key(raw_key)
+
+    # Deterministic from the secret, not from PRNG state.
+    assert key_a == key_b
+    # And it must be the SHA-256 derivation, not the old random.getrandbits output.
+    import base64
+    import hashlib
+
+    expected = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
+    assert key_a == expected
 
 
 def test_password_helpers_roundtrip(auth_service: AuthService):


### PR DESCRIPTION
## Summary
`ensure_fernet_key()` derived the 32-byte Fernet encryption key by seeding Python's non-cryptographic `random` (Mersenne-Twister) PRNG with `SECRET_KEY` whenever the key was shorter than 32 characters, then reading `getrandbits`. This made the derived encryption key predictable from the secret and mutated process-global PRNG state as a side effect (**GHSA-jxw3-mjmx-3pqm**).

This replaces that path with a deterministic **SHA-256** derivation: stable for a given secret, but not predictable/reversible the way the PRNG output was.

## Impact / migration
Only affects deployments that explicitly set `LANGFLOW_SECRET_KEY` to **fewer than 32 characters**. Those derive a different key after upgrading and must re-enter encrypted secrets (API keys, global variables). The default 43-char `secrets.token_urlsafe(32)` key takes the base64-padding branch and is **unaffected**.

## Test plan
- Added `test_ensure_fernet_key_short_key_independent_of_random_state` — asserts the short-key derivation is independent of global `random` state and equals the SHA-256 derivation.
- Existing `test_encrypt_decrypt_roundtrip_with_short_key` / `test_ensure_fernet_key_with_44_char_key` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication key derivation mechanism. Deployments with short secrets require re-encryption of stored encrypted secrets after this update.

* **Tests**
  * Added regression test to verify authentication key derivation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->