### PR TITLE
test(mcp): use allowlisted commands + disable SSRF in mocked MCP unit tests

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
@@ -161,7 +161,7 @@ class TestMCPTimeoutConfiguration:
         """Test that update_tools passes timeout when creating MCPStdioClient."""
         server_config = {
             "mode": "Stdio",
-            "command": "test-command",
+            "command": "uvx",
             "args": [],
         }
 
@@ -181,8 +181,11 @@ class TestMCPTimeoutConfiguration:
             mock_client_class.assert_called_once_with(tool_execution_timeout=250)
 
     @pytest.mark.asyncio
-    async def test_update_tools_passes_timeout_to_http_client(self):
+    async def test_update_tools_passes_timeout_to_http_client(self, monkeypatch):
         """Test that update_tools passes timeout when creating MCPStreamableHttpClient."""
+        # The placeholder host is not resolvable; this test exercises timeout plumbing, not URL
+        # safety (which has its own SSRF tests), so disable SSRF validation here.
+        monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")
         server_config = {
             "mode": "Streamable_HTTP",
             "url": "http://test-server",
@@ -316,7 +319,7 @@ class TestMCPTimeoutBehavior:
 
         server_config = {
             "mode": "Stdio",
-            "command": "test-command",
+            "command": "uvx",
             "args": [],
         }
 
@@ -336,9 +339,13 @@ class TestMCPTimeoutBehavior:
             assert initial_client._tool_execution_timeout == 250
 
     @pytest.mark.asyncio
-    async def test_mcp_sse_client_receives_timeout(self):
+    async def test_mcp_sse_client_receives_timeout(self, monkeypatch):
         """Test that mcp_sse_client (backward compatibility alias) receives timeout."""
         from lfx.base.mcp.util import update_tools
+
+        # The placeholder host is not resolvable; this test exercises timeout plumbing, not URL
+        # safety (which has its own SSRF tests), so disable SSRF validation here.
+        monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")
 
         # Create an SSE client (which is actually a StreamableHttpClient)
         sse_client = MCPStreamableHttpClient(tool_execution_timeout=100)

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -1060,7 +1060,7 @@ class TestUpdateToolsStdioHeaders:
         mock_stdio._connected = True
 
         server_config = {
-            "command": "some-tool",
+            "command": "uvx",
             "args": ["--verbose", "--debug"],
             "headers": {"Authorization": "Bearer tok"},
         }
@@ -1068,7 +1068,7 @@ class TestUpdateToolsStdioHeaders:
         await update_tools("test-server", server_config, mcp_stdio_client=mock_stdio)
 
         full_command = mock_stdio.connect_to_server.call_args[0][0]
-        assert full_command == "some-tool --verbose --debug --headers authorization 'Bearer tok'"
+        assert full_command == "uvx --verbose --debug --headers authorization 'Bearer tok'"
 
     @pytest.mark.asyncio
     async def test_stdio_headers_appended_when_last_token_is_flag_value(self):
@@ -1078,7 +1078,7 @@ class TestUpdateToolsStdioHeaders:
         mock_stdio._connected = True
 
         server_config = {
-            "command": "some-tool",
+            "command": "uvx",
             "args": ["--port", "8080"],
             "headers": {"Authorization": "Bearer tok"},
         }
@@ -1087,7 +1087,7 @@ class TestUpdateToolsStdioHeaders:
 
         full_command = mock_stdio.connect_to_server.call_args[0][0]
         # 8080 is a value for --port, not a positional arg, so headers go at the end
-        assert full_command == "some-tool --port 8080 --headers authorization 'Bearer tok'"
+        assert full_command == "uvx --port 8080 --headers authorization 'Bearer tok'"
 
     @pytest.mark.asyncio
     async def test_stdio_headers_inserted_before_positional_with_flag_value_pairs(self):
@@ -1194,7 +1194,7 @@ class TestUpdateToolsPerToolResilience:
         ):
             mode, tool_list, tool_cache = await update_tools(
                 server_name="linear-like",
-                server_config={"command": "fake-cmd", "args": []},
+                server_config={"command": "uvx", "args": []},
                 mcp_stdio_client=mock_stdio,
             )
 
@@ -1244,7 +1244,7 @@ class TestUpdateToolsPerToolResilience:
         with patch("lfx.base.mcp.util.create_input_schema_from_json_schema", side_effect=selective_converter):
             _, tool_list, tool_cache = await update_tools(
                 server_name="stress",
-                server_config={"command": "fake-cmd", "args": []},
+                server_config={"command": "uvx", "args": []},
                 mcp_stdio_client=mock_stdio,
             )
 
@@ -3769,7 +3769,7 @@ class TestMCPStructuredToolToolCallId:
         mock_client.run_tool = AsyncMock(return_value=raw_result)
         mock_client._connected = True
 
-        server_config = {"command": "fake-server"}
+        server_config = {"command": "uvx"}
         _, tools, _ = await update_tools("test-server", server_config, mcp_stdio_client=mock_client)
         assert tools, "update_tools() must return at least one tool"
         return tools[0]


### PR DESCRIPTION
## Summary

The `security-hardening` branch's two MCP hardening features — the **stdio command allowlist** (`lfx.base.mcp.security`) and the **connector SSRF guard** — both fire inside `update_tools`. Several pre-existing MCP unit tests mock the connection but pass **placeholder values** that those guards reject:

- Commands not in the allowlist (`fake-cmd`, `fake-server`, `some-tool`, `test-command`) → `MCPStdioSecurityError: Command '...' is not allowed`
- An unresolvable SSE host (`http://test-server`) → `SSRFProtectionError: DNS resolution failed for test-server`

These 13 failures were **masked** until now: earlier CI runs fail-fast-cancelled at the Ollama `validate-provider` failure (fixed separately) before this test group ran, so they only surfaced once that was green.

These tests exercise **tool-resilience and timeout plumbing**, not command/URL security — which have their own dedicated suites (`test_mcp_command_injection_security.py`, `test_mcp_stdio_security.py`). So the fix is to make their placeholders realistic:

- Swap placeholder commands → an allowlisted `uvx` (cosmetic for the mocked connection; the two `full_command` assertions updated to match).
- Disable SSRF in the two SSE timeout tests via `monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")`.

No production code changes — test-only.

## Test plan

- `test_mcp_util.py` + `test_mcp_timeout_configuration.py` + `test_mcp_command_injection_security.py`: **298 passed, 7 skipped** locally (was 13 failed).
- The dedicated MCP command-injection security tests still pass (the allowlist/SSRF features are unchanged).
- Adjacent MCP config-parsing test files (`test_mcp_component.py`, `test_mcp_component_cache.py`, `test_config_utils.py`, `test_mcp_servers_file.py`): **87 passed** — they don't connect, so they never hit the guards.

## Notes
Stacked on the `security-hardening` branch (#13530) — base is `security-hardening`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)