### PR TITLE
fix(cache): use CACHE_MISS sentinel in async cache _upsert

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -472,7 +472,7 @@ class AsyncInMemoryCache(AsyncBaseCacheService, Generic[AsyncLockType]):
 
     async def _upsert(self, key, value, lock: asyncio.Lock | None = None) -> None:
         existing_value = await self.get(key, lock)
-        if existing_value is not None and isinstance(existing_value, dict) and isinstance(value, dict):
+        if existing_value is not CACHE_MISS and isinstance(existing_value, dict) and isinstance(value, dict):
             existing_value.update(value)
             value = existing_value
         await self.set(key, value, lock)


### PR DESCRIPTION
## What problem are we solving?

`AsyncInMemoryCache._upsert` (`services/cache/service.py:475`) used `is not None` to check whether a key exists, but `get()` returns the `CACHE_MISS` sentinel object (not `None`) when the key is missing. This is inconsistent with the synchronous `InMemoryCache.upsert` (line 151) which correctly uses `is not CACHE_MISS`.

If a `None` value is ever cached as a legitimate value, `_upsert` would misinterpret it as "key not found" and overwrite instead of merging dicts — diverging from the sync cache behavior.

## How are we solving the problem?

Change `existing_value is not None` to `existing_value is not CACHE_MISS` to match the synchronous implementation. `CACHE_MISS` is already imported at line 16 (`from lfx.services.cache.utils import CACHE_MISS`).

## How is the PR tested?

- Verified the async cache `_upsert` correctly merges dict values and overwrites non-dict values.
- Confirmed behavior now matches the synchronous `InMemoryCache.upsert`.
- Existing cache service tests still pass.

## Checks
- [x] Code formatted (ruff)
- [x] Tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache update behavior so expired or missing entries are handled correctly during writes.
  * Prevented unintended merge logic from running when a cached value is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->