### PR TITLE
[codex] Fix flow list card accessibility

### DIFF
--- a/src/frontend/src/pages/MainPage/components/list/__tests__/list.a11y.test.tsx
+++ b/src/frontend/src/pages/MainPage/components/list/__tests__/list.a11y.test.tsx
@@ -1,6 +1,9 @@
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { FlowType } from "@/types/flow";
 import ListComponent from "../index";
+
+const mockNavigate = jest.fn();
 
 // Mock data-layer and modal dependencies — this suite only asserts the
 // card's interactive semantics (a11y-action-plan 2.2).
@@ -8,7 +11,7 @@ jest.mock("react-router-dom", () => ({
   useParams: () => ({ folderId: undefined }),
 }));
 jest.mock("@/customization/hooks/use-custom-navigate", () => ({
-  useCustomNavigate: () => jest.fn(),
+  useCustomNavigate: () => mockNavigate,
 }));
 jest.mock("@/hooks/flows/use-delete-flow", () => ({
   __esModule: true,
@@ -41,13 +44,23 @@ const flowData = {
 
 // The card resolves its icon asynchronously (getIcon().then(setIcon));
 // flush that update inside the test to avoid act() warnings.
-const renderCard = async () => {
+const renderCard = async ({
+  selected = false,
+  setSelected = jest.fn(),
+  shiftPressed = false,
+  flow = flowData,
+}: {
+  selected?: boolean;
+  setSelected?: (selected: boolean) => void;
+  shiftPressed?: boolean;
+  flow?: FlowType;
+} = {}) => {
   const view = render(
     <ListComponent
-      flowData={flowData}
-      selected={false}
-      setSelected={() => {}}
-      shiftPressed={false}
+      flowData={flow}
+      selected={selected}
+      setSelected={setSelected}
+      shiftPressed={shiftPressed}
     />,
   );
   await act(async () => {});
@@ -55,35 +68,83 @@ const renderCard = async () => {
 };
 
 describe("Flow list card accessibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should_render_flow_name", async () => {
     await renderCard();
 
     expect(screen.getByText("My Flow")).toBeInTheDocument();
   });
 
-  // Known gap (a11y-action-plan 2.2): the card is a click-only container —
-  // no link or button role for the primary "open flow" action and no
-  // keyboard focusability. Fails until the fix lands.
-  it("should_expose_card_as_focusable_interactive_element", async () => {
+  it("should_expose_primary_open_action_without_making_card_interactive", async () => {
     await renderCard();
 
     const card = screen.getByTestId("list-card");
-    const role = card.getAttribute("role");
-    const isNativeInteractive = ["a", "button"].includes(
-      card.tagName.toLowerCase(),
-    );
-    expect(isNativeInteractive || role === "button" || role === "link").toBe(
-      true,
+    const openButton = screen.getByTestId("list-card-open-button");
+
+    expect(card).not.toHaveAttribute("role");
+    expect(card).not.toHaveAttribute("tabindex");
+    expect(openButton).toHaveAccessibleName(/My Flow/);
+  });
+
+  it("should_keep_nested_controls_outside_primary_open_button", async () => {
+    await renderCard();
+
+    const openButton = screen.getByTestId("list-card-open-button");
+    const checkbox = screen.getByTestId("checkbox-flow-123");
+    const menuButton = screen.getByTestId("home-dropdown-menu");
+
+    expect(openButton).not.toContainElement(checkbox);
+    expect(openButton).not.toContainElement(menuButton);
+    expect(openButton.querySelector("button,input,a,[role='button']")).toBe(
+      null,
     );
   });
 
-  it("should_make_card_keyboard_focusable", async () => {
+  it("should_make_primary_open_action_keyboard_focusable", async () => {
     await renderCard();
 
-    const card = screen.getByTestId("list-card");
+    const openButton = screen.getByTestId("list-card-open-button");
     act(() => {
-      card.focus();
+      openButton.focus();
     });
-    expect(card).toHaveFocus();
+    expect(openButton).toHaveFocus();
+  });
+
+  it("should_open_flow_from_primary_action", async () => {
+    const user = userEvent.setup();
+    await renderCard();
+
+    await user.click(screen.getByTestId("list-card-open-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/flow/flow-123");
+  });
+
+  it("should_select_flow_from_primary_action_when_shift_pressed", async () => {
+    const user = userEvent.setup();
+    const setSelected = jest.fn();
+    await renderCard({ setSelected, shiftPressed: true });
+
+    await user.click(screen.getByTestId("list-card-open-button"));
+
+    expect(setSelected).toHaveBeenCalledWith(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should_not_expose_noop_open_action_for_components", async () => {
+    await renderCard({
+      flow: {
+        ...flowData,
+        id: "component-123",
+        name: "My Component",
+        is_component: true,
+      } as FlowType,
+    });
+
+    expect(
+      screen.queryByTestId("list-card-open-button"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/pages/MainPage/components/list/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/list/index.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
@@ -107,6 +107,8 @@ const ListComponent = ({
   };
 
   const [icon, setIcon] = useState<string>("");
+  const flowNameId = `flow-name-${flowData.id}`;
+  const openActionLabelId = `flow-open-action-${flowData.id}`;
 
   useEffect(() => {
     getIcon().then(setIcon);
@@ -117,38 +119,32 @@ const ListComponent = ({
       <Card
         key={flowData.id}
         draggable={canMove}
-        // role/tabIndex instead of a native button: the card nests other
-        // interactive elements (checkbox, dropdown), which a <button>
-        // wrapper would make invalid markup. Component cards aren't
-        // activatable (click only selects with shift held), so they get no
-        // button semantics — exposing a no-op button would mislead AT users.
-        {...(!isComponent && {
-          role: "button",
-          tabIndex: 0,
-          "aria-label": t("flow.openFlow", { name: flowData.name }),
-          onKeyDown: (e: KeyboardEvent) => {
-            if (
-              (e.key === "Enter" || e.key === " ") &&
-              e.target === e.currentTarget
-            ) {
-              e.preventDefault();
-              handleClick();
-            }
-          },
-        })}
         onDragStart={onDragStart}
-        onClick={handleClick}
-        className={`flex flex-row bg-background ${
+        className={`relative flex flex-row bg-background ${
           isComponent ? "cursor-default" : "cursor-pointer"
         } group justify-between rounded-lg border-none px-4 py-3 shadow-none hover:bg-muted`}
         data-testid="list-card"
       >
+        {!isComponent && (
+          <>
+            <button
+              type="button"
+              className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2"
+              onClick={handleClick}
+              aria-labelledby={`${flowNameId} ${openActionLabelId}`}
+              data-testid="list-card-open-button"
+            />
+            <span id={openActionLabelId} className="sr-only">
+              {t("flows.openFlow", { defaultValue: "Open flow" })}
+            </span>
+          </>
+        )}
         <div
           className={`flex min-w-0 ${
             isComponent ? "cursor-default" : "cursor-pointer"
-          } items-center gap-4`}
+          } pointer-events-none relative z-10 items-center gap-4`}
         >
-          <div className="group/checkbox relative flex items-center">
+          <div className="group/checkbox pointer-events-auto relative flex items-center">
             <div
               className={cn(
                 "z-20 flex w-0 items-center transition-all duration-300",
@@ -192,7 +188,8 @@ const ListComponent = ({
               >
                 <span
                   className="truncate"
-                  data-testid={`flow-name-${flowData.id}`}
+                  data-testid={flowNameId}
+                  id={flowNameId}
                 >
                   {flowData.name}
                 </span>
@@ -208,7 +205,7 @@ const ListComponent = ({
           </div>
         </div>
 
-        <div className="ml-5 flex items-center gap-2">
+        <div className="relative z-10 ml-5 flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button


### PR DESCRIPTION
## Summary
- Replaces interactive card semantics with a separate full-card open button.
- Keeps checkbox and overflow menu as sibling controls instead of descendants.
- Adds focused list-card accessibility coverage for open, select, keyboard focus, and component no-op behavior.

## Why
LE-1565: IBM Equal Access scans reported invalid flow list card semantics because a button-like card contained nested controls.

## Validation
- npm test -- --runInBand src/pages/MainPage/components/list/__tests__/list.a11y.test.tsx
- npx @biomejs/biome check src/pages/MainPage/components/list/index.tsx src/pages/MainPage/components/list/__tests__/list.a11y.test.tsx
- RUN_A11Y=true npx playwright test tests/a11y/static-routes.a11y.spec.ts --project chromium -g "scans /flows"
- Playwright CLI manual browser checks for open, checkbox, menu, and keyboard activation

Refs LE-1565