### PR TITLE
fix(a11y): add accessible names and hide decorative icons in LangflowCounts

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/components/__tests__/langflow-counts.a11y.test.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/__tests__/langflow-counts.a11y.test.tsx
@@ -2,8 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { LangflowCounts } from "../langflow-counts";
 
 jest.mock("@/stores/darkStore", () => ({
-  useDarkStore: (selector: (s: { stars: number; discordCount: number }) => unknown) =>
-    selector({ stars: 1234, discordCount: 5678 }),
+  useDarkStore: (
+    selector: (s: { stars: number; discordCount: number }) => unknown,
+  ) => selector({ stars: 1234, discordCount: 5678 }),
 }));
 
 jest.mock("react-i18next", () => ({
@@ -30,8 +31,13 @@ jest.mock("@/utils/utils", () => ({
 }));
 
 jest.mock("@/shared/components/caseComponent", () => ({
-  Case: ({ condition, children }: { condition: boolean; children: React.ReactNode }) =>
-    condition ? <>{children}</> : null,
+  Case: ({
+    condition,
+    children,
+  }: {
+    condition: boolean;
+    children: React.ReactNode;
+  }) => (condition ? <>{children}</> : null),
 }));
 
 describe("LangflowCounts accessibility", () => {

--- a/src/frontend/src/components/core/appHeaderComponent/components/__tests__/langflow-counts.a11y.test.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/__tests__/langflow-counts.a11y.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { LangflowCounts } from "../langflow-counts";
+
+jest.mock("@/stores/darkStore", () => ({
+  useDarkStore: (selector: (s: { stars: number; discordCount: number }) => unknown) =>
+    selector({ stars: 1234, discordCount: 5678 }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        "header.goToGithub": "Go to GitHub repo",
+        "header.goToDiscord": "Go to Discord server",
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+jest.mock("@/components/common/shadTooltipComponent", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/utils/utils", () => ({
+  formatNumber: (n: number) => String(n),
+  cn: (...classes: (string | undefined | null | false)[]) =>
+    classes.filter(Boolean).join(" "),
+}));
+
+jest.mock("@/shared/components/caseComponent", () => ({
+  Case: ({ condition, children }: { condition: boolean; children: React.ReactNode }) =>
+    condition ? <>{children}</> : null,
+}));
+
+describe("LangflowCounts accessibility", () => {
+  beforeEach(() => {
+    render(<LangflowCounts />);
+  });
+
+  it("should_expose_github_button_with_accessible_name", () => {
+    expect(
+      screen.getByRole("button", { name: /go to github repo/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should_expose_discord_button_with_accessible_name", () => {
+    expect(
+      screen.getByRole("button", { name: /go to discord server/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should_hide_github_icon_from_assistive_technology", () => {
+    const githubButton = screen.getByRole("button", {
+      name: /go to github repo/i,
+    });
+    const svg = githubButton.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should_hide_discord_icon_from_assistive_technology", () => {
+    const discordButton = screen.getByRole("button", {
+      name: /go to discord server/i,
+    });
+    const svg = discordButton.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
@@ -27,10 +27,11 @@ export const LangflowCounts = () => {
           onClick={() => window.open(GITHUB_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
         >
+          <span className="sr-only">{t("header.goToGithub")}</span>
           <div className="relative items-center rounded-md px-2 py-1 flex">
-            <FaGithub className="h-4 w-4" />
+            <FaGithub aria-hidden="true" className="h-4 w-4" />
             <Case condition={Boolean(formattedStars) && formattedStars !== "0"}>
-              <span className="text-xs font-semibold pl-2">
+              <span className="text-xs font-semibold pl-2" aria-hidden="true">
                 {formattedStars}
               </span>
             </Case>
@@ -48,14 +49,15 @@ export const LangflowCounts = () => {
           onClick={() => window.open(DISCORD_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
         >
+          <span className="sr-only">{t("header.goToDiscord")}</span>
           <div className="relative items-center rounded-md px-2 py-1 flex">
-            <FaDiscord className="h-4 w-4" />
+            <FaDiscord aria-hidden="true" className="h-4 w-4" />
             <Case
               condition={
                 Boolean(formattedDiscordCount) && formattedDiscordCount !== "0"
               }
             >
-              <span className="text-xs font-semibold pl-2">
+              <span className="text-xs font-semibold pl-2" aria-hidden="true">
                 {formattedDiscordCount}
               </span>
             </Case>


### PR DESCRIPTION
## Summary

- Add visually-hidden `sr-only` spans to the GitHub and Discord buttons
  in `LangflowCounts` so screen readers announce "Go to GitHub repo" /
  "Go to Discord server" instead of just the star/member count
- Mark `FaGithub`, `FaDiscord`, and the count spans as
  `aria-hidden="true"` so AT skips the decorative content and relies on
  the `sr-only` label
- Add `langflow-counts.a11y.test.tsx` — a dedicated test file that
  renders `LangflowCounts` directly (not via the mocked header shell)
  and asserts accessible names and `aria-hidden` on both buttons

Fixes two WCAG 2.1 criteria:
- **1.1.1 Non-text Content** — SVG icons now hidden from AT
- **2.4.6 Headings and Labels** — buttons now have a computed accessible
  name matching the visible tooltip text

## Test plan

- [ ] `npx jest langflow-counts.a11y --no-coverage` → 4 assertions green
- [ ] `npx jest appHeader.a11y --no-coverage` → 3 existing assertions
  unchanged
  
## Screenshot (errors decreased by 2)
Before
<img width="1644" height="819" alt="Screenshot 2026-06-17 at 3 35 07 PM" src="https://github.com/user-attachments/assets/0e0baee1-9f8d-46e3-9597-0a774c6299d4" />
After
<img width="1644" height="819" alt="Screenshot 2026-06-17 at 3 35 39 PM" src="https://github.com/user-attachments/assets/77100c23-ffc2-4bc0-821c-820d75ff505f" />

