### PR TITLE
fix: block public builds of code execution agents

### DIFF
--- a/src/backend/tests/unit/test_process.py
+++ b/src/backend/tests/unit/test_process.py
@@ -634,6 +634,28 @@ def test_apply_tweaks_blocks_removed_python_code_structured_tool_code():
     assert node["data"]["node"]["template"]["tool_code"]["value"] == "stored_code"
 
 
+def test_apply_tweaks_blocks_csv_agent_dangerous_code_flag():
+    """CSVAgent's LangChain Python-execution opt-in is a sandbox boundary."""
+    from langflow.processing.process import apply_tweaks
+
+    node = {
+        "id": "n",
+        "data": {
+            "type": "CSVAgent",
+            "node": {
+                "template": {
+                    "allow_dangerous_code": {"value": False, "type": "bool"},
+                    "input_value": {"value": "summarize", "type": "str"},
+                }
+            },
+        },
+    }
+    apply_tweaks(node, {"allow_dangerous_code": True, "input_value": "count rows"})
+
+    assert node["data"]["node"]["template"]["allow_dangerous_code"]["value"] is False
+    assert node["data"]["node"]["template"]["input_value"]["value"] == "count rows"
+
+
 def test_apply_tweaks_smart_transform_blocks_instruction_allows_data():
     """Smart Transform's 'filter_instruction' drives an eval()'d lambda → blocked.
 

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -42,6 +42,7 @@ CODE_EXECUTION_COMPONENT_TYPES: frozenset[str] = frozenset(
     {
         "CSVAgent",  # LangChain CSV agent can execute Python when allow_dangerous_code is enabled
         "CodeActAgentSmolagents",  # smolagents CodeAgent executes model-generated code
+        "Cuga",  # CUGA agent executes model-generated Python via its built-in executor
         "OpenDsStarAgent",  # OpenDsStar data-science agent executes model-generated Python
         "PythonCodeStructuredTool",  # legacy raw exec() (component removed; type retained to block stored code)
         "PythonREPLComponent",  # "Python Interpreter"

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -40,6 +40,9 @@ class PublicFlowValidationError(CustomComponentValidationError):
 # unauthenticated public path — authenticated builds are unaffected.
 CODE_EXECUTION_COMPONENT_TYPES: frozenset[str] = frozenset(
     {
+        "CSVAgent",  # LangChain CSV agent can execute Python when allow_dangerous_code is enabled
+        "CodeActAgentSmolagents",  # smolagents CodeAgent executes model-generated code
+        "OpenDsStarAgent",  # OpenDsStar data-science agent executes model-generated Python
         "PythonCodeStructuredTool",  # legacy raw exec() (component removed; type retained to block stored code)
         "PythonREPLComponent",  # "Python Interpreter"
         "PythonREPLTool",  # legacy "Python REPL" tool
@@ -52,20 +55,23 @@ CODE_EXECUTION_COMPONENT_TYPES: frozenset[str] = frozenset(
 # (StrInput / MultilineInput → template type "str"), so the field-type=="code" guard
 # in apply_tweaks() does NOT catch them; the Tweaks API must additionally refuse to
 # override them by name on a code-execution node. Kept beside
-# CODE_EXECUTION_COMPONENT_TYPES so the two consumers stay in sync — adding a new
-# code-execution component means registering both its type above and its code input
-# here. This sync is enforced by test_every_code_execution_type_has_registered_code_fields
-# in test_process.py, which fails if a new type is added without its code field. The
-# conventional "code" field name is blocked globally in apply_tweaks() and so is
-# intentionally omitted here.
+# CODE_EXECUTION_COMPONENT_TYPES so the two consumers stay in sync when a component
+# has tweakable code/sandbox inputs. Components that execute runtime/model-generated
+# code without such a template field still belong in CODE_EXECUTION_COMPONENT_TYPES,
+# but do not need entries here. This sync is enforced by
+# test_every_code_execution_type_has_registered_code_fields in test_process.py.
+# The conventional "code" field name is blocked globally in apply_tweaks() and so
+# is intentionally omitted here.
 #   - python_code:        Python Interpreter (PythonREPLComponent) exec input
 #   - tool_code:          removed PythonCodeStructuredTool exec input (type retained)
 #   - filter_instruction: Smart Transform instruction → LLM-generated, eval()'d lambda
 #   - global_imports:     import allow-list that populates the exec() namespace; the
 #                         documented sandbox boundary (powerful modules must be opted
 #                         into here), so it must not be widened via tweaks
+#   - allow_dangerous_code: CSVAgent switch that enables LangChain Python execution
 CODE_EXECUTION_FIELD_NAMES: frozenset[str] = frozenset(
     {
+        "allow_dangerous_code",
         "python_code",
         "tool_code",
         "filter_instruction",
@@ -659,9 +665,9 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
     Two classes of component are rejected on that path:
 
     * Direct code execution (``CODE_EXECUTION_COMPONENT_TYPES``) — the Python
-      interpreter/REPL components, the legacy Python Code Structured tool and
-      the Smart Transform lambda — which run user- or model-supplied code
-      (report H1-3754930).
+      interpreter/REPL components, the legacy Python Code Structured tool,
+      Smart Transform lambda and code-capable agent components — which run
+      user- or model-supplied code (reports H1-3754930 and H1-3813558).
     * Flow invocation (``FLOW_REFERENCE_COMPONENT_TYPES``) — Run Flow, Sub Flow
       and Flow as Tool — which load and execute *another* saved owner flow by
       id/name at runtime. That referenced flow is read straight from the

--- a/src/lfx/tests/unit/test_process.py
+++ b/src/lfx/tests/unit/test_process.py
@@ -101,6 +101,21 @@ def test_apply_tweaks_blocks_removed_python_code_structured_tool_code():
     assert node["data"]["node"]["template"]["tool_code"]["value"] == "stored_code"
 
 
+def test_apply_tweaks_blocks_csv_agent_dangerous_code_flag():
+    """CSVAgent's LangChain Python-execution opt-in is a sandbox boundary."""
+    node = _template_node(
+        {
+            "allow_dangerous_code": {"value": False, "type": "bool"},
+            "input_value": {"value": "summarize", "type": "str"},
+        },
+        node_type="CSVAgent",
+    )
+    apply_tweaks(node, {"allow_dangerous_code": True, "input_value": "count rows"})
+
+    assert node["data"]["node"]["template"]["allow_dangerous_code"]["value"] is False
+    assert node["data"]["node"]["template"]["input_value"]["value"] == "count rows"
+
+
 def test_apply_tweaks_smart_transform_blocks_instruction_allows_data():
     """Smart Transform's filter_instruction drives an eval()'d lambda → blocked; data is not."""
     node = _template_node(
@@ -116,21 +131,31 @@ def test_apply_tweaks_smart_transform_blocks_instruction_allows_data():
     assert node["data"]["node"]["template"]["sample_size"]["value"] == 25
 
 
-# The intended code/sandbox inputs for every code-execution component type, kept
-# independently from the production sets so this test acts as a checksum on the
-# comment-only sync between CODE_EXECUTION_COMPONENT_TYPES and
-# CODE_EXECUTION_FIELD_NAMES (see lfx/utils/flow_validation.py). "code" is the
-# conventional exec input that apply_tweaks() blocks globally by name, so it is
-# allowed here without being listed in CODE_EXECUTION_FIELD_NAMES.
+# The intended code/sandbox inputs for code-execution component types that expose
+# such fields in their templates, kept independently from the production sets so
+# this test acts as a checksum on the comment-only sync between
+# CODE_EXECUTION_COMPONENT_TYPES and CODE_EXECUTION_FIELD_NAMES (see
+# lfx/utils/flow_validation.py). "code" is the conventional exec input that
+# apply_tweaks() blocks globally by name, so it is allowed here without being
+# listed in CODE_EXECUTION_FIELD_NAMES.
+#   - CSVAgent: allow_dangerous_code enables LangChain Python execution
 #   - PythonREPLComponent (Python Interpreter): python_code exec + global_imports sandbox
 #   - PythonREPLTool (Python REPL): code exec (global block) + global_imports sandbox
 #   - Smart Transform (LambdaFilterComponent): filter_instruction → eval()'d lambda
 #   - PythonCodeStructuredTool (removed): tool_code exec input, type retained
 _EXPECTED_CODE_FIELDS_BY_TYPE: dict[str, set[str]] = {
+    "CSVAgent": {"allow_dangerous_code"},
     "PythonREPLComponent": {"python_code", "global_imports"},
     "PythonREPLTool": {"code", "global_imports"},
     "Smart Transform": {"filter_instruction"},
     "PythonCodeStructuredTool": {"tool_code"},
+}
+
+# Code-execution components with no tweakable code/sandbox field. They are still
+# blocked on unauthenticated public builds by CODE_EXECUTION_COMPONENT_TYPES.
+_CODE_EXECUTION_TYPES_WITHOUT_TWEAK_CODE_FIELDS = {
+    "CodeActAgentSmolagents",
+    "OpenDsStarAgent",
 }
 
 # Field name globally blocked by apply_tweaks() regardless of component type.
@@ -140,16 +165,17 @@ _GLOBALLY_BLOCKED_FIELD = "code"
 def test_every_code_execution_type_has_registered_code_fields():
     """Tripwire: each registered code-exec type must declare its code fields here.
 
-    Forcing function for the "next person" who adds a fifth code-execution
-    component: adding a type to CODE_EXECUTION_COMPONENT_TYPES without an entry
-    here fails immediately, and the coverage assert below then fails until the
-    type's code input is actually added to CODE_EXECUTION_FIELD_NAMES. This is
-    what keeps the by-name half of the guard from silently going stale, since the
-    component classes themselves aren't importable in this unit env (optional deps).
+    Forcing function for the next code-execution component: adding a type to
+    CODE_EXECUTION_COMPONENT_TYPES without either registered code/sandbox fields
+    or an explicit no-field entry fails immediately. This keeps the by-name half
+    of the guard from silently going stale, since the component classes themselves
+    aren't importable in this unit env (optional deps).
     """
-    assert set(_EXPECTED_CODE_FIELDS_BY_TYPE) == set(CODE_EXECUTION_COMPONENT_TYPES), (
+    expected_component_types = set(_EXPECTED_CODE_FIELDS_BY_TYPE) | _CODE_EXECUTION_TYPES_WITHOUT_TWEAK_CODE_FIELDS
+    assert expected_component_types == set(CODE_EXECUTION_COMPONENT_TYPES), (
         "CODE_EXECUTION_COMPONENT_TYPES changed without updating _EXPECTED_CODE_FIELDS_BY_TYPE. "
-        "Register the new component's code/sandbox input field name(s) so the Tweaks guard covers it."
+        "Register the new component's code/sandbox input field name(s), or explicitly mark it as a "
+        "runtime code-execution component with no tweakable code/sandbox fields."
     )
 
     covered = set(CODE_EXECUTION_FIELD_NAMES) | {_GLOBALLY_BLOCKED_FIELD}

--- a/src/lfx/tests/unit/test_process.py
+++ b/src/lfx/tests/unit/test_process.py
@@ -155,6 +155,7 @@ _EXPECTED_CODE_FIELDS_BY_TYPE: dict[str, set[str]] = {
 # blocked on unauthenticated public builds by CODE_EXECUTION_COMPONENT_TYPES.
 _CODE_EXECUTION_TYPES_WITHOUT_TWEAK_CODE_FIELDS = {
     "CodeActAgentSmolagents",
+    "Cuga",
     "OpenDsStarAgent",
 }
 

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -1,5 +1,7 @@
 """Unit tests for LFX flow validation helpers."""
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -287,6 +289,13 @@ async def test_prepare_public_flow_build_noop_on_empty(monkeypatch, empty):
 # --- validate_public_flow_no_code_execution (report H1-3754930) -------------------
 
 
+REPORTED_CODE_EXECUTION_AGENT_TYPES = (
+    "CSVAgent",
+    "CodeActAgentSmolagents",
+    "OpenDsStarAgent",
+)
+
+
 def _flow_with_component(component_type: str) -> dict:
     """Build minimal raw graph data containing a single node of ``component_type``."""
     node_id = f"{component_type}-1"
@@ -303,6 +312,27 @@ def _flow_with_component(component_type: str) -> dict:
         ],
         "edges": [],
     }
+
+
+@pytest.mark.parametrize("component_type", REPORTED_CODE_EXECUTION_AGENT_TYPES)
+def test_public_flow_blocks_reported_code_execution_agents(component_type):
+    """Regression for H1-3813558: shipped code agents must not build anonymously."""
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(_flow_with_component(component_type))
+    assert component_type in str(exc_info.value)
+
+
+def test_public_flow_blocks_structured_data_analysis_starter_template():
+    """The bundled data-analysis starter contains OpenDsStarAgent and must be rejected publicly."""
+    repo_root = Path(__file__).resolve().parents[5]
+    starter_path = (
+        repo_root / "src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json"
+    )
+    starter_flow = json.loads(starter_path.read_text())
+
+    with pytest.raises(PublicFlowValidationError) as exc_info:
+        validate_public_flow_no_code_execution(starter_flow)
+    assert "OpenDsStarAgent" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("component_type", sorted(CODE_EXECUTION_COMPONENT_TYPES))

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -292,6 +292,7 @@ async def test_prepare_public_flow_build_noop_on_empty(monkeypatch, empty):
 REPORTED_CODE_EXECUTION_AGENT_TYPES = (
     "CSVAgent",
     "CodeActAgentSmolagents",
+    "Cuga",
     "OpenDsStarAgent",
 )
 


### PR DESCRIPTION
## Summary

- Block unauthenticated public-flow builds for the shipped CSVAgent, CodeActAgentSmolagents, and OpenDsStarAgent code-execution agents.
- Reject the bundled Structured Data Analysis starter template on the public build path because it contains OpenDsStarAgent.
- Treat CSVAgent's `allow_dangerous_code` toggle as a tweak-protected sandbox boundary.

## Test plan

- `uv run ruff check src/lfx/src/lfx/utils/flow_validation.py src/lfx/tests/unit/utils/test_flow_validation.py src/lfx/tests/unit/test_process.py src/backend/tests/unit/test_process.py`
- `uv run pytest src/backend/tests/unit/test_process.py::test_apply_tweaks_blocks_csv_agent_dangerous_code_flag src/backend/tests/unit/test_chat_endpoint.py::test_build_public_tmp_rejects_code_execution_components -q`
- `(cd src/lfx && uv sync --group dev && uv run pytest tests/unit/utils/test_flow_validation.py tests/unit/test_process.py -q)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened flow validation so additional code-capable agent setups are blocked on public builds.
  * Prevented a dangerous code-related option from being overridden in CSV-based agent configurations, while keeping other safe settings editable.

* **Tests**
  * Added coverage for code-execution restrictions and agent validation to help catch regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->