### PR TITLE
fix(security): run server-trusted component code on the restricted build path

### DIFF
--- a/src/backend/base/langflow/interface/initialize/loading.py
+++ b/src/backend/base/langflow/interface/initialize/loading.py
@@ -36,8 +36,14 @@ def instantiate_class(
         msg = "No base type provided for vertex"
         raise ValueError(msg)
 
+    from lfx.utils.flow_validation import resolve_trusted_code_for_build
+
     custom_params = get_params(vertex.params)
     code = custom_params.pop("code")
+    # Restricted-mode hardening (allow_custom_components=False): exec the server's trusted copy
+    # keyed by this code's hash, never the node's stored bytes, to close the 48-bit hash-collision
+    # RCE on the authenticated build path. No-op in permissive mode (the default).
+    code = resolve_trusted_code_for_build(code)
     class_object: type[CustomComponent | Component] = eval_custom_component_code(code)
     custom_component: CustomComponent | Component = class_object(
         _user_id=user_id,

--- a/src/lfx/src/lfx/interface/initialize/loading.py
+++ b/src/lfx/src/lfx/interface/initialize/loading.py
@@ -41,8 +41,14 @@ def instantiate_class(
         msg = "No base type provided for vertex"
         raise ValueError(msg)
 
+    from lfx.utils.flow_validation import resolve_trusted_code_for_build
+
     custom_params = get_params(vertex.params)
     code = custom_params.pop("code")
+    # Restricted-mode hardening (allow_custom_components=False): exec the server's trusted copy
+    # keyed by this code's hash, never the node's stored bytes, to close the 48-bit hash-collision
+    # RCE on the authenticated build path. No-op in permissive mode (the default).
+    code = resolve_trusted_code_for_build(code)
     class_object: type[CustomComponent | Component] = eval_custom_component_code(code)
     custom_component: CustomComponent | Component = class_object(
         _user_id=user_id,

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -385,6 +385,38 @@ def get_trusted_code_for_validation(code: str) -> str | None:
     return code_by_hash.get(_compute_code_hash(code))
 
 
+def resolve_trusted_code_for_build(code: str) -> str:
+    """Return the component code to ``exec`` for a build, enforcing restricted-mode substitution.
+
+    In permissive mode (``allow_custom_components=True``, the default) the node's own ``code`` is
+    returned unchanged — no behavior change.
+
+    In restricted mode (``allow_custom_components=False``) the node only reached the build because
+    it cleared the truncated-hash gate. Because that gate is a 48-bit prefix, a second-preimage
+    collision could carry attacker bytes whose hash matches a built-in. Substitute the server's
+    trusted source keyed by the same hash so a collision merely re-runs the server's own
+    component. Fail closed (raise) when no trusted source is known for the hash, rather than fall
+    back to the client bytes.
+    """
+    from lfx.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    # Missing settings cannot prove permissive mode, but every consumer of allow_custom_components
+    # in this module treats a missing attribute as the True default, so mirror that here.
+    allow_custom_components = True
+    if settings_service is not None:
+        allow_custom_components = getattr(settings_service.settings, "allow_custom_components", True)
+
+    if allow_custom_components:
+        return code
+
+    trusted = get_trusted_code_for_validation(code)
+    if trusted is None:
+        msg = "Flow build blocked: no trusted server component matches this component's code."
+        raise CustomComponentValidationError(msg)
+    return trusted
+
+
 def check_flow_and_raise(
     flow_data: dict | None,
     *,

--- a/src/lfx/tests/unit/utils/test_resolve_trusted_code_for_build.py
+++ b/src/lfx/tests/unit/utils/test_resolve_trusted_code_for_build.py
@@ -1,0 +1,57 @@
+"""Tests for resolve_trusted_code_for_build (LE-1680 / CWE-345).
+
+When LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false, the authenticated flow-build path validates each
+node's code only by a 48-bit truncated hash, then execs the node's stored bytes. A second-preimage
+collision against a built-in's template hash therefore yields RCE. resolve_trusted_code_for_build
+closes this by substituting the server's trusted copy (keyed by the code's hash) before exec, and
+failing closed when no trusted copy is known — while leaving permissive mode (the default) untouched.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from lfx.utils import flow_validation
+from lfx.utils.flow_validation import CustomComponentValidationError, resolve_trusted_code_for_build
+
+
+def _set_allow_custom_components(monkeypatch, *, allow: bool) -> None:
+    fake = SimpleNamespace(settings=SimpleNamespace(allow_custom_components=allow))
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: fake)
+
+
+def test_permissive_mode_returns_code_unchanged(monkeypatch):
+    """Default mode (allow_custom_components=True): the node's own code runs, untouched."""
+    _set_allow_custom_components(monkeypatch, allow=True)
+
+    def _must_not_be_called(_code):
+        pytest.fail("trusted lookup must not run in permissive mode")
+
+    monkeypatch.setattr(flow_validation, "get_trusted_code_for_validation", _must_not_be_called)
+    assert resolve_trusted_code_for_build("user-authored code") == "user-authored code"
+
+
+def test_restricted_mode_substitutes_trusted_copy(monkeypatch):
+    """Restricted mode + a hash match: the server's trusted source runs, not the node's bytes."""
+    _set_allow_custom_components(monkeypatch, allow=False)
+    monkeypatch.setattr(flow_validation, "get_trusted_code_for_validation", lambda _code: "SERVER_TRUSTED_SRC")
+    # Even a forged blob that collides with a known hash resolves to the server copy.
+    assert resolve_trusted_code_for_build("forged colliding blob") == "SERVER_TRUSTED_SRC"
+
+
+def test_restricted_mode_no_match_fails_closed(monkeypatch):
+    """Restricted mode + no trusted hash match: fail closed (never fall back to client bytes)."""
+    _set_allow_custom_components(monkeypatch, allow=False)
+    monkeypatch.setattr(flow_validation, "get_trusted_code_for_validation", lambda _code: None)
+    with pytest.raises(CustomComponentValidationError):
+        resolve_trusted_code_for_build("attacker code with no trusted match")
+
+
+def test_missing_settings_service_defaults_permissive(monkeypatch):
+    """If settings are unavailable, mirror the module's default (allow) and run the code unchanged."""
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: None)
+
+    def _fail_if_called(_code):
+        pytest.fail("trusted lookup must not run when settings unavailable (permissive default)")
+
+    monkeypatch.setattr(flow_validation, "get_trusted_code_for_validation", _fail_if_called)
+    assert resolve_trusted_code_for_build("some code") == "some code"


### PR DESCRIPTION
## Summary

When `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`, the **authenticated** flow-build path validated each node's component code only by a **48-bit truncated SHA-256** hash (`flow_validation._compute_code_hash` → `_get_invalid_components`), then built from and **`exec`'d the node's stored `template.code.value` bytes** at `instantiate_class`. A ~2^48 second-preimage collision against any built-in component's known template hash lets an authenticated, custom-components-disabled tenant smuggle attacker code past the gate and execute it (CWE-345 / RCE).

The `/custom_component` endpoint and the **unauthenticated public build path** already substitute the server's trusted copy on a hash match; the **authenticated build path did not** — it ran the node's bytes.

## Fix

- New `resolve_trusted_code_for_build(code)` in `src/lfx/src/lfx/utils/flow_validation.py`:
  - **Permissive mode** (`allow_custom_components=True`, the default): returns `code` unchanged — no behavior change, doesn't even consult the trusted map.
  - **Restricted mode** (`allow_custom_components=False`): returns the server's trusted source keyed by the code's hash (`get_trusted_code_for_validation`), and **fails closed** (`CustomComponentValidationError`) when no trusted copy matches. A collision therefore re-runs the server's own component, never attacker bytes.
- Called at the **universal exec chokepoint** `instantiate_class`, in **both** copies (`src/lfx/.../interface/initialize/loading.py` and `src/backend/base/langflow/interface/initialize/loading.py`), immediately before `eval_custom_component_code(code)`.

This is hash-keyed (not type-keyed), so a node whose declared `type` is a built-in but whose code was swapped is decided by what the code *hashes to* — a non-matching swap fails closed. Every authenticated build entry (JSON-payload builds via `Graph.from_payload`, and the lfx-CLI object builds) converges on `instantiate_class`, so this one chokepoint covers them all, including inlined sub-flow nodes (flattened to top-level vertices before build).

## Notes / scope
- `block_code_interpreter_components` (a type-name block) is unaffected — substitution doesn't relabel a node's type.
- Admin-curated `components_path` allow-list components are registered in the trusted map, so they keep building under restricted mode.
- The distributed `stepflow` worker also calls `eval_custom_component_code` on a separate surface; that's out of scope here and noted as a follow-up.

## Test plan
New `src/lfx/tests/unit/utils/test_resolve_trusted_code_for_build.py`:
- Permissive mode returns the node's code unchanged (and never consults the trusted lookup).
- Restricted mode + hash match → returns the server's trusted source (even for a forged colliding blob).
- Restricted mode + no match → fails closed (`CustomComponentValidationError`).
- Missing settings service → permissive default (code unchanged).

All 4 pass; the existing 74 `test_flow_validation.py` tests still pass.

## Notes
Stacked on the `security-hardening` branch (#13530) — base is `security-hardening`.