### PR TITLE
fix: isolate FAISS persistence by user (lfx-bundles copy)

### DIFF
--- a/src/backend/tests/unit/components/bundles/faiss/test_faiss_vector_store_component.py
+++ b/src/backend/tests/unit/components/bundles/faiss/test_faiss_vector_store_component.py
@@ -1,11 +1,126 @@
-"""Regression tests for FaissVectorStoreComponent security defaults."""
+"""Regression tests for FaissVectorStoreComponent security defaults and per-user isolation."""
+
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 pytest.importorskip("langchain_community")
 
+from langchain_core.documents import Document
 from lfx.io import BoolInput
+from lfx.schema.data import Data
 from lfx_bundles.faiss.faiss import FaissVectorStoreComponent
+
+
+class _FakeFAISS:
+    def __init__(self, documents: list[Document]) -> None:
+        self._documents = documents
+
+    @classmethod
+    def from_documents(cls, documents: list[Document], embedding: Any) -> "_FakeFAISS":  # noqa: ARG003
+        return cls(documents)
+
+    @classmethod
+    def load_local(
+        cls,
+        folder_path: str,
+        embeddings: Any,  # noqa: ARG003
+        index_name: str,
+        allow_dangerous_deserialization: bool,  # noqa: FBT001
+    ) -> "_FakeFAISS":
+        if not allow_dangerous_deserialization:
+            msg = "Dangerous deserialization is disabled."
+            raise ValueError(msg)
+        index_path = Path(folder_path) / f"{index_name}.faiss"
+        return cls([Document(page_content=index_path.read_text())])
+
+    def save_local(self, folder_path: str, index_name: str) -> None:
+        index_path = Path(folder_path) / f"{index_name}.faiss"
+        index_path.write_text(self._documents[0].page_content)
+
+    def similarity_search(self, query: str, k: int) -> list[Document]:  # noqa: ARG002
+        return self._documents[:k]
+
+
+def _component(user_id: str, persist_directory: Path, document: str, search_query: str) -> FaissVectorStoreComponent:
+    return FaissVectorStoreComponent(_user_id=user_id).set(
+        index_name="shared_index",
+        persist_directory=str(persist_directory),
+        ingest_data=[Data(text=document)],
+        embedding=object(),
+        search_query=search_query,
+        number_of_results=1,
+        allow_dangerous_deserialization=True,
+    )
+
+
+def test_faiss_persist_directory_is_scoped_by_user(tmp_path: Path) -> None:
+    owner_component = _component("owner-user", tmp_path, "owner document", "owner")
+    attacker_component = _component("attacker-user", tmp_path, "attacker document", "attacker")
+
+    owner_path = owner_component.get_persist_directory()
+    attacker_path = attacker_component.get_persist_directory()
+
+    assert owner_path != attacker_path
+    assert owner_path.parent == attacker_path.parent
+    assert tmp_path in owner_path.parents
+    assert tmp_path in attacker_path.parents
+
+
+def test_faiss_same_namespace_cannot_load_another_users_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    attacker_document = "ATTACKER_PRESEEDED_FAISS_DOCUMENT"
+    owner_document = "OWNER_EXPECTED_FAISS_DOCUMENT"
+
+    monkeypatch.setattr("lfx_bundles.faiss.faiss.FAISS", _FakeFAISS)
+
+    attacker_component = _component("attacker-user", tmp_path, attacker_document, "attacker")
+    attacker_results = attacker_component.search_documents()
+    assert attacker_results[0].text == attacker_document
+
+    owner_component = _component("owner-user", tmp_path, owner_document, "owner")
+    owner_results = owner_component.search_documents()
+
+    assert owner_results[0].text == owner_document
+    assert owner_results[0].text != attacker_document
+
+
+def test_faiss_index_name_cannot_escape_user_scope(tmp_path: Path) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name="../attacker")
+
+    with pytest.raises(ValueError, match="FAISS index name must be a file name"):
+        component.get_index_name()
+
+
+@pytest.mark.parametrize(
+    "index_name",
+    [
+        "D:shared",  # Windows drive-relative prefix escapes the per-user directory
+        "C:",  # bare drive letter
+        ":",  # bare colon
+        "a:b",  # embedded colon
+        ".",  # current directory reference
+        "..",  # parent directory reference
+        "...",  # all-dot name
+    ],
+)
+def test_faiss_index_name_rejects_drive_qualified_names(tmp_path: Path, index_name: str) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name=index_name)
+
+    with pytest.raises(ValueError, match="FAISS index name must be a file name"):
+        component.get_index_name()
+
+
+def test_faiss_index_name_accepts_portable_file_name(tmp_path: Path) -> None:
+    component = _component("owner-user", tmp_path, "owner document", "owner").set(index_name="my_index")
+
+    assert component.get_index_name() == "my_index"
+
+
+def test_faiss_persist_directory_is_unscoped_without_runtime_user(tmp_path: Path) -> None:
+    component = FaissVectorStoreComponent().set(persist_directory=str(tmp_path))
+
+    assert component.get_persist_directory() == tmp_path.resolve()
 
 
 class TestFaissVectorStoreComponentDefaults:

--- a/src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/faiss/faiss.py
@@ -1,3 +1,5 @@
+import re
+from hashlib import sha256
 from pathlib import Path
 
 from langchain_community.vectorstores import FAISS
@@ -14,6 +16,13 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
     description: str = "FAISS Vector Store with search capabilities"
     name = "FAISS"
     icon = "FAISS"
+
+    # Strict portable allow-list for the index file prefix: letters, digits, dot,
+    # underscore and hyphen only, and the name must contain at least one
+    # non-dot character. This rejects empty, ".", "..", path separators
+    # ("/", "\\") and drive-relative prefixes (e.g. "D:shared") that could escape
+    # the per-user persist directory.
+    _INDEX_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*$")
 
     inputs = [
         StrInput(
@@ -46,6 +55,17 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
     ]
 
     @staticmethod
+    def _user_scope(user_id: object) -> str | None:
+        if user_id is None:
+            return None
+
+        user_id_str = str(user_id).strip()
+        if not user_id_str or user_id_str.lower() == "none":
+            return None
+
+        return sha256(user_id_str.encode("utf-8")).hexdigest()[:32]
+
+    @staticmethod
     def resolve_path(path: str) -> str:
         """Resolve the path relative to the Langflow root.
 
@@ -56,16 +76,26 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
         """
         return str(Path(path).resolve())
 
+    def get_index_name(self) -> str:
+        """Returns the validated FAISS index file prefix."""
+        index_name = str(self.index_name or "").strip()
+        if not self._INDEX_NAME_PATTERN.match(index_name):
+            msg = "FAISS index name must be a file name, not a path."
+            raise ValueError(msg)
+        return index_name
+
     def get_persist_directory(self) -> Path:
-        """Returns the resolved persist directory path or the current directory if not set."""
-        if self.persist_directory:
-            return Path(self.resolve_path(self.persist_directory))
-        return Path()
+        """Returns the resolved, user-scoped persist directory path."""
+        path = Path(self.resolve_path(self.persist_directory)) if self.persist_directory else Path()
+        if user_scope := self._user_scope(self.user_id):
+            return path / ".langflow_faiss" / "users" / user_scope
+        return path
 
     @check_cached_vector_store
     def build_vector_store(self) -> FAISS:
         """Builds the FAISS object."""
         path = self.get_persist_directory()
+        index_name = self.get_index_name()
         path.mkdir(parents=True, exist_ok=True)
 
         # Convert DataFrame to Data if needed using parent's method
@@ -79,13 +109,14 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
                 documents.append(_input)
 
         faiss = FAISS.from_documents(documents=documents, embedding=self.embedding)
-        faiss.save_local(str(path), self.index_name)
+        faiss.save_local(str(path), index_name)
         return faiss
 
     def search_documents(self) -> list[Data]:
         """Search for documents in the FAISS vector store."""
         path = self.get_persist_directory()
-        index_path = path / f"{self.index_name}.faiss"
+        index_name = self.get_index_name()
+        index_path = path / f"{index_name}.faiss"
 
         if not index_path.exists():
             vector_store = self.build_vector_store()
@@ -93,7 +124,7 @@ class FaissVectorStoreComponent(LCVectorStoreComponent):
             vector_store = FAISS.load_local(
                 folder_path=str(path),
                 embeddings=self.embedding,
-                index_name=self.index_name,
+                index_name=index_name,
                 allow_dangerous_deserialization=self.allow_dangerous_deserialization,
             )
 


### PR DESCRIPTION
## Summary

Forward-port of #13871 to the metapackage-split bundle lineage (`release-1.11.0`).

#13871 closed a cross-user FAISS data leak on `release-1.10.2` by scoping persisted indexes under a per-user subdirectory and validating `index_name` against a strict allow-list. But on `release-1.11.0` the FAISS component was extracted from lfx-core into **lfx-bundles** (`lfx_bundles.faiss.faiss`); the lfx-core path is now only an import shim. Without this change, `release-1.11.0` (and `main`, once the bundle split merges into it) would ship the **bundle copy unpatched**.

This applies the **identical** fix to the bundle copy:

- Scope persisted FAISS indexes under a deterministic per-user directory `…/.langflow_faiss/users/<sha256(user_id)[:32]>/` when runtime user context exists (`get_persist_directory` + `_user_scope`).
- Reject path-like `index_name` values via a strict portable allow-list (`_INDEX_NAME_PATTERN` + `get_index_name`) so the name cannot escape the per-user directory — rejects path separators (`/`, `\`), drive-relative prefixes (`D:shared`, `C:`), colons, and pure-dot names (`.`, `..`, `...`).
- Applied consistently at all three sinks: `save_local` in `build_vector_store`, the `.faiss` existence check, and `FAISS.load_local` in `search_documents`.

## Tests

Added to the consolidated bundle-test path `src/backend/tests/unit/components/bundles/faiss/test_faiss_vector_store_component.py` (from #13895), retargeted to `lfx_bundles.faiss.faiss`:

- Cross-user isolation test: pre-seed an attacker index, assert the owner cannot read it.
- Per-user persist-directory scoping + `index_name` allow-list tests (incl. drive-qualified / pure-dot rejection).
- **Retained** `TestFaissVectorStoreComponentDefaults` (regression guard for `allow_dangerous_deserialization=False`, PVR0699083).

RED-verified: the cross-user isolation, persist-scope, and `index_name`-escape tests fail against the unpatched bundle copy and pass with the patch.

## Scope notes

- **No `component_index.json` restamp** — FAISS is not tracked in the post-bundle-split index (17 lfx-core modules only); lfx index tests stay green (27/27).
- **No starter-project / `.secrets.baseline` change** — unlike #13871 on `release-1.10.2`, no live starter project embeds FAISS on `release-1.11.0` (only the frozen 1.6.0 migration fixture, untouched).
- `main`'s remaining lfx-core FAISS copy still needs the plain #13871 forward-port; tracked separately, out of scope here.

## Validation

- `uv run ruff check` + `uv run ruff format --check` on both files — clean
- `uv run pytest src/backend/tests/unit/components/bundles/faiss/test_faiss_vector_store_component.py` — 14 passed
- `cd src/lfx && uv run --isolated pytest tests/unit/test_component_index.py` — 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FAISS indexes are now stored in a user-specific location when a user is signed in, helping prevent cross-user data overlap.
  * Loading existing indexes now respects that user-specific scope, improving isolation between accounts.
  * Index names are validated more strictly to block unsafe or unsupported values and avoid path-style issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->