### PR TITLE
fix: isolate CrewAI runtime state across build_crew calls

### DIFF
--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -1496,7 +1496,7 @@
           "icon": "CrewAI",
           "legacy": true,
           "metadata": {
-            "code_hash": "144be482cfb0",
+            "code_hash": "9f2c4e99e4d9",
             "dependencies": {
               "dependencies": [
                 {
@@ -1574,7 +1574,7 @@
               "show": true,
               "title_case": false,
               "type": "code",
-              "value": "from lfx.base.agents.crewai.crew import BaseCrewComponent\nfrom lfx.io import HandleInput\n\n\nclass HierarchicalCrewComponent(BaseCrewComponent):\n    display_name: str = \"Hierarchical Crew\"\n    description: str = (\n        \"Represents a group of agents, defining how they should collaborate and the tasks they should perform.\"\n    )\n    documentation: str = \"https://docs.crewai.com/how-to/Hierarchical/\"\n    icon = \"CrewAI\"\n    legacy = True\n    replacement = \"agents.Agent\"\n\n    inputs = [\n        *BaseCrewComponent.get_base_inputs(),\n        HandleInput(name=\"agents\", display_name=\"Agents\", input_types=[\"Agent\"], is_list=True),\n        HandleInput(name=\"tasks\", display_name=\"Tasks\", input_types=[\"HierarchicalTask\"], is_list=True),\n        HandleInput(name=\"manager_llm\", display_name=\"Manager LLM\", input_types=[\"LanguageModel\"], required=False),\n        HandleInput(name=\"manager_agent\", display_name=\"Manager Agent\", input_types=[\"Agent\"], required=False),\n    ]\n\n    def build_crew(self):\n        try:\n            from crewai import Crew, Process\n        except ImportError as e:\n            msg = \"CrewAI is not installed. Please install it with `uv pip install crewai`.\"\n            raise ImportError(msg) from e\n\n        tasks, agents = self.get_tasks_and_agents()\n        manager_llm = self.get_manager_llm()\n\n        return Crew(\n            agents=agents,\n            tasks=tasks,\n            process=Process.hierarchical,\n            verbose=self.verbose,\n            memory=self.memory,\n            cache=self.use_cache,\n            max_rpm=self.max_rpm,\n            share_crew=self.share_crew,\n            function_calling_llm=self.function_calling_llm,\n            manager_agent=self.manager_agent,\n            manager_llm=manager_llm,\n            step_callback=self.get_step_callback(),\n            task_callback=self.get_task_callback(),\n        )\n"
+              "value": "from lfx.base.agents.crewai.crew import BaseCrewComponent\nfrom lfx.io import HandleInput\n\n\nclass HierarchicalCrewComponent(BaseCrewComponent):\n    display_name: str = \"Hierarchical Crew\"\n    description: str = (\n        \"Represents a group of agents, defining how they should collaborate and the tasks they should perform.\"\n    )\n    documentation: str = \"https://docs.crewai.com/how-to/Hierarchical/\"\n    icon = \"CrewAI\"\n    legacy = True\n    replacement = \"agents.Agent\"\n\n    inputs = [\n        *BaseCrewComponent.get_base_inputs(),\n        HandleInput(name=\"agents\", display_name=\"Agents\", input_types=[\"Agent\"], is_list=True),\n        HandleInput(name=\"tasks\", display_name=\"Tasks\", input_types=[\"HierarchicalTask\"], is_list=True),\n        HandleInput(name=\"manager_llm\", display_name=\"Manager LLM\", input_types=[\"LanguageModel\"], required=False),\n        HandleInput(name=\"manager_agent\", display_name=\"Manager Agent\", input_types=[\"Agent\"], required=False),\n    ]\n\n    def build_crew(self):\n        try:\n            from crewai import Crew, Process\n        except ImportError as e:\n            msg = \"CrewAI is not installed. Please install it with `uv pip install crewai`.\"\n            raise ImportError(msg) from e\n\n        tasks, agents = self.get_tasks_and_agents()\n        manager_llm = self.get_manager_llm()\n        manager_agent = self.get_manager_agent()\n\n        return Crew(\n            agents=agents,\n            tasks=tasks,\n            process=Process.hierarchical,\n            verbose=self.verbose,\n            memory=self.memory,\n            cache=self.use_cache,\n            max_rpm=self.max_rpm,\n            share_crew=self.share_crew,\n            function_calling_llm=self.function_calling_llm,\n            manager_agent=manager_agent,\n            manager_llm=manager_llm,\n            step_callback=self.get_step_callback(),\n            task_callback=self.get_task_callback(),\n        )\n"
             },
             "function_calling_llm": {
               "_input_type": "HandleInput",
@@ -30976,6 +30976,6 @@
     "num_components": 127,
     "num_modules": 16
   },
-  "sha256": "5ebb02640116cbbe998805b52b7a11052c83cd51f74ae34bc29a9edc5c68e681",
+  "sha256": "f02b420e10fbc57304dba1e56e1a68ce67edaf53a139bf8860b82a999f7e076f",
   "version": "1.12.0"
 }

--- a/src/lfx/src/lfx/base/agents/crewai/crew.py
+++ b/src/lfx/src/lfx/base/agents/crewai/crew.py
@@ -159,22 +159,57 @@ class BaseCrewComponent(Component):
         # Allow passing a custom list of agents
         if not agents_list:
             agents_list = self.agents or []
+        source_tasks = self.tasks or []
+
+        # CrewAI agents own runtime objects such as locks and HTTP clients, so use
+        # CrewAI's copy APIs instead of deepcopy. Copy each distinct agent once to
+        # preserve shared agent references across tasks.
+        agent_copies_by_id = {}
+        agents_copy = []
+        for agent in agents_list:
+            agent_id = id(agent)
+            if agent_id not in agent_copies_by_id:
+                agent_copies_by_id[agent_id] = agent.copy()
+            agents_copy.append(agent_copies_by_id[agent_id])
+
+        task_mapping = {}
+        tasks = []
+        for task in source_tasks:
+            task_copy = task.copy(agents_copy, task_mapping)
+            if task.agent is not None and id(task.agent) in agent_copies_by_id:
+                task_copy.agent = agent_copies_by_id[id(task.agent)]
+            tasks.append(task_copy)
+            task_mapping[task.key] = task_copy
+
+        # CrewAI performs this second pass in Crew.copy() so context references
+        # point at the copied tasks even when they were reconstructed separately.
+        task_copies_by_id = {id(task): task_copy for task, task_copy in zip(source_tasks, tasks, strict=True)}
+        for task, task_copy in zip(source_tasks, tasks, strict=True):
+            if isinstance(task.context, list):
+                task_copy.context = [task_copies_by_id[id(context_task)] for context_task in task.context]
 
         # Set all the agents llm attribute to the crewai llm
-        for agent in agents_list:
+        for agent in agent_copies_by_id.values():
             # Convert Agent LLM and Tools to proper format
             agent.llm = convert_llm(agent.llm)
             agent.tools = convert_tools(agent.tools)
 
-        return self.tasks, agents_list
+        return tasks, agents_copy
 
     def get_manager_llm(self):
         if not self.manager_llm:
             return None
 
-        self.manager_llm = convert_llm(self.manager_llm)
+        return convert_llm(self.manager_llm)
 
-        return self.manager_llm
+    def get_manager_agent(self):
+        if not getattr(self, "manager_agent", None):
+            return None
+
+        manager_agent = self.manager_agent.copy()
+        manager_agent.llm = convert_llm(manager_agent.llm)
+        manager_agent.tools = convert_tools(manager_agent.tools)
+        return manager_agent
 
     def build_crew(self):
         msg = "build_crew must be implemented in subclasses"

--- a/src/lfx/src/lfx/components/crewai/hierarchical_crew.py
+++ b/src/lfx/src/lfx/components/crewai/hierarchical_crew.py
@@ -29,6 +29,7 @@ class HierarchicalCrewComponent(BaseCrewComponent):
 
         tasks, agents = self.get_tasks_and_agents()
         manager_llm = self.get_manager_llm()
+        manager_agent = self.get_manager_agent()
 
         return Crew(
             agents=agents,
@@ -40,7 +41,7 @@ class HierarchicalCrewComponent(BaseCrewComponent):
             max_rpm=self.max_rpm,
             share_crew=self.share_crew,
             function_calling_llm=self.function_calling_llm,
-            manager_agent=self.manager_agent,
+            manager_agent=manager_agent,
             manager_llm=manager_llm,
             step_callback=self.get_step_callback(),
             task_callback=self.get_task_callback(),

--- a/src/lfx/tests/unit/base/agents/test_crewai_component_isolation.py
+++ b/src/lfx/tests/unit/base/agents/test_crewai_component_isolation.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from threading import Lock
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from lfx.components.crewai.hierarchical_crew import HierarchicalCrewComponent
+from lfx.components.crewai.sequential_crew import SequentialCrewComponent
+
+
+@dataclass
+class FakeAgent:
+    role: str
+    llm: object = None
+    tools: list = field(default_factory=list)
+    runtime_lock: object = field(default_factory=Lock, repr=False, compare=False)
+
+    def copy(self):
+        return type(self)(role=self.role, llm=self.llm, tools=list(self.tools))
+
+
+@dataclass
+class FakeTask:
+    description: str
+    agent: FakeAgent | None
+    context: list[FakeTask] | None = None
+    tools: list = field(default_factory=list)
+
+    @property
+    def key(self) -> str:
+        return self.description
+
+    def copy(self, agents, task_mapping):
+        copied_agent = next((agent for agent in agents if self.agent and agent.role == self.agent.role), None)
+        copied_context = (
+            [task_mapping[context_task.key] for context_task in self.context]
+            if isinstance(self.context, list)
+            else None
+        )
+        return type(self)(
+            description=self.description,
+            agent=copied_agent,
+            context=copied_context,
+            tools=list(self.tools),
+        )
+
+
+@dataclass
+class FakeCrew:
+    agents: list
+    tasks: list
+    manager_agent: FakeAgent | None = None
+    kwargs: dict = field(default_factory=dict)
+
+    def __init__(self, **kwargs):
+        self.agents = kwargs["agents"]
+        self.tasks = kwargs["tasks"]
+        self.manager_agent = kwargs.get("manager_agent")
+        self.kwargs = kwargs
+
+
+@dataclass
+class FakeLLM:
+    model: str
+    api_key: str | None = None
+    api_base: str | None = None
+    extra: dict = field(default_factory=dict)
+
+    def __init__(self, model, api_key=None, api_base=None, **kwargs):
+        self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
+        self.extra = kwargs
+
+
+class FakeToolAdapter:
+    @staticmethod
+    def from_langchain(tool):
+        return {"tool": tool}
+
+
+@pytest.fixture
+def fake_crewai(monkeypatch):
+    crewai_module = ModuleType("crewai")
+    crewai_module.__path__ = []
+    crewai_module.Crew = FakeCrew
+    crewai_module.LLM = FakeLLM
+    crewai_module.Process = SimpleNamespace(sequential="sequential", hierarchical="hierarchical")
+
+    tools_module = ModuleType("crewai.tools")
+    tools_module.__path__ = []
+    base_tool_module = ModuleType("crewai.tools.base_tool")
+    base_tool_module.Tool = FakeToolAdapter
+    task_module = ModuleType("crewai.task")
+    task_module.TaskOutput = type("TaskOutput", (), {})
+
+    monkeypatch.setitem(sys.modules, "crewai", crewai_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools", tools_module)
+    monkeypatch.setitem(sys.modules, "crewai.tools.base_tool", base_tool_module)
+    monkeypatch.setitem(sys.modules, "crewai.task", task_module)
+
+
+def test_sequential_build_crew_returns_fresh_agents_and_tasks(fake_crewai):  # noqa: ARG001
+    agent = FakeAgent(role="researcher", tools=["tool-a"])
+    same_role_agent = FakeAgent(role="researcher", tools=["tool-c"])
+    first_task = FakeTask(description="research", agent=agent)
+    second_task = FakeTask(description="answer", agent=agent, context=[first_task])
+    third_task = FakeTask(description="review", agent=same_role_agent, context=[second_task])
+    component = SequentialCrewComponent()
+    component.tasks = [first_task, second_task, third_task]
+    component.memory = True
+    component.use_cache = True
+    component.max_rpm = 10
+    component.share_crew = False
+    component.function_calling_llm = None
+    component.verbose = 0
+
+    crew_one = component.build_crew()
+    crew_two = component.build_crew()
+
+    assert crew_one.agents[0] is crew_one.agents[1]
+    assert crew_one.agents[0] is not crew_one.agents[2]
+    assert crew_one.agents[0] is not crew_two.agents[0]
+    assert crew_one.tasks[0] is not crew_two.tasks[0]
+    assert crew_one.tasks[0].agent is crew_one.agents[0]
+    assert crew_one.tasks[1].agent is crew_one.agents[0]
+    assert crew_one.tasks[2].agent is crew_one.agents[2]
+    assert crew_one.tasks[1].context == [crew_one.tasks[0]]
+    assert crew_one.tasks[2].context == [crew_one.tasks[1]]
+    assert crew_two.tasks[1].context == [crew_two.tasks[0]]
+
+    crew_one.agents[0].tools.append("tool-b")
+    crew_one.tasks[0].description = "changed"
+
+    assert crew_two.agents[0].tools == [{"tool": "tool-a"}]
+    assert crew_two.tasks[0].description == "research"
+    assert agent.tools == ["tool-a"]
+    assert first_task.agent is agent
+    assert second_task.context == [first_task]
+
+
+def test_hierarchical_build_crew_returns_fresh_manager_agent(fake_crewai):  # noqa: ARG001
+    worker = FakeAgent(role="worker", tools=["tool-a"])
+    manager = FakeAgent(role="manager", tools=["tool-b"])
+    task = FakeTask(description="plan", agent=worker)
+    component = HierarchicalCrewComponent()
+    component.agents = [worker]
+    component.tasks = [task]
+    component.manager_agent = manager
+    component.manager_llm = None
+    component.memory = False
+    component.use_cache = True
+    component.max_rpm = 10
+    component.share_crew = False
+    component.function_calling_llm = None
+    component.verbose = 0
+
+    crew_one = component.build_crew()
+    crew_two = component.build_crew()
+
+    assert crew_one.manager_agent is not crew_two.manager_agent
+    assert crew_one.manager_agent is not manager
+
+    crew_one.manager_agent.tools.append("tool-c")
+
+    assert crew_two.manager_agent.tools == [{"tool": "tool-b"}]
+    assert manager.tools == ["tool-b"]
+
+
+def test_real_crewai_agent_with_rpm_lock_can_be_copied(monkeypatch):
+    crewai = pytest.importorskip("crewai", reason="crewai is an optional dependency")
+    monkeypatch.setattr("lfx.base.agents.crewai.crew.convert_llm", lambda llm: llm)
+    monkeypatch.setattr("lfx.base.agents.crewai.crew.convert_tools", lambda tools: list(tools or []))
+
+    agent = crewai.Agent(
+        role="researcher",
+        goal="research",
+        backstory="researcher",
+        llm="gpt-4o-mini",
+        max_rpm=7,
+    )
+    task = crewai.Task(description="answer", expected_output="answer", agent=agent)
+    component = SequentialCrewComponent()
+    component.tasks = [task]
+    component.memory = False
+    component.use_cache = True
+    component.max_rpm = 10
+    component.share_crew = False
+    component.function_calling_llm = None
+    component.verbose = 0
+
+    crew_one = component.build_crew()
+    crew_two = component.build_crew()
+
+    assert crew_one.agents[0] is not crew_two.agents[0]
+    assert crew_one.agents[0] is not agent
+    assert crew_one.tasks[0].agent is crew_one.agents[0]
+    assert crew_two.tasks[0].agent is crew_two.agents[0]
+    assert crew_one.agents[0].max_rpm == 7


### PR DESCRIPTION
Addresses the agent/task runtime-state reuse portion of #13846.

## Background

CrewAI mutates `Agent` and `Task` instances while constructing and running a `Crew` (for example, by attaching cache and RPM runtime handlers). If the same built objects reach `build_crew()` again—such as through a repeated build on one graph or a frozen-output cache—the two crews can share that mutable runtime state.

Normal API flow execution constructs a fresh graph and component instance per request, so this PR does not rely on or claim universal component-instance reuse across requests. It isolates the mutable CrewAI objects at the boundary where Langflow hands them to `Crew(...)`.

## Root cause

`BaseCrewComponent.get_tasks_and_agents()` returned component-owned `Task` instances and mutated component-owned `Agent` instances in place. `HierarchicalCrewComponent.build_crew()` also passed `self.manager_agent` directly. A later crew construction could therefore replace runtime handlers that an earlier crew still referenced.

Generic `deepcopy` is not safe here: valid CrewAI agents with `max_rpm` contain thread locks and fail with `TypeError: cannot pickle '_thread.lock' object`.

## Changes

- Use CrewAI's supported `Agent.copy()` and `Task.copy()` APIs instead of generic `deepcopy`
- Copy each source agent once per build so repeated agent references remain aliases
- Restore task-to-agent links by source identity (CrewAI's task copy matches agents by role) and remap task contexts to copied tasks
- Copy the hierarchical manager agent and avoid mutating `self.manager_llm`
- Add scoped regression tests for repeated sequential and hierarchical builds, duplicate agent references, task contexts, manager isolation, source-object preservation, and lock-bearing real CrewAI agents
- Regenerate the component index from the `release-1.12.0` baseline

## Memory scope

Langflow's `memory` input here is a boolean. CrewAI creates fresh in-memory wrapper objects when a new `Crew` is constructed, so there is no memory object on this component to copy. CrewAI's persistent memory storage/scope can still be shared by its own defaults; request/user/flow namespacing for that storage is separate work and is not claimed by this PR.

## Release target

The branch is rebuilt directly on the live `release-1.12.0` head. Its release diff is limited to the two CrewAI source files, the focused regression test, and the generated component index.

## Verification

- `ruff check` on the changed Python files
- `30 passed, 1 skipped` for the new regression tests plus component-index tests (the optional real-CrewAI pytest is skipped when CrewAI is not installed)
- Copy-path compatibility repro passes with CrewAI `0.126.0` and `1.15.10`, including lock-bearing agents/managers, same-role agent mapping, and task-context mapping
