### PR TITLE
fix(security): do not execute code in validate_code (GHSA-2wcq-pvw2-xh7v)

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -703,7 +703,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/tests/unit/utils/test_validate.py
+++ b/src/backend/tests/unit/utils/test_validate.py
@@ -119,6 +119,24 @@ def error_function():
         assert result["imports"]["errors"] == []
         assert result["function"]["errors"] == []
 
+    def test_validate_code_does_not_execute_default_args(self, tmp_path):
+        """validate_code must not run function-definition-time code.
+
+        Regression for GHSA-2wcq-pvw2-xh7v (LE-1247 / duplicate LE-1168): the
+        validator previously exec()'d each function definition, so a default
+        argument (or decorator) expression executed during validation. Here a
+        default arg would create a file as a side effect; it must NOT run.
+        """
+        marker = tmp_path / "pwned.txt"
+        code = f'def exploit(x=open({str(marker)!r}, "w").write("pwned")):\n    return x\n'
+
+        result = validate_code(code)
+
+        # No code executed -> the side-effect file was never created.
+        assert not marker.exists()
+        # Validation still returns the normal structure (valid syntax, no imports).
+        assert result["imports"]["errors"] == []
+
     def test_code_with_multiple_imports(self):
         """Test validation handles multiple imports."""
         code = """

--- a/src/lfx/src/lfx/custom/validate.py
+++ b/src/lfx/src/lfx/custom/validate.py
@@ -57,16 +57,22 @@ def validate_code(code):
                 except ModuleNotFoundError as e:
                     errors["imports"]["errors"].append(str(e))
 
-    # Evaluate the function definition with langflow context
+    # Validate each function definition WITHOUT executing it.
+    #
+    # Security (GHSA-2wcq-pvw2-xh7v / LE-1247, LE-1168): this endpoint only
+    # *validates* code, but it previously compiled and exec()'d every function
+    # definition. Executing a function definition evaluates its decorators and
+    # default-argument expressions at definition time, so a payload such as
+    #     def f(x=__import__("os").system("...")): ...
+    # achieves arbitrary code execution during "validation" — the function never
+    # has to be called. Compile only, to surface syntax/compile errors; never
+    # exec untrusted code on the validation path.
     for node in tree.body:
         if isinstance(node, ast.FunctionDef):
-            code_obj = compile(ast.Module(body=[node], type_ignores=[]), "<string>", "exec")
             try:
-                # Create execution context with common langflow imports
-                exec_globals = _create_langflow_execution_context()
-                exec(code_obj, exec_globals)
+                compile(ast.Module(body=[node], type_ignores=[]), "<string>", "exec")
             except Exception as e:  # noqa: BLE001
-                logger.debug("Error executing function code", exc_info=True)
+                logger.debug("Error compiling function code", exc_info=True)
                 errors["function"]["errors"].append(str(e))
 
     # Return the errors dictionary


### PR DESCRIPTION
## Summary
`POST /api/v1/validate/code` is a *validation* endpoint, but `validate_code()` compiled **and `exec()`'d** every function definition in the submitted source. Executing a function definition evaluates its **decorators** and **default-argument** expressions at definition time, so a payload such as:

```python
def f(x=__import__("os").system("id > /tmp/pwned")): ...
```

runs arbitrary code during "validation" — the function is never called. This is an authenticated RCE, and effectively unauthenticated under Langflow's default single-user `AUTO_LOGIN` setup (**GHSA-2wcq-pvw2-xh7v**).

## Fix
`validate_code()` now **compiles** each `FunctionDef` only (to surface syntax/compile errors) and never `exec()`s it. The legitimate component-execution helpers (`create_function` / `execute_function` / `eval_function`), which are separately gated by `allow_custom_components`, are untouched.

## Test plan
- Added `test_validate_code_does_not_execute_default_args` — a default-arg side effect (file write) no longer runs during validation.
- All existing `TestValidateCode` cases pass (import-error detection and syntax-error reporting are unaffected).

Addresses **LE-1247** and its duplicate **LE-1168**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation to prevent code execution within function definitions and default arguments. Validation now only performs syntax and compilation error checking without executing code.

* **Tests**
  * Added regression tests to verify code within function definitions is not executed during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->