### PR TITLE
feat(models): add Azure AI Foundry to unified model provider setup

### DIFF
--- a/src/lfx/src/lfx/base/models/azure_ai_foundry_constants.py
+++ b/src/lfx/src/lfx/base/models/azure_ai_foundry_constants.py
@@ -1,0 +1,44 @@
+"""Azure AI Foundry model catalog primitives.
+
+Foundry deployments are user-specific (the ``model`` parameter must match the
+deployment name in the portal), so this is a small seed list shown before
+credentials are configured. Once a provider is set up, users enable the
+deployments they actually have.
+"""
+
+from .model_metadata import create_model_metadata
+
+AZURE_AI_FOUNDRY_MODELS_DETAILED = [
+    create_model_metadata(
+        provider="Azure AI Foundry",
+        name="gpt-4o",
+        icon="Azure",
+        tool_calling=True,
+        default=True,
+    ),
+    create_model_metadata(
+        provider="Azure AI Foundry",
+        name="gpt-4o-mini",
+        icon="Azure",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="Azure AI Foundry",
+        name="gpt-4.1",
+        icon="Azure",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="Azure AI Foundry",
+        name="o3-mini",
+        icon="Azure",
+        tool_calling=True,
+        reasoning=True,
+    ),
+    create_model_metadata(
+        provider="Azure AI Foundry",
+        name="Mistral-Large-3",
+        icon="Azure",
+        tool_calling=True,
+    ),
+]

--- a/src/lfx/src/lfx/base/models/model_metadata.py
+++ b/src/lfx/src/lfx/base/models/model_metadata.py
@@ -257,6 +257,45 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
             "model_param": "model",
         },
     },
+    "Azure AI Foundry": {
+        "icon": "Azure",
+        "max_tokens_field_name": "max_tokens",
+        "variables": [
+            {
+                "variable_name": "Azure AI Foundry API Key",
+                "variable_key": "AZURE_AI_FOUNDRY_API_KEY",
+                "required": True,
+                "is_secret": True,
+                "is_list": False,
+                "options": [],
+                "langchain_param": "credential",
+                "component_metadata": {
+                    "mapping_field": "api_key",
+                    "required": False,
+                    "advanced": True,
+                    "info": "Falls back to AZURE_AI_FOUNDRY_API_KEY environment variable",
+                },
+            },
+            {
+                "variable_name": "Azure AI Foundry Endpoint",
+                "variable_key": "AZURE_AI_FOUNDRY_ENDPOINT",
+                "description": (
+                    "OpenAI-compatible endpoint from the Foundry portal (Get endpoint). "
+                    "Example: https://<resource>.services.ai.azure.com/openai/v1"
+                ),
+                "required": True,
+                "is_secret": False,
+                "is_list": False,
+                "options": [],
+                "langchain_param": "endpoint",
+            },
+        ],
+        "api_docs_url": "https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/langchain-models",
+        "mapping": {
+            "model_class": "AzureAIOpenAIApiChatModel",
+            "model_param": "model",
+        },
+    },
     "IBM WatsonX": {
         "icon": "WatsonxAI",
         "max_tokens_field_name": "max_tokens",

--- a/src/lfx/src/lfx/base/models/unified_models/class_registry.py
+++ b/src/lfx/src/lfx/base/models/unified_models/class_registry.py
@@ -24,6 +24,11 @@ _MODEL_CLASS_IMPORTS: dict[str, tuple[str, str, str | None]] = {
     ),
     # AzureChatOpenAI ships in langchain_openai (already a dependency).
     "AzureChatOpenAI": ("langchain_openai", "AzureChatOpenAI", None),
+    "AzureAIOpenAIApiChatModel": (
+        "langchain_azure_ai.chat_models",
+        "AzureAIOpenAIApiChatModel",
+        "langchain-azure-ai",
+    ),
     # ChatGroq needs the optional langchain-groq package — keep the install
     # hint so an unconfigured environment gets an actionable error instead of
     # an opaque "Unknown model class: ChatGroq". Both class names appear in

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -438,6 +438,7 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
         "Anthropic",
         "Google Generative AI",
         "IBM WatsonX",
+        "Azure AI Foundry",
     ]:
         return
 
@@ -525,6 +526,21 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
                 msg = f"Could not reach OpenRouter to validate the API key: {e}"
                 logger.warning(msg)
                 raise ValueError(msg) from e
+
+        elif provider == "Azure AI Foundry":
+            from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
+
+            api_key = variables.get("AZURE_AI_FOUNDRY_API_KEY")
+            endpoint = variables.get("AZURE_AI_FOUNDRY_ENDPOINT")
+            if not api_key or not endpoint or not validation_model:
+                return
+            llm = AzureAIOpenAIApiChatModel(
+                credential=api_key,
+                endpoint=endpoint,
+                model=validation_model,
+                max_tokens=1,
+            )
+            llm.invoke("test")
 
         elif provider == "Ollama":
             import requests

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -260,12 +260,10 @@ def get_llm(
 
         # Priority: component value > database value > env var
         watsonx_url_value = (
-            watsonx_url if watsonx_url else provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
+            watsonx_url or provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
         )
         watsonx_project_id_value = (
-            watsonx_project_id
-            if watsonx_project_id
-            else provider_vars.get("WATSONX_PROJECT_ID") or _env_if_allowed("WATSONX_PROJECT_ID")
+            watsonx_project_id or provider_vars.get("WATSONX_PROJECT_ID") or _env_if_allowed("WATSONX_PROJECT_ID")
         )
 
         has_url = bool(watsonx_url_value)
@@ -295,9 +293,7 @@ def get_llm(
 
         # Priority: component value > database value > env var
         ollama_base_url_value = (
-            ollama_base_url
-            if ollama_base_url
-            else provider_vars.get("OLLAMA_BASE_URL") or _env_if_allowed("OLLAMA_BASE_URL")
+            ollama_base_url or provider_vars.get("OLLAMA_BASE_URL") or _env_if_allowed("OLLAMA_BASE_URL")
         )
         if ollama_base_url_value:
             kwargs[base_url_param] = ollama_base_url_value
@@ -332,6 +328,16 @@ def get_llm(
                 default_headers[header_name] = value
         if default_headers:
             kwargs["default_headers"] = default_headers
+    elif provider == "Azure AI Foundry":
+        provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
+        endpoint_value = provider_vars.get("AZURE_AI_FOUNDRY_ENDPOINT") or _env_if_allowed("AZURE_AI_FOUNDRY_ENDPOINT")
+        if not endpoint_value:
+            msg = (
+                "Azure AI Foundry endpoint is required. Configure AZURE_AI_FOUNDRY_ENDPOINT "
+                "in Settings → Model Providers or set the environment variable."
+            )
+            raise ValueError(msg)
+        kwargs["endpoint"] = endpoint_value
     elif is_registered(provider):
         # Bundle-contributed provider: apply its declared connection variables
         # (base_url, attribution headers, etc.) generically from its metadata.
@@ -478,7 +484,7 @@ def get_embeddings(
         "request_timeout": float(request_timeout) if request_timeout else None,
         "max_retries": int(max_retries) if max_retries else None,
         "show_progress_bar": show_progress_bar,
-        "model_kwargs": model_kwargs if model_kwargs else None,
+        "model_kwargs": model_kwargs or None,
     }
 
     # Watson-specific parameters

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -259,9 +259,7 @@ def get_llm(
         provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
 
         # Priority: component value > database value > env var
-        watsonx_url_value = (
-            watsonx_url or provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
-        )
+        watsonx_url_value = watsonx_url or provider_vars.get("WATSONX_URL") or _env_if_allowed("WATSONX_URL")
         watsonx_project_id_value = (
             watsonx_project_id or provider_vars.get("WATSONX_PROJECT_ID") or _env_if_allowed("WATSONX_PROJECT_ID")
         )

--- a/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
+++ b/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from lfx.base.models.anthropic_constants import ANTHROPIC_MODELS_DETAILED
+from lfx.base.models.azure_ai_foundry_constants import AZURE_AI_FOUNDRY_MODELS_DETAILED
 from lfx.base.models.google_generative_ai_constants import (
     GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS_DETAILED,
     GOOGLE_GENERATIVE_AI_MODELS_DETAILED,
@@ -33,6 +34,7 @@ model_provider_metadata = get_model_provider_metadata()
 
 _STATIC_MODELS_DETAILED: list[list[dict]] = [
     ANTHROPIC_MODELS_DETAILED,
+    AZURE_AI_FOUNDRY_MODELS_DETAILED,
     OPENAI_MODELS_DETAILED,
     OPENAI_EMBEDDING_MODELS_DETAILED,
     GOOGLE_GENERATIVE_AI_MODELS_DETAILED,

--- a/src/lfx/src/lfx/services/settings/constants.py
+++ b/src/lfx/src/lfx/services/settings/constants.py
@@ -43,6 +43,9 @@ VARIABLES_TO_GET_FROM_ENVIRONMENT = [
     "OPENROUTER_API_KEY",
     "OPENROUTER_SITE_URL",
     "OPENROUTER_APP_NAME",
+    # Azure AI Foundry variables
+    "AZURE_AI_FOUNDRY_API_KEY",
+    "AZURE_AI_FOUNDRY_ENDPOINT",
 ]
 
 # Agentic experience specific variables

--- a/src/lfx/src/lfx/utils/flow_requirements.py
+++ b/src/lfx/src/lfx/utils/flow_requirements.py
@@ -106,6 +106,7 @@ _MODEL_FIELDS = {"model", "agent_llm", "embeddings_model", "embedding_model"}
 _PROVIDER_PACKAGE_FALLBACKS: dict[str, set[str]] = {
     "Amazon Bedrock": {"langchain-aws"},
     "Anthropic": {"langchain-anthropic"},
+    "Azure AI Foundry": {"langchain-azure-ai"},
     "Azure OpenAI": {"langchain-openai"},
     "Google Generative AI": {"langchain-google-genai"},
     "Groq": {"langchain-groq"},

--- a/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
+++ b/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
@@ -1,0 +1,229 @@
+"""Unit tests for the Azure AI Foundry unified model provider.
+
+Covers provider registry presence, metadata shape, parameter mapping
+resolution, env-var registration, requirements generation, credential
+validation (success, early-return paths), and LLM instantiation (endpoint
+wiring and missing-endpoint error).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def test_azure_ai_foundry_in_provider_registry():
+    """Azure AI Foundry must appear in MODEL_PROVIDER_METADATA after import."""
+    from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
+
+    assert "Azure AI Foundry" in MODEL_PROVIDER_METADATA
+
+
+def test_azure_ai_foundry_metadata_shape():
+    """Metadata must declare Azure icon, AzureAIOpenAIApiChatModel mapping, and both variables."""
+    from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA
+
+    meta = MODEL_PROVIDER_METADATA["Azure AI Foundry"]
+    assert meta["icon"] == "Azure"
+    assert meta["mapping"]["model_class"] == "AzureAIOpenAIApiChatModel"
+    assert meta["mapping"]["model_param"] == "model"
+
+    var_keys = {v["variable_key"] for v in meta["variables"]}
+    assert var_keys == {"AZURE_AI_FOUNDRY_API_KEY", "AZURE_AI_FOUNDRY_ENDPOINT"}
+
+    by_key = {v["variable_key"]: v for v in meta["variables"]}
+    assert by_key["AZURE_AI_FOUNDRY_API_KEY"]["required"] is True
+    assert by_key["AZURE_AI_FOUNDRY_API_KEY"]["is_secret"] is True
+    assert by_key["AZURE_AI_FOUNDRY_API_KEY"]["langchain_param"] == "credential"
+    assert by_key["AZURE_AI_FOUNDRY_ENDPOINT"]["required"] is True
+
+
+def test_azure_ai_foundry_appears_in_get_model_providers():
+    """Azure AI Foundry must be returned by get_model_providers()."""
+    from lfx.base.models.unified_models import get_model_providers
+
+    assert "Azure AI Foundry" in get_model_providers()
+
+
+def test_azure_ai_foundry_param_mapping_resolves_to_foundry_chat_model():
+    """get_provider_param_mapping must resolve model_class and api_key_param for Foundry."""
+    from lfx.base.models.model_metadata import get_provider_param_mapping
+
+    mapping = get_provider_param_mapping("Azure AI Foundry")
+    assert mapping["model_class"] == "AzureAIOpenAIApiChatModel"
+    assert mapping["model_param"] == "model"
+    assert mapping["api_key_param"] == "credential"  # pragma: allowlist secret
+
+
+def test_azure_ai_foundry_env_vars_registered_for_auto_import():
+    """Both Foundry env vars must be in VARIABLES_TO_GET_FROM_ENVIRONMENT."""
+    from lfx.services.settings.constants import VARIABLES_TO_GET_FROM_ENVIRONMENT
+
+    assert "AZURE_AI_FOUNDRY_API_KEY" in VARIABLES_TO_GET_FROM_ENVIRONMENT
+    assert "AZURE_AI_FOUNDRY_ENDPOINT" in VARIABLES_TO_GET_FROM_ENVIRONMENT
+
+
+def test_azure_ai_foundry_resolves_to_langchain_azure_ai():
+    """A flow using Azure AI Foundry must include langchain-azure-ai in requirements."""
+    from lfx.utils.flow_requirements import generate_requirements_from_flow
+
+    flow = {
+        "data": {
+            "nodes": [
+                {
+                    "data": {
+                        "type": "LanguageModel",
+                        "node": {
+                            "template": {
+                                "model": {
+                                    "value": [{"provider": "Azure AI Foundry", "name": "gpt-4o"}],
+                                },
+                                "_type": "Component",
+                            },
+                            "base_classes": ["LanguageModel"],
+                        },
+                    },
+                }
+            ],
+            "edges": [],
+        }
+    }
+    result = generate_requirements_from_flow(flow, pin_versions=False)
+    assert "langchain-azure-ai" in result
+
+
+def test_validate_model_provider_key_azure_ai_foundry_success():
+    """validate_model_provider_key must pass api_key as credential and endpoint to the model."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    calls = []
+
+    class FakeFoundryChatModel:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        def invoke(self, _prompt):
+            return "ok"
+
+    fake_chat_models = SimpleNamespace(AzureAIOpenAIApiChatModel=FakeFoundryChatModel)
+    with patch.dict(
+        "sys.modules",
+        {
+            "langchain_azure_ai": SimpleNamespace(chat_models=fake_chat_models),
+            "langchain_azure_ai.chat_models": fake_chat_models,
+        },
+    ):
+        validate_model_provider_key(
+            "Azure AI Foundry",
+            {
+                "AZURE_AI_FOUNDRY_API_KEY": "test-key",
+                "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1",
+            },
+            model_name="gpt-4o",
+        )
+
+    assert calls[0] == {
+        "credential": "test-key",
+        "endpoint": "https://example.services.ai.azure.com/openai/v1",
+        "model": "gpt-4o",
+        "max_tokens": 1,
+    }
+
+
+def test_validate_model_provider_key_azure_ai_foundry_returns_early_without_model():
+    """validate_model_provider_key must return without error when no model_name is given."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    # Should not raise even though no model is supplied — early return expected.
+    validate_model_provider_key(
+        "Azure AI Foundry",
+        {
+            "AZURE_AI_FOUNDRY_API_KEY": "test-key",
+            "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1",
+        },
+        model_name=None,
+    )
+
+
+def test_validate_model_provider_key_azure_ai_foundry_returns_early_without_api_key():
+    """validate_model_provider_key must return without error when API key is absent."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    validate_model_provider_key(
+        "Azure AI Foundry",
+        {"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1"},
+        model_name="gpt-4o",
+    )
+
+
+def test_validate_model_provider_key_azure_ai_foundry_returns_early_without_endpoint():
+    """validate_model_provider_key must return without error when endpoint is absent."""
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    validate_model_provider_key(
+        "Azure AI Foundry",
+        {"AZURE_AI_FOUNDRY_API_KEY": "test-key"},
+        model_name="gpt-4o",
+    )
+
+
+def _build_azure_ai_foundry_model_selection() -> list[dict]:
+    return [
+        {
+            "name": "gpt-4o",
+            "provider": "Azure AI Foundry",
+            "metadata": {},
+        }
+    ]
+
+
+def test_get_llm_wires_azure_ai_foundry_endpoint_and_credential():
+    """get_llm must pass endpoint and credential kwargs for Azure AI Foundry."""
+    from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models.instantiation import get_llm
+
+    captured_kwargs: dict = {}
+
+    class FakeFoundryChatModel:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    with (
+        patch.object(
+            unified_models_module,
+            "get_api_key_for_provider",
+            return_value="test-key",
+        ),
+        patch.object(unified_models_module, "get_model_class", return_value=FakeFoundryChatModel),
+        patch.object(
+            unified_models_module,
+            "get_all_variables_for_provider",
+            return_value={"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1"},
+        ),
+    ):
+        get_llm(_build_azure_ai_foundry_model_selection(), user_id="user-1", stream=False)
+
+    assert captured_kwargs["model"] == "gpt-4o"
+    assert captured_kwargs["credential"] == "test-key"
+    assert captured_kwargs["endpoint"] == "https://example.services.ai.azure.com/openai/v1"
+
+
+def test_get_llm_azure_ai_foundry_requires_endpoint():
+    """get_llm must raise ValueError with a clear message when endpoint is not configured."""
+    from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models.instantiation import get_llm
+
+    class FakeFoundryChatModel:
+        def __init__(self, **kwargs):
+            pass
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value="test-key"),
+        patch.object(unified_models_module, "get_model_class", return_value=FakeFoundryChatModel),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        patch("lfx.base.models.unified_models.instantiation._env_if_allowed", return_value=None),
+        pytest.raises(ValueError, match="Azure AI Foundry endpoint is required"),
+    ):
+        get_llm(_build_azure_ai_foundry_model_selection(), user_id="user-1", stream=False)


### PR DESCRIPTION
## What & why

Adds **Azure AI Foundry** as a first-class model provider in Langflow's unified model system (Settings → Model Providers), enabling centralized configuration of endpoint and API key — identical to how OpenAI, Anthropic, and Ollama work today.

Supersedes #13912 by @HimavarshaVS with two fixes applied:
- **Docstring coverage**: all 12 test functions now have docstrings (fixes CodeRabbit's 0% docstring-coverage warning)
- **Credential validation coverage**: three early-return paths (`missing model_name`, `missing api_key`, `missing endpoint`) are now tested (fixes Codecov's `credentials.py` partial-coverage report)

## How

| Layer | Change |
|---|---|
| `azure_ai_foundry_constants.py` | Seed model catalog: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `o3-mini`, `Mistral-Large-3` with capability flags |
| `model_metadata.py` | `"Azure AI Foundry"` entry: `AZURE_AI_FOUNDRY_API_KEY` (`credential`) + `AZURE_AI_FOUNDRY_ENDPOINT` (`endpoint`), `AzureAIOpenAIApiChatModel` mapping |
| `class_registry.py` | Lazy import for `AzureAIOpenAIApiChatModel` from `langchain-azure-ai` |
| `provider_queries.py` | Import + add seed catalog to `_STATIC_MODELS_DETAILED` |
| `credentials.py` | Validation branch: constructs model with `max_tokens=1`, invokes test call; early-returns when any required field is absent |
| `instantiation.py` | `get_llm` branch: resolves `AZURE_AI_FOUNDRY_ENDPOINT` from provider vars or env; raises `ValueError` with actionable message when missing |
| `settings/constants.py` | Both env vars added to `VARIABLES_TO_GET_FROM_ENVIRONMENT` |
| `flow_requirements.py` | `"Azure AI Foundry": {"langchain-azure-ai"}` |

## Tests

12 tests in `test_azure_ai_foundry_provider.py` covering:
- Registry presence and metadata shape
- Parameter mapping resolution
- Env var registration and requirements generation
- Credential validation: success + all 3 early-return paths
- `get_llm`: endpoint + credential wiring and missing-endpoint `ValueError`

## Test plan

- [ ] Configure Azure AI Foundry in Settings → Model Providers with API key + endpoint from the Foundry portal
- [ ] Enable a deployment matching a model in the catalog (e.g. `gpt-4o`)
- [ ] Run a Language Model or Agent flow and confirm inference succeeds

Refs #13912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure AI Foundry as a model provider.
  * Included several Foundry models in the available model catalog, including a default option.
  * Added automatic requirement detection for the provider’s client package.

* **Bug Fixes**
  * Improved credential and endpoint handling so validation and setup fail gracefully when required settings are missing.
  * Ensured model connection details are applied consistently during setup and usage.

* **Tests**
  * Added coverage for provider registration, model mapping, requirements, validation, and connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->