### PR TITLE
fix: Block Python interpreter format traversal

### DIFF
--- a/src/backend/tests/unit/components/tools/test_python_repl_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_repl_tool.py
@@ -11,6 +11,27 @@ field = "{0." + parts[0] + "." + parts[1] + "." + parts[2] + "[sys].modules[os].
 print("canary_present=" + str("PVR0800453_CANARY" in field.format(math)))
 """
 
+# Sibling formatter sinks: the same __globals__ traversal lives in a *string* argument
+# (invisible to the AST attribute check) when fed through string.Formatter primitives or
+# operator.attrgetter. Each leaks os.environ unless the validator rejects the call.
+FORMATTER_VFORMAT_TRAVERSAL_CODE = """
+f = lambda: 0
+leaked = string.Formatter().vformat("{0.__globals__[os].environ[PVR0800453_CANARY]}", (f,), {})
+print("leaked=" + str(leaked))
+"""
+
+FORMATTER_GET_FIELD_TRAVERSAL_CODE = """
+f = lambda: 0
+obj, _ = string.Formatter().get_field("0.__globals__[os].environ[PVR0800453_CANARY]", (f,), {})
+print("leaked=" + str(obj))
+"""
+
+ATTRGETTER_TRAVERSAL_CODE = """
+f = lambda: 0
+leaked = operator.attrgetter("__globals__")(f)["os"].environ["PVR0800453_CANARY"]
+print("leaked=" + str(leaked))
+"""
+
 
 class TestPythonREPLComponent(ComponentTestBaseWithoutClient):
     @pytest.fixture
@@ -119,6 +140,30 @@ class TestPythonREPLComponentSecurity:
         """Dynamically-built str.format() fields cannot bypass the AST validator."""
         monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
         data = self._run(DYNAMIC_FORMAT_TRAVERSAL_CODE)
+        assert "error" in data
+        assert "not allowed" in data["error"]
+        assert "SHOULD_NOT_LEAK" not in str(data)
+
+    def test_formatter_vformat_traversal_is_blocked(self, monkeypatch):
+        """string.Formatter().vformat carries the dunder chain in a string arg; blocked."""
+        monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
+        data = self._run(FORMATTER_VFORMAT_TRAVERSAL_CODE, global_imports="math,string")
+        assert "error" in data
+        assert "not allowed" in data["error"]
+        assert "SHOULD_NOT_LEAK" not in str(data)
+
+    def test_formatter_get_field_traversal_is_blocked(self, monkeypatch):
+        """string.Formatter().get_field traverses a dotted string path; blocked."""
+        monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
+        data = self._run(FORMATTER_GET_FIELD_TRAVERSAL_CODE, global_imports="math,string")
+        assert "error" in data
+        assert "not allowed" in data["error"]
+        assert "SHOULD_NOT_LEAK" not in str(data)
+
+    def test_attrgetter_traversal_is_blocked(self, monkeypatch):
+        """operator.attrgetter('__globals__') reaches os.environ via a string arg; blocked."""
+        monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
+        data = self._run(ATTRGETTER_TRAVERSAL_CODE, global_imports="math,operator")
         assert "error" in data
         assert "not allowed" in data["error"]
         assert "SHOULD_NOT_LEAK" not in str(data)

--- a/src/backend/tests/unit/components/tools/test_python_repl_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_repl_tool.py
@@ -5,6 +5,12 @@ from lfx.components.utilities.python_repl_core import PythonREPLComponent
 
 from tests.base import DID_NOT_EXIST, ComponentTestBaseWithoutClient
 
+DYNAMIC_FORMAT_TRAVERSAL_CODE = """
+parts = ["__loader__", "find_spec", "__globals__"]
+field = "{0." + parts[0] + "." + parts[1] + "." + parts[2] + "[sys].modules[os].environ}"
+print("canary_present=" + str("PVR0800453_CANARY" in field.format(math)))
+"""
+
 
 class TestPythonREPLComponent(ComponentTestBaseWithoutClient):
     @pytest.fixture
@@ -109,6 +115,14 @@ class TestPythonREPLComponentSecurity:
         assert "error" in data
         assert "not allowed" in data["error"]
 
+    def test_dynamic_format_string_traversal_is_blocked(self, monkeypatch):
+        """Dynamically-built str.format() fields cannot bypass the AST validator."""
+        monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
+        data = self._run(DYNAMIC_FORMAT_TRAVERSAL_CODE)
+        assert "error" in data
+        assert "not allowed" in data["error"]
+        assert "SHOULD_NOT_LEAK" not in str(data)
+
     def test_default_global_imports_excludes_pandas(self):
         """The default allow-list is minimal (no pandas) to avoid bundling a deserialization sink."""
         template = PythonREPLComponent().to_frontend_node()["data"]["node"]["template"]
@@ -155,6 +169,12 @@ class TestPythonREPLToolComponentSecurity:
     def test_tool_blocks_subclasses_escape(self):
         with pytest.raises(ToolException, match="not allowed"):
             self._func()("().__class__.__bases__[0].__subclasses__()")
+
+    def test_tool_blocks_dynamic_format_string_traversal(self, monkeypatch):
+        monkeypatch.setenv("PVR0800453_CANARY", "SHOULD_NOT_LEAK")
+        with pytest.raises(ToolException, match="not allowed") as exc_info:
+            self._func()(DYNAMIC_FORMAT_TRAVERSAL_CODE)
+        assert "SHOULD_NOT_LEAK" not in str(exc_info.value)
 
     def test_tool_blocks_import_builtin(self):
         """__import__ is a bare name; PythonREPL surfaces the NameError as a string."""

--- a/src/lfx/src/lfx/utils/python_repl_security.py
+++ b/src/lfx/src/lfx/utils/python_repl_security.py
@@ -21,10 +21,11 @@ This module restricts that environment:
   (``().__class__.__subclasses__()``) and frame/traceback introspection
   (``gen.gi_frame.f_back.f_globals``). It also rejects ``str.format`` /
   ``str.format_map`` and the lower-level formatter sinks (``string.Formatter`` traversal
-  primitives and ``operator.attrgetter``) because replacement fields / dotted paths are
-  evaluated at runtime and can traverse attributes that are invisible to the AST, and it
-  rejects literal replacement-field templates that reach into a dunder regardless of
-  which formatter ultimately consumes them.
+  primitives, ``operator.attrgetter`` and ``operator.methodcaller``) because replacement
+  fields / dotted paths / deferred method names are evaluated at runtime and can traverse
+  attributes that are invisible to the AST, and it rejects literal replacement-field
+  templates that reach into a dunder regardless of which formatter ultimately consumes
+  them.
 
 This is defense-in-depth, NOT a guaranteed sandbox — Python sandboxing is notoriously
 hard and determined attackers may still find gadgets. The primary control for untrusted
@@ -156,6 +157,17 @@ _BLOCKED_ATTRIBUTES = frozenset(
         "format_field",
         "convert_field",
         "attrgetter",
+        # ``operator.methodcaller`` defers a method *name* (a runtime string) to call
+        # time, so it reaches the same sinks invisibly to the AST: a runtime-assembled
+        # template defeats the ``_FORMAT_FIELD_DUNDER_RE`` literal scan, and
+        # ``methodcaller("format", f)(tmpl)`` (== ``tmpl.format(f)``) /
+        # ``methodcaller("format_map", d)(tmpl)`` carry the dunder chain in ``tmpl``.
+        # More generally ``methodcaller("__getattribute__", "__globals__")(f)`` would
+        # bypass the dunder-attribute check entirely, so block the factory by name.
+        # (``operator.itemgetter`` is intentionally NOT blocked: it only performs
+        # subscription, cannot do the attribute traversal needed to bootstrap an escape,
+        # and is common in legitimate data code.)
+        "methodcaller",
         "mro",  # int.mro() reaches the object hierarchy without a dunder attribute
     }
 )

--- a/src/lfx/src/lfx/utils/python_repl_security.py
+++ b/src/lfx/src/lfx/utils/python_repl_security.py
@@ -20,8 +20,11 @@ This module restricts that environment:
   ``import`` or reaches the classic builtin-free escape gadgets: dunder attribute access
   (``().__class__.__subclasses__()``) and frame/traceback introspection
   (``gen.gi_frame.f_back.f_globals``). It also rejects ``str.format`` /
-  ``str.format_map`` method calls because replacement fields are evaluated by the
-  formatter at runtime and can traverse attributes that are invisible to the AST.
+  ``str.format_map`` and the lower-level formatter sinks (``string.Formatter`` traversal
+  primitives and ``operator.attrgetter``) because replacement fields / dotted paths are
+  evaluated at runtime and can traverse attributes that are invisible to the AST, and it
+  rejects literal replacement-field templates that reach into a dunder regardless of
+  which formatter ultimately consumes them.
 
 This is defense-in-depth, NOT a guaranteed sandbox — Python sandboxing is notoriously
 hard and determined attackers may still find gadgets. The primary control for untrusted
@@ -33,6 +36,7 @@ from __future__ import annotations
 
 import ast
 import builtins
+import re
 
 # Builtins considered safe to expose to interpreter code. Deliberately excludes anything
 # that can import modules, execute/compile code, touch the filesystem, or reach
@@ -139,9 +143,28 @@ _BLOCKED_ATTRIBUTES = frozenset(
         "__dict__",
         "format",
         "format_map",
+        # ``str.format``/``format_map`` are not the only formatter sinks: the same
+        # dunder-traversal lives in a *string* argument (invisible to the AST attribute
+        # check) when fed through the lower-level ``string.Formatter`` primitives or
+        # ``operator.attrgetter``. Block the method names so e.g.
+        # ``string.Formatter().vformat("{0.__globals__[os]...}", (f,), {})``,
+        # ``Formatter().get_field("0.__globals__...", (f,), {})`` and
+        # ``operator.attrgetter("__globals__")(f)`` are rejected as ast.Attribute.
+        "vformat",
+        "get_field",
+        "get_value",
+        "format_field",
+        "convert_field",
+        "attrgetter",
         "mro",  # int.mro() reaches the object hierarchy without a dunder attribute
     }
 )
+
+# Matches a dunder reached inside a str.format()/Formatter replacement field, e.g.
+# "{0.__globals__}" or "{0[__builtins__]}". Such traversals live inside a literal
+# template string and are invisible to the AST attribute check below, so a literal
+# dunder-bearing template is rejected regardless of which formatter consumes it.
+_FORMAT_FIELD_DUNDER_RE = re.compile(r"\{[^{}]*__")
 
 
 class CodeExecutionDisabledError(ValueError):
@@ -238,4 +261,15 @@ def validate_code_safety(code: str) -> None:
             raise ValueError(msg)  # noqa: TRY004 -- forbidden construct, not an argument type error
         if isinstance(node, ast.Attribute) and _is_blocked_attribute(node.attr):
             msg = f"Access to attribute '{node.attr}' is not allowed."
+            raise ValueError(msg)
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and _FORMAT_FIELD_DUNDER_RE.search(node.value)
+        ):
+            # Blocks "{0.__globals__}" style traversal that the AST attribute check cannot
+            # see because the attribute chain lives inside a literal string. Catches the
+            # template regardless of which formatter (str.format, Formatter.vformat, ...)
+            # ultimately consumes it.
+            msg = "Access to dunder attributes via format strings is not allowed."
             raise ValueError(msg)

--- a/src/lfx/src/lfx/utils/python_repl_security.py
+++ b/src/lfx/src/lfx/utils/python_repl_security.py
@@ -19,7 +19,9 @@ This module restricts that environment:
 * :func:`validate_code_safety` rejects code that bypasses the allow-list with an inline
   ``import`` or reaches the classic builtin-free escape gadgets: dunder attribute access
   (``().__class__.__subclasses__()``) and frame/traceback introspection
-  (``gen.gi_frame.f_back.f_globals``).
+  (``gen.gi_frame.f_back.f_globals``). It also rejects ``str.format`` /
+  ``str.format_map`` method calls because replacement fields are evaluated by the
+  formatter at runtime and can traverse attributes that are invisible to the AST.
 
 This is defense-in-depth, NOT a guaranteed sandbox — Python sandboxing is notoriously
 hard and determined attackers may still find gadgets. The primary control for untrusted
@@ -31,7 +33,6 @@ from __future__ import annotations
 
 import ast
 import builtins
-import re
 
 # Builtins considered safe to expose to interpreter code. Deliberately excludes anything
 # that can import modules, execute/compile code, touch the filesystem, or reach
@@ -136,14 +137,11 @@ _BLOCKED_ATTRIBUTES = frozenset(
         "func_globals",
         "func_code",
         "__dict__",
+        "format",
+        "format_map",
         "mro",  # int.mro() reaches the object hierarchy without a dunder attribute
     }
 )
-
-# Matches a str.format()/format_map() replacement field that reaches into a dunder
-# attribute or item (e.g. "{0.__globals__}", "{0[__builtins__]}"). Such traversals live
-# inside the template string and are invisible to the AST attribute check below.
-_FORMAT_FIELD_DUNDER_RE = re.compile(r"\{[^{}]*__")
 
 
 class CodeExecutionDisabledError(ValueError):
@@ -223,7 +221,8 @@ def validate_code_safety(code: str) -> None:
 
     This complements :func:`safe_builtins`: restricted builtins stop ``__import__`` /
     ``open`` / ``eval`` etc., while this AST check stops the builtin-free escapes
-    (dunder attribute traversal and frame introspection) and inline imports.
+    (dunder attribute traversal, formatter traversal, and frame introspection) and
+    inline imports.
 
     Args:
         code: The Python source to be executed.
@@ -239,13 +238,4 @@ def validate_code_safety(code: str) -> None:
             raise ValueError(msg)  # noqa: TRY004 -- forbidden construct, not an argument type error
         if isinstance(node, ast.Attribute) and _is_blocked_attribute(node.attr):
             msg = f"Access to attribute '{node.attr}' is not allowed."
-            raise ValueError(msg)
-        if (
-            isinstance(node, ast.Constant)
-            and isinstance(node.value, str)
-            and _FORMAT_FIELD_DUNDER_RE.search(node.value)
-        ):
-            # Blocks str.format("{0.__globals__}") style traversal that the AST attribute
-            # check cannot see because the attribute chain is inside a literal string.
-            msg = "Access to dunder attributes via format strings is not allowed."
             raise ValueError(msg)

--- a/src/lfx/tests/unit/utils/test_python_repl_security.py
+++ b/src/lfx/tests/unit/utils/test_python_repl_security.py
@@ -81,10 +81,13 @@ class TestValidateCodeSafety:
             '"{0.__globals__}".format(f)',
             '"{0[__builtins__]}".format(f)',
             '"{0.__class__}".format(obj)',
+            "'{0}'.format(1)",
+            "'{name}'.format_map({'name': 'x'})",
+            "template = '{0.' + 'value' + '}'\ntemplate.format(obj)",
         ],
     )
     def test_blocks_escape_and_import(self, code):
-        """Inline imports, dunder/frame escape gadgets, and format-string dunder access are rejected."""
+        """Inline imports, escape gadgets, and formatter method access are rejected."""
         with pytest.raises(ValueError, match="not allowed"):
             validate_code_safety(code)
 
@@ -97,9 +100,8 @@ class TestValidateCodeSafety:
             "math.sqrt(16)",
             "result = [i * 2 for i in range(5)]\nprint(sum(result))",
             "data = {'a': 1, 'b': 2}\nprint(sorted(data.items()))",
-            "'{0} and {1}'.format(1, 2)",
-            "'{name}'.format(name='x')",
-            "'{0:.2f}'.format(3.14159)",
+            "name = 'x'\nprint(f'{name}')",
+            "print(format(3.14159, '.2f'))",
         ],
     )
     def test_allows_safe_code(self, code):

--- a/src/lfx/tests/unit/utils/test_python_repl_security.py
+++ b/src/lfx/tests/unit/utils/test_python_repl_security.py
@@ -90,6 +90,12 @@ class TestValidateCodeSafety:
             'string.Formatter().get_field("0.__loader__.find_spec.__globals__[sys]", (f,), {})',
             "string.Formatter().get_value(0, (f,), {})",
             'operator.attrgetter("__globals__")(f)',
+            # ``operator.methodcaller`` defers a method name to call time, so a
+            # runtime-assembled template (no literal "{...__" for the regex to catch)
+            # reaches str.format/format_map invisibly. Blocked via the factory name.
+            'operator.methodcaller("format", f)(tmpl)',
+            'operator.methodcaller("format_map", d)(tmpl)',
+            'operator.methodcaller("__getattribute__", "__globals__")(f)',
             # A literal dunder-bearing template reaches a non-blocked formatter via a var;
             # the literal-field scan rejects the template regardless of the consumer.
             't = "{0.__globals__}"\nstring.Formatter().vformat(t, (f,), {})',
@@ -128,10 +134,10 @@ class TestFormatterSinkBypassesAreBlocked:
 
     ``str.format``/``format_map`` are not the only formatter sinks: the same
     ``__globals__`` traversal lives in a *string* argument (invisible to the AST
-    attribute check) when fed through ``string.Formatter`` traversal primitives or
-    ``operator.attrgetter``. Each test first proves the gadget *does* leak an env var
-    canary when run unguarded, then asserts ``validate_code_safety`` rejects the exact
-    input before it could execute.
+    attribute check) when fed through ``string.Formatter`` traversal primitives,
+    ``operator.attrgetter`` or ``operator.methodcaller``. Each test first proves the
+    gadget *does* leak an env var canary when run unguarded, then asserts
+    ``validate_code_safety`` rejects the exact input before it could execute.
     """
 
     @staticmethod
@@ -182,6 +188,46 @@ class TestFormatterSinkBypassesAreBlocked:
         assert leaked == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
 
         code = 'operator.attrgetter("__globals__")(f)'
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_code_safety(code)
+
+    def test_operator_methodcaller_format_bypass(self, monkeypatch):
+        """``operator.methodcaller('format', f)`` invokes str.format on a runtime template.
+
+        Unlike a literal ``"{0.__globals__}".format(f)``, the template is assembled at
+        runtime so the ``_FORMAT_FIELD_DUNDER_RE`` literal scan never sees ``{...__``,
+        and ``methodcaller`` keeps the method name ``"format"`` in a *string* argument so
+        there is no ``ast.Attribute`` named ``format`` either. Blocking the ``methodcaller``
+        factory name is what rejects it.
+        """
+        import operator
+
+        monkeypatch.setenv("LFX_REPL_CANARY", "SHOULD_NOT_LEAK")
+        # Template built from fragments at runtime — invisible to the literal-field scan.
+        tmpl = "{0." + "__globals__" + "[os].environ[LFX_REPL_CANARY]}"
+        leaked = operator.methodcaller("format", self._func_with_os())(tmpl)
+        assert leaked == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
+
+        code = 'operator.methodcaller("format", f)(tmpl)'
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_code_safety(code)
+
+    def test_operator_methodcaller_getattribute_bypass(self, monkeypatch):
+        """``methodcaller('__getattribute__', '__globals__')`` reaches an attr by string name.
+
+        ``methodcaller`` can invoke *any* method — including ``__getattribute__`` — with the
+        attribute name supplied as a runtime string, bypassing the dunder-attribute AST
+        check. Blocked via the ``methodcaller`` factory name.
+        """
+        import operator
+
+        monkeypatch.setenv("LFX_REPL_CANARY", "SHOULD_NOT_LEAK")
+        leaked = operator.methodcaller("__getattribute__", "__globals__")(self._func_with_os())["os"].environ[
+            "LFX_REPL_CANARY"
+        ]
+        assert leaked == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
+
+        code = 'operator.methodcaller("__getattribute__", "__globals__")(f)'
         with pytest.raises(ValueError, match="not allowed"):
             validate_code_safety(code)
 

--- a/src/lfx/tests/unit/utils/test_python_repl_security.py
+++ b/src/lfx/tests/unit/utils/test_python_repl_security.py
@@ -84,6 +84,15 @@ class TestValidateCodeSafety:
             "'{0}'.format(1)",
             "'{name}'.format_map({'name': 'x'})",
             "template = '{0.' + 'value' + '}'\ntemplate.format(obj)",
+            # Sibling formatter sinks that carry the dunder chain in a *string* argument
+            # (invisible to the AST attribute check) — blocked via the method name.
+            'string.Formatter().vformat("{0.__globals__[os].environ[SECRET]}", (f,), {})',
+            'string.Formatter().get_field("0.__loader__.find_spec.__globals__[sys]", (f,), {})',
+            "string.Formatter().get_value(0, (f,), {})",
+            'operator.attrgetter("__globals__")(f)',
+            # A literal dunder-bearing template reaches a non-blocked formatter via a var;
+            # the literal-field scan rejects the template regardless of the consumer.
+            't = "{0.__globals__}"\nstring.Formatter().vformat(t, (f,), {})',
         ],
     )
     def test_blocks_escape_and_import(self, code):
@@ -112,6 +121,69 @@ class TestValidateCodeSafety:
         """Unparseable code surfaces a SyntaxError to the caller."""
         with pytest.raises(SyntaxError):
             validate_code_safety("print('unterminated")
+
+
+class TestFormatterSinkBypassesAreBlocked:
+    """Env-canary regression for the sibling-formatter sandbox bypass.
+
+    ``str.format``/``format_map`` are not the only formatter sinks: the same
+    ``__globals__`` traversal lives in a *string* argument (invisible to the AST
+    attribute check) when fed through ``string.Formatter`` traversal primitives or
+    ``operator.attrgetter``. Each test first proves the gadget *does* leak an env var
+    canary when run unguarded, then asserts ``validate_code_safety`` rejects the exact
+    input before it could execute.
+    """
+
+    @staticmethod
+    def _func_with_os():
+        """A function whose ``__globals__`` deterministically contains ``os``.
+
+        The gadget escapes via ``func.__globals__[os]``, so the precondition only leaks
+        when ``os`` is bound in the function's module globals. Building the function with
+        an explicit globals dict makes the leak reproducible regardless of which modules
+        this test file happens to import.
+        """
+        import os
+
+        namespace = {"os": os}
+        exec("def _f():\n    return 0", namespace)  # noqa: S102 - test-only controlled exec
+        return namespace["_f"]
+
+    def test_formatter_vformat_bypass(self, monkeypatch):
+        """``string.Formatter().vformat`` reaches os.environ; the call is blocked."""
+        import string
+
+        monkeypatch.setenv("LFX_REPL_CANARY", "SHOULD_NOT_LEAK")
+        leaked = string.Formatter().vformat("{0.__globals__[os].environ[LFX_REPL_CANARY]}", (self._func_with_os(),), {})
+        assert leaked == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
+
+        code = 'string.Formatter().vformat("{0.__globals__[os].environ[LFX_REPL_CANARY]}", (f,), {})'
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_code_safety(code)
+
+    def test_formatter_get_field_bypass(self, monkeypatch):
+        """``string.Formatter().get_field`` traverses a dotted path; the call is blocked."""
+        import string
+
+        monkeypatch.setenv("LFX_REPL_CANARY", "SHOULD_NOT_LEAK")
+        obj, _ = string.Formatter().get_field("0.__globals__[os].environ[LFX_REPL_CANARY]", (self._func_with_os(),), {})
+        assert obj == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
+
+        code = 'string.Formatter().get_field("0.__globals__[os].environ[LFX_REPL_CANARY]", (f,), {})'
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_code_safety(code)
+
+    def test_operator_attrgetter_bypass(self, monkeypatch):
+        """``operator.attrgetter('__globals__')`` reaches os.environ; the call is blocked."""
+        import operator
+
+        monkeypatch.setenv("LFX_REPL_CANARY", "SHOULD_NOT_LEAK")
+        leaked = operator.attrgetter("__globals__")(self._func_with_os())["os"].environ["LFX_REPL_CANARY"]
+        assert leaked == "SHOULD_NOT_LEAK"  # gadget is real when unguarded
+
+        code = 'operator.attrgetter("__globals__")(f)'
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_code_safety(code)
 
 
 class TestEnsureCodeExecutionEnabled:


### PR DESCRIPTION
## Summary

- Confirmed `release-1.10.2` still allowed Python Interpreter / Python REPL validation to miss dynamically constructed formatter traversal.
- Reject `.format` and `.format_map` method access in the Python REPL AST validator, while keeping the safe builtin `format()` available.
- Add regression coverage for both the Python Interpreter component and the legacy Python REPL tool path.

## Validation

- Before the fix, the new backend regression failed: the Interpreter returned `{"result": "canary_present=True"}` and the tool path did not raise.
- `uv run pytest src/backend/tests/unit/components/tools/test_python_repl_tool.py -q`
- From `src/lfx`: `env UV_PROJECT_ENVIRONMENT=/private/tmp/langflow-pvr0800453-lfx-venv uv run pytest tests/unit/utils/test_python_repl_security.py -q`
- `uv run ruff check src/lfx/src/lfx/utils/python_repl_security.py src/backend/tests/unit/components/tools/test_python_repl_tool.py src/lfx/tests/unit/utils/test_python_repl_security.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Python REPL safety checks so formatting-based escape attempts are blocked.
  * Improved error handling to prevent sensitive values from appearing in failure messages.
  * Added regression coverage for both the REPL component and tool-level behavior.
* **Tests**
  * Expanded validation cases to cover blocked format-string traversal patterns and confirmed safe code still works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->