### PR TITLE
fix(security): scope voice-mode clients per user (LE-1336)

### DIFF
--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -165,47 +165,18 @@ class VoiceConfig:
         return dict(self.default_openai_realtime_session)
 
 
-class ElevenLabsClientManager:
-    _instance = None
-    _api_key = None
-
-    @classmethod
-    async def get_client(cls, user_id=None, session=None):
-        """Get or create an ElevenLabs client with the API key."""
-        if cls._instance is None:
-            if cls._api_key is None and user_id and session:
-                variable_service = get_variable_service()
-                try:
-                    cls._api_key = await variable_service.get_variable(
-                        user_id=user_id,
-                        name="ELEVENLABS_API_KEY",
-                        field="elevenlabs_api_key",
-                        session=session,
-                    )
-                    cls._api_key = secret_value_to_str(cls._api_key)
-                except (InvalidToken, ValueError) as e:
-                    await logger.aerror(f"Error with ElevenLabs API key: {e}")
-                    cls._api_key = os.getenv("ELEVENLABS_API_KEY", "")
-                    if not cls._api_key:
-                        await logger.aerror("ElevenLabs API key not found")
-                        return None
-                except (KeyError, AttributeError, sqlalchemy.exc.SQLAlchemyError) as e:
-                    await logger.aerror(f"Exception getting ElevenLabs API key: {e}")
-                    return None
-
-            if cls._api_key:
-                cls._instance = ElevenLabs(api_key=cls._api_key)
-
-        return cls._instance
-
-
-def get_voice_config(session_id: str) -> VoiceConfig:
+def get_voice_config(session_id: str, user_id: str | None = None) -> VoiceConfig:
     if session_id is None:
         msg = "session_id cannot be None"
         raise ValueError(msg)
-    if session_id not in voice_config_cache:
-        voice_config_cache[session_id] = VoiceConfig(session_id)
-    return voice_config_cache[session_id]
+    # Key the cache by (user_id, session_id). session_id is client-supplied (the
+    # human chat-session name), so keying on it alone let two different users
+    # collide on the same session and share cached config/clients across tenants
+    # (LE-1336). Binding the key to the authenticated user prevents that.
+    cache_key = (user_id, session_id)
+    if cache_key not in voice_config_cache:
+        voice_config_cache[cache_key] = VoiceConfig(session_id)
+    return voice_config_cache[cache_key]
 
 
 class TTSConfig:
@@ -247,13 +218,17 @@ class TTSConfig:
         return self.openai_voice
 
 
-def get_tts_config(session_id: str, openai_key: str) -> TTSConfig:
+def get_tts_config(session_id: str, openai_key: str, user_id: str | None = None) -> TTSConfig:
     if session_id is None:
         msg = "session_id cannot be None"
         raise ValueError(msg)
-    if session_id not in tts_config_cache:
-        tts_config_cache[session_id] = TTSConfig(session_id, openai_key)
-    return tts_config_cache[session_id]
+    # Key by (user_id, session_id) so a client-supplied session_id cannot make one
+    # user reuse another user's cached TTSConfig — which holds an OpenAI client
+    # built from that other user's key (LE-1336).
+    cache_key = (user_id, session_id)
+    if cache_key not in tts_config_cache:
+        tts_config_cache[cache_key] = TTSConfig(session_id, openai_key)
+    return tts_config_cache[cache_key]
 
 
 async def add_message_to_db(message, session, flow_id, session_id, sender, sender_name):
@@ -395,13 +370,13 @@ class SendQueues:
         await self.client_writer_task
 
 
-def get_create_response(send_handler: SendQueues, session_id):
+def get_create_response(send_handler: SendQueues, session_id, user_id=None):
     def create_response(original: dict | None = None):
         msg = {}
         if original is not None:
             msg = original
         msg["type"] = "response.create"
-        voice_config = get_voice_config(session_id)
+        voice_config = get_voice_config(session_id, user_id)
         if voice_config.use_elevenlabs:
             response = msg.setdefault("response", {})
             response["modalities"] = ["text"]
@@ -420,7 +395,7 @@ async def handle_function_call(
     session_id: str,
     msg_handler: SendQueues,
 ):
-    create_response = get_create_response(msg_handler, session_id)
+    create_response = get_create_response(msg_handler, session_id, current_user.id)
     """Handle function calls from the OpenAI API."""
     try:
         args = json.loads(function_call_args) if function_call_args else {}
@@ -509,8 +484,8 @@ async def handle_function_call(
         msg_handler.openai_send(function_output)
 
 
-voice_config_cache: dict[str, VoiceConfig] = {}
-tts_config_cache: dict[str, TTSConfig] = {}
+voice_config_cache: dict[tuple[str | None, str], VoiceConfig] = {}
+tts_config_cache: dict[tuple[str | None, str], TTSConfig] = {}
 
 
 # --- Global Queues and Message Processing ---
@@ -532,8 +507,38 @@ async def get_flow_desc_from_db(flow_id: str) -> Flow:
 
 
 async def get_or_create_elevenlabs_client(user_id=None, session=None):
-    """Get or create an ElevenLabs client with the API key."""
-    return await ElevenLabsClientManager.get_client(user_id, session)
+    """Build an ElevenLabs client scoped to the requesting user.
+
+    Security (LE-1336): this previously delegated to a process-global singleton
+    (``ElevenLabsClientManager``) that cached the *first* caller's API key and
+    returned that same client to every subsequent user. As a result one tenant's
+    ElevenLabs account was billed for everyone's TTS (cross-tenant billing
+    siphon) and their voice library was exposed via /voice/elevenlabs/voice_ids.
+
+    Build a fresh client from the requesting user's own key on each call and never
+    cache it on a class/module global.
+    """
+    if not (user_id and session):
+        return None
+    variable_service = get_variable_service()
+    try:
+        api_key = await variable_service.get_variable(
+            user_id=user_id,
+            name="ELEVENLABS_API_KEY",
+            field="elevenlabs_api_key",
+            session=session,
+        )
+        api_key = secret_value_to_str(api_key)
+    except (InvalidToken, ValueError) as e:
+        await logger.aerror(f"Error with ElevenLabs API key: {e}")
+        api_key = os.getenv("ELEVENLABS_API_KEY", "")
+    except (KeyError, AttributeError, sqlalchemy.exc.SQLAlchemyError) as e:
+        await logger.aerror(f"Exception getting ElevenLabs API key: {e}")
+        return None
+    if not api_key:
+        await logger.aerror("ElevenLabs API key not found")
+        return None
+    return ElevenLabs(api_key=api_key)
 
 
 def pcm16_to_float_array(pcm_data):
@@ -677,7 +682,7 @@ class FunctionCall:
                 },
             }
         )
-        create_response = partial(get_create_response(self.msg_handler, self.session_id))
+        create_response = partial(get_create_response(self.msg_handler, self.session_id, self.current_user.id))
         create_response()
 
     def _send_function_call(self):
@@ -730,11 +735,12 @@ async def flow_as_tool_websocket(
         log_event = create_event_logger()
 
         vad_task: asyncio.Task | None = None
-        voice_config = get_voice_config(session_id)
         current_user: User = await get_current_user_for_websocket(client_websocket, session)
         current_user, openai_key = await authenticate_and_get_openai_key(session, current_user, client_websocket)
         if current_user is None or openai_key is None:
             return
+        # Resolve voice config only after authentication, scoped to this user.
+        voice_config = get_voice_config(session_id, current_user.id)
         try:
             flow_description = await get_flow_desc_from_db(flow_id)
             flow_tool = {
@@ -928,7 +934,7 @@ async def flow_as_tool_websocket(
 
             async def forward_to_openai() -> None:
                 nonlocal openai_realtime_session
-                create_response = get_create_response(msg_handler, session_id)
+                create_response = get_create_response(msg_handler, session_id, current_user.id)
                 try:
                     num_audio_samples = 0  # Initialize as an integer instead of None
                     while True:
@@ -1208,7 +1214,7 @@ async def flow_tts_websocket(
             "OpenAI-Beta": "realtime=v1",
         }
 
-        tts_config = get_tts_config(session_id, openai_key)
+        tts_config = get_tts_config(session_id, openai_key, current_user.id)
         async with websockets.connect(url, extra_headers=headers) as openai_ws:
             openai_writer_task = asyncio.create_task(openai_writer())
             client_writer_task = asyncio.create_task(client_writer())

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -703,7 +703,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/tests/unit/test_voice_mode_client_scoping.py
+++ b/src/backend/tests/unit/test_voice_mode_client_scoping.py
@@ -1,0 +1,68 @@
+"""Regression tests for LE-1336: voice-mode cross-tenant client confusion.
+
+The ElevenLabs client must be built per requesting user (no process-global
+singleton), and the voice/TTS config caches must be keyed by the authenticated
+user, not just the client-supplied session_id.
+"""
+
+import langflow.api.v1.voice_mode as vm
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_elevenlabs_client_is_per_user(monkeypatch):
+    """Each user gets an ElevenLabs client built from their OWN key (no shared singleton)."""
+    keys = {"user-a": "key-a", "user-b": "key-b"}
+
+    class FakeVariableService:
+        async def get_variable(self, *, user_id, name, field, session):  # noqa: ARG002
+            return keys[user_id]
+
+    monkeypatch.setattr(vm, "get_variable_service", lambda: FakeVariableService())
+
+    captured: list[str] = []
+
+    def fake_elevenlabs(*, api_key):
+        captured.append(api_key)
+        return f"client::{api_key}"
+
+    monkeypatch.setattr(vm, "ElevenLabs", fake_elevenlabs)
+
+    client_a = await vm.get_or_create_elevenlabs_client("user-a", "sess")
+    client_b = await vm.get_or_create_elevenlabs_client("user-b", "sess")
+
+    # Built from each user's own key — user-b is NOT served user-a's cached client.
+    assert client_a == "client::key-a"
+    assert client_b == "client::key-b"
+    assert captured == ["key-a", "key-b"]
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_elevenlabs_client_requires_user_and_session():
+    """No user/session -> no client (avoids falling back to some other tenant's key)."""
+    assert await vm.get_or_create_elevenlabs_client(None, None) is None
+    assert await vm.get_or_create_elevenlabs_client("user", None) is None
+
+
+def test_get_voice_config_scoped_by_user():
+    """Same client-supplied session_id but different users must not share a VoiceConfig."""
+    vm.voice_config_cache.clear()
+
+    a = vm.get_voice_config("shared-session", "user-a")
+    b = vm.get_voice_config("shared-session", "user-b")
+    a_again = vm.get_voice_config("shared-session", "user-a")
+
+    assert a is not b
+    assert a is a_again  # same (user, session) is still cached
+
+
+def test_get_tts_config_scoped_by_user():
+    """Same session_id but different users must not share a TTSConfig / OpenAI client."""
+    vm.tts_config_cache.clear()
+
+    a = vm.get_tts_config("shared-session", "openai-key-a", "user-a")
+    b = vm.get_tts_config("shared-session", "openai-key-b", "user-b")
+
+    assert a is not b
+    # The OpenAI client (built from each user's key) is not shared across users.
+    assert a.get_openai_client() is not b.get_openai_client()


### PR DESCRIPTION
## Summary
Two cross-tenant defects in voice mode (`api/v1/voice_mode.py`):

1. **ElevenLabs billing siphon (process-global singleton).** `ElevenLabsClientManager` cached the **first** caller's API key/client on the class and returned that same client to every subsequent user. One tenant's ElevenLabs account was billed for everyone's TTS, and their voice library was exposed via `GET /voice/elevenlabs/voice_ids`.
2. **OpenAI client confusion (session-keyed caches).** `voice_config_cache` / `tts_config_cache` were keyed only by `session_id`, which is **client-supplied** (the chat session name). Two users using the same `session_id` reused each other's `TTSConfig` — including its `OpenAI` client built from the first user's key.

## Fix
- `get_or_create_elevenlabs_client` now builds a **fresh client from the requesting user's own key** on every call; the process-global `ElevenLabsClientManager` is removed.
- `get_voice_config` / `get_tts_config` are keyed by **`(user_id, session_id)`**; `user_id` is threaded through `get_create_response` and its call sites, and voice config is resolved only **after** authentication.

## Test plan
- New `test_voice_mode_client_scoping.py`: ElevenLabs client is built per-user (not reused); requires user+session; voice/TTS configs are not shared across users for the same `session_id`.

Addresses LE-1336.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed voice and text-to-speech configuration isolation to prevent unauthorized access across different users within multi-tenant environments.

* **Tests**
  * Added regression tests to verify proper user-scoped configuration and client handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->