### PR TITLE
feat: add TwelveLabs Video Search component

### DIFF
--- a/src/backend/tests/unit/components/bundles/twelvelabs/test_twelvelabs_components.py
+++ b/src/backend/tests/unit/components/bundles/twelvelabs/test_twelvelabs_components.py
@@ -1,11 +1,13 @@
 """Unit tests for TwelveLabs components cloud validation."""
 
 import os
-from unittest.mock import patch
+import types
+from unittest.mock import MagicMock, patch
 
 import pytest
 from lfx_bundles.twelvelabs.split_video import SplitVideoComponent
 from lfx_bundles.twelvelabs.video_file import VideoFileComponent
+from lfx_bundles.twelvelabs.video_search import SearchError, TwelveLabsVideoSearch
 
 
 @pytest.mark.unit
@@ -33,3 +35,97 @@ class TestTwelveLabsCloudValidation:
 
             error_msg = str(exc_info.value).lower()
             assert "astra" in error_msg or "cloud" in error_msg
+
+
+@pytest.mark.unit
+class TestTwelveLabsVideoSearch:
+    """Tests for the TwelveLabs Video Search component."""
+
+    def test_search_requires_inputs(self):
+        """Missing required inputs raise SearchError before any network call."""
+        for kwargs in (
+            {"api_key": "", "index_id": "i", "query": "q"},
+            {"api_key": "k", "index_id": "", "query": "q"},
+            {"api_key": "k", "index_id": "i", "query": ""},
+        ):
+            with pytest.raises(SearchError):
+                TwelveLabsVideoSearch(**kwargs).search()
+
+    def test_search_wiring_and_data_conversion(self):
+        """Search wires the SDK call and converts results to Data (no network)."""
+        clip = types.SimpleNamespace(
+            score=92.5, start=10.0, end=14.0, video_id="vid123", confidence="high", thumbnail_url="https://x/t.jpg"
+        )
+        fake_result = types.SimpleNamespace(data=[clip])
+
+        component = TwelveLabsVideoSearch(
+            api_key="k",
+            index_id="idx1",
+            query="a dog playing",
+            search_options="visual,audio",
+            group_by="clip",
+            threshold="medium",
+            page_limit=5,
+        )
+
+        with patch("lfx_bundles.twelvelabs.video_search.TwelveLabs") as mock_tl:
+            client = MagicMock()
+            client.search.query.return_value = fake_result
+            mock_tl.return_value = client
+            results = component.search()
+
+        call_kwargs = client.search.query.call_args.kwargs
+        assert call_kwargs["index_id"] == "idx1"
+        assert call_kwargs["options"] == ["visual", "audio"]
+        assert call_kwargs["query_text"] == "a dog playing"
+        assert call_kwargs["group_by"] == "clip"
+        assert call_kwargs["threshold"] == "medium"
+        assert call_kwargs["page_limit"] == 5
+
+        assert len(results) == 1
+        data = results[0].data
+        assert data["video_id"] == "vid123"
+        assert data["start"] == 10.0
+        assert data["end"] == 14.0
+        assert data["score"] == 92.5
+        assert data["index_id"] == "idx1"
+        assert "vid123" in results[0].text
+
+    def test_search_falls_back_to_raw_response_on_parse_error(self):
+        """When the typed SDK call fails to parse, the raw transport response is used."""
+        component = TwelveLabsVideoSearch(api_key="k", index_id="idx1", query="goal")
+
+        with patch("lfx_bundles.twelvelabs.video_search.TwelveLabs") as mock_tl:
+            client = MagicMock()
+            client.search.query.side_effect = ValueError("validation error")
+            client.search._post.return_value = {"data": [{"video_id": "v9", "start": 0, "end": 8, "rank": 1}]}
+            mock_tl.return_value = client
+            results = component.search()
+
+        assert len(results) == 1
+        assert results[0].data["video_id"] == "v9"
+        assert results[0].data["rank"] == 1
+
+    @pytest.mark.skipif(not os.getenv("TWELVELABS_API_KEY"), reason="requires TWELVELABS_API_KEY")
+    def test_search_live(self):
+        """Live smoke test: search a Marengo-enabled index for matching clips."""
+        api_key = os.environ["TWELVELABS_API_KEY"]
+        index_id = os.getenv("TWELVELABS_SEARCH_INDEX_ID")
+        if not index_id:
+            from twelvelabs import TwelveLabs
+
+            client = TwelveLabs(api_key=api_key)
+            index_id = next(
+                (idx.id for idx in client.index.list() if any("marengo" in m.name for m in (idx.models or []))),
+                None,
+            )
+            if not index_id:
+                pytest.skip("no Marengo-enabled index available")
+
+        component = TwelveLabsVideoSearch(
+            api_key=api_key, index_id=index_id, query="a person", threshold="low", page_limit=3
+        )
+        results = component.search()
+        assert isinstance(results, list)
+        for data in results:
+            assert data.data.get("video_id")

--- a/src/bundles/lfx-bundles/src/lfx_bundles/twelvelabs/__init__.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/twelvelabs/__init__.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from .twelvelabs_pegasus import TwelveLabsPegasus
     from .video_embeddings import TwelveLabsVideoEmbeddingsComponent
     from .video_file import VideoFileComponent
+    from .video_search import TwelveLabsVideoSearch
 
 _dynamic_imports = {
     "ConvertAstraToTwelveLabs": "convert_astra_results",
@@ -20,6 +21,7 @@ _dynamic_imports = {
     "TwelveLabsPegasus": "twelvelabs_pegasus",
     "TwelveLabsTextEmbeddingsComponent": "text_embeddings",
     "TwelveLabsVideoEmbeddingsComponent": "video_embeddings",
+    "TwelveLabsVideoSearch": "video_search",
     "VideoFileComponent": "video_file",
 }
 
@@ -30,6 +32,7 @@ __all__ = [
     "TwelveLabsPegasus",
     "TwelveLabsTextEmbeddingsComponent",
     "TwelveLabsVideoEmbeddingsComponent",
+    "TwelveLabsVideoSearch",
     "VideoFileComponent",
 ]
 

--- a/src/bundles/lfx-bundles/src/lfx_bundles/twelvelabs/video_search.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/twelvelabs/video_search.py
@@ -1,0 +1,193 @@
+from typing import Any
+
+from lfx.custom import Component
+from lfx.inputs import DropdownInput, IntInput, MessageTextInput, SecretStrInput, StrInput
+from lfx.io import Output
+from lfx.schema import Data
+from twelvelabs import TwelveLabs
+
+
+class TwelveLabsError(Exception):
+    """Base exception for TwelveLabs errors."""
+
+
+class SearchError(TwelveLabsError):
+    """Error raised when a search request fails."""
+
+
+class TwelveLabsVideoSearch(Component):
+    """Search inside an indexed video library using the TwelveLabs Marengo engine."""
+
+    display_name = "TwelveLabs Video Search"
+    description = "Run a semantic search over videos in a TwelveLabs index and return matching clips."
+    icon = "TwelveLabs"
+    name = "TwelveLabsVideoSearch"
+    documentation = "https://github.com/twelvelabs-io/twelvelabs-developer-experience/blob/main/integrations/Langflow/TWELVE_LABS_COMPONENTS_README.md"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="TwelveLabs API Key",
+            info="Enter your TwelveLabs API Key.",
+            required=True,
+        ),
+        StrInput(
+            name="index_id",
+            display_name="Index ID",
+            info="ID of the index to search (e.g. from the Pegasus Index Video component).",
+            required=True,
+        ),
+        MessageTextInput(
+            name="query",
+            display_name="Query",
+            info="Natural-language query to search for inside the indexed videos.",
+            required=True,
+        ),
+        DropdownInput(
+            name="search_options",
+            display_name="Search Options",
+            info="Which modalities to search over.",
+            options=["visual", "audio", "visual,audio"],
+            value="visual,audio",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="group_by",
+            display_name="Group By",
+            info="Return individual clips or group results by video.",
+            options=["clip", "video"],
+            value="clip",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="threshold",
+            display_name="Confidence Threshold",
+            info="Minimum confidence level for returned matches.",
+            options=["high", "medium", "low", "none"],
+            value="medium",
+            advanced=True,
+        ),
+        IntInput(
+            name="page_limit",
+            display_name="Max Results",
+            info="Maximum number of matches to return.",
+            value=10,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            display_name="Search Results",
+            name="results",
+            method="search",
+            output_types=["Data"],
+            is_list=True,
+        ),
+    ]
+
+    @staticmethod
+    def _field(item: Any, name: str) -> Any:
+        """Read a field from either a pydantic model or a raw dict.
+
+        The pinned SDK's response models can lag the live API, so we also
+        accept the raw JSON dict returned by the lower-level transport.
+        """
+        if isinstance(item, dict):
+            return item.get(name)
+        return getattr(item, name, None)
+
+    def _to_data(self, item: Any) -> Data:
+        """Convert a single search result (model or dict) into a Langflow Data object."""
+        start = self._field(item, "start")
+        end = self._field(item, "end")
+        video_id = self._field(item, "video_id")
+        score = self._field(item, "score")
+        confidence = self._field(item, "confidence")
+        rank = self._field(item, "rank")
+        thumbnail_url = self._field(item, "thumbnail_url")
+
+        text = f"Match in video {video_id} from {start}s to {end}s (confidence: {confidence})"
+        return Data(
+            text=text,
+            data={
+                "video_id": video_id,
+                "start": start,
+                "end": end,
+                "score": score,
+                "confidence": confidence,
+                "rank": rank,
+                "thumbnail_url": thumbnail_url,
+                "index_id": self.index_id,
+            },
+        )
+
+    def search(self) -> list[Data]:
+        """Search the index and return matching clips as Data objects."""
+        if not self.api_key:
+            error_msg = "TwelveLabs API Key is required"
+            raise SearchError(error_msg)
+        if not self.index_id:
+            error_msg = "Index ID is required"
+            raise SearchError(error_msg)
+        if not self.query:
+            error_msg = "Query is required"
+            raise SearchError(error_msg)
+
+        options = [opt.strip() for opt in self.search_options.split(",") if opt.strip()]
+
+        client = TwelveLabs(api_key=self.api_key)
+        self.status = f"Searching index {self.index_id} for: {self.query}"
+        entries = self._run_query(client, options)
+
+        results: list[Data] = []
+        for group in entries:
+            # When group_by="video" each entry exposes nested clips; otherwise it is a clip itself.
+            clips = self._field(group, "clips")
+            if clips:
+                results.extend(self._to_data(clip) for clip in clips)
+            else:
+                results.append(self._to_data(group))
+
+        self.status = f"Found {len(results)} match(es)."
+        return results
+
+    def _run_query(self, client: TwelveLabs, options: list[str]) -> list[Any]:
+        """Run the search, falling back to the raw response when the SDK can't parse it.
+
+        Returns a list of result entries (pydantic models or raw dicts).
+        """
+        try:
+            result = client.search.query(
+                index_id=self.index_id,
+                options=options,
+                query_text=self.query,
+                group_by=self.group_by,
+                threshold=self.threshold,
+                page_limit=self.page_limit,
+            )
+            return list(result.data)
+        except Exception as typed_error:  # noqa: BLE001 - SDK may raise ValidationError, HTTP errors, etc.
+            # The typed call failed (often the pinned SDK's models lagging the live
+            # API). Retry against the raw transport so a parse-only mismatch doesn't
+            # break search; re-raise the original error if the raw call also fails.
+            try:
+                raw = client.search._post(  # noqa: SLF001 - intentional raw-transport fallback
+                    "search",
+                    data={
+                        "index_id": self.index_id,
+                        "search_options": options,
+                        "query_text": self.query,
+                        "group_by": self.group_by,
+                        "threshold": self.threshold,
+                        "page_limit": self.page_limit,
+                    },
+                    files={"_": ""},
+                )
+            except Exception:  # noqa: BLE001 - surface the original, more meaningful error
+                error_msg = f"TwelveLabs search failed: {typed_error!s}"
+                self.status = error_msg
+                raise SearchError(error_msg) from typed_error
+
+            data = raw.get("data", []) if isinstance(raw, dict) else []
+            return list(data)

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -2302,6 +2302,26 @@
       "added_in": "1.11.0"
     },
     {
+      "bare_class_name": "TwelveLabsVideoSearch",
+      "target": "ext:twelvelabs:TwelveLabsVideoSearch@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "import_path": "lfx.components.twelvelabs.video_search.TwelveLabsVideoSearch",
+      "target": "ext:twelvelabs:TwelveLabsVideoSearch@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "import_path": "lfx.components.twelvelabs.TwelveLabsVideoSearch",
+      "target": "ext:twelvelabs:TwelveLabsVideoSearch@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "legacy_slot": "ext:twelvelabs:TwelveLabsVideoSearch@official-pre-a",
+      "target": "ext:twelvelabs:TwelveLabsVideoSearch@official",
+      "added_in": "1.11.0"
+    },
+    {
       "bare_class_name": "JigsawStackAIScraperComponent",
       "target": "ext:jigsawstack:JigsawStackAIScraperComponent@official",
       "added_in": "1.11.0"


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds
A new **TwelveLabs Video Search** component (`TwelveLabsVideoSearch`) in the existing `twelvelabs` bundle. It runs a semantic (Marengo) search over the videos in a TwelveLabs index and returns the matching clips as `Data` (video_id, start/end, score/confidence/rank, thumbnail_url, index_id).

## Why it helps Langflow
The bundle already lets you index videos (Pegasus Index Video) and embed them (Marengo embeddings), but there was no component for TwelveLabs' flagship capability: searching *inside* videos by natural-language query. This closes the loop — index your videos, then search them — directly in a flow, with results that drop straight into downstream RAG/agent steps.

## Opt-in / non-breaking
- New component only; no existing component, default, or behavior changes.
- Reuses the already-pinned `twelvelabs` SDK (`>=0.4.7,<1.0.0`) — **no new dependency**.
- Registered via the bundle's existing lazy-import `__init__.py`, same pattern as the other TwelveLabs components.
- Result parsing reads fields defensively and falls back to the raw search response when the pinned SDK's models lag the live API, so search keeps working across API revisions.

## How it was tested
- No-network unit tests for input validation, SDK call wiring + `Data` conversion, and the raw-response fallback.
- A live smoke test gated on `TWELVELABS_API_KEY` (skips without it) that searches a Marengo-enabled index. I ran it live against a real index and it returned matching clips end-to-end.
- `ruff check` and `ruff format` (0.13.1, repo config) pass on all changed files.

Per CONTRIBUTING this targets the `release-1.11.0` branch rather than `main`.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video search support for TwelveLabs, including query options, grouping, confidence threshold, and page limits.
  * Search results now return structured items with video-related details.

* **Bug Fixes**
  * Improved search reliability by handling missing inputs and falling back to a raw response when the typed response cannot be parsed.

* **Tests**
  * Added unit and smoke test coverage for search behavior, result mapping, and live API validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->