### PR TITLE
fix(security): HMAC-sign RedisCache payloads before dill deserialization (LE-1248)

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -703,7 +703,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -1,5 +1,7 @@
 import asyncio
 import atexit
+import hashlib
+import hmac
 import os
 import pickle
 import tempfile
@@ -232,6 +234,9 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
     KEY_PREFIX = "langflow:cache:"
 
+    # Size of the HMAC-SHA256 tag prepended to every stored payload.
+    _HMAC_DIGEST_SIZE = hashlib.sha256().digest_size
+
     def __init__(self, host="localhost", port=6379, db=0, url=None, expiration_time=60 * 60) -> None:
         """Initialize a new RedisCache instance.
 
@@ -252,10 +257,24 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
         else:
             self._client = StrictRedis(host=host, port=port, db=db)
         self.expiration_time = expiration_time
+        self._signing_key: bytes | None = None
 
     def _key(self, key) -> str:
         """Return the namespaced Redis key."""
         return f"{self.KEY_PREFIX}{key}"
+
+    def _get_signing_key(self) -> bytes:
+        """Derive the HMAC key for cache payload integrity from the server secret.
+
+        Bound to the same ``SECRET_KEY`` used elsewhere, so no extra config is
+        required. Cached after first use (the secret does not change at runtime).
+        """
+        if self._signing_key is None:
+            from lfx.services.deps import get_settings_service
+
+            secret = get_settings_service().auth_settings.SECRET_KEY.get_secret_value()
+            self._signing_key = hashlib.sha256(b"langflow-redis-cache-hmac:" + secret.encode()).digest()
+        return self._signing_key
 
     async def is_connected(self) -> bool:
         """Check if the Redis client is connected."""
@@ -274,13 +293,32 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
         if key is None:
             return CACHE_MISS
         value = await self._client.get(self._key(key))
-        return dill.loads(value) if value else CACHE_MISS
+        if not value:
+            return CACHE_MISS
+        # Integrity check before deserializing. The Redis datastore is an
+        # untrusted boundary (a co-tenant on a shared Redis, an exposed/un-ACL'd
+        # port, or anyone able to write under the langflow:cache: namespace could
+        # plant a payload). dill.loads() executes embedded reduce gadgets, so we
+        # only deserialize bytes carrying a valid HMAC produced with the server
+        # secret. Unsigned/tampered/legacy entries are treated as a miss and are
+        # never passed to dill.loads (CWE-502 / LE-1248).
+        if len(value) < self._HMAC_DIGEST_SIZE:
+            return CACHE_MISS
+        tag, payload = value[: self._HMAC_DIGEST_SIZE], value[self._HMAC_DIGEST_SIZE :]
+        expected = hmac.new(self._get_signing_key(), payload, hashlib.sha256).digest()
+        if not hmac.compare_digest(tag, expected):
+            await logger.awarning("RedisCache: discarding cache entry with an invalid integrity tag (key=%s)", key)
+            return CACHE_MISS
+        return dill.loads(payload)
 
     @override
     async def set(self, key, value, lock=None) -> None:
         try:
             if pickled := dill.dumps(value, recurse=True):
-                result = await self._client.setex(self._key(key), self.expiration_time, pickled)
+                # Prefix an HMAC tag so get() can reject tampered/forged payloads
+                # before deserialization (see get()).
+                tag = hmac.new(self._get_signing_key(), pickled, hashlib.sha256).digest()
+                result = await self._client.setex(self._key(key), self.expiration_time, tag + pickled)
                 if not result:
                     msg = "RedisCache could not set the value."
                     raise ValueError(msg)

--- a/src/backend/tests/unit/services/cache/test_redis_cache.py
+++ b/src/backend/tests/unit/services/cache/test_redis_cache.py
@@ -86,3 +86,71 @@ class TestRedisCacheTeardown:
                 await cache.teardown()
 
             mock_client.aclose.assert_called_once()
+
+
+_MARKER_PATH_HOLDER: list[str] = []
+
+
+def _deser_side_effect(path: str) -> str:
+    """Module-level callable used as a pickle reduce gadget in the test below."""
+    _MARKER_PATH_HOLDER.append(path)
+    return path
+
+
+class _Gadget:
+    """A picklable object whose deserialization would run _deser_side_effect."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def __reduce__(self):
+        return (_deser_side_effect, (self.path,))
+
+
+@pytest.mark.asyncio
+class TestRedisCacheDeserializationIntegrity:
+    """Regression for LE-1248 (insecure dill.loads of untrusted Redis bytes)."""
+
+    async def test_get_rejects_payload_without_valid_hmac(self):
+        """A payload lacking a valid HMAC tag must not be deserialized (no gadget run)."""
+        import dill
+        from lfx.services.cache.utils import CACHE_MISS
+
+        _MARKER_PATH_HOLDER.clear()
+        with patch("redis.asyncio.StrictRedis") as mock_redis_class:
+            mock_client = AsyncMock()
+            mock_redis_class.return_value = mock_client
+            cache = RedisCache(host="localhost", port=6379, db=0, expiration_time=3600)
+            cache._signing_key = b"k" * 32  # inject a fixed key (no settings dependency)
+
+            # Attacker-written value: a reduce gadget, prefixed with a WRONG 32-byte tag.
+            forged = b"\x00" * cache._HMAC_DIGEST_SIZE + dill.dumps(_Gadget("gadget-ran"))
+            mock_client.get.return_value = forged
+
+            result = await cache.get("k")
+
+            assert result is CACHE_MISS  # rejected before dill.loads
+            assert _MARKER_PATH_HOLDER == []  # gadget never executed
+
+    async def test_set_get_roundtrip_with_signature(self):
+        """Values written by set() carry a valid tag and round-trip through get()."""
+        with patch("redis.asyncio.StrictRedis") as mock_redis_class:
+            mock_client = AsyncMock()
+            mock_redis_class.return_value = mock_client
+            cache = RedisCache(host="localhost", port=6379, db=0, expiration_time=3600)
+            cache._signing_key = b"k" * 32
+
+            store: dict[str, bytes] = {}
+
+            async def fake_setex(key, _ttl, value):
+                store[key] = value
+                return True
+
+            async def fake_get(key):
+                return store.get(key)
+
+            mock_client.setex.side_effect = fake_setex
+            mock_client.get.side_effect = fake_get
+
+            await cache.set("k", {"a": 1, "b": [2, 3]})
+            assert await cache.get("k") == {"a": 1, "b": [2, 3]}


### PR DESCRIPTION
## Summary
`RedisCache.get()` called `dill.loads()` directly on bytes returned from Redis. `dill`/`pickle` execute embedded `__reduce__` gadgets during deserialization, so the Redis datastore is a trust boundary: anyone able to write under the `langflow:cache:` key namespace — a co-tenant on a shared Redis, an exposed/un-ACL'd Redis port, or any cache-key injection — could plant a payload that runs **arbitrary code** in the Langflow process on the next `get()` (CWE-502).

Only reachable when `LANGFLOW_CACHE_TYPE=redis` (the default is in-memory `async`), but when reachable it is an unauthenticated RCE.

## Fix
Cache payloads are now **HMAC-SHA256 signed** with a key derived from the server `SECRET_KEY`:
- `set()` stores `tag(32 bytes) || dill.dumps(value)`.
- `get()` recomputes the tag and verifies it with `hmac.compare_digest` **before** deserializing. Unsigned/tampered/legacy entries are treated as a cache miss and are never handed to `dill.loads()`.

An attacker who cannot forge the HMAC (i.e. doesn't know `SECRET_KEY`) can no longer get their bytes deserialized. No new configuration required.

## Test plan
- `test_get_rejects_payload_without_valid_hmac` — a reduce gadget with an invalid tag returns `CACHE_MISS` and is never executed.
- `test_set_get_roundtrip_with_signature` — signed round-trip works.

Addresses LE-1248.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Cache system now includes automatic data validation to ensure reliable cached operations and prevent stale or corrupted data retrieval
* Invalid cached entries are now automatically detected and properly handled by triggering fresh data retrieval from source
* Enhanced test coverage for cache validation scenarios provides ongoing reliability assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->