### PR TITLE
docs: fix empty see also sections in extensions

### DIFF
--- a/docs/docs/Develop/extensions-manifest.mdx
+++ b/docs/docs/Develop/extensions-manifest.mdx
@@ -129,3 +129,6 @@ The loader and validator both emit typed errors keyed by the manifest field that
 Run `lfx extension validate <path>` to see every error as a structured object with `code`, `message`, `location`, `hint`, and `ref_url`.
 
 ## See also
+
+- [Bundle extensions overview](./extensions-overview)
+- [Build your first extension](./extensions-quickstart)

--- a/docs/docs/Develop/extensions-overview.mdx
+++ b/docs/docs/Develop/extensions-overview.mdx
@@ -71,3 +71,8 @@ lfx extension list
 If you have custom components that you want to distribute and version independently of your Langflow install, you can package them as an extension.
 
 For more information, see [Build your first Langflow Extension](./extensions-quickstart.mdx).
+
+## See also
+
+- [Build your first extension](./extensions-quickstart)
+- [Manifest reference](./extensions-manifest)

--- a/docs/docs/Develop/extensions-quickstart.mdx
+++ b/docs/docs/Develop/extensions-quickstart.mdx
@@ -107,3 +107,6 @@ The scaffold ships a working `Component` subclass that prints `"Hello, {name}!"`
     The bundle appears in the palette without further configuration.
 
 ## See also
+
+- [Bundle extensions overview](./extensions-overview)
+- [Manifest reference](./extensions-manifest)

--- a/docs/versioned_docs/version-1.10.0/Develop/extensions-manifest.mdx
+++ b/docs/versioned_docs/version-1.10.0/Develop/extensions-manifest.mdx
@@ -129,3 +129,6 @@ The loader and validator both emit typed errors keyed by the manifest field that
 Run `lfx extension validate <path>` to see every error as a structured object with `code`, `message`, `location`, `hint`, and `ref_url`.
 
 ## See also
+
+- [Bundle extensions overview](./extensions-overview)
+- [Build your first extension](./extensions-quickstart)

--- a/docs/versioned_docs/version-1.10.0/Develop/extensions-overview.mdx
+++ b/docs/versioned_docs/version-1.10.0/Develop/extensions-overview.mdx
@@ -71,3 +71,8 @@ lfx extension list
 If you have custom components that you want to distribute and version independently of your Langflow install, you can package them as an extension.
 
 For more information, see [Build your first Langflow Extension](./extensions-quickstart.mdx).
+
+## See also
+
+- [Build your first extension](./extensions-quickstart)
+- [Manifest reference](./extensions-manifest)

--- a/docs/versioned_docs/version-1.10.0/Develop/extensions-quickstart.mdx
+++ b/docs/versioned_docs/version-1.10.0/Develop/extensions-quickstart.mdx
@@ -107,3 +107,6 @@ The scaffold ships a working `Component` subclass that prints `"Hello, {name}!"`
     The bundle appears in the palette without further configuration.
 
 ## See also
+
+- [Bundle extensions overview](./extensions-overview)
+- [Manifest reference](./extensions-manifest)


### PR DESCRIPTION
Add links to the See also sections of extensions.