### PR TITLE
fix(faiss): isolate FAISS persistence by user in lfx-bundles copy

### DIFF
--- a/src/backend/tests/unit/components/vectorstores/test_faiss_vector_store_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_faiss_vector_store_component.py
@@ -1,11 +1,58 @@
 """Regression tests for FaissVectorStoreComponent security defaults."""
 
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 pytest.importorskip("langchain_community")
 
+from langchain_core.documents import Document
 from lfx.io import BoolInput
+from lfx.schema.data import Data
 from lfx_bundles.faiss.faiss import FaissVectorStoreComponent
+
+
+class _FakeFAISS:
+    def __init__(self, documents: list[Document]) -> None:
+        self._documents = documents
+
+    @classmethod
+    def from_documents(cls, documents: list[Document], embedding: Any) -> "_FakeFAISS":  # noqa: ARG003
+        return cls(documents)
+
+    @classmethod
+    def load_local(
+        cls,
+        folder_path: str,
+        embeddings: Any,  # noqa: ARG003
+        index_name: str,
+        allow_dangerous_deserialization: bool,  # noqa: FBT001
+    ) -> "_FakeFAISS":
+        if not allow_dangerous_deserialization:
+            msg = "Dangerous deserialization is disabled."
+            raise ValueError(msg)
+        index_path = Path(folder_path) / f"{index_name}.faiss"
+        return cls([Document(page_content=index_path.read_text())])
+
+    def save_local(self, folder_path: str, index_name: str) -> None:
+        index_path = Path(folder_path) / f"{index_name}.faiss"
+        index_path.write_text(self._documents[0].page_content)
+
+    def similarity_search(self, query: str, k: int) -> list[Document]:  # noqa: ARG002
+        return self._documents[:k]
+
+
+def _component(user_id: str, persist_directory: Path, document: str, search_query: str) -> FaissVectorStoreComponent:
+    return FaissVectorStoreComponent(_user_id=user_id).set(
+        index_name="shared_index",
+        persist_directory=str(persist_directory),
+        ingest_data=[Data(text=document)],
+        embedding=object(),
+        search_query=search_query,
+        number_of_results=1,
+        allow_dangerous_deserialization=True,
+    )
 
 
 class TestFaissVectorStoreComponentDefaults:
@@ -35,3 +82,71 @@ class TestFaissVectorStoreComponentDefaults:
             if isinstance(inp, BoolInput) and inp.name == "allow_dangerous_deserialization"
         )
         assert input_def.advanced is True
+
+
+def test_faiss_persist_directory_is_scoped_by_user(tmp_path: Path) -> None:
+    owner_component = _component("owner-user", tmp_path, "owner document", "owner")
+    attacker_component = _component("attacker-user", tmp_path, "attacker document", "attacker")
+
+    owner_path = owner_component.get_persist_directory()
+    attacker_path = attacker_component.get_persist_directory()
+
+    assert owner_path != attacker_path
+    assert owner_path.parent == attacker_path.parent
+    assert tmp_path in owner_path.parents
+    assert tmp_path in attacker_path.parents
+
+
+def test_faiss_same_namespace_cannot_load_another_users_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    attacker_document = "ATTACKER_PRESEEDED_FAISS_DOCUMENT"
+    owner_document = "OWNER_EXPECTED_FAISS_DOCUMENT"
+
+    monkeypatch.setattr("lfx_bundles.faiss.faiss.FAISS", _FakeFAISS)
+
+    attacker_component = _component("attacker-user", tmp_path, attacker_document, "attacker")
+    attacker_results = attacker_component.search_documents()
+    assert attacker_results[0].text == attacker_document
+
+    owner_component = _component("owner-user", tmp_path, owner_document, "owner")
+    owner_results = owner_component.search_documents()
+
+    assert owner_results[0].text == owner_document
+    assert owner_results[0].text != attacker_document
+
+
+def test_faiss_index_name_cannot_escape_user_scope(tmp_path: Path) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name="../attacker")
+
+    with pytest.raises(ValueError, match="FAISS index name must be a file name"):
+        component.get_index_name()
+
+
+@pytest.mark.parametrize(
+    "index_name",
+    [
+        "D:shared",  # Windows drive-relative prefix escapes the per-user directory
+        "C:",  # bare drive letter
+        ":",  # bare colon
+        "a:b",  # embedded colon
+        ".",  # current directory reference
+        "..",  # parent directory reference
+        "...",  # all-dot name
+    ],
+)
+def test_faiss_index_name_rejects_drive_qualified_names(tmp_path: Path, index_name: str) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name=index_name)
+
+    with pytest.raises(ValueError, match="FAISS index name must be a file name"):
+        component.get_index_name()
+
+
+def test_faiss_index_name_accepts_portable_file_name(tmp_path: Path) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name="my_index")
+
+    assert component.get_index_name() == "my_index"
+
+
+def test_faiss_persist_directory_is_unscoped_without_runtime_user(tmp_path: Path) -> None:
+    component = FaissVectorStoreComponent().set(persist_directory=str(tmp_path))
+
+    assert component.get_persist_directory() == tmp_path.resolve()

--- a/src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py
@@ -1,3 +1,5 @@
+import re
+from hashlib import sha256
 from pathlib import Path
 
 from langchain_community.vectorstores import FAISS
@@ -14,6 +16,13 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
     description: str = "FAISS Vector Store with search capabilities"
     name = "FAISS"
     icon = "FAISS"
+
+    # Strict portable allow-list for the index file prefix: letters, digits, dot,
+    # underscore and hyphen only, and the name must contain at least one
+    # non-dot character. This rejects empty, ".", "..", path separators
+    # ("/", "\\") and drive-relative prefixes (e.g. "D:shared") that could escape
+    # the per-user persist directory.
+    _INDEX_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*$")
 
     inputs = [
         StrInput(
@@ -46,6 +55,17 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
     ]
 
     @staticmethod
+    def _user_scope(user_id: object) -> str | None:
+        if user_id is None:
+            return None
+
+        user_id_str = str(user_id).strip()
+        if not user_id_str or user_id_str.lower() == "none":
+            return None
+
+        return sha256(user_id_str.encode("utf-8")).hexdigest()[:32]
+
+    @staticmethod
     def resolve_path(path: str) -> str:
         """Resolve the path relative to the Langflow root.
 
@@ -56,16 +76,26 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
         """
         return str(Path(path).resolve())
 
+    def get_index_name(self) -> str:
+        """Returns the validated FAISS index file prefix."""
+        index_name = str(self.index_name or "").strip()
+        if not self._INDEX_NAME_PATTERN.match(index_name):
+            msg = "FAISS index name must be a file name, not a path."
+            raise ValueError(msg)
+        return index_name
+
     def get_persist_directory(self) -> Path:
-        """Returns the resolved persist directory path or the current directory if not set."""
-        if self.persist_directory:
-            return Path(self.resolve_path(self.persist_directory))
-        return Path()
+        """Returns the resolved, user-scoped persist directory path."""
+        path = Path(self.resolve_path(self.persist_directory)) if self.persist_directory else Path()
+        if user_scope := self._user_scope(self.user_id):
+            return path / ".langflow_faiss" / "users" / user_scope
+        return path
 
     @check_cached_vector_store
     def build_vector_store(self) -> FAISS:
         """Builds the FAISS object."""
         path = self.get_persist_directory()
+        index_name = self.get_index_name()
         path.mkdir(parents=True, exist_ok=True)
 
         # Convert DataFrame to Data if needed using parent's method
@@ -79,13 +109,14 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
                 documents.append(_input)
 
         faiss = FAISS.from_documents(documents=documents, embedding=self.embedding)
-        faiss.save_local(str(path), self.index_name)
+        faiss.save_local(str(path), index_name)
         return faiss
 
     def search_documents(self) -> list[Data]:
         """Search for documents in the FAISS vector store."""
         path = self.get_persist_directory()
-        index_path = path / f"{self.index_name}.faiss"
+        index_name = self.get_index_name()
+        index_path = path / f"{index_name}.faiss"
 
         if not index_path.exists():
             vector_store = self.build_vector_store()
@@ -93,7 +124,7 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
             vector_store = FAISS.load_local(
                 folder_path=str(path),
                 embeddings=self.embedding,
-                index_name=self.index_name,
+                index_name=index_name,
                 allow_dangerous_deserialization=self.allow_dangerous_deserialization,
             )
 


### PR DESCRIPTION
## Summary

Forward-port of #13871 ("fix: isolate FAISS persistence by user", on `release-1.10.2`) to the bundle-split line.

On `release-1.10.2` the FAISS hardening landed on the lfx-core copy `src/lfx/src/lfx/components/FAISS/faiss.py`. On the bundle-split branches the FAISS implementation lives **only** in the extracted bundle copy `src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py` (the lfx-core path is now a `# lfx-bundles-shim`). Without this port, main/bundle builds were still exposed to the **cross-user FAISS data leak**.

The bundle diff is byte-for-byte equivalent to #13871's `faiss.py` change.

## What changed

`src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py`:
- **Per-user persist directory** — `get_persist_directory()` scopes to `…/.langflow_faiss/users/<sha256(user_id)[:32]>` when a runtime user exists (new `_user_scope()` staticmethod; returns `None` for missing/`"none"` users, preserving the unscoped path).
- **Strict index-name allow-list** — new `get_index_name()` validates against `^[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*$`, rejecting empty, `.`, `..`, path separators, and drive-relative prefixes (e.g. `D:shared`); raises `ValueError` otherwise.
- The **validated** index name is used in `build_vector_store.save_local` and both `search_documents` sites (the `.faiss` existence check and `FAISS.load_local`).

## Tests

Ported the #13871 regression tests into the existing `src/backend/tests/unit/components/vectorstores/test_faiss_vector_store_component.py`, following this branch's bundle-component convention (`pytest.importorskip("langchain_community")` + import from `lfx_bundles.faiss.faiss`, monkeypatch `lfx_bundles.faiss.faiss.FAISS`). Kept the pre-existing `allow_dangerous_deserialization` defaults tests; added coverage for per-user dir scoping, cross-user index isolation, and index-name rejection (incl. Windows drive-relative names).

**14 passed** locally — verified in both a minimal venv and the fully-synced backend suite.

## No `component_index.json` change

FAISS is a bundle component and is **not** in the static core index. Verified by rebuilding the index in a full env with `lfx-bundles[all-no-torch]` installed: still 128 components / 17 modules, FAISS absent (bundles load dynamically via the `lfx.bundles` entry point, not the static index). So no code_hash/sha256 restamp is needed.

## Test plan
- [x] `pytest src/backend/tests/unit/components/vectorstores/test_faiss_vector_store_component.py` → 14 passed
- [x] `ruff check` / `ruff format` clean (pre-commit passed)
- [ ] CI: cross-bundle test + backend unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)