### PR TITLE
fix: validate file paths by resolved cache containment

### DIFF
--- a/src/backend/tests/unit/template/utils/test_file_path_value.py
+++ b/src/backend/tests/unit/template/utils/test_file_path_value.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from lfx.template import utils as template_utils
+
+
+def _set_cache_dir(monkeypatch, cache_dir: Path) -> None:
+    monkeypatch.setattr(template_utils, "user_cache_dir", lambda _app_name, _app_author: str(cache_dir))
+
+
+def test_get_file_path_value_accepts_existing_cache_file(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    uploaded_file = cache_dir / "upload.txt"
+    uploaded_file.write_text("allowed")
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    assert template_utils.get_file_path_value(str(uploaded_file)) == str(uploaded_file.resolve())
+
+
+def test_get_file_path_value_rejects_traversal_outside_cache(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("secret")
+    traversal_path = cache_dir / ".." / outside_file.name
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    assert str(traversal_path).startswith(str(cache_dir))
+    assert traversal_path.exists()
+    assert template_utils.get_file_path_value(str(traversal_path)) == ""
+
+
+def test_get_file_path_value_rejects_sibling_prefix_match(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    sibling_dir = tmp_path / "cache-malicious"
+    cache_dir.mkdir()
+    sibling_dir.mkdir()
+    sibling_file = sibling_dir / "outside.txt"
+    sibling_file.write_text("secret")
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    assert str(sibling_file).startswith(str(cache_dir))
+    assert template_utils.get_file_path_value(str(sibling_file)) == ""
+
+
+def test_update_template_field_clears_traversal_file_path(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("secret")
+    traversal_path = cache_dir / ".." / outside_file.name
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    new_template = {
+        "target_file": {
+            "type": "file",
+            "value": "previous-value",
+            "file_path": "",
+        }
+    }
+    previous_value_dict = {
+        "type": "file",
+        "value": "previous-value",
+        "file_path": str(traversal_path),
+    }
+
+    template_utils.update_template_field(new_template, "target_file", previous_value_dict)
+
+    assert new_template["target_file"]["value"] == ""
+    assert new_template["target_file"]["file_path"] == ""

--- a/src/backend/tests/unit/template/utils/test_file_path_value.py
+++ b/src/backend/tests/unit/template/utils/test_file_path_value.py
@@ -43,6 +43,26 @@ def test_get_file_path_value_rejects_sibling_prefix_match(tmp_path: Path, monkey
     assert template_utils.get_file_path_value(str(sibling_file)) == ""
 
 
+def test_get_file_path_value_rejects_directory_inside_cache(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    inner_dir = cache_dir / "subdir"
+    inner_dir.mkdir()
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    # A directory inside the cache is contained but is not a real file.
+    assert template_utils.get_file_path_value(str(inner_dir)) == ""
+
+
+def test_get_file_path_value_rejects_empty_string(tmp_path: Path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    _set_cache_dir(monkeypatch, cache_dir)
+
+    # An empty string resolves to the CWD (a directory), which must not yield a path.
+    assert template_utils.get_file_path_value("") == ""
+
+
 def test_update_template_field_clears_traversal_file_path(tmp_path: Path, monkeypatch) -> None:
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()

--- a/src/lfx/src/lfx/template/utils.py
+++ b/src/lfx/src/lfx/template/utils.py
@@ -15,20 +15,21 @@ def raw_frontend_data_is_valid(raw_frontend_data):
 def get_file_path_value(file_path):
     """Get the file path value if the file exists, else return empty string."""
     try:
-        path = Path(file_path)
-    except TypeError:
+        path = Path(file_path).resolve()
+        cache_dir = Path(user_cache_dir("langflow", "langflow")).resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
         return ""
 
     # Check for safety
     # If the path is not in the cache dir, return empty string
     # This is to prevent access to files outside the cache dir
     # If the path is not a file, return empty string
-    if not str(path).startswith(user_cache_dir("langflow", "langflow")):
+    if not path.is_relative_to(cache_dir):
         return ""
 
     if not path.exists():
         return ""
-    return file_path
+    return str(path)
 
 
 def update_template_field(new_template, key, previous_value_dict) -> None:

--- a/src/lfx/src/lfx/template/utils.py
+++ b/src/lfx/src/lfx/template/utils.py
@@ -27,7 +27,7 @@ def get_file_path_value(file_path):
     if not path.is_relative_to(cache_dir):
         return ""
 
-    if not path.exists():
+    if not path.is_file():
         return ""
     return str(path)
 


### PR DESCRIPTION
## Summary

- validate saved file paths with resolved cache-directory containment instead of raw string prefix matching
- clear invalid FileInput paths when template values are copied forward
- add regression coverage for traversal-style and sibling-prefix paths

## Validation

- `uv run ruff check src/lfx/src/lfx/template/utils.py src/backend/tests/unit/template/utils/test_file_path_value.py`
- `uv run pytest src/backend/tests/unit/template/utils/test_file_path_value.py -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-path validation so only files inside the configured cache location are accepted.
  * Prevented unsafe or misleading paths from being treated as valid, including traversal-style paths and similar-looking sibling paths.
  * When an invalid path is detected, related template field values are now cleared consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->