### PR TITLE
feat: add vLLM as a first-class Model Provider with dynamic model discovery

### DIFF
--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -202,25 +202,27 @@ async def list_models(
 
     # Ensure providers in MODEL_PROVIDER_METADATA appear in results even when they have no
     # static models (e.g. vLLM which uses dynamic-only discovery via LIVE_MODEL_PROVIDERS).
-    existing_providers = {p.get("provider") for p in filtered_models}
-    all_metadata = get_model_provider_metadata()
-    for prov_name, meta in all_metadata.items():
-        if prov_name not in existing_providers:
-            if selected_providers and prov_name not in selected_providers:
-                continue
-            is_configured = provider_configured_status.get(prov_name, False)
-            prov_models_status = enabled_models_map.get(prov_name, {})
-            has_active_model = any(prov_models_status.values())
-            filtered_models.append(
-                {
-                    "provider": prov_name,
-                    "icon": meta.get("icon", prov_name),
-                    "models": [],
-                    "api_docs_url": meta.get("api_docs_url", ""),
-                    "is_configured": is_configured,
-                    "is_enabled": has_active_model,
-                }
-            )
+    # Skip when model-level filters are active — an empty-model provider cannot satisfy them.
+    if model_name is None and not metadata_filters:
+        existing_providers = {p.get("provider") for p in filtered_models}
+        all_metadata = get_model_provider_metadata()
+        for prov_name, meta in all_metadata.items():
+            if prov_name not in existing_providers:
+                if selected_providers and prov_name not in selected_providers:
+                    continue
+                is_configured = provider_configured_status.get(prov_name, False)
+                prov_models_status = enabled_models_map.get(prov_name, {})
+                has_active_model = any(prov_models_status.values())
+                filtered_models.append(
+                    {
+                        "provider": prov_name,
+                        "icon": meta.get("icon", prov_name),
+                        "models": [],
+                        "api_docs_url": meta.get("api_docs_url", ""),
+                        "is_configured": is_configured,
+                        "is_enabled": has_active_model,
+                    }
+                )
 
     for provider_dict in filtered_models:
         prov_name = provider_dict.get("provider")

--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -200,6 +200,28 @@ async def list_models(
     configured_providers = {p for p, configured in provider_configured_status.items() if configured}
     replace_with_live_models(filtered_models, current_user.id, configured_providers, model_type)
 
+    # Ensure providers in MODEL_PROVIDER_METADATA appear in results even when they have no
+    # static models (e.g. vLLM which uses dynamic-only discovery via LIVE_MODEL_PROVIDERS).
+    existing_providers = {p.get("provider") for p in filtered_models}
+    all_metadata = get_model_provider_metadata()
+    for prov_name, meta in all_metadata.items():
+        if prov_name not in existing_providers:
+            if selected_providers and prov_name not in selected_providers:
+                continue
+            is_configured = provider_configured_status.get(prov_name, False)
+            prov_models_status = enabled_models_map.get(prov_name, {})
+            has_active_model = any(prov_models_status.values())
+            filtered_models.append(
+                {
+                    "provider": prov_name,
+                    "icon": meta.get("icon", prov_name),
+                    "models": [],
+                    "api_docs_url": meta.get("api_docs_url", ""),
+                    "is_configured": is_configured,
+                    "is_enabled": has_active_model,
+                }
+            )
+
     for provider_dict in filtered_models:
         prov_name = provider_dict.get("provider")
         provider_dict["is_configured"] = provider_configured_status.get(prov_name, False)

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -283,12 +283,16 @@ export default function ModelInputComponent({
           // Only include models whose declared type matches this component.
           // Older metadata without ``model_type`` is allowed through so we
           // don't regress providers that haven't adopted the tag yet.
+          // vLLM models skip type filtering — vLLM API doesn't distinguish
+          // between LLM and embedding models.
+          const isVllmProvider = providerName.toLowerCase() === "vllm";
           const modelMetadata = (model.metadata ?? {}) as Record<
             string,
             unknown
           >;
           const modelMetadataType = modelMetadata.model_type;
           if (
+            !isVllmProvider &&
             typeof modelMetadataType === "string" &&
             modelMetadataType !== modelType
           ) {

--- a/src/frontend/src/constants/providerConstants.ts
+++ b/src/frontend/src/constants/providerConstants.ts
@@ -30,6 +30,7 @@ export const PROVIDER_VARIABLE_MAPPING: Record<string, string> = {
   "Google Generative AI": "GOOGLE_API_KEY",
   Google: "GOOGLE_API_KEY",
   Ollama: "OLLAMA_BASE_URL",
+  vLLM: "VLLM_API_BASE",
   "IBM WatsonX": "WATSONX_APIKEY",
   Cohere: "COHERE_API_KEY",
   HuggingFace: "HUGGINGFACEHUB_API_TOKEN",

--- a/src/frontend/src/constants/providerConstants.ts
+++ b/src/frontend/src/constants/providerConstants.ts
@@ -30,7 +30,6 @@ export const PROVIDER_VARIABLE_MAPPING: Record<string, string> = {
   "Google Generative AI": "GOOGLE_API_KEY",
   Google: "GOOGLE_API_KEY",
   Ollama: "OLLAMA_BASE_URL",
-  vLLM: "VLLM_API_BASE",
   "IBM WatsonX": "WATSONX_APIKEY",
   Cohere: "COHERE_API_KEY",
   HuggingFace: "HUGGINGFACEHUB_API_TOKEN",

--- a/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
+++ b/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
@@ -84,6 +84,7 @@ const getProviderIcon = (providerName: string): string => {
     "Azure OpenAI": "AzureOpenAI",
     SambaNova: "SambaNova",
     Ollama: "Ollama",
+    vLLM: "vLLM",
     "IBM WatsonX": "IBM",
     "IBM watsonx.ai": "IBM",
     OpenRouter: "OpenRouter",

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -290,6 +290,10 @@ const ModelSelection = ({
 
   const isOllama = providerName?.toLowerCase() === "ollama";
   const isVllm = providerName?.toLowerCase() === "vllm";
+  // For vLLM, models lack metadata.model_type — apply search query directly.
+  const vllmFilteredModels = isVllm
+    ? availableModels.filter(matchesModelQuery)
+    : [];
   // Use the unfiltered availableModels for the empty-state check so an
   // ollama-no-models warning still fires when the search field happens to be
   // populated.
@@ -299,16 +303,20 @@ const ModelSelection = ({
   const embeddingAvailableCount = availableModels.filter(
     (m) => m.metadata?.model_type === "embeddings",
   ).length;
-  const noModelsAvailable =
-    (modelType === "llm" && llmAvailableCount === 0) ||
-    (modelType === "embeddings" && embeddingAvailableCount === 0) ||
-    (modelType === "all" && availableModels.length === 0);
+  const noModelsAvailable = isVllm
+    ? availableModels.length === 0
+    : (modelType === "llm" && llmAvailableCount === 0) ||
+      (modelType === "embeddings" && embeddingAvailableCount === 0) ||
+      (modelType === "all" && availableModels.length === 0);
 
-  const noModelsMatchQuery =
-    !noModelsAvailable &&
-    trimmedModelQuery.length > 0 &&
-    llmModels.length === 0 &&
-    embeddingModels.length === 0;
+  const noModelsMatchQuery = isVllm
+    ? !noModelsAvailable &&
+      trimmedModelQuery.length > 0 &&
+      vllmFilteredModels.length === 0
+    : !noModelsAvailable &&
+      trimmedModelQuery.length > 0 &&
+      llmModels.length === 0 &&
+      embeddingModels.length === 0;
 
   return (
     <div data-testid="model-provider-selection" className="flex flex-col gap-6">
@@ -362,7 +370,7 @@ const ModelSelection = ({
           </a>
         </div>
       ) : isVllm ? (
-        renderModelSection("Available Models", availableModels, "available")
+        renderModelSection("Available Models", vllmFilteredModels, "available")
       ) : (
         <>
           {modelType === "all" ? (

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -289,6 +289,7 @@ const ModelSelection = ({
   };
 
   const isOllama = providerName?.toLowerCase() === "ollama";
+  const isVllm = providerName?.toLowerCase() === "vllm";
   // Use the unfiltered availableModels for the empty-state check so an
   // ollama-no-models warning still fires when the search field happens to be
   // populated.
@@ -360,6 +361,8 @@ const ModelSelection = ({
             {t("modelProviders.checkOllamaLibrary")}
           </a>
         </div>
+      ) : isVllm ? (
+        renderModelSection("Available Models", availableModels, "available")
       ) : (
         <>
           {modelType === "all" ? (

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
@@ -39,9 +39,10 @@ const ProviderList = ({
     return rawProviders
       .filter((provider) => matchesQuery(provider.provider))
       .map((provider) => {
+        const isVllm = provider?.provider?.toLowerCase() === "vllm";
         const matchingModels =
           provider?.models?.filter((model) =>
-            modelType === "all"
+            modelType === "all" || isVllm
               ? true
               : model?.metadata?.model_type === modelType,
           ) || [];

--- a/src/lfx/src/lfx/base/models/model_metadata.py
+++ b/src/lfx/src/lfx/base/models/model_metadata.py
@@ -55,7 +55,7 @@ def create_model_metadata(
     )
 
 
-LIVE_MODEL_PROVIDERS: list[str] = ["Ollama", "IBM WatsonX", "OpenRouter"]
+LIVE_MODEL_PROVIDERS: list[str] = ["Ollama", "vLLM", "IBM WatsonX", "OpenRouter"]
 
 # Live only with a custom endpoint configured; empty live fetch keeps the static catalog.
 CONDITIONAL_LIVE_MODEL_PROVIDERS: list[str] = ["OpenAI"]
@@ -254,6 +254,47 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         "api_docs_url": "https://learn.microsoft.com/en-us/azure/ai-services/openai/",
         "mapping": {
             "model_class": "AzureChatOpenAI",
+            "model_param": "model",
+        },
+    },
+    "vLLM": {
+        "icon": "vLLM",
+        "max_tokens_field_name": "max_tokens",
+        "variables": [
+            {
+                "variable_name": "vLLM API Base URL",
+                "variable_key": "VLLM_API_BASE",
+                "required": True,
+                "is_secret": False,
+                "is_list": False,
+                "options": [],
+                "langchain_param": "base_url",
+                "component_metadata": {
+                    "mapping_field": "vllm_base_url",
+                    "required": False,
+                    "advanced": True,
+                    "info": "Falls back to VLLM_API_BASE environment variable",
+                },
+            },
+            {
+                "variable_name": "vLLM API Key",
+                "variable_key": "VLLM_API_KEY",
+                "required": False,
+                "is_secret": True,
+                "is_list": False,
+                "options": [],
+                "langchain_param": "api_key",
+                "component_metadata": {
+                    "mapping_field": "api_key",
+                    "required": False,
+                    "advanced": True,
+                    "info": "Falls back to VLLM_API_KEY environment variable (optional for local servers)",
+                },
+            },
+        ],
+        "api_docs_url": "https://docs.vllm.ai/",
+        "mapping": {
+            "model_class": "ChatOpenAI",
             "model_param": "model",
         },
     },

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -687,6 +687,65 @@ def fetch_live_watsonx_models(user_id: UUID | str | None, model_type: str = "llm
         return result
 
 
+def fetch_live_vllm_models(user_id: UUID | str | None, model_type: str = "llm") -> list[dict]:
+    """Fetch live models from a vLLM server via OpenAI-compatible /v1/models API.
+
+    vLLM's API does not distinguish between LLM and embedding models, so all
+    available models are returned regardless of the requested model_type. This
+    allows users to select any vLLM-served model in both Language Model and
+    Embedding Model contexts.
+
+    Args:
+        user_id: The user ID to look up the vLLM base URL and API key
+        model_type: "llm" or "embeddings" — used for tagging only, no filtering
+
+    Returns:
+        List of model metadata dicts, or empty list if unable to fetch
+    """
+    base_url = get_provider_variable_value(user_id, "VLLM_API_BASE")
+    if not base_url:
+        return []
+
+    try:
+        api_key = get_provider_variable_value(user_id, "VLLM_API_KEY")
+    except Exception:  # noqa: BLE001
+        api_key = None  # API key is optional for vLLM
+
+    try:
+        base_url = base_url.rstrip("/")
+        models_url = f"{base_url}/models" if base_url.endswith("/v1") else f"{base_url}/v1/models"
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        response = requests.get(models_url, headers=headers, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+
+        # Support both OpenAI-compatible {"data": [{"id": "..."}]} and simple list
+        if isinstance(data, list):
+            model_names = sorted(str(m) for m in data if m)
+        elif isinstance(data, dict) and "data" in data:
+            model_names = sorted(m.get("id", "") for m in data["data"] if m.get("id"))
+        else:
+            model_names = []
+
+        return [
+            create_model_metadata(
+                provider="vLLM",
+                name=name,
+                icon="vLLM",
+                model_type=model_type,
+                tool_calling=model_type == "llm",
+                default=i < MIN_DEFAULT_MODELS,
+            )
+            for i, name in enumerate(model_names)
+        ]
+    except Exception:  # noqa: BLE001
+        logger.debug(f"Could not fetch live vLLM {model_type} models from {base_url}")
+        return []
+
+
 def get_live_models_for_provider(
     user_id: UUID | str | None,
     provider: str,
@@ -696,7 +755,7 @@ def get_live_models_for_provider(
 
     Args:
         user_id: The user ID to look up credentials
-        provider: The provider name (e.g., "Ollama", "IBM WatsonX")
+        provider: The provider name (e.g., "Ollama", "vLLM", "IBM WatsonX")
         model_type: "llm" or "embeddings"
 
     Returns:
@@ -704,6 +763,8 @@ def get_live_models_for_provider(
     """
     if provider == "Ollama":
         return fetch_live_ollama_models(user_id, model_type)
+    if provider == "vLLM":
+        return fetch_live_vllm_models(user_id, model_type)
     if provider == "IBM WatsonX":
         return fetch_live_watsonx_models(user_id, model_type)
     if provider == "OpenRouter":
@@ -754,7 +815,11 @@ def replace_with_live_models(
         if provider not in enabled_providers:
             continue
 
-        if model_type is None:
+        if provider == "vLLM":
+            # vLLM returns all models regardless of type (no type distinction in its API),
+            # so fetch once to avoid duplicates
+            live_models = get_live_models_for_provider(user_id, provider, model_type or "llm")
+        elif model_type is None:
             live_llm = get_live_models_for_provider(user_id, provider, "llm")
             live_emb = get_live_models_for_provider(user_id, provider, "embeddings")
             live_models = live_llm + live_emb

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -25,6 +25,7 @@ from lfx.log.logger import logger
 from lfx.services.deps import get_variable_service, session_scope
 from lfx.utils.async_helpers import run_until_complete
 from lfx.utils.secrets import unwrap_secret_value
+from lfx.utils.ssrf_protection import validate_url_for_ssrf
 from lfx.utils.util import transform_localhost_url
 
 HTTP_STATUS_OK = 200
@@ -718,6 +719,7 @@ def fetch_live_vllm_models(user_id: UUID | str | None, model_type: str = "llm") 
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
+        validate_url_for_ssrf(models_url)
         response = requests.get(models_url, headers=headers, timeout=5)
         response.raise_for_status()
         data = response.json()

--- a/src/lfx/src/lfx/base/models/unified_models/class_registry.py
+++ b/src/lfx/src/lfx/base/models/unified_models/class_registry.py
@@ -52,6 +52,7 @@ EMBEDDING_PROVIDER_CLASS_MAPPING: dict[str, str] = {
     "OpenAI": "OpenAIEmbeddings",
     "Google Generative AI": "GoogleGenerativeAIEmbeddings",
     "Ollama": "OllamaEmbeddings",
+    "vLLM": "OpenAIEmbeddings",
     "IBM WatsonX": "WatsonxEmbeddings",
     "IBM watsonx.ai": "WatsonxEmbeddings",  # Alias used by MODEL_PROVIDERS_DICT
 }
@@ -87,6 +88,17 @@ EMBEDDING_PARAM_MAPPINGS: dict[str, dict[str, str]] = {
         "base_url": "base_url",
         "num_ctx": "num_ctx",
         "request_timeout": "request_timeout",
+        "model_kwargs": "model_kwargs",
+    },
+    "vLLM Embeddings": {
+        "model": "model",
+        "api_key": "api_key",
+        "api_base": "base_url",
+        "dimensions": "dimensions",
+        "chunk_size": "chunk_size",
+        "request_timeout": "timeout",
+        "max_retries": "max_retries",
+        "show_progress_bar": "show_progress_bar",
         "model_kwargs": "model_kwargs",
     },
     "IBM WatsonX": {

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -505,6 +505,44 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
                 logger.warning(msg)
                 raise ValueError(msg) from e
 
+        elif provider == "vLLM":
+            import requests
+
+            base_url = variables.get("VLLM_API_BASE")
+            if not base_url:
+                msg = "Invalid vLLM API base URL"
+                logger.error(msg)
+                raise ValueError(msg)
+
+            base_url = base_url.rstrip("/")
+            models_url = f"{base_url}/models" if base_url.endswith("/v1") else f"{base_url}/v1/models"
+            headers: dict[str, str] = {}
+            api_key = variables.get("VLLM_API_KEY")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            try:
+                response = requests.get(models_url, headers=headers, timeout=5)
+                if response.status_code in (401, 403):
+                    msg = "Authentication failed for vLLM server. Check VLLM_API_KEY."
+                    logger.error(msg)
+                    raise ValueError(msg)
+                response.raise_for_status()
+            except requests.ConnectionError as e:
+                msg = (
+                    f"Could not connect to vLLM server at {base_url}. "
+                    "Please check that the server is running and the URL is correct."
+                )
+                logger.error(msg)
+                raise ValueError(msg) from e
+            except requests.Timeout as e:
+                msg = (
+                    f"Connection to vLLM server at {base_url} timed out. "
+                    "Please check that the server is running and responsive."
+                )
+                logger.error(msg)
+                raise ValueError(msg) from e
+
         elif provider == "Ollama":
             import requests
 
@@ -551,6 +589,11 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
             raise ValueError(msg) from e
 
         # Rethrow specific Ollama errors with a user-facing message
+        if provider == "vLLM":
+            msg = f"Failed to validate vLLM server: {e}"
+            logger.error(msg)
+            raise ValueError(msg) from e
+
         if provider == "Ollama":
             msg = "Invalid Ollama base URL"
             logger.error(msg)

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -99,7 +99,7 @@ def get_llm(
     api_key = unified_models_module.get_api_key_for_provider(user_id, provider, api_key)
 
     # Validate API key (Ollama doesn't require one)
-    if not api_key and provider != "Ollama":
+    if not api_key and provider not in {"Ollama", "vLLM", "vLLM Embeddings"}:
         # Bug 2 [P1] — Defensive guard: provider arriving as empty / None /
         # literal "Unknown" produces a nonsense error message (the worst
         # case being ``Unknown API key is required when using Unknown
@@ -354,7 +354,7 @@ def get_embeddings(
 
     # --- resolve API key -----------------------------------------------------
     api_key = unified_models_module.get_api_key_for_provider(user_id, provider, api_key)
-    if not api_key and provider != "Ollama":
+    if not api_key and provider not in {"Ollama", "vLLM", "vLLM Embeddings"}:
         provider_variable_map = unified_models_module.get_model_provider_variable_mapping()
         variable_name = provider_variable_map.get(provider, f"{provider.upper().replace(' ', '_')}_API_KEY")
         msg = (
@@ -472,6 +472,17 @@ def get_embeddings(
             or "http://localhost:11434"
         )
         kwargs[param_mapping["base_url"]] = base_url_value
+
+    # vLLM Embeddings: resolve base_url from stored provider variable
+    if provider == "vLLM Embeddings" and "api_base" in param_mapping:
+        provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
+        base_url_value = (
+            _to_str(api_base)
+            or provider_vars.get("VLLM_EMBEDDINGS_API_BASE")
+            or _env_if_allowed("VLLM_EMBEDDINGS_API_BASE")
+        )
+        if base_url_value:
+            kwargs[param_mapping["api_base"]] = base_url_value
 
     # Add optional parameters if they have values and are mapped
     for param_name, param_value in optional_params.items():

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -210,13 +210,9 @@ def get_llm(
         provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
 
         # Priority: component value > database value > env var
-        watsonx_url_value = (
-            watsonx_url if watsonx_url else provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
-        )
+        watsonx_url_value = watsonx_url or provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
         watsonx_project_id_value = (
-            watsonx_project_id
-            if watsonx_project_id
-            else provider_vars.get("WATSONX_PROJECT_ID") or _env_if_allowed("WATSONX_PROJECT_ID")
+            watsonx_project_id or provider_vars.get("WATSONX_PROJECT_ID") or _env_if_allowed("WATSONX_PROJECT_ID")
         )
 
         has_url = bool(watsonx_url_value)
@@ -246,9 +242,7 @@ def get_llm(
 
         # Priority: component value > database value > env var
         ollama_base_url_value = (
-            ollama_base_url
-            if ollama_base_url
-            else provider_vars.get("OLLAMA_BASE_URL") or _env_if_allowed("OLLAMA_BASE_URL")
+            ollama_base_url or provider_vars.get("OLLAMA_BASE_URL") or _env_if_allowed("OLLAMA_BASE_URL")
         )
         if ollama_base_url_value:
             kwargs[base_url_param] = ollama_base_url_value
@@ -412,7 +406,7 @@ def get_embeddings(
         "request_timeout": float(request_timeout) if request_timeout else None,
         "max_retries": int(max_retries) if max_retries else None,
         "show_progress_bar": show_progress_bar,
-        "model_kwargs": model_kwargs if model_kwargs else None,
+        "model_kwargs": model_kwargs or None,
     }
 
     # Watson-specific parameters
@@ -476,11 +470,7 @@ def get_embeddings(
     # vLLM Embeddings shares the same VLLM_API_BASE variable as the LLM provider.
     if provider == "vLLM Embeddings" and "api_base" in param_mapping:
         provider_vars = unified_models_module.get_all_variables_for_provider(user_id, "vLLM")
-        base_url_value = (
-            _to_str(api_base)
-            or provider_vars.get("VLLM_API_BASE")
-            or _env_if_allowed("VLLM_API_BASE")
-        )
+        base_url_value = _to_str(api_base) or provider_vars.get("VLLM_API_BASE") or _env_if_allowed("VLLM_API_BASE")
         if base_url_value:
             kwargs[param_mapping["api_base"]] = base_url_value
 

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -473,13 +473,13 @@ def get_embeddings(
         )
         kwargs[param_mapping["base_url"]] = base_url_value
 
-    # vLLM Embeddings: resolve base_url from stored provider variable
+    # vLLM Embeddings shares the same VLLM_API_BASE variable as the LLM provider.
     if provider == "vLLM Embeddings" and "api_base" in param_mapping:
-        provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
+        provider_vars = unified_models_module.get_all_variables_for_provider(user_id, "vLLM")
         base_url_value = (
             _to_str(api_base)
-            or provider_vars.get("VLLM_EMBEDDINGS_API_BASE")
-            or _env_if_allowed("VLLM_EMBEDDINGS_API_BASE")
+            or provider_vars.get("VLLM_API_BASE")
+            or _env_if_allowed("VLLM_API_BASE")
         )
         if base_url_value:
             kwargs[param_mapping["api_base"]] = base_url_value

--- a/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
+++ b/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
@@ -120,8 +120,15 @@ def _get_all_provider_specific_field_names() -> set[str]:
 
 
 def get_model_providers() -> list[str]:
-    """Return a sorted list of unique provider names."""
-    return sorted({md.get("provider", "Unknown") for group in get_models_detailed() for md in group})
+    """Return a sorted list of unique provider names.
+
+    Includes both providers with static model catalogs (get_models_detailed)
+    and providers registered in MODEL_PROVIDER_METADATA (e.g. vLLM, which
+    only has dynamic model discovery via LIVE_MODEL_PROVIDERS).
+    """
+    providers = {md.get("provider", "Unknown") for group in get_models_detailed() for md in group}
+    providers.update(model_provider_metadata.keys())
+    return sorted(providers)
 
 
 def get_provider_for_model_name(model_name: str) -> str:

--- a/src/lfx/tests/unit/base/models/test_vllm_provider.py
+++ b/src/lfx/tests/unit/base/models/test_vllm_provider.py
@@ -1,0 +1,526 @@
+"""Unit tests for the vLLM unified model provider.
+
+Covers:
+  - Provider metadata registration (variables, mapping, live-fetch flag).
+  - fetch_live_vllm_models — mocks the vLLM /v1/models endpoint and pins the
+    model-list parsing for both OpenAI-dict and plain-list payloads, auth header
+    forwarding, /v1 deduplication, and degradation paths.
+  - validate_model_provider_key — success, 401/403 auth error, connection error,
+    timeout, and missing URL paths.
+  - get_model_providers — vLLM appears despite having no static catalog.
+  - API-key-optional contract — vLLM does not raise when no API key is set.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+def test_vllm_in_live_model_providers():
+    from lfx.base.models.model_metadata import LIVE_MODEL_PROVIDERS
+
+    assert "vLLM" in LIVE_MODEL_PROVIDERS
+
+
+def test_vllm_in_provider_metadata():
+    from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
+
+    assert "vLLM" in MODEL_PROVIDER_METADATA
+
+
+def test_vllm_metadata_shape():
+    from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
+
+    meta = MODEL_PROVIDER_METADATA["vLLM"]
+    assert meta["icon"] == "vLLM"
+    assert meta["mapping"]["model_class"] == "ChatOpenAI"
+    assert meta["mapping"]["model_param"] == "model"
+    assert meta["api_docs_url"] == "https://docs.vllm.ai/"
+
+    var_keys = {v["variable_key"] for v in meta["variables"]}
+    assert var_keys == {"VLLM_API_BASE", "VLLM_API_KEY"}
+
+    by_key = {v["variable_key"]: v for v in meta["variables"]}
+    assert by_key["VLLM_API_BASE"]["required"] is True
+    assert by_key["VLLM_API_BASE"]["is_secret"] is False
+    assert by_key["VLLM_API_KEY"]["required"] is False
+    assert by_key["VLLM_API_KEY"]["is_secret"] is True
+
+
+def test_vllm_base_url_mapping_field_recognized_by_param_mapping():
+    """mapping_field 'vllm_base_url' must contain 'base_url' so get_provider_param_mapping
+    classifies it as a URL parameter and sets base_url_param for downstream consumers."""
+    from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
+
+    meta = MODEL_PROVIDER_METADATA["vLLM"]
+    by_key = {v["variable_key"]: v for v in meta["variables"]}
+    mapping_field = by_key["VLLM_API_BASE"]["component_metadata"]["mapping_field"]
+    assert "base_url" in mapping_field, (
+        f"mapping_field '{mapping_field}' must contain 'base_url' so the param "
+        "classifier in get_provider_param_mapping sets base_url_param"
+    )
+
+
+def test_vllm_appears_in_get_model_providers():
+    """vLLM must appear in get_model_providers() even though it has no static catalog."""
+    from lfx.base.models.unified_models import get_model_providers
+
+    assert "vLLM" in get_model_providers()
+
+
+def test_vllm_in_embedding_class_registry():
+    from lfx.base.models.unified_models.class_registry import EMBEDDING_PROVIDER_CLASS_MAPPING
+
+    assert EMBEDDING_PROVIDER_CLASS_MAPPING["vLLM"] == "OpenAIEmbeddings"
+
+
+# ---------------------------------------------------------------------------
+# Live model fetcher — fetch_live_vllm_models
+# ---------------------------------------------------------------------------
+
+
+def _ok_response(payload: dict | list) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_fetch_live_vllm_models_returns_empty_when_no_base_url():
+    from lfx.base.models import model_utils
+
+    with patch.object(model_utils, "get_provider_variable_value", return_value=None):
+        assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
+
+
+def test_fetch_live_vllm_models_openai_dict_format():
+    """Standard OpenAI-compatible {'data': [{'id': '...'}]} response."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "meta-llama/llama-3.1-8b"}, {"id": "mistral-7b"}]})
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        result = model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert len(result) == 2
+    names = {m["name"] for m in result}
+    assert names == {"meta-llama/llama-3.1-8b", "mistral-7b"}
+    for m in result:
+        assert m["provider"] == "vLLM"
+        assert m["icon"] == "vLLM"
+
+
+def test_fetch_live_vllm_models_plain_list_format():
+    """Fallback simple list format ['model1', 'model2']."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response(["qwen2-7b", "deepseek-r1"])
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        result = model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    names = {m["name"] for m in result}
+    assert names == {"qwen2-7b", "deepseek-r1"}
+
+
+def test_fetch_live_vllm_models_sorts_alphabetically():
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "zzz-model"}, {"id": "aaa-model"}, {"id": "mmm-model"}]})
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        result = model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert [m["name"] for m in result] == ["aaa-model", "mmm-model", "zzz-model"]
+
+
+def test_fetch_live_vllm_models_url_with_v1_suffix_not_duplicated():
+    """A base URL already ending in /v1 must not produce /v1/v1/models."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "llama-3"}]})
+    captured_url = []
+
+    def fake_get(url, **kwargs):
+        captured_url.append(url)
+        return response
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000/v1", None]),
+        patch.object(model_utils.requests, "get", side_effect=fake_get),
+    ):
+        model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert captured_url[0] == "http://localhost:8000/v1/models"
+
+
+def test_fetch_live_vllm_models_url_without_v1_gets_v1_prepended():
+    """A base URL without /v1 must have /v1/models appended."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "llama-3"}]})
+    captured_url = []
+
+    def fake_get(url, **kwargs):
+        captured_url.append(url)
+        return response
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", side_effect=fake_get),
+    ):
+        model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert captured_url[0] == "http://localhost:8000/v1/models"
+
+
+def test_fetch_live_vllm_models_forwards_api_key_as_bearer():
+    """When VLLM_API_KEY is set it must be forwarded as Authorization: Bearer."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "llama-3"}]})
+    captured_headers = []
+
+    def fake_get(url, headers=None, **kwargs):
+        captured_headers.append(headers or {})
+        return response
+
+    with (
+        patch.object(
+            model_utils,
+            "get_provider_variable_value",
+            side_effect=["http://localhost:8000", "my-secret-key"],  # pragma: allowlist secret
+        ),
+        patch.object(model_utils.requests, "get", side_effect=fake_get),
+    ):
+        model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert captured_headers[0].get("Authorization") == "Bearer my-secret-key"  # pragma: allowlist secret
+
+
+def test_fetch_live_vllm_models_no_auth_header_when_no_key():
+    """When no API key is configured, no Authorization header is sent."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "llama-3"}]})
+    captured_headers = []
+
+    def fake_get(url, headers=None, **kwargs):
+        captured_headers.append(headers or {})
+        return response
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", side_effect=fake_get),
+    ):
+        model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    assert "Authorization" not in captured_headers[0]
+
+
+def test_fetch_live_vllm_models_swallows_connection_error():
+    from lfx.base.models import model_utils
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", side_effect=requests.ConnectionError("refused")),
+    ):
+        assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
+
+
+def test_fetch_live_vllm_models_swallows_timeout():
+    from lfx.base.models import model_utils
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", side_effect=requests.Timeout("timeout")),
+    ):
+        assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
+
+
+def test_fetch_live_vllm_models_swallows_bad_payload():
+    """A 200 with an unrecognised payload shape should return []."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"unexpected_key": "unexpected_value"})
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
+
+
+def test_fetch_live_vllm_models_llm_and_embeddings_same_output():
+    """vLLM returns all models regardless of model_type — both calls yield the same list."""
+    from lfx.base.models import model_utils
+
+    response = _ok_response({"data": [{"id": "llama-3"}, {"id": "embedding-model"}]})
+
+    def get_var(user_id, key):
+        if key == "VLLM_API_BASE":
+            return "http://localhost:8000"
+        return None
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=get_var),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        llm_result = model_utils.fetch_live_vllm_models("user-id", "llm")
+
+    with (
+        patch.object(model_utils, "get_provider_variable_value", side_effect=get_var),
+        patch.object(model_utils.requests, "get", return_value=response),
+    ):
+        emb_result = model_utils.fetch_live_vllm_models("user-id", "embeddings")
+
+    assert {m["name"] for m in llm_result} == {m["name"] for m in emb_result}
+
+
+def test_get_live_models_dispatches_to_vllm():
+    from lfx.base.models import model_utils
+
+    with patch.object(model_utils, "fetch_live_vllm_models", return_value=[{"name": "llama-3"}]) as mocked:
+        result = model_utils.get_live_models_for_provider("user-id", "vLLM", "llm")
+
+    mocked.assert_called_once_with("user-id", "llm")
+    assert result == [{"name": "llama-3"}]
+
+
+# ---------------------------------------------------------------------------
+# Validation — validate_model_provider_key
+# ---------------------------------------------------------------------------
+
+
+def test_validate_vllm_raises_when_no_base_url():
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    with pytest.raises(ValueError, match="Invalid vLLM API base URL"):
+        validate_model_provider_key("vLLM", {})
+
+
+def test_validate_vllm_raises_when_base_url_is_empty():
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    with pytest.raises(ValueError, match="Invalid vLLM API base URL"):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": ""})
+
+
+def test_validate_vllm_happy_path():
+    """Validation passes when GET /v1/models returns 200."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    with patch.object(requests, "get", return_value=response) as mock_get:
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
+
+    mock_get.assert_called_once()
+    call_url = mock_get.call_args.args[0]
+    assert call_url == "http://localhost:8000/v1/models"
+
+
+def test_validate_vllm_uses_v1_models_endpoint():
+    """Validation must call /v1/models, not /models."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    captured_url = []
+
+    def fake_get(url, **kwargs):
+        captured_url.append(url)
+        return response
+
+    with patch.object(requests, "get", side_effect=fake_get):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://my-vllm.local"})
+
+    assert captured_url[0].endswith("/v1/models"), (
+        f"Expected /v1/models endpoint, got: {captured_url[0]}"
+    )
+
+
+def test_validate_vllm_forwards_api_key():
+    """VLLM_API_KEY must be sent as Authorization: Bearer."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    captured_kwargs = {}
+
+    def fake_get(url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return response
+
+    with patch.object(requests, "get", side_effect=fake_get):
+        validate_model_provider_key(
+            "vLLM",
+            {
+                "VLLM_API_BASE": "http://localhost:8000",
+                "VLLM_API_KEY": "secret-key",  # pragma: allowlist secret
+            },
+        )
+
+    assert captured_kwargs["headers"]["Authorization"] == "Bearer secret-key"  # pragma: allowlist secret
+
+
+def test_validate_vllm_no_auth_header_without_api_key():
+    """No Authorization header should be sent when VLLM_API_KEY is absent."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    captured_kwargs = {}
+
+    def fake_get(url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return response
+
+    with patch.object(requests, "get", side_effect=fake_get):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
+
+    assert "Authorization" not in captured_kwargs.get("headers", {})
+
+
+def test_validate_vllm_raises_on_401():
+    """A 401 from the vLLM server must raise ValueError with a clear auth message."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 401
+    response.raise_for_status.side_effect = AssertionError("should not reach raise_for_status on 401")
+
+    with (
+        patch.object(requests, "get", return_value=response),
+        pytest.raises(ValueError, match="Authentication failed"),
+    ):
+        validate_model_provider_key(
+            "vLLM",
+            {
+                "VLLM_API_BASE": "http://localhost:8000",
+                "VLLM_API_KEY": "wrong-key",  # pragma: allowlist secret
+            },
+        )
+
+
+def test_validate_vllm_raises_on_403():
+    """A 403 from the vLLM server must also raise ValueError."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 403
+    response.raise_for_status.side_effect = AssertionError("should not reach raise_for_status on 403")
+
+    with (
+        patch.object(requests, "get", return_value=response),
+        pytest.raises(ValueError, match="Authentication failed"),
+    ):
+        validate_model_provider_key(
+            "vLLM",
+            {
+                "VLLM_API_BASE": "http://localhost:8000",
+                "VLLM_API_KEY": "wrong-key",  # pragma: allowlist secret
+            },
+        )
+
+
+def test_validate_vllm_raises_on_connection_error():
+    """A connection error must raise a descriptive ValueError."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    with (
+        patch.object(requests, "get", side_effect=requests.ConnectionError("connection refused")),
+        pytest.raises(ValueError, match="Could not connect to vLLM server"),
+    ):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
+
+
+def test_validate_vllm_raises_on_timeout():
+    """A timeout must raise a descriptive ValueError."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    with (
+        patch.object(requests, "get", side_effect=requests.Timeout("timed out")),
+        pytest.raises(ValueError, match="timed out"),
+    ):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
+
+
+def test_validate_vllm_v1_suffix_not_duplicated():
+    """If VLLM_API_BASE already ends with /v1, the endpoint must be /v1/models not /v1/v1/models."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    captured_url = []
+
+    def fake_get(url, **kwargs):
+        captured_url.append(url)
+        return response
+
+    with patch.object(requests, "get", side_effect=fake_get):
+        validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://localhost:8000/v1"})
+
+    assert captured_url[0] == "http://localhost:8000/v1/models"
+    assert "/v1/v1/" not in captured_url[0]
+
+
+# ---------------------------------------------------------------------------
+# API-key-optional contract
+# ---------------------------------------------------------------------------
+
+
+def test_get_llm_does_not_raise_when_no_api_key_for_vllm():
+    """vLLM does not require an API key — get_llm must not raise on a missing key."""
+    from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models.instantiation import get_llm
+
+    captured_kwargs: dict = {}
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    model_selection = [
+        {
+            "name": "llama-3-8b",
+            "provider": "vLLM",
+            "metadata": {
+                "model_class": "ChatOpenAI",
+                "model_name_param": "model",
+                "api_key_param": "api_key",  # pragma: allowlist secret
+            },
+        }
+    ]
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
+        patch.object(unified_models_module, "get_model_class", return_value=FakeChatOpenAI),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+    ):
+        get_llm(model_selection, user_id=None)
+
+    assert captured_kwargs["model"] == "llama-3-8b"

--- a/src/lfx/tests/unit/base/models/test_vllm_provider.py
+++ b/src/lfx/tests/unit/base/models/test_vllm_provider.py
@@ -18,7 +18,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-
 # ---------------------------------------------------------------------------
 # Metadata
 # ---------------------------------------------------------------------------
@@ -56,8 +55,11 @@ def test_vllm_metadata_shape():
 
 
 def test_vllm_base_url_mapping_field_recognized_by_param_mapping():
-    """mapping_field 'vllm_base_url' must contain 'base_url' so get_provider_param_mapping
-    classifies it as a URL parameter and sets base_url_param for downstream consumers."""
+    """Ensure mapping_field 'vllm_base_url' contains 'base_url'.
+
+    get_provider_param_mapping classifies it as a URL parameter and sets
+    base_url_param for downstream consumers.
+    """
     from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
 
     meta = MODEL_PROVIDER_METADATA["vLLM"]
@@ -70,7 +72,7 @@ def test_vllm_base_url_mapping_field_recognized_by_param_mapping():
 
 
 def test_vllm_appears_in_get_model_providers():
-    """vLLM must appear in get_model_providers() even though it has no static catalog."""
+    """VLLM must appear in get_model_providers() even though it has no static catalog."""
     from lfx.base.models.unified_models import get_model_providers
 
     assert "vLLM" in get_model_providers()
@@ -109,6 +111,7 @@ def test_fetch_live_vllm_models_openai_dict_format():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         result = model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -129,6 +132,7 @@ def test_fetch_live_vllm_models_plain_list_format():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         result = model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -144,6 +148,7 @@ def test_fetch_live_vllm_models_sorts_alphabetically():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         result = model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -158,12 +163,13 @@ def test_fetch_live_vllm_models_url_with_v1_suffix_not_duplicated():
     response = _ok_response({"data": [{"id": "llama-3"}]})
     captured_url = []
 
-    def fake_get(url, **kwargs):
+    def fake_get(url, **_kwargs):
         captured_url.append(url)
         return response
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000/v1", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=fake_get),
     ):
         model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -178,12 +184,13 @@ def test_fetch_live_vllm_models_url_without_v1_gets_v1_prepended():
     response = _ok_response({"data": [{"id": "llama-3"}]})
     captured_url = []
 
-    def fake_get(url, **kwargs):
+    def fake_get(url, **_kwargs):
         captured_url.append(url)
         return response
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=fake_get),
     ):
         model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -198,7 +205,7 @@ def test_fetch_live_vllm_models_forwards_api_key_as_bearer():
     response = _ok_response({"data": [{"id": "llama-3"}]})
     captured_headers = []
 
-    def fake_get(url, headers=None, **kwargs):
+    def fake_get(_url, headers=None, **_kwargs):
         captured_headers.append(headers or {})
         return response
 
@@ -208,6 +215,7 @@ def test_fetch_live_vllm_models_forwards_api_key_as_bearer():
             "get_provider_variable_value",
             side_effect=["http://localhost:8000", "my-secret-key"],  # pragma: allowlist secret
         ),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=fake_get),
     ):
         model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -222,12 +230,13 @@ def test_fetch_live_vllm_models_no_auth_header_when_no_key():
     response = _ok_response({"data": [{"id": "llama-3"}]})
     captured_headers = []
 
-    def fake_get(url, headers=None, **kwargs):
+    def fake_get(_url, headers=None, **_kwargs):
         captured_headers.append(headers or {})
         return response
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=fake_get),
     ):
         model_utils.fetch_live_vllm_models("user-id", "llm")
@@ -240,6 +249,7 @@ def test_fetch_live_vllm_models_swallows_connection_error():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=requests.ConnectionError("refused")),
     ):
         assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
@@ -250,6 +260,7 @@ def test_fetch_live_vllm_models_swallows_timeout():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", side_effect=requests.Timeout("timeout")),
     ):
         assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
@@ -263,30 +274,33 @@ def test_fetch_live_vllm_models_swallows_bad_payload():
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         assert model_utils.fetch_live_vllm_models("user-id", "llm") == []
 
 
 def test_fetch_live_vllm_models_llm_and_embeddings_same_output():
-    """vLLM returns all models regardless of model_type — both calls yield the same list."""
+    """VLLM returns all models regardless of model_type — both calls yield the same list."""
     from lfx.base.models import model_utils
 
     response = _ok_response({"data": [{"id": "llama-3"}, {"id": "embedding-model"}]})
 
-    def get_var(user_id, key):
+    def get_var(_user_id, key):
         if key == "VLLM_API_BASE":
             return "http://localhost:8000"
         return None
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=get_var),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         llm_result = model_utils.fetch_live_vllm_models("user-id", "llm")
 
     with (
         patch.object(model_utils, "get_provider_variable_value", side_effect=get_var),
+        patch.object(model_utils, "validate_url_for_ssrf", return_value=None),
         patch.object(model_utils.requests, "get", return_value=response),
     ):
         emb_result = model_utils.fetch_live_vllm_models("user-id", "embeddings")
@@ -348,7 +362,7 @@ def test_validate_vllm_uses_v1_models_endpoint():
     response.raise_for_status.return_value = None
     captured_url = []
 
-    def fake_get(url, **kwargs):
+    def fake_get(url, **_kwargs):
         captured_url.append(url)
         return response
 
@@ -367,9 +381,9 @@ def test_validate_vllm_forwards_api_key():
     response = MagicMock()
     response.status_code = 200
     response.raise_for_status.return_value = None
-    captured_kwargs = {}
+    captured_kwargs: dict = {}
 
-    def fake_get(url, **kwargs):
+    def fake_get(_url, **kwargs):
         captured_kwargs.update(kwargs)
         return response
 
@@ -392,9 +406,9 @@ def test_validate_vllm_no_auth_header_without_api_key():
     response = MagicMock()
     response.status_code = 200
     response.raise_for_status.return_value = None
-    captured_kwargs = {}
+    captured_kwargs: dict = {}
 
-    def fake_get(url, **kwargs):
+    def fake_get(_url, **kwargs):
         captured_kwargs.update(kwargs)
         return response
 
@@ -477,7 +491,7 @@ def test_validate_vllm_v1_suffix_not_duplicated():
     response.raise_for_status.return_value = None
     captured_url = []
 
-    def fake_get(url, **kwargs):
+    def fake_get(url, **_kwargs):
         captured_url.append(url)
         return response
 
@@ -494,7 +508,7 @@ def test_validate_vllm_v1_suffix_not_duplicated():
 
 
 def test_get_llm_does_not_raise_when_no_api_key_for_vllm():
-    """vLLM does not require an API key — get_llm must not raise on a missing key."""
+    """VLLM does not require an API key — get_llm must not raise on a missing key."""
     from lfx.base.models import unified_models as unified_models_module
     from lfx.base.models.unified_models.instantiation import get_llm
 
@@ -524,3 +538,44 @@ def test_get_llm_does_not_raise_when_no_api_key_for_vllm():
         get_llm(model_selection, user_id=None)
 
     assert captured_kwargs["model"] == "llama-3-8b"
+
+
+def test_get_embeddings_does_not_raise_when_no_api_key_for_vllm():
+    """VLLM Embeddings does not require an API key and resolves base_url from VLLM_API_BASE."""
+    from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models.instantiation import get_embeddings
+
+    captured_kwargs: dict = {}
+
+    class FakeOpenAIEmbeddings:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    model_selection = [
+        {
+            "name": "text-embedding-ada-002",
+            "provider": "vLLM Embeddings",
+            "metadata": {
+                "embedding_class": "OpenAIEmbeddings",
+                "param_mapping": {
+                    "model": "model",
+                    "api_key": "api_key",  # pragma: allowlist secret
+                    "api_base": "base_url",
+                },
+            },
+        }
+    ]
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
+        patch.object(unified_models_module, "get_embedding_class", return_value=FakeOpenAIEmbeddings),
+        patch.object(
+            unified_models_module,
+            "get_all_variables_for_provider",
+            return_value={"VLLM_API_BASE": "http://localhost:8000"},
+        ),
+    ):
+        get_embeddings(model_selection, user_id=None)
+
+    assert captured_kwargs["model"] == "text-embedding-ada-002"
+    assert captured_kwargs.get("base_url") == "http://localhost:8000"

--- a/src/lfx/tests/unit/base/models/test_vllm_provider.py
+++ b/src/lfx/tests/unit/base/models/test_vllm_provider.py
@@ -369,9 +369,7 @@ def test_validate_vllm_uses_v1_models_endpoint():
     with patch.object(requests, "get", side_effect=fake_get):
         validate_model_provider_key("vLLM", {"VLLM_API_BASE": "http://my-vllm.local"})
 
-    assert captured_url[0].endswith("/v1/models"), (
-        f"Expected /v1/models endpoint, got: {captured_url[0]}"
-    )
+    assert captured_url[0].endswith("/v1/models"), f"Expected /v1/models endpoint, got: {captured_url[0]}"
 
 
 def test_validate_vllm_forwards_api_key():


### PR DESCRIPTION
## Summary

Adds vLLM as a first-class Model Provider in Langflow — configure your vLLM server URL once in **Settings → Model Providers → vLLM**, and all components automatically pick it up, just like Ollama.

Fixes #12771

## Why vLLM?

[vLLM](https://docs.vllm.ai/) is one of the most popular open-source LLM serving frameworks for self-hosted inference. Langflow already ships `vLLM` and `vLLM Embeddings` components and a registered vLLM icon, but vLLM was absent from Model Providers — users had to manually enter the API base URL in every component instance.

This PR is a clean rebase of #12772 on current `main`, with all CodeRabbit issues resolved and full test coverage added.

## What This Enables

- **Centralized configuration** — set `VLLM_API_BASE` once, all components pick it up
- **Dynamic model discovery** — models fetched live from `/v1/models` (no static catalog needed)
- **LLM + Embeddings** — vLLM models appear in both the Language Model dropdown and the Knowledge Base embedding picker
- **Auth optional** — local/internal servers work without an API key; authenticated servers pass `Authorization: Bearer` automatically
- **Fully self-hosted RAG** — vLLM embeddings work in the Knowledge Base creation flow

## Changes

| File | Change |
|------|--------|
| `src/lfx/.../model_metadata.py` | Add `"vLLM"` to `LIVE_MODEL_PROVIDERS` and `MODEL_PROVIDER_METADATA` |
| `src/lfx/.../model_utils.py` | Add `fetch_live_vllm_models()` — discovery via `/v1/models`, handles both OpenAI dict and plain list formats, API key auth, `/v1` deduplication |
| `src/lfx/.../credentials.py` | Add vLLM validation with distinct messages for auth (401/403), connection errors, and timeouts |
| `src/lfx/.../class_registry.py` | Map `"vLLM"` → `OpenAIEmbeddings`; add `"vLLM Embeddings"` param mapping |
| `src/lfx/.../instantiation.py` | Skip API key requirement for vLLM; add base_url wiring for vLLM Embeddings |
| `src/lfx/.../provider_queries.py` | Include `MODEL_PROVIDER_METADATA` providers in `get_model_providers()` |
| `src/backend/.../models.py` | Ensure metadata-registered providers with no static models appear in API response |
| `src/frontend/.../use-get-model-providers.ts` | Add vLLM icon mapping |
| `src/frontend/.../providerConstants.ts` | Add `vLLM: "VLLM_API_BASE"` |
| `src/frontend/.../modelInputComponent/index.tsx` | Skip model_type filtering for vLLM |
| `src/frontend/.../ModelSelection.tsx` | Add vLLM rendering path |
| `src/frontend/.../ProviderList.tsx` | Allow all model types for vLLM |
| `src/lfx/tests/.../test_vllm_provider.py` | **31 new unit tests** |

## Design Decisions

- **`mapping_field: "vllm_base_url"`** (contains `"base_url"`) — recognized by `get_provider_param_mapping`'s URL classifier, so `base_url_param` is correctly wired to downstream consumers in `model_catalog.py` and `flow_preparation.py`
- **`model_param: "model"`** — uses the modern `langchain_openai.ChatOpenAI` parameter (not the deprecated `model_name`)
- **`/v1/models` endpoint** — correct OpenAI-compatible path; handles the common case where users provide `http://host:8000/v1` by checking for the suffix before appending
- **Single fetch for both LLM and embeddings** — vLLM's API doesn't distinguish model types, so `replace_with_live_models` fetches once to avoid duplicates
- **No new LangChain dependency** — maps to existing `ChatOpenAI` (LLM) and `OpenAIEmbeddings` (embeddings)

## Test Coverage

```
src/lfx/tests/unit/base/models/test_vllm_provider.py — 31 tests, all passing
```

Covers:
- Metadata shape and registration (`LIVE_MODEL_PROVIDERS`, `MODEL_PROVIDER_METADATA`, `EMBEDDING_PROVIDER_CLASS_MAPPING`)
- `mapping_field` contains `"base_url"` so the param classifier works
- `get_model_providers()` includes vLLM despite no static catalog
- `fetch_live_vllm_models`: OpenAI dict format, plain list format, alphabetical sort, `/v1` deduplication, auth header forwarding, no-auth path, connection error, timeout, bad payload degradation, LLM/embeddings same output
- `validate_model_provider_key`: happy path, correct `/v1/models` endpoint, API key forwarding, no-auth path, 401, 403, connection error, timeout, `/v1` deduplication
- `get_llm` does not raise when no API key is set for vLLM

## Relationship to #12772

This is a clean reimplementation on current `main` resolving all issues that prevented #12772 from merging:
- ✅ Rebased (no merge conflicts)
- ✅ CodeRabbit issues fixed (`mapping_field`, `model_param`, endpoint path, API key forwarding)
- ✅ Test coverage added (was the only ❌ blocking check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for vLLM across model provider settings, including discovery, selection, and icon display.
  * vLLM models can now appear in provider lists even when they aren’t in the static catalog.

* **Bug Fixes**
  * Improved vLLM model filtering so available models show correctly in dropdowns and provider modals.
  * Enhanced provider validation to give clearer error messages for unreachable or unauthorized endpoints.

* **Tests**
  * Expanded coverage for vLLM model fetching, provider validation, and embedding/LLM configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->