### PR TITLE
chore(deps): bump toolguard floor to 0.2.20

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -343,7 +343,7 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 # Toolguard Integration
-toolguard = ["toolguard>=0.2.16,<1.0.0"]
+toolguard = ["toolguard>=0.2.20,<1.0.0"]
 
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels

--- a/uv.lock
+++ b/uv.lock
@@ -8964,7 +8964,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4.0,<26.0.0" },
     { name = "supabase", marker = "extra == 'supabase'", specifier = ">=2.6.0,<3.0.0" },
     { name = "tiktoken", marker = "extra == 'docling-chunking'", specifier = ">=0.7.0" },
-    { name = "toolguard", marker = "extra == 'toolguard'", specifier = ">=0.2.16,<1.0.0" },
+    { name = "toolguard", marker = "extra == 'toolguard'", specifier = ">=0.2.20,<1.0.0" },
     { name = "traceloop-sdk", marker = "extra == 'traceloop'", specifier = ">=0.43.1,<1.0.0" },
     { name = "transformers", specifier = ">=5.6.0,<6.0.0" },
     { name = "trustcall", specifier = ">=0.0.38,<1.0.0" },
@@ -18254,7 +18254,7 @@ wheels = [
 
 [[package]]
 name = "toolguard"
-version = "0.2.19"
+version = "0.2.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datamodel-code-generator" },
@@ -18270,9 +18270,9 @@ dependencies = [
     { name = "pytest-json-report" },
     { name = "smolagents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/80/9cd3efd4d32dcf2cb08339ea23d827142e13ba9cee398bb332f840aed367/toolguard-0.2.19.tar.gz", hash = "sha256:a4f11dbfe7d53b3d6b5425005ae2d066a06a80ebe80b212ef3e560d15ffc6f4c", size = 68499, upload-time = "2026-05-28T07:49:19.733Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/05/4adc710f0b11beb340dfb3be680f539cf509b4566aad40f6cfa9ab6506a9/toolguard-0.2.20.tar.gz", hash = "sha256:d88044bdd72525f2b65355c6526b267c2a41c234836d3a8fa786ee9ef0571333", size = 69224, upload-time = "2026-06-21T06:20:23.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/82/246bde4c05a167ea25aead64f4626711fb59e8c4f5d6d78d90d7fa4e33bb/toolguard-0.2.19-py3-none-any.whl", hash = "sha256:2102d568e84082466ded4c1d99654cc22d060c9708cfe975e90169eef31dfe97", size = 99932, upload-time = "2026-05-28T07:49:18.206Z" },
+    { url = "https://files.pythonhosted.org/packages/71/17/adc658a7262f41d29b408cb2c6fafaff2c051cdca2a62d4b1c525c6cc2e9/toolguard-0.2.20-py3-none-any.whl", hash = "sha256:e8fda5fbe95766ec21be8e61dec268c1725800dd049f3cfa540bacd4adc61e27", size = 100717, upload-time = "2026-06-21T06:20:22.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the `toolguard` dependency floor from `>=0.2.16` to `>=0.2.20` (and re-locks `uv.lock` to **0.2.20**, published 2026-06-21).

`toolguard` 0.2.20 ships the Windows build-time code-generation fixes from upstream [AgentToolkit/toolguard#28](https://github.com/AgentToolkit/toolguard/pull/28) (merged one minute before the 0.2.20 release). Those fixes make the Policies/ToolGuard **Guard-mode** green-loop codegen actually work on Windows instead of silently falling back to a `pass` stub:

1. **`pytest` runner paths** are embedded via `repr()` (`_build_runner_code`) — previously a raw `WindowsPath` interpolated into executed source produced `\U`/`\C` `SyntaxError`, so the JSON report was never written.
2. **File reads use `encoding="utf-8"`** in `buildtime/utils/py.py` and `buildtime/gen_spec/utils.py` — previously charmap `UnicodeDecodeError` on Windows.
3. **`pyright` resolution** via `_resolve_pyright()` (`sys.executable` dir → `which` → bare) — previously a bare `"pyright"` spawn raised `FileNotFoundError [WinError 2]` when the venv `Scripts` dir wasn't on `PATH`.

This is the upstream-library half of the Windows Guard-mode fix; the langflow-side path-separator fix already landed in #13751 on this branch. The `>=0.2.20` floor *guarantees* Windows users receive the working codegen rather than merely permitting it.

## Notes

- **No langflow source changes** — pure dependency bump. The diff is `src/backend/base/pyproject.toml` (one line) + the corresponding `uv.lock` entries; no transitive churn (toolguard's own dependency set is identical between 0.2.19 and 0.2.20).
- **No `_warm_circular_imports()` impact** — the `toolguard.runtime` ↔ `toolguard.runtime.runtime` circular-import structure that lfx pre-warms is unchanged in 0.2.20, so the existing helper still applies (the path-encoding fix is buildtime-only).
- `requires-python` for 0.2.20 is `>=3.10,<3.15`, compatible with langflow's 3.10–3.14 support range.

## Test plan

- [x] `uv lock --upgrade-package toolguard` resolves cleanly (toolguard 0.2.19 → 0.2.20, no other packages touched)
- [x] Released sdist verified to contain all three #28 fixes
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated optional dependency to ensure compatibility with the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->