### PR TITLE
fix(lfx): read local files under S3 storage to unblock the Assistant

### DIFF
--- a/src/lfx/src/lfx/base/data/storage_utils.py
+++ b/src/lfx/src/lfx/base/data/storage_utils.py
@@ -24,6 +24,26 @@ if TYPE_CHECKING:
 EXPECTED_PATH_PARTS = 2  # Path format: "flow_id/filename"
 
 
+def _is_existing_local_file(file_path: str) -> bool:
+    """Return True when file_path is an absolute path to a real local file.
+
+    Under S3 storage some callers still hand us genuine local paths (e.g. the
+    Langflow Assistant injects the installed lfx components dir into a Directory
+    node). A real local file is never an S3 key, so it must be read from disk
+    instead of being parsed as "flow_id/filename". See issue #13798.
+
+    The check is restricted to ABSOLUTE paths on purpose: S3 keys are always
+    relative ("flow_id/filename"), so requiring an absolute path makes it
+    impossible to mistake a relative S3 key for a same-named file that happens
+    to exist relative to the process CWD.
+    """
+    try:
+        path_obj = Path(file_path)
+        return path_obj.is_absolute() and path_obj.is_file()
+    except OSError:
+        return False
+
+
 def parse_storage_path(path: str) -> tuple[str, str] | None:
     """Parse a storage service path into flow_id and filename.
 
@@ -68,6 +88,9 @@ async def read_file_bytes(
     settings = get_settings_service().settings
 
     if settings.storage_type == "s3":
+        if _is_existing_local_file(file_path):
+            return Path(file_path).read_bytes()
+
         parsed = parse_storage_path(file_path)
         if not parsed:
             msg = f"Invalid S3 path format: {file_path}. Expected 'flow_id/filename'"
@@ -154,6 +177,9 @@ def get_file_size(file_path: str, storage_service: StorageService | None = None)
     settings = get_settings_service().settings
 
     if settings.storage_type == "s3":
+        if _is_existing_local_file(file_path):
+            return Path(file_path).stat().st_size
+
         parsed = parse_storage_path(file_path)
         if not parsed:
             msg = f"Invalid S3 path format: {file_path}. Expected 'flow_id/filename'"

--- a/src/lfx/tests/unit/base/data/test_storage_utils.py
+++ b/src/lfx/tests/unit/base/data/test_storage_utils.py
@@ -143,6 +143,58 @@ class TestReadFileBytes:
 
         mock_storage.get_file.assert_called_once_with("flow_456", "subdir1/subdir2/file.txt")
 
+    async def test_should_read_existing_local_file_when_storage_type_is_s3(self, tmp_path):
+        """Regression for #13798: a real local file must be read from disk under S3 mode.
+
+        The Langflow Assistant injects an absolute local path (the installed lfx
+        components dir) into a Directory node. That path is not an S3 key, so the
+        S3 reader must fall back to a local read instead of raising
+        "Invalid S3 path format".
+        """
+        test_file = tmp_path / "_importing.py"
+        test_content = b"x = 1\n"
+        test_file.write_bytes(test_content)
+
+        mock_settings = Mock()
+        mock_settings.settings.storage_type = "s3"
+
+        mock_storage = AsyncMock()
+
+        with (
+            patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings),
+            patch("lfx.base.data.storage_utils.get_storage_service", return_value=mock_storage),
+        ):
+            content = await read_file_bytes(str(test_file))
+
+        assert content == test_content
+        mock_storage.get_file.assert_not_called()
+
+    async def test_should_route_relative_key_to_s3_even_if_cwd_file_collides(self, tmp_path, monkeypatch):
+        """A relative S3 key must always go to S3, never to a same-named CWD file.
+
+        S3 keys are relative ("flow_id/filename"). The local-file short-circuit is
+        absolute-only so a coincidental file under the process CWD can never hijack
+        a legitimate S3 fetch (#13798 hardening).
+        """
+        (tmp_path / "flow_123").mkdir()
+        (tmp_path / "flow_123" / "test.txt").write_bytes(b"local decoy")
+        monkeypatch.chdir(tmp_path)
+
+        mock_settings = Mock()
+        mock_settings.settings.storage_type = "s3"
+
+        mock_storage = AsyncMock()
+        mock_storage.get_file.return_value = b"from s3"
+
+        with (
+            patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings),
+            patch("lfx.base.data.storage_utils.get_storage_service", return_value=mock_storage),
+        ):
+            content = await read_file_bytes("flow_123/test.txt")
+
+        assert content == b"from s3"
+        mock_storage.get_file.assert_called_once_with("flow_123", "test.txt")
+
 
 @pytest.mark.asyncio
 class TestReadFileText:
@@ -193,6 +245,26 @@ class TestReadFileText:
 
         assert content == expected_content
 
+    async def test_should_read_existing_local_text_file_when_storage_type_is_s3(self, tmp_path):
+        """Regression for #13798: read_file_text must read a real local file under S3 mode."""
+        test_file = tmp_path / "notes.txt"
+        test_content = "hello from disk"
+        test_file.write_text(test_content, encoding="utf-8")
+
+        mock_settings = Mock()
+        mock_settings.settings.storage_type = "s3"
+
+        mock_storage = AsyncMock()
+
+        with (
+            patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings),
+            patch("lfx.base.data.storage_utils.get_storage_service", return_value=mock_storage),
+        ):
+            content = await read_file_text(str(test_file))
+
+        assert content == test_content
+        mock_storage.get_file.assert_not_called()
+
 
 class TestGetFileSize:
     """Test get_file_size function."""
@@ -219,6 +291,25 @@ class TestGetFileSize:
         with patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings):  # noqa: SIM117
             with pytest.raises(FileNotFoundError):
                 get_file_size("/nonexistent/file.txt")
+
+    def test_should_get_existing_local_file_size_when_storage_type_is_s3(self, tmp_path):
+        """Regression for #13798: get_file_size must stat a real local file under S3 mode."""
+        test_file = tmp_path / "sized.txt"
+        test_file.write_bytes(b"X" * 1234)
+
+        mock_settings = Mock()
+        mock_settings.settings.storage_type = "s3"
+
+        mock_storage = AsyncMock()
+
+        with (
+            patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings),
+            patch("lfx.base.data.storage_utils.get_storage_service", return_value=mock_storage),
+        ):
+            size = get_file_size(str(test_file))
+
+        assert size == 1234
+        mock_storage.get_file_size.assert_not_called()
 
     def test_get_s3_file_size(self):
         """Test getting size of S3 file."""

--- a/src/lfx/tests/unit/base/data/test_utils.py
+++ b/src/lfx/tests/unit/base/data/test_utils.py
@@ -1,6 +1,6 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from lfx.base.data.utils import read_text_file
+from lfx.base.data.utils import parse_text_file_to_data, read_text_file
 
 
 class TestReadTextFile:
@@ -48,3 +48,30 @@ class TestReadTextFile:
         # Should not raise, should fall back to latin-1
         result = read_text_file(str(f))
         assert len(result) == 128
+
+
+class TestParseTextFileToDataS3Mode:
+    """Regression tests for issue #13798.
+
+    When S3 storage is configured, reading a real local file (e.g. the bundled
+    lfx components directory the Langflow Assistant scans) must still read from
+    disk instead of being forced through the S3 key parser.
+    """
+
+    def test_should_read_existing_local_file_when_storage_type_is_s3(self, tmp_path):
+        """A real local file on disk must be read locally even when storage_type is s3."""
+        local_file = tmp_path / "_importing.py"
+        local_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_settings = Mock()
+        mock_settings.settings.storage_type = "s3"
+
+        with (
+            patch("lfx.base.data.utils.get_settings_service", return_value=mock_settings),
+            patch("lfx.base.data.storage_utils.get_settings_service", return_value=mock_settings),
+        ):
+            result = parse_text_file_to_data(str(local_file), silent_errors=False)
+
+        assert result is not None
+        assert result.data["text"] == "x = 1\n"
+        assert result.data["file_path"] == str(local_file)


### PR DESCRIPTION
## What

When `LANGFLOW_STORAGE_TYPE=s3` is configured, the storage-aware file readers (`read_file_bytes`, `read_file_text`, and `get_file_size`) incorrectly routed **every** path through the S3 key parser, including genuine local filesystem paths.

As a result, attempting to read an absolute local path raised:

```text
ValueError: Invalid S3 path format: /app/.venv/.../lfx/components/_importing.py.
Expected 'flow_id/filename'
```

This broke the **Langflow Assistant**. It injects the installed `lfx` components directory into a `Directory` node (`inject_lfx_components_path`), which scans the local filesystem and passes absolute file paths to `parse_text_file_to_data()`. Since those paths were incorrectly treated as S3 object keys, the read failed with:

```text
Error building Component Directory
```

Fixes #13798.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local files can now be read and sized correctly even when storage is set to S3.
  * Absolute file paths are treated as local files, preventing invalid S3 path errors.
  * S3-style relative file keys still route to storage correctly and won’t be mistaken for local files.
  * Text parsing now works consistently for existing local files in S3 mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->