### PR TITLE
feat: add langflow-extra-providers package for OpenAI-compatible prov…

### DIFF
--- a/langflow-extra-providers/.gitignore
+++ b/langflow-extra-providers/.gitignore
@@ -1,0 +1,5 @@
+dist/
+build/
+*.egg-info/
+__pycache__/
+*.pyc

--- a/langflow-extra-providers/README.md
+++ b/langflow-extra-providers/README.md
@@ -1,0 +1,124 @@
+# langflow-extra-providers
+
+Add **OpenAI-compatible model providers** (DeepSeek, GLM/Z.ai, and any other
+OpenAI-API-compatible endpoint) to Langflow's **Model providers** dialog —
+**without editing Langflow's source code**.
+
+This is a standalone pip package that you install *alongside* Langflow. It
+registers the extra providers at runtime by mutating Langflow's in-memory model
+catalog. Because it lives in its own package (not in Langflow's source tree), it
+**survives `pip install -U langflow`** — you install it once and never have to
+re-patch after an update.
+
+## Why this exists
+
+Langflow's provider catalog (`MODEL_PROVIDER_METADATA`) and model lists are
+hardcoded in `lfx`. Adding a provider normally means editing those files, which
+gets overwritten on every Langflow update. This package injects the providers at
+runtime instead, so there is nothing to re-apply after upgrading.
+
+DeepSeek and GLM both expose an OpenAI-compatible API, so they reuse Langflow's
+existing `ChatOpenAI` integration — just pointed at a different `base_url`.
+
+## Install
+
+Install into the **same environment** as your Langflow server:
+
+```bash
+pip install langflow-extra-providers          # from a wheel/PyPI
+# or, from this directory:
+pip install .
+```
+
+Then activate auto-loading (writes a tiny `.pth` file into the environment's
+`site-packages` so the providers register every time Langflow starts):
+
+```bash
+python -m langflow_extra_providers install
+```
+
+Restart the Langflow server. **DeepSeek** and **GLM (Z.ai)** now appear in
+*Settings → Model providers*. Click **+**, paste your API key, and use them like
+any built-in provider.
+
+> The `install` step is a one-time action and survives Langflow upgrades. Run
+> `python -m langflow_extra_providers uninstall` to deactivate.
+
+### Commands
+
+```bash
+python -m langflow_extra_providers install     # activate auto-load (.pth)
+python -m langflow_extra_providers uninstall   # deactivate auto-load
+python -m langflow_extra_providers status      # show state + configured providers
+python -m langflow_extra_providers apply       # register once in the current process
+```
+
+## Configure / add more providers (no code changes)
+
+The built-ins are DeepSeek and GLM (Z.ai). To change endpoints, add models, or
+register additional OpenAI-compatible providers, set the
+`LANGFLOW_EXTRA_PROVIDERS` environment variable to inline JSON **or a path to a
+`.json` file**. It is merged on top of the defaults.
+
+```bash
+export LANGFLOW_EXTRA_PROVIDERS='{
+  "GLM (Z.ai)": { "base_url": "https://open.bigmodel.cn/api/paas/v4" },
+  "Moonshot": {
+    "base_url": "https://api.moonshot.cn/v1",
+    "api_key_var": "MOONSHOT_API_KEY",
+    "api_docs_url": "https://platform.moonshot.cn/docs",
+    "models": [
+      { "name": "moonshot-v1-8k",  "tool_calling": true },
+      { "name": "moonshot-v1-32k", "tool_calling": true }
+    ]
+  }
+}'
+```
+
+Per-provider spec fields:
+
+| field             | required | description                                                        |
+|-------------------|----------|--------------------------------------------------------------------|
+| `base_url`        | yes      | OpenAI-compatible endpoint, e.g. `https://api.deepseek.com`         |
+| `api_key_var`     | yes      | Global-variable / env key for the API key, e.g. `DEEPSEEK_API_KEY` |
+| `models`          | no       | List of `{ "name": ..., "tool_calling": bool, "reasoning": bool }` |
+| `api_docs_url`    | no       | Link shown in the provider settings panel                          |
+| `icon`            | no       | Frontend icon name (defaults to `OpenAI`; unknown → generic icon)  |
+| `description`     | no       | Help text shown for the API-key field                              |
+| `default_headers` | no       | Extra HTTP headers sent on every request                           |
+
+Set `LANGFLOW_EXTRA_PROVIDERS_DISABLE_DEFAULTS=1` to drop the built-in DeepSeek /
+GLM entries and use only your own.
+
+The API key can also be provided via the matching environment variable
+(e.g. `export DEEPSEEK_API_KEY=...`) instead of the Settings UI.
+
+## How it works (no monkey-business in your flows)
+
+* Adds entries to `MODEL_PROVIDER_METADATA` (so the provider + its API-key field
+  show up in Settings) and to the static model catalog (so the provider and its
+  models appear in the dialog and dropdowns).
+* Pre-seeds `lfx`'s model-class cache with a small factory that returns a
+  `langchain_openai.ChatOpenAI` bound to the provider's `base_url`. Langflow's
+  `get_llm()` resolves the class through that cache, so **no change to
+  instantiation code is needed**.
+* Registration is armed by a lightweight `sys.meta_path` hook that fires the
+  moment Langflow loads its model catalog — it does **not** import the heavy
+  `lfx` package on unrelated `python` invocations.
+* Everything is wrapped in defensive `try/except`: if a future Langflow refactor
+  changes these internals, the worst case is the extra providers silently not
+  registering — your Langflow install keeps working.
+
+## Compatibility note
+
+This package relies on `lfx` internals (the model catalog structures). It targets
+the Langflow version it ships with. If a future Langflow release reorganizes the
+model-provider internals, update this package. Pin it next to your Langflow
+version if you need strict reproducibility.
+
+## Uninstall
+
+```bash
+python -m langflow_extra_providers uninstall   # remove the .pth
+pip uninstall langflow-extra-providers
+```

--- a/langflow-extra-providers/langflow_extra_providers/__init__.py
+++ b/langflow-extra-providers/langflow_extra_providers/__init__.py
@@ -1,0 +1,30 @@
+"""Register extra OpenAI-compatible model providers in Langflow.
+
+Importing this package arms a lazy hook that injects the configured providers
+(DeepSeek, GLM/Z.ai by default) into Langflow's model catalog when Langflow
+loads — without editing any Langflow / lfx source file.
+
+Public API:
+    from langflow_extra_providers import apply
+    apply()        # force registration immediately (returns provider names)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .patch import apply
+
+logger = logging.getLogger("langflow_extra_providers")
+
+__all__ = ["apply"]
+__version__ = "0.1.0"
+
+# Arm the auto-apply hook on import. Wrapped so a failure here can never break
+# the host interpreter (the .pth file imports us at startup for every process).
+try:
+    from .hook import install as _install
+
+    _install()
+except Exception:  # noqa: BLE001
+    logger.exception("langflow-extra-providers: failed to install auto-apply hook")

--- a/langflow-extra-providers/langflow_extra_providers/__init__.py
+++ b/langflow-extra-providers/langflow_extra_providers/__init__.py
@@ -26,5 +26,5 @@ try:
     from .hook import install as _install
 
     _install()
-except Exception:  # noqa: BLE001
+except Exception:
     logger.exception("langflow-extra-providers: failed to install auto-apply hook")

--- a/langflow-extra-providers/langflow_extra_providers/__main__.py
+++ b/langflow-extra-providers/langflow_extra_providers/__main__.py
@@ -1,0 +1,105 @@
+"""CLI to activate / deactivate auto-loading and to inspect registration.
+
+The reliable, cross-platform way to run code at interpreter startup after a pip
+install is a ``.pth`` file in the environment's ``site-packages`` whose single
+line is ``import langflow_extra_providers``. Python's ``site`` module executes
+that import on every interpreter start, which arms our lazy hook.
+
+This file is written into the *active* environment's site-packages by the
+``install`` command (run it once, in the same venv as Langflow). It survives
+``pip install -U langflow`` because it lives alongside this package, not inside
+Langflow's source tree.
+
+Usage:
+    python -m langflow_extra_providers install     # activate auto-load
+    python -m langflow_extra_providers uninstall   # deactivate auto-load
+    python -m langflow_extra_providers status      # show state + providers
+    python -m langflow_extra_providers apply       # apply once in this process
+"""
+
+from __future__ import annotations
+
+import argparse
+import sysconfig
+from pathlib import Path
+
+_PTH_NAME = "langflow_extra_providers.pth"
+_PTH_LINE = "import langflow_extra_providers\n"
+
+
+def _pth_path() -> Path:
+    return Path(sysconfig.get_path("purelib")) / _PTH_NAME
+
+
+def cmd_install() -> int:
+    path = _pth_path()
+    try:
+        path.write_text(_PTH_LINE, encoding="utf-8")
+    except OSError as exc:
+        print(f"Failed to write {path}: {exc}")
+        print("You may need to run this inside the virtualenv where Langflow is installed.")
+        return 1
+    print(f"Activated auto-load: {path}")
+    print("Restart the Langflow server to pick up the extra providers.")
+    return 0
+
+
+def cmd_uninstall() -> int:
+    path = _pth_path()
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError as exc:
+            print(f"Failed to remove {path}: {exc}")
+            return 1
+        print(f"Deactivated auto-load: removed {path}")
+    else:
+        print(f"Auto-load was not active (no {path}).")
+    return 0
+
+
+def cmd_status() -> int:
+    path = _pth_path()
+    print(f"Auto-load .pth: {'present' if path.exists() else 'absent'} ({path})")
+    from .config import load_provider_specs
+
+    specs = load_provider_specs()
+    print(f"Configured providers ({len(specs)}):")
+    for name, spec in specs.items():
+        models = ", ".join(m.get("name", "?") for m in spec.get("models", []))
+        print(f"  - {name}: base_url={spec['base_url']} key={spec['api_key_var']}")
+        if models:
+            print(f"      models: {models}")
+    return 0
+
+
+def cmd_apply() -> int:
+    from .patch import apply
+
+    added = apply(force=True)
+    if added:
+        print(f"Registered providers in this process: {', '.join(added)}")
+    else:
+        print("No providers registered (is lfx / Langflow importable here?).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="langflow-extra-providers")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("install", help="Write the .pth file so providers auto-load at startup.")
+    sub.add_parser("uninstall", help="Remove the .pth file.")
+    sub.add_parser("status", help="Show auto-load state and configured providers.")
+    sub.add_parser("apply", help="Register providers once in the current process.")
+    args = parser.parse_args(argv)
+
+    return {
+        "install": cmd_install,
+        "uninstall": cmd_uninstall,
+        "status": cmd_status,
+        "apply": cmd_apply,
+    }[args.command]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/langflow-extra-providers/langflow_extra_providers/config.py
+++ b/langflow-extra-providers/langflow_extra_providers/config.py
@@ -1,0 +1,135 @@
+"""Provider specifications for langflow-extra-providers.
+
+Each entry describes one OpenAI-compatible provider. The shape is intentionally
+small because every provider here speaks the OpenAI wire format and is
+instantiated through ``langchain_openai.ChatOpenAI`` with a baked-in
+``base_url``.
+
+Defaults ship DeepSeek and GLM (Z.ai). You can override or extend them WITHOUT
+editing this file via the ``LANGFLOW_EXTRA_PROVIDERS`` environment variable
+(inline JSON or a path to a ``.json`` file). Set
+``LANGFLOW_EXTRA_PROVIDERS_DISABLE_DEFAULTS=1`` to drop the built-ins and use
+only your own.
+
+Spec schema (per provider, keyed by display name):
+    {
+        "base_url": "https://api.example.com/v1",   # required
+        "api_key_var": "EXAMPLE_API_KEY",            # required (global-variable / env key)
+        "api_docs_url": "https://...",               # optional
+        "icon": "OpenAI",                            # optional, frontend icon name
+        "description": "...",                        # optional, shown in settings
+        "default_headers": {"X-Title": "Langflow"},  # optional, sent on every call
+        "models": [
+            {"name": "model-id", "tool_calling": true, "reasoning": false},
+            ...
+        ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("langflow_extra_providers")
+
+# ---------------------------------------------------------------------------
+# Built-in defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROVIDERS: dict[str, dict[str, Any]] = {
+    "DeepSeek": {
+        "base_url": "https://api.deepseek.com",
+        "api_key_var": "DEEPSEEK_API_KEY",
+        "api_docs_url": "https://api-docs.deepseek.com",
+        "icon": "OpenAI",
+        "description": "DeepSeek (OpenAI-compatible API). Configure DEEPSEEK_API_KEY.",
+        "models": [
+            {"name": "deepseek-chat", "tool_calling": True},
+            {"name": "deepseek-reasoner", "tool_calling": True, "reasoning": True},
+        ],
+    },
+    # GLM / Zhipu. Defaults to the international Z.ai OpenAI-compatible endpoint.
+    # For the China endpoint use base_url "https://open.bigmodel.cn/api/paas/v4"
+    # via the LANGFLOW_EXTRA_PROVIDERS override.
+    "GLM (Z.ai)": {
+        "base_url": "https://api.z.ai/api/paas/v4",
+        "api_key_var": "GLM_API_KEY",
+        "api_docs_url": "https://docs.z.ai/guides/llm/glm-4.6",
+        "icon": "OpenAI",
+        "description": "GLM / Z.ai (OpenAI-compatible API). Configure GLM_API_KEY.",
+        "models": [
+            {"name": "glm-4.6", "tool_calling": True},
+            {"name": "glm-4.5", "tool_calling": True},
+            {"name": "glm-4.5-air", "tool_calling": True},
+            {"name": "glm-4-flash", "tool_calling": True},
+        ],
+    },
+}
+
+_ENV_SPECS = "LANGFLOW_EXTRA_PROVIDERS"
+_ENV_DISABLE_DEFAULTS = "LANGFLOW_EXTRA_PROVIDERS_DISABLE_DEFAULTS"
+
+_REQUIRED_KEYS = ("base_url", "api_key_var")
+
+
+def _load_override() -> dict[str, dict[str, Any]]:
+    """Parse the ``LANGFLOW_EXTRA_PROVIDERS`` env var (inline JSON or file path)."""
+    raw = os.environ.get(_ENV_SPECS)
+    if not raw or not raw.strip():
+        return {}
+    raw = raw.strip()
+    text = raw
+    # Treat a value that points at an existing file as a path.
+    if not raw.startswith("{"):
+        path = Path(raw).expanduser()
+        if path.is_file():
+            text = path.read_text(encoding="utf-8")
+        else:
+            logger.warning(
+                "%s does not look like JSON and is not an existing file: %r", _ENV_SPECS, raw
+            )
+            return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("Could not parse %s as JSON: %s", _ENV_SPECS, exc)
+        return {}
+    if not isinstance(data, dict):
+        logger.warning("%s must be a JSON object keyed by provider name.", _ENV_SPECS)
+        return {}
+    return data
+
+
+def _is_truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def load_provider_specs() -> dict[str, dict[str, Any]]:
+    """Return the merged, validated provider specs (defaults + env override)."""
+    specs: dict[str, dict[str, Any]] = {}
+    if not _is_truthy(os.environ.get(_ENV_DISABLE_DEFAULTS)):
+        # Deep-ish copy so callers can't mutate the module defaults.
+        for name, spec in DEFAULT_PROVIDERS.items():
+            specs[name] = json.loads(json.dumps(spec))
+
+    for name, spec in _load_override().items():
+        if not isinstance(spec, dict):
+            logger.warning("Ignoring %r: provider spec must be an object.", name)
+            continue
+        specs[name] = {**specs.get(name, {}), **spec}
+
+    # Validate
+    valid: dict[str, dict[str, Any]] = {}
+    for name, spec in specs.items():
+        missing = [k for k in _REQUIRED_KEYS if not spec.get(k)]
+        if missing:
+            logger.warning("Ignoring provider %r: missing required field(s) %s", name, missing)
+            continue
+        spec.setdefault("icon", "OpenAI")
+        spec.setdefault("models", [])
+        valid[name] = spec
+    return valid

--- a/langflow-extra-providers/langflow_extra_providers/config.py
+++ b/langflow-extra-providers/langflow_extra_providers/config.py
@@ -89,9 +89,7 @@ def _load_override() -> dict[str, dict[str, Any]]:
         if path.is_file():
             text = path.read_text(encoding="utf-8")
         else:
-            logger.warning(
-                "%s does not look like JSON and is not an existing file: %r", _ENV_SPECS, raw
-            )
+            logger.warning("%s does not look like JSON and is not an existing file: %r", _ENV_SPECS, raw)
             return {}
     try:
         data = json.loads(text)

--- a/langflow-extra-providers/langflow_extra_providers/hook.py
+++ b/langflow-extra-providers/langflow_extra_providers/hook.py
@@ -1,0 +1,82 @@
+"""Lazy, low-overhead auto-apply hook.
+
+The package is auto-imported at interpreter startup (via a ``.pth`` line). We do
+NOT want to import the (heavy) lfx package on every ``python`` invocation in the
+environment, so instead of applying eagerly we install a ``sys.meta_path``
+finder that triggers :func:`langflow_extra_providers.patch.apply` exactly once,
+right after Langflow imports its model-catalog module.
+
+If lfx's model catalog is already imported when we load (e.g. someone imported
+us late), we apply immediately.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+import logging
+import sys
+
+logger = logging.getLogger("langflow_extra_providers")
+
+# Importing this module finalizes the provider registration, so it is the right
+# trigger point: by the time it finishes executing, MODEL_PROVIDER_METADATA and
+# _STATIC_MODELS_DETAILED exist and are safe to mutate.
+_TRIGGER_MODULE = "lfx.base.models.unified_models.provider_queries"
+
+
+def _run_apply() -> None:
+    try:
+        from .patch import apply
+
+        apply()
+    except Exception:  # noqa: BLE001 - never break a host process on our account
+        logger.exception("langflow-extra-providers: auto-apply failed")
+
+
+class _ApplyOnImportFinder(importlib.abc.MetaPathFinder):
+    """Fires :func:`_run_apply` after the trigger module is executed, once."""
+
+    def __init__(self) -> None:
+        self._fired = False
+
+    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
+        if self._fired or fullname != _TRIGGER_MODULE:
+            return None
+        # Resolve the real spec without re-entering ourselves.
+        try:
+            sys.meta_path.remove(self)
+        except ValueError:
+            return None
+        try:
+            spec = importlib.util.find_spec(fullname)
+        except Exception:  # noqa: BLE001
+            return None
+        if spec is None or spec.loader is None:
+            return None
+
+        loader = spec.loader
+        real_exec_module = loader.exec_module
+
+        def exec_module(module, _real=real_exec_module):
+            _real(module)
+            # Guard against double-fire; this finder is already detached.
+            if not self._fired:
+                self._fired = True
+                _run_apply()
+
+        # Patching this spec's own loader instance is safe — FileFinder hands
+        # out a fresh loader per module.
+        loader.exec_module = exec_module  # type: ignore[method-assign]
+        return spec
+
+
+def install() -> None:
+    """Apply now if the catalog is already loaded, else arm the import hook."""
+    if _TRIGGER_MODULE in sys.modules:
+        _run_apply()
+        return
+    # Avoid installing twice.
+    if any(isinstance(f, _ApplyOnImportFinder) for f in sys.meta_path):
+        return
+    sys.meta_path.insert(0, _ApplyOnImportFinder())

--- a/langflow-extra-providers/langflow_extra_providers/hook.py
+++ b/langflow-extra-providers/langflow_extra_providers/hook.py
@@ -30,7 +30,7 @@ def _run_apply() -> None:
         from .patch import apply
 
         apply()
-    except Exception:  # noqa: BLE001 - never break a host process on our account
+    except Exception:
         logger.exception("langflow-extra-providers: auto-apply failed")
 
 

--- a/langflow-extra-providers/langflow_extra_providers/patch.py
+++ b/langflow-extra-providers/langflow_extra_providers/patch.py
@@ -1,0 +1,175 @@
+"""Runtime registration of extra OpenAI-compatible model providers.
+
+This module mutates Langflow's in-memory model catalog so providers like
+DeepSeek and GLM appear in the "Model providers" dialog, can be configured with
+an API key, and instantiate through ``langchain_openai.ChatOpenAI`` pointed at
+the provider's ``base_url`` — all WITHOUT editing any Langflow / lfx source
+file.
+
+Why this works without touching ``get_llm``:
+  * The provider catalog (``MODEL_PROVIDER_METADATA``) and the static model
+    lists (``_STATIC_MODELS_DETAILED``) are read every request from the *same*
+    objects we mutate here, so in-place mutation is visible immediately.
+  * Instantiation resolves the LangChain class via ``get_model_class(name)``,
+    which checks ``_model_class_cache`` first. We pre-seed that cache with a
+    small factory that injects the right ``base_url``. No per-provider
+    ``if/elif`` branch in ``get_llm`` is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from typing import Any, Callable
+
+from .config import load_provider_specs
+
+logger = logging.getLogger("langflow_extra_providers")
+
+# Providers we have registered, and the catalog group list we own per provider
+# (kept so re-applying refreshes contents instead of duplicating rows).
+_OWNED_GROUPS: dict[str, list] = {}
+# Generated factories, also exposed as module attributes so the lfx class
+# registry can re-import them by name if its cache is ever rebuilt.
+_FACTORIES: dict[str, Callable[..., Any]] = {}
+
+
+def _class_name_for(provider_name: str) -> str:
+    slug = re.sub(r"\W+", "_", provider_name).strip("_")
+    return f"ChatOpenAICompat__{slug}"
+
+
+def _make_factory(base_url: str, default_headers: dict[str, str] | None) -> Callable[..., Any]:
+    """Build a callable that returns a ChatOpenAI bound to ``base_url``.
+
+    ``get_llm`` calls ``model_class(**kwargs)``; a factory is sufficient (the
+    only consumer instantiates it). Importing ChatOpenAI is deferred to call
+    time so merely registering a provider never imports langchain_openai.
+    """
+
+    def _factory(**kwargs: Any) -> Any:
+        from langchain_openai import ChatOpenAI
+
+        kwargs.setdefault("base_url", base_url)
+        if default_headers:
+            merged = dict(default_headers)
+            merged.update(kwargs.get("default_headers") or {})
+            kwargs["default_headers"] = merged
+        return ChatOpenAI(**kwargs)
+
+    return _factory
+
+
+def apply(*, force: bool = False) -> list[str]:
+    """Register the configured extra providers into Langflow's catalog.
+
+    Idempotent: calling it again refreshes provider definitions without
+    creating duplicate catalog rows. Returns the list of provider names added
+    (or refreshed). Safe to call when lfx is not importable (returns []).
+    """
+    try:
+        from lfx.base.models import model_metadata as mm
+        from lfx.base.models.model_metadata import create_model_metadata
+        from lfx.base.models.unified_models import class_registry as cr
+        from lfx.base.models.unified_models import provider_queries as pq
+    except Exception as exc:  # noqa: BLE001 - lfx absent or internal change
+        logger.debug("langflow-extra-providers: lfx unavailable, skipping (%s)", exc)
+        return []
+
+    specs = load_provider_specs()
+    touched: list[str] = []
+
+    for provider_name, spec in specs.items():
+        owned = provider_name in _OWNED_GROUPS
+        # Never clobber a provider that Langflow itself defines (e.g. if a
+        # future release ships a same-named provider). Only skip when we are
+        # not the ones who put it there.
+        if provider_name in mm.MODEL_PROVIDER_METADATA and not owned:
+            logger.warning(
+                "langflow-extra-providers: %r already defined by Langflow; skipping.",
+                provider_name,
+            )
+            continue
+        if owned and not force:
+            # Already registered by us this process; nothing changed.
+            touched.append(provider_name)
+            continue
+
+        class_name = _class_name_for(provider_name)
+        factory = _make_factory(spec["base_url"], spec.get("default_headers"))
+        _FACTORIES[class_name] = factory
+        setattr(sys.modules[__name__], class_name, factory)
+        # Pre-seed the cache (checked first in _import_class) and add a registry
+        # entry as a fallback for any future cache rebuild.
+        cr._model_class_cache[class_name] = factory  # noqa: SLF001
+        cr._MODEL_CLASS_IMPORTS[class_name] = (__name__, class_name, None)  # noqa: SLF001
+
+        api_key_var = spec["api_key_var"]
+        icon = spec.get("icon", "OpenAI")
+        mm.MODEL_PROVIDER_METADATA[provider_name] = {
+            "icon": icon,
+            "max_tokens_field_name": "max_tokens",
+            "variables": [
+                {
+                    "variable_name": f"{provider_name} API Key",
+                    "variable_key": api_key_var,
+                    "description": spec.get(
+                        "description",
+                        f"API key for {provider_name} (OpenAI-compatible).",
+                    ),
+                    "required": True,
+                    "is_secret": True,
+                    "is_list": False,
+                    "options": [],
+                    "langchain_param": "api_key",
+                    "component_metadata": {
+                        "mapping_field": "api_key",
+                        "required": False,
+                        "advanced": True,
+                        "info": f"Falls back to {api_key_var} environment variable",
+                    },
+                }
+            ],
+            "api_docs_url": spec.get("api_docs_url", ""),
+            "mapping": {"model_class": class_name, "model_param": "model"},
+        }
+
+        # Build / refresh the catalog group we own for this provider.
+        group = _OWNED_GROUPS.get(provider_name)
+        if group is None:
+            group = []
+            _OWNED_GROUPS[provider_name] = group
+            pq._STATIC_MODELS_DETAILED.append(group)  # noqa: SLF001
+        group.clear()
+        for model in spec.get("models", []):
+            name = model.get("name")
+            if not name:
+                continue
+            group.append(
+                create_model_metadata(
+                    provider=provider_name,
+                    name=name,
+                    icon=icon,
+                    tool_calling=bool(model.get("tool_calling", True)),
+                    reasoning=bool(model.get("reasoning", False)),
+                )
+            )
+        touched.append(provider_name)
+
+    # Invalidate derived lru_caches so the new providers are visible.
+    for fn in (
+        getattr(pq, "get_models_detailed", None),
+        getattr(pq, "get_model_provider_variable_mapping", None),
+        getattr(pq, "_get_all_provider_specific_field_names", None),
+    ):
+        clear = getattr(fn, "cache_clear", None)
+        if clear is not None:
+            try:
+                clear()
+            except Exception:  # noqa: BLE001
+                logger.debug("cache_clear failed for %s", fn, exc_info=True)
+
+    if touched:
+        logger.info("langflow-extra-providers: registered providers %s", touched)
+    return touched

--- a/langflow-extra-providers/langflow_extra_providers/patch.py
+++ b/langflow-extra-providers/langflow_extra_providers/patch.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 import logging
 import re
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .config import load_provider_specs
 

--- a/langflow-extra-providers/pyproject.toml
+++ b/langflow-extra-providers/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "langflow-extra-providers"
+version = "0.1.0"
+description = "Register extra OpenAI-compatible model providers (DeepSeek, GLM/Z.ai, ...) in Langflow without patching core source."
+readme = "README.md"
+requires-python = ">=3.10"
+# Intentionally no runtime dependencies: this package is installed *into* an
+# existing Langflow environment and reuses its already-present lfx /
+# langchain-openai. It must never pull a second copy of Langflow.
+dependencies = []
+
+[project.scripts]
+langflow-extra-providers = "langflow_extra_providers.__main__:main"
+
+[tool.setuptools]
+packages = ["langflow_extra_providers"]


### PR DESCRIPTION
…iders

Standalone, pip-installable package that registers extra OpenAI-compatible model providers (DeepSeek and GLM/Z.ai by default) into Langflow's "Model providers" dialog at runtime, without editing any Langflow/lfx source file.

It survives `pip install -U langflow` because it lives in its own package:
- mutates MODEL_PROVIDER_METADATA + the static model catalog in place
- pre-seeds the lfx model-class cache with a ChatOpenAI factory bound to the provider's base_url (no change to get_llm needed)
- arms a lightweight sys.meta_path hook so registration fires when Langflow loads its catalog, without importing lfx on unrelated python startups
- providers/models/endpoints configurable via LANGFLOW_EXTRA_PROVIDERS

Activate with `python -m langflow_extra_providers install` (writes a .pth).


Claude-Session: https://claude.ai/code/session_011eSjF5oc8us7P4yyAU6Yzt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone package to register extra OpenAI-compatible model providers in Langflow at runtime.
  * Introduced a command-line tool to install, remove, check, and apply provider loading in the active environment.
  * Added support for configuring additional providers through environment settings, including custom provider lists and optional defaults.

* **Documentation**
  * Added setup, usage, configuration, and compatibility guidance for the new package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->