### PR TITLE
fix(security): stop issuing 365-day superuser token via auto_login (GHSA-fjgc-vj2f-77hm)

### DIFF
--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -143,6 +143,19 @@ async def auto_login(response: Response, db: DbSession):
     if auth_settings.AUTO_LOGIN:
         auth = get_auth_service()
         user_id, tokens = await auth.create_user_longterm_token(db)
+        # The auto-login token is now short-lived, so set the refresh
+        # cookie too — the client refreshes it transparently via /refresh instead
+        # of relying on a year-long token.
+        if tokens.get("refresh_token"):
+            response.set_cookie(
+                "refresh_token_lf",
+                tokens["refresh_token"],
+                httponly=auth_settings.REFRESH_HTTPONLY,
+                samesite=auth_settings.REFRESH_SAME_SITE,
+                secure=auth_settings.REFRESH_SECURE,
+                expires=auth_settings.REFRESH_TOKEN_EXPIRE_SECONDS,
+                domain=auth_settings.COOKIE_DOMAIN,
+            )
         response.set_cookie(
             "access_token_lf",
             tokens["access_token"],

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -373,7 +373,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2452,7 +2452,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1320,7 +1320,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1522,7 +1522,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -961,7 +961,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1918,7 +1918,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -347,7 +347,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1195,7 +1195,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -703,7 +703,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -414,7 +414,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1205,7 +1205,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -893,7 +893,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1189,7 +1189,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1775,7 +1775,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2113,7 +2113,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1254,7 +1254,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -162,7 +162,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -775,7 +775,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1624,7 +1624,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1773,7 +1773,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2824,7 +2824,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -378,7 +378,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -633,7 +633,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -906,7 +906,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -955,7 +955,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -964,7 +964,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2416,7 +2416,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2995,7 +2995,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -3814,7 +3814,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -658,7 +658,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -953,7 +953,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -152,7 +152,7 @@
                 "dependencies": [
                   {
                     "name": "apify_client",
-                    "version": "3.0.2"
+                    "version": "3.0.3"
                   },
                   {
                     "name": "langchain_community",
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",
@@ -384,7 +384,7 @@
                 "dependencies": [
                   {
                     "name": "apify_client",
-                    "version": "3.0.2"
+                    "version": "3.0.3"
                   },
                   {
                     "name": "langchain_community",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",
@@ -983,7 +983,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1305,7 +1305,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "lfx",
@@ -1093,7 +1093,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",
@@ -2101,7 +2101,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -5231,7 +5231,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -831,7 +831,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1113,7 +1113,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -2637,7 +2637,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1735,7 +1735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2324,7 +2324,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -2913,7 +2913,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -405,7 +405,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "48.0.0"
+                    "version": "48.0.1"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.7"
+                    "version": "1.4.8"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.137.1"
+                    "version": "0.137.2"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.0"
+                    "version": "1.4.7"
                   }
                 ],
                 "total_dependencies": 3
@@ -1303,7 +1303,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.3"
+                    "version": "0.137.1"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/services/auth/constants.py
+++ b/src/backend/base/langflow/services/auth/constants.py
@@ -6,3 +6,8 @@ AUTO_LOGIN_ERROR = (
     "Set LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true to skip this check. "
     "Please update your authentication method."
 )
+AUTO_LOGIN_SESSION_WARNING = (
+    "LANGFLOW_AUTO_LOGIN is enabled: /auto_login is issuing a superuser session "
+    "without credentials. Disable AUTO_LOGIN and create a real superuser for any "
+    "non-local or shared deployment."
+)

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -16,7 +16,7 @@ from lfx.services.auth.base import BaseAuthService
 from sqlalchemy.exc import IntegrityError
 
 from langflow.helpers.user import get_user_by_flow_id_or_endpoint_name
-from langflow.services.auth.constants import AUTO_LOGIN_ERROR, AUTO_LOGIN_WARNING
+from langflow.services.auth.constants import AUTO_LOGIN_ERROR, AUTO_LOGIN_SESSION_WARNING, AUTO_LOGIN_WARNING
 from langflow.services.auth.exceptions import (
     InactiveUserError,
     InvalidCredentialsError,
@@ -551,19 +551,18 @@ class AuthService(BaseAuthService):
 
         if not super_user:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Super user hasn't been created")
-        access_token_expires_longterm = timedelta(days=365)
-        access_token = self.create_token(
-            data={"sub": str(super_user.id), "type": "access"},
-            expires_delta=access_token_expires_longterm,
-        )
 
-        await update_user_last_login_at(super_user.id, db)
-
-        return super_user.id, {
-            "access_token": access_token,
-            "refresh_token": None,
-            "token_type": "bearer",
-        }
+        # Security (GHSA-fjgc-vj2f-77hm): AUTO_LOGIN defaults on, so an
+        # unauthenticated GET /api/v1/auto_login reaches this code. It previously
+        # minted a 365-day superuser access token (with no refresh token) — i.e.
+        # a year-long superuser bearer token handed out without credentials.
+        # Issue normally-scoped tokens instead: a short-lived access token plus a
+        # refresh token (see create_user_tokens). The auto-login session stays
+        # seamless via refresh, but a leaked token is now bounded by
+        # ACCESS_TOKEN_EXPIRE_SECONDS instead of a year.
+        logger.warning(AUTO_LOGIN_SESSION_WARNING)
+        tokens = await self.create_user_tokens(user_id=super_user.id, db=db, update_last_login=True)
+        return super_user.id, tokens
 
     def create_user_api_key(self, user_id: UUID) -> dict:
         access_token = self.create_token(

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -222,6 +222,7 @@ async def test_auto_login_longterm_token_is_short_lived_with_refresh(
     # the fixture), nowhere near a year.
     claims = jwt.decode(tokens["access_token"], options={"verify_signature": False})
     lifetime = claims["exp"] - int(datetime.now(timezone.utc).timestamp())
+    assert lifetime > 0
     assert lifetime <= auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS + 5
     assert lifetime < 60 * 60 * 24  # far below a day, definitely not 365 days
 

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -193,6 +193,40 @@ async def test_authenticate_with_credentials_auto_login_skip_missing_superuser_r
 
 
 @pytest.mark.anyio
+async def test_auto_login_longterm_token_is_short_lived_with_refresh(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """auto_login must not mint a 365-day superuser token.
+
+    Regression for GHSA-fjgc-vj2f-77hm: create_user_longterm_token
+    previously issued a 365-day access token with no refresh token. It must now
+    issue a normally-scoped access token (ACCESS_TOKEN_EXPIRE_SECONDS) plus a
+    refresh token.
+    """
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.SUPERUSER = "admin"
+    superuser = _dummy_user(uuid4())
+
+    with (
+        patch("langflow.services.auth.service.get_user_by_username", new=AsyncMock(return_value=superuser)),
+        patch("langflow.services.auth.service.update_user_last_login_at", new=AsyncMock()),
+    ):
+        user_id, tokens = await auth_service.create_user_longterm_token(AsyncMock())
+
+    assert user_id == superuser.id
+    # A refresh token is now issued (previously None).
+    assert tokens["refresh_token"]
+
+    # The access token lifetime is bounded by ACCESS_TOKEN_EXPIRE_SECONDS (60 in
+    # the fixture), nowhere near a year.
+    claims = jwt.decode(tokens["access_token"], options={"verify_signature": False})
+    lifetime = claims["exp"] - int(datetime.now(timezone.utc).timestamp())
+    assert lifetime <= auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS + 5
+    assert lifetime < 60 * 60 * 24  # far below a day, definitely not 365 days
+
+
+@pytest.mark.anyio
 async def test_authenticate_with_credentials_auto_login_skip_empty_superuser_config_raises():
     """AUTO_LOGIN + skip_auth_auto_login with an empty SUPERUSER config rejects without a DB lookup.
 

--- a/src/frontend/src/components/authorization/authGuard/__tests__/proactive-refresh.test.tsx
+++ b/src/frontend/src/components/authorization/authGuard/__tests__/proactive-refresh.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for the ProtectedRoute proactive token refresh.
+ *
+ * GHSA-fjgc-vj2f-77hm shortened the auto-login access token from 365 days to
+ * ACCESS_TOKEN_EXPIRE_SECONDS (default 1h) and added a refresh_token_lf cookie.
+ * The proactive refresh interval used to be armed only for manual sessions
+ * (`!autoLogin`), so under default AUTO_LOGIN a tab left open past the token
+ * lifetime would 401 with no client-side recovery. The interval must now be
+ * armed for auto-login sessions too so they refresh transparently via /refresh.
+ */
+
+import { act, render } from "@testing-library/react";
+
+// Mirrors the mocked LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS below (seconds → ms).
+const ACCESS_TOKEN_EXPIRE_SECONDS = 3240;
+const INTERVAL_MS = ACCESS_TOKEN_EXPIRE_SECONDS * 1000;
+
+const mockMutateRefresh = jest.fn();
+let mockAuthState: {
+  isAuthenticated: boolean;
+  autoLogin: boolean | undefined;
+} = {
+  isAuthenticated: true,
+  autoLogin: true,
+};
+
+jest.mock("@/constants/constants", () => ({
+  IS_AUTO_LOGIN: true,
+  LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS: 3240,
+  LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV: Number.NaN,
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useRefreshAccessToken: () => ({ mutate: mockMutateRefresh }),
+}));
+
+jest.mock("@/customization/components/custom-navigate", () => ({
+  CustomNavigate: () => null,
+}));
+
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: (selector: (state: typeof mockAuthState) => unknown) =>
+    selector(mockAuthState),
+}));
+
+import { ProtectedRoute } from "../index";
+
+describe("ProtectedRoute - proactive token refresh", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockMutateRefresh.mockClear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("arms the proactive refresh under auto-login (GHSA-fjgc-vj2f-77hm)", () => {
+    mockAuthState = { isAuthenticated: true, autoLogin: true };
+
+    render(
+      <ProtectedRoute>
+        <div>child</div>
+      </ProtectedRoute>,
+    );
+
+    // Auto-login just minted a fresh token, so there is no redundant immediate
+    // refresh on mount.
+    expect(mockMutateRefresh).not.toHaveBeenCalled();
+
+    // The interval keeps the now short-lived token alive via /refresh.
+    act(() => {
+      jest.advanceTimersByTime(INTERVAL_MS);
+    });
+    expect(mockMutateRefresh).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(INTERVAL_MS);
+    });
+    expect(mockMutateRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes immediately on mount for manual sessions (unchanged)", () => {
+    mockAuthState = { isAuthenticated: true, autoLogin: false };
+
+    render(
+      <ProtectedRoute>
+        <div>child</div>
+      </ProtectedRoute>,
+    );
+
+    // Manual sessions validate the cookie session once on mount...
+    expect(mockMutateRefresh).toHaveBeenCalledTimes(1);
+
+    // ...then keep refreshing on the interval.
+    act(() => {
+      jest.advanceTimersByTime(INTERVAL_MS);
+    });
+    expect(mockMutateRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not arm a refresh until autoLogin is determined", () => {
+    mockAuthState = { isAuthenticated: false, autoLogin: undefined };
+
+    render(
+      <ProtectedRoute>
+        <div>child</div>
+      </ProtectedRoute>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(INTERVAL_MS * 2);
+    });
+    expect(mockMutateRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/authorization/authGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authGuard/index.tsx
@@ -32,12 +32,24 @@ export const ProtectedRoute = ({ children }) => {
       mutateRefresh();
     };
 
-    if (autoLogin !== undefined && !autoLogin && isAuthenticated) {
+    // Proactively refresh the access token before it expires for any
+    // authenticated session — manual login AND auto-login. Auto-login tokens
+    // are now short-lived (ACCESS_TOKEN_EXPIRE_SECONDS) and ``/auto_login`` sets
+    // a ``refresh_token_lf`` cookie, so the session must refresh transparently
+    // via ``/refresh`` instead of relying on a long-lived token. Without this, a
+    // tab left open past the token lifetime would 401 with no client-side
+    // recovery until a full page reload.
+    if (autoLogin !== undefined && isAuthenticated) {
       const intervalId = setInterval(intervalFunction, accessTokenTimer * 1000);
-      intervalFunction();
+      // Manual sessions refresh once on mount to validate the cookie session.
+      // Auto-login just minted a fresh token via ``/auto_login``, so skip the
+      // redundant immediate refresh and let the interval keep it alive.
+      if (!autoLogin) {
+        intervalFunction();
+      }
       return () => clearInterval(intervalId);
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, autoLogin]);
 
   if (shouldRedirect || testMockAutoLogin) {
     const currentPath = window.location.pathname;


### PR DESCRIPTION
## Summary
`AUTO_LOGIN` defaults to `True`, so an **unauthenticated** `GET /api/v1/auto_login` reaches `create_user_longterm_token`, which minted a **365-day** superuser access token with **no refresh token**. In effect, the default configuration hands out a year-long superuser bearer token to anyone who can reach the endpoint (**GHSA-fjgc-vj2f-77hm**).

> Note: the worse *silent* variant — every no-credential request being treated as superuser — is already gated behind `skip_auth_auto_login` (default off). This PR closes the remaining named-endpoint token issuance.

## Fix (non-breaking hardening)
- `create_user_longterm_token` now delegates to `create_user_tokens`: a short-lived access token (`ACCESS_TOKEN_EXPIRE_SECONDS`, default 1h) **plus a refresh token**.
- The `auto_login` route now sets the `refresh_token_lf` cookie, so the auto-login session refreshes transparently via `/refresh` instead of depending on a year-long token — the dev UX is unchanged.
- A loud warning is logged whenever `auto_login` issues a session.
- `AUTO_LOGIN` default is intentionally left `True`; flipping it is a breaking change staged for v2.0. This PR bounds the blast radius of the issued token without breaking fresh-install/dev UX.

## Test plan
- Added `test_auto_login_longterm_token_is_short_lived_with_refresh` — asserts a refresh token is issued and the access-token lifetime is `ACCESS_TOKEN_EXPIRE_SECONDS` (not 365 days).
- Full `test_auth_service.py` suite passes (47 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-login now issues short-lived access tokens with refresh token support instead of year-long tokens for enhanced security.
  * Added refresh token handling to auto-login session management.
  * Added security guidance for auto-login deployments on shared systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->