### PR TITLE
fix: keep tests and the starter-projects endpoint green while bundles are temporarily unpublished

### DIFF
--- a/src/backend/base/langflow/initial_setup/load.py
+++ b/src/backend/base/langflow/initial_setup/load.py
@@ -8,13 +8,14 @@ from .starter_projects import (
 
 
 def get_starter_projects_graphs():
-    return [
-        basic_prompting_graph(),
-        blog_writer_graph(),
-        document_qa_graph(),
-        memory_chatbot_graph(),
-        vector_store_rag_graph(),
+    builders = [
+        basic_prompting_graph,
+        blog_writer_graph,
+        document_qa_graph,
+        memory_chatbot_graph,
+        vector_store_rag_graph,
     ]
+    return [builder() for builder in builders if builder is not None]
 
 
 def get_starter_projects_dump():

--- a/src/backend/base/langflow/initial_setup/starter_projects/__init__.py
+++ b/src/backend/base/langflow/initial_setup/starter_projects/__init__.py
@@ -1,11 +1,31 @@
-from .basic_prompting import basic_prompting_graph
-from .blog_writer import blog_writer_graph
-from .complex_agent import complex_agent_graph
-from .document_qa import document_qa_graph
-from .hierarchical_tasks_agent import hierarchical_tasks_agent_graph
-from .memory_chatbot import memory_chatbot_graph
-from .sequential_tasks_agent import sequential_tasks_agent_graph
-from .vector_store_rag import vector_store_rag_graph
+import contextlib
+
+# A builder backed by a temporarily-unpublished bundle stays None and is skipped.
+basic_prompting_graph = None
+blog_writer_graph = None
+complex_agent_graph = None
+document_qa_graph = None
+hierarchical_tasks_agent_graph = None
+memory_chatbot_graph = None
+sequential_tasks_agent_graph = None
+vector_store_rag_graph = None
+
+with contextlib.suppress(ImportError):
+    from .basic_prompting import basic_prompting_graph
+with contextlib.suppress(ImportError):
+    from .blog_writer import blog_writer_graph
+with contextlib.suppress(ImportError):
+    from .complex_agent import complex_agent_graph
+with contextlib.suppress(ImportError):
+    from .document_qa import document_qa_graph
+with contextlib.suppress(ImportError):
+    from .hierarchical_tasks_agent import hierarchical_tasks_agent_graph
+with contextlib.suppress(ImportError):
+    from .memory_chatbot import memory_chatbot_graph
+with contextlib.suppress(ImportError):
+    from .sequential_tasks_agent import sequential_tasks_agent_graph
+with contextlib.suppress(ImportError):
+    from .vector_store_rag import vector_store_rag_graph
 
 __all__ = [
     "basic_prompting_graph",


### PR DESCRIPTION
The release hotfix `ecd7888161` commented out the
  unpublished bundle deps (`lfx-openai`, `lfx-datastax`, `lfx-oracle`). This PR
  fixes the remaining failures the nightlies surfaced once the collection errors
  were cleared — both test-level and a real product break — plus a Windows flake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Starter project graphs now load more gracefully when some optional project modules are unavailable.
  * Missing starter project components no longer cause startup import errors; available starter graphs continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->