### PR TITLE
fix(security): bump residual deprecated transitive uuid to v11 (LE-1245)

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -13481,14 +13481,17 @@
       }
     },
     "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -18,6 +18,9 @@
     "jest-message-util": {
       "picomatch": "^4.0.4"
     },
+    "jest-junit": {
+      "uuid": "^11.1.0"
+    },
     "playwright": "^1.59.1",
     "brace-expansion": "^5.0.5",
     "handlebars": "^4.7.9",


### PR DESCRIPTION
## Summary
LE-1245 (OSS 1.10.1 dependency updates) was filed for the scanner-flagged **`uuid 10.0.0`**. That was already resolved on `release-1.10.1` by the direct bump to **`uuid ^14`** (commit `11f2591f44`) — the lockfile's root `uuid` is `14.0.0` and no `uuid 10.0.0` remains.

The only old `uuid` left in the tree was a **dev-only transitive `uuid 8.3.2`** pulled by `jest-junit` (the JUnit test reporter), which carries the `uuid@10 and below is no longer supported` deprecation. This PR adds a scoped npm `overrides` entry forcing `jest-junit`'s `uuid` to **`^11`** — the CommonJS-compatible version upstream recommends — clearing the deprecated transitive from the lockfile.

## Scope / impact
- Dev dependency only (test reporting); no runtime/bundle impact.
- Override is scoped to `jest-junit` so the root `uuid@14` is unaffected.
- Minimal lockfile change (`jest-junit/node_modules/uuid` `8.3.2` → `11.1.1`).

Addresses LE-1245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version pinning to ensure consistent build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->