### PR TITLE
fix: disable mem0 telemetry by default

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -8899,7 +8899,7 @@
         "filename": "src/lfx/src/lfx/components/mem0/mem0_chat_memory.py",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 41,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T23:00:36Z"
+  "generated_at": "2026-06-24T23:54:39Z"
 }

--- a/scripts/lint/check_component_env_writes.py
+++ b/scripts/lint/check_component_env_writes.py
@@ -54,6 +54,10 @@ ALLOWLIST: dict[str, set[str]] = {
     # the process environment. It is a known multi-tenant hazard flagged for separate
     # review; allow only the load_dotenv call, still flagging any direct os.environ write.
     "src/lfx/src/lfx/components/datastax/dotenv.py": {"load_dotenv"},
+    # mem0 creates PostHog clients at import time unless MEM0_TELEMETRY is
+    # disabled. This import-time default is process-wide by design, preserves an
+    # explicit deployer opt-in, and does not carry per-request values or secrets.
+    "src/lfx/src/lfx/components/mem0/mem0_chat_memory.py": {"mutate:setdefault"},
 }
 
 _MUTATING_METHODS = {"setdefault", "update", "pop", "clear", "popitem", "__setitem__", "__delitem__"}

--- a/src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
+++ b/src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
@@ -11,6 +11,14 @@ from lfx.components.mem0.mem0_chat_memory import Mem0MemoryComponent
 class TestMem0CloudValidation:
     """Test Mem0 component cloud validation."""
 
+    def test_mem0_telemetry_is_disabled_by_default(self):
+        """Langflow should not start mem0's PostHog telemetry on component import."""
+        from mem0.memory import telemetry as mem0_telemetry
+
+        assert os.environ["MEM0_TELEMETRY"] == "False"
+        assert mem0_telemetry.MEM0_TELEMETRY is False
+        assert mem0_telemetry.client_telemetry.posthog is None
+
     def test_build_mem0_disabled_in_astra_cloud(self):
         """Test that build_mem0 raises an error when ASTRA_CLOUD_DISABLE_COMPONENT is true."""
         with patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "true"}):
@@ -32,14 +40,15 @@ class TestMem0CloudValidation:
         """
         with patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "false"}):
             os.environ.pop("OPENAI_API_KEY", None)
-            component = Mem0MemoryComponent(openai_api_key="test-key")
+            fake_key = "not-a-real-openai-key"
+            component = Mem0MemoryComponent(openai_api_key=fake_key)
             component.build_mem0()
 
             # Key flows through config, not the environment.
             mock_memory.from_config.assert_called_once()
             config = mock_memory.from_config.call_args.kwargs["config_dict"]
-            assert config["llm"]["config"]["api_key"] == "test-key"
-            assert config["embedder"]["config"]["api_key"] == "test-key"
+            assert config["llm"]["config"]["api_key"] == fake_key
+            assert config["embedder"]["config"]["api_key"] == fake_key
             # Regression guard for the credential-bleed bug: never pollute os.environ.
             assert "OPENAI_API_KEY" not in os.environ
 

--- a/src/lfx/src/lfx/components/mem0/mem0_chat_memory.py
+++ b/src/lfx/src/lfx/components/mem0/mem0_chat_memory.py
@@ -1,4 +1,5 @@
-from mem0 import Memory, MemoryClient
+import importlib
+import os
 
 from lfx.base.memory.model import LCChatMemoryComponent
 from lfx.inputs.inputs import DictInput, HandleInput, MessageTextInput, NestedDictInput, SecretStrInput
@@ -6,6 +7,14 @@ from lfx.io import Output
 from lfx.log.logger import logger
 from lfx.schema.data import Data
 from lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component
+
+# mem0 creates PostHog clients at import time. Keep that third-party telemetry
+# disabled by default unless the deployer explicitly opts in.
+os.environ.setdefault("MEM0_TELEMETRY", "False")
+
+_mem0 = importlib.import_module("mem0")
+Memory = _mem0.Memory
+MemoryClient = _mem0.MemoryClient
 
 disable_component_in_astra_cloud_msg = (
     "Mem0 chat memory is not supported in Astra cloud environment. Please use local storage mode or mem0 cloud."


### PR DESCRIPTION
## Summary
- default MEM0_TELEMETRY to False before importing mem0, preventing mem0ai from creating PostHog clients during component import
- keep explicit deployer opt-in intact by using setdefault
- add a focused regression test and a narrow env-write lint allowlist entry for this import-time default

## Verification
- uv run ruff check scripts/lint/check_component_env_writes.py src/lfx/src/lfx/components/mem0/mem0_chat_memory.py src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
- uv run python scripts/lint/check_component_env_writes.py src/lfx/src/lfx/components/mem0/mem0_chat_memory.py
- uv run pytest src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
- import/notice probe prints: False None, with no [FEATURE FLAGS] warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mem0 now disables telemetry by default when loaded, reducing unexpected tracking during use.
  * Updated validation to avoid flagging a permitted environment-setting pattern in this component.
  * Fixed the recorded location for a detected secret and refreshed the secrets baseline.

* **Tests**
  * Expanded coverage to confirm telemetry stays off by default and configuration values are passed through correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->