### PR TITLE
fix: handle invalid session auth tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4882,7 +4882,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 99,
         "is_secret": false
       },
       {
@@ -4890,7 +4890,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 115,
         "is_secret": false
       }
     ],

--- a/src/backend/tests/unit/services/telemetry_writer/test_service.py
+++ b/src/backend/tests/unit/services/telemetry_writer/test_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import tempfile
+import warnings
 from pathlib import Path
 from uuid import uuid4
 
@@ -340,6 +341,21 @@ async def test_flush_inserts_transactions_and_vertex_builds(writer_with_engine) 
     # Sweeper-driven retention requires dirty-flow tracking; flush populates it.
     assert str(flow_id) in writer._dirty_tx_flows
     assert str(flow_id) in writer._dirty_vb_flows
+
+
+async def test_flush_and_retention_do_not_emit_deprecated_session_execute_warning(writer_with_engine) -> None:
+    writer, _ = writer_with_engine
+    writer.settings_service.settings.max_transactions_to_keep = 1
+    writer.settings_service.settings.max_vertex_builds_to_keep = 1
+    flow_id = uuid4()
+
+    tx_batch = [_make_transaction_row(flow_id) for _ in range(3)]
+    vb_batch = [_make_vertex_build_row(flow_id, vertex_id="v1") for _ in range(3)]
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="(?s).*session\\.exec\\(\\).*", category=DeprecationWarning)
+        await writer._flush(tx_batch, vb_batch)
+        await writer._run_retention_pass()
 
 
 async def test_retention_sweep_caps_transactions_per_flow(writer_with_engine) -> None:

--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import jwt
 import pytest
+from langflow.services.auth.exceptions import InvalidTokenError
 from langflow.services.database.models.auth import SSOUserProfile
 from langflow.services.database.models.user import User
 from langflow.services.deps import get_auth_service, get_settings_service, session_scope
@@ -118,6 +120,21 @@ async def test_login_unsuccessful_wrong_password(client, test_user, async_sessio
 async def test_session_endpoint_unauthenticated(client):
     """Test /session endpoint returns authenticated=False for unauthenticated requests."""
     response = await client.get("api/v1/session")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["authenticated"] is False
+    assert data["user"] is None
+    assert data["store_api_key"] is None
+
+
+async def test_session_endpoint_invalid_token_returns_unauthenticated(client):
+    """Test /session endpoint handles invalid tokens as unauthenticated sessions."""
+    auth_service = AsyncMock()
+    auth_service.get_current_user_from_access_token.side_effect = InvalidTokenError("Invalid token")
+
+    with patch("langflow.api.v1.login.get_auth_service", return_value=auth_service):
+        response = await client.get("api/v1/session", headers={"Authorization": "Bearer invalid-token"})
+
     assert response.status_code == 200
     data = response.json()
     assert data["authenticated"] is False


### PR DESCRIPTION
## Summary

- cherry-picks the invalid-session-token regression coverage from #13823 onto `release-1.11.0`
- keeps the existing `release-1.11.0` runtime handler in `login.py`, which already catches `AuthenticationError`
- adds adapted telemetry writer warning coverage from #13821
- updates `.secrets.baseline` line numbers for the current release test file

## Notes

The original PR's generated `component_index.json` change was from the older 1.10.x asset set, so the conflict was resolved by keeping the current `release-1.11.0` asset.

The telemetry writer service change from #13821 is already superseded on `release-1.11.0` by #13845, which switches the writer to SQLAlchemy `AsyncSession`. This PR keeps that implementation and carries over the warning regression coverage so the release branch stays protected.

## Testing

- `uv run ruff check src/backend/base/langflow/api/v1/login.py src/backend/tests/unit/test_login.py`
- `uv run ruff check src/backend/base/langflow/api/v1/login.py src/backend/tests/unit/test_login.py src/backend/base/langflow/services/telemetry_writer/service.py src/backend/tests/unit/services/telemetry_writer/test_service.py`
- `uv run pytest src/backend/tests/unit/test_login.py -q`
- `uv run pytest src/backend/tests/unit/services/telemetry_writer/test_service.py -q`
