### PR TITLE
fix: changed image base to be ubi10

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -112,6 +112,9 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
 # compose file) with the non-root user as owner. When the official compose mounts

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -9,7 +9,11 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install the project into `/app`
 WORKDIR /app
@@ -23,25 +27,23 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
+RUN microdnf update -y \
+    && microdnf install -y tar xz python3.14-devel \
     # deps for building python deps
-    build-essential \
+    gcc gcc-c++ make \
     git \
     # gcc
     gcc \
     curl \
-   && ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+   && ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION="22.14.0" \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
     && npm install -g npm@latest \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # Copy files first to avoid permission issues with bind mounts
 COPY ./uv.lock /app/uv.lock
@@ -89,19 +91,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14-slim-trixie AS runtime
-
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y curl git libpq5 gnupg xz-utils \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
+RUN microdnf update -y \
+    && microdnf install -y curl git libpq gnupg xz tar shadow-utils \
+    && microdnf clean all
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -27,8 +27,7 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz python3.14-devel \
+RUN microdnf install -y tar xz python3.14-devel \
     # deps for building python deps
     gcc gcc-c++ make \
     git \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -20,8 +20,7 @@ WORKDIR /app
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
 # Install build dependencies
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
         gcc gcc-c++ make python3.14-devel \
         gcc \
         git \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -8,7 +8,11 @@
 ################################
 # BUILDER
 ################################
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 WORKDIR /app
 
@@ -16,15 +20,13 @@ WORKDIR /app
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
 # Install build dependencies
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
-        build-essential \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
+        gcc gcc-c++ make \
         gcc \
         git \
         curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # Copy only backend source (excludes frontend)
 COPY ./src/backend ./src/backend
@@ -52,25 +54,23 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################################
 # RUNTIME
 ################################
-FROM python:3.14-slim-trixie AS runtime
-
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
 # Install minimal runtime dependencies
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
         curl \
         git \
-        libpq5 \
+        libpq \
         gnupg \
-        xz-utils \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        xz tar \
+    && microdnf clean all
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
 # Install Node.js (required for npx-based MCP stdio servers)
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -36,6 +36,9 @@ COPY ./src/sdk ./src/sdk
 # Using uv pip instead of uv sync to avoid workspace complexities
 RUN uv venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 ENV VIRTUAL_ENV="/app/.venv"
 
 # Install langflow-base with all extras except dev (which includes Playwright).
@@ -84,6 +87,9 @@ RUN useradd --uid 1000 --gid 0 --no-create-home --home-dir /app/data user
 # Copy only the virtual environment
 COPY --from=builder --chown=1000:0 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Create home directory and ensure proper ownership
 # The user needs write access to /app/data (home) and /app (workdir).

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -22,7 +22,7 @@ ENV RUSTFLAGS='--cfg reqwest_unstable'
 # Install build dependencies
 RUN microdnf update -y \
     && microdnf install -y tar xz \
-        gcc gcc-c++ make \
+        gcc gcc-c++ make python3.14-devel \
         gcc \
         git \
         curl \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -28,8 +28,7 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
     # deps for building python deps
     gcc gcc-c++ make python3.14-devel \
     git \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -114,6 +114,9 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
 # compose file) with the non-root user as owner. When the official compose mounts

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -10,7 +10,11 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install the project into `/app`
 WORKDIR /app
@@ -24,18 +28,16 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
     # deps for building python deps
-    build-essential \
+    gcc gcc-c++ make \
     git \
     # npm
     npm \
     # gcc
     gcc \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # Copy files first to avoid permission issues with bind mounts
 COPY ./uv.lock /app/uv.lock
@@ -92,19 +94,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14-slim-trixie AS runtime
-
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y curl git libpq5 gnupg xz-utils \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
+RUN microdnf update -y \
+    && microdnf install -y curl git libpq gnupg xz tar shadow-utils \
+    && microdnf clean all
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -31,7 +31,7 @@ ENV RUSTFLAGS='--cfg reqwest_unstable'
 RUN microdnf update -y \
     && microdnf install -y tar xz \
     # deps for building python deps
-    gcc gcc-c++ make \
+    gcc gcc-c++ make python3.14-devel \
     git \
     # npm
     npm \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -30,7 +30,7 @@ ENV RUSTFLAGS='--cfg reqwest_unstable'
 RUN microdnf update -y \
     && microdnf install -y tar xz \
     # deps for building python deps
-    gcc gcc-c++ make \
+    gcc gcc-c++ make python3.14-devel \
     git \
     # npm
     npm \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -9,7 +9,11 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install the project into `/app`
 WORKDIR /app
@@ -23,18 +27,16 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
     # deps for building python deps
-    build-essential \
+    gcc gcc-c++ make \
     git \
     # npm
     npm \
     # gcc
     gcc \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # Copy files first to avoid permission issues with bind mounts
 COPY ./uv.lock /app/uv.lock
@@ -80,18 +82,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14-slim-trixie AS runtime
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y curl git libpq5 gnupg xz-utils \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
+RUN microdnf update -y \
+    && microdnf install -y curl git libpq gnupg xz tar shadow-utils \
+    && microdnf clean all
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -27,8 +27,7 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
     # deps for building python deps
     gcc gcc-c++ make python3.14-devel \
     git \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -102,6 +102,9 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
 # compose file) with the non-root user as owner. When the official compose mounts

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -30,7 +30,7 @@ ENV RUSTFLAGS='--cfg reqwest_unstable'
 RUN microdnf update -y \
     && microdnf install -y tar xz \
     # deps for building python deps
-    gcc gcc-c++ make \
+    gcc gcc-c++ make python3.14-devel \
     git \
     # npm
     npm \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -27,8 +27,7 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
     # deps for building python deps
     gcc gcc-c++ make python3.14-devel \
     git \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -102,6 +102,9 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Pre-create LANGFLOW_CONFIG_DIR (the default location used by the docker_example
 # compose file) with the non-root user as owner. When the official compose mounts

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -9,7 +9,11 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install the project into `/app`
 WORKDIR /app
@@ -23,18 +27,16 @@ ENV UV_LINK_MODE=copy
 # Set RUSTFLAGS for reqwest unstable features needed by apify-client v2.0.0
 ENV RUSTFLAGS='--cfg reqwest_unstable'
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
     # deps for building python deps
-    build-essential \
+    gcc gcc-c++ make \
     git \
     # npm
     npm \
     # gcc
     gcc \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # Copy files first to avoid permission issues with bind mounts
 COPY ./uv.lock /app/uv.lock
@@ -80,19 +82,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14-slim-trixie AS runtime
-
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y curl git libpq5 gnupg xz-utils \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
+RUN microdnf update -y \
+    && microdnf install -y curl git libpq gnupg xz tar shadow-utils \
+    && microdnf clean all
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-RUN ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; \
-       elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
+       elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \

--- a/docker/cdk.Dockerfile
+++ b/docker/cdk.Dockerfile
@@ -3,8 +3,7 @@ USER root
 WORKDIR /app
 
 # Install Poetry
-RUN microdnf update -y \
-    && microdnf install -y python3.14-devel tar xz gcc gcc-c++ make curl postgresql-devel \
+RUN microdnf install -y python3.14-devel tar xz gcc gcc-c++ make curl postgresql-devel \
     && microdnf clean all
 RUN curl -sSL https://install.python-poetry.org | python3 -
 # # Add Poetry to PATH

--- a/docker/cdk.Dockerfile
+++ b/docker/cdk.Dockerfile
@@ -1,13 +1,11 @@
-FROM --platform=linux/amd64 python:3.10-slim
-
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/python-314-minimal
+USER root
 WORKDIR /app
 
 # Install Poetry
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install gcc g++ curl build-essential postgresql-server-dev-all -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN microdnf update -y \
+    && microdnf install -y python3.14-devel tar xz gcc gcc-c++ make curl postgresql-devel \
+    && microdnf clean all
 RUN curl -sSL https://install.python-poetry.org | python3 -
 # # Add Poetry to PATH
 ENV PATH="${PATH}:/root/.local/bin"

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,17 +1,19 @@
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 ENV TZ=UTC
 
 WORKDIR /app
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y \
-    build-essential \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
+    gcc gcc-c++ make \
     curl \
     npm \
     git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 COPY . /app
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -7,8 +7,7 @@ ENV TZ=UTC
 
 WORKDIR /app
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
     gcc gcc-c++ make python3.14-devel \
     curl \
     npm \

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 RUN microdnf update -y \
     && microdnf install -y tar xz \
-    gcc gcc-c++ make \
+    gcc gcc-c++ make python3.14-devel \
     curl \
     npm \
     git \

--- a/src/lfx/docker/Dockerfile
+++ b/src/lfx/docker/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=uv_installer /uv /usr/local/bin/uv
 COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install build dependencies needed for some Python packages on Alpine
-RUN microdnf install -y python3.14-devel tar xz gcc gcc-c++ make libaio-dev kernel-headers
+RUN microdnf install -y python3.14-devel tar xz gcc gcc-c++ make libaio-devel kernel-headers
 
 WORKDIR /app
 

--- a/src/lfx/docker/Dockerfile
+++ b/src/lfx/docker/Dockerfile
@@ -7,10 +7,14 @@
 ################################
 
 # Use an Alpine-based Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.14-alpine AS builder
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 # Install build dependencies needed for some Python packages on Alpine
-RUN apk add --no-cache build-base libaio-dev linux-headers
+RUN microdnf install -y python3.14-devel tar xz gcc gcc-c++ make libaio-dev kernel-headers
 
 WORKDIR /app
 
@@ -47,15 +51,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14-alpine AS runtime
-
+FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
+USER root
 # Create a non-root user
 # -D: Don't assign a password
 # -u: Set user ID
 # -G: Add to group (root)
 # -h: Set home directory
 # -s: Set shell
-RUN adduser -D -u 1000 -G root -h /app/data -s /sbin/nologin lfx
+RUN microdnf install -y tar xz shadow-utils && useradd -u 1000 -g 0 --no-create-home -d /app/data -s /sbin/nologin lfx
 
 # Copy the virtual environment from the builder stage
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/src/lfx/docker/Dockerfile
+++ b/src/lfx/docker/Dockerfile
@@ -66,6 +66,9 @@ COPY --from=builder --chown=1000 /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 LABEL org.opencontainers.image.title=lfx
 LABEL org.opencontainers.image.authors=['Langflow']

--- a/src/lfx/docker/Dockerfile.dev
+++ b/src/lfx/docker/Dockerfile.dev
@@ -17,8 +17,7 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
-RUN microdnf update -y \
-    && microdnf install -y tar xz \
+RUN microdnf install -y tar xz \
     gcc gcc-c++ make python3.14-devel \
     curl \
     git \

--- a/src/lfx/docker/Dockerfile.dev
+++ b/src/lfx/docker/Dockerfile.dev
@@ -19,7 +19,7 @@ ENV UV_LINK_MODE=copy
 
 RUN microdnf update -y \
     && microdnf install -y tar xz \
-    gcc gcc-c++ make \
+    gcc gcc-c++ make python3.14-devel \
     curl \
     git \
     vim \

--- a/src/lfx/docker/Dockerfile.dev
+++ b/src/lfx/docker/Dockerfile.dev
@@ -54,6 +54,9 @@ WORKDIR /app/src/lfx
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+ENV BASH_ENV="" \
+    ENV="" \
+    PROMPT_COMMAND=""
 
 # Expose any ports that might be needed for development
 EXPOSE 8000

--- a/src/lfx/docker/Dockerfile.dev
+++ b/src/lfx/docker/Dockerfile.dev
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 # Development Dockerfile for LFX
 
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:latest AS uv_installer
+FROM registry.access.redhat.com/ubi10/python-314-minimal
+USER root
+COPY --from=uv_installer /uv /usr/local/bin/uv
+COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
 ENV TZ=UTC
 
@@ -13,15 +17,13 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y \
-    build-essential \
+RUN microdnf update -y \
+    && microdnf install -y tar xz \
+    gcc gcc-c++ make \
     curl \
     git \
     vim \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && microdnf clean all
 
 # --- Copy only files that affect dependency resolution (best cache) ---
 # Workspace root metadata + lockfile


### PR DESCRIPTION
This pull request refactors all Dockerfiles to use Red Hat's `ubi10/python-314-minimal` base image instead of various Debian/Alpine-based Python images, and standardizes package installation using `microdnf` instead of `apt-get` or `apk`. It also changes the way the `uv` and `uvx` binaries are installed, now copying them from a separate `uv_installer` stage based on the `ghcr.io/astral-sh/uv:latest` image. These changes improve security, consistency, and compatibility across build and runtime Docker images.

**Base image and package manager migration:**

* All Dockerfiles now use `registry.access.redhat.com/ubi10/python-314-minimal` as the base Python image for both build and runtime stages, replacing Debian, Alpine, and other Python images. [[1]](diffhunk://#diff-b3bac7333e6b802f4fad29c96d5e0bda6a8b528a8919e57dd1952d3acd5f24bfL12-R16) [[2]](diffhunk://#diff-e0341de978afb40e04ebf43f839d19c380eaa4649302beb3c3f8a263944e3dbaL11-R29) [[3]](diffhunk://#diff-32abd041c294159a4a26950a88b120d6f3df94db4f00939465d71d8c72dc381dL13-R17) [[4]](diffhunk://#diff-774026a983ab9016559579119e44c81fa3554ed8293dcef6cfe60bca936891d8L12-R16) [[5]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL12-R16) [[6]](diffhunk://#diff-22fcd619e62c278c7cceaf1d8acda55adc4330ee78fd8852448b7d8cb8e2172eL1-R8) [[7]](diffhunk://#diff-ce12efbf469bed72c3a4b2fd19c4f08a5cb9788cea9243ab85b415601bb42d96L1-R16) [[8]](diffhunk://#diff-d1527b8807b6b6cd3d3ea5053af49bcf63418dcc160fb663abb3f8a51618b6c4L10-R17) [[9]](diffhunk://#diff-b850613b550baf03cf62bc589b93da4c457de9a6a73a2c22624af3f60b834cc1L4-R8)
* All package installations are now performed with `microdnf` (and `microdnf clean all`), replacing `apt-get` and `apk` commands, ensuring consistency and compatibility with UBI images. [[1]](diffhunk://#diff-b3bac7333e6b802f4fad29c96d5e0bda6a8b528a8919e57dd1952d3acd5f24bfL26-R46) [[2]](diffhunk://#diff-e0341de978afb40e04ebf43f839d19c380eaa4649302beb3c3f8a263944e3dbaL11-R29) [[3]](diffhunk://#diff-32abd041c294159a4a26950a88b120d6f3df94db4f00939465d71d8c72dc381dL27-R40) [[4]](diffhunk://#diff-774026a983ab9016559579119e44c81fa3554ed8293dcef6cfe60bca936891d8L26-R39) [[5]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL26-R39) [[6]](diffhunk://#diff-22fcd619e62c278c7cceaf1d8acda55adc4330ee78fd8852448b7d8cb8e2172eL1-R8) [[7]](diffhunk://#diff-ce12efbf469bed72c3a4b2fd19c4f08a5cb9788cea9243ab85b415601bb42d96L1-R16) [[8]](diffhunk://#diff-d1527b8807b6b6cd3d3ea5053af49bcf63418dcc160fb663abb3f8a51618b6c4L10-R17) [[9]](diffhunk://#diff-b850613b550baf03cf62bc589b93da4c457de9a6a73a2c22624af3f60b834cc1L16-R26)

**uv/uvx installation refactor:**

* The `uv` and `uvx` binaries are now copied from a dedicated `uv_installer` stage based on `ghcr.io/astral-sh/uv:latest`, rather than relying on them being present in the base image. This makes the installation explicit and consistent. [[1]](diffhunk://#diff-b3bac7333e6b802f4fad29c96d5e0bda6a8b528a8919e57dd1952d3acd5f24bfL12-R16) [[2]](diffhunk://#diff-e0341de978afb40e04ebf43f839d19c380eaa4649302beb3c3f8a263944e3dbaL11-R29) [[3]](diffhunk://#diff-32abd041c294159a4a26950a88b120d6f3df94db4f00939465d71d8c72dc381dL13-R17) [[4]](diffhunk://#diff-774026a983ab9016559579119e44c81fa3554ed8293dcef6cfe60bca936891d8L12-R16) [[5]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL12-R16) [[6]](diffhunk://#diff-ce12efbf469bed72c3a4b2fd19c4f08a5cb9788cea9243ab85b415601bb42d96L1-R16) [[7]](diffhunk://#diff-d1527b8807b6b6cd3d3ea5053af49bcf63418dcc160fb663abb3f8a51618b6c4L10-R17) [[8]](diffhunk://#diff-b850613b550baf03cf62bc589b93da4c457de9a6a73a2c22624af3f60b834cc1L4-R8)

**Runtime image improvements:**

* Runtime images now use UBI Python and install runtime dependencies with `microdnf`, and the logic for installing Node.js is updated to use `uname -m` instead of `dpkg --print-architecture` for better cross-platform compatibility. [[1]](diffhunk://#diff-b3bac7333e6b802f4fad29c96d5e0bda6a8b528a8919e57dd1952d3acd5f24bfL92-R103) [[2]](diffhunk://#diff-e0341de978afb40e04ebf43f839d19c380eaa4649302beb3c3f8a263944e3dbaL55-R73) [[3]](diffhunk://#diff-32abd041c294159a4a26950a88b120d6f3df94db4f00939465d71d8c72dc381dL95-R106) [[4]](diffhunk://#diff-774026a983ab9016559579119e44c81fa3554ed8293dcef6cfe60bca936891d8L83-R94) [[5]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL83-R94) [[6]](diffhunk://#diff-d1527b8807b6b6cd3d3ea5053af49bcf63418dcc160fb663abb3f8a51618b6c4L50-R62)

**User creation and permissions:**

* Where necessary, user creation is updated to use `useradd` (from `shadow-utils`) with UBI images, replacing `adduser` or Alpine-specific commands.

These changes make the Docker builds more secure, predictable, and easier to maintain across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple container builds to use Red Hat UBI 10 Python 3.14 base images.
  * Standardized package installation on `microdnf` and cleaned up image build steps.
  * Improved support for multiple CPU architectures when downloading Node.js.
  * Kept development, backend, and runtime images aligned across build variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->