### PR TITLE
fix(frontend): guard IME composition in inline rename Enter handlers

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx
@@ -62,7 +62,7 @@ export default function NodeName({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       handleBlur();
       toggleEditNameDescription();
     }

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-rename.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-rename.tsx
@@ -43,7 +43,7 @@ export const SessionRename: React.FC<SessionRenameProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       e.preventDefault();
       e.stopPropagation();
       commit();

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/EditableHeaderContent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/EditableHeaderContent.tsx
@@ -130,7 +130,7 @@ export default function EditableHeaderContent({
   };
 
   const handleNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       e.preventDefault();
       // Save and exit edit mode
       handleSave();

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review/editable-tool-name.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review/editable-tool-name.tsx
@@ -47,7 +47,8 @@ export function EditableToolName({
           onBlur={confirm}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
-            if (event.key === "Enter") confirm();
+            if (event.key === "Enter" && !event.nativeEvent.isComposing)
+              confirm();
             if (event.key === "Escape") cancel();
           }}
         />


### PR DESCRIPTION
### Problem

A few inline rename inputs commit on `Enter` without checking whether an IME composition is in progress. With a Japanese, Chinese, or Korean IME, the `Enter` that confirms a candidate also fires the rename, so the field commits mid-conversion and closes before the user has finished typing the name.

The codebase already guards this in the inputs that were written with IME in mind. The chat input checks `!event.nativeEvent.isComposing`, and `SaveVersionDialog` tracks an `isComposing` ref before acting on `Enter`. The four rename handlers below were missing the same check:

- `session-rename.tsx` (rename a chat session)
- `NodeName` (rename a node)
- `EditableHeaderContent` (rename in the inspection panel)
- `editable-tool-name.tsx` (tool name in the deployments review step)

### Change

Added `&& !e.nativeEvent.isComposing` to the existing `Enter` branch in each handler, matching the guard the chat input already uses. `Escape`, blur, and the button-based confirm paths are untouched.

When no composition is active `isComposing` is `false`, so behavior is unchanged for plain (non-IME) input. The guard only suppresses the `Enter` keystroke that ends a composition.

`npx @biomejs/biome check` passes on the four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard behavior for several editable text fields so pressing Enter no longer confirms changes while an IME composition is in progress.
  * This helps prevent accidental saves, renames, or exits when entering text in languages that use composition-based input.
  * Escape and blur behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->