### PR TITLE
ci: serialize starter project template shard

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -378,21 +378,28 @@ jobs:
       - name: Execute Playwright Tests
         uses: nick-fields/retry@v3
         with:
-          # Bumped from 12 → 18 minutes. Shard 38 carries all four
-          # starter-projects-shardN tests + the sentiment streaming test;
-          # iterating 8 templates per test under Linux nightly load
-          # consistently runs past 12 minutes once a single iteration
-          # triggers a per-test Playwright retry.
+          # Bumped from 12 → 18 minutes. The shard carrying the
+          # starter-projects-shardN tests iterates every starter template;
+          # under Linux CI load that work can run past 12 minutes once a
+          # single iteration triggers a per-test Playwright retry.
           timeout_minutes: 18
           max_attempts: 2
           command: |
             cd src/frontend
             echo 'Running tests with pattern: ${{ needs.determine-test-suite.outputs.test_grep }}'
-            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list --retries=3
-            # echo command before running
-            echo "npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers 2 --retries=3"
+            TEST_LIST="$(npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list --retries=3)"
+            printf '%s\n' "$TEST_LIST"
 
-            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers 2 --retries=3
+            WORKERS=2
+            if printf '%s\n' "$TEST_LIST" | grep -q 'starter-projects-shard'; then
+              echo "Detected starter project template sweep in this shard; running it with one worker to avoid shared backend contention."
+              WORKERS=1
+            fi
+
+            # echo command before running
+            echo "npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers $WORKERS --retries=3"
+
+            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers "$WORKERS" --retries=3
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
## Summary

- run Playwright shards that include `starter-projects-shardN` with one worker
- keep ordinary frontend shards on two workers
- refresh the stale shard-number comment now that the template sweep can move between shard numbers

## Testing

- `git diff --check`
- `npx playwright test tests/core/integrations/starter-projects-shard1.spec.ts tests/core/integrations/starter-projects-shard2.spec.ts tests/core/integrations/starter-projects-shard3.spec.ts tests/core/integrations/starter-projects-shard4.spec.ts --list`
- `npx playwright test --grep= --shard 35/64 --list --retries=3`
- shell sanity checks for the worker-selection branch
- `uv run git commit -m "ci: serialize starter project template shard"` pre-commit checks

Note: `actionlint .github/workflows/typescript_test.yml` is still blocked by existing unrelated workflow findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution to choose a safer worker count for certain shards, helping reduce test contention and improve reliability.
  * Added a preliminary test-list check before running shard tests, with clearer command output during trace runs.
  * Kept existing timeout and retry settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->