### PR TITLE
fix(ci): resolve pre-release cross-platform install failure; graduate py3.13, add py3.14 experimental

### DIFF
--- a/.github/workflows/cross-platform-test.md
+++ b/.github/workflows/cross-platform-test.md
@@ -58,9 +58,12 @@ jobs:
 - **macOS**: Intel (AMD64), Apple Silicon (ARM64)
 - **Windows**: AMD64
 - **Python versions**:
-  - **All platforms**: 3.10, 3.12, and 3.13
-  - **Stability**: 3.10 and 3.12 are required to pass (blocking)
-  - **Preview**: 3.13 testing is optional (non-blocking) to monitor ecosystem readiness
+  - **All platforms**: 3.10, 3.12, 3.13, and 3.14
+  - **Stability**: 3.10, 3.12, and 3.13 are required to pass (blocking)
+  - **Preview**: 3.14 testing is optional (non-blocking) to monitor ecosystem readiness
+  - **Note**: on the blocking matrix, macOS Intel (x86_64) runs only Python 3.12 to
+    limit use of the costly `macos-latest-large` runner; newer Python versions get
+    macOS Intel coverage through the non-blocking experimental (3.14) set instead
 
 ## What Gets Tested
 
@@ -103,8 +106,8 @@ gh workflow run cross-platform-test.yml \
 - **Timeout**: Configurable timeout with proper cross-platform handling
 
 ### Platform-Specific Optimizations
-- **Stable versions**: Python 3.10 and 3.12 provide reliable package ecosystem support
-- **Preview testing**: Python 3.13 runs as non-blocking to monitor when it becomes viable
+- **Stable versions**: Python 3.10, 3.12, and 3.13 provide reliable package ecosystem support
+- **Preview testing**: Python 3.14 runs as non-blocking to monitor when it becomes viable
 - **Virtual Environments**: Uses `uv venv --seed` for consistent pip availability
 
 ### Workflow Architecture
@@ -187,9 +190,11 @@ error: command '/usr/bin/clang++' failed with exit code 1
 3. **macOS clang** doesn't support `-march=native` flag used by `chroma-hnswlib` compilation
 
 **Current Status**:
-- **Stable testing**: Python 3.10 and 3.12 are required to pass (blocking jobs)
-- **Preview testing**: Python 3.13 runs as non-blocking to monitor ecosystem readiness
-- **Compilation issues**: Python 3.13 may still fail due to `chroma-hnswlib` but won't block releases
+- **Stable testing**: Python 3.10, 3.12, and 3.13 are required to pass (blocking jobs)
+- **Preview testing**: Python 3.14 runs as non-blocking to monitor ecosystem readiness
+- **Compilation issues**: the historical `chroma-hnswlib` failure is avoided on the tested install
+  paths (workspace/source builds exclude `chromadb`); a similar upstream issue surfacing on the
+  preview (3.14) tier stays non-blocking
 - **Manual testing**: Source builds now use the same dependency transformation as nightly builds for testing parity
 
 **Files Involved**:

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -178,6 +178,23 @@ jobs:
             arch: amd64
             runner: windows-latest
             python-version: "3.12"
+          # Python 3.13 - graduated from experimental to stable (blocking).
+          # macOS Intel (amd64) is intentionally omitted here: like 3.10/3.12 above
+          # it stays on the costly macos-latest-large runner only at 3.12. Intel
+          # coverage for newer Python continues (non-blocking) in the experimental
+          # 3.14 set below.
+          - os: linux
+            arch: amd64
+            runner: ubuntu-latest
+            python-version: "3.13"
+          - os: macos
+            arch: arm64
+            runner: macos-latest
+            python-version: "3.13"
+          - os: windows
+            arch: amd64
+            runner: windows-latest
+            python-version: "3.13"
 
     steps:
       - name: Determine install method
@@ -454,23 +471,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Python 3.13 - Experimental
+          # Python 3.14 - Experimental (non-blocking) to monitor ecosystem readiness.
+          # Mirrors the platform set that 3.13 used while it was experimental. On
+          # macOS Intel (x86_64) the torch-dependent extras are excluded via
+          # pyproject markers (sys_platform/platform_machine), so the install still
+          # resolves there; this job is non-blocking via continue-on-error regardless.
           - os: linux
             arch: amd64
             runner: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows
             arch: amd64
             runner: windows-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: macos
             arch: amd64
             runner: macos-latest-large
-            python-version: "3.13"
+            python-version: "3.14"
           - os: macos
             arch: arm64
             runner: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
 
     steps:
       - name: Determine install method
@@ -615,6 +636,19 @@ jobs:
       - name: Force reinstall local wheels to prevent downgrades (Windows)
         if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows'
         run: |
+          # Expose the local wheel dirs so dependency re-resolution (the
+          # pre-release path below drops --no-deps) can find the local
+          # pre-release lfx/base wheels. Without these, uv re-resolves
+          # langflow-base's `lfx>=X.Y.Zrc0` constraint against PyPI only, where
+          # the matching rc/dev wheel is not published yet, and fails with
+          # "No solution found when resolving dependencies".
+          FIND_LINKS=()
+          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
+            if [ -d "$wheel_dir" ]; then
+              FIND_LINKS+=(--find-links "$wheel_dir")
+            fi
+          done
+
           # Reinstall LFX if it was provided
           if [ -n "${{ inputs.lfx-artifact-name || needs.build-if-needed.outputs.lfx-artifact-name }}" ]; then
             LFX_WHEEL=$(find ./lfx-dist -name "*.whl" -type f | head -1)
@@ -633,7 +667,7 @@ jobs:
               if [ "${{ inputs.pre_release }}" = "true" ]; then
                 NO_DEPS=""
               fi
-              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe "${INSTALL_WHEELS[@]}"
+              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/Scripts/python.exe "${INSTALL_WHEELS[@]}"
             fi
           fi
 
@@ -645,13 +679,26 @@ jobs:
             if [ "${{ inputs.pre_release }}" = "true" ]; then
               NO_DEPS=""
             fi
-            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe "$BASE_WHEEL"
+            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/Scripts/python.exe "$BASE_WHEEL"
           fi
         shell: bash
 
       - name: Force reinstall local wheels to prevent downgrades (Unix)
         if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows'
         run: |
+          # Expose the local wheel dirs so dependency re-resolution (the
+          # pre-release path below drops --no-deps) can find the local
+          # pre-release lfx/base wheels. Without these, uv re-resolves
+          # langflow-base's `lfx>=X.Y.Zrc0` constraint against PyPI only, where
+          # the matching rc/dev wheel is not published yet, and fails with
+          # "No solution found when resolving dependencies".
+          FIND_LINKS=()
+          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
+            if [ -d "$wheel_dir" ]; then
+              FIND_LINKS+=(--find-links "$wheel_dir")
+            fi
+          done
+
           # Reinstall LFX if it was provided
           if [ -n "${{ inputs.lfx-artifact-name || needs.build-if-needed.outputs.lfx-artifact-name }}" ]; then
             LFX_WHEEL=$(find ./lfx-dist -name "*.whl" -type f | head -1)
@@ -670,7 +717,7 @@ jobs:
               if [ "${{ inputs.pre_release }}" = "true" ]; then
                 NO_DEPS=""
               fi
-              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/bin/python "${INSTALL_WHEELS[@]}"
+              uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/bin/python "${INSTALL_WHEELS[@]}"
             fi
           fi
 
@@ -682,7 +729,7 @@ jobs:
             if [ "${{ inputs.pre_release }}" = "true" ]; then
               NO_DEPS=""
             fi
-            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit --python ./test-env/bin/python "$BASE_WHEEL"
+            uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/bin/python "$BASE_WHEEL"
           fi
         shell: bash
 
@@ -826,9 +873,9 @@ jobs:
             if [ "$experimental_result" = "success" ]; then
               if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                 if [ -n "${{ inputs.langflow-version }}" ]; then
-                  echo "✅ All PyPI installation tests passed (including Python 3.13)"
+                  echo "✅ All PyPI installation tests passed (including Python 3.14)"
                 else
-                  echo "✅ All source build and installation tests passed (including Python 3.13)"
+                  echo "✅ All source build and installation tests passed (including Python 3.14)"
                 fi
               else
                 echo "✅ All cross-platform tests passed - PyPI upload can proceed"
@@ -836,17 +883,17 @@ jobs:
             else
               if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                 if [ -n "${{ inputs.langflow-version }}" ]; then
-                  echo "✅ PyPI installation tests passed (Python 3.13 experimental failures are acceptable)"
+                  echo "✅ PyPI installation tests passed (Python 3.14 experimental failures are acceptable)"
                 else
-                  echo "✅ Source build and installation tests passed (Python 3.13 experimental failures are acceptable)"
+                  echo "✅ Source build and installation tests passed (Python 3.14 experimental failures are acceptable)"
                 fi
               else
-                echo "✅ Cross-platform tests passed - Python 3.13 experimental failures are acceptable - PyPI upload can proceed"
+                echo "✅ Cross-platform tests passed - Python 3.14 experimental failures are acceptable - PyPI upload can proceed"
               fi
             fi
           elif [ "$stable_result" = "failure" ]; then
             echo "❌ Critical platform tests failed - blocking release"
-            echo "Stable platforms (Python 3.10, 3.12) must pass for release"
+            echo "Stable platforms (Python 3.10, 3.12, 3.13) must pass for release"
             exit 1
           elif [ "$stable_result" = "cancelled" ]; then
             echo "❌ Critical platform tests were cancelled"


### PR DESCRIPTION
## Problem

The release pipeline's **Cross-Platform Installation Test** failed **only** when **Pre-release** was selected in the release workflow — specifically in the **Python 3.13 (Experimental)** jobs (linux / windows / macOS-arm / macOS-intel). A normal (non-pre-release) release of the same code passed cleanly. See run [27970474987](https://github.com/langflow-ai/langflow/actions/runs/27970474987).

## Root cause

The experimental job has a **"Force reinstall local wheels to prevent downgrades"** step. When `pre_release=true`, that step intentionally drops `--no-deps` so dependency resolution can pick up pre-release versions — **but it never passed `--find-links`** to the local wheel directories.

So uv re-resolved `langflow-base`'s transitive constraint against **PyPI only**, where the matching pre-release wheel isn't published yet:

```
Force reinstalling langflow-base: ./base-dist/langflow_base-0.10.1rc0-py3-none-any.whl
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of lfx are available:
          lfx<1.10.1rc0
          lfx>=1.11.dev0
      and langflow-base==0.10.1rc0 depends on lfx>=1.10.1rc0,<1.11.dev0,
      ... your requirements are unsatisfiable.
```

Stable releases keep `--no-deps`, so they never re-resolve and never hit this. The stable 3.10/3.12 jobs (which have no force-reinstall step at all) passed on the *same* pre-release run — confirming the force-reinstall step is the sole trigger.

## Fix

Build a `FIND_LINKS` array over the local wheel dirs (`sdk-dist` / `lfx-dist` / `base-dist` / `bundles-dist`, dirs that exist) and thread it into **both** force-reinstall `uv pip install` commands (Windows + Unix). This mirrors the `refresh_find_links()` helper already used in the main "Install packages from wheel" step.

- On the pre-release path (`--no-deps` dropped) the local pre-release `lfx`/`base` wheels are now discoverable → resolves.
- On the stable path (`--no-deps` kept) `--find-links` is inert → behavior unchanged.

A reviewer reproduced this live with uv: without `--find-links` → the exact CI error; with it → the local `rc` resolves.

## Also in this PR (per request)

- **Graduate Python 3.13 → stable (blocking)** on `linux amd64`, `macOS arm64`, `windows amd64`. macOS Intel (`macos-latest-large`) stays at **3.12 only** on the blocking matrix to limit use of the costly runner — consistent with the existing 3.10/3.12 design.
- **Add Python 3.14 → experimental (non-blocking, `continue-on-error`)**, mirroring the exact platform set 3.13 had as a preview (including macOS Intel). The `--find-links` fix means 3.14 is added *without* the pre-release bug.
- Updated the test-summary echo messages and `cross-platform-test.md` to match (3.13 blocking, 3.14 preview).

### Notes
- `release_nightly.yml` calls this workflow without `pre_release`, so it keeps `--no-deps` and is unaffected.
- `requires-python = ">=3.10,<3.15"` across all packages, so 3.14 is a valid target.
- macOS Intel resolves on py≥3.13 because the torch-heavy extras are excluded there via pyproject platform markers; PyTorch's lack of macOS x86_64 wheels for py≥3.13 is therefore not a blocker for these install tests.

## Test plan
- [ ] Re-run the release workflow with **Pre-release** checked — the (now stable) 3.13 jobs and the new 3.14 experimental jobs should resolve and install.
- [ ] Confirm a normal (non-pre-release) release still passes (unchanged `--no-deps` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python version coverage and stability tiers for cross-platform testing documentation.

* **Chores**
  * Added Python 3.14 as non-blocking preview support in CI/CD testing.
  * Promoted Python 3.13 to stable testing matrix.
  * Enhanced local wheel dependency handling in test installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->