### PR TITLE
fix: block Python REPL formatter traversal

### DIFF
--- a/src/backend/tests/unit/components/tools/test_python_repl_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_repl_tool.py
@@ -5,6 +5,12 @@ from lfx.components.utilities.python_repl_core import PythonREPLComponent
 
 from tests.base import DID_NOT_EXIST, ComponentTestBaseWithoutClient
 
+DYNAMIC_FORMAT_TRAVERSAL_CODE = """
+parts = ["__loader__", "find_spec", "__globals__"]
+field = "{0." + parts[0] + "." + parts[1] + "." + parts[2] + "[sys].modules[os].environ}"
+print("canary_present=" + str("PVR0792532_CANARY" in field.format(math)))
+"""
+
 
 class TestPythonREPLComponent(ComponentTestBaseWithoutClient):
     @pytest.fixture
@@ -109,6 +115,14 @@ class TestPythonREPLComponentSecurity:
         assert "error" in data
         assert "not allowed" in data["error"]
 
+    def test_dynamic_format_string_traversal_is_blocked(self, monkeypatch):
+        """Runtime-built format fields must not reach process state from default imports."""
+        monkeypatch.setenv("PVR0792532_CANARY", "SHOULD_NOT_LEAK")
+        data = self._run(DYNAMIC_FORMAT_TRAVERSAL_CODE)
+        assert "error" in data
+        assert "not allowed" in data["error"]
+        assert "SHOULD_NOT_LEAK" not in str(data)
+
     def test_default_global_imports_excludes_pandas(self):
         """The default allow-list is minimal (no pandas) to avoid bundling a deserialization sink."""
         template = PythonREPLComponent().to_frontend_node()["data"]["node"]["template"]
@@ -155,6 +169,12 @@ class TestPythonREPLToolComponentSecurity:
     def test_tool_blocks_subclasses_escape(self):
         with pytest.raises(ToolException, match="not allowed"):
             self._func()("().__class__.__bases__[0].__subclasses__()")
+
+    def test_tool_blocks_dynamic_format_string_traversal(self, monkeypatch):
+        monkeypatch.setenv("PVR0792532_CANARY", "SHOULD_NOT_LEAK")
+        with pytest.raises(ToolException, match="not allowed") as exc_info:
+            self._func()(DYNAMIC_FORMAT_TRAVERSAL_CODE)
+        assert "SHOULD_NOT_LEAK" not in str(exc_info.value)
 
     def test_tool_blocks_import_builtin(self):
         """__import__ is a bare name; PythonREPL surfaces the NameError as a string."""

--- a/src/lfx/src/lfx/utils/python_repl_security.py
+++ b/src/lfx/src/lfx/utils/python_repl_security.py
@@ -19,7 +19,8 @@ This module restricts that environment:
 * :func:`validate_code_safety` rejects code that bypasses the allow-list with an inline
   ``import`` or reaches the classic builtin-free escape gadgets: dunder attribute access
   (``().__class__.__subclasses__()``) and frame/traceback introspection
-  (``gen.gi_frame.f_back.f_globals``).
+  (``gen.gi_frame.f_back.f_globals``). It also rejects string formatter methods whose
+  replacement-field traversal happens inside CPython after validation.
 
 This is defense-in-depth, NOT a guaranteed sandbox — Python sandboxing is notoriously
 hard and determined attackers may still find gadgets. The primary control for untrusted
@@ -31,7 +32,6 @@ from __future__ import annotations
 
 import ast
 import builtins
-import re
 
 # Builtins considered safe to expose to interpreter code. Deliberately excludes anything
 # that can import modules, execute/compile code, touch the filesystem, or reach
@@ -116,9 +116,12 @@ _SAFE_BUILTIN_NAMES = frozenset(
 # Attribute names that expose interpreter internals or sandbox-escape gadgets even
 # without any dangerous builtin. Dunder attributes (``__class__``, ``__subclasses__``,
 # ``__globals__``, ``__mro__``, ``__builtins__``, ...) are handled generically; this set
-# covers the non-dunder frame / coroutine / traceback introspection attributes.
+# covers the non-dunder frame / coroutine / traceback introspection attributes and
+# formatter methods that perform attribute/item traversal internally.
 _BLOCKED_ATTRIBUTES = frozenset(
     {
+        "format",
+        "format_map",
         "gi_frame",
         "gi_code",
         "cr_frame",
@@ -139,11 +142,6 @@ _BLOCKED_ATTRIBUTES = frozenset(
         "mro",  # int.mro() reaches the object hierarchy without a dunder attribute
     }
 )
-
-# Matches a str.format()/format_map() replacement field that reaches into a dunder
-# attribute or item (e.g. "{0.__globals__}", "{0[__builtins__]}"). Such traversals live
-# inside the template string and are invisible to the AST attribute check below.
-_FORMAT_FIELD_DUNDER_RE = re.compile(r"\{[^{}]*__")
 
 
 class CodeExecutionDisabledError(ValueError):
@@ -223,7 +221,8 @@ def validate_code_safety(code: str) -> None:
 
     This complements :func:`safe_builtins`: restricted builtins stop ``__import__`` /
     ``open`` / ``eval`` etc., while this AST check stops the builtin-free escapes
-    (dunder attribute traversal and frame introspection) and inline imports.
+    (dunder attribute traversal and frame introspection), inline imports, and
+    ``str.format``/``format_map`` replacement-field traversal.
 
     Args:
         code: The Python source to be executed.
@@ -239,13 +238,4 @@ def validate_code_safety(code: str) -> None:
             raise ValueError(msg)  # noqa: TRY004 -- forbidden construct, not an argument type error
         if isinstance(node, ast.Attribute) and _is_blocked_attribute(node.attr):
             msg = f"Access to attribute '{node.attr}' is not allowed."
-            raise ValueError(msg)
-        if (
-            isinstance(node, ast.Constant)
-            and isinstance(node.value, str)
-            and _FORMAT_FIELD_DUNDER_RE.search(node.value)
-        ):
-            # Blocks str.format("{0.__globals__}") style traversal that the AST attribute
-            # check cannot see because the attribute chain is inside a literal string.
-            msg = "Access to dunder attributes via format strings is not allowed."
             raise ValueError(msg)

--- a/src/lfx/tests/unit/utils/test_python_repl_security.py
+++ b/src/lfx/tests/unit/utils/test_python_repl_security.py
@@ -81,10 +81,13 @@ class TestValidateCodeSafety:
             '"{0.__globals__}".format(f)',
             '"{0[__builtins__]}".format(f)',
             '"{0.__class__}".format(obj)',
+            "'{0}'.format(1)",
+            "'{name}'.format_map({'name': 'x'})",
+            "template = '{0.' + 'value' + '}'\ntemplate.format(obj)",
         ],
     )
     def test_blocks_escape_and_import(self, code):
-        """Inline imports, dunder/frame escape gadgets, and format-string dunder access are rejected."""
+        """Inline imports, escape gadgets, and formatter methods are rejected."""
         with pytest.raises(ValueError, match="not allowed"):
             validate_code_safety(code)
 
@@ -97,9 +100,8 @@ class TestValidateCodeSafety:
             "math.sqrt(16)",
             "result = [i * 2 for i in range(5)]\nprint(sum(result))",
             "data = {'a': 1, 'b': 2}\nprint(sorted(data.items()))",
-            "'{0} and {1}'.format(1, 2)",
-            "'{name}'.format(name='x')",
-            "'{0:.2f}'.format(3.14159)",
+            "first = 1\nsecond = 2\nprint(f'{first} and {second}')",
+            "print(format(3.14159, '.2f'))",
         ],
     )
     def test_allows_safe_code(self, code):


### PR DESCRIPTION
## Summary

- reject `str.format` / `format_map` access in the Python REPL validator because replacement-field traversal happens inside CPython after static validation
- add regression coverage for runtime-built formatter traversal through the Python Interpreter component and legacy Python REPL tool
- update validator tests so f-strings and the `format()` builtin remain allowed while formatter methods are blocked

## Test plan

- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/unit/utils/test_python_repl_security.py -q` from `src/lfx`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest src/backend/tests/unit/components/tools/test_python_repl_tool.py -q`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check src/lfx/src/lfx/utils/python_repl_security.py src/lfx/tests/unit/utils/test_python_repl_security.py src/backend/tests/unit/components/tools/test_python_repl_tool.py`
- patched component canary smoke returns `Access to attribute 'format' is not allowed.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Python REPL security checks so unsafe formatter-based access patterns are blocked more reliably.
  * Prevented runtime-built formatting strings from leaking environment data during execution.
  * Expanded test coverage to verify blocked execution does not expose sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->