### PR TITLE
fix(security): enforce KB-root containment for username-derived paths (CVE-2026-33186)

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -226,6 +226,13 @@ def _resolve_kb_path(kb_name: str, owner_user) -> Path:
     kb_user_path = (kb_root_path / kb_user).resolve()
     kb_path = (kb_user_path / kb_name).resolve()
 
+    # The username roots the KB directory, so a username containing path separators
+    # or ".." (e.g. "../../etc") could make kb_user_path resolve outside kb_root_path
+    # while kb_path stays "contained" within that escaped base — bypassing the kb_name
+    # check below and enabling arbitrary-directory access/deletion. Check containment
+    # against the real root first, then the user dir for kb_name, matching the list
+    # endpoint's guard.
+    _validate_kb_path_containment(kb_root_path.resolve(), kb_user_path, kb_name, kb_user)
     _validate_kb_path_containment(kb_user_path, kb_path, kb_name, kb_user)
 
     if not kb_path.exists() or not kb_path.is_dir():
@@ -705,6 +712,9 @@ async def create_knowledge_base(
         # rejected before any directory is created.
         kb_user_path = (kb_root_path / kb_user).resolve()
         kb_path = (kb_user_path / kb_name).resolve()
+        # The username also roots the path, so it must be contained within the KB root
+        # too (a username with ".." would otherwise escape it before mkdir).
+        _validate_kb_path_containment(kb_root_path.resolve(), kb_user_path, kb_name, kb_user)
         _validate_kb_path_containment(kb_user_path, kb_path, kb_name, kb_user)
 
         # Check both durable DB state and legacy disk state. During

--- a/src/backend/tests/unit/api/v1/test_kb_username_path_traversal.py
+++ b/src/backend/tests/unit/api/v1/test_kb_username_path_traversal.py
@@ -1,0 +1,56 @@
+"""Regression tests for KB path traversal via username (CVE-2026-33186).
+
+``_resolve_kb_path`` and ``create_knowledge_base`` build the KB directory from the owner's
+``username`` and previously only checked that ``kb_name`` stayed within the username-derived
+base — never that the username-derived base stayed within the KB root. A username containing
+``..`` therefore escaped the root, enabling arbitrary-directory access / deletion across the
+read / update / delete / ingest / query routes (and the JWT-secret directory). Both paths now
+check containment against the real root first, matching the list endpoint's guard.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from langflow.api.v1 import knowledge_bases
+from langflow.api.v1.knowledge_bases import _resolve_kb_path
+
+
+@pytest.fixture
+def kb_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(knowledge_bases.KBStorageHelper, "get_root_path", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.mark.usefixtures("kb_root")
+def test_username_traversal_blocked():
+    """A username with '..' must not escape the KB root."""
+    owner = SimpleNamespace(username="../../etc")
+    with pytest.raises(HTTPException) as exc:
+        _resolve_kb_path("cron.d", owner)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.usefixtures("kb_root")
+def test_username_with_separator_blocked():
+    owner = SimpleNamespace(username="../victim")
+    with pytest.raises(HTTPException) as exc:
+        _resolve_kb_path("evil", owner)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.usefixtures("kb_root")
+def test_kbname_traversal_still_blocked():
+    """The pre-existing kb_name traversal guard is preserved."""
+    owner = SimpleNamespace(username="alice")
+    with pytest.raises(HTTPException) as exc:
+        _resolve_kb_path("../bob/secret", owner)
+    assert exc.value.status_code == 403
+
+
+def test_contained_path_allowed(kb_root):
+    """A normal username + kb_name resolves without error."""
+    owner = SimpleNamespace(username="alice")
+    (kb_root / "alice" / "mykb").mkdir(parents=True)
+    resolved = _resolve_kb_path("mykb", owner)
+    assert resolved == (kb_root / "alice" / "mykb").resolve()


### PR DESCRIPTION
## Summary

The Knowledge Bases API roots each KB directory at the **owner's username**: `kb_root / username / kb_name`. Two code paths built that path but only checked that `kb_name` stayed inside the username-derived base — never that the username-derived base itself stayed inside the KB root:

- `_resolve_kb_path` ([knowledge_bases.py:212](src/backend/base/langflow/api/v1/knowledge_bases.py)) — feeds the KB **read, update, delete, bulk-delete, ingest, and query** routes.
- `create_knowledge_base` — the create path.

Because `username` *is* the base segment, a username like `../../etc` makes `kb_user_path` resolve to `/etc` while `kb_path = /etc/<kb_name>` is still "contained" within that escaped base — so the existing `kb_name` guard passes. An authenticated user (or anyone who can register, depending on signup config) could thus traverse out of the KB root to **delete/destroy arbitrary directories, wipe other users' KBs, or wipe the JWT-secret directory** (CWE-22, CVE-2026-33186).

This is an **incomplete-fix**: the KB **list** endpoint already does the correct root-containment check (with a comment naming this exact "username containing path separators … would escape the root" threat), but `_resolve_kb_path` and `create_knowledge_base` were left unhardened.

## Fix

In both paths, validate containment against the **real KB root first**, then against the user directory for `kb_name` — mirroring the list endpoint's guard:

```python
_validate_kb_path_containment(kb_root_path.resolve(), kb_user_path, kb_name, kb_user)  # username can't escape root
_validate_kb_path_containment(kb_user_path, kb_path, kb_name, kb_user)                 # kb_name can't escape user dir
```

No behavior change for legitimate usernames; a `..`/separator username now gets a `403` instead of escaping the root.

## Test plan

New `src/backend/tests/unit/api/v1/test_kb_username_path_traversal.py`:
- A `..` username (`../../etc`) → `403` (the escape is blocked).
- A separator username (`../victim`) → `403`.
- A `..` `kb_name` (`../bob/secret`) → `403` (pre-existing guard preserved).
- A normal `username`/`kb_name` → resolves correctly, no error.

All 4 pass locally.

## Notes

- Stacked on the `security-hardening` branch (#13530) — base is `security-hardening`, not `release-1.11.0`. Neither that branch nor `release-1.11.0` touched these files.
- **Defense-in-depth follow-up (not in this PR):** a `username` format validator at the user-creation boundary (reject path separators and `.`/`..` segments) would close this class of bug at the source for any other username-as-path use; left out here to keep the diff tight and avoid touching the user model.