### PR TITLE
fix: make IBM WatsonX models selectable and runnable in the Langflow Assistant

### DIFF
--- a/docs/features/langflow-assistant.md
+++ b/docs/features/langflow-assistant.md
@@ -1523,6 +1523,27 @@ The agent resolves these tokens with the **existing** MCP tools `get_flow_compon
 
 ---
 
+### ADR-032: Live-Only Providers (IBM WatsonX) Usable in the Assistant
+
+**Status**: Accepted
+
+#### Context
+With WatsonX configured (9 live models visible in the model-providers modal), the assistant still showed "No Model Provider Configured", and after that was fixed, selecting any WatsonX model failed with `400 "model <id> not found"`. Two distinct defects compounded, both specific to a *live-only* provider whose entire static catalog is deprecated (only WatsonX today):
+
+1. **Listing**: `list_models` computed each provider's `is_enabled`/`is_configured` *before* `replace_with_live_models`. WatsonX is absent from the non-deprecated static catalog, so it is only **appended** by the live replacement — after the status loop had already run. The appended entry carried no `is_enabled`, and the assistant panel (`useEnabledModels` → `.filter(p => p.is_enabled)`) dropped it.
+2. **Routing**: `build_model_config` (and `TranslationFlow._build_model_config`) read the non-existent metadata key `model_name_param` from `get_provider_param_mapping`, which only emits `model_param`. It silently defaulted to `"model"`. For WatsonX this set `ChatWatsonx.model` instead of `.model_id`, which routes through the OpenAI-compatible **AI Gateway** (foundation-model ids not provisioned → `400 "model not found"`) instead of the native `ModelInference` foundation-models API. OpenAI/Anthropic were unaffected because their `model_param` is already `"model"`.
+
+#### Decision
+1. Run `replace_with_live_models` **before** computing `is_configured`/`is_enabled` so live-appended providers receive status like any other.
+2. Read `model_param` (not `model_name_param`) when building the assistant/translation model config, matching the canonical `unified_models/model_catalog.py` path, so WatsonX is instantiated with `model_id` and routes through `ModelInference`.
+
+#### Key Files
+- `src/backend/.../api/v1/models.py` — `list_models` ordering (status after live replacement)
+- `src/backend/.../agentic/flows/model_config.py` — `build_model_config` reads `model_param`
+- `src/backend/.../agentic/flows/translation_flow.py` — `_build_model_config` reads `model_param`
+
+---
+
 ## 6. Technical Specification
 
 ### 6.1 Dependencies

--- a/src/backend/base/langflow/agentic/flows/model_config.py
+++ b/src/backend/base/langflow/agentic/flows/model_config.py
@@ -21,7 +21,7 @@ def build_model_config(provider: str, model_name: str) -> list[dict]:
         "api_key_param": mapping.get("api_key_param", "api_key"),  # pragma: allowlist secret
         "context_length": 128000,
         "model_class": mapping.get("model_class", "ChatOpenAI"),
-        "model_name_param": mapping.get("model_name_param", "model"),
+        "model_name_param": mapping.get("model_param", "model"),
     }
     for extra_param in ("url_param", "project_id_param", "base_url_param"):
         if extra_param in mapping:

--- a/src/backend/base/langflow/agentic/flows/translation_flow.py
+++ b/src/backend/base/langflow/agentic/flows/translation_flow.py
@@ -302,7 +302,7 @@ def _build_model_config(provider: str, model_name: str) -> list[dict]:
         "api_key_param": param_mapping.get("api_key_param", "api_key"),
         "context_length": 128000,
         "model_class": param_mapping.get("model_class", "ChatOpenAI"),
-        "model_name_param": param_mapping.get("model_name_param", "model"),
+        "model_name_param": param_mapping.get("model_param", "model"),
     }
     # Include extra params like base_url_param for providers like Ollama
     for extra_param in ("url_param", "project_id_param", "base_url_param"):

--- a/src/backend/base/langflow/agentic/services/flow_preparation.py
+++ b/src/backend/base/langflow/agentic/services/flow_preparation.py
@@ -10,12 +10,8 @@ from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA, get_provider
 import lfx
 from langflow.agentic.helpers.assistant_workspace import resolve_assistant_fs_root
 
-# Relative path embedded in the bundled LangflowAssistant.json flow for the
-# Directory component that scans built-in lfx components. It only resolves
-# correctly when the process CWD is the monorepo root, which is never the
-# case for a packaged install (Langflow Desktop, `pip install langflow`,
-# Docker, etc.). inject_lfx_components_path rewrites it to an absolute path
-# derived from the installed lfx package at runtime.
+# Resolves only from the monorepo root; inject_lfx_components_path rewrites it to
+# an absolute path at runtime so packaged installs (Desktop, pip, Docker) work.
 LFX_COMPONENTS_PATH_SENTINEL = "./src/lfx/src/lfx/components/"
 
 logger = logging.getLogger(__name__)
@@ -86,17 +82,15 @@ def inject_model_into_flow(
         raise ValueError(msg)
     param_mapping = get_provider_param_mapping(provider)
 
-    # Use provided api_key_var or default from config
     api_key_var = api_key_var or provider_config.get("variable_name")
 
     metadata = {
         "api_key_param": param_mapping.get("api_key_param", provider_config.get("api_key_param", "api_key")),
         "context_length": 128000,
         "model_class": param_mapping.get("model_class", provider_config.get("model_class", "ChatOpenAI")),
-        "model_name_param": param_mapping.get("model_name_param", provider_config.get("model_name_param", "model")),
+        "model_name_param": param_mapping.get("model_param", provider_config.get("model_param", "model")),
     }
 
-    # Add extra params from param mapping (url_param, project_id_param, base_url_param)
     for extra_param in ("url_param", "project_id_param", "base_url_param"):
         if extra_param in param_mapping:
             metadata[extra_param] = param_mapping[extra_param]
@@ -113,7 +107,6 @@ def inject_model_into_flow(
         }
     ]
 
-    # Resolve provider-specific template fields to inject into Agent nodes
     provider_fields: dict[str, str] = {}
     pv = provider_vars or {}
 
@@ -129,7 +122,6 @@ def inject_model_into_flow(
         if pv.get("OLLAMA_BASE_URL"):
             provider_fields["base_url_ollama"] = pv["OLLAMA_BASE_URL"]
 
-    # Inject into all Agent nodes
     for node in flow_data.get("data", {}).get("nodes", []):
         node_data = node.get("data", {})
         if node_data.get("type") != "Agent":
@@ -137,9 +129,7 @@ def inject_model_into_flow(
         template = node_data.get("node", {}).get("template", {})
 
         if "model" not in template:
-            # Silent skip here means the run later fails with an
-            # opaque "No model selected" — leave a diagnostic with
-            # the node id so the cause is traceable.
+            # Silent skip surfaces later as an opaque "No model selected"; log the node id.
             logger.warning(
                 "assistant.inject_model.agent_missing_model_field node_id=%s provider=%s",
                 node.get("id", "<unknown>"),
@@ -155,14 +145,8 @@ def inject_model_into_flow(
         existing_provider = existing_entry.get("provider")
 
         if not overwrite_existing_model and existing_name:
-            # Preserve the user's/agent's explicit model — NEVER silently swap
-            # it for our verified model. When it's the SAME provider, REBUILD a
-            # COMPLETE value carrying the user's model NAME but the full,
-            # well-formed metadata/icon (the value the agent set via
-            # configure_component is often a bare ``{provider, name}`` with no
-            # metadata, which can make the run fail to resolve the model). Also
-            # top up the credential so the run authenticates. Cross-provider, we
-            # don't hold that provider's verified key, so leave it untouched.
+            # Keep the user's explicit model. Same provider: rebuild a complete value (full
+            # metadata + credential) since the agent's may be a bare {provider,name}; else leave it.
             if existing_provider == provider:
                 template["model"]["value"] = [{**model_value[0], "name": existing_name}]
                 for field_name, field_value in provider_fields.items():
@@ -171,7 +155,6 @@ def inject_model_into_flow(
             continue
 
         template["model"]["value"] = model_value
-        # Inject provider-specific fields (API key, URLs, project IDs)
         for field_name, field_value in provider_fields.items():
             if field_name in template:
                 template[field_name]["value"] = field_value
@@ -242,10 +225,8 @@ def inject_assistant_fs_root(flow_data: dict) -> dict:
     return flow_data
 
 
-# Parsed bundled-flow templates, keyed by path → ((mtime_ns, size),
-# parsed dict). The raw template is stable per file; re-reading +
-# json.loads on every request (and x4 on validation retries) was
-# blocking the event loop. A genuine file change (mtime/size) re-parses.
+# Cache parsed templates by path+stat: re-reading + json.loads on every request
+# (x4 on validation retries) blocked the event loop; mtime/size change re-parses.
 _FLOW_TEMPLATE_CACHE: dict[str, tuple[tuple[int, int], dict]] = {}
 
 

--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -195,32 +195,23 @@ async def list_models(
         **metadata_filters,
     )
 
-    # Add configured and enabled status to each provider
+    # Run before status is computed so live-only providers appended here (e.g. IBM WatsonX,
+    # whose static catalog is fully deprecated) still receive is_enabled/is_configured (#13735).
+    configured_providers = {p for p, configured in provider_configured_status.items() if configured}
+    replace_with_live_models(filtered_models, current_user.id, configured_providers, model_type)
+
     for provider_dict in filtered_models:
         prov_name = provider_dict.get("provider")
         provider_dict["is_configured"] = provider_configured_status.get(prov_name, False)
-
-        # Provider is "enabled" (active) if it has at least one enabled model
         prov_models_status = enabled_models_map.get(prov_name, {})
         has_active_model = any(prov_models_status.values())
         provider_dict["is_enabled"] = has_active_model
 
-    # Replace static models with live models for providers that support it
-    configured_providers = {p for p, configured in provider_configured_status.items() if configured}
-    replace_with_live_models(filtered_models, current_user.id, configured_providers, model_type)
-
-    # Sort providers:
-    # 1. Provider with default model first
-    # 2. Configured providers next
-    # 3. Alphabetically after that
     def sort_key(provider_dict):
         provider_name = provider_dict.get("provider", "")
-        # Use is_configured for sorting priority (so they appear at top when ready)
         is_configured = provider_dict.get("is_configured", False)
         is_default = provider_name == default_provider
-
-        # Return tuple for sorting: (not is_default, not is_configured, provider_name)
-        # This way default comes first (False < True), then configured, then alphabetical
+        # default first, then configured, then alphabetical (False sorts before True)
         return (not is_default, not is_configured, provider_name)
 
     filtered_models.sort(key=sort_key)
@@ -528,17 +519,14 @@ async def get_enabled_models(
     model_names: Annotated[list[str] | None, Query()] = None,
 ):
     """Get enabled models for the current user."""
-    # Get all models - this returns a list of provider dicts with nested models
     all_models_by_provider = get_unified_models_detailed(
         include_unsupported=True,
         include_deprecated=True,
     )
 
-    # Get enabled providers status
     enabled_providers_result = await get_enabled_providers(session=session, current_user=current_user)
     provider_status = enabled_providers_result.get("provider_status", {})
 
-    # Replace static models with live models for providers that support it
     configured_providers = {p for p, configured in provider_status.items() if configured}
     replace_with_live_models(all_models_by_provider, current_user.id, configured_providers)
 
@@ -546,10 +534,8 @@ async def get_enabled_models(
     disabled_models = await _get_disabled_models(session=session, current_user=current_user)
     explicitly_enabled_models = await _get_enabled_models(session=session, current_user=current_user)
 
-    # Build model status based on provider enablement
     enabled_models: dict[str, dict[str, bool]] = {}
 
-    # Iterate through providers and their models
     for provider_dict in all_models_by_provider:
         provider = provider_dict.get("provider")
         models = provider_dict.get("models", [])
@@ -567,13 +553,6 @@ async def get_enabled_models(
             is_not_supported = metadata.get("not_supported", False)
             is_default = metadata.get("default", False)
 
-            # Model is enabled if:
-            # 1. Provider is enabled
-            # 2. Model is not deprecated/unsupported
-            # 3. Model is either:
-            #    - Marked as default (default=True), OR
-            #    - Explicitly enabled by user (in explicitly_enabled_models), AND
-            #    - NOT explicitly disabled by user (not in disabled_models)
             is_enabled = (
                 provider_status.get(provider, False)
                 and not is_deprecated

--- a/src/backend/tests/unit/agentic/flows/test_agentic_model_config.py
+++ b/src/backend/tests/unit/agentic/flows/test_agentic_model_config.py
@@ -54,6 +54,27 @@ class TestBuildModelConfigUsesRegisteredClassNames:
         assert build_model_config(provider, "m")[0]["metadata"]["model_class"] == expected
 
 
+class TestBuildModelConfigUsesCorrectModelParamName:
+    """WatsonX died with 400 "model <id> not found" (GitHub #13735 follow-up).
+
+    ``build_model_config`` read the non-existent key ``model_name_param`` from
+    ``get_provider_param_mapping`` (which only emits ``model_param``), so it fell
+    back to "model" for every provider and explicitly set metadata["model_name_param"]="model".
+    That truthy value defeats the #13684 fallback in get_llm, so for WatsonX it passes
+    ``model=`` instead of ``model_id=`` — routing ChatWatsonx through the OpenAI-compatible
+    AI Gateway (400 "model not found") instead of native ModelInference. OpenAI/Anthropic
+    were unaffected because their ``model_param`` is already "model".
+    """
+
+    def test_should_use_model_id_param_when_provider_is_watsonx(self):
+        config = build_model_config("IBM WatsonX", "mistral-large-2512")
+        assert config[0]["metadata"]["model_name_param"] == "model_id"
+
+    @pytest.mark.parametrize("provider", ["OpenAI", "Anthropic"])
+    def test_should_keep_model_param_for_openai_and_anthropic(self, provider):
+        assert build_model_config(provider, "m")[0]["metadata"]["model_name_param"] == "model"
+
+
 class TestRegistryKnowsGroqAndAzure:
     """Latent variant of Bug #1 — Groq / Azure class names must be registered.
 

--- a/src/backend/tests/unit/agentic/services/test_flow_preparation.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_preparation.py
@@ -146,6 +146,30 @@ class TestInjectModelIntoFlow:
         assert metadata["url_param"] == "azure_endpoint"
         assert metadata["base_url_param"] == "base_url"
 
+    def test_should_use_model_id_param_for_watsonx(self):
+        """WatsonX must inject model_id, not the generic model (GitHub #13735).
+
+        inject_model_into_flow read the non-existent key model_name_param from
+        get_provider_param_mapping (which emits model_param), defaulting to "model".
+        For WatsonX that sets ChatWatsonx.model, routing to the OpenAI-compatible AI
+        Gateway (400 "model not found") instead of native ModelInference (model_id).
+        Uses the real WatsonX provider mapping (no mock) so the key drift is exercised.
+        """
+        flow_data = _make_flow_data(["Agent"])
+
+        result = inject_model_into_flow(
+            flow_data,
+            "IBM WatsonX",
+            "openai/gpt-oss-120b",
+            provider_vars={
+                "WATSONX_URL": "https://us-south.ml.cloud.ibm.com",
+                "WATSONX_PROJECT_ID": "pid",
+            },
+        )
+
+        metadata = result["data"]["nodes"][0]["data"]["node"]["template"]["model"]["value"][0]["metadata"]
+        assert metadata["model_name_param"] == "model_id"
+
     def test_should_handle_flow_without_agent_nodes(self):
         """Flow with no Agent nodes should return data without modification."""
         flow_data = _make_flow_data(["ChatInput", "ChatOutput"])

--- a/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
@@ -537,6 +537,53 @@ async def test_list_models_returns_live_ollama_models_when_configured(client: As
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_list_models_marks_live_only_provider_enabled(client: AsyncClient, logged_in_headers):
+    """A configured live-only provider with a fully-deprecated static catalog stays enabled.
+
+    IBM WatsonX must still report is_enabled=True from /models. WatsonX never appears in the
+    non-deprecated static catalog, so it is only added by replace_with_live_models. If is_enabled
+    is computed before that append, the WatsonX entry is returned without an is_enabled flag and the
+    Assistant filters it out, showing "No Model Provider Configured" (GitHub #13735).
+    """
+    live_watsonx_models = [
+        {"name": "ibm/granite-4-h-small", "icon": "IBM", "tool_calling": True, "default": True},
+        {"name": "meta-llama/llama-3-3-70b-instruct", "icon": "IBM", "tool_calling": True, "default": True},
+    ]
+
+    async def mock_get_enabled_providers(*_args, **_kwargs):
+        return {
+            "enabled_providers": ["IBM WatsonX"],
+            "provider_status": {"IBM WatsonX": True},
+        }
+
+    def mock_get_live_models(_user_id, provider, model_type="llm"):
+        if provider == "IBM WatsonX" and model_type == "llm":
+            return live_watsonx_models
+        return []
+
+    with (
+        mock.patch(
+            "langflow.api.v1.models.get_enabled_providers",
+            side_effect=mock_get_enabled_providers,
+        ),
+        mock.patch(
+            "lfx.base.models.model_utils.get_live_models_for_provider",
+            side_effect=mock_get_live_models,
+        ),
+    ):
+        response = await client.get("api/v1/models", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    watsonx_provider = next((p for p in data if p.get("provider") == "IBM WatsonX"), None)
+    assert watsonx_provider is not None, "WatsonX should be present via live-model append"
+    model_names = [m["model_name"] for m in watsonx_provider["models"]]
+    assert set(model_names) == {"ibm/granite-4-h-small", "meta-llama/llama-3-3-70b-instruct"}
+    assert watsonx_provider.get("is_enabled") is True
+    assert watsonx_provider.get("is_configured") is True
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_list_models_ollama_empty_when_live_fetch_returns_empty(client: AsyncClient, logged_in_headers):
     """When Ollama is configured but live fetch returns no models, Ollama should have no models (no static fallback)."""
 


### PR DESCRIPTION
## Summary
IBM WatsonX could not be used in the Langflow Assistant: it either showed **"No Model Provider Configured"** (even with 9 live models visible in the provider modal), or, once it appeared, every selected model failed on execution with `400 "model <id> not found"`. Two distinct, compounding bugs — both specific to WatsonX as a *live-only* provider whose entire static catalog is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed model configuration for IBM WatsonX and other providers to use correct parameter names.
  * Improved detection and enablement status of live-only providers in model listings.

* **Tests**
  * Added test coverage for provider-specific model parameter configuration and live-only provider handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->