### PR TITLE
fix(ci): pin lfx[extra] refs to exact dev version in nightly base bump

### DIFF
--- a/scripts/ci/test_update_lf_base_dependency.py
+++ b/scripts/ci/test_update_lf_base_dependency.py
@@ -1,0 +1,83 @@
+"""Regression tests for ``update_lf_base_dependency``.
+
+The nightly bump pins base's ``lfx`` dependency to the exact ``==X.Y.0.devN`` so the dev
+release resolves down the tree. Base also carries ``lfx[extra]`` references (the relocated
+cassio/toolguard features) that are pulled by ``langflow-base[complete]``. If those keep a
+``~=X.Y.0`` floor while the bare ``lfx`` dep is pinned to the dev version, the floor
+(``>=X.Y.0``) excludes ``X.Y.0.devN`` (PEP 440 dev releases sort *below* the final) and the
+resolve becomes unsatisfiable. These tests lock in that all ``lfx`` forms -- bare and with
+extras -- get the same exact dev pin.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import update_lf_base_dependency as mod
+
+
+@pytest.fixture
+def pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A throwaway pyproject whose lfx refs mirror src/backend/base/pyproject.toml."""
+    content = (
+        "[project]\n"
+        "dependencies = [\n"
+        '    "lfx~=1.11.0",\n'
+        "]\n"
+        "\n"
+        "[project.optional-dependencies]\n"
+        'cassandra = ["lfx[cassandra]~=1.11.0"]\n'
+        'toolguard = ["lfx[toolguard]~=1.11.0"]\n'
+        'beautifulsoup = ["lfx~=1.11.0"]\n'
+    )
+    path = tmp_path / "pyproject.toml"
+    path.write_text(content, encoding="utf-8")
+    # The script resolves paths relative to BASE_DIR; point it at tmp_path.
+    monkeypatch.setattr(mod, "BASE_DIR", tmp_path)
+    return path
+
+
+def test_pins_bare_and_extras_lfx_to_exact_dev(pyproject: Path) -> None:
+    mod.update_lfx_dep_in_base(pyproject.name, "1.11.0.dev26")
+    result = pyproject.read_text(encoding="utf-8")
+
+    # Every lfx reference -- bare and with extras -- is pinned to the exact dev version.
+    assert '"lfx==1.11.0.dev26"' in result
+    assert '"lfx[cassandra]==1.11.0.dev26"' in result
+    assert '"lfx[toolguard]==1.11.0.dev26"' in result
+
+    # No `~=` floor survives -- a surviving floor is exactly what makes the nightly
+    # resolve unsatisfiable.
+    assert "~=" not in result
+    # Extras are preserved, never dropped.
+    assert "[cassandra]" in result
+    assert "[toolguard]" in result
+
+
+def test_idempotent_on_already_pinned(pyproject: Path) -> None:
+    mod.update_lfx_dep_in_base(pyproject.name, "1.11.0.dev26")
+    once = pyproject.read_text(encoding="utf-8")
+    mod.update_lfx_dep_in_base(pyproject.name, "1.11.0.dev26")
+    twice = pyproject.read_text(encoding="utf-8")
+    assert once == twice
+
+
+def test_raises_when_no_lfx_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text('[project]\ndependencies = ["langflow-base~=1.11.0"]\n', encoding="utf-8")
+    monkeypatch.setattr(mod, "BASE_DIR", tmp_path)
+    with pytest.raises(ValueError, match="LFX dependency not found"):
+        mod.update_lfx_dep_in_base(path.name, "1.11.0.dev26")
+
+
+def test_pattern_skips_unrelated_packages(pyproject: Path) -> None:
+    """Sibling packages whose names merely start with ``lfx`` must not be repinned."""
+    extra = '    "lfx-bundles~=1.11.0",\n    "lfxthing~=1.11.0",\n'
+    pyproject.write_text(pyproject.read_text(encoding="utf-8") + extra, encoding="utf-8")
+    mod.update_lfx_dep_in_base(pyproject.name, "1.11.0.dev26")
+    result = pyproject.read_text(encoding="utf-8")
+    # The dedicated `lfx` distribution and its extras are repinned...
+    assert '"lfx==1.11.0.dev26"' in result
+    # ...but `lfx-bundles` / `lfxthing` keep their own floors untouched.
+    assert re.search(r'"lfx-bundles~=1\.11\.0"', result)
+    assert re.search(r'"lfxthing~=1\.11\.0"', result)

--- a/scripts/ci/update_lf_base_dependency.py
+++ b/scripts/ci/update_lf_base_dependency.py
@@ -45,19 +45,22 @@ def update_lfx_dep_in_base(pyproject_path: str, lfx_version: str) -> None:
     content = filepath.read_text(encoding="utf-8")
 
     # Updated pattern to handle PEP 440 version suffixes, both ~= and == version specifiers,
-    # and both lfx and lfx-nightly names
-    pattern = re.compile(r'("lfx(?:-nightly)?(?:~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*")')
+    # both lfx and lfx-nightly names, and extras (e.g. lfx[cassandra], lfx[toolguard]).
+    # The extras group (2) MUST be preserved: base's `[complete]` extra pulls these
+    # `lfx[extra]` references, and if they keep a `~=X.Y.0` floor while base's bare `lfx`
+    # dep is pinned to `==X.Y.0.devN`, the floor (>=X.Y.0) excludes the dev release and
+    # the nightly resolve becomes unsatisfiable.
+    pattern = re.compile(r'"lfx(?:-nightly)?((?:\[[^\]]+\])?)(?:~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*"')
     # Pin base's lfx dep to the exact canonical dev version (single `lfx` distribution, no
     # `lfx-nightly`), so there is no `lfx` vs `lfx-nightly` install collision with the bundles.
-    replacement = f'"lfx=={lfx_version}"'
 
     # Check if the pattern is found
     if not pattern.search(content):
         msg = f'LFX dependency not found in "{filepath}"'
         raise ValueError(msg)
 
-    # Replace the matched pattern with the new one
-    content = pattern.sub(replacement, content)
+    # Replace each match, preserving its own extras (e.g. `[cassandra]`, `[toolguard]`).
+    content = pattern.sub(lambda m: f'"lfx{m.group(1)}=={lfx_version}"', content)
     filepath.write_text(content, encoding="utf-8")
 
 


### PR DESCRIPTION
## What

Forward-port of the nightly resolution fix from `release-1.11.0` (commit `227c35f744`) to `main`.

`scripts/ci/update_lf_base_dependency.py::update_lfx_dep_in_base` only matched **bare** `lfx~=X.Y.0` references. It silently skipped `lfx[cassandra]` / `lfx[toolguard]` (the relocated cassio/toolguard features that `langflow-base[complete]` pulls).

During a nightly bump the bare `lfx` dep is pinned to the exact `==X.Y.0.devN`, but the `lfx[extra]` refs keep their `~=X.Y.0` floor. `~=X.Y.0` expands to `>=X.Y.0`, and under PEP 440 a dev release sorts **below** the final, so `>=X.Y.0` excludes `X.Y.0.devN`. The result: `langflow-base` and `langflow-base[complete]` resolve to conflicting `lfx` constraints and the install is unsatisfiable:

```
Because langflow-base[complete]==1.11.0.dev26 depends on lfx[cassandra]>=1.11.0,<1.12.dev0
and langflow-base==1.11.0.dev26 depends on lfx==1.11.0.dev26, we can conclude that
langflow-base==1.11.0.dev26 and langflow-base[complete]==1.11.0.dev26 are incompatible.
```

## Fix

Teach the regex to capture and preserve the optional extras bracket (mirroring `update_base_dep`, which already handles extras) so every `lfx` form — bare and with extras — receives the same exact `==devN` pin.

## Why port to `main` (it's currently latent here)

`main` carries the **same buggy regex** but does **not yet** have the `lfx[cassandra]` / `lfx[toolguard]` lines in `src/backend/base/pyproject.toml` — those were introduced on `release-1.11.0`. So the break is dormant on `main` today and will activate on the next back-merge of `release-1.11.0`. Landing the regex fix first keeps that back-merge safe. Since the scheduled nightly runs off `main`'s scripts, the fix needs to live here regardless.

## Test plan

- [x] New `scripts/ci/test_update_lf_base_dependency.py` — bare + `[cassandra]` + `[toolguard]` all pinned to exact dev, no `~=` floor survives, idempotency, no-lfx error path, and sibling names (`lfx-bundles`, `lfxthing`) left untouched.
- [x] Passes against `main`'s tree (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency version updates so `lfx` entries are pinned correctly while preserving any optional extras.
  * Updated matching logic to handle both range-based and exact version references more reliably.
  * Prevented unrelated packages with similar names from being modified.
  * Kept the update process idempotent when dependencies are already pinned.
* **Tests**
  * Added regression coverage for pinned versions, extras, missing dependencies, and non-matching package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->