### PR TITLE
fix: guard temporarily-disabled bundle deps across backend + frontend tests

### DIFF
--- a/src/backend/tests/integration/components/astra/test_astra_component.py
+++ b/src/backend/tests/integration/components/astra/test_astra_component.py
@@ -1,14 +1,18 @@
 import pytest
 from astrapy import DataAPIClient
-from langchain_astradb import AstraDBVectorStore, VectorServiceOptions
 from langchain_core.documents import Document
 from lfx.schema.data import Data
-from lfx_datastax import AstraDBVectorStoreComponent
-from lfx_openai.components.openai.openai import OpenAIEmbeddingsComponent
 
 from tests.api_keys import get_astradb_api_endpoint, get_astradb_application_token, get_openai_api_key
 from tests.integration.components.mock_components import TextToData
 from tests.integration.utils import ComponentInputHandle, run_single_component
+
+pytest.importorskip("langchain_astradb")
+pytest.importorskip("lfx_datastax")
+pytest.importorskip("lfx_openai")
+from langchain_astradb import AstraDBVectorStore, VectorServiceOptions
+from lfx_datastax import AstraDBVectorStoreComponent
+from lfx_openai.components.openai.openai import OpenAIEmbeddingsComponent
 
 BASIC_COLLECTION = "test_basic"
 SEARCH_COLLECTION = "test_search"

--- a/src/backend/tests/integration/components/output_parsers/test_output_parser.py
+++ b/src/backend/tests/integration/components/output_parsers/test_output_parser.py
@@ -1,9 +1,11 @@
 import pytest
 from lfx.components.models_and_agents import PromptComponent
 from lfx.components.processing import OutputParserComponent
-from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 from tests.integration.utils import ComponentInputHandle, run_single_component
+
+pytest.importorskip("lfx_openai")
+from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 
 @pytest.mark.api_key_required

--- a/src/backend/tests/integration/test_dynamic_import_integration.py
+++ b/src/backend/tests/integration/test_dynamic_import_integration.py
@@ -10,6 +10,8 @@ import time
 import pytest
 from langflow.components.data import APIRequestComponent
 from langflow.components.models_and_agents import AgentComponent  # Backwards compatibility alias
+
+pytest.importorskip("lfx_openai")
 from langflow.components.openai import OpenAIModelComponent
 
 

--- a/src/backend/tests/unit/base/tools/test_component_toolkit.py
+++ b/src/backend/tests/unit/base/tools/test_component_toolkit.py
@@ -8,7 +8,6 @@ from lfx.components.input_output.chat_output import ChatOutput
 from lfx.components.langchain_utilities import ToolCallingAgentComponent
 from lfx.components.tools.calculator import CalculatorToolComponent
 from lfx.graph.graph.base import Graph
-from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 from pydantic import BaseModel
 
 from tests.api_keys import get_openai_api_key
@@ -125,6 +124,9 @@ def test_component_tool():
 @pytest.mark.api_key_required
 @pytest.mark.usefixtures("client")
 async def test_component_tool_with_api_key():
+    pytest.importorskip("lfx_openai")
+    from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
+
     chat_output = ChatOutput()
     openai_llm = OpenAIModelComponent()
     openai_llm.set(api_key=get_openai_api_key())
@@ -147,6 +149,9 @@ async def test_component_tool_with_api_key():
 @pytest.mark.api_key_required
 @pytest.mark.usefixtures("client")
 async def test_sql_component_to_toolkit(test_db):
+    pytest.importorskip("lfx_openai")
+    from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
+
     sql_component = SQLComponent()
     sql_component.set(database_url=f"sqlite:///{test_db}")
     tool = await sql_component.to_toolkit()

--- a/src/backend/tests/unit/base/tools/test_vector_store_decorator.py
+++ b/src/backend/tests/unit/base/tools/test_vector_store_decorator.py
@@ -1,9 +1,11 @@
 from typing import Any
 
 import pytest
-from lfx_datastax import AstraDBVectorStoreComponent
 
 from tests.base import ComponentTestBaseWithoutClient, VersionComponentMapping
+
+pytest.importorskip("lfx_datastax")
+from lfx_datastax import AstraDBVectorStoreComponent
 
 
 class TestVectorStoreDecorator(ComponentTestBaseWithoutClient):

--- a/src/backend/tests/unit/components/flow_controls/test_loop.py
+++ b/src/backend/tests/unit/components/flow_controls/test_loop.py
@@ -14,7 +14,6 @@ from lfx.components.models_and_agents import PromptComponent
 from lfx.components.processing import ParserComponent, SplitTextComponent
 from lfx.graph import Graph
 from lfx.schema.data import Data
-from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 from tests.api_keys import get_openai_api_key, has_api_key
 from tests.base import ComponentTestBaseWithClient
@@ -129,6 +128,9 @@ class TestLoopComponentWithAPI(ComponentTestBaseWithClient):
 @pytest.mark.skipif(not has_api_key("OPENAI_API_KEY"), reason="OPENAI_API_KEY is not set")
 def loop_flow():
     """Complete loop flow that processes multiple URLs through a loop."""
+    pytest.importorskip("lfx_openai")
+    from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
+
     # Create URL component to fetch content from multiple sources
     url_component = URLComponent()
     url_component.set(urls=["https://docs.langflow.org/"])

--- a/src/backend/tests/unit/components/languagemodels/test_openai_model.py
+++ b/src/backend/tests/unit/components/languagemodels/test_openai_model.py
@@ -2,10 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_openai import ChatOpenAI
-from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 from tests.api_keys import get_openai_api_key, has_api_key
 from tests.base import ComponentTestBaseWithoutClient
+
+pytest.importorskip("lfx_openai")
+from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 
 class TestOpenAIModelComponent(ComponentTestBaseWithoutClient):

--- a/src/backend/tests/unit/components/models_and_agents/test_cuga_agent.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_cuga_agent.py
@@ -186,6 +186,7 @@ class TestCugaComponent(ComponentTestBaseWithoutClient):
         This test verifies that the component's build configuration is properly
         updated when selecting different model providers using the provider system.
         """
+        pytest.importorskip("lfx_openai")
         component = await self.component_setup(component_class, default_kwargs)
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
@@ -393,6 +394,7 @@ class TestCugaComponentWithClient(ComponentTestBaseWithClient):
         Requires:
             OPENAI_API_KEY environment variable
         """
+        pytest.importorskip("lfx_openai")
         from tests.api_keys import get_openai_api_key
 
         api_key = get_openai_api_key()
@@ -434,6 +436,7 @@ class TestCugaComponentWithClient(ComponentTestBaseWithClient):
         Requires:
             OPENAI_API_KEY environment variable
         """
+        pytest.importorskip("lfx_openai")
         from tests.api_keys import get_openai_api_key
 
         api_key = get_openai_api_key()
@@ -485,6 +488,7 @@ class TestCugaComponentWithClient(ComponentTestBaseWithClient):
         Requires:
             OPENAI_API_KEY environment variable
         """
+        pytest.importorskip("lfx_openai")
         from tests.api_keys import get_openai_api_key
 
         api_key = get_openai_api_key()

--- a/src/backend/tests/unit/components/models_and_agents/test_tool_calling_agent.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_tool_calling_agent.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 import pytest
 from lfx.components.langchain_utilities import ToolCallingAgentComponent
 from lfx.components.tools.calculator import CalculatorToolComponent
-from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 
 class TestToolCallingAgentUpdateBuildConfig:
@@ -310,6 +309,9 @@ async def test_tool_calling_agent_component():
     tools = [CalculatorToolComponent().build_tool()]  # Use the Calculator component as a tool
     input_value = "What is 2 + 2?"
     chat_history = []
+    pytest.importorskip("lfx_openai")
+    from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
+
     from tests.api_keys import get_openai_api_key
 
     api_key = get_openai_api_key()

--- a/src/backend/tests/unit/components/vectorstores/test_chroma_vector_store_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_chroma_vector_store_component.py
@@ -74,6 +74,7 @@ class TestChromaVectorStoreComponent(ComponentTestBaseWithoutClient):
     @pytest.fixture
     def default_kwargs(self, tmp_path: Path) -> dict[str, Any]:
         """Return the default kwargs for the component."""
+        pytest.importorskip("lfx_openai")
         from lfx_openai.components.openai.openai import OpenAIEmbeddingsComponent
 
         from tests.api_keys import get_openai_api_key

--- a/src/backend/tests/unit/components/vectorstores/test_graph_rag_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_graph_rag_component.py
@@ -5,9 +5,11 @@ from faker import Faker
 from langchain_community.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.documents import Document
 from langchain_core.vectorstores.in_memory import InMemoryVectorStore
-from lfx_datastax.components.datastax.graph_rag import GraphRAGComponent
 
 from tests.base import ComponentTestBaseWithoutClient
+
+pytest.importorskip("lfx_datastax")
+from lfx_datastax.components.datastax.graph_rag import GraphRAGComponent
 
 
 class TestGraphRAGComponent(ComponentTestBaseWithoutClient):

--- a/src/backend/tests/unit/components/vectorstores/test_local_db_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_local_db_component.py
@@ -21,6 +21,7 @@ class TestLocalDBComponent(ComponentTestBaseWithoutClient):
     @pytest.fixture
     def default_kwargs(self, tmp_path: Path) -> dict[str, Any]:
         """Return the default kwargs for the component."""
+        pytest.importorskip("lfx_openai")
         from lfx_openai.components.openai.openai import OpenAIEmbeddingsComponent
 
         from tests.api_keys import get_openai_api_key

--- a/src/backend/tests/unit/initial_setup/starter_projects/test_memory_chatbot.py
+++ b/src/backend/tests/unit/initial_setup/starter_projects/test_memory_chatbot.py
@@ -9,6 +9,8 @@ from lfx.components.models_and_agents import PromptComponent
 from lfx.components.processing.converter import TypeConverterComponent
 from lfx.graph.graph.base import Graph
 from lfx.graph.graph.constants import Finish
+
+pytest.importorskip("lfx_openai")
 from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent
 
 if TYPE_CHECKING:

--- a/src/backend/tests/unit/initial_setup/starter_projects/test_vector_store_rag.py
+++ b/src/backend/tests/unit/initial_setup/starter_projects/test_vector_store_rag.py
@@ -13,6 +13,9 @@ from lfx.graph.graph.constants import Finish
 from lfx.schema import Data
 from lfx.schema.dataframe import DataFrame
 from lfx.schema.message import Message
+
+pytest.importorskip("lfx_datastax")
+pytest.importorskip("lfx_openai")
 from lfx_datastax import AstraDBVectorStoreComponent
 from lfx_openai.components.openai.openai import OpenAIEmbeddingsComponent
 from lfx_openai.components.openai.openai_chat_model import OpenAIModelComponent

--- a/src/bundles/lfx-bundles/src/lfx_bundles/cuga/cuga_agent.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/cuga/cuga_agent.py
@@ -113,9 +113,12 @@ class CugaComponent(ToolCallingAgentComponent):
             value="OpenAI",
             real_time_refresh=True,
             input_types=[],
-            options_metadata=[MODELS_METADATA[key] for key in MODEL_PROVIDERS_LIST] + [{"icon": "brain"}],
+            options_metadata=[MODELS_METADATA[key] for key in MODEL_PROVIDERS_LIST if key in MODELS_METADATA]
+            + [{"icon": "brain"}],
         ),
-        *MODEL_PROVIDERS_DICT["OpenAI"]["inputs"],
+        # OpenAI ships in a bundle that can be temporarily unpublished; fall back to no
+        # provider inputs so the component still imports until the bundle is restored.
+        *MODEL_PROVIDERS_DICT.get("OpenAI", {}).get("inputs", []),
         MultilineInput(
             name="instructions",
             display_name="Instructions",
@@ -496,13 +499,11 @@ class CugaComponent(ToolCallingAgentComponent):
                 raise TypeError(msg)
             self.tools.append(current_date_tool)
 
-        # --- ADDED LOGGING START ---
         logger.debug("[CUGA] Retrieved agent requirements: LLM, chat history, and tools.")
         logger.debug(f"[CUGA] LLM model: {self.model_name}")
         logger.debug(f"[CUGA] Number of chat history messages: {len(self.chat_history)}")
         logger.debug(f"[CUGA] Tools available: {[tool.name for tool in self.tools]}")
         logger.debug(f"[CUGA] metadata: {[tool.metadata for tool in self.tools]}")
-        # --- ADDED LOGGING END ---
 
         return llm_model, self.chat_history, self.tools
 
@@ -522,9 +523,8 @@ class CugaComponent(ToolCallingAgentComponent):
         logger.debug(f"[CUGA] input_value type: {type(self.input_value)}")
         logger.debug(f"[CUGA] input_value id: {getattr(self.input_value, 'id', None)}")
 
-        # Scope by flow_id (issue #13059): the ad-hoc MemoryComponent used previously
-        # had no _vertex, so it could not see the running flow's flow_id and emitted
-        # an unscoped query. The helper also honors n_messages == 0 as "disabled".
+        # Scope by flow_id (issue #13059): the previous ad-hoc MemoryComponent had no _vertex,
+        # so it emitted an unscoped query. The helper also honors n_messages == 0 as "disabled".
         messages = await aget_agent_chat_history(
             session_id=str(self.graph.session_id),
             flow_id=getattr(self.graph, "flow_id", None),

--- a/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
+++ b/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
@@ -71,7 +71,6 @@ test(
       "disclosure-utilities",
       "disclosure-bundles-langchain",
       "disclosure-bundles-assemblyai",
-      "disclosure-bundles-datastax",
     ];
 
     const elementTestIds = [
@@ -93,6 +92,13 @@ test(
         return expect(page.getByTestId(id)).toBeVisible();
       }),
     );
+
+    // Astra DB ships in the temporarily-unpublished datastax bundle; assert its
+    // disclosure only when present so the rest of the coverage still runs.
+    const datastaxDisclosure = page.getByTestId("disclosure-bundles-datastax");
+    if (await datastaxDisclosure.isVisible().catch(() => false)) {
+      await expect(datastaxDisclosure).toBeVisible();
+    }
 
     await Promise.all(
       elementTestIds.map(async (id) => {

--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -5,6 +5,7 @@ import { loadDotenvIfLocal } from "../../utils/env/load-dotenv";
 import { skipIfMissing } from "../../utils/env/skip-if-missing";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 import { initialGPTsetup } from "../../utils/initialGPTsetup";
+import { skipIfComponentUnavailable } from "../../utils/skip-if-component-unavailable";
 
 test(
   "should copy code from playground modal",
@@ -40,6 +41,11 @@ test(
     await page
       .getByTestId("sidebar-search-input")
       .fill(TEXTS.providerOpenAiSearch);
+
+    await skipIfComponentUnavailable(
+      page.getByTestId("openaiOpenAI"),
+      "OpenAI",
+    );
 
     await page
       .getByTestId("openaiOpenAI")


### PR DESCRIPTION
  - **Backend:** test modules that `from lfx_openai…` / `from lfx_datastax…` at
    module level raised `ModuleNotFoundError` during *collection* — a single bad
    import aborts the whole pytest group, which is why all groups failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional AI and database-related features so unavailable add-ons no longer cause test or startup failures.
  * Made bundled model/provider selection more resilient when some provider data is missing.
  * Updated end-to-end checks to account for feature-specific UI elements only when they are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->