### PR TITLE
fix(frontend): stop browser autofill from corrupting component config fields

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4156,7 +4156,7 @@
         "filename": "src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T18:03:47Z"
+  "generated_at": "2026-06-19T14:41:53Z"
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/__tests__/input-component-autofill.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/__tests__/input-component-autofill.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import InputComponent from "../index";
+
+/**
+ * Locks the autofill scoping for InputComponent:
+ *  - node-config fields (the non-form CustomInputPopover path, incl. API-key /
+ *    secret fields) suppress autofill so the browser cannot inject saved
+ *    credentials that autosave persists;
+ *  - real credential forms opt back in via isForm + allowAutofill and must NOT
+ *    carry the password-manager opt-out attributes.
+ */
+describe("InputComponent — autofill scoping", () => {
+  const IGNORE_ATTRS = [
+    "data-1p-ignore",
+    "data-lpignore",
+    "data-bwignore",
+    "data-form-type",
+  ];
+
+  const getInput = (ui: React.ReactElement): HTMLInputElement => {
+    const { container } = render(ui);
+    const input = container.querySelector("input");
+    if (!input) throw new Error("input not found");
+    return input;
+  };
+
+  it("suppresses autofill with new-password on a node-config secret field", () => {
+    const input = getInput(
+      <InputComponent id="api_key" value="" password={true} />,
+    );
+    expect(input.getAttribute("autocomplete")).toBe("new-password");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(true);
+    }
+  });
+
+  it("suppresses autofill with off on a node-config text field", () => {
+    const input = getInput(
+      <InputComponent id="field" value="" password={false} />,
+    );
+    expect(input.getAttribute("autocomplete")).toBe("off");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(true);
+    }
+  });
+
+  it("keeps autofill working on a credential form (isForm + allowAutofill) with no opt-outs", () => {
+    const input = getInput(
+      <InputComponent
+        id="login-password"
+        value=""
+        password={true}
+        isForm
+        allowAutofill
+      />,
+    );
+    expect(input.getAttribute("autocomplete")).not.toBe("new-password");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(false);
+    }
+  });
+
+  it("still suppresses a form input that does not opt in (e.g. folder rename)", () => {
+    const input = getInput(
+      <InputComponent id="folder" value="" password={false} isForm />,
+    );
+    expect(input.getAttribute("autocomplete")).toBe("off");
+    expect(input.hasAttribute("data-1p-ignore")).toBe(true);
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -16,6 +16,10 @@ import {
   PopoverContent,
   PopoverContentWithoutPortal,
 } from "@/components/ui/popover";
+import {
+  getSuppressedAutoComplete,
+  PASSWORD_MANAGER_IGNORE_PROPS,
+} from "@/utils/inputAutofill";
 import { cn } from "@/utils/utils";
 import { useIMEInputForOnChange } from "../../../../hooks/use-ime-input";
 
@@ -301,7 +305,8 @@ const CustomInputPopover = ({
 
           {(!selectedOption?.length && !selectedOptions?.length) || disabled ? (
             <input
-              autoComplete="off"
+              autoComplete={getSuppressedAutoComplete(!!password)}
+              {...PASSWORD_MANAGER_IGNORE_PROPS}
               onFocus={() => setIsFocused(true)}
               autoFocus={autoFocus}
               id={id}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
@@ -30,6 +30,7 @@ interface FormInputBranchProps {
   blurOnEnter: boolean;
   name?: string;
   id: string;
+  allowAutofill?: boolean;
 }
 
 function FormInputBranch({
@@ -49,6 +50,7 @@ function FormInputBranch({
   blurOnEnter,
   name,
   id,
+  allowAutofill,
 }: FormInputBranchProps) {
   const [cursor, setCursor] = useState<number | null>(null);
 
@@ -91,6 +93,7 @@ function FormInputBranch({
         name={name}
         id={"form-" + id}
         ref={refInput}
+        allowAutofill={allowAutofill}
         autoFocus={autoFocus}
         type={password && !pwdVisible ? "password" : "text"}
         {...imeInputProps}
@@ -126,6 +129,7 @@ export default function InputComponent({
   disabled,
   required = false,
   isForm = false,
+  allowAutofill = false,
   password,
   editNode = false,
   placeholder = "Type something...",
@@ -190,6 +194,7 @@ export default function InputComponent({
           blurOnEnter={blurOnEnter}
           name={name}
           id={id}
+          allowAutofill={allowAutofill}
         />
       ) : (
         <>

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -5,6 +5,7 @@ import { useDarkStore } from "@/stores/darkStore";
 import "@/style/ag-theme-shadcn.css"; // Custom CSS applied to the grid
 import type { ColDef } from "ag-grid-community";
 import type { TableOptionsTypeAPI } from "@/types/api";
+import { suppressAutofillOnElement } from "@/utils/inputAutofill";
 import { cn } from "@/utils/utils";
 import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
 import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional Theme applied to the grid
@@ -331,6 +332,22 @@ const TableComponent = forwardRef<
         params.api.sizeColumnsToFit();
       }
     };
+    const onCellEditingStarted = (event) => {
+      // ag-grid mounts its cell editor <input>/<textarea> outside React, so the
+      // hardened Input primitive doesn't cover them. Stamp the autofill-
+      // suppression attributes on the active editor so the browser can't inject
+      // saved credentials into editable cells (which autosave persists). Defer a
+      // frame so the editor DOM exists; cover inline and popup (large-text)
+      // editors.
+      requestAnimationFrame(() => {
+        document
+          .querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+            ".ag-cell-inline-editing input, .ag-cell-inline-editing textarea, .ag-popup-editor input, .ag-popup-editor textarea",
+          )
+          .forEach(suppressAutofillOnElement);
+      });
+      props.onCellEditingStarted?.(event);
+    };
     if (props.rowData.length === 0 && displayEmptyAlert) {
       return (
         <div className="flex h-full w-full items-center justify-center rounded-md border">
@@ -406,6 +423,7 @@ const TableComponent = forwardRef<
           }}
           onGridReady={onGridReady}
           onColumnMoved={onColumnMoved}
+          onCellEditingStarted={onCellEditingStarted}
           onCellValueChanged={
             props.onCellValueChanged
               ? (e) => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -4,6 +4,7 @@ import { customGetHostProtocol } from "@/customization/utils/custom-get-host-pro
 import { getCurlWebhookCode } from "@/modals/apiModal/utils/get-curl-code";
 import ComponentTextModal from "@/modals/textAreaModal";
 import { useUtilityStore } from "@/stores/utilityStore";
+import { getSuppressedAutoComplete } from "@/utils/inputAutofill";
 import { cn } from "../../../../../utils/utils";
 import IconComponent from "../../../../common/genericIconComponent";
 import { Input } from "../../../../ui/input";
@@ -211,6 +212,9 @@ export default function TextAreaComponent({
         placeholder={getPlaceholder(disabled, placeholder)}
         aria-label={disabled ? displayValue : undefined}
         ref={inputRef}
+        // Keyed on the secret-ness, not the live type, so revealing a masked
+        // value doesn't re-arm autofill.
+        autoComplete={getSuppressedAutoComplete(!!password)}
         type={password ? (passwordVisible ? "text" : "password") : "text"}
         readOnly={isWebhook}
       />

--- a/src/frontend/src/components/ui/__tests__/input-autofill.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/input-autofill.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { Input } from "../input";
+
+/**
+ * Guards the autofill-suppression contract of the base Input primitive.
+ *
+ * Browsers (notably Chrome) ignore autocomplete="off" for credential-like
+ * fields and inject saved values that Langflow's autosave then persists,
+ * corrupting flows. The primitive therefore suppresses autofill by default and
+ * only opts back in for real credential forms via `allowAutofill`.
+ */
+describe("Input — autofill suppression", () => {
+  const IGNORE_ATTRS = [
+    "data-1p-ignore",
+    "data-lpignore",
+    "data-bwignore",
+    "data-form-type",
+  ];
+
+  const getInput = (ui: React.ReactElement): HTMLInputElement => {
+    const { container } = render(ui);
+    const input = container.querySelector("input");
+    if (!input) throw new Error("input not found");
+    return input;
+  };
+
+  it("suppresses autofill by default on a text field (off + password-manager opt-outs)", () => {
+    const input = getInput(<Input placeholder="name" />);
+    expect(input.getAttribute("autocomplete")).toBe("off");
+    expect(input.getAttribute("data-1p-ignore")).toBe("true");
+    expect(input.getAttribute("data-lpignore")).toBe("true");
+    expect(input.getAttribute("data-bwignore")).toBe("true");
+    expect(input.getAttribute("data-form-type")).toBe("other");
+  });
+
+  it("uses new-password on a password/secret field so Chrome won't inject a saved credential", () => {
+    const input = getInput(<Input type="password" placeholder="API Key" />);
+    expect(input.getAttribute("autocomplete")).toBe("new-password");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(true);
+    }
+  });
+
+  it("opts back into autofill (no password-manager opt-outs) when allowAutofill is set", () => {
+    const input = getInput(<Input allowAutofill placeholder="username" />);
+    expect(input.getAttribute("autocomplete")).toBe("off");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(false);
+    }
+  });
+
+  it("does NOT force new-password on an allowAutofill password field (real login password)", () => {
+    const input = getInput(<Input allowAutofill type="password" />);
+    expect(input.getAttribute("autocomplete")).not.toBe("new-password");
+    for (const attr of IGNORE_ATTRS) {
+      expect(input.hasAttribute(attr)).toBe(false);
+    }
+  });
+
+  it("lets a caller-provided autoComplete win over the suppressed default", () => {
+    const input = getInput(<Input autoComplete="email" />);
+    expect(input.getAttribute("autocomplete")).toBe("email");
+  });
+});

--- a/src/frontend/src/components/ui/__tests__/input-autofill.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/input-autofill.test.tsx
@@ -41,9 +41,11 @@ describe("Input — autofill suppression", () => {
     }
   });
 
-  it("opts back into autofill (no password-manager opt-outs) when allowAutofill is set", () => {
+  it("opts back into autofill (no autocomplete attr, no password-manager opt-outs) when allowAutofill is set", () => {
     const input = getInput(<Input allowAutofill placeholder="username" />);
-    expect(input.getAttribute("autocomplete")).toBe("off");
+    // With no explicit autoComplete, an opted-in field emits no attribute so
+    // the browser applies its normal (wanted) autofill behavior.
+    expect(input.getAttribute("autocomplete")).toBeNull();
     for (const attr of IGNORE_ATTRS) {
       expect(input.hasAttribute(attr)).toBe(false);
     }
@@ -55,6 +57,13 @@ describe("Input — autofill suppression", () => {
     for (const attr of IGNORE_ATTRS) {
       expect(input.hasAttribute(attr)).toBe(false);
     }
+  });
+
+  it("honors an explicit autoComplete on an allowAutofill field (e.g. username/current-password)", () => {
+    const input = getInput(
+      <Input allowAutofill autoComplete="current-password" />,
+    );
+    expect(input.getAttribute("autocomplete")).toBe("current-password");
   });
 
   it("lets a caller-provided autoComplete win over the suppressed default", () => {

--- a/src/frontend/src/components/ui/input.tsx
+++ b/src/frontend/src/components/ui/input.tsx
@@ -53,10 +53,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             autoComplete ?? getSuppressedAutoComplete(type === "password"),
           ...PASSWORD_MANAGER_IGNORE_PROPS,
         };
-          autoComplete:
-            autoComplete ?? getSuppressedAutoComplete(type === "password"),
-          ...PASSWORD_MANAGER_IGNORE_PROPS,
-        };
 
     // Support legacy string endIcon (icon name) for backwards compatibility
     const resolvedEndIcon =

--- a/src/frontend/src/components/ui/input.tsx
+++ b/src/frontend/src/components/ui/input.tsx
@@ -45,8 +45,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     // opt back in via `allowAutofill`. A caller-provided `autoComplete` always
     // wins. See utils/inputAutofill.ts for the rationale.
     const autofillProps = allowAutofill
-      ? { autoComplete: autoComplete ?? "off" }
+      ? autoComplete !== undefined
+        ? { autoComplete }
+        : {}
       : {
+          autoComplete:
+            autoComplete ?? getSuppressedAutoComplete(type === "password"),
+          ...PASSWORD_MANAGER_IGNORE_PROPS,
+        };
           autoComplete:
             autoComplete ?? getSuppressedAutoComplete(type === "password"),
           ...PASSWORD_MANAGER_IGNORE_PROPS,

--- a/src/frontend/src/components/ui/input.tsx
+++ b/src/frontend/src/components/ui/input.tsx
@@ -1,4 +1,8 @@
 import * as React from "react";
+import {
+  getSuppressedAutoComplete,
+  PASSWORD_MANAGER_IGNORE_PROPS,
+} from "@/utils/inputAutofill";
 import { cn } from "../../utils/utils";
 import ForwardedIconComponent from "../common/genericIconComponent";
 
@@ -11,6 +15,14 @@ export interface InputProps
   endIcon?: React.ReactNode;
   /** @deprecated use endIcon with JSX directly */
   endIconClassName?: string;
+  /**
+   * Opt back into browser / password-manager autofill. Defaults to false so
+   * Langflow inputs (node-config fields, modals) suppress autofill — otherwise
+   * the browser can inject saved credentials that autosave then persists,
+   * corrupting flows. Only real credential-entry forms (login / signup / admin
+   * login) set this to true.
+   */
+  allowAutofill?: boolean;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -23,10 +35,23 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       endIconClassName = "",
       type,
       placeholder,
+      autoComplete,
+      allowAutofill = false,
       ...props
     },
     ref,
   ) => {
+    // Suppress browser/password-manager autofill by default; credential forms
+    // opt back in via `allowAutofill`. A caller-provided `autoComplete` always
+    // wins. See utils/inputAutofill.ts for the rationale.
+    const autofillProps = allowAutofill
+      ? { autoComplete: autoComplete ?? "off" }
+      : {
+          autoComplete:
+            autoComplete ?? getSuppressedAutoComplete(type === "password"),
+          ...PASSWORD_MANAGER_IGNORE_PROPS,
+        };
+
     // Support legacy string endIcon (icon name) for backwards compatibility
     const resolvedEndIcon =
       typeof endIcon === "string" ? (
@@ -55,7 +80,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           />
         )}
         <input
-          autoComplete="off"
+          {...autofillProps}
           type={type}
           placeholder={placeholder}
           className={cn(

--- a/src/frontend/src/components/ui/textarea.tsx
+++ b/src/frontend/src/components/ui/textarea.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { PASSWORD_MANAGER_IGNORE_PROPS } from "@/utils/inputAutofill";
 import { cn } from "../../utils/utils";
 
 export interface TextareaProps
@@ -13,6 +14,10 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <div className="h-full w-full">
         <textarea
           data-testid="textarea"
+          // Suppress autofill: node-config textareas (prompts, descriptions)
+          // are not web forms; an injected value would be autosaved.
+          autoComplete="off"
+          {...PASSWORD_MANAGER_IGNORE_PROPS}
           className={cn(
             "nopan nodelete nodrag noflow textarea-primary nowheel",
             className,

--- a/src/frontend/src/pages/AdminPage/LoginPage/index.tsx
+++ b/src/frontend/src/pages/AdminPage/LoginPage/index.tsx
@@ -61,6 +61,7 @@ export default function LoginAdminPage() {
           {t("auth.adminTitle")}
         </span>
         <Input
+          allowAutofill
           onChange={({ target: { value } }) => {
             handleInput({ target: { name: "username", value } });
           }}
@@ -69,6 +70,7 @@ export default function LoginAdminPage() {
         />
         <Input
           type="password"
+          allowAutofill
           onChange={({ target: { value } }) => {
             handleInput({ target: { name: "password", value } });
           }}

--- a/src/frontend/src/pages/LoginPage/index.tsx
+++ b/src/frontend/src/pages/LoginPage/index.tsx
@@ -93,6 +93,7 @@ export default function LoginPage(): JSX.Element {
               <Form.Control asChild>
                 <Input
                   type="username"
+                  allowAutofill
                   onChange={({ target: { value } }) => {
                     handleInput({ target: { name: "username", value } });
                   }}
@@ -121,6 +122,7 @@ export default function LoginPage(): JSX.Element {
                 }}
                 value={password}
                 isForm
+                allowAutofill
                 password={true}
                 required
                 placeholder={t("auth.passwordPlaceholder")}

--- a/src/frontend/src/pages/SignUpPage/index.tsx
+++ b/src/frontend/src/pages/SignUpPage/index.tsx
@@ -111,6 +111,7 @@ export default function SignUp(): JSX.Element {
               <Form.Control asChild>
                 <Input
                   type="username"
+                  allowAutofill
                   onChange={({ target: { value } }) => {
                     handleInput({ target: { name: "username", value } });
                   }}
@@ -143,6 +144,7 @@ export default function SignUp(): JSX.Element {
                 }}
                 value={password}
                 isForm
+                allowAutofill
                 password={true}
                 required
                 placeholder={t("auth.passwordPlaceholder")}
@@ -183,6 +185,7 @@ export default function SignUp(): JSX.Element {
                 }}
                 value={cnfPassword}
                 isForm
+                allowAutofill
                 password={true}
                 required
                 placeholder={t("auth.confirmPasswordPlaceholder")}

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -26,6 +26,13 @@ export type InputComponentType = {
   password: boolean;
   required?: boolean;
   isForm?: boolean;
+  /**
+   * Opt back into browser / password-manager autofill (default false). Only set
+   * by real credential-entry forms (login / signup / admin login); node-config
+   * inputs leave it false so autofill cannot inject values that autosave
+   * persists. See utils/inputAutofill.ts.
+   */
+  allowAutofill?: boolean;
   editNode?: boolean;
   onChangePass?: (value: boolean | boolean) => void;
   showPass?: boolean;

--- a/src/frontend/src/utils/__tests__/inputAutofill.test.ts
+++ b/src/frontend/src/utils/__tests__/inputAutofill.test.ts
@@ -1,0 +1,39 @@
+import {
+  getSuppressedAutoComplete,
+  PASSWORD_MANAGER_IGNORE_PROPS,
+  suppressAutofillOnElement,
+} from "../inputAutofill";
+
+describe("getSuppressedAutoComplete", () => {
+  it("returns new-password for secret fields and off otherwise", () => {
+    expect(getSuppressedAutoComplete(true)).toBe("new-password");
+    expect(getSuppressedAutoComplete(false)).toBe("off");
+  });
+});
+
+describe("suppressAutofillOnElement", () => {
+  const IGNORE_ATTRS = Object.keys(PASSWORD_MANAGER_IGNORE_PROPS);
+
+  it("stamps autocomplete=off and every password-manager opt-out on an input", () => {
+    const input = document.createElement("input");
+    suppressAutofillOnElement(input);
+    expect(input.getAttribute("autocomplete")).toBe("off");
+    expect(input.getAttribute("data-1p-ignore")).toBe("true");
+    expect(input.getAttribute("data-lpignore")).toBe("true");
+    expect(input.getAttribute("data-bwignore")).toBe("true");
+    expect(input.getAttribute("data-form-type")).toBe("other");
+  });
+
+  it("works on a textarea (e.g. ag-grid large-text editor)", () => {
+    const textarea = document.createElement("textarea");
+    suppressAutofillOnElement(textarea);
+    for (const attr of IGNORE_ATTRS) {
+      expect(textarea.hasAttribute(attr)).toBe(true);
+    }
+  });
+
+  it("is a no-op when given null/undefined", () => {
+    expect(() => suppressAutofillOnElement(null)).not.toThrow();
+    expect(() => suppressAutofillOnElement(undefined)).not.toThrow();
+  });
+});

--- a/src/frontend/src/utils/inputAutofill.ts
+++ b/src/frontend/src/utils/inputAutofill.ts
@@ -1,0 +1,38 @@
+/**
+ * Attribute bundle that opts a field out of browser + password-manager autofill.
+ *
+ * Langflow component-configuration fields are not login/web forms, yet browsers
+ * (notably Chrome) and password managers heuristically classify them as
+ * credential fields and inject saved values into them. Because Langflow
+ * autosaves, an injected value silently overwrites the real one and persists it,
+ * corrupting the flow.
+ *
+ * `autocomplete="off"` alone is NOT honored by Chrome for credential-like fields
+ * (a deliberate behavior since 2014), so suppression additionally:
+ *   - marks secret/password fields as `new-password` — the browser-endorsed
+ *     token that suppresses saved-credential injection AND removes the field
+ *     from the username/password pairing heuristic that fills adjacent text
+ *     fields (e.g. the component name) with a saved username; and
+ *   - emits the data-* opt-outs understood by 1Password / LastPass / Bitwarden /
+ *     Dashlane.
+ *
+ * These are non-standard data attributes, so they are spread as raw DOM props.
+ */
+export const PASSWORD_MANAGER_IGNORE_PROPS = {
+  "data-1p-ignore": "true",
+  "data-lpignore": "true",
+  "data-bwignore": "true",
+  "data-form-type": "other",
+} as const;
+
+/**
+ * Resolves the `autocomplete` value for an autofill-suppressed input.
+ *
+ * Keyed on the field's intrinsic secret-ness, NOT its live `type`, so toggling
+ * password visibility (password <-> text) does not re-arm autofill.
+ *
+ * @param isPassword whether the field holds a secret (API key, token, password).
+ */
+export function getSuppressedAutoComplete(isPassword: boolean): string {
+  return isPassword ? "new-password" : "off";
+}

--- a/src/frontend/src/utils/inputAutofill.ts
+++ b/src/frontend/src/utils/inputAutofill.ts
@@ -36,3 +36,20 @@ export const PASSWORD_MANAGER_IGNORE_PROPS = {
 export function getSuppressedAutoComplete(isPassword: boolean): string {
   return isPassword ? "new-password" : "off";
 }
+
+/**
+ * Stamps the autofill-suppression attributes onto a raw input/textarea element.
+ *
+ * For inputs that React props cannot reach — e.g. ag-grid cell editors, which
+ * render their own `<input>`/`<textarea>` outside React when a cell enters edit
+ * mode. Idempotent; safe to call on every editing-started event.
+ */
+export function suppressAutofillOnElement(
+  element: HTMLInputElement | HTMLTextAreaElement | null | undefined,
+): void {
+  if (!element) return;
+  element.setAttribute("autocomplete", "off");
+  for (const [key, value] of Object.entries(PASSWORD_MANAGER_IGNORE_PROPS)) {
+    element.setAttribute(key, value);
+  }
+}


### PR DESCRIPTION
## Problem

Browser autofill (observed in Chrome) injects saved values into Langflow component-configuration fields — component names, API keys, and other inputs. Because Langflow **autosaves**, simply opening a flow and clicking a component can silently overwrite correct field values with autofill-suggested ones (e.g. `admin` in a name field, a non-key string in an API-key field) and **persist the garbage**, corrupting the flow. It reproduces across multiple users on the same instance, including users who never logged in — so it is not tied to individual browser history.

## Root cause

It is **not** a simple missing `autocomplete="off"` — that attribute is *already* present on the base `Input`, the node-config popover input, and the dropdown. The problem is that **Chrome deliberately ignores `autocomplete="off"` for fields it heuristically classifies as credentials** (intentional since 2014).

Each node's config panel renders an API-key field as `type="password"`. Chrome's password heuristic finds that password field, walks to the nearest preceding text field, labels it the "username", and — when it has a saved credential for the origin — injects the saved username into that adjacent text/name field and the saved password into the key field. That fires React's `onChange` → `setNode` → `useAutoSaveFlow` (debounced) → `saveFlow` PATCH, persisting the corruption.

## Fix

Suppress autofill on node-config inputs by default, while preserving wanted autofill on real credential forms:

- **Base `Input` / `Textarea` primitives** now emit, by default, `autocomplete="new-password"` for secret fields / `off` for text, plus the password-manager opt-out attributes (`data-1p-ignore`, `data-lpignore="true"`, `data-bwignore`, `data-form-type="other"`) for 1Password / LastPass / Bitwarden / Dashlane. `new-password` is the browser-team-endorsed token that stops saved-credential injection **and removes the field from the username/password pairing heuristic**, so the adjacent component-name/text fields stop being filled too.
- **The popover input** (API-key/secret + str path) and **`TextAreaComponent`** secret fields key the token on the field's intrinsic secret-ness (`password`), **not** the live `type`, so toggling password visibility does not re-arm autofill.
- **ag-grid table cell editors** (TableNodeComponent → TableModal → shared `TableComponent`, plus global variables and other editable grids) render their own `<input>`/`<textarea>` outside React. An `onCellEditingStarted` handler stamps the same suppression attributes onto the active editor (inline and large-text popup editors) via a reusable `suppressAutofillOnElement` helper.
- **Real credential forms** (login / signup / admin login) opt back in via a new `allowAutofill` prop, so wanted password-manager autofill keeps working there. With no explicit `autoComplete` they emit no attribute (browser default); auth-form `name` attributes (used as Playwright selectors) are untouched.

Because the fix lands at the shared primitives + the shared table, every base-`Input`/`Textarea`/table consumer in the flow editor is covered in one place — node name, keypair cells, input-list rows, query/search/copy fields, the object-option popover, prompt/description editors, and editable table cells.

## Why suppression is a complete fix

These inputs are React controlled components whose only state-write path is `onChange`, fed by the browser's native `input` event. If the browser never autofills, no `onChange` fires, `setNode` is never called, and autosave is never triggered — the injected value never reaches the backend.

## Scope / regression safety

- Login / signup / admin-login keep autofill via `allowAutofill` (verified they route through the shared primitives). No `name`/`data-testid` attributes changed, so Playwright selectors are unaffected.
- IME composition is unaffected (`imeInputProps` carry no `autoComplete`/`type`/`name` and are spread after the new attributes).
- A caller-provided `autoComplete` still wins over the suppressed default.

## Remaining low-risk gaps (not credential-like, not the reported vector)

Chakra numeric inputs (int/float), the slider numeric input, the read-only file-path input, and the Ace code editor still bypass these primitives. They are not credential-like and Chrome does not autofill usernames into numeric/code editors, so they are intentionally left as-is.

## Tests

New unit tests lock the contract (suppressed `new-password`/`off` + opt-out data-* on node-config secret/text fields; **no** opt-outs on `allowAutofill` credential forms; the `suppressAutofillOnElement` DOM helper):

- `src/frontend/src/components/ui/__tests__/input-autofill.test.tsx`
- `src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/__tests__/input-component-autofill.test.tsx`
- `src/frontend/src/utils/__tests__/inputAutofill.test.ts`

Verified locally: related Jest suites pass (incl. inputComponent, inspection panel, dropdown, model input, cursor-input, popoverObject, tableComponent), `biome check`/`lint` clean, and `tsc` clean for all touched files.

## Test plan

- [ ] In Chrome with a saved credential for the Langflow origin, open a node that has both an API-key field and text/name fields; confirm neither the name nor the key field is autofilled, and autosave does not persist injected values.
- [ ] Confirm editable table cells (e.g. a DataFrame/dict table) are not autofilled.
- [ ] Confirm the login / signup / admin-login pages still offer password-manager autofill.
- [ ] Confirm IME (CJK/dead-key) input into a node-config field still commits correctly.