### PR TITLE
fix(ci): drop macOS Intel from py3.14 cross-platform set (onnxruntime x86_64 wheel gap)

### DIFF
--- a/.github/workflows/cross-platform-test.md
+++ b/.github/workflows/cross-platform-test.md
@@ -61,9 +61,11 @@ jobs:
   - **All platforms**: 3.10, 3.12, 3.13, and 3.14
   - **Stability**: 3.10, 3.12, and 3.13 are required to pass (blocking)
   - **Preview**: 3.14 testing is optional (non-blocking) to monitor ecosystem readiness
-  - **Note**: on the blocking matrix, macOS Intel (x86_64) runs only Python 3.12 to
-    limit use of the costly `macos-latest-large` runner; newer Python versions get
-    macOS Intel coverage through the non-blocking experimental (3.14) set instead
+  - **Note**: macOS Intel (x86_64) is tested only on Python 3.12. macOS x86_64 is
+    being dropped across the ecosystem — PyTorch ships no x86_64 wheels for py>=3.13
+    and onnxruntime shipped none after 1.23 — and langflow requires `onnxruntime>=1.26`
+    on py>=3.14, so macOS Intel + py>=3.14 cannot resolve. The 3.13 (blocking) and
+    3.14 (preview) sets therefore run on Linux, Windows, and macOS arm64 only
 
 ## What Gets Tested
 

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -472,10 +472,13 @@ jobs:
       matrix:
         include:
           # Python 3.14 - Experimental (non-blocking) to monitor ecosystem readiness.
-          # Mirrors the platform set that 3.13 used while it was experimental. On
-          # macOS Intel (x86_64) the torch-dependent extras are excluded via
-          # pyproject markers (sys_platform/platform_machine), so the install still
-          # resolves there; this job is non-blocking via continue-on-error regardless.
+          # macOS Intel (x86_64) is intentionally omitted: langflow requires
+          # onnxruntime>=1.26 on Python >=3.14 (pyproject.toml), but onnxruntime
+          # dropped macOS x86_64 wheels at 1.24 — so macOS Intel + py3.14 is
+          # permanently unsatisfiable (older onnxruntime that still ships macOS
+          # x86_64 wheels has no cp314 ABI). macOS Intel resolves fine through 3.13;
+          # arm64 has cp314 wheels. Running it would only burn the costly
+          # macos-latest-large runner on a guaranteed, no-signal failure.
           - os: linux
             arch: amd64
             runner: ubuntu-latest
@@ -483,10 +486,6 @@ jobs:
           - os: windows
             arch: amd64
             runner: windows-latest
-            python-version: "3.14"
-          - os: macos
-            arch: amd64
-            runner: macos-latest-large
             python-version: "3.14"
           - os: macos
             arch: arm64


### PR DESCRIPTION
## Summary

Follow-up to #13772. The new **Python 3.14 experimental** job on **macOS Intel** (`macos-latest-large` / x86_64) fails at dependency resolution:

```
× No solution found when resolving dependencies:
  ... onnxruntime>=1.24.1 has no wheels with a matching platform tag (macosx_*_x86_64)
  ... onnxruntime>=1.17.0,<=1.23.2 has no cp314 ABI
  ... lfx==1.10.1rc0 depends on markitdown -> magika -> onnxruntime ... unsatisfiable
```

## Why (this is **not** the find-links bug)

It's a permanent **macOS x86_64 ecosystem gap**:

- langflow pins **`onnxruntime>=1.26; python_version>='3.14'`** (`pyproject.toml`), and
- **onnxruntime dropped macOS x86_64 wheels at 1.24** — `>=1.26` ships only linux / win / `macosx_14_0_arm64`.
- The older onnxruntime that *still* ships macOS x86_64 wheels (`<=1.23.2`) has **no cp314 ABI**.

So macOS Intel + py3.14 can never resolve, from both directions.

- **macOS Intel 3.13** is fine — the `python_version<'3.14'` branch pins `onnxruntime<1.24`, which still has x86_64 wheels.
- **macOS arm64 3.14** is fine — arm64 has cp314 wheels (this is why it works locally).

The job is non-blocking (`continue-on-error`), so it never blocked a release, but it's a guaranteed, no-signal failure that burns the costly `macos-latest-large` runner on every release.

## Change

Drop macOS Intel from the **3.14 experimental** matrix (keep linux / windows / macOS arm64). macOS Intel coverage stays at 3.12 on the stable matrix — consistent with the broader macOS x86_64 deprecation (PyTorch already ships no x86_64 wheels for py≥3.13). Docs/comments updated to explain the wheel gap.

## Test plan
- [ ] Re-run the release workflow (pre-release) — the 3.14 experimental set runs only on linux/windows/macOS-arm64, all of which have cp314 onnxruntime wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure documentation to clarify platform support limitations and removed unsupported platform combinations from the experimental test matrix for newer Python versions due to dependency wheel availability constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->