### PR TITLE
perf: enhance event manager cleanup and improve cache expiration handling

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import contextlib
 import os
 import pickle
 import tempfile
@@ -77,6 +78,8 @@ class ThreadingInMemoryCache(CacheService, Generic[LockType]):
         b = cache["b"]
     """
 
+    _SWEEP_INTERVAL = 60  # seconds between background expiry sweeps
+
     def __init__(self, max_size=None, expiration_time=60 * 60) -> None:
         """Initialize a new InMemoryCache instance.
 
@@ -88,6 +91,12 @@ class ThreadingInMemoryCache(CacheService, Generic[LockType]):
         self._lock = threading.RLock()
         self.max_size = max_size
         self.expiration_time = expiration_time
+        self._stop_sweep = threading.Event()
+        if expiration_time is not None:
+            self._sweep_thread = threading.Thread(target=self._sweep_loop, daemon=True, name="cache-sweep")
+            self._sweep_thread.start()
+        else:
+            self._sweep_thread = None
 
     def get(self, key, lock: Union[threading.Lock, None] = None):  # noqa: UP007
         """Retrieve an item from the cache.
@@ -207,6 +216,25 @@ class ThreadingInMemoryCache(CacheService, Generic[LockType]):
     def __repr__(self) -> str:
         """Return a string representation of the InMemoryCache instance."""
         return f"InMemoryCache(max_size={self.max_size}, expiration_time={self.expiration_time})"
+
+    def _sweep_loop(self) -> None:
+        """Daemon thread: periodically delete entries whose TTL has elapsed."""
+        while not self._stop_sweep.wait(timeout=self._SWEEP_INTERVAL):
+            self._sweep_expired()
+
+    def _sweep_expired(self) -> None:
+        """Remove all cache entries that have passed their expiration time."""
+        if self.expiration_time is None:
+            return
+        now = time.time()
+        with self._lock:
+            expired = [k for k, v in self._cache.items() if now - v["time"] >= self.expiration_time]
+            for k in expired:
+                self._cache.pop(k, None)
+
+    async def teardown(self) -> None:
+        """Signal the sweep thread to stop."""
+        self._stop_sweep.set()
 
 
 class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
@@ -341,12 +369,48 @@ class RedisCache(ExternalAsyncBaseCacheService, Generic[LockType]):
 
 
 class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
+    _SWEEP_INTERVAL = 60  # seconds between background expiry sweeps
+
     def __init__(self, max_size=None, expiration_time=3600) -> None:
         self.cache: OrderedDict = OrderedDict()
 
         self.lock = asyncio.Lock()
         self.max_size = max_size
         self.expiration_time = expiration_time
+        self._sweep_task: asyncio.Task | None = None
+
+    def _ensure_sweep_task(self) -> None:
+        """Start the background sweep task the first time the cache is written to."""
+        if self.expiration_time is None:
+            return
+        if self._sweep_task is None or self._sweep_task.done():
+            self._sweep_task = asyncio.create_task(self._sweep_loop())
+
+    async def _sweep_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._SWEEP_INTERVAL)
+                await self._sweep_expired()
+        except asyncio.CancelledError:
+            pass
+
+    async def _sweep_expired(self) -> None:
+        """Remove all cache entries that have passed their expiration time."""
+        if self.expiration_time is None:
+            return
+        now = time.time()
+        async with self.lock:
+            expired = [k for k, v in self.cache.items() if now - v["time"] >= self.expiration_time]
+            for k in expired:
+                self.cache.pop(k, None)
+
+    async def teardown(self) -> None:
+        """Cancel the background sweep task."""
+        if self._sweep_task is not None:
+            self._sweep_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._sweep_task
+            self._sweep_task = None
 
     async def get(self, key, lock: asyncio.Lock | None = None):
         async with lock or self.lock:
@@ -363,6 +427,7 @@ class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
         return CACHE_MISS
 
     async def set(self, key, value, lock: asyncio.Lock | None = None) -> None:
+        self._ensure_sweep_task()
         async with lock or self.lock:
             await self._set(
                 key,

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -380,9 +380,22 @@ class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
         self._sweep_task: asyncio.Task | None = None
 
     def _ensure_sweep_task(self) -> None:
-        """Start the background sweep task the first time the cache is written to."""
         if self.expiration_time is None:
             return
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # No running loop; cannot schedule a task right now
+
+        if (
+            self._sweep_task is not None
+            and not self._sweep_task.done()
+            and self._sweep_task.get_loop() is not running_loop
+        ):
+            # Task is bound to a different loop; discard it without awaiting.
+            self._sweep_task.cancel()
+            self._sweep_task = None
+
         if self._sweep_task is None or self._sweep_task.done():
             self._sweep_task = asyncio.create_task(self._sweep_loop())
 
@@ -405,12 +418,18 @@ class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
                 self.cache.pop(k, None)
 
     async def teardown(self) -> None:
-        """Cancel the background sweep task."""
-        if self._sweep_task is not None:
-            self._sweep_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._sweep_task
-            self._sweep_task = None
+        # Cancel the sweep task, awaiting it only if it's on the current event loop.
+        if self._sweep_task is None:
+            return
+        self._sweep_task.cancel()
+        try:
+            running_loop = asyncio.get_running_loop()
+            if self._sweep_task.get_loop() is running_loop:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._sweep_task
+        except RuntimeError:
+            pass
+        self._sweep_task = None
 
     async def get(self, key, lock: asyncio.Lock | None = None):
         async with lock or self.lock:

--- a/src/backend/base/langflow/services/event_manager.py
+++ b/src/backend/base/langflow/services/event_manager.py
@@ -96,6 +96,9 @@ class WebhookEventManager:
                 # Clean up empty sets
                 if not self._listeners[flow_id]:
                     del self._listeners[flow_id]
+
+                    # Clear build-start timestamps for this flow when all listeners disconnect.
+                    self._vertex_start_times.pop(flow_id, None)
                     logger.info(f"All subscribers disconnected for flow {flow_id}")
                 else:
                     logger.info(f"Subscriber disconnected from flow {flow_id}. Remaining: {listener_count}")

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import os
 import platform
@@ -40,7 +41,7 @@ class TelemetryService(Service):
         super().__init__()
         self.settings_service = settings_service
         self.base_url = settings_service.settings.telemetry_base_url
-        self.telemetry_queue: asyncio.Queue = asyncio.Queue()
+        self.telemetry_queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)
         self.client = httpx.AsyncClient(timeout=10.0)  # Set a reasonable timeout
         self.running = False
         self._stopping = False
@@ -127,7 +128,8 @@ class TelemetryService(Service):
     async def _queue_event(self, payload) -> None:
         if self.do_not_track or self._stopping:
             return
-        await self.telemetry_queue.put(payload)
+        with contextlib.suppress(asyncio.QueueFull):
+            self.telemetry_queue.put_nowait(payload)
 
     def _get_langflow_desktop(self) -> bool:
         # Coerce to bool, could be 1, 0, True, False, "1", "0", "True", "False"

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
@@ -329,6 +330,8 @@ class TracingService(Service):
                 await trace_context.traces_queue.join()
             if trace_context.worker_task:
                 trace_context.worker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await trace_context.worker_task
                 trace_context.worker_task = None
 
         except Exception:  # noqa: BLE001
@@ -360,16 +363,19 @@ class TracingService(Service):
         trace_context = trace_context_var.get()
         if trace_context is None:
             return
-        await self._stop(trace_context)
-        self._end_all_tracers(trace_context, outputs, error)
+        try:
+            await self._stop(trace_context)
+            self._end_all_tracers(trace_context, outputs, error)
 
-        native_tracer = trace_context.tracers.get("native")
-        if native_tracer:
-            # Deferred import breaks the circular dependency between service.py and native.py.
-            from langflow.services.tracing.native import NativeTracer
+            native_tracer = trace_context.tracers.get("native")
+            if native_tracer:
+                # Deferred import breaks the circular dependency between service.py and native.py.
+                from langflow.services.tracing.native import NativeTracer
 
-            if isinstance(native_tracer, NativeTracer):
-                await native_tracer.wait_for_flush()
+                if isinstance(native_tracer, NativeTracer):
+                    await native_tracer.wait_for_flush()
+        finally:
+            trace_context_var.set(None)
 
     @staticmethod
     def _cleanup_inputs(inputs: dict[str, Any]):
@@ -456,25 +462,30 @@ class TracingService(Service):
         inputs = self._cleanup_inputs(inputs)
         component_trace_context = ComponentTraceContext(trace_id, trace_name, trace_type, vertex, inputs, metadata)
         component_context_var.set(component_trace_context)
-        trace_context = trace_context_var.get()
-        if trace_context is None:
-            msg = "called trace_component but no trace context found"
-            logger.warning(msg)
-            yield self
-            return
-        trace_context.all_inputs[trace_name] |= inputs or {}
-        await trace_context.traces_queue.put((self._start_component_traces, (component_trace_context, trace_context)))
         try:
-            yield self
-        except Exception as e:
+            trace_context = trace_context_var.get()
+            if trace_context is None:
+                msg = "called trace_component but no trace context found"
+                logger.warning(msg)
+                yield self
+                return
+            trace_context.all_inputs[trace_name] |= inputs or {}
             await trace_context.traces_queue.put(
-                (self._end_component_traces, (component_trace_context, trace_context, e))
+                (self._start_component_traces, (component_trace_context, trace_context))
             )
-            raise
-        else:
-            await trace_context.traces_queue.put(
-                (self._end_component_traces, (component_trace_context, trace_context, None))
-            )
+            try:
+                yield self
+            except Exception as e:
+                await trace_context.traces_queue.put(
+                    (self._end_component_traces, (component_trace_context, trace_context, e))
+                )
+                raise
+            else:
+                await trace_context.traces_queue.put(
+                    (self._end_component_traces, (component_trace_context, trace_context, None))
+                )
+        finally:
+            component_context_var.set(None)
 
     @property
     def project_name(self):

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1592,6 +1592,8 @@ class Graph:
         )
 
     def _record_snapshot(self, vertex_id: str | None = None) -> None:
+        # Keep only the latest snapshot to prevent memory growth.
+        self._snapshots.clear()
         self._snapshots.append(self.get_snapshot())
         if vertex_id:
             self._call_order.append(vertex_id)


### PR DESCRIPTION
- Added cleanup for accumulated build-start timestamps in WebhookEventManager when all listeners are disconnected.
- Introduced a background sweep mechanism in ThreadingInMemoryCache and AsyncInMemoryCache to periodically remove expired cache entries.
- Set a maximum size for the telemetry queue in TelemetryService to prevent overflow and added logic to drop events when the queue is full.
- Improved error handling in TracingService to ensure proper cancellation of tasks and cleanup of trace contexts.
- Cleared previous snapshots in Graph class to prevent memory growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of expired cached data so memory usage stays lower over time.
  * Fixed event/session cleanup so disconnected listeners no longer leave behind stale state.
  * Made tracing shutdown more reliable, ensuring in-progress work is cleaned up even if an error occurs.
  * Prevented graph snapshots from growing without limit by keeping only the latest snapshot.
  * Added safer telemetry handling so the app won’t block when event volume is high.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->