### PR TITLE
fix: ensure compatibility with @radix-ui/react-slot@1.3.0

### DIFF
--- a/src/frontend/src/components/ui/__tests__/button.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/button.test.tsx
@@ -14,18 +14,12 @@ describe("Button — loading + asChild", () => {
     expect(link).not.toBeNull();
     expect(link?.textContent).toBe("Docs");
 
-    expect(
-      container.querySelector(".animate-spin"),
-    ).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
   });
 
   it("renders the loading spinner when loading is enabled on a normal button", () => {
-    const { container } = render(
-      <Button loading>Submit</Button>,
-    );
+    const { container } = render(<Button loading>Submit</Button>);
 
-    expect(
-      container.querySelector(".animate-spin"),
-    ).not.toBeNull();
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
   });
 });

--- a/src/frontend/src/components/ui/__tests__/button.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { Button } from "../button";
+
+describe("Button — loading + asChild", () => {
+  it("does not render the loading spinner when rendered asChild", () => {
+    const { container } = render(
+      <Button loading asChild>
+        <a href="/docs">Docs</a>
+      </Button>,
+    );
+
+    const link = container.querySelector("a");
+
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("Docs");
+
+    expect(
+      container.querySelector(".animate-spin"),
+    ).toBeNull();
+  });
+
+  it("renders the loading spinner when loading is enabled on a normal button", () => {
+    const { container } = render(
+      <Button loading>Submit</Button>,
+    );
+
+    expect(
+      container.querySelector(".animate-spin"),
+    ).not.toBeNull();
+  });
+});

--- a/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
@@ -44,8 +44,6 @@ describe("SelectTrigger", () => {
       </Select>,
     );
 
-    expect(
-      screen.getByRole("combobox"),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select-custom";
+
+/**
+ * Regression test for SelectPrimitive.Icon.
+ *
+ * Rendering SelectPrimitive.Icon with `asChild`
+ * but without a child element causes a runtime error.
+ */
+describe("SelectTrigger", () => {
+  it("should_render_successfully_with_default_icon", () => {
+    expect(() =>
+      render(
+        <Select>
+          <SelectTrigger>
+            <SelectValue placeholder="Select option" />
+          </SelectTrigger>
+
+          <SelectContent>
+            <SelectItem value="1">Option 1</SelectItem>
+          </SelectContent>
+        </Select>,
+      ),
+    ).not.toThrow();
+  });
+
+  it("should_render_combobox_trigger", () => {
+    render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Select option" />
+        </SelectTrigger>
+
+        <SelectContent>
+          <SelectItem value="1">Option 1</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(
+      screen.getByRole("combobox"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/ui/button.tsx
+++ b/src/frontend/src/components/ui/button.tsx
@@ -110,7 +110,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           ref={ref}
           {...props}
         >
-          {loading ? (
+          {loading && !asChild ? (
             <span className="relative flex items-center justify-center">
               <span
                 className={cn(

--- a/src/frontend/src/components/ui/select-custom.tsx
+++ b/src/frontend/src/components/ui/select-custom.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild></SelectPrimitive.Icon>
+    <SelectPrimitive.Icon></SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;


### PR DESCRIPTION
## Summary

This PR fixes UI runtime errors that occur after upgrading `@radix-ui/react-slot` from the version specified in `package.json` (`^1.2.4`) to `v1.3.0`.

After installing `@radix-ui/react-slot@1.3.0` and starting the Langflow frontend, the application immediately throws UI errors. These changes resolve the compatibility issues while preserving the existing component behavior.

## Changes

### 1. Fix empty children issue in `SelectPrimitive.Icon`

**File**
- `src/frontend/src/components/ui/select-custom.tsx`

Removed the `asChild` prop from:

```tsx
<SelectPrimitive.Icon asChild>
```

to:

```tsx
<SelectPrimitive.Icon>
```

This prevents an error caused by rendering `SelectPrimitive.Icon` with `asChild` but without a child element.

### 2. Prevent loading indicator conflicts with `asChild`

**File**
- `src/frontend/src/components/ui/button.tsx`

Changed:

```tsx
{loading && (
```

to:

```tsx
{loading && !asChild ? (
```

This prevents the loading indicator from being rendered when `asChild` is enabled, avoiding conflicts with Radix Slot behavior.

## Motivation

These changes improve compatibility with `@radix-ui/react-slot` v1.3.0 while maintaining the current behavior of the components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button loading behavior so the spinner no longer appears in embedded button usage.
  * Adjusted the select dropdown trigger icon rendering for more consistent UI composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->