### PR TITLE
fix(security): stop trusting X-Forwarded-For for the MCP install locality check

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -765,7 +765,18 @@ def is_local_ip(ip_str: str) -> bool:
 
 
 def get_client_ip(request: Request) -> str:
-    """Extract the client IP address from a FastAPI request.
+    """Resolve the client IP for the local-only install locality check.
+
+    ``X-Forwarded-For`` is client-controlled and must NOT be trusted by default:
+    trusting it lets a remote caller spoof a loopback address and defeat the
+    local-only restriction on :func:`install_mcp_config` (which writes MCP client
+    config to the host filesystem). By default we use the real TCP peer
+    (``request.client.host``), so a spoofed header has no effect.
+
+    Only when the operator has explicitly opted into a trusted proxy
+    (``rate_limit_trust_proxy``) do we consult ``X-Forwarded-For``, and then we
+    take the rightmost entry — the last hop added by the trusted proxy, which a
+    client cannot forge — mirroring ``langflow.services.rate_limit.service.get_client_ip``.
 
     Args:
         request: FastAPI Request object
@@ -773,13 +784,16 @@ def get_client_ip(request: Request) -> str:
     Returns:
         str: The client's IP address
     """
-    # Check for X-Forwarded-For header (common when behind proxies)
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        # The client IP is the first one in the list
-        return forwarded_for.split(",")[0].strip()
+    # Only consult X-Forwarded-For when an operator has explicitly declared a
+    # trusted proxy; otherwise the header is attacker-controlled.
+    if get_settings_service().settings.rate_limit_trust_proxy:
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            # Rightmost entry = last hop added by the trusted proxy (unspoofable);
+            # the leftmost entry is client-supplied and must never be trusted.
+            return forwarded_for.split(",")[-1].strip()
 
-    # If no proxy headers, use the client's direct IP
+    # Default: trust only the real TCP peer.
     if request.client:
         return request.client.host
 

--- a/src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py
@@ -1,0 +1,62 @@
+"""Regression tests for the MCP install locality check (CWE-348, improper trust of X-Forwarded-For).
+
+``POST /api/v1/mcp/project/{project_id}/install`` is restricted to local connections because it
+writes MCP client config (``~/.cursor/mcp.json`` etc.) to the host filesystem. Previously
+``get_client_ip`` returned the **leftmost** ``X-Forwarded-For`` entry, so a remote authenticated
+caller could spoof ``X-Forwarded-For: 127.0.0.1`` and pass the ``is_local_ip`` gate. The client IP
+must come from the real TCP peer unless a trusted proxy is explicitly configured, in which case the
+unspoofable rightmost entry is used.
+"""
+
+from types import SimpleNamespace
+
+from langflow.api.v1 import mcp_projects
+from langflow.api.v1.mcp_projects import get_client_ip, is_local_ip
+
+
+def _request(headers: dict | None = None, host: str | None = "203.0.113.7"):
+    client = SimpleNamespace(host=host) if host is not None else None
+    return SimpleNamespace(headers=headers or {}, client=client)
+
+
+def _set_trust_proxy(monkeypatch, *, value: bool) -> None:
+    fake = SimpleNamespace(settings=SimpleNamespace(rate_limit_trust_proxy=value))
+    monkeypatch.setattr(mcp_projects, "get_settings_service", lambda: fake)
+
+
+def test_spoofed_xff_ignored_by_default(monkeypatch):
+    """Default (no trusted proxy): a spoofed loopback XFF must not be trusted."""
+    _set_trust_proxy(monkeypatch, value=False)
+    req = _request(headers={"X-Forwarded-For": "127.0.0.1"}, host="203.0.113.7")
+    ip = get_client_ip(req)
+    assert ip == "203.0.113.7"
+    # The spoof no longer bypasses the local-only install gate.
+    assert is_local_ip(ip) is False
+
+
+def test_real_local_peer_is_local_by_default(monkeypatch):
+    """A genuine loopback TCP peer is still recognized as local."""
+    _set_trust_proxy(monkeypatch, value=False)
+    req = _request(headers={}, host="127.0.0.1")
+    ip = get_client_ip(req)
+    assert ip == "127.0.0.1"
+    assert is_local_ip(ip) is True
+
+
+def test_trusted_proxy_uses_rightmost_xff(monkeypatch):
+    """With a trusted proxy, use the rightmost (last-hop) entry, not the client-spoofable leftmost."""
+    _set_trust_proxy(monkeypatch, value=True)
+    # The client spoofs 127.0.0.1 as the leftmost entry; the trusted proxy appends the real last hop.
+    req = _request(headers={"X-Forwarded-For": "127.0.0.1, 203.0.113.7"}, host="10.0.0.2")
+    ip = get_client_ip(req)
+    assert ip == "203.0.113.7"
+    assert is_local_ip(ip) is False
+
+
+def test_no_client_falls_back_to_non_local(monkeypatch):
+    """When the peer cannot be determined, fall back to a non-routable, non-local IP."""
+    _set_trust_proxy(monkeypatch, value=False)
+    req = _request(headers={}, host=None)
+    ip = get_client_ip(req)
+    assert ip == "255.255.255.255"
+    assert is_local_ip(ip) is False


### PR DESCRIPTION
## Summary

`POST /api/v1/mcp/project/{project_id}/install` writes MCP client configuration (`~/.cursor/mcp.json`, `~/.codeium/windsurf/mcp_config.json`, the Claude desktop config) to the **host** filesystem, and is therefore restricted to local connections via `is_local_ip(get_client_ip(request))`.

`get_client_ip` returned the **leftmost** `X-Forwarded-For` entry — a fully client-controlled value. A remote, authenticated caller could send `X-Forwarded-For: 127.0.0.1` to pass the locality gate and write attacker-controlled MCP server config to the host (CWE-348, improper trust of a client-supplied header).

## Fix

`get_client_ip` now:
- Uses the **real TCP peer** (`request.client.host`) by default, so a spoofed `X-Forwarded-For` has no effect.
- Consults `X-Forwarded-For` **only** when the operator has explicitly opted into a trusted proxy (`rate_limit_trust_proxy`, default `False`), and then takes the **rightmost** entry — the last hop added by the trusted proxy, which a client cannot forge.

This mirrors the existing secure pattern already used by `langflow.services.rate_limit.service.get_client_ip`, reusing the same `rate_limit_trust_proxy` setting rather than introducing a parallel proxy-trust flag.

## Test plan

New `src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py`:
- Default config: a spoofed `X-Forwarded-For: 127.0.0.1` is **ignored**; the real peer is used and `is_local_ip` returns `False` (the bypass is closed).
- Default config: a genuine loopback peer is still treated as local.
- Trusted-proxy config: the rightmost (last-hop) entry is used, not the client-spoofable leftmost.
- Missing peer falls back to a non-routable, non-local IP.

All 4 pass locally (`uv run pytest src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py`).

## Notes

Stacked on the `security-hardening` branch (#13530) — base is `security-hardening`, not `release-1.11.0`. `mcp_projects.py` was not touched by that PR, so this gap remained.