### PR TITLE
fix: authz flow permission gates

### DIFF
--- a/src/backend/base/langflow/alembic/versions/4f0d2c9a8b7e_backfill_flow_create_system_roles.py
+++ b/src/backend/base/langflow/alembic/versions/4f0d2c9a8b7e_backfill_flow_create_system_roles.py
@@ -82,21 +82,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    if not migration.table_exists("authz_role", conn):
-        return
-
-    authz_role = _authz_role_table()
-    for role_name in _ROLE_NAMES:
-        row = conn.execute(
-            sa.select(authz_role.c.permissions)
-            .where(authz_role.c.name == role_name)
-            .where(authz_role.c.is_system.is_(True))
-        ).first()
-        if row is None:
-            continue
-
-        permissions = [
-            permission for permission in _permission_list(row.permissions) if permission != _FLOW_CREATE_PERMISSION
-        ]
-        _set_permissions(conn, role_name, permissions)
+    # This data backfill is intentionally irreversible: after upgrade runs,
+    # there is no durable way to distinguish permissions that predated this
+    # migration from permissions appended by it.
+    return

--- a/src/backend/base/langflow/alembic/versions/4f0d2c9a8b7e_backfill_flow_create_system_roles.py
+++ b/src/backend/base/langflow/alembic/versions/4f0d2c9a8b7e_backfill_flow_create_system_roles.py
@@ -1,0 +1,102 @@
+"""Backfill flow:create on built-in system roles.
+
+Revision ID: 4f0d2c9a8b7e
+Revises: b7c4d8e9f012
+Create Date: 2026-06-26
+
+Phase: MIGRATE
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "4f0d2c9a8b7e"  # pragma: allowlist secret
+down_revision: str | None = "b7c4d8e9f012"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FLOW_CREATE_PERMISSION = "flow:create"
+_ROLE_NAMES = ("developer", "admin")
+
+
+def _authz_role_table():
+    return sa.table(
+        "authz_role",
+        sa.column("name", sa.String()),
+        sa.column("is_system", sa.Boolean()),
+        sa.column("permissions", sa.JSON()),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def _permission_list(raw_permissions: Any) -> list[str]:
+    if raw_permissions is None:
+        return []
+    if isinstance(raw_permissions, str):
+        raw_permissions = json.loads(raw_permissions)
+    return list(raw_permissions)
+
+
+def _set_permissions(conn: sa.Connection, role_name: str, permissions: list[str]) -> None:
+    authz_role = _authz_role_table()
+    conn.execute(
+        authz_role.update()
+        .where(authz_role.c.name == role_name)
+        .where(authz_role.c.is_system.is_(True))
+        .values(
+            permissions=permissions,
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not migration.table_exists("authz_role", conn):
+        return
+
+    authz_role = _authz_role_table()
+    for role_name in _ROLE_NAMES:
+        row = conn.execute(
+            sa.select(authz_role.c.permissions)
+            .where(authz_role.c.name == role_name)
+            .where(authz_role.c.is_system.is_(True))
+        ).first()
+        if row is None:
+            continue
+
+        permissions = _permission_list(row.permissions)
+        if _FLOW_CREATE_PERMISSION in permissions:
+            continue
+        _set_permissions(conn, role_name, [*permissions, _FLOW_CREATE_PERMISSION])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if not migration.table_exists("authz_role", conn):
+        return
+
+    authz_role = _authz_role_table()
+    for role_name in _ROLE_NAMES:
+        row = conn.execute(
+            sa.select(authz_role.c.permissions)
+            .where(authz_role.c.name == role_name)
+            .where(authz_role.c.is_system.is_(True))
+        ).first()
+        if row is None:
+            continue
+
+        permissions = [
+            permission for permission in _permission_list(row.permissions) if permission != _FLOW_CREATE_PERMISSION
+        ]
+        _set_permissions(conn, role_name, permissions)

--- a/src/backend/base/langflow/api/v1/authz_route_dependencies.py
+++ b/src/backend/base/langflow/api/v1/authz_route_dependencies.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, status
 
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.v1.flows_helpers import _read_flow
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.database.models.flow.model import Flow, FlowCreate
+
+_FLOW_WRITE_DENIED_DETAIL = "You don't have permission to edit this flow."
 
 
 async def _get_authorized_flow(
@@ -35,6 +37,19 @@ async def _get_authorized_flow(
             folder_id=flow.folder_id,
         )
     except HTTPException as exc:
+        if act == FlowAction.WRITE and exc.status_code == status.HTTP_403_FORBIDDEN:
+            try:
+                await ensure_flow_permission(
+                    current_user,
+                    FlowAction.READ,
+                    flow_id=flow_id,
+                    flow_user_id=flow.user_id,
+                    workspace_id=flow.workspace_id,
+                    folder_id=flow.folder_id,
+                )
+            except HTTPException as read_exc:
+                raise deny_to_404(read_exc, detail="Flow not found") from read_exc
+            raise HTTPException(status_code=403, detail=_FLOW_WRITE_DENIED_DETAIL) from exc
         raise deny_to_404(exc, detail="Flow not found") from exc
     return flow
 

--- a/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
+++ b/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
@@ -8,7 +8,8 @@ and exercise the *real* flow routes over HTTP, validating that:
 
 * the per-route guards (``ensure_flow_permission`` via the ``Authorized*Flow``
   dependencies) actually gate read/write/delete/create/execute by role,
-* cross-user denials are masked as 404 (not 403) on fetch routes,
+* cross-user denials are masked as 404 (not 403) on fetch routes, while
+  write denials on readable flows return an explicit 403,
 * the share-aware fetch + ``authz_share`` rows grant cross-user access, and
 * domain resolution (``_resolve_authz_domain``) scopes a domain-bound grant.
 
@@ -110,9 +111,10 @@ async def test_viewer_can_read_and_execute_but_not_write_delete_or_create(client
         # execute (build) -> allowed (viewer has flow:execute)
         build = await client.post(f"api/v1/build/{flow_id}/flow", headers=headers, json={})
         assert build.status_code == 200, build.text
-        # write -> denied, masked as 404 (NOT 403) on a fetch route
+        # write -> denied, but the flow is readable so return an edit-permission 403.
         patch = await client.patch(f"api/v1/flows/{flow_id}", headers=headers, json={"name": f"x_{uuid4().hex}"})
-        assert patch.status_code == 404
+        assert patch.status_code == 403
+        assert patch.json()["detail"] == "You don't have permission to edit this flow."
         # delete -> denied, masked as 404
         assert (await client.delete(f"api/v1/flows/{flow_id}", headers=headers)).status_code == 404
         # create -> denied; 403 is correct here (no existing resource UUID to protect)
@@ -224,9 +226,11 @@ async def test_read_only_share_allows_get_but_denies_write_and_execute(client):
 
     with install_policy_authz(settings):
         assert (await client.get(f"api/v1/flows/{flow_id}", headers=bob_headers)).status_code == 200
-        # write is not granted by a read-level share -> deny -> 404
+        # write is not granted by a read-level share, but the flow is readable
+        # so return an edit-permission 403 instead of a "not found" mask.
         patch = await client.patch(f"api/v1/flows/{flow_id}", headers=bob_headers, json={"name": "nope"})
-        assert patch.status_code == 404
+        assert patch.status_code == 403
+        assert patch.json()["detail"] == "You don't have permission to edit this flow."
         # execute is modeled independently from write — a read-level share must
         # not grant build either -> deny -> 404
         build = await client.post(f"api/v1/build/{flow_id}/flow", headers=bob_headers, json={})

--- a/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
@@ -219,6 +219,36 @@ describe("useAutoSaveFlow", () => {
     expect(mockSaveFlow).not.toHaveBeenCalled();
   });
 
+  it("should flush a pending autosave after permissions finish loading", () => {
+    let isLoading = true;
+    const can = jest.fn(() => true);
+    (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
+      (selector) => {
+        const state = {
+          autoSaving: true,
+          autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
+        };
+        return selector(state);
+      },
+    );
+    mockUsePermissions.mockImplementation(() => ({
+      can,
+      isLoading,
+    }));
+
+    const { result, rerender } = renderHook(() => useAutoSaveFlow());
+    const mockFlow = makeMockFlow();
+    result.current(mockFlow);
+    expect(mockSaveFlow).not.toHaveBeenCalled();
+
+    isLoading = false;
+    rerender();
+
+    expect(can).toHaveBeenCalledWith("flow-1", "write");
+    expect(mockSaveFlow).toHaveBeenCalledWith(mockFlow);
+  });
+
   it("should not call saveFlow when write permission is denied", () => {
     const can = jest.fn(() => false);
     (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(

--- a/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
@@ -1,13 +1,25 @@
 import { renderHook } from "@testing-library/react";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
+import type { FlowType } from "@/types/flow";
 import { useDebounce } from "../../use-debounce";
 import useAutoSaveFlow from "../use-autosave-flow";
 import useSaveFlow from "../use-save-flow";
+
+const mockUsePermissions = jest.fn();
+
+const makeMockFlow = (): FlowType =>
+  ({
+    id: "flow-1",
+    name: "Test Flow",
+  }) as FlowType;
 
 // Mock dependencies
 jest.mock("../use-save-flow");
 jest.mock("../../use-debounce");
 jest.mock("@/stores/flowsManagerStore");
+jest.mock("@/contexts/permissionsContext", () => ({
+  usePermissions: () => mockUsePermissions(),
+}));
 
 describe("useAutoSaveFlow", () => {
   const mockSaveFlow = jest.fn();
@@ -21,6 +33,10 @@ describe("useAutoSaveFlow", () => {
       mockDebouncedFn.mockImplementation(fn);
       return mockDebouncedFn;
     });
+    mockUsePermissions.mockReturnValue({
+      can: jest.fn(() => true),
+      isLoading: false,
+    });
   });
 
   it("should return a debounced autosave function", () => {
@@ -29,6 +45,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: true,
           autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -46,6 +63,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: true,
           autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -54,7 +72,7 @@ describe("useAutoSaveFlow", () => {
     const { result } = renderHook(() => useAutoSaveFlow());
     const autoSaveFlow = result.current;
 
-    const mockFlow = { id: "flow-1", name: "Test Flow" } as any;
+    const mockFlow = makeMockFlow();
     autoSaveFlow(mockFlow);
 
     expect(mockSaveFlow).toHaveBeenCalledWith(mockFlow);
@@ -66,6 +84,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: false,
           autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -74,7 +93,7 @@ describe("useAutoSaveFlow", () => {
     const { result } = renderHook(() => useAutoSaveFlow());
     const autoSaveFlow = result.current;
 
-    const mockFlow = { id: "flow-1", name: "Test Flow" } as any;
+    const mockFlow = makeMockFlow();
     autoSaveFlow(mockFlow);
 
     expect(mockSaveFlow).not.toHaveBeenCalled();
@@ -86,6 +105,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: true,
           autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -107,6 +127,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: true,
           autoSavingInterval: customInterval,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -131,6 +152,7 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving: true,
           autoSavingInterval: 10000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
@@ -152,13 +174,14 @@ describe("useAutoSaveFlow", () => {
         const state = {
           autoSaving,
           autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
         };
         return selector(state);
       },
     );
 
     const { result, rerender } = renderHook(() => useAutoSaveFlow());
-    const mockFlow = { id: "flow-1", name: "Test Flow" } as any;
+    const mockFlow = makeMockFlow();
 
     // AutoSaving enabled
     result.current(mockFlow);
@@ -171,6 +194,52 @@ describe("useAutoSaveFlow", () => {
     rerender();
 
     result.current(mockFlow);
+    expect(mockSaveFlow).not.toHaveBeenCalled();
+  });
+
+  it("should not call saveFlow while permissions are loading", () => {
+    (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
+      (selector) => {
+        const state = {
+          autoSaving: true,
+          autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
+        };
+        return selector(state);
+      },
+    );
+    mockUsePermissions.mockReturnValue({
+      can: jest.fn(() => true),
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useAutoSaveFlow());
+    result.current(makeMockFlow());
+
+    expect(mockSaveFlow).not.toHaveBeenCalled();
+  });
+
+  it("should not call saveFlow when write permission is denied", () => {
+    const can = jest.fn(() => false);
+    (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
+      (selector) => {
+        const state = {
+          autoSaving: true,
+          autoSavingInterval: 3000,
+          currentFlowId: "flow-1",
+        };
+        return selector(state);
+      },
+    );
+    mockUsePermissions.mockReturnValue({
+      can,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useAutoSaveFlow());
+    result.current(makeMockFlow());
+
+    expect(can).toHaveBeenCalledWith("flow-1", "write");
     expect(mockSaveFlow).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/hooks/flows/use-autosave-flow.ts
+++ b/src/frontend/src/hooks/flows/use-autosave-flow.ts
@@ -1,12 +1,19 @@
+import { useEffect, useRef } from "react";
 import { usePermissions } from "@/contexts/permissionsContext";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import type { FlowType } from "@/types/flow";
 import { useDebounce } from "../use-debounce";
 import useSaveFlow from "./use-save-flow";
 
+type PendingAutoSave = {
+  flow?: FlowType;
+  flowId: string | undefined;
+};
+
 const useAutoSaveFlow = () => {
   const { can, isLoading } = usePermissions();
   const saveFlow = useSaveFlow();
+  const pendingAutoSaveRef = useRef<PendingAutoSave | null>(null);
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
   const autoSavingInterval = useFlowsManagerStore(
     (state) => state.autoSavingInterval,
@@ -15,10 +22,36 @@ const useAutoSaveFlow = () => {
 
   const autoSaveFlow = useDebounce((flow?: FlowType) => {
     const flowId = flow?.id ?? currentFlowId;
-    if (autoSaving && !isLoading && can(flowId, "write")) {
+    if (!autoSaving) {
+      pendingAutoSaveRef.current = null;
+      return;
+    }
+    if (isLoading) {
+      pendingAutoSaveRef.current = { flow, flowId };
+      return;
+    }
+    if (can(flowId, "write")) {
+      pendingAutoSaveRef.current = null;
       saveFlow(flow);
     }
   }, autoSavingInterval);
+
+  useEffect(() => {
+    const pendingAutoSave = pendingAutoSaveRef.current;
+    if (!pendingAutoSave || isLoading) {
+      return;
+    }
+    if (!autoSaving) {
+      pendingAutoSaveRef.current = null;
+      return;
+    }
+    const flowId =
+      pendingAutoSave.flowId ?? pendingAutoSave.flow?.id ?? currentFlowId;
+    if (can(flowId, "write")) {
+      pendingAutoSaveRef.current = null;
+      saveFlow(pendingAutoSave.flow);
+    }
+  }, [autoSaving, can, currentFlowId, isLoading, saveFlow]);
 
   return autoSaveFlow;
 };

--- a/src/frontend/src/hooks/flows/use-autosave-flow.ts
+++ b/src/frontend/src/hooks/flows/use-autosave-flow.ts
@@ -1,17 +1,21 @@
+import { usePermissions } from "@/contexts/permissionsContext";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import type { FlowType } from "@/types/flow";
 import { useDebounce } from "../use-debounce";
 import useSaveFlow from "./use-save-flow";
 
 const useAutoSaveFlow = () => {
+  const { can, isLoading } = usePermissions();
   const saveFlow = useSaveFlow();
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
   const autoSavingInterval = useFlowsManagerStore(
     (state) => state.autoSavingInterval,
   );
+  const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
 
   const autoSaveFlow = useDebounce((flow?: FlowType) => {
-    if (autoSaving) {
+    const flowId = flow?.id ?? currentFlowId;
+    if (autoSaving && !isLoading && can(flowId, "write")) {
       saveFlow(flow);
     }
   }, autoSavingInterval);

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -9,6 +9,7 @@ import {
   SimpleSidebar,
   SimpleSidebarProvider,
 } from "@/components/ui/simple-sidebar";
+import { PermissionsProvider } from "@/contexts/permissionsContext";
 import { useGetFlow } from "@/controllers/API/queries/flows/use-get-flow";
 import { useGetTypes } from "@/controllers/API/queries/flows/use-get-types";
 import { ENABLE_NEW_SIDEBAR } from "@/customization/feature-flags";
@@ -341,10 +342,20 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
                     )}
                   >
                     <div className="h-full w-full">
-                      <FlowPageMainContent
-                        flowId={id}
-                        setIsLoading={setIsLoading}
-                      />
+                      <PermissionsProvider
+                        resourceType="flow"
+                        resourceIds={currentFlow?.id ? [currentFlow.id] : []}
+                        domain={
+                          currentFlow?.folder_id
+                            ? `project:${currentFlow.folder_id}`
+                            : undefined
+                        }
+                      >
+                        <FlowPageMainContent
+                          flowId={id}
+                          setIsLoading={setIsLoading}
+                        />
+                      </PermissionsProvider>
                     </div>
                   </main>
                 </FlowSearchProvider>


### PR DESCRIPTION
## Summary

- backfill `flow:create` onto existing developer/admin system roles so enforced installs can create flows after the original seed has already run
- return an explicit 403 edit-permission error when a user can read a flow but cannot write it
- wrap the flow canvas in the permission provider and suppress autosave while write permission is loading or denied

## Tests

- `uv run ruff check src/backend/base/langflow/api/v1/authz_route_dependencies.py src/backend/base/langflow/alembic/versions/4f0d2c9a8b7e_backfill_flow_create_system_roles.py src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py`
- `uv run pytest src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py`
- `npm run check-format -- src/hooks/flows/use-autosave-flow.ts src/hooks/flows/__tests__/use-autosave-flow.test.ts src/pages/FlowPage/index.tsx`
- `npm test -- src/hooks/flows/__tests__/use-autosave-flow.test.ts --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flow pages now use permission-aware access for the current flow, improving how editing and viewing rights are applied.
  * Autosave now respects permission checks before saving changes.

* **Bug Fixes**
  * Users without write access to a readable flow now see a clear permission denied message instead of a “not found” response.
  * Autosave no longer runs while permissions are still loading or when write access is denied.

* **Tests**
  * Updated coverage to reflect the new permission and autosave behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->