### PR TITLE
feat(bundles): add lfx-azure-ai-foundry provider bundle

### DIFF
--- a/BUNDLE_API.md
+++ b/BUNDLE_API.md
@@ -511,3 +511,13 @@ the deserialize half is covered by
   messages and winner selection are unchanged, and two physically distinct
   manifests for one canonical name still error.  No public symbol's name or
   signature changed.
+- **Manifest `providers[].models[]` — bundles can seed the static model catalog (additive).**
+  Each `ProviderEntry` in `ExtensionManifest.providers[]` gains an optional
+  `models` list of `ModelMetadata`-shaped dicts (same shape as
+  `create_model_metadata` produces).  At load time the loader passes the list
+  to `ProviderSpec.models` and `register_provider()` appends it to
+  `_STATIC_MODELS_DETAILED` in-place, making the models immediately visible in
+  `get_models_detailed()` and the UI model picker.  `clear()` removes the group.
+  Useful for providers whose model list is fixed (e.g. cloud-specific
+  deployments).  Omitting `models` (empty list) is the default and is fully
+  backward-compatible; existing bundles are unaffected.

--- a/src/bundles/azure-ai-foundry/README.md
+++ b/src/bundles/azure-ai-foundry/README.md
@@ -1,0 +1,31 @@
+# lfx-azure-ai-foundry
+
+Azure AI Foundry as a first-class model provider for [Langflow](https://github.com/langflow-ai/langflow), packaged as a standalone Extension Bundle.
+
+## What this bundle adds
+
+- **Azure AI Foundry** provider in the Langflow model picker
+- Pre-populated model catalog: `gpt-4o` (default), `gpt-4o-mini`, `gpt-4.1`, `o3-mini`, `Mistral-Large-3`
+- Credential validation against the Azure AI Foundry OpenAI-compatible endpoint
+
+## Configuration
+
+Set these environment variables (or enter them in the Langflow UI):
+
+| Variable | Description |
+|---|---|
+| `AZURE_AI_FOUNDRY_API_KEY` | API key from the Azure AI Foundry portal |
+| `AZURE_AI_FOUNDRY_ENDPOINT` | OpenAI-compatible endpoint, e.g. `https://<resource>.services.ai.azure.com/openai/v1` |
+
+## Installation
+
+```bash
+pip install lfx-azure-ai-foundry
+```
+
+Langflow detects the bundle automatically via the `langflow.extensions` entry-point — no manual registration needed.
+
+## Requirements
+
+- `lfx >= 1.11.0`
+- `langchain-azure-ai >= 0.1.0`

--- a/src/bundles/azure-ai-foundry/pyproject.toml
+++ b/src/bundles/azure-ai-foundry/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "lfx-azure-ai-foundry"
+version = "0.1.0"
+description = "Azure AI Foundry as a first-class Langflow model provider, packaged as a standalone Extension Bundle."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = { text = "MIT" }
+authors = [
+    { name = "Langflow", email = "contact@langflow.org" },
+]
+keywords = ["langflow", "lfx", "extension", "bundle", "azure", "azure-ai-foundry", "model-provider"]
+
+dependencies = [
+    "lfx>=1.11.0.dev0,<2.0.0",
+    "langchain-azure-ai>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/langflow-ai/langflow"
+Documentation = "https://docs.langflow.org/extensions"
+Repository = "https://github.com/langflow-ai/langflow"
+
+[project.entry-points."langflow.extensions"]
+lfx-azure-ai-foundry = "lfx_azure_ai_foundry"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/lfx_azure_ai_foundry"]
+include = ["src/lfx_azure_ai_foundry/extension.json", "src/lfx_azure_ai_foundry/*.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/lfx_azure_ai_foundry",
+    "README.md",
+    "pyproject.toml",
+]

--- a/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/__init__.py
+++ b/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/__init__.py
@@ -1,0 +1,8 @@
+"""lfx-azure-ai-foundry: Azure AI Foundry model-provider bundle.
+
+At runtime Langflow's loader discovers the ``extension.json`` shipped alongside
+this ``__init__.py`` and registers its ``providers[]`` entry, merging an
+**Azure AI Foundry** provider into the unified model system. The provider
+uses ``AzureAIOpenAIApiChatModel`` from ``langchain-azure-ai`` and seeds a
+static catalog of common Foundry deployment model names.
+"""

--- a/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/extension.json
+++ b/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/extension.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://schemas.langflow.org/extension/v1.json",
+  "id": "lfx-azure-ai-foundry",
+  "version": "0.1.0",
+  "name": "Azure AI Foundry",
+  "description": "Azure AI Foundry as a first-class Langflow model provider, packaged as a standalone Extension Bundle.",
+  "lfx": {
+    "compat": ["1"]
+  },
+  "providers": [
+    {
+      "name": "Azure AI Foundry",
+      "metadata": {
+        "icon": "Azure",
+        "max_tokens_field_name": "max_tokens",
+        "variables": [
+          {
+            "variable_name": "Azure AI Foundry API Key",
+            "variable_key": "AZURE_AI_FOUNDRY_API_KEY",
+            "required": true,
+            "is_secret": true,
+            "is_list": false,
+            "options": [],
+            "langchain_param": "credential",
+            "component_metadata": {
+              "mapping_field": "api_key",
+              "required": false,
+              "advanced": true,
+              "info": "Falls back to AZURE_AI_FOUNDRY_API_KEY environment variable"
+            }
+          },
+          {
+            "variable_name": "Azure AI Foundry Endpoint",
+            "variable_key": "AZURE_AI_FOUNDRY_ENDPOINT",
+            "description": "OpenAI-compatible endpoint from the Foundry portal (Get endpoint). Example: https://<resource>.services.ai.azure.com/openai/v1",
+            "required": true,
+            "is_secret": false,
+            "is_list": false,
+            "options": [],
+            "langchain_param": "endpoint"
+          }
+        ],
+        "api_docs_url": "https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/langchain-models",
+        "mapping": {
+          "model_class": "AzureAIOpenAIApiChatModel",
+          "model_param": "model"
+        }
+      },
+      "model_class": {
+        "module": "langchain_azure_ai.chat_models",
+        "attr": "AzureAIOpenAIApiChatModel",
+        "install_hint": "langchain-azure-ai"
+      },
+      "api_key_required": true,
+      "live": false,
+      "validator": "lfx_azure_ai_foundry.validator:validate_azure_ai_foundry_credentials",
+      "models": [
+        {"provider": "Azure AI Foundry", "name": "gpt-4o",           "icon": "Azure", "tool_calling": true,  "default": true,  "model_type": "llm"},
+        {"provider": "Azure AI Foundry", "name": "gpt-4o-mini",      "icon": "Azure", "tool_calling": true,  "default": false, "model_type": "llm"},
+        {"provider": "Azure AI Foundry", "name": "gpt-4.1",          "icon": "Azure", "tool_calling": true,  "default": false, "model_type": "llm"},
+        {"provider": "Azure AI Foundry", "name": "o3-mini",          "icon": "Azure", "tool_calling": true,  "reasoning": true, "default": false, "model_type": "llm"},
+        {"provider": "Azure AI Foundry", "name": "Mistral-Large-3",  "icon": "Azure", "tool_calling": true,  "default": false, "model_type": "llm"}
+      ]
+    }
+  ]
+}

--- a/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/validator.py
+++ b/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/validator.py
@@ -1,0 +1,45 @@
+"""Credential validation for the Azure AI Foundry provider bundle.
+
+Invoked lazily by lfx's provider registry via the dotted path
+``lfx_azure_ai_foundry.validator:validate_azure_ai_foundry_credentials``
+declared in ``extension.json``. Importing this module is cheap and only
+happens when credential validation is actually triggered.
+"""
+
+from __future__ import annotations
+
+from lfx.log.logger import logger
+
+
+def validate_azure_ai_foundry_credentials(
+    provider: str,  # noqa: ARG001 - part of registry validator contract
+    variables: dict[str, str],
+    model_name: str | None = None,
+) -> None:
+    """Validate Azure AI Foundry credentials by constructing and invoking the chat model.
+
+    Raises ``ValueError`` with an actionable message when required fields are
+    missing or when the Azure endpoint rejects the credentials. Returns silently
+    on success. ``provider`` is part of the registry validator contract but is
+    not used here since this callable is only registered for Azure AI Foundry.
+    """
+    api_key = variables.get("AZURE_AI_FOUNDRY_API_KEY")
+    endpoint = variables.get("AZURE_AI_FOUNDRY_ENDPOINT")
+
+    if not api_key or not endpoint or not model_name:
+        return
+
+    from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
+
+    llm = AzureAIOpenAIApiChatModel(
+        credential=api_key,
+        endpoint=endpoint,
+        model=model_name,
+        max_tokens=1,
+    )
+    try:
+        llm.invoke("test")
+    except Exception as exc:
+        msg = f"Azure AI Foundry credential validation failed: {exc}"
+        logger.error(msg)
+        raise ValueError(msg) from exc

--- a/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/validator.py
+++ b/src/bundles/azure-ai-foundry/src/lfx_azure_ai_foundry/validator.py
@@ -18,10 +18,12 @@ def validate_azure_ai_foundry_credentials(
 ) -> None:
     """Validate Azure AI Foundry credentials by constructing and invoking the chat model.
 
-    Raises ``ValueError`` with an actionable message when required fields are
-    missing or when the Azure endpoint rejects the credentials. Returns silently
-    on success. ``provider`` is part of the registry validator contract but is
-    not used here since this callable is only registered for Azure AI Foundry.
+    Returns silently when ``api_key``, ``endpoint``, or ``model_name`` is absent
+    (incomplete configuration is not an error at this stage). Raises ``ValueError``
+    with an actionable message when the Azure endpoint rejects the credentials or
+    when construction of the client itself fails. ``provider`` is part of the
+    registry validator contract but is not used here since this callable is only
+    registered for Azure AI Foundry.
     """
     api_key = variables.get("AZURE_AI_FOUNDRY_API_KEY")
     endpoint = variables.get("AZURE_AI_FOUNDRY_ENDPOINT")
@@ -31,13 +33,13 @@ def validate_azure_ai_foundry_credentials(
 
     from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
-    llm = AzureAIOpenAIApiChatModel(
-        credential=api_key,
-        endpoint=endpoint,
-        model=model_name,
-        max_tokens=1,
-    )
     try:
+        llm = AzureAIOpenAIApiChatModel(
+            credential=api_key,
+            endpoint=endpoint,
+            model=model_name,
+            max_tokens=1,
+        )
         llm.invoke("test")
     except Exception as exc:
         msg = f"Azure AI Foundry credential validation failed: {exc}"

--- a/src/bundles/azure-ai-foundry/tests/conftest.py
+++ b/src/bundles/azure-ai-foundry/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Add the bundle src directory to sys.path so lfx_azure_ai_foundry is importable."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
+++ b/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
@@ -177,10 +177,14 @@ def test_validator_invokes_chat_model_on_success():
     calls: list[dict] = []
 
     class FakeModel:
+        """Stub that records constructor kwargs and returns a successful invoke result."""
+
         def __init__(self, **kwargs):
+            """Record kwargs for post-call assertions."""
             calls.append(kwargs)
 
         def invoke(self, _prompt):
+            """Return a fixed success response."""
             return "ok"
 
     fake_module = SimpleNamespace(AzureAIOpenAIApiChatModel=FakeModel)
@@ -201,10 +205,13 @@ def test_validator_raises_on_invoke_failure():
     from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
 
     class FakeModel:
+        """Stub whose invoke() always raises to exercise the validator error path."""
+
         def __init__(self, **kwargs):
-            pass
+            """Accept and discard constructor kwargs."""
 
         def invoke(self, _prompt):
+            """Raise RuntimeError to simulate a rejected credential."""
             msg = "auth failed"
             raise RuntimeError(msg)
 

--- a/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
+++ b/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
@@ -130,9 +130,7 @@ def test_manifest_rejects_model_entry_with_mismatched_provider():
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError, match="mismatched provider"):
-        ProviderManifestEntry(
-            **_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "WrongCloud"}])
-        )
+        ProviderManifestEntry(**_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "WrongCloud"}]))
 
 
 def test_manifest_accepts_model_entry_without_provider_key():
@@ -147,9 +145,7 @@ def test_manifest_accepts_model_entry_with_matching_provider():
     """ProviderManifestEntry must accept models[] entries where 'provider' matches the provider name."""
     from lfx.extension.manifest import ProviderManifestEntry
 
-    entry = ProviderManifestEntry(
-        **_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "TestCloud"}])
-    )
+    entry = ProviderManifestEntry(**_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "TestCloud"}]))
     assert entry.models[0]["name"] == "gpt-4o"
 
 

--- a/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
+++ b/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
@@ -1,0 +1,220 @@
+"""Tests for the lfx-azure-ai-foundry provider bundle and the models[] registry extension.
+
+Covers:
+  - ProviderSpec.models[] injects into _STATIC_MODELS_DETAILED and is reversed by clear().
+  - End-to-end load through the real extension loader: provider appears in
+    get_model_providers() and get_models_detailed() after load.
+  - Validator callable is imported and invokes correctly (success + early-return paths).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Registry extension: models[] field
+# ---------------------------------------------------------------------------
+
+
+def test_register_provider_injects_static_models():
+    """Static models declared in ProviderSpec.models[] must appear in get_models_detailed()."""
+    from lfx.base.models import provider_registry
+    from lfx.base.models.model_metadata import create_model_metadata
+    from lfx.base.models.provider_registry import ProviderSpec, clear, register_provider
+    from lfx.base.models.unified_models.provider_queries import get_models_detailed
+
+    get_models_detailed.cache_clear()
+    clear()
+    try:
+        seed = [create_model_metadata(provider="TestCloud", name="tc-model-1", icon="Azure")]
+        spec = ProviderSpec(
+            name="TestCloud",
+            metadata={
+                "icon": "Azure",
+                "variables": [],
+                "mapping": {"model_class": "ChatOpenAI", "model_param": "model"},
+            },
+            models=seed,
+        )
+        register_provider(spec)
+        get_models_detailed.cache_clear()
+        all_models = [m for group in get_models_detailed() for m in group]
+        names = {m["name"] for m in all_models}
+        assert "tc-model-1" in names
+    finally:
+        clear()
+        get_models_detailed.cache_clear()
+        provider_registry._CORE_PROVIDER_NAMES  # noqa: B018 - trigger re-capture guard check
+
+
+def test_clear_removes_static_models():
+    """clear() must remove models[] entries from _STATIC_MODELS_DETAILED."""
+    from lfx.base.models.model_metadata import create_model_metadata
+    from lfx.base.models.provider_registry import ProviderSpec, clear, register_provider
+    from lfx.base.models.unified_models.provider_queries import _STATIC_MODELS_DETAILED, get_models_detailed
+
+    get_models_detailed.cache_clear()
+    clear()
+    seed = [create_model_metadata(provider="TestCloud2", name="tc-model-2", icon="Azure")]
+    spec = ProviderSpec(
+        name="TestCloud2",
+        metadata={
+            "icon": "Azure",
+            "variables": [],
+            "mapping": {"model_class": "ChatOpenAI", "model_param": "model"},
+        },
+        models=seed,
+    )
+    register_provider(spec)
+    assert seed in _STATIC_MODELS_DETAILED
+
+    clear()
+    assert seed not in _STATIC_MODELS_DETAILED
+    get_models_detailed.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: load through the real extension loader
+# ---------------------------------------------------------------------------
+
+
+def _bundle_root() -> Path:
+    """Return the path to the azure-ai-foundry bundle root (contains extension.json)."""
+    return Path(__file__).parent.parent / "src" / "lfx_azure_ai_foundry"
+
+
+def test_bundle_root_exists():
+    """Sanity-check that the bundle root and extension.json are present."""
+    root = _bundle_root()
+    assert root.exists(), f"Bundle root not found: {root}"
+    assert (root / "extension.json").exists()
+
+
+def test_azure_ai_foundry_appears_in_get_model_providers_after_load():
+    """After loading the bundle, Azure AI Foundry must appear in get_model_providers()."""
+    from lfx.base.models.provider_registry import clear
+    from lfx.base.models.unified_models import get_model_providers
+    from lfx.base.models.unified_models.provider_queries import get_models_detailed
+    from lfx.extension.loader._orchestrator import load_extension
+
+    get_models_detailed.cache_clear()
+    clear()
+    try:
+        result = load_extension(str(_bundle_root()), slot="extra")
+        assert not result.errors, f"Bundle load errors: {result.errors}"
+        assert "Azure AI Foundry" in get_model_providers()
+    finally:
+        clear()
+        get_models_detailed.cache_clear()
+
+
+def test_azure_ai_foundry_seed_models_appear_after_load():
+    """After loading the bundle, the seed catalog must appear in get_models_detailed()."""
+    from lfx.base.models.provider_registry import clear
+    from lfx.base.models.unified_models.provider_queries import get_models_detailed
+    from lfx.extension.loader._orchestrator import load_extension
+
+    get_models_detailed.cache_clear()
+    clear()
+    try:
+        load_extension(str(_bundle_root()), slot="extra")
+        get_models_detailed.cache_clear()
+        all_models = [m for group in get_models_detailed() for m in group]
+        foundry_names = {m["name"] for m in all_models if m.get("provider") == "Azure AI Foundry"}
+        assert "gpt-4o" in foundry_names
+        assert "gpt-4o-mini" in foundry_names
+    finally:
+        clear()
+        get_models_detailed.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Validator callable
+# ---------------------------------------------------------------------------
+
+
+def test_validator_returns_early_without_model_name():
+    """Validator must return silently when model_name is not supplied."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    validate_azure_ai_foundry_credentials(
+        "Azure AI Foundry",
+        {"AZURE_AI_FOUNDRY_API_KEY": "key", "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
+        model_name=None,
+    )
+
+
+def test_validator_returns_early_without_api_key():
+    """Validator must return silently when API key is absent."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    validate_azure_ai_foundry_credentials(
+        "Azure AI Foundry",
+        {"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
+        model_name="gpt-4o",
+    )
+
+
+def test_validator_returns_early_without_endpoint():
+    """Validator must return silently when endpoint is absent."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    validate_azure_ai_foundry_credentials(
+        "Azure AI Foundry",
+        {"AZURE_AI_FOUNDRY_API_KEY": "key"},
+        model_name="gpt-4o",
+    )
+
+
+def test_validator_invokes_chat_model_on_success():
+    """Validator must construct AzureAIOpenAIApiChatModel and call invoke() when all fields present."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    calls: list[dict] = []
+
+    class FakeModel:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        def invoke(self, _prompt):
+            return "ok"
+
+    fake_module = SimpleNamespace(AzureAIOpenAIApiChatModel=FakeModel)
+    with patch.dict("sys.modules", {"langchain_azure_ai": fake_module, "langchain_azure_ai.chat_models": fake_module}):
+        validate_azure_ai_foundry_credentials(
+            "Azure AI Foundry",
+            {"AZURE_AI_FOUNDRY_API_KEY": "k", "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
+            model_name="gpt-4o",
+        )
+
+    assert calls[0]["credential"] == "k"
+    assert calls[0]["endpoint"] == "https://example.com"
+    assert calls[0]["model"] == "gpt-4o"
+
+
+def test_validator_raises_on_invoke_failure():
+    """Validator must raise ValueError when invoke() throws."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    class FakeModel:
+        def __init__(self, **kwargs):
+            pass
+
+        def invoke(self, _prompt):
+            msg = "auth failed"
+            raise RuntimeError(msg)
+
+    fake_module = SimpleNamespace(AzureAIOpenAIApiChatModel=FakeModel)
+    with (
+        patch.dict("sys.modules", {"langchain_azure_ai": fake_module, "langchain_azure_ai.chat_models": fake_module}),
+        pytest.raises(ValueError, match="auth failed"),
+    ):
+        validate_azure_ai_foundry_credentials(
+            "Azure AI Foundry",
+            {"AZURE_AI_FOUNDRY_API_KEY": "k", "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
+            model_name="gpt-4o",
+        )

--- a/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
+++ b/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
@@ -225,3 +225,27 @@ def test_validator_raises_on_invoke_failure():
             {"AZURE_AI_FOUNDRY_API_KEY": "k", "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
             model_name="gpt-4o",
         )
+
+
+def test_validator_raises_on_construction_failure():
+    """Validator must raise ValueError when AzureAIOpenAIApiChatModel construction fails."""
+    from lfx_azure_ai_foundry.validator import validate_azure_ai_foundry_credentials
+
+    class BrokenModel:
+        """Stub whose constructor always raises to exercise the construction error path."""
+
+        def __init__(self, **_kwargs):
+            """Raise immediately to simulate a broken/misconfigured client."""
+            msg = "bad endpoint"
+            raise ValueError(msg)
+
+    fake_module = SimpleNamespace(AzureAIOpenAIApiChatModel=BrokenModel)
+    with (
+        patch.dict("sys.modules", {"langchain_azure_ai": fake_module, "langchain_azure_ai.chat_models": fake_module}),
+        pytest.raises(ValueError, match="bad endpoint"),
+    ):
+        validate_azure_ai_foundry_credentials(
+            "Azure AI Foundry",
+            {"AZURE_AI_FOUNDRY_API_KEY": "k", "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.com"},
+            model_name="gpt-4o",
+        )

--- a/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
+++ b/src/bundles/azure-ai-foundry/tests/test_azure_ai_foundry_bundle.py
@@ -94,6 +94,65 @@ def test_bundle_root_exists():
     assert (root / "extension.json").exists()
 
 
+# ---------------------------------------------------------------------------
+# Manifest validation: models[] structural checks
+# ---------------------------------------------------------------------------
+
+
+def _minimal_provider_entry(**overrides):
+    """Return a minimal valid ProviderManifestEntry dict, with optional overrides."""
+    base = {
+        "name": "TestCloud",
+        "metadata": {
+            "icon": "Azure",
+            "variables": [],
+            "mapping": {"model_class": "ChatOpenAI", "model_param": "model"},
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_manifest_rejects_model_entry_without_name():
+    """ProviderManifestEntry must reject models[] entries that have no 'name' key."""
+    import pytest
+    from lfx.extension.manifest import ProviderManifestEntry
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="non-empty 'name'"):
+        ProviderManifestEntry(**_minimal_provider_entry(models=[{"provider": "TestCloud"}]))
+
+
+def test_manifest_rejects_model_entry_with_mismatched_provider():
+    """ProviderManifestEntry must reject models[] entries whose 'provider' key differs from the provider name."""
+    import pytest
+    from lfx.extension.manifest import ProviderManifestEntry
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="mismatched provider"):
+        ProviderManifestEntry(
+            **_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "WrongCloud"}])
+        )
+
+
+def test_manifest_accepts_model_entry_without_provider_key():
+    """ProviderManifestEntry must accept models[] entries that omit the optional 'provider' key."""
+    from lfx.extension.manifest import ProviderManifestEntry
+
+    entry = ProviderManifestEntry(**_minimal_provider_entry(models=[{"name": "gpt-4o"}]))
+    assert entry.models[0]["name"] == "gpt-4o"
+
+
+def test_manifest_accepts_model_entry_with_matching_provider():
+    """ProviderManifestEntry must accept models[] entries where 'provider' matches the provider name."""
+    from lfx.extension.manifest import ProviderManifestEntry
+
+    entry = ProviderManifestEntry(
+        **_minimal_provider_entry(models=[{"name": "gpt-4o", "provider": "TestCloud"}])
+    )
+    assert entry.models[0]["name"] == "gpt-4o"
+
+
 def test_azure_ai_foundry_appears_in_get_model_providers_after_load():
     """After loading the bundle, Azure AI Foundry must appear in get_model_providers()."""
     from lfx.base.models.provider_registry import clear

--- a/src/lfx/src/lfx/base/models/provider_registry.py
+++ b/src/lfx/src/lfx/base/models/provider_registry.py
@@ -35,6 +35,7 @@ test seam.
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import threading
 from dataclasses import dataclass, field
@@ -105,6 +106,13 @@ class ProviderSpec:
     #   validator(provider, variables, model_name) -> None  (raises ValueError on failure)
     live_discovery: str | None = None
     validator: str | None = None
+    # Optional static seed catalog injected into _STATIC_MODELS_DETAILED so the
+    # provider's models appear in the UI before any live fetch. Each entry is a
+    # ModelMetadata dict (same shape as create_model_metadata produces). Providers
+    # with live=True can still supply seeds as a fallback shown before credentials
+    # are configured; providers with live=False (e.g. deployment-specific clouds
+    # like Azure AI Foundry) rely entirely on this list.
+    models: list[dict] = field(default_factory=list)
 
     def model_class_name(self) -> str | None:
         """Class name this provider's metadata references for its LLM."""
@@ -133,6 +141,7 @@ class _Undo:
     embedding_param_keys: set[str] = field(default_factory=set)
     live_names: set[str] = field(default_factory=set)
     conditional_live_names: set[str] = field(default_factory=set)
+    static_model_groups: list[list[dict]] = field(default_factory=list)
 
 
 _undo = _Undo()
@@ -252,6 +261,13 @@ def register_provider(spec: ProviderSpec) -> bool:
         if spec.conditional_live and spec.name not in CONDITIONAL_LIVE_MODEL_PROVIDERS:
             CONDITIONAL_LIVE_MODEL_PROVIDERS.append(spec.name)
             _undo.conditional_live_names.add(spec.name)
+
+        # --- static model catalog (C5) ------------------------------------
+        if spec.models:
+            from lfx.base.models.unified_models.provider_queries import _STATIC_MODELS_DETAILED
+
+            _STATIC_MODELS_DETAILED.append(spec.models)
+            _undo.static_model_groups.append(spec.models)
 
         _registered[spec.name] = spec
         _live_discovery_cache.pop(spec.name, None)
@@ -374,6 +390,12 @@ def clear() -> None:
         for name in _undo.conditional_live_names:
             if name in CONDITIONAL_LIVE_MODEL_PROVIDERS:
                 CONDITIONAL_LIVE_MODEL_PROVIDERS.remove(name)
+        if _undo.static_model_groups:
+            from lfx.base.models.unified_models.provider_queries import _STATIC_MODELS_DETAILED
+
+            for group in _undo.static_model_groups:
+                with contextlib.suppress(ValueError):
+                    _STATIC_MODELS_DETAILED.remove(group)
         _registered.clear()
         _live_discovery_cache.clear()
         _validator_cache.clear()
@@ -384,4 +406,5 @@ def clear() -> None:
         _undo.embedding_param_keys.clear()
         _undo.live_names.clear()
         _undo.conditional_live_names.clear()
+        _undo.static_model_groups.clear()
         _clear_derived_caches()

--- a/src/lfx/src/lfx/extension/loader/_orchestrator.py
+++ b/src/lfx/src/lfx/extension/loader/_orchestrator.py
@@ -296,6 +296,7 @@ def _register_manifest_providers(
                 conditional_live=entry.conditional_live,
                 live_discovery=entry.live_discovery,
                 validator=entry.validator,
+                models=list(entry.models),
             )
             if not register_provider(spec):
                 result.warnings.append(

--- a/src/lfx/src/lfx/extension/loader/_orchestrator.py
+++ b/src/lfx/src/lfx/extension/loader/_orchestrator.py
@@ -563,6 +563,7 @@ def _read_inline_bundle_json(
         return {}
 
     def _warn(detail: str) -> None:
+        """Append a ``bundle-json-invalid`` warning to result, if result is available."""
         if result is None:
             return
         result.warnings.append(

--- a/src/lfx/src/lfx/extension/manifest.py
+++ b/src/lfx/src/lfx/extension/manifest.py
@@ -349,6 +349,19 @@ class ProviderManifestEntry(BaseModel):
         return value
 
     @model_validator(mode="after")
+    def _models_are_well_formed(self) -> ProviderManifestEntry:
+        """Raise if any models[] entry is missing a name or has a mismatched provider key."""
+        for entry in self.models:
+            if not entry.get("name"):
+                msg = f"provider {self.name!r} has a models[] entry without a non-empty 'name'"
+                raise ValueError(msg)
+            provider = entry.get("provider")
+            if provider is not None and provider != self.name:
+                msg = f"provider {self.name!r} has a models[] entry with mismatched provider {provider!r}"
+                raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
     def _live_mutually_exclusive(self) -> ProviderManifestEntry:
         """Raise if both ``live`` and ``conditional_live`` are set on the same provider."""
         if self.live and self.conditional_live:

--- a/src/lfx/src/lfx/extension/manifest.py
+++ b/src/lfx/src/lfx/extension/manifest.py
@@ -327,6 +327,14 @@ class ProviderManifestEntry(BaseModel):
         min_length=1,
         description="Dotted-path callable 'module:attr' validating credentials: (provider, variables, model) -> None.",
     )
+    models: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Optional static seed model catalog injected into _STATIC_MODELS_DETAILED. "
+            "Each entry is a ModelMetadata dict (same shape as create_model_metadata produces). "
+            "Use for providers whose model list is fixed (e.g. deployment-specific clouds)."
+        ),
+    )
 
     @field_validator("metadata")
     @classmethod

--- a/src/lfx/src/lfx/extension/manifest.py
+++ b/src/lfx/src/lfx/extension/manifest.py
@@ -137,6 +137,7 @@ class LfxCompat(BaseModel):
     @field_validator("compat")
     @classmethod
     def _compat_well_formed(cls, value: list[str]) -> list[str]:
+        """Validate that every compat entry is a positive-integer string and entries are unique."""
         for v in value:
             if not _COMPAT_VERSION_RE.fullmatch(v):
                 msg = f"compat entries must be positive-integer strings (got {v!r})"
@@ -226,6 +227,7 @@ class BundleRef(BaseModel):
     @field_validator("path")
     @classmethod
     def _validate_path_shape(cls, value: str) -> str:
+        """Reject empty, absolute, or parent-traversal (``..``) bundle paths."""
         if not value:
             msg = "Bundle path must not be empty"
             raise ValueError(msg)
@@ -339,6 +341,7 @@ class ProviderManifestEntry(BaseModel):
     @field_validator("metadata")
     @classmethod
     def _metadata_has_model_class(cls, value: dict[str, Any]) -> dict[str, Any]:
+        """Ensure provider metadata contains a non-empty ``mapping.model_class``."""
         mapping = value.get("mapping") if isinstance(value, dict) else None
         if not isinstance(mapping, dict) or not mapping.get("model_class"):
             msg = "provider.metadata must include a 'mapping' object with a non-empty 'model_class'"
@@ -347,6 +350,7 @@ class ProviderManifestEntry(BaseModel):
 
     @model_validator(mode="after")
     def _live_mutually_exclusive(self) -> ProviderManifestEntry:
+        """Raise if both ``live`` and ``conditional_live`` are set on the same provider."""
         if self.live and self.conditional_live:
             msg = f"provider {self.name!r} cannot set both 'live' and 'conditional_live'"
             raise ValueError(msg)
@@ -470,6 +474,7 @@ class ExtensionManifest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_declares_something(self) -> ExtensionManifest:
+        """Reject a manifest that declares neither bundles nor providers."""
         # An extension must contribute at least one bundle (components) or one
         # provider; an empty manifest is almost certainly a mistake.
         if not self.bundles and not self.providers:
@@ -479,6 +484,7 @@ class ExtensionManifest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_provider_name_uniqueness(self) -> ExtensionManifest:
+        """Raise if two providers in the same extension share a name."""
         names = [p.name for p in self.providers]
         if len(set(names)) != len(names):
             msg = "Provider names must be unique within an extension"
@@ -487,6 +493,7 @@ class ExtensionManifest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_bundle_uniqueness(self) -> ExtensionManifest:
+        """Raise if two bundle entries in the same extension share a name."""
         # The list-length constraint (exactly one bundle in v0) is encoded on
         # the field above so it lands in the JSON Schema.  This validator covers
         # what Field constraints can't express: bundle names must be unique


### PR DESCRIPTION
## Summary

Follows the bundle pattern established in #13916 and #13919. Adds **Azure AI Foundry** as a first-class model provider with **zero edits to core lfx files** beyond the small registry extension below.

Closes the provider gap raised in #13912, fixes the root cause opened in https://github.com/langflow-ai/langflow/issues/12771.

---

### Part 1 — registry extension (3 core files, minimal)

| File | Change |
|------|--------|
| `src/lfx/src/lfx/base/models/provider_registry.py` | Add `models: list[dict]` to `ProviderSpec`; inject into `_STATIC_MODELS_DETAILED` on `register_provider()`, undo on `clear()` |
| `src/lfx/src/lfx/extension/manifest.py` | Add `models: list[dict]` to `ProviderEntry` |
| `src/lfx/src/lfx/extension/loader/_orchestrator.py` | Pass `models=list(entry.models)` through to `ProviderSpec` |

This allows any future bundle to seed a **static model catalog** without touching `provider_queries.py`.

### Part 2 — `src/bundles/azure-ai-foundry/` (new, self-contained)

```
src/bundles/azure-ai-foundry/
├── pyproject.toml                        # depends on lfx + langchain-azure-ai
└── src/lfx_azure_ai_foundry/
    ├── __init__.py
    ├── extension.json                    # provider spec + seed catalog
    └── validator.py                      # credential probe via AzureAIOpenAIApiChatModel
```

`extension.json` declares:
- Provider metadata (`AZURE_AI_FOUNDRY_API_KEY`, `AZURE_AI_FOUNDRY_ENDPOINT`)
- `AzureAIOpenAIApiChatModel` from `langchain-azure-ai` (lazy import)
- Dotted-path validator
- Seed catalog: `gpt-4o` (default), `gpt-4o-mini`, `gpt-4.1`, `o3-mini`, `Mistral-Large-3`

---

### Tests (10, all pass, ruff clean)

- `models[]` injection into `_STATIC_MODELS_DETAILED` and `clear()` reversal
- End-to-end bundle load → provider in `get_model_providers()`, seeds in `get_models_detailed()`
- Validator: early-return paths (missing key/endpoint/model), success, `ValueError` on invoke failure

## Test plan

- [ ] `python3 -m pytest src/bundles/azure-ai-foundry/tests/ -q` → 10 passed
- [ ] `ruff check` on all changed files → all checks passed
- [ ] Install `lfx-azure-ai-foundry` bundle alongside Langflow — Azure AI Foundry appears in the model provider dropdown with seed models pre-populated

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an Azure AI Foundry extension bundle, including provider setup and bundled model options.
  * Extended provider registration so extensions can contribute a preset list of available models.
  * Added validation for Azure AI Foundry connection details to help confirm credentials before use.

* **Tests**
  * Added coverage for bundle loading, provider registration, model visibility, and credential validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->