### PR TITLE
fix(docker): force HTTP/1.1 on frontend nginx upstream proxy (#9010)

### DIFF
--- a/docker/frontend/default.conf.template
+++ b/docker/frontend/default.conf.template
@@ -39,12 +39,15 @@ http {
 
         location /api {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
         }
         location /health_check {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
         }
         location /health {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
         }
 
         include /etc/nginx/extra-conf.d/*.conf;

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -18,12 +18,15 @@ server {
     }
     location /api {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
     }
     location /health_check {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
     }
     location /health {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
     }
 
     include /etc/nginx/extra-conf.d/*.conf;


### PR DESCRIPTION
## Summary

The frontend nginx config proxies to the backend without setting `proxy_http_version`, so nginx uses its default of **HTTP/1.0** for upstream requests. Behind an HTTP/1.1-only proxy — such as an Istio/Envoy service-mesh sidecar — those requests are rejected with **HTTP 426 Upgrade Required**, breaking every frontend endpoint that passes through nginx (`/api`, `/health`, `/health_check`).

Fixes #9010

## Fix

Set `proxy_http_version 1.1;` on every `proxy_pass` block in both nginx files:

- `docker/frontend/default.conf.template` — rendered into the production frontend image (`build_and_push_frontend.Dockerfile` → `start-nginx.sh` via `envsubst`).
- `docker/frontend/nginx.conf` — same gap (not used by the image build, fixed for consistency).

Version-independent: keeps working behind HTTP/1.1-only proxies regardless of which nginx the image ships. The image pins `nginxinc/nginx-unprivileged:stable-bookworm-perl` (nginx 1.28.0), whose upstream default is still HTTP/1.0, so a directive — not an nginx bump — is the real fix.

## Verification

Reproduced with the **exact pinned image** (nginx 1.28.0), template rendered via the real `start-nginx.sh`, in front of a mock upstream that rejects HTTP/1.0 (emulating Envoy's HTTP/1.1 requirement):

| | `/api` | `/health` | `/health_check` | upstream received |
|---|---|---|---|---|
| Before | 426 | 426 | 426 | HTTP/1.0 |
| After | 200 | 200 | 200 | HTTP/1.1 |

`nginx -t` on the rendered `nginx.conf` reports `syntax is ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP protocol configuration for API and health check endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->