### PR TITLE
fix: restrict log retrieval to superusers

### DIFF
--- a/docs/docs/API-Reference/api-logs.mdx
+++ b/docs/docs/API-Reference/api-logs.mdx
@@ -18,6 +18,8 @@ import exampleJavascriptApiLogsRetrieveLogsWithOptionalParameters from '!!raw-lo
 
 Retrieve logs for your Langflow flows and server.
 
+Requests to `/logs` and `/logs-stream` require a superuser API key or session.
+
 ## Enable log retrieval
 
 The `/logs` endpoint requires log retrieval to be enabled in your Langflow instance.

--- a/src/backend/base/langflow/api/log_router.py
+++ b/src/backend/base/langflow/api/log_router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from lfx.log.logger import log_buffer
 
-from langflow.services.auth.utils import get_current_active_user
+from langflow.services.auth.utils import get_current_active_superuser
 
 log_router = APIRouter(tags=["Log"])
 
@@ -52,13 +52,13 @@ async def event_generator(request: Request):
         await asyncio.sleep(1)
 
 
-@log_router.get("/logs-stream", dependencies=[Depends(get_current_active_user)])
+@log_router.get("/logs-stream", dependencies=[Depends(get_current_active_superuser)])
 async def stream_logs(
     request: Request,
 ):
     """HTTP/2 Server-Sent-Event (SSE) endpoint for streaming logs.
 
-    Requires authentication to prevent exposure of sensitive log data.
+    Requires superuser authentication to prevent exposure of sensitive log data.
     It establishes a long-lived connection to the server and receives log messages in real-time.
     The client should use the header "Accept: text/event-stream".
     """
@@ -72,15 +72,15 @@ async def stream_logs(
     return StreamingResponse(event_generator(request), media_type="text/event-stream")
 
 
-@log_router.get("/logs", dependencies=[Depends(get_current_active_user)])
+@log_router.get("/logs", dependencies=[Depends(get_current_active_superuser)])
 async def logs(
     lines_before: Annotated[int, Query(description="The number of logs before the timestamp or the last log")] = 0,
     lines_after: Annotated[int, Query(description="The number of logs after the timestamp")] = 0,
     timestamp: Annotated[int, Query(description="The timestamp to start getting logs from")] = 0,
 ):
-    """Retrieve application logs with authentication required.
+    """Retrieve application logs with superuser authentication required.
 
-    SECURITY: Logs may contain sensitive information and require authentication.
+    SECURITY: Logs may contain sensitive information and require superuser authentication.
     """
     global log_buffer  # noqa: PLW0602
     if log_buffer.enabled() is False:

--- a/src/backend/tests/unit/api/test_log_router.py
+++ b/src/backend/tests/unit/api/test_log_router.py
@@ -1,0 +1,84 @@
+from collections.abc import Callable
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from langflow.api.log_router import log_router
+from langflow.services.auth.utils import get_current_active_superuser, get_current_active_user
+from lfx.log.logger import log_buffer
+
+
+@pytest.fixture(autouse=True)
+def buffered_logs():
+    original_max = log_buffer.max
+    original_buffer = list(log_buffer.buffer)
+    log_buffer.max = 10
+    with log_buffer.get_write_lock():
+        log_buffer.buffer.clear()
+        log_buffer.buffer.append((1234, "victim job_id leaked-from-debug-logs"))
+    yield
+    log_buffer.max = original_max
+    with log_buffer.get_write_lock():
+        log_buffer.buffer.clear()
+        log_buffer.buffer.extend(original_buffer)
+
+
+def _client_with_log_auth(
+    *,
+    active_user_dependency: Callable,
+    superuser_dependency: Callable,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(log_router)
+    app.dependency_overrides[get_current_active_user] = active_user_dependency
+    app.dependency_overrides[get_current_active_superuser] = superuser_dependency
+    return TestClient(app)
+
+
+def test_logs_reject_active_non_superuser() -> None:
+    def allow_active_user():
+        return object()
+
+    def reject_superuser():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The user doesn't have enough privileges",
+        )
+
+    client = _client_with_log_auth(
+        active_user_dependency=allow_active_user,
+        superuser_dependency=reject_superuser,
+    )
+
+    response = client.get("/logs?lines_before=1")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "leaked-from-debug-logs" not in response.text
+
+
+def test_logs_allow_superuser() -> None:
+    def reject_active_user():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="unexpected dependency")
+
+    def allow_superuser():
+        return object()
+
+    client = _client_with_log_auth(
+        active_user_dependency=reject_active_user,
+        superuser_dependency=allow_superuser,
+    )
+
+    response = client.get("/logs?lines_before=1")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"1234": "victim job_id leaked-from-debug-logs"}
+
+
+@pytest.mark.parametrize("path", ["/logs", "/logs-stream"])
+def test_log_routes_require_superuser_dependency(path: str) -> None:
+    route = next(route for route in log_router.routes if isinstance(route, APIRoute) and route.path == path)
+    dependency_calls = [dependency.call for dependency in route.dependant.dependencies]
+
+    assert get_current_active_superuser in dependency_calls
+    assert get_current_active_user not in dependency_calls


### PR DESCRIPTION
## Summary

- require superuser authentication for `/logs` and `/logs-stream`
- document that log retrieval requires a superuser API key or session
- add regression coverage for non-admin denial, superuser access, and route dependency wiring

## Validation

- `uv run pytest src/backend/tests/unit/api/test_log_router.py -q`
- `uv run pytest src/backend/tests/unit/test_chat_endpoint.py::test_private_job_id_blocked_on_public_events_endpoint src/backend/tests/unit/test_chat_endpoint.py::test_private_job_id_blocked_on_public_cancel_endpoint -q`
- `uv run ruff check src/backend/base/langflow/api/log_router.py src/backend/tests/unit/api/test_log_router.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Access to log retrieval endpoints now requires a superuser API key or active superuser session, improving log security.
  * Updated the API documentation to clearly reflect the new access requirements for log endpoints.

* **Tests**
  * Added coverage to verify that non-superusers are blocked and superusers can successfully view logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->