### PR TITLE
fix(security): scrub stored secrets from public flow read

### DIFF
--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json as _json
 import re
 from datetime import timedelta
@@ -100,6 +101,42 @@ def remove_api_keys(flow: dict):
                 value["value"] = None
 
     return flow
+
+
+def strip_secret_field_values(flow_data: dict | None) -> dict | None:
+    """Return a deep copy of ``flow_data`` with every secret field value removed.
+
+    Unlike :func:`remove_api_keys` (which only nulls password fields whose name
+    looks like an API key), this nulls the value of *every* template field marked
+    ``password`` regardless of its name. It is meant for exposing a flow to
+    unauthenticated callers (e.g. ``GET /flows/public_flow/{id}``), where any
+    stored secret — API key, token, password, connection string — must not leak.
+
+    ``flow_data`` is the flow's ``data`` mapping (``{"nodes": [...], ...}``). The
+    input is not mutated: a deep copy is returned so the caller never persists the
+    nulled values back onto the ORM object.
+    """
+    if not flow_data:
+        return flow_data
+
+    scrubbed = copy.deepcopy(flow_data)
+    for node in scrubbed.get("nodes", []):
+        if not isinstance(node, dict):
+            continue
+        node_data = node.get("data")
+        if not isinstance(node_data, dict):
+            continue
+        node_inner = node_data.get("node")
+        if not isinstance(node_inner, dict):
+            continue
+        template = node_inner.get("template")
+        if not isinstance(template, dict):
+            continue
+        for value in template.values():
+            if isinstance(value, dict) and value.get("password"):
+                value["value"] = None
+
+    return scrubbed
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -23,6 +23,7 @@ from langflow.api.utils import (
     normalize_code_for_import,
     validate_is_component,
 )
+from langflow.api.utils.core import strip_secret_field_values
 from langflow.api.utils.zip_utils import extract_flows_from_zip
 from langflow.api.v1.authz_route_dependencies import (
     AuthorizedDeleteFlow,
@@ -295,13 +296,20 @@ async def read_public_flow(
     session: DbSession,
     flow_id: UUID,
 ):
-    """Read a public flow without requiring authorization (public means public)."""
+    """Read a public flow without requiring authorization (public means public).
+
+    Because this endpoint is unauthenticated, secret field values (every template
+    field marked ``password``) are stripped before returning so a PUBLIC flow does
+    not leak the owner's stored API keys / credentials to anonymous callers.
+    """
     flow = (await session.exec(select(Flow).where(Flow.id == flow_id))).first()
     if flow is None:
         raise HTTPException(status_code=404, detail="Flow not found")
     if flow.access_type is not AccessTypeEnum.PUBLIC:
         raise HTTPException(status_code=403, detail="Flow is not public")
-    return FlowRead.model_validate(flow, from_attributes=True)
+    flow_read = FlowRead.model_validate(flow, from_attributes=True)
+    flow_read.data = strip_secret_field_values(flow_read.data)
+    return flow_read
 
 
 @router.patch("/{flow_id}", response_model=FlowRead, status_code=200)

--- a/src/backend/tests/unit/api/v1/test_public_flow_secret_scrub.py
+++ b/src/backend/tests/unit/api/v1/test_public_flow_secret_scrub.py
@@ -1,0 +1,134 @@
+"""Regression tests for LE-1676 / H1-3724458.
+
+The unauthenticated ``GET /api/v1/flows/public_flow/{flow_id}`` endpoint must not
+leak the flow owner's stored secrets. Every template field marked ``password``
+(API keys, tokens, passwords, connection strings) has its value stripped before
+the flow is returned to anonymous callers.
+"""
+
+import json
+
+from fastapi import status
+from httpx import AsyncClient
+from langflow.api.utils.core import strip_secret_field_values
+
+
+def _flow_payload() -> dict:
+    """A flow whose first node carries two secret fields and one public field."""
+    return {
+        "name": "le1676-secret-leak-flow",
+        "description": "regression flow for public-flow secret scrubbing",
+        "data": {
+            "nodes": [
+                {
+                    "id": "node-1",
+                    "type": "genericNode",
+                    "position": {"x": 0, "y": 0},
+                    "data": {
+                        "id": "node-1",
+                        "type": "OpenAIModel",
+                        "node": {
+                            "template": {
+                                # name matches API terms -> caught by remove_api_keys too
+                                "api_key": {
+                                    "name": "api_key",
+                                    "password": True,
+                                    "value": "sk-SUPERSECRET",  # pragma: allowlist secret
+                                    "type": "str",
+                                },
+                                # password field whose name does NOT look like an API key:
+                                # only the stricter strip_secret_field_values nulls this one.
+                                "service_token": {
+                                    "name": "service_token",
+                                    "password": True,
+                                    "value": "tok-DEADBEEF",  # pragma: allowlist secret
+                                    "type": "str",
+                                },
+                                # non-secret field must be preserved
+                                "base_url": {
+                                    "name": "base_url",
+                                    "password": False,
+                                    "value": "https://api.openai.com/v1",
+                                    "type": "str",
+                                },
+                            }
+                        },
+                    },
+                }
+            ],
+            "edges": [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_strip_secret_field_values_nulls_all_password_fields():
+    data = _flow_payload()["data"]
+    scrubbed = strip_secret_field_values(data)
+    template = scrubbed["nodes"][0]["data"]["node"]["template"]
+    assert template["api_key"]["value"] is None
+    assert template["service_token"]["value"] is None
+    # non-secret field preserved
+    assert template["base_url"]["value"] == "https://api.openai.com/v1"
+
+
+def test_strip_secret_field_values_does_not_mutate_input():
+    data = _flow_payload()["data"]
+    original_secret = data["nodes"][0]["data"]["node"]["template"]["api_key"]["value"]
+    strip_secret_field_values(data)
+    # input untouched (deep copy returned) so the ORM object is never altered
+    assert data["nodes"][0]["data"]["node"]["template"]["api_key"]["value"] == original_secret
+
+
+def test_strip_secret_field_values_handles_none_and_empty():
+    assert strip_secret_field_values(None) is None
+    assert strip_secret_field_values({}) == {}
+
+
+def test_strip_secret_field_values_tolerates_malformed_nodes():
+    # Non-dict nodes / missing keys must not raise.
+    data = {
+        "nodes": [
+            "not-a-dict",
+            {"id": "x"},
+            {"id": "y", "data": "not-a-dict"},
+            {"id": "z", "data": {"node": {"template": "not-a-dict"}}},
+            {"id": "ok", "data": {"node": {"template": {"pw": {"password": True, "value": "s"}}}}},
+        ]
+    }
+    scrubbed = strip_secret_field_values(data)
+    assert scrubbed["nodes"][-1]["data"]["node"]["template"]["pw"]["value"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration test through the unauthenticated endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_public_flow_read_strips_secrets(client: AsyncClient, logged_in_headers):
+    # Create a flow that contains secret field values.
+    create_resp = await client.post(
+        "api/v1/flows/", json=json.loads(json.dumps(_flow_payload())), headers=logged_in_headers
+    )
+    assert create_resp.status_code == status.HTTP_201_CREATED
+    flow_id = create_resp.json()["id"]
+
+    # Make it public.
+    patch_resp = await client.patch(
+        f"api/v1/flows/{flow_id}", json={"access_type": "PUBLIC"}, headers=logged_in_headers
+    )
+    assert patch_resp.status_code == status.HTTP_200_OK
+
+    # Read it as an anonymous caller (drop auth cookies).
+    client.cookies.clear()
+    resp = await client.get(f"api/v1/flows/public_flow/{flow_id}")
+    assert resp.status_code == status.HTTP_200_OK
+
+    template = resp.json()["data"]["nodes"][0]["data"]["node"]["template"]
+    assert template["api_key"]["value"] is None, "API key leaked through public flow read"
+    assert template["service_token"]["value"] is None, "non-api-named secret leaked through public flow read"
+    assert template["base_url"]["value"] == "https://api.openai.com/v1", "non-secret field should be preserved"


### PR DESCRIPTION
## Summary

The unauthenticated `GET /api/v1/flows/public_flow/{flow_id}` endpoint returned the full node template of a `PUBLIC` flow, including stored secret field values. Any anonymous caller could read the flow owner's API keys, tokens, and other credentials embedded in the flow (CWE-200, exposure of sensitive information).

`read_public_flow` deserialized the flow with `FlowRead.model_validate(...)` and returned it verbatim — no secret scrubbing was applied (the existing `remove_api_keys` helper is only used on export/download, never here).

## Fix

- New helper `strip_secret_field_values` in `langflow/api/utils/core.py` that **deep-copies** the flow `data` and nulls the value of **every** template field marked `password`, regardless of name.
  - Stricter than `remove_api_keys`, which only nulls password fields whose *name* matches API-key terms — so generic secrets (tokens, connection strings, passwords) were still leaking.
  - Deep-copy guarantees the ORM object is never mutated, so nulled values can't be persisted back to the DB.
- `read_public_flow` now scrubs `flow_read.data` before returning.

## Test plan

New `src/backend/tests/unit/api/v1/test_public_flow_secret_scrub.py`:
- Unit tests of the helper: nulls all `password` fields, preserves non-secret fields, does not mutate the input, handles `None`/empty/malformed nodes.
- Integration test: creates a flow with secret fields, makes it public, reads it **unauthenticated**, and asserts both an API-named secret and a non-API-named secret come back `null` while a non-secret field is preserved.

All 5 pass locally (`uv run pytest src/backend/tests/unit/api/v1/test_public_flow_secret_scrub.py`).

## Notes

Stacked on the `security-hardening` branch (#13530) — base is `security-hardening`, not `release-1.11.0`. This addresses a multi-tenant secret-exposure gap not covered by that PR.