### PR TITLE
feat: support custom subpaths via VITE_BASENAME (#8503)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <base href="/" />
+    <base href="%VITE_BASENAME%/" />
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/frontend/src/customization/config-constants.ts
+++ b/src/frontend/src/customization/config-constants.ts
@@ -1,9 +1,9 @@
-export const BASENAME = "";
+export const BASENAME = import.meta.env?.VITE_BASENAME || "";
 export const PORT = 3000;
 export const PROXY_TARGET = "http://localhost:7860";
 export const API_ROUTES = ["^/api/v1/", "^/api/v2/", "/health"];
-export const BASE_URL_API = "/api/v1/";
-export const BASE_URL_API_V2 = "/api/v2/";
+export const BASE_URL_API = `${BASENAME}/api/v1/`;
+export const BASE_URL_API_V2 = `${BASENAME}/api/v2/`;
 export const HEALTH_CHECK_URL = "/health_check";
 export const DOCS_LINK = "https://docs.langflow.org";
 

--- a/src/frontend/src/customization/config-constants.ts
+++ b/src/frontend/src/customization/config-constants.ts
@@ -1,4 +1,4 @@
-export const BASENAME = import.meta.env?.VITE_BASENAME || "";
+export const BASENAME = (import.meta.env?.VITE_BASENAME || "").replace(/\/$/, "");
 export const PORT = 3000;
 export const PROXY_TARGET = "http://localhost:7860";
 export const API_ROUTES = ["^/api/v1/", "^/api/v2/", "/health"];

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -39,7 +39,7 @@ export default defineConfig(({ mode }) => {
   }, {});
 
   return {
-    base: env.VITE_BASENAME || "",
+    base: env.VITE_BASENAME ? env.VITE_BASENAME.replace(/\/$/, '') + '/' : '/',
     build: {
       outDir: "build",
     },

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -39,7 +39,7 @@ export default defineConfig(({ mode }) => {
   }, {});
 
   return {
-    base: BASENAME || "",
+    base: env.VITE_BASENAME || "",
     build: {
       outDir: "build",
     },


### PR DESCRIPTION
Fixes #8503 by allowing the VITE_BASENAME environment variable to dictate the base URL for the frontend and API routes, enabling deployment behind reverse proxies on non-root paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configuration to support the application serving from custom base paths.
  * API endpoints now correctly resolve based on deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->