### PR TITLE
fix: restore route discovery under FastAPI 0.137 lazy include_router

### DIFF
--- a/src/backend/base/langflow/plugin_routes.py
+++ b/src/backend/base/langflow/plugin_routes.py
@@ -4,11 +4,45 @@ Plugins register via the ``langflow.plugins`` entry-point group. They receive
 a wrapper so they cannot overwrite or shadow existing Langflow routes.
 """
 
+from collections.abc import Iterable, Iterator
 from importlib.metadata import entry_points
+from typing import Any
 
 from fastapi import FastAPI
 from lfx.extension import filter_component_entry_points
 from lfx.log.logger import logger
+
+
+def _iter_route_keys(routes: Iterable[Any], prefix: str = "") -> Iterator[tuple[str, str]]:
+    """Yield ``(path, method)`` for every concrete route reachable from ``routes``.
+
+    FastAPI >=0.137 includes sub-routers lazily: ``include_router`` stores an
+    internal ``_IncludedRouter`` wrapper instead of copying the child
+    ``APIRoute`` objects onto the parent. Descend through that wrapper (via its
+    public ``original_router`` / ``include_context``) so route discovery sees the
+    routes the app will actually serve, on both eager (<=0.136) and lazy
+    (>=0.137) FastAPI. ``HEAD`` is skipped (it usually mirrors ``GET``); mounts
+    are reported as ``(path, "*")``.
+    """
+    for route in routes:
+        original_router = getattr(route, "original_router", None)
+        if original_router is not None:
+            include_context = getattr(route, "include_context", None)
+            include_prefix = getattr(include_context, "prefix", "") or ""
+            yield from _iter_route_keys(original_router.routes, prefix + include_prefix)
+            continue
+        path = getattr(route, "path", None)
+        if path is None:
+            continue
+        full_path = prefix + path
+        methods = getattr(route, "methods", None)
+        if methods is not None:
+            for method in methods:
+                if method != "HEAD":  # often same as GET
+                    yield (full_path, method)
+        elif hasattr(route, "path_regex"):
+            # Mount or similar: reserve path for all methods
+            yield (full_path, "*")
 
 
 def _get_route_keys(app: FastAPI) -> set[tuple[str, str]]:
@@ -17,16 +51,7 @@ def _get_route_keys(app: FastAPI) -> set[tuple[str, str]]:
     Used to build the reserved set before loading plugins so that plugin
     routes cannot overwrite or shadow existing Langflow routes.
     """
-    keys: set[tuple[str, str]] = set()
-    for route in app.router.routes:
-        if hasattr(route, "path") and hasattr(route, "methods"):
-            for method in route.methods:
-                if method != "HEAD":  # often same as GET
-                    keys.add((route.path, method))
-        elif hasattr(route, "path") and hasattr(route, "path_regex"):
-            # Mount or similar: reserve path for all methods
-            keys.add((route.path, "*"))
-    return keys
+    return set(_iter_route_keys(app.router.routes))
 
 
 class _PluginAppWrapper:

--- a/src/backend/tests/unit/api/v1/test_deployments_routes.py
+++ b/src/backend/tests/unit/api/v1/test_deployments_routes.py
@@ -4,21 +4,38 @@ These tests guard against route-order regressions where static routes could be
 captured by the dynamic `/{deployment_id}` route.
 """
 
+from collections.abc import Iterator
 from uuid import uuid4
 
 import langflow.api.router as api_router_module
 import pytest
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter
 from fastapi.routing import APIRoute
 from langflow.api.v1.deployments import router
 from starlette.routing import Match
 
 
+def _flatten_api_routes(router: APIRouter) -> Iterator[APIRoute]:
+    """Yield every ``APIRoute`` reachable from ``router``.
+
+    FastAPI >=0.137 includes sub-routers lazily: ``include_router`` stores an
+    internal ``_IncludedRouter`` wrapper instead of eagerly copying the child
+    ``APIRoute`` objects into ``router.routes``. Descend through that wrapper via
+    its public ``original_router`` reference so these tests work on both the
+    eager (<=0.136) and lazy (>=0.137) inclusion behaviours.
+    """
+    for route in router.routes:
+        if isinstance(route, APIRoute):
+            yield route
+        else:
+            original = getattr(route, "original_router", None)
+            if original is not None:
+                yield from _flatten_api_routes(original)
+
+
 @pytest.fixture
 def deployment_routes() -> list[APIRoute]:
-    app = FastAPI()
-    app.include_router(router)
-    return [route for route in app.router.routes if isinstance(route, APIRoute)]
+    return list(_flatten_api_routes(router))
 
 
 def _resolve_endpoint_name(routes: list[APIRoute], *, path: str, method: str = "GET") -> str:
@@ -104,7 +121,7 @@ def test_include_deployment_router_skips_routes_when_feature_disabled(monkeypatc
     router_v1 = APIRouter(prefix="/v1")
     api_router_module.include_deployment_router(router_v1)
 
-    assert all("/deployments" not in route.path for route in router_v1.routes)
+    assert all("/deployments" not in route.path for route in _flatten_api_routes(router_v1))
 
 
 def test_include_deployment_router_adds_routes_when_feature_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,4 +130,4 @@ def test_include_deployment_router_adds_routes_when_feature_enabled(monkeypatch:
     router_v1 = APIRouter(prefix="/v1")
     api_router_module.include_deployment_router(router_v1)
 
-    assert any("/deployments" in route.path for route in router_v1.routes)
+    assert any("/deployments" in route.path for route in _flatten_api_routes(router_v1))

--- a/src/backend/tests/unit/api/v1/test_extensions_route_guard.py
+++ b/src/backend/tests/unit/api/v1/test_extensions_route_guard.py
@@ -92,7 +92,16 @@ def test_route_is_mounted_unconditionally() -> None:
     def collect_paths(routes, prefix: str = "") -> list[str]:
         out: list[str] = []
         for route in routes:
-            if hasattr(route, "routes"):
+            # FastAPI >=0.137 includes sub-routers lazily via an internal
+            # `_IncludedRouter` wrapper (no `.routes`/`.path`); descend through
+            # its public `original_router` / `include_context` so this works on
+            # both eager (<=0.136) and lazy (>=0.137) inclusion.
+            original_router = getattr(route, "original_router", None)
+            if original_router is not None:
+                include_context = getattr(route, "include_context", None)
+                include_prefix = getattr(include_context, "prefix", "") or ""
+                out.extend(collect_paths(original_router.routes, prefix + include_prefix))
+            elif hasattr(route, "routes"):
                 out.extend(collect_paths(route.routes, prefix + getattr(route, "prefix", "")))
             elif hasattr(route, "path"):
                 out.append(prefix + route.path)
@@ -120,7 +129,16 @@ def test_no_runtime_mutation_routes() -> None:
     def collect_paths(routes, prefix: str = "") -> list[str]:
         out: list[str] = []
         for route in routes:
-            if hasattr(route, "routes"):
+            # FastAPI >=0.137 includes sub-routers lazily via an internal
+            # `_IncludedRouter` wrapper (no `.routes`/`.path`); descend through
+            # its public `original_router` / `include_context` so this works on
+            # both eager (<=0.136) and lazy (>=0.137) inclusion.
+            original_router = getattr(route, "original_router", None)
+            if original_router is not None:
+                include_context = getattr(route, "include_context", None)
+                include_prefix = getattr(include_context, "prefix", "") or ""
+                out.extend(collect_paths(original_router.routes, prefix + include_prefix))
+            elif hasattr(route, "routes"):
                 out.extend(collect_paths(route.routes, prefix + getattr(route, "prefix", "")))
             elif hasattr(route, "path"):
                 out.append(prefix + route.path)


### PR DESCRIPTION
## Summary

The recent `chore: update uv` (`4a138e241e`) bumped **FastAPI 0.136.3 → 0.137.1** (Starlette 1.2.1 → 1.3.1). FastAPI 0.137 changed `include_router` to **lazy inclusion**: an included sub-router is now stored as an internal `_IncludedRouter` wrapper instead of eagerly flattening its `APIRoute` objects onto the parent. Any code that introspects `app.router.routes` no longer sees the nested routes.

This is unrelated to any feature PR — it surfaced on `release-1.10.1` itself (e.g. on the backend Unit Tests job for [#13704](https://github.com/langflow-ai/langflow/pull/13704), where `test_deployments_routes.py` failed with `AssertionError: No matching route for GET /deployments/configs`).

## Production impact (not just tests)

`_get_route_keys` in `plugin_routes.py` iterates `app.router.routes` to build the **reserved-path set** before loading plugins, so plugins cannot shadow core Langflow routes. With the core routers now hidden behind `_IncludedRouter` wrappers, the reserved set was effectively **empty**, silently defeating plugin conflict-protection:

```python
# release-1.10.1 today, after the FastAPI bump:
_get_route_keys(app)  # core routes like /api/v1/flows are NOT in the set
```

Fixed by descending through the wrapper via its public `original_router` / `include_context` (accumulating the include-time prefix), so discovery is correct on **both** eager (≤0.136) and lazy (≥0.137) inclusion.

## Changes

- **`plugin_routes.py`** (production): new `_iter_route_keys` helper that flattens routes through lazy `_IncludedRouter` wrappers; `_get_route_keys` now uses it. Restores plugin route conflict-protection. Fixes `test_plugin_routes.py::test_include_router_allows_non_conflicting_prefix`.
- **`test_deployments_routes.py`**: the fixture read `app.router.routes` after `include_router` and filtered for `APIRoute` (now empty under lazy inclusion). Reads routes from the router directly via a version-agnostic flattener.
- **`test_extensions_route_guard.py`**: the local `collect_paths` recursed via `hasattr(route, "routes")`, which the lazy wrapper lacks. It now descends through `original_router` (this also restores the `test_no_runtime_mutation_routes` invariant, which had been passing vacuously).

## Test plan

- `test_deployments_routes.py` — 11 passed
- `test_plugin_routes.py` — 13 passed
- `test_extensions_route_guard.py` — 5 passed
- Verified `_get_route_keys` now reserves nested core routes (`/api/v1/flows` present in the reserved set)
- `lfx` serve-app route tests (which use `@app.get` decorators directly, not `include_router`) confirmed unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route conflict detection in the plugin system to properly handle lazy-loaded routes and nested sub-routers for more robust route management.

* **Tests**
  * Updated deployment and extension route tests to work consistently with FastAPI's lazy router inclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->