### PR TITLE
fix(security): block code-bearing nodes with empty type in flow validation (GHSA-mfp9-86w4-493f)

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -703,7 +703,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -209,27 +209,34 @@ def _get_invalid_components(
         node_info = node_data.get("node", {})
 
         component_type = node_data.get("type")
-        if not component_type:
-            continue
 
         node_template = node_info.get("template", {})
         node_code_field = node_template.get("code", {})
         node_code = node_code_field.get("value") if isinstance(node_code_field, dict) else None
 
-        if not node_code:
-            continue
+        if node_code:
+            display_name = node_info.get("display_name") or component_type or "unknown"
+            node_id = node_data.get("id") or node.get("id", "unknown")
+            label = f"{display_name} ({node_id})"
 
-        display_name = node_info.get("display_name") or component_type
-        node_id = node_data.get("id") or node.get("id", "unknown")
-        label = f"{display_name} ({node_id})"
-
-        expected_hashes = type_to_current_hash.get(component_type)
-        if expected_hashes is None:
-            blocked.append(label)
-        else:
-            node_hash = _compute_code_hash(node_code)
-            if node_hash not in expected_hashes:
-                outdated.append(label)
+            # A node carrying executable code must resolve to a known component
+            # type so its code hash can be checked against the trusted set. If the
+            # type is missing/empty (or otherwise unknown), it can never match a
+            # known hash, so block it instead of silently skipping it.
+            #
+            # Security (GHSA-mfp9-86w4-493f): this previously did
+            # `if not component_type: continue`, so a crafted node with an empty
+            # `type` but a populated `template.code.value` bypassed the
+            # allow_custom_components gate while its stored code still executed at
+            # build time (instantiate_class runs the node's stored code, which
+            # does not consult the type).
+            expected_hashes = type_to_current_hash.get(component_type) if component_type else None
+            if expected_hashes is None:
+                blocked.append(label)
+            else:
+                node_hash = _compute_code_hash(node_code)
+                if node_hash not in expected_hashes:
+                    outdated.append(label)
 
         flow_data = node_info.get("flow", {})
         if isinstance(flow_data, dict):

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -166,6 +166,30 @@ def test_substitute_trusted_node_code_leaves_codeless_nodes_untouched():
     assert fv._substitute_trusted_node_code([_node("note", "NoteNode", None)], {"ChatInput": "# trusted"}) == []
 
 
+def test_get_invalid_components_blocks_codebearing_node_with_empty_type():
+    """A code-bearing node with an empty/missing type must be blocked, not skipped.
+
+    Regression for GHSA-mfp9-86w4-493f: _get_invalid_components used to
+    `continue` on a falsy ``type``, so a crafted node bypassed the
+    allow_custom_components gate while its stored code still executed at build.
+    """
+    from lfx.utils import flow_validation as fv
+
+    type_to_hash = {"ChatInput": {"deadbeef"}}
+
+    # Code present, type empty -> can never match a trusted hash -> blocked.
+    sneaky = _node("x", "", "import os; os.system('id')", display_name="Sneaky")
+    blocked, outdated = fv._get_invalid_components([sneaky], type_to_hash)
+    assert "Sneaky (x)" in blocked
+    assert outdated == []
+
+    # Control: an empty-type node with no code carries no execution vector.
+    codeless = _node("n", "", None)
+    blocked2, outdated2 = fv._get_invalid_components([codeless], type_to_hash)
+    assert blocked2 == []
+    assert outdated2 == []
+
+
 @pytest.mark.asyncio
 async def test_prepare_public_flow_build_substitutes_trusted_code(monkeypatch):
     """Default mode replaces stored built-in code with the server's trusted copy (no 'outdated' break)."""


### PR DESCRIPTION
## Summary
`_get_invalid_components` (the build-time `allow_custom_components` gate) started each node with `if not component_type: continue`. A crafted flow node with an **empty/missing `data.type`** but a populated `template.code.value` was therefore skipped by the validator — while `instantiate_class` still executed the node's stored `code` at build time (it keys off the code field, not the type). An authenticated user could use this to bypass `allow_custom_components=false` and execute arbitrary Python (**GHSA-mfp9-86w4-493f**).

## Fix
A node that carries executable code is now classified by whether its code hash matches a **known trusted type**. If the type is missing/empty (or otherwise unknown) it can never match, so it is **blocked** rather than silently skipped. Code-less nodes are still ignored. This mirrors the fail-closed posture already used by `_substitute_trusted_node_code` on the public-flow path.

## Test plan
- Added `test_get_invalid_components_blocks_codebearing_node_with_empty_type` (blocks empty-type+code; leaves empty-type+no-code alone).
- Full `tests/unit/utils/test_flow_validation.py` suite passes (41 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced component validation to properly detect and block configurations with executable code that lack a valid component type, preventing previously undetected invalid states.

* **Tests**
  * Added test coverage for validation scenarios involving components with missing or empty type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->