### PR TITLE
fix: block dangerous MCP stdio env vars

### DIFF
--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from lfx.base.mcp.util import DANGEROUS_MCP_ENV_VARS, is_dangerous_mcp_env_var
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from langflow.logging import logger
@@ -46,47 +47,7 @@ DANGEROUS_KEYWORDS = frozenset(
 
 # SECURITY: Environment variables that enable code injection via approved commands.
 # Grouped by attack category. All comparisons are case-insensitive.
-DANGEROUS_ENV_VARS = frozenset(
-    {
-        # -- Shared-object / dylib injection (arbitrary native code execution) --
-        "ld_preload",
-        "ld_library_path",
-        "ld_audit",
-        "dyld_insert_libraries",
-        "dyld_library_path",
-        # -- glibc iconv module injection (loads arbitrary .so via iconv) --
-        "gconv_path",
-        # -- Command resolution override (redirects which binary bash executes) --
-        "path",
-        # -- Shell startup-script injection (bash executes these before the command) --
-        "bash_env",
-        "env",
-        "bash_func_",  # Shellshock-style function export prefix
-        # -- Shell word-splitting / globbing manipulation --
-        "ifs",
-        "cdpath",
-        # -- Node.js code injection --
-        "node_options",
-        "node_extra_ca_certs",
-        # -- Python code injection --
-        "pythonstartup",
-        "pythonpath",
-        # -- Home / config directory redirection (loads attacker-controlled configs) --
-        "home",
-        "xdg_config_home",
-        "xdg_data_home",
-        # -- Temp directory redirection --
-        "tmpdir",
-        "tmp",
-        "temp",
-        # -- DNS / network manipulation --
-        "hostaliases",
-        "localdomain",
-        "res_options",
-        # -- Locale / getconf injection (can load arbitrary .so on some glibc) --
-        "getconf_dir",
-    }
-)
+DANGEROUS_ENV_VARS = DANGEROUS_MCP_ENV_VARS
 
 # SECURITY: Docker-specific arguments that break container isolation
 DOCKER_DANGEROUS_ARGS = frozenset({"--privileged", "--cap-add"})
@@ -268,8 +229,7 @@ class MCPServerConfig(BaseModel):
             return None
 
         for key in v:
-            lower_key = key.lower()
-            if lower_key in DANGEROUS_ENV_VARS or lower_key.startswith("bash_func_"):
+            if is_dangerous_mcp_env_var(key):
                 msg = f"Environment variable '{key}' is not allowed for security reasons"
                 logger.warning("MCP env var rejected: '{}'", key)
                 raise ValueError(msg)

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -24,10 +24,28 @@ from lfx.base.mcp.util import (
     _is_transient_streamable_http_error,
     _process_headers,
     _should_attempt_sse_after_streamable_failure,
+    _validate_mcp_stdio_env,
     update_tools,
     validate_headers,
 )
 from lfx.schema.data import Data
+
+
+def test_validate_mcp_stdio_env_rejects_shellopts_ps4_combo():
+    with pytest.raises(ValueError, match="SHELLOPTS"):
+        _validate_mcp_stdio_env({"SHELLOPTS": "xtrace", "PS4": "$(id)"})
+
+
+@pytest.mark.parametrize("env_var", ["SHELLOPTS", "shellopts", "BASHOPTS", "PS4"])
+def test_validate_mcp_stdio_env_rejects_bash_trace_controls(env_var):
+    with pytest.raises(ValueError, match="Environment variable"):
+        _validate_mcp_stdio_env({env_var: "malicious_value"})
+
+
+def test_validate_mcp_stdio_env_allows_regular_env():
+    env = {"DEBUG": "true", "PORT": "8080"}
+
+    assert _validate_mcp_stdio_env(env) is env
 
 
 class TestMCPSessionManager:

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -579,6 +579,24 @@ class TestMCPCommandInjectionSecurity:
         error_msg = str(exc_info.value)
         assert "not allowed" in error_msg.lower()
 
+    def test_shellopts_ps4_trace_env_rejected(self):
+        """Test that SHELLOPTS/PS4 env vars are rejected (bash xtrace prompt command substitution)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="python3",
+                args=["-V"],
+                env={"SHELLOPTS": "xtrace", "PS4": "$(id)"},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    @pytest.mark.parametrize("env_var", ["SHELLOPTS", "BASHOPTS", "PS4"])
+    def test_bash_trace_control_env_rejected(self, env_var):
+        """Test that bash option and trace-prompt env vars are rejected."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig(command="node", args=["server.js"], env={env_var: "malicious_value"})
+
     def test_ifs_env_rejected(self):
         """Test that IFS env var is rejected (shell word-splitting manipulation).
 

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -43,8 +43,70 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 HTTP_UNAUTHORIZED = 401
 HTTP_FORBIDDEN = 403
 
+DANGEROUS_MCP_ENV_VARS = frozenset(
+    {
+        # Shared-object / dylib injection
+        "ld_preload",
+        "ld_library_path",
+        "ld_audit",
+        "dyld_insert_libraries",
+        "dyld_library_path",
+        # glibc iconv module injection
+        "gconv_path",
+        # Command resolution override
+        "path",
+        # Shell startup, option, and tracing injection
+        "bash_env",
+        "env",
+        "bash_func_",
+        "shellopts",
+        "bashopts",
+        "ps4",
+        # Shell word-splitting / globbing manipulation
+        "ifs",
+        "cdpath",
+        # Node.js code injection
+        "node_options",
+        "node_extra_ca_certs",
+        # Python code injection
+        "pythonstartup",
+        "pythonpath",
+        # Home / config directory redirection
+        "home",
+        "xdg_config_home",
+        "xdg_data_home",
+        # Temp directory redirection
+        "tmpdir",
+        "tmp",
+        "temp",
+        # DNS / network manipulation
+        "hostaliases",
+        "localdomain",
+        "res_options",
+        # Locale / getconf injection
+        "getconf_dir",
+    }
+)
+
 # MCP Session Manager constants - lazy loaded
 _mcp_settings_cache: dict[str, Any] = {}
+
+
+def is_dangerous_mcp_env_var(key: str) -> bool:
+    lower_key = key.lower()
+    return lower_key in DANGEROUS_MCP_ENV_VARS or lower_key.startswith("bash_func_")
+
+
+def _validate_mcp_stdio_env(env: dict[str, str] | None) -> dict[str, str]:
+    if env is None:
+        return {}
+
+    for key in env:
+        if is_dangerous_mcp_env_var(key):
+            msg = f"Environment variable '{key}' is not allowed for MCP stdio servers"
+            raise ValueError(msg)
+
+    return env
 
 
 def _get_mcp_setting(key: str, default: Any = None) -> Any:
@@ -1586,7 +1648,7 @@ class MCPStdioClient:
            ``shell=False`` semantics).  This would eliminate an entire class of
            injection vectors (shell metacharacters, IFS manipulation,
            BASH_ENV/BASH_FUNC_* startup injection) and allow removing several
-           entries from ``DANGEROUS_ENV_VARS`` in ``schemas.py``.  Requires:
+           entries from ``DANGEROUS_MCP_ENV_VARS``.  Requires:
            1. Changing the signature to accept ``(command, args)`` separately.
            2. Updating ``update_tools()`` to stop joining into a shell string.
            3. Handling multi-word ``command`` config values (e.g.
@@ -1599,7 +1661,8 @@ class MCPStdioClient:
         from mcp import StdioServerParameters
 
         command = shlex.split(command_str)
-        env_data: dict[str, str] = {"DEBUG": "true", "PATH": os.environ["PATH"], **(env or {})}
+        safe_env = _validate_mcp_stdio_env(env)
+        env_data: dict[str, str] = {"DEBUG": "true", "PATH": os.environ["PATH"], **safe_env}
 
         if platform.system() == "Windows":
             server_params = StdioServerParameters(


### PR DESCRIPTION
## Summary

- centralize MCP stdio dangerous environment-variable checks in `lfx`
- block Bash option and trace-prompt env vars before stdio launcher process creation
- reuse the same predicate for API v2 MCP server registration validation
- add regression coverage for the rejected env combination and legitimate env values

## Validation

- `uv run pytest src/backend/tests/unit/base/mcp/test_mcp_util.py::test_validate_mcp_stdio_env_rejects_shellopts_ps4_combo src/backend/tests/unit/base/mcp/test_mcp_util.py::test_validate_mcp_stdio_env_rejects_bash_trace_controls src/backend/tests/unit/base/mcp/test_mcp_util.py::test_validate_mcp_stdio_env_allows_regular_env src/backend/tests/unit/test_mcp_command_injection_security.py -q`
- `uv run ruff check src/backend/base/langflow/api/v2/schemas.py src/lfx/src/lfx/base/mcp/util.py src/backend/tests/unit/test_mcp_command_injection_security.py src/backend/tests/unit/base/mcp/test_mcp_util.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-variable safety for MCP connections by blocking unsafe shell-related variables during startup.
  * Added stricter validation so disallowed values are rejected before a subprocess is created.
  * Kept support for normal, non-sensitive environment variables.

* **Tests**
  * Added coverage for rejected unsafe variable combinations and malicious values.
  * Added checks to confirm valid environment variables continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->