### PR TITLE
feat: add PaddleOCR partner bundle (lfx-paddle) — inherits #13779

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "lfx-oracle>=0.1.0,<1.0.0",
     "lfx-firecrawl>=0.1.0,<1.0.0",
     "lfx-nextplaid>=0.1.0,<1.0.0",
+    "lfx-paddle>=0.1.0,<1.0.0",
     # langflow-extensions:bundle-deps-end
 ]
 
@@ -110,6 +111,7 @@ lfx-cohere = { workspace = true }
 lfx-oracle = { workspace = true }
 lfx-firecrawl = { workspace = true }
 lfx-nextplaid = { workspace = true }
+lfx-paddle = { workspace = true }
 # langflow-extensions:bundle-sources-end
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
@@ -135,6 +137,7 @@ members = [
     "src/bundles/oracle",
     "src/bundles/firecrawl",
     "src/bundles/nextplaid",
+    "src/bundles/paddle",
     # langflow-extensions:bundle-members-end
 ]
 

--- a/src/bundles/paddle/README.md
+++ b/src/bundles/paddle/README.md
@@ -1,0 +1,39 @@
+# lfx-paddle
+
+PaddleOCR as a standalone Langflow Extension Bundle.
+
+Ships the **PaddleOCR** component, which performs either layout-aware document
+parsing into Markdown (`PP-StructureV3`, `PaddleOCR-VL-1.6`) or plain OCR text
+recognition (`PP-OCRv5`, `PP-OCRv6`). It talks to the PaddleOCR
+[AI Studio async Job HTTP API](https://paddlepaddle.github.io/PaddleOCR/latest/en/version3.x/paddleocr_and_ppstructure.html)
+(`submit -> poll -> fetch`) directly via `httpx`, so it does **not** require the
+`paddleocr` Python SDK (whose transitive `pyyaml` constraint conflicts with
+Langflow's dependency tree).
+
+## Install
+
+```bash
+pip install lfx-paddle
+```
+
+The bundle is registered automatically via the `langflow.extensions`
+entry-point. After install, restart your Langflow server; the component will
+appear in the palette under the `paddle` group.
+
+You will need an AI Studio access token
+(<https://aistudio.baidu.com/account/accessToken>) to run the component.
+
+## Develop
+
+```bash
+cd src/bundles/paddle
+pip install -e .
+lfx extension validate src/lfx_paddle
+```
+
+## Migration
+
+Saved flows referencing the legacy class name or the old import paths under
+`lfx.components.paddle.*` are rewritten to the new namespaced ID
+`ext:paddle:PaddleOCRComponent@official` by the migration table in
+`src/lfx/src/lfx/extension/migration/migration_table.json`.

--- a/src/bundles/paddle/pyproject.toml
+++ b/src/bundles/paddle/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "lfx-paddle"
+version = "0.1.0"
+description = "PaddleOCR component (OCR and layout-aware document parsing via the AI Studio async Job API) as a standalone Langflow Extension Bundle."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = { text = "MIT" }
+authors = [
+    { name = "Langflow", email = "contact@langflow.org" },
+]
+keywords = ["langflow", "lfx", "extension", "bundle", "paddle", "paddleocr", "ocr"]
+
+# Runtime deps: lfx (the BUNDLE_API surface) plus any third-party imports the
+# bundle's components rely on.  The PaddleOCR component talks to the PaddleOCR
+# AI Studio async Job HTTP API directly via ``httpx`` -- it intentionally does
+# NOT depend on the ``paddleocr`` SDK, whose transitive ``pyyaml`` constraint
+# conflicts with Langflow's dependency tree.  ``httpx`` is already a runtime
+# dependency of ``lfx``; it is declared here too because the component imports
+# it directly.
+# lfx is floored at the current major.minor line and capped below the next lfx
+# major; the floor is read from src/lfx/pyproject.toml at port time and
+# re-synced on ``make patch`` via scripts/ci/sync_bundle_lfx_pin.py.
+# Fine-grained BUNDLE_API compatibility is enforced via extension.json's
+# lfx.compat list against BUNDLE_API_VERSION.
+dependencies = [
+    "lfx>=1.11.0.dev0,<2.0.0",
+    "httpx>=0.24.0,<1.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/langflow-ai/langflow"
+Documentation = "https://docs.langflow.org/extensions"
+Repository = "https://github.com/langflow-ai/langflow"
+
+# Manifest-shipping distributions are discovered via the
+# ``langflow.extensions`` entry-point.  Editable installs whose
+# ``dist.files`` only surfaces dist-info entries fall back to this
+# entry-point to find the manifest.
+[project.entry-points."langflow.extensions"]
+lfx-paddle = "lfx_paddle"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# extension.json + components live inside the lfx_paddle package so
+# ``importlib.metadata.files(dist)`` finds them and the loader resolves
+# bundles[].path relative to the manifest's directory.
+packages = ["src/lfx_paddle"]
+include = ["src/lfx_paddle/extension.json", "src/lfx_paddle/components/**/*.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/lfx_paddle",
+    "extension.json",
+    "README.md",
+    "pyproject.toml",
+]

--- a/src/bundles/paddle/src/lfx_paddle/__init__.py
+++ b/src/bundles/paddle/src/lfx_paddle/__init__.py
@@ -1,0 +1,11 @@
+"""lfx-paddle: PaddleOCR bundle.
+
+Distribution unit ``lfx-paddle``.  At runtime Langflow's loader discovers
+``extension.json`` shipped alongside this ``__init__.py`` and registers the
+bundle's component under the namespaced ID
+``ext:paddle:PaddleOCRComponent@official``.
+"""
+
+from lfx_paddle.components.paddle.paddleocr import PaddleOCRComponent
+
+__all__ = ["PaddleOCRComponent"]

--- a/src/bundles/paddle/src/lfx_paddle/components/paddle/__init__.py
+++ b/src/bundles/paddle/src/lfx_paddle/components/paddle/__init__.py
@@ -1,0 +1,10 @@
+"""Component re-exports for the ``paddle`` bundle.
+
+Saved-flow migration entries that target ``lfx.components.paddle.<Class>``
+resolve through this package, so the moved Component class(es) must be
+importable from here by name.
+"""
+
+from .paddleocr import PaddleOCRComponent
+
+__all__ = ["PaddleOCRComponent"]

--- a/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
+++ b/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
@@ -209,9 +209,16 @@ class PaddleOCRComponent(BaseFileComponent):
         }
         poll_timeout = int(self.poll_timeout or 600)
 
+        # ``base_url`` is operator-configurable, so the submit and poll requests
+        # (which carry the bearer token and the uploaded file) are validated for
+        # SSRF up front and DNS-pinned for the rest of the run.  Like
+        # ``_fetch_result``, this is a no-op when SSRF protection is disabled
+        # (the default), so default behavior is unchanged.
+        _validated_url, base_ips = validate_and_resolve_url(base_url)
+
         try:
             for file in file_list:
-                file.data = self._process_file(file.path, base_url, headers, poll_timeout)
+                file.data = self._process_file(file.path, base_url, base_ips, headers, poll_timeout)
         except Exception as e:
             error_message = self._format_paddleocr_error(e)
             self.log(error_message)
@@ -219,20 +226,31 @@ class PaddleOCRComponent(BaseFileComponent):
 
         return file_list
 
-    def _process_file(self, file_path: Path, base_url: str, headers: dict[str, str], poll_timeout: int) -> Data:
+    def _process_file(
+        self, file_path: Path, base_url: str, base_ips: list[str], headers: dict[str, str], poll_timeout: int
+    ) -> Data:
         options = self._build_ocr_options() if self.task_type == "ocr" else self._build_document_parsing_options()
-        job_id = self._submit_job(base_url=base_url, headers=headers, file_path=file_path, options=options)
-        jsonl_data = self._poll_job(base_url=base_url, headers=headers, job_id=job_id, poll_timeout=poll_timeout)
+        job_id = self._submit_job(
+            base_url=base_url, base_ips=base_ips, headers=headers, file_path=file_path, options=options
+        )
+        jsonl_data = self._poll_job(
+            base_url=base_url, base_ips=base_ips, headers=headers, job_id=job_id, poll_timeout=poll_timeout
+        )
 
         if self.task_type == "ocr":
             return self._ocr_result_to_data(job_id, jsonl_data, file_path)
         return self._document_result_to_data(job_id, jsonl_data, file_path)
 
-    def _submit_job(self, *, base_url: str, headers: dict[str, str], file_path: Path, options: dict[str, Any]) -> str:
+    def _submit_job(
+        self, *, base_url: str, base_ips: list[str], headers: dict[str, str], file_path: Path, options: dict[str, Any]
+    ) -> str:
         url = f"{base_url}{self.API_PATH}"
         data = {"model": self.model, "optionalPayload": json.dumps(options)}
-        with file_path.open("rb") as file_obj:
-            response = httpx.post(
+        with (
+            file_path.open("rb") as file_obj,
+            self._build_client(url, base_ips) as client,
+        ):
+            response = client.post(
                 url,
                 data=data,
                 files={"file": (file_path.name, file_obj)},
@@ -241,7 +259,7 @@ class PaddleOCRComponent(BaseFileComponent):
             )
         response.raise_for_status()
         payload = response.json()
-        job_id = payload.get("data", {}).get("jobId") or payload.get("jobId")
+        job_id = (payload.get("data") or {}).get("jobId") or payload.get("jobId")
         if not job_id:
             msg = f"PaddleOCR job ID not found in response: {payload}"
             raise ValueError(msg)
@@ -251,6 +269,7 @@ class PaddleOCRComponent(BaseFileComponent):
         self,
         *,
         base_url: str,
+        base_ips: list[str],
         headers: dict[str, str],
         job_id: str,
         poll_timeout: int,
@@ -259,30 +278,34 @@ class PaddleOCRComponent(BaseFileComponent):
         deadline = time.monotonic() + poll_timeout
         interval = self.INITIAL_POLL_INTERVAL
 
-        while True:
-            if time.monotonic() >= deadline:
-                msg = f"PaddleOCR job {job_id} timed out."
-                raise TimeoutError(msg)
+        with self._build_client(status_url, base_ips) as client:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    msg = f"PaddleOCR job {job_id} timed out."
+                    raise TimeoutError(msg)
 
-            response = httpx.get(status_url, headers=headers, timeout=self.REQUEST_TIMEOUT)
-            response.raise_for_status()
-            payload = response.json()
-            data = payload.get("data", {})
-            state = data.get("state") or payload.get("state")
+                # Bound each request by the remaining budget so a hung poll cannot
+                # overrun ``poll_timeout`` by up to ``REQUEST_TIMEOUT``.
+                response = client.get(status_url, headers=headers, timeout=min(self.REQUEST_TIMEOUT, remaining))
+                response.raise_for_status()
+                payload = response.json()
+                data = payload.get("data") or {}
+                state = data.get("state") or payload.get("state")
 
-            if state == "done":
-                result_url = data.get("resultJsonUrl") or (data.get("resultUrl") or {}).get("jsonUrl")
-                if not result_url:
-                    msg = f"PaddleOCR result URL not found in response: {payload}"
-                    raise ValueError(msg)
-                return self._fetch_result(result_url)
+                if state == "done":
+                    result_url = data.get("resultJsonUrl") or (data.get("resultUrl") or {}).get("jsonUrl")
+                    if not result_url:
+                        msg = f"PaddleOCR result URL not found in response: {payload}"
+                        raise ValueError(msg)
+                    return self._fetch_result(result_url)
 
-            if state == "failed":
-                msg = f"PaddleOCR job failed: {payload}"
-                raise RuntimeError(msg)
+                if state == "failed":
+                    msg = f"PaddleOCR job failed: {payload}"
+                    raise RuntimeError(msg)
 
-            time.sleep(min(interval, max(deadline - time.monotonic(), 0)))
-            interval = min(interval * self.POLL_MULTIPLIER, self.MAX_POLL_INTERVAL)
+                time.sleep(min(interval, max(deadline - time.monotonic(), 0)))
+                interval = min(interval * self.POLL_MULTIPLIER, self.MAX_POLL_INTERVAL)
 
     def _fetch_result(self, result_url: str) -> list[dict[str, Any]]:
         # ``result_url`` comes from the remote job-status response, not from
@@ -295,7 +318,7 @@ class PaddleOCRComponent(BaseFileComponent):
         # and pins DNS to the validated IPs.  This mirrors the shared pattern in
         # ``lfx.components.data_source.api_request``.
         _validated_url, validated_ips = validate_and_resolve_url(result_url)
-        with self._build_result_client(result_url, validated_ips) as client:
+        with self._build_client(result_url, validated_ips) as client:
             response = client.get(result_url)
         response.raise_for_status()
         text = response.text.strip()
@@ -313,13 +336,14 @@ class PaddleOCRComponent(BaseFileComponent):
             return [payload]
         return []
 
-    def _build_result_client(self, url: str, validated_ips: list[str]) -> httpx.Client:
-        """Create the HTTP client used to fetch the result, pinning DNS when SSRF protection applies.
+    def _build_client(self, url: str, validated_ips: list[str]) -> httpx.Client:
+        """Create the HTTP client for ``url``, pinning DNS when SSRF protection applies.
 
-        Returns a client that pins DNS to ``validated_ips`` (preventing rebinding)
-        when SSRF protection is enabled and the host resolved to validated IPs;
-        otherwise a standard client (protection disabled, allowlisted host, or
-        hostname extraction failure).
+        Used for the submit, poll, and result-fetch requests.  Returns a client
+        that pins DNS to ``validated_ips`` (preventing rebinding) when SSRF
+        protection is enabled and the host resolved to validated IPs; otherwise a
+        standard client (protection disabled, allowlisted host, or hostname
+        extraction failure).
         """
         if is_ssrf_protection_enabled() and validated_ips:
             hostname = httpx.URL(url).host

--- a/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
+++ b/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from lfx.base.data.base_file import BaseFileComponent
+from lfx.inputs.inputs import BoolInput, DropdownInput, FloatInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.schema.data import Data
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class PaddleOCRComponent(BaseFileComponent):
+    display_name = "PaddleOCR"
+    description = "Use PaddleOCR for either layout-aware document parsing into Markdown or plain OCR text recognition."
+    documentation = "https://paddlepaddle.github.io/PaddleOCR/latest/en/version3.x/paddleocr_and_ppstructure.html"
+    icon = "file-search"
+    name = "PaddleOCR"
+
+    VALID_EXTENSIONS = ["png", "jpg", "jpeg", "bmp", "tiff", "webp", "pdf"]
+    DEFAULT_BASE_URL = "https://paddleocr.aistudio-app.com"
+    API_PATH = "/api/v2/ocr/jobs"
+    REQUEST_TIMEOUT = 300.0
+    INITIAL_POLL_INTERVAL = 3.0
+    POLL_MULTIPLIER = 1.5
+    MAX_POLL_INTERVAL = 15.0
+
+    inputs = [
+        *BaseFileComponent.get_base_inputs(),
+        SecretStrInput(
+            name="access_token",
+            display_name="AI Studio Access Token",
+            required=True,
+            info="AI Studio access token. Get it from https://aistudio.baidu.com/account/accessToken.",
+        ),
+        MessageTextInput(
+            name="base_url",
+            display_name="Base URL",
+            required=False,
+            value="",
+            info="Optional PaddleOCR service root URL. Leave empty to use the official default service.",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="task_type",
+            display_name="Task Type",
+            options=["document_parsing", "ocr"],
+            value="document_parsing",
+            info=(
+                "document_parsing: preserves reading order and layout as Markdown — "
+                "best when you need structure-aware text (PDFs, scanned documents, tables).\n"
+                "ocr: extracts text regions in scan order — best for images with simple text content."
+            ),
+            real_time_refresh=True,
+        ),
+        DropdownInput(
+            name="model",
+            display_name="Model",
+            options=["PP-StructureV3", "PaddleOCR-VL-1.6"],
+            value="PP-StructureV3",
+            info="PaddleOCR model to use for the selected task type.",
+        ),
+        IntInput(
+            name="poll_timeout",
+            display_name="Timeout (s)",
+            value=600,
+            info="Maximum time to wait for the PaddleOCR job to complete.",
+            advanced=True,
+        ),
+        BoolInput(
+            name="use_doc_orientation_classify",
+            display_name="Document Orientation Classification",
+            value=False,
+            advanced=True,
+            info="OCR/document parsing option. Enable document orientation classification.",
+        ),
+        BoolInput(
+            name="use_doc_unwarping",
+            display_name="Document Unwarping",
+            value=False,
+            advanced=True,
+            info="OCR/document parsing option. Enable document unwarping.",
+        ),
+        BoolInput(
+            name="use_textline_orientation",
+            display_name="Text Line Orientation",
+            value=False,
+            advanced=True,
+            info="OCR option. Enable text line orientation detection.",
+        ),
+        FloatInput(
+            name="text_det_thresh",
+            display_name="Text Detection Threshold",
+            required=False,
+            advanced=True,
+            info="OCR option. Text detection threshold.",
+        ),
+        FloatInput(
+            name="text_det_box_thresh",
+            display_name="Text Detection Box Threshold",
+            required=False,
+            advanced=True,
+            info="OCR option. Text detection box threshold.",
+        ),
+        FloatInput(
+            name="text_det_unclip_ratio",
+            display_name="Text Detection Unclip Ratio",
+            required=False,
+            advanced=True,
+            info="OCR option. Text detection unclip ratio.",
+        ),
+        FloatInput(
+            name="text_rec_score_thresh",
+            display_name="Text Recognition Score Threshold",
+            required=False,
+            advanced=True,
+            info="OCR option. Text recognition score threshold.",
+        ),
+        BoolInput(
+            name="use_table_recognition",
+            display_name="Table Recognition",
+            value=True,
+            advanced=True,
+            info="Document parsing option. Enable table recognition.",
+        ),
+        BoolInput(
+            name="use_formula_recognition",
+            display_name="Formula Recognition",
+            value=False,
+            advanced=True,
+            info="Document parsing option. Enable formula recognition.",
+        ),
+        BoolInput(
+            name="use_chart_recognition",
+            display_name="Chart Recognition",
+            value=False,
+            advanced=True,
+            info="Document parsing option. Enable chart recognition.",
+        ),
+        BoolInput(
+            name="use_seal_recognition",
+            display_name="Seal Recognition",
+            value=False,
+            advanced=True,
+            info="Document parsing option. Enable seal recognition.",
+        ),
+        BoolInput(
+            name="prettify_markdown",
+            display_name="Prettify Markdown",
+            value=True,
+            advanced=True,
+            info="Document parsing option. Return prettier Markdown when supported.",
+        ),
+        FloatInput(
+            name="temperature",
+            display_name="Temperature",
+            required=False,
+            advanced=True,
+            info="PaddleOCR-VL option. Sampling temperature.",
+        ),
+        FloatInput(
+            name="top_p",
+            display_name="Top P",
+            required=False,
+            advanced=True,
+            info="PaddleOCR-VL option. Nucleus sampling top_p.",
+        ),
+        BoolInput(
+            name="visualize",
+            display_name="Visualize",
+            value=False,
+            advanced=True,
+            info="Document parsing option. Generate visualization outputs when supported.",
+        ),
+    ]
+
+    outputs = [*BaseFileComponent.get_base_outputs()]
+
+    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
+        if field_name == "task_type":
+            if field_value == "ocr":
+                build_config["model"]["options"] = ["PP-OCRv6", "PP-OCRv5"]
+                build_config["model"]["value"] = "PP-OCRv6"
+            else:
+                build_config["model"]["options"] = ["PP-StructureV3", "PaddleOCR-VL-1.6"]
+                build_config["model"]["value"] = "PP-StructureV3"
+
+        return build_config
+
+    def process_files(self, file_list: list[BaseFileComponent.BaseFile]) -> list[BaseFileComponent.BaseFile]:
+        if not file_list:
+            self.log("No files to process.")
+            return file_list
+
+        access_token = str(self.access_token or "").strip()
+        if not access_token:
+            msg = "AI Studio Access Token is required."
+            raise ValueError(msg)
+
+        base_url = (str(self.base_url or "").strip() or self.DEFAULT_BASE_URL).rstrip("/")
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Client-Platform": "langflow",
+        }
+        poll_timeout = int(self.poll_timeout or 600)
+
+        try:
+            for file in file_list:
+                file.data = self._process_file(file.path, base_url, headers, poll_timeout)
+        except Exception as e:
+            error_message = self._format_paddleocr_error(e)
+            self.log(error_message)
+            raise RuntimeError(error_message) from e
+
+        return file_list
+
+    def _process_file(self, file_path: Path, base_url: str, headers: dict[str, str], poll_timeout: int) -> Data:
+        options = self._build_ocr_options() if self.task_type == "ocr" else self._build_document_parsing_options()
+        job_id = self._submit_job(base_url=base_url, headers=headers, file_path=file_path, options=options)
+        jsonl_data = self._poll_job(base_url=base_url, headers=headers, job_id=job_id, poll_timeout=poll_timeout)
+
+        if self.task_type == "ocr":
+            return self._ocr_result_to_data(job_id, jsonl_data, file_path)
+        return self._document_result_to_data(job_id, jsonl_data, file_path)
+
+    def _submit_job(self, *, base_url: str, headers: dict[str, str], file_path: Path, options: dict[str, Any]) -> str:
+        url = f"{base_url}{self.API_PATH}"
+        data = {"model": self.model, "optionalPayload": json.dumps(options)}
+        with file_path.open("rb") as file_obj:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (file_path.name, file_obj)},
+                headers=headers,
+                timeout=self.REQUEST_TIMEOUT,
+            )
+        response.raise_for_status()
+        payload = response.json()
+        job_id = payload.get("data", {}).get("jobId") or payload.get("jobId")
+        if not job_id:
+            msg = f"PaddleOCR job ID not found in response: {payload}"
+            raise ValueError(msg)
+        return job_id
+
+    def _poll_job(
+        self,
+        *,
+        base_url: str,
+        headers: dict[str, str],
+        job_id: str,
+        poll_timeout: int,
+    ) -> list[dict[str, Any]]:
+        status_url = f"{base_url}{self.API_PATH}/{job_id}"
+        deadline = time.monotonic() + poll_timeout
+        interval = self.INITIAL_POLL_INTERVAL
+
+        while True:
+            if time.monotonic() >= deadline:
+                msg = f"PaddleOCR job {job_id} timed out."
+                raise TimeoutError(msg)
+
+            response = httpx.get(status_url, headers=headers, timeout=self.REQUEST_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+            data = payload.get("data", {})
+            state = data.get("state") or payload.get("state")
+
+            if state == "done":
+                result_url = data.get("resultJsonUrl") or (data.get("resultUrl") or {}).get("jsonUrl")
+                if not result_url:
+                    msg = f"PaddleOCR result URL not found in response: {payload}"
+                    raise ValueError(msg)
+                return self._fetch_result(result_url)
+
+            if state == "failed":
+                msg = f"PaddleOCR job failed: {payload}"
+                raise RuntimeError(msg)
+
+            time.sleep(min(interval, max(deadline - time.monotonic(), 0)))
+            interval = min(interval * self.POLL_MULTIPLIER, self.MAX_POLL_INTERVAL)
+
+    def _fetch_result(self, result_url: str) -> list[dict[str, Any]]:
+        response = httpx.get(result_url, timeout=self.REQUEST_TIMEOUT)
+        response.raise_for_status()
+        text = response.text.strip()
+        if not text:
+            return []
+
+        try:
+            payload = response.json()
+        except ValueError:
+            return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            return [payload]
+        return []
+
+    def _build_ocr_options(self) -> dict[str, Any]:
+        return self._collect_options(
+            [
+                "use_doc_orientation_classify",
+                "use_doc_unwarping",
+                "use_textline_orientation",
+                "text_det_thresh",
+                "text_det_box_thresh",
+                "text_det_unclip_ratio",
+                "text_rec_score_thresh",
+            ]
+        )
+
+    def _build_document_parsing_options(self) -> dict[str, Any]:
+        return self._collect_options(
+            [
+                "use_doc_orientation_classify",
+                "use_doc_unwarping",
+                "use_table_recognition",
+                "use_formula_recognition",
+                "use_chart_recognition",
+                "use_seal_recognition",
+                "prettify_markdown",
+                "temperature",
+                "top_p",
+                "visualize",
+            ]
+        )
+
+    def _collect_options(self, option_names: list[str]) -> dict[str, Any]:
+        options: dict[str, Any] = {}
+        for name in option_names:
+            value = getattr(self, name, None)
+            if value is not None:
+                options[name] = value
+        return options
+
+    def _ocr_result_to_data(self, job_id: str, jsonl_data: list[dict[str, Any]], file_path: Path) -> Data:
+        pages_payload: list[dict[str, Any]] = []
+        text_parts: list[str] = []
+
+        for line_obj in jsonl_data:
+            result = line_obj.get("result", line_obj)
+            for item in result.get("ocrResults", []) or []:
+                pruned_result = item.get("prunedResult", {}) or {}
+                rec_texts = pruned_result.get("rec_texts", []) or []
+                if rec_texts:
+                    text_parts.append("\n".join(str(text) for text in rec_texts))
+                pages_payload.append(
+                    {
+                        "pruned_result": pruned_result,
+                        "ocr_image_url": item.get("ocrImage"),
+                    }
+                )
+
+        text = "\n\n".join(part for part in text_parts if part)
+        return Data(
+            text=text,
+            data={
+                self.SERVER_FILE_PATH_FIELDNAME: str(file_path),
+                "text": text,
+                "task_type": "ocr",
+                "output_format": "plain_text",
+                "model": self.model,
+                "job_id": job_id,
+                "pages": pages_payload,
+            },
+        )
+
+    def _document_result_to_data(self, job_id: str, jsonl_data: list[dict[str, Any]], file_path: Path) -> Data:
+        pages_payload: list[dict[str, Any]] = []
+        text_parts: list[str] = []
+
+        for line_obj in jsonl_data:
+            result = line_obj.get("result", line_obj)
+            layout_results = result.get("layoutParsingResults", []) or []
+            if layout_results:
+                self._append_layout_results(layout_results, pages_payload, text_parts)
+                continue
+            self._append_ocr_fallback_results(result.get("ocrResults", []) or [], pages_payload, text_parts)
+
+        markdown_text = "\n\n".join(part for part in text_parts if part)
+        return Data(
+            text=markdown_text,
+            data={
+                self.SERVER_FILE_PATH_FIELDNAME: str(file_path),
+                "text": markdown_text,
+                "task_type": "document_parsing",
+                "output_format": "markdown",
+                "model": self.model,
+                "job_id": job_id,
+                "pages": pages_payload,
+            },
+        )
+
+    def _append_layout_results(
+        self,
+        layout_results: list[dict[str, Any]],
+        pages_payload: list[dict[str, Any]],
+        text_parts: list[str],
+    ) -> None:
+        for item in layout_results:
+            markdown = item.get("markdown", {}) or {}
+            markdown_text = markdown.get("text") or item.get("markdown_text") or ""
+            if markdown_text:
+                text_parts.append(str(markdown_text))
+            pages_payload.append(
+                {
+                    "markdown_text": markdown_text,
+                    "markdown_images": markdown.get("images", {}) or {},
+                    "output_images": item.get("outputImages", {}) or {},
+                }
+            )
+
+    def _append_ocr_fallback_results(
+        self,
+        ocr_results: list[dict[str, Any]],
+        pages_payload: list[dict[str, Any]],
+        text_parts: list[str],
+    ) -> None:
+        for item in ocr_results:
+            pruned_result = item.get("prunedResult", {}) or {}
+            rec_texts = pruned_result.get("rec_texts", []) or []
+            text = "\n".join(str(text) for text in rec_texts)
+            if text:
+                text_parts.append(text)
+            pages_payload.append(
+                {
+                    "markdown_text": text,
+                    "markdown_images": {},
+                    "output_images": {},
+                    "pruned_result": pruned_result,
+                    "ocr_image_url": item.get("ocrImage"),
+                }
+            )
+
+    def _format_paddleocr_error(self, error: Exception) -> str:
+        if isinstance(error, httpx.HTTPStatusError):
+            status_code = error.response.status_code
+            if status_code in {401, 403}:
+                return "PaddleOCR authentication failed. Please check the AI Studio Access Token."
+            return f"PaddleOCR API error ({status_code}): {error.response.text}"
+        if isinstance(error, httpx.TimeoutException | TimeoutError):
+            return "PaddleOCR job timed out. Increase the timeout or try again later."
+        if isinstance(error, httpx.HTTPError):
+            return f"PaddleOCR network error: {error}"
+        return f"PaddleOCR failed: {error}"

--- a/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
+++ b/src/bundles/paddle/src/lfx_paddle/components/paddle/paddleocr.py
@@ -8,6 +8,8 @@ import httpx
 from lfx.base.data.base_file import BaseFileComponent
 from lfx.inputs.inputs import BoolInput, DropdownInput, FloatInput, IntInput, MessageTextInput, SecretStrInput
 from lfx.schema.data import Data
+from lfx.utils.ssrf_protection import is_ssrf_protection_enabled, validate_and_resolve_url
+from lfx.utils.ssrf_transport import create_ssrf_protected_sync_client
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -283,7 +285,18 @@ class PaddleOCRComponent(BaseFileComponent):
             interval = min(interval * self.POLL_MULTIPLIER, self.MAX_POLL_INTERVAL)
 
     def _fetch_result(self, result_url: str) -> list[dict[str, Any]]:
-        response = httpx.get(result_url, timeout=self.REQUEST_TIMEOUT)
+        # ``result_url`` comes from the remote job-status response, not from
+        # operator input, so it is validated for SSRF before being fetched: a
+        # compromised/rogue endpoint could otherwise point it at internal or
+        # cloud-metadata addresses and have the worker fetch them server-side.
+        # ``validate_and_resolve_url`` is a no-op (returns no pinned IPs) when
+        # SSRF protection is disabled -- the default -- so behavior is unchanged
+        # unless an operator opts in; when enabled it blocks internal targets
+        # and pins DNS to the validated IPs.  This mirrors the shared pattern in
+        # ``lfx.components.data_source.api_request``.
+        _validated_url, validated_ips = validate_and_resolve_url(result_url)
+        with self._build_result_client(result_url, validated_ips) as client:
+            response = client.get(result_url)
         response.raise_for_status()
         text = response.text.strip()
         if not text:
@@ -299,6 +312,22 @@ class PaddleOCRComponent(BaseFileComponent):
         if isinstance(payload, dict):
             return [payload]
         return []
+
+    def _build_result_client(self, url: str, validated_ips: list[str]) -> httpx.Client:
+        """Create the HTTP client used to fetch the result, pinning DNS when SSRF protection applies.
+
+        Returns a client that pins DNS to ``validated_ips`` (preventing rebinding)
+        when SSRF protection is enabled and the host resolved to validated IPs;
+        otherwise a standard client (protection disabled, allowlisted host, or
+        hostname extraction failure).
+        """
+        if is_ssrf_protection_enabled() and validated_ips:
+            hostname = httpx.URL(url).host
+            if hostname:
+                return create_ssrf_protected_sync_client(
+                    hostname=hostname, validated_ips=validated_ips, timeout=self.REQUEST_TIMEOUT
+                )
+        return httpx.Client(timeout=self.REQUEST_TIMEOUT)
 
     def _build_ocr_options(self) -> dict[str, Any]:
         return self._collect_options(

--- a/src/bundles/paddle/src/lfx_paddle/extension.json
+++ b/src/bundles/paddle/src/lfx_paddle/extension.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schemas.langflow.org/extension/v1.json",
+  "id": "lfx-paddle",
+  "version": "0.1.0",
+  "name": "PaddleOCR",
+  "description": "PaddleOCR component (OCR and layout-aware document parsing via the AI Studio async Job API) as a standalone Langflow Extension Bundle.",
+  "lfx": {
+    "compat": ["1"]
+  },
+  "bundles": [
+    {
+      "name": "paddle",
+      "path": "components/paddle"
+    }
+  ]
+}

--- a/src/bundles/paddle/tests/test_paddleocr_component.py
+++ b/src/bundles/paddle/tests/test_paddleocr_component.py
@@ -214,6 +214,43 @@ def test_paddleocr_formats_auth_error():
     )
 
 
+def test_build_result_client_is_plain_when_ssrf_disabled():
+    # SSRF protection is off by default, so the result fetch uses a standard client
+    # (no DNS pinning) and behavior matches the pre-hardening port.
+    component = PaddleOCRComponent()
+    client = component._build_result_client("https://example.com/result.json", [])
+    try:
+        assert isinstance(client, httpx.Client)
+    finally:
+        client.close()
+
+
+def test_fetch_result_parses_json_list(monkeypatch):
+    component = PaddleOCRComponent()
+
+    def handler(_request):
+        return httpx.Response(200, json=[{"x": 1}])
+
+    def fake_build_client(_self, _url, _ips):
+        return httpx.Client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(PaddleOCRComponent, "_build_result_client", fake_build_client)
+    assert component._fetch_result("https://example.com/result.json") == [{"x": 1}]
+
+
+def test_fetch_result_parses_jsonl_fallback(monkeypatch):
+    component = PaddleOCRComponent()
+
+    def handler(_request):
+        return httpx.Response(200, text='{"a": 1}\n{"b": 2}\n')
+
+    def fake_build_client(_self, _url, _ips):
+        return httpx.Client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(PaddleOCRComponent, "_build_result_client", fake_build_client)
+    assert component._fetch_result("https://example.com/result.jsonl") == [{"a": 1}, {"b": 2}]
+
+
 def test_task_type_updates_model_options():
     component = PaddleOCRComponent()
     build_config = {

--- a/src/bundles/paddle/tests/test_paddleocr_component.py
+++ b/src/bundles/paddle/tests/test_paddleocr_component.py
@@ -33,18 +33,20 @@ def test_paddleocr_ocr_mode_processes_text(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_submit(_self, *, base_url, headers, file_path, options):
+    def fake_submit(_self, *, base_url, base_ips, headers, file_path, options):
         captured["submit"] = {
             "base_url": base_url,
+            "base_ips": base_ips,
             "headers": headers,
             "file_path": file_path,
             "options": options,
         }
         return "ocr-job-id"
 
-    def fake_poll(_self, *, base_url, headers, job_id, poll_timeout):
+    def fake_poll(_self, *, base_url, base_ips, headers, job_id, poll_timeout):
         captured["poll"] = {
             "base_url": base_url,
+            "base_ips": base_ips,
             "headers": headers,
             "job_id": job_id,
             "poll_timeout": poll_timeout,
@@ -105,8 +107,14 @@ def test_paddleocr_document_parsing_processes_markdown(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_submit(_self, *, base_url, headers, file_path, options):
-        captured["submit"] = {"base_url": base_url, "headers": headers, "file_path": file_path, "options": options}
+    def fake_submit(_self, *, base_url, base_ips, headers, file_path, options):
+        captured["submit"] = {
+            "base_url": base_url,
+            "base_ips": base_ips,
+            "headers": headers,
+            "file_path": file_path,
+            "options": options,
+        }
         return "doc-job-id"
 
     def fake_poll(_self, **_kwargs):
@@ -214,15 +222,58 @@ def test_paddleocr_formats_auth_error():
     )
 
 
-def test_build_result_client_is_plain_when_ssrf_disabled():
-    # SSRF protection is off by default, so the result fetch uses a standard client
+def test_build_client_is_plain_when_ssrf_disabled():
+    # SSRF protection is off by default, so requests use a standard client
     # (no DNS pinning) and behavior matches the pre-hardening port.
     component = PaddleOCRComponent()
-    client = component._build_result_client("https://example.com/result.json", [])
+    client = component._build_client("https://example.com/result.json", [])
     try:
         assert isinstance(client, httpx.Client)
     finally:
         client.close()
+
+
+def test_build_client_pins_dns_when_ssrf_enabled(monkeypatch):
+    # When SSRF protection is enabled and the host resolved to validated IPs,
+    # the request goes through the DNS-pinned protected client.
+    import lfx_paddle.components.paddle.paddleocr as mod
+
+    sentinel = httpx.Client()
+    captured = {}
+
+    def fake_protected_client(*, hostname, validated_ips, **_kwargs):
+        captured["hostname"] = hostname
+        captured["validated_ips"] = validated_ips
+        return sentinel
+
+    monkeypatch.setattr(mod, "is_ssrf_protection_enabled", lambda: True)
+    monkeypatch.setattr(mod, "create_ssrf_protected_sync_client", fake_protected_client)
+
+    component = PaddleOCRComponent()
+    try:
+        client = component._build_client("https://example.com/result.json", ["93.184.216.34"])
+        assert client is sentinel
+        assert captured["hostname"] == "example.com"
+        assert captured["validated_ips"] == ["93.184.216.34"]
+    finally:
+        sentinel.close()
+
+
+def test_fetch_result_blocks_internal_url_when_ssrf_enabled(monkeypatch):
+    # An internal/metadata result URL is rejected before any request is made
+    # when SSRF protection is enabled.
+    import lfx_paddle.components.paddle.paddleocr as mod
+    from lfx.utils.ssrf_protection import SSRFProtectionError
+
+    def fake_validate(url):
+        msg = f"Access to {url} is blocked by SSRF protection"
+        raise SSRFProtectionError(msg)
+
+    monkeypatch.setattr(mod, "validate_and_resolve_url", fake_validate)
+
+    component = PaddleOCRComponent()
+    with pytest.raises(SSRFProtectionError):
+        component._fetch_result("http://169.254.169.254/latest/meta-data/")
 
 
 def test_fetch_result_parses_json_list(monkeypatch):
@@ -234,7 +285,7 @@ def test_fetch_result_parses_json_list(monkeypatch):
     def fake_build_client(_self, _url, _ips):
         return httpx.Client(transport=httpx.MockTransport(handler))
 
-    monkeypatch.setattr(PaddleOCRComponent, "_build_result_client", fake_build_client)
+    monkeypatch.setattr(PaddleOCRComponent, "_build_client", fake_build_client)
     assert component._fetch_result("https://example.com/result.json") == [{"x": 1}]
 
 
@@ -247,7 +298,7 @@ def test_fetch_result_parses_jsonl_fallback(monkeypatch):
     def fake_build_client(_self, _url, _ips):
         return httpx.Client(transport=httpx.MockTransport(handler))
 
-    monkeypatch.setattr(PaddleOCRComponent, "_build_result_client", fake_build_client)
+    monkeypatch.setattr(PaddleOCRComponent, "_build_client", fake_build_client)
     assert component._fetch_result("https://example.com/result.jsonl") == [{"a": 1}, {"b": 2}]
 
 

--- a/src/bundles/paddle/tests/test_paddleocr_component.py
+++ b/src/bundles/paddle/tests/test_paddleocr_component.py
@@ -1,0 +1,229 @@
+"""Unit tests for the PaddleOCR extension bundle (``lfx-paddle``).
+
+The component previously lived at ``lfx.components.baidu.paddleocr`` on the
+contributor branch; it now ships as a standalone bundle, so these tests travel
+with the bundle and import the public bundle entry point. They exercise the
+server-free surface (OCR / document-parsing result shaping, the
+document-parsing OCR fallback, access-token validation, auth-error formatting,
+and the task-type model-option switch) with ``_submit_job`` / ``_poll_job``
+monkeypatched -- no network access or PaddleOCR service is required.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from lfx.base.data.base_file import BaseFileComponent
+from lfx.schema.data import Data
+from lfx_paddle import PaddleOCRComponent
+
+
+def make_base_file(path):
+    return BaseFileComponent.BaseFile(Data(data={"file_path": str(path)}), path)
+
+
+def test_bundle_entrypoint_export():
+    assert PaddleOCRComponent.__name__ == "PaddleOCRComponent"
+    assert PaddleOCRComponent.name == "PaddleOCR"
+
+
+def test_paddleocr_ocr_mode_processes_text(monkeypatch, tmp_path):
+    file_path = tmp_path / "sample.png"
+    file_path.write_bytes(b"fake image")
+
+    captured = {}
+
+    def fake_submit(_self, *, base_url, headers, file_path, options):
+        captured["submit"] = {
+            "base_url": base_url,
+            "headers": headers,
+            "file_path": file_path,
+            "options": options,
+        }
+        return "ocr-job-id"
+
+    def fake_poll(_self, *, base_url, headers, job_id, poll_timeout):
+        captured["poll"] = {
+            "base_url": base_url,
+            "headers": headers,
+            "job_id": job_id,
+            "poll_timeout": poll_timeout,
+        }
+        return [
+            {
+                "result": {
+                    "ocrResults": [
+                        {
+                            "prunedResult": {"rec_texts": ["hello", "world"]},
+                            "ocrImage": "https://example.com/ocr.png",
+                        }
+                    ]
+                }
+            }
+        ]
+
+    monkeypatch.setattr(PaddleOCRComponent, "_submit_job", fake_submit)
+    monkeypatch.setattr(PaddleOCRComponent, "_poll_job", fake_poll)
+
+    component = PaddleOCRComponent()
+    component.set_attributes(
+        {
+            "access_token": "token",
+            "base_url": "",
+            "task_type": "ocr",
+            "model": "PP-OCRv6",
+            "poll_timeout": 123,
+            "use_doc_orientation_classify": False,
+            "use_doc_unwarping": False,
+            "use_textline_orientation": False,
+        }
+    )
+
+    processed = component.process_files([make_base_file(file_path)])
+
+    data = processed[0].data[0].data
+    assert data["text"] == "hello\nworld"
+    assert data["task_type"] == "ocr"
+    assert data["output_format"] == "plain_text"
+    assert data["model"] == "PP-OCRv6"
+    assert data["job_id"] == "ocr-job-id"
+    assert data["pages"][0]["pruned_result"] == {"rec_texts": ["hello", "world"]}
+
+    assert captured["submit"]["base_url"] == PaddleOCRComponent.DEFAULT_BASE_URL
+    assert captured["submit"]["headers"] == {
+        "Authorization": "Bearer token",
+        "Client-Platform": "langflow",
+    }
+    assert captured["submit"]["file_path"] == file_path
+    assert captured["submit"]["options"]["use_doc_orientation_classify"] is False
+    assert captured["poll"]["poll_timeout"] == 123
+
+
+def test_paddleocr_document_parsing_processes_markdown(monkeypatch, tmp_path):
+    file_path = tmp_path / "sample.pdf"
+    file_path.write_bytes(b"fake pdf")
+
+    captured = {}
+
+    def fake_submit(_self, *, base_url, headers, file_path, options):
+        captured["submit"] = {"base_url": base_url, "headers": headers, "file_path": file_path, "options": options}
+        return "doc-job-id"
+
+    def fake_poll(_self, **_kwargs):
+        return [
+            {
+                "result": {
+                    "layoutParsingResults": [
+                        {
+                            "markdown": {
+                                "text": "# Title",
+                                "images": {"image.png": "https://example.com/image.png"},
+                            },
+                            "outputImages": {},
+                        }
+                    ]
+                }
+            }
+        ]
+
+    monkeypatch.setattr(PaddleOCRComponent, "_submit_job", fake_submit)
+    monkeypatch.setattr(PaddleOCRComponent, "_poll_job", fake_poll)
+
+    component = PaddleOCRComponent()
+    component.set_attributes(
+        {
+            "access_token": "token",
+            "base_url": "https://example.com/",
+            "task_type": "document_parsing",
+            "model": "PaddleOCR-VL-1.6",
+            "poll_timeout": 600,
+            "use_doc_orientation_classify": False,
+            "use_doc_unwarping": False,
+            "use_table_recognition": True,
+            "use_formula_recognition": False,
+            "use_chart_recognition": False,
+            "use_seal_recognition": False,
+            "prettify_markdown": True,
+            "visualize": False,
+        }
+    )
+
+    processed = component.process_files([make_base_file(file_path)])
+
+    data = processed[0].data[0].data
+    assert data["text"] == "# Title"
+    assert data["task_type"] == "document_parsing"
+    assert data["output_format"] == "markdown"
+    assert data["model"] == "PaddleOCR-VL-1.6"
+    assert data["job_id"] == "doc-job-id"
+    assert data["pages"][0]["markdown_text"] == "# Title"
+    assert data["pages"][0]["markdown_images"] == {"image.png": "https://example.com/image.png"}
+
+    assert captured["submit"]["base_url"] == "https://example.com"
+    assert captured["submit"]["file_path"] == file_path
+    assert captured["submit"]["options"]["use_table_recognition"] is True
+
+
+def test_paddleocr_document_parsing_falls_back_to_ocr_results(tmp_path):
+    file_path = tmp_path / "sample.pdf"
+    file_path.write_bytes(b"fake pdf")
+
+    component = PaddleOCRComponent()
+    component.set_attributes({"task_type": "document_parsing", "model": "PP-OCRv6"})
+
+    data = component._document_result_to_data(
+        "job-id",
+        [
+            {
+                "result": {
+                    "ocrResults": [
+                        {
+                            "prunedResult": {"rec_texts": ["fallback", "text"]},
+                            "ocrImage": "https://example.com/ocr.png",
+                        }
+                    ]
+                }
+            }
+        ],
+        file_path,
+    ).data
+
+    assert data["text"] == "fallback\ntext"
+    assert data["pages"][0]["pruned_result"] == {"rec_texts": ["fallback", "text"]}
+
+
+def test_paddleocr_requires_access_token(tmp_path):
+    file_path = tmp_path / "sample.png"
+    file_path.write_bytes(b"fake image")
+
+    component = PaddleOCRComponent()
+    component.set_attributes({"access_token": "", "task_type": "ocr", "model": "PP-OCRv6"})
+
+    with pytest.raises(ValueError, match="Access Token is required"):
+        component.process_files([make_base_file(file_path)])
+
+
+def test_paddleocr_formats_auth_error():
+    component = PaddleOCRComponent()
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(401, request=request, text="unauthorized")
+    error = httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    assert component._format_paddleocr_error(error) == (
+        "PaddleOCR authentication failed. Please check the AI Studio Access Token."
+    )
+
+
+def test_task_type_updates_model_options():
+    component = PaddleOCRComponent()
+    build_config = {
+        "model": {"options": ["PP-StructureV3", "PaddleOCR-VL-1.6"], "value": "PP-StructureV3"},
+    }
+
+    updated = component.update_build_config(build_config, "ocr", "task_type")
+    assert updated["model"]["options"] == ["PP-OCRv6", "PP-OCRv5"]
+    assert updated["model"]["value"] == "PP-OCRv6"
+
+    updated = component.update_build_config(build_config, "document_parsing", "task_type")
+    assert updated["model"]["options"] == ["PP-StructureV3", "PaddleOCR-VL-1.6"]
+    assert updated["model"]["value"] == "PP-StructureV3"

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -4810,6 +4810,26 @@
       "legacy_slot": "ext:vlmrun:VLMRunTranscription@official-pre-a",
       "target": "ext:vlmrun:VLMRunTranscription@official",
       "added_in": "1.11.0"
+    },
+    {
+      "bare_class_name": "PaddleOCRComponent",
+      "target": "ext:paddle:PaddleOCRComponent@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "import_path": "lfx.components.paddle.paddleocr.PaddleOCRComponent",
+      "target": "ext:paddle:PaddleOCRComponent@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "import_path": "lfx.components.paddle.PaddleOCRComponent",
+      "target": "ext:paddle:PaddleOCRComponent@official",
+      "added_in": "1.11.0"
+    },
+    {
+      "legacy_slot": "ext:paddle:PaddleOCRComponent@official-pre-a",
+      "target": "ext:paddle:PaddleOCRComponent@official",
+      "added_in": "1.11.0"
     }
   ],
   "ambiguous_bare_names": [

--- a/src/lfx/tests/integration/extension/test_pilot_paddle_upgrade.py
+++ b/src/lfx/tests/integration/extension/test_pilot_paddle_upgrade.py
@@ -80,6 +80,19 @@ def test_short_import_path_flow_upgrades(migration_table) -> None:
 
 
 @pytest.mark.integration
+def test_legacy_slot_flow_upgrades(migration_table) -> None:
+    """The pre-Phase-A ``@official-pre-a`` slot form upgrades to the canonical ID."""
+    from lfx.extension.migration.rewrite import migrate_flow_payload
+
+    flow = _saved_flow(_saved_flow_node("paddle-4", "ext:paddle:PaddleOCRComponent@official-pre-a"))
+    report = migrate_flow_payload(flow, table=migration_table)
+
+    assert report.rewritten_count == 1
+    assert flow["data"]["nodes"][0]["data"]["type"] == EXPECTED_TARGET
+    assert report.records[0].legacy_form_kind == "legacy_slot"
+
+
+@pytest.mark.integration
 def test_lfx_paddle_distribution_is_importable() -> None:
     """The bundle's package is importable in the development workspace."""
     try:

--- a/src/lfx/tests/integration/extension/test_pilot_paddle_upgrade.py
+++ b/src/lfx/tests/integration/extension/test_pilot_paddle_upgrade.py
@@ -1,0 +1,127 @@
+"""Integration test: legacy paddle flows upgrade cleanly.
+
+Mirrors ``test_pilot_firecrawl_upgrade.py`` for ``PaddleOCRComponent`` (the
+``lfx-paddle`` bundle).
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+import pytest
+from lfx.extension.migration.loader import load_migration_table
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+TABLE_PATH = REPO_ROOT / "src" / "lfx" / "src" / "lfx" / "extension" / "migration" / "migration_table.json"
+EXPECTED_TARGET = "ext:paddle:PaddleOCRComponent@official"
+
+
+@pytest.fixture(scope="module")
+def migration_table():
+    table, error = load_migration_table(TABLE_PATH)
+    assert error is None, f"failed to load migration table: {error}"
+    assert table is not None
+    return table
+
+
+def _saved_flow_node(node_id: str, type_value: str) -> dict:
+    """Build a minimal saved-flow node skeleton for testing."""
+    return {
+        "id": node_id,
+        "type": "genericNode",
+        "data": {"id": node_id, "type": type_value, "node": {"template": {}}},
+    }
+
+
+def _saved_flow(*nodes: dict) -> dict:
+    return {"data": {"nodes": list(nodes), "edges": []}}
+
+
+@pytest.mark.integration
+def test_legacy_bare_name_flow_upgrades(migration_table) -> None:
+    """Pre-Phase-A flow with the bare class name upgrades to the canonical ID."""
+    from lfx.extension.migration.rewrite import migrate_flow_payload
+
+    flow = _saved_flow(_saved_flow_node("paddle-1", "PaddleOCRComponent"))
+    report = migrate_flow_payload(flow, table=migration_table)
+
+    assert report.rewritten_count == 1
+    assert flow["data"]["nodes"][0]["data"]["type"] == EXPECTED_TARGET
+    [record] = report.records
+    assert record.legacy_form_kind == "bare_class_name"
+    assert record.new_value == EXPECTED_TARGET
+
+
+@pytest.mark.integration
+def test_legacy_import_path_flow_upgrades(migration_table) -> None:
+    """Dotted import-path form upgrades to the canonical ID."""
+    from lfx.extension.migration.rewrite import migrate_flow_payload
+
+    flow = _saved_flow(_saved_flow_node("paddle-2", "lfx.components.paddle.paddleocr.PaddleOCRComponent"))
+    report = migrate_flow_payload(flow, table=migration_table)
+
+    assert report.rewritten_count == 1
+    assert flow["data"]["nodes"][0]["data"]["type"] == EXPECTED_TARGET
+    assert report.records[0].legacy_form_kind == "import_path"
+
+
+@pytest.mark.integration
+def test_short_import_path_flow_upgrades(migration_table) -> None:
+    """Package-level import-path form (via ``__init__.py`` re-export) upgrades."""
+    from lfx.extension.migration.rewrite import migrate_flow_payload
+
+    flow = _saved_flow(_saved_flow_node("paddle-3", "lfx.components.paddle.PaddleOCRComponent"))
+    report = migrate_flow_payload(flow, table=migration_table)
+
+    assert report.rewritten_count == 1
+    assert flow["data"]["nodes"][0]["data"]["type"] == EXPECTED_TARGET
+
+
+@pytest.mark.integration
+def test_lfx_paddle_distribution_is_importable() -> None:
+    """The bundle's package is importable in the development workspace."""
+    try:
+        from lfx_paddle import PaddleOCRComponent
+    except ImportError:
+        pytest.skip("lfx-paddle not installed in this test environment")
+
+    assert PaddleOCRComponent.__name__ == "PaddleOCRComponent"
+
+
+def _is_editable_install(dist: importlib_metadata.Distribution) -> bool:
+    direct_url = dist.read_text("direct_url.json")
+    if not direct_url:
+        return False
+    try:
+        payload = json.loads(direct_url)
+    except json.JSONDecodeError:
+        return False
+    return bool(payload.get("dir_info", {}).get("editable"))
+
+
+@pytest.mark.integration
+def test_lfx_paddle_ships_manifest() -> None:
+    """``importlib.metadata`` can find ``extension.json`` for the installed dist."""
+    try:
+        dist = importlib_metadata.distribution("lfx-paddle")
+    except importlib_metadata.PackageNotFoundError:
+        pytest.skip("lfx-paddle not installed in this test environment")
+
+    if _is_editable_install(dist):
+        import lfx_paddle
+
+        package_dir = Path(lfx_paddle.__file__).parent
+        manifest_path = package_dir / "extension.json"
+        assert manifest_path.is_file()
+    else:
+        files = dist.files or []
+        manifests = [f for f in files if f.parts and f.parts[-1] == "extension.json"]
+        assert manifests
+        manifest_path = Path(dist.locate_file(manifests[0]))
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["id"] == "lfx-paddle"
+    assert manifest["lfx"]["compat"] == ["1"]
+    assert any(b["name"] == "paddle" for b in manifest["bundles"])

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,7 @@ members = [
     "lfx-nextplaid",
     "lfx-openai",
     "lfx-oracle",
+    "lfx-paddle",
 ]
 overrides = [
     { name = "dynaconf", specifier = ">=3.2.13" },
@@ -7888,6 +7889,7 @@ dependencies = [
     { name = "lfx-nextplaid" },
     { name = "lfx-openai" },
     { name = "lfx-oracle" },
+    { name = "lfx-paddle" },
 ]
 
 [package.optional-dependencies]
@@ -7990,6 +7992,7 @@ requires-dist = [
     { name = "lfx-nextplaid", editable = "src/bundles/nextplaid" },
     { name = "lfx-openai", editable = "src/bundles/openai" },
     { name = "lfx-oracle", editable = "src/bundles/oracle" },
+    { name = "lfx-paddle", editable = "src/bundles/paddle" },
     { name = "nv-ingest-api", marker = "python_full_version >= '3.12' and extra == 'nv-ingest'", specifier = ">=26.1.0,<27.0.0" },
     { name = "nv-ingest-client", marker = "python_full_version >= '3.12' and extra == 'nv-ingest'", specifier = ">=26.1.0,<27.0.0" },
     { name = "sentence-transformers", marker = "extra == 'local'", specifier = ">=2.3.1" },
@@ -10074,6 +10077,21 @@ requires-dist = [
     { name = "langchain-oracledb", specifier = ">=1.0.1,<2.0.0" },
     { name = "lfx", editable = "src/lfx" },
     { name = "oracledb", specifier = ">=2.2.0,<4.0.0" },
+]
+
+[[package]]
+name = "lfx-paddle"
+version = "0.1.0"
+source = { editable = "src/bundles/paddle" }
+dependencies = [
+    { name = "httpx" },
+    { name = "lfx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.24.0,<1.0.0" },
+    { name = "lfx", editable = "src/lfx" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ships the **PaddleOCR** component from **#13779** (by @Rander7) as a standalone
Langflow Extension Bundle, **`lfx-paddle`**, instead of an in-tree provider
component. This PR inherits @Rander7's work — the original `feat:` commit is
preserved with their authorship — and adapts it to the bundle architecture used
on `release-1.11.0` (where provider components live as `lfx-*` bundles rather
than under `lfx.components.*`).

Credit for the component goes to @Rander7 (#13779); thank you! 🙏

The component performs either:
- **Document parsing** → layout-aware Markdown (`PP-StructureV3`, `PaddleOCR-VL-1.6`)
- **OCR** → scan-order plain text (`PP-OCRv5`, `PP-OCRv6`)

It talks to the PaddleOCR **AI Studio async Job HTTP API** (`submit → poll →
fetch`) directly via `httpx`, and intentionally does **not** depend on the
`paddleocr` SDK, whose transitive `pyyaml==6.0.2` constraint conflicts with
Langflow's dependency tree (the rationale from #13779).

## What changed vs. #13779

The component logic is ported **verbatim** from #13779, with three deliberate
adaptations required for the bundle architecture:

1. **New standalone bundle `src/bundles/paddle/`** (`lfx-paddle`) — mirrors the
   layout of `lfx-firecrawl` / `lfx-nextplaid`: `pyproject.toml`,
   `extension.json`, package re-exports, and the component under
   `components/paddle/`. The component is no longer added to `lfx.components.baidu`
   and the static `component_index.json` is **not** touched (bundle components
   are excluded from the core index by design).
2. **Test rewritten as plain pytest functions** importing the bundle entry point
   (`from lfx_paddle import PaddleOCRComponent`), dropping the
   `tests.base.ComponentTestBaseWithoutClient` import — that module does not
   exist inside a standalone bundle, so the original test would fail at
   collection. (CodeRabbit flagged the same harness issue on #13779.)
3. **Workspace wiring + migration table** — registered as a workspace member /
   curated dependency in the root `pyproject.toml`, with migration entries
   mapping the bare class name and legacy import paths to
   `ext:paddle:PaddleOCRComponent@official`.

## Security hardening (HIGH — SSRF)

A multi-lens review of #13779 surfaced a **HIGH SSRF** the verbatim component
inherited: in `_poll_job`, the job **`result_url` is taken from the remote
job-status response** (not operator input) and fetched with a bare
`httpx.get(...)`. A compromised / rogue / MITM'd endpoint could return an
internal or cloud-metadata URL (`http://169.254.169.254/...`,
`http://127.0.0.1:.../`) and have the worker fetch it server-side and return the
body into the flow.

This PR routes `_fetch_result` through Langflow's existing SSRF protection
(`lfx.utils.ssrf_protection.validate_and_resolve_url` +
`lfx.utils.ssrf_transport.create_ssrf_protected_sync_client`), mirroring
`data_source/api_request`. It is a **no-op when SSRF protection is disabled (the
default)** — default behavior is unchanged; when an operator enables protection
it blocks internal targets and pins DNS to the validated IPs.

### Noted follow-ups (non-blocking, inherited from #13779)
Tracked for post-merge hardening rather than gating this port:
- `{"data": null}` in an API response crashes the `.get(...)` chains in
  `_submit_job` / `_poll_job` (trivial `payload.get("data") or {}` fix).
- `poll_timeout` is a soft, not hard, ceiling — a status GET near the deadline
  can overrun by up to `REQUEST_TIMEOUT` (300s).
- Raw upstream `response.text` / full payload dicts are interpolated into the
  re-raised `RuntimeError` (bypasses the `self.log` secret scrubber); bounded
  info-disclosure.
- A few defensive `isinstance` guards on remote response shapes.

## Test plan

- [x] `uv lock` resolves (adds `lfx-paddle` v0.1.0); `uv sync` installs it editable
- [x] `uv run lfx extension validate src/bundles/paddle/src/lfx_paddle` → ok
- [x] Bundle imports: `from lfx_paddle import PaddleOCRComponent`
- [x] Loader discovers the editable install (`installed_extension_roots()`)
- [x] `uv run pytest src/bundles/paddle/tests` → **10 passed** (incl. new HTTP-layer / SSRF-path tests)
- [x] `uv run pytest tests/unit/extension/migration` (lfx-isolated) → **156 passed** (bare-name uniqueness + append-only + completeness)
- [x] `uv run pytest tests/integration/extension/test_pilot_paddle_upgrade.py` (lfx-isolated) → **3 passed, 2 skipped** (dist-not-installed skips)
- [x] `ruff check` + `ruff format --check` clean across touched files
- [ ] Manual UI smoke test with a real AI Studio token (per #13779's plan)

## Manual testing plan (from #13779)

1. `LFX_DEV=1 make backend` + `make frontend`
2. Find **PaddleOCR** under the `paddle` bundle group
3. Image + `Task Type = ocr`, `Model = PP-OCRv6`
4. PDF + `Task Type = document_parsing`, `Model = PP-StructureV3` / `PaddleOCR-VL-1.6`
5. Confirm the output DataFrame includes `text`, `file_path`, `task_type`,
   `output_format`, `model`, `job_id`, `pages`
6. Confirm invalid token / base URL errors are clear and do not leak the token

---

Supersedes #13779 (component converted to the `lfx-paddle` partner bundle).
Co-authored with @Rander7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PaddleOCR extension bundle for processing documents and images.
  * Introduced support for OCR and document-parsing workflows with Markdown/text output.

* **Documentation**
  * Added setup, validation, and migration guidance for the new bundle.

* **Bug Fixes**
  * Improved error handling for authentication, network, timeout, and result-fetching issues.
  * Added migration support for older saved flows so existing content upgrades smoothly.

* **Tests**
  * Added coverage for bundle loading, output formatting, result parsing, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->