### PR TITLE
fix: handle invalid session auth tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4007,7 +4007,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 29,
         "is_secret": false
       },
       {
@@ -4015,7 +4015,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 45,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T23:00:36Z"
+  "generated_at": "2026-06-24T23:37:56Z"
 }

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -12,6 +12,7 @@ from slowapi.wrappers import Limit
 from langflow.api.utils import DbSession
 from langflow.api.v1.schemas import Token
 from langflow.initial_setup.setup import get_or_create_default_folder
+from langflow.services.auth.exceptions import AuthenticationError
 from langflow.services.database.models.user.crud import get_user_by_id
 from langflow.services.database.models.user.model import UserRead
 from langflow.services.deps import get_auth_service, get_settings_service, get_variable_service
@@ -265,7 +266,7 @@ async def get_session(
             authenticated=True,
             user=UserRead.model_validate(user, from_attributes=True),
         )
-    except (HTTPException, ValueError) as _:
+    except (AuthenticationError, HTTPException, ValueError) as _:
         # Any authentication error means not authenticated
         return SessionResponse(authenticated=False)
 

--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -1,4 +1,7 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from langflow.services.auth.exceptions import InvalidTokenError
 from langflow.services.database.models.user import User
 from langflow.services.deps import get_auth_service, session_scope
 from sqlalchemy.exc import IntegrityError
@@ -47,6 +50,21 @@ async def test_login_unsuccessful_wrong_password(client, test_user, async_sessio
 async def test_session_endpoint_unauthenticated(client):
     """Test /session endpoint returns authenticated=False for unauthenticated requests."""
     response = await client.get("api/v1/session")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["authenticated"] is False
+    assert data["user"] is None
+    assert data["store_api_key"] is None
+
+
+async def test_session_endpoint_invalid_token_returns_unauthenticated(client):
+    """Test /session endpoint handles invalid tokens as unauthenticated sessions."""
+    auth_service = AsyncMock()
+    auth_service.get_current_user_from_access_token.side_effect = InvalidTokenError("Invalid token")
+
+    with patch("langflow.api.v1.login.get_auth_service", return_value=auth_service):
+        response = await client.get("api/v1/session", headers={"Authorization": "Bearer invalid-token"})
+
     assert response.status_code == 200
     data = response.json()
     assert data["authenticated"] is False


### PR DESCRIPTION
## Summary

- handle Langflow AuthenticationError from /api/v1/session as an unauthenticated session
- add regression coverage for invalid session tokens
- update the secrets baseline line metadata touched by the new test

## Testing

- uv run ruff check src/backend/base/langflow/api/v1/login.py src/backend/tests/unit/test_login.py
- uv run pytest src/backend/tests/unit/test_login.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status handling so invalid or expired login attempts are treated as unauthenticated instead of causing errors.
  * Updated the session endpoint to return a consistent unauthenticated response in more failure cases.

* **Tests**
  * Added coverage for invalid token behavior to confirm the session endpoint responds safely and predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->