### PR TITLE
fix: correct "occured" -> "occurred" typo in error messages

### DIFF
--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -870,16 +870,16 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         resource_key: str,
     ) -> list[ProviderSnapshotBinding]:
         if get_result.provider_data is None:
-            msg = "An internal error occured. provider_data is required from wxO adapter for get()."
+            msg = "An internal error occurred. provider_data is required from wxO adapter for get()."
             raise ValueError(msg)
         if "tool_ids" not in get_result.provider_data:
-            msg = "An internal error occured. provider_data must contain 'tool_ids' from wxO adapter for get()."
+            msg = "An internal error occurred. provider_data must contain 'tool_ids' from wxO adapter for get()."
             raise ValueError(msg)
 
         tool_ids = get_result.provider_data["tool_ids"]
 
         if not isinstance(tool_ids, list):
-            msg = "An internal error occured. provider_data['tool_ids'] must be a list from wxO adapter for get()."
+            msg = "An internal error occurred. provider_data['tool_ids'] must be a list from wxO adapter for get()."
             raise ValueError(msg)  # noqa: TRY004
 
         return [

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -1071,7 +1071,7 @@ def test_watsonx_mapper_extract_snapshot_bindings_for_get_requires_tool_ids():
 
     with pytest.raises(
         ValueError,
-        match=r"^An internal error occured\. provider_data must contain 'tool_ids' from wxO adapter for get\(\)\.$",
+        match=r"^An internal error occurred\. provider_data must contain 'tool_ids' from wxO adapter for get\(\)\.$",
     ):
         mapper.extract_snapshot_bindings_for_get(get_result, resource_key="agent-1")
 
@@ -1087,7 +1087,7 @@ def test_watsonx_mapper_extract_snapshot_bindings_for_get_requires_provider_data
 
     with pytest.raises(
         ValueError,
-        match=r"^An internal error occured\. provider_data is required from wxO adapter for get\(\)\.$",
+        match=r"^An internal error occurred\. provider_data is required from wxO adapter for get\(\)\.$",
     ):
         mapper.extract_snapshot_bindings_for_get(get_result, resource_key="agent-1")
 
@@ -1104,7 +1104,7 @@ def test_watsonx_mapper_extract_snapshot_bindings_for_get_requires_tool_ids_list
     with pytest.raises(
         ValueError,
         match=(
-            r"^An internal error occured\. provider_data\['tool_ids'\] must be a list "
+            r"^An internal error occurred\. provider_data\['tool_ids'\] must be a list "
             r"from wxO adapter for get\(\)\.$"
         ),
     ):

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/content-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/content-view.tsx
@@ -71,7 +71,7 @@ export const ErrorView = ({
                             {content.component && (
                               <>
                                 <span>
-                                  An error occured in the{" "}
+                                  An error occurred in the{" "}
                                   <span
                                     className={cn(
                                       closeChat ?? "cursor-pointer underline",

--- a/src/frontend/tests/fixtures.ts
+++ b/src/frontend/tests/fixtures.ts
@@ -189,7 +189,7 @@ export const test = base.extend({
               /AttributeError: .+/,
               /ImportError: .+/,
               /KeyError: .+/,
-              /An error occured .+/,
+              /An error occurred .+/,
             ];
 
             for (const pattern of exceptionPatterns) {


### PR DESCRIPTION
## Description

Fixes the misspelling **"occured"** → **"occurred"** in user-facing error messages.

Affected strings:
- `watsonx_orchestrate` deployment mapper internal error messages (`mapper.py`, 3 occurrences)
- Chat view component error banner ("An error occurred in the …")

The corresponding test assertions and the Playwright error-pattern fixture were updated to match the corrected text, so existing tests continue to pass.

## Changes
- `src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py`
- `src/backend/tests/unit/api/v1/test_deployment_sync.py`
- `src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/content-view.tsx`
- `src/frontend/tests/fixtures.ts`

No behavior change — spelling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected several user-facing error messages to use the proper spelling of “occurred.”
  * Improved error handling for deployment sync checks so failures now report clearer reasons when required data is missing or malformed.
  * Updated UI and test expectations to match the corrected error text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->