### PR TITLE
fix: degrade gracefully when caching unpicklable values in RedisCache

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -334,20 +334,31 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
     @override
     async def set(self, key, value, lock=None) -> None:
+        # Serialize first, in isolation from the network write. Live objects built during
+        # a flow run -- LLM clients holding an ``ssl.SSLContext``, httpx clients, thread
+        # locks, dynamically-created pydantic models -- are inherently unpicklable, and
+        # dill signals this with a variety of exception types (a bare ``TypeError`` for an
+        # SSLContext, ``AttributeError`` for dynamic classes, ``RecursionError`` for deep
+        # graphs, etc.) -- not only ``pickle.PicklingError``. Failing to serialize must not
+        # crash the caller (e.g. the vertex build); skip the cache write instead, which
+        # just means the value is recomputed on the next access. See issue #13764.
         try:
-            if pickled := dill.dumps(value, recurse=True):
-                # Prefix an HMAC tag so get() can reject tampered/forged payloads
-                # before deserialization (see get()). The tag is bound to the
-                # namespaced key so it cannot be replayed under a different key.
-                namespaced_key = self._key(key)
-                tag = self._integrity_tag(namespaced_key, pickled)
-                result = await self._client.setex(namespaced_key, self.expiration_time, tag + pickled)
-                if not result:
-                    msg = "RedisCache could not set the value."
-                    raise ValueError(msg)
-        except pickle.PicklingError as exc:
-            msg = "RedisCache only accepts values that can be pickled. "
-            raise TypeError(msg) from exc
+            pickled = dill.dumps(value, recurse=True)
+        except Exception as exc:  # noqa: BLE001
+            await logger.awarning(
+                f"RedisCache skipping cache for key '{key}': value is not serializable ({type(exc).__name__}: {exc})."
+            )
+            return
+        if pickled:
+            # Prefix an HMAC tag so get() can reject tampered/forged payloads
+            # before deserialization (see get()). The tag is bound to the
+            # namespaced key so it cannot be replayed under a different key.
+            namespaced_key = self._key(key)
+            tag = self._integrity_tag(namespaced_key, pickled)
+            result = await self._client.setex(namespaced_key, self.expiration_time, tag + pickled)
+            if not result:
+                msg = "RedisCache could not set the value."
+                raise ValueError(msg)
 
     @override
     async def upsert(self, key, value, lock=None) -> None:

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -348,6 +348,11 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
             await logger.awarning(
                 f"RedisCache skipping cache for key '{key}': value is not serializable ({type(exc).__name__}: {exc})."
             )
+            # Drop any previously-cached value for this key. ``upsert`` does
+            # get -> merge -> set, so leaving an older entry in place would let a
+            # later get() serve stale data instead of recomputing. (DEL of a
+            # missing key is a harmless no-op.)
+            await self._client.delete(self._key(key))
             return
         if pickled:
             # Prefix an HMAC tag so get() can reject tampered/forged payloads

--- a/src/backend/tests/unit/services/cache/test_redis_cache.py
+++ b/src/backend/tests/unit/services/cache/test_redis_cache.py
@@ -260,3 +260,20 @@ class TestRedisCacheSerialization:
         await cache.set("ok-key", value)
 
         assert await cache.get("ok-key") == value
+
+    async def test_unpicklable_set_evicts_stale_value(self):
+        """A skipped write must drop any previously cached value for that key.
+
+        ``upsert`` is get -> merge -> set; if a later value is unserializable we
+        skip the write, but a stale entry left in Redis would be served on the
+        next get() instead of triggering recomputation.
+        """
+        cache = self._cache()
+        await cache.set("vertex-id", {"built_object": "old-serializable"})
+        assert await cache.get("vertex-id") == {"built_object": "old-serializable"}
+
+        # New value for the same key is unserializable -> write skipped...
+        await cache.upsert("vertex-id", {"built_object": ssl.create_default_context()})
+
+        # ...and the stale entry is gone, so the next access recomputes.
+        assert await cache.get("vertex-id") is CACHE_MISS

--- a/src/backend/tests/unit/services/cache/test_redis_cache.py
+++ b/src/backend/tests/unit/services/cache/test_redis_cache.py
@@ -1,9 +1,12 @@
 """Tests for RedisCache teardown functionality."""
 
+import ssl
 from unittest.mock import AsyncMock, patch
 
+import fakeredis
 import pytest
 from langflow.services.cache.service import RedisCache
+from lfx.services.cache.utils import CACHE_MISS
 
 
 @pytest.mark.asyncio
@@ -206,3 +209,54 @@ class TestRedisCacheDeserializationIntegrity:
 
             # The tag was bound to "a"'s key, so it fails verification under "b".
             assert await cache.get("b") is CACHE_MISS
+
+
+@pytest.mark.asyncio
+class TestRedisCacheSerialization:
+    """Test that RedisCache degrades gracefully on unpicklable values.
+
+    Live objects built during a flow run (e.g. an LLM client holding an
+    ``ssl.SSLContext``, httpx clients, thread locks) cannot be serialized. The
+    cache write must not crash the flow build; the value should simply be
+    skipped. See https://github.com/langflow-ai/langflow/issues/13764.
+    """
+
+    def _cache(self) -> RedisCache:
+        with patch("redis.asyncio.StrictRedis"):
+            cache = RedisCache(expiration_time=3600)
+        cache._client = fakeredis.FakeAsyncRedis()
+        return cache
+
+    async def test_set_unpicklable_value_does_not_raise(self):
+        """An unpicklable value (SSLContext) is skipped instead of raising.
+
+        ``dill.dumps`` raises a bare ``TypeError`` for an ``SSLContext`` (not a
+        ``pickle.PicklingError``), so the original narrow ``except`` let it
+        escape and crash the build.
+        """
+        cache = self._cache()
+        value = {"result": {"built_object": ssl.create_default_context()}, "type": dict}
+
+        # Should not raise (previously raised TypeError: cannot pickle 'SSLContext').
+        await cache.set("vertex-id", value)
+
+        # The value was skipped, so a later read is a cache miss rather than stale data.
+        assert await cache.get("vertex-id") is CACHE_MISS
+
+    async def test_upsert_unpicklable_value_does_not_raise(self):
+        """upsert() (used by the build cache path) also degrades gracefully."""
+        cache = self._cache()
+        value = {"built_object": ssl.create_default_context()}
+
+        await cache.upsert("vertex-id", value)
+
+        assert await cache.get("vertex-id") is CACHE_MISS
+
+    async def test_picklable_value_still_round_trips(self):
+        """Regression: ordinary picklable values continue to cache and load."""
+        cache = self._cache()
+        value = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}}
+
+        await cache.set("ok-key", value)
+
+        assert await cache.get("ok-key") == value


### PR DESCRIPTION
## Fixes #13764

### Problem

With the Redis cache backend (`LANGFLOW_CACHE_TYPE=redis`), running a flow that contains an Agent or Language Model component backed by a live LLM client (e.g. `ChatGoogleGenerativeAI`) crashes during the vertex build — even on a trivial input like `"hello"`. The crash is not about user input; it happens because the live model client is created during build and **caching that object** is what breaks.

Two reported variants, both from the same cache-write path:

```
TypeError: cannot pickle 'SSLContext' object
```
```
RedisCache only accepts values that can be pickled.
... AttributeError: module 'lfx.io.schema' has no attribute 'InputSchema'
```

### Root cause

After a vertex builds, `Graph.build_vertex()` caches a dict containing the live `built_object`. For an in-memory cache this is harmless (the reference is stored as-is), but Redis must serialize the value.

`RedisCache.set` guarded serialization with `except pickle.PicklingError`:

```python
try:
    if pickled := dill.dumps(value, recurse=True):
        ...
except pickle.PicklingError as exc:
    raise TypeError("RedisCache only accepts values that can be pickled. ") from exc
```

But `dill.dumps` on inherently unserializable live objects raises exception types that **do not subclass `pickle.PicklingError`**:
- a bare `TypeError` for an `ssl.SSLContext` (held by the model's httpx/google-genai client),
- `AttributeError` for dynamically-created pydantic models (`InputSchema` is created at runtime by `create_input_schema()`),
- and others (`RecursionError`, etc.).

So the guard was bypassed and the raw error propagated up through `ChatService.set_cache → upsert → set → build_vertex`, **failing the entire build** instead of degrading gracefully.

This is the same class of bug the prior fix (#7092, referenced by #13171) missed: it only switched `pickle`→`dill` and `TypeError`→`pickle.PicklingError`, never handling genuinely non-serializable live objects.

### Fix

Serialize in isolation from the network write, and treat **any** serialization failure as an uncacheable value: log a warning and skip the cache write rather than raising. A skipped write simply means the value is recomputed on next access — matching how the in-memory cache already tolerates these objects. Genuine Redis write failures (the `setex` path) still surface unchanged.

```python
try:
    pickled = dill.dumps(value, recurse=True)
except Exception as exc:  # noqa: BLE001
    await logger.awarning(...skip...)
    return
if pickled:
    result = await self._client.setex(...)
    ...
```

`built_object` is intentionally left in the cached dict so the in-memory backend keeps its existing behavior; only the Redis serialization boundary is hardened.

### Tests

Adds `TestRedisCacheSerialization` (using `fakeredis`, no live server) which was **RED before / GREEN after**:
- `set()` of an `SSLContext`-bearing value no longer raises; a subsequent `get()` is a clean `CACHE_MISS`.
- `upsert()` (the build cache path) degrades the same way.
- Regression: ordinary picklable values still round-trip through `set`/`get`.

### Test plan
- [x] `pytest src/backend/tests/unit/services/cache/test_redis_cache.py` (7 passed)
- [x] `pytest src/backend/tests/unit/services/test_cache_factory.py src/backend/tests/unit/graph/test_cache_restoration.py` (15 passed)
- [x] `ruff check` / `ruff format` clean; pre-commit hooks pass
- [x] Reproduced the original crash and verified the fix end-to-end via the issue's `fakeredis` snippet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache error handling to gracefully handle serialization failures instead of raising errors.
  * Cache now skips storing values that cannot be serialized, allowing the application to continue normally while logging details for debugging.

* **Tests**
  * Added comprehensive tests for cache serialization behavior with unpicklable values and standard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->