### PR TITLE
fix(telemetry): use SQLAlchemy AsyncSession to stop deprecation-warning log flood

### DIFF
--- a/src/backend/base/langflow/services/telemetry_writer/service.py
+++ b/src/backend/base/langflow/services/telemetry_writer/service.py
@@ -39,9 +39,8 @@ from uuid import UUID
 
 from lfx.log.logger import logger
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import col
-from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
 
 from langflow.services.base import Service
 from langflow.services.database.models.transactions.model import TransactionTable
@@ -320,7 +319,13 @@ class TelemetryWriterService(Service):
         self._prune_stale_foreign_outboxes(outbox_root)
 
         self._engine = self._create_dedicated_engine()
-        self._session_maker = async_sessionmaker(self._engine, class_=SQLModelAsyncSession, expire_on_commit=False)
+        # Use SQLAlchemy's AsyncSession (not SQLModel's). This service issues only
+        # Core-style bulk statements via ``session.execute()`` (Table.insert(),
+        # delete(), select().scalars()); it never needs SQLModel's ``exec()``.
+        # SQLModel's AsyncSession marks ``execute()`` as deprecated, so using it
+        # here floods runtime logs with a multi-line DeprecationWarning on every
+        # batch flush and retention sweep.
+        self._session_maker = async_sessionmaker(self._engine, class_=AsyncSession, expire_on_commit=False)
         self._shutdown_event = asyncio.Event()
         self._writer_task = asyncio.create_task(self._run_writer(), name="telemetry-writer")
         self._sweeper_task = asyncio.create_task(self._run_sweeper(), name="telemetry-sweeper")


### PR DESCRIPTION
## Problem

The starter-projects Playwright shard CI jobs (each tests a quarter of the templates) have their `[WebServer]` output flooded with this multi-line block, repeated continuously throughout the run:

```
[WebServer] .../langflow/services/telemetry_writer/service.py:866: DeprecationWarning:
[WebServer]         🚨 You probably want to use `session.exec()` instead of `session.execute()`.
[WebServer]         This is the original SQLAlchemy `session.execute()` method ...
[WebServer]   await session.execute(
```

It reads like a wall of database errors. It is not a hard error, but it is genuine **service-side noise** — and it makes real failures (the occasional `flow-builder-welcome-panel` timeout that passes on retry) much harder to spot in the logs.

## Root cause

`TelemetryWriterService` builds its dedicated, off-pool sessionmaker with **SQLModel's** `AsyncSession`:

```python
from sqlmodel.ext.asyncio.session import AsyncSession as SQLModelAsyncSession
...
self._session_maker = async_sessionmaker(self._engine, class_=SQLModelAsyncSession, expire_on_commit=False)
```

But the service only ever issues **Core-style bulk statements** through `session.execute()`:
- batched `TransactionTable.__table__.insert()` / `VertexBuildTable.__table__.insert()`
- retention `delete(...)` and `select(...).scalars().all()`

It never calls SQLModel's `exec()`. SQLModel marks `AsyncSession.execute()` as deprecated via a PEP 702 `@deprecated` decorator, so **every** batch flush and **every** retention sweep emits the warning at runtime (6 call sites: lines 755, 761, 820, 830, 850, 866). pytest's `filterwarnings` hides it in unit tests, but the Playwright `[WebServer]` is a real subprocess and logs it verbatim.

## Fix

Use SQLAlchemy's plain `AsyncSession` — which is what this service actually needs — and document why so it isn't reverted:

```python
from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
...
self._session_maker = async_sessionmaker(self._engine, class_=AsyncSession, expire_on_commit=False)
```

No behavioral change: bulk insert/delete/select + `.scalars()`/`.commit()` are session-class-agnostic, and the existing `test_service.py` fixture already runs the service against a plain `async_sessionmaker(...)`. SQLModel is still a dependency (`from sqlmodel import col` is unchanged).

## Verification

- ✅ `ruff check` clean
- ✅ All 38 tests in `src/backend/tests/unit/services/telemetry_writer/test_service.py` pass
- ✅ Direct check: the new sessionmaker yields a `sqlalchemy ... AsyncSession` and `execute()` emits **0** SQLModel "use exec()" deprecation warnings

## Scope notes

- Two other signals in the same CI logs were investigated and are **intentionally out of scope**:
  - The MCP `Unclosed MemoryObjectReceiveStream` `ResourceWarning` is benign GC-time noise (streams are closed via `async with`) and is already covered by a warning filter in `main.py`.
  - The intermittent `flow-builder-welcome-panel` 30s timeout (passes on retry) traces to `/api/v1/all` latency on slow runners — a separate, higher-risk change that deserves its own PR.
- `main` carries the identical code (lines 44 / 323), so this should be forward-ported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of telemetry data saving in the background.
  * Reduced the chance of write failures by switching to a more standard database session setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->