### PR TITLE
fix(i18n): correct mistranslated Japanese "Current Flow" label

### DIFF
--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -2048,7 +2048,7 @@
   "updateComponents.updatesAvailable_one": "{{count}} コンポーネントのアップデートが利用可能です",
   "updateComponents.updatesAvailable_other": "{{count}} のコンポーネントのアップデートが利用可能です",
   "updateComponents.upgradeRequired": "フローを実行するにはアップグレードが必要です",
-  "version.currentFlow": "電流の流れ",
+  "version.currentFlow": "現在のフロー",
   "version.loadingPreview": "プレビューの読み込み中...",
   "version.previewing": "『 {{label}} 』のプレビュー",
   "version.readOnly": "(読み取り専用)",


### PR DESCRIPTION
The Japanese `version.currentFlow` string reads "電流の流れ" (the flow of electric current), but here "Current Flow" means the present flow version. It sits with the version-preview labels (`version.previewing`, `version.readOnly`, `version.loadingPreview`), so it labels the live flow as opposed to a historical version that is being previewed.

The same `ja.json` already translates this correctly elsewhere: `deployments.updateDeploymentDescription` renders "current flow version" as "現在のフローバージョン", and every other "Current" string uses 現在 (`deployments.current`, `flowVersion.currentLabel`, `editNode.currentValue`). This change brings `version.currentFlow` in line with those.

en: "Current Flow"
before: 電流の流れ (electric current)
after: 現在のフロー

The same homograph is present in the other locale files (zh-Hans, de, fr, es, pt) if a follow-up is wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Japanese label for “current flow” to a clearer, more accurate phrase: “現在のフロー.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->