### PR TITLE
fix(memory): propagate message cancellation

### DIFF
--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -184,6 +184,16 @@ async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:
         return [MessageRead.model_validate(message, from_attributes=True) for message in updated_messages]
 
 
+async def _rollback_session_after_cancel(session: AsyncSession) -> None:
+    rollback_task = asyncio.create_task(session.rollback())
+    while not rollback_task.done():
+        try:
+            await asyncio.shield(rollback_task)
+        except asyncio.CancelledError:
+            continue
+    await rollback_task
+
+
 async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession):
     """Add messages to the database.
 
@@ -203,7 +213,7 @@ async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession
         for message in messages:
             await session.refresh(message)
     except asyncio.CancelledError:
-        await session.rollback()
+        await _rollback_session_after_cancel(session)
         raise
     except Exception as e:
         await logger.aexception(e)

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -186,12 +186,25 @@ async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:
 
 async def _rollback_session_after_cancel(session: AsyncSession) -> None:
     rollback_task = asyncio.create_task(session.rollback())
-    while not rollback_task.done():
+    # Cleanup failures should be logged without replacing the original cancellation.
+    while True:
         try:
             await asyncio.shield(rollback_task)
         except asyncio.CancelledError:
-            continue
-    await rollback_task
+            if not rollback_task.done():
+                continue
+            try:
+                await rollback_task
+            except asyncio.CancelledError:
+                return
+            except Exception as e:  # noqa: BLE001
+                await logger.aexception(e)
+            return
+        except Exception as e:  # noqa: BLE001
+            await logger.aexception(e)
+            return
+        else:
+            return
 
 
 async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession):

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -184,44 +184,27 @@ async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:
         return [MessageRead.model_validate(message, from_attributes=True) for message in updated_messages]
 
 
-async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession, retry_count: int = 0):
-    """Add messages to the database with retry logic for CancelledError.
+async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession):
+    """Add messages to the database.
 
     Args:
         messages: List of MessageTable objects to add
         session: Database session
-        retry_count: Internal retry counter (max 3 retries to prevent infinite loops)
 
-    This function includes a workaround for CancelledError that can occur during
-    session.commit() when called from build_public_tmp but not from build_flow.
-    The retry mechanism has a limit to prevent infinite recursion.
+    CancelledError must propagate so task cancellation can be handled by the
+    caller and event loop.
     """
-    max_retries = 3
     try:
-        try:
-            for message in messages:
-                result = session.add(message)
-                if asyncio.iscoroutine(result):
-                    await result
-            await session.commit()
-            # This is a hack.
-            # We are doing this because build_public_tmp causes the CancelledError to be raised
-            # while build_flow does not.
-        except asyncio.CancelledError:
-            await session.rollback()
-            if retry_count >= max_retries:
-                await logger.awarning(
-                    f"Max retries ({max_retries}) reached for aadd_messagetables due to CancelledError"
-                )
-                error_msg = "Add Message operation cancelled after multiple retries"
-                raise ValueError(error_msg) from None
-            return await aadd_messagetables(messages, session, retry_count + 1)
+        for message in messages:
+            result = session.add(message)
+            if asyncio.iscoroutine(result):
+                await result
+        await session.commit()
         for message in messages:
             await session.refresh(message)
-    except asyncio.CancelledError as e:
-        await logger.aexception(e)
-        error_msg = "Operation cancelled"
-        raise ValueError(error_msg) from e
+    except asyncio.CancelledError:
+        await session.rollback()
+        raise
     except Exception as e:
         await logger.aexception(e)
         raise

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -154,6 +154,41 @@ async def test_aadd_messagetables_propagates_cancelled_error_from_refresh():
     session.rollback.assert_awaited_once()
 
 
+async def test_aadd_messagetables_finishes_rollback_when_cleanup_is_cancelled():
+    message = MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")
+    rollback_started = asyncio.Event()
+    finish_rollback = asyncio.Event()
+    rollback_completed = False
+
+    async def rollback():
+        nonlocal rollback_completed
+        rollback_started.set()
+        await finish_rollback.wait()
+        rollback_completed = True
+
+    session = SimpleNamespace(
+        add=lambda _message: None,
+        commit=AsyncMock(side_effect=asyncio.CancelledError()),
+        refresh=AsyncMock(),
+        rollback=AsyncMock(side_effect=rollback),
+    )
+    add_task = asyncio.create_task(aadd_messagetables([message], session))
+
+    await rollback_started.wait()
+    add_task.cancel()
+    await asyncio.sleep(0)
+
+    assert not add_task.done()
+    assert not rollback_completed
+
+    finish_rollback.set()
+    with pytest.raises(asyncio.CancelledError):
+        await add_task
+
+    assert rollback_completed
+    session.rollback.assert_awaited_once()
+
+
 @pytest.mark.usefixtures("client")
 def test_delete_messages():
     session_id = "new_session_id"

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -1,6 +1,8 @@
+import asyncio
 import base64
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -116,6 +118,40 @@ async def test_aadd_messagetables(async_session):
     added_messages = await aadd_messagetables(messages, async_session)
     assert len(added_messages) == 1
     assert added_messages[0].text == "New Test message"
+
+
+async def test_aadd_messagetables_propagates_cancelled_error_from_commit():
+    message = MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")
+    session = SimpleNamespace(
+        add=lambda _message: None,
+        commit=AsyncMock(side_effect=asyncio.CancelledError()),
+        refresh=AsyncMock(),
+        rollback=AsyncMock(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await aadd_messagetables([message], session)
+
+    session.commit.assert_awaited_once()
+    session.rollback.assert_awaited_once()
+    session.refresh.assert_not_awaited()
+
+
+async def test_aadd_messagetables_propagates_cancelled_error_from_refresh():
+    message = MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")
+    session = SimpleNamespace(
+        add=lambda _message: None,
+        commit=AsyncMock(),
+        refresh=AsyncMock(side_effect=asyncio.CancelledError()),
+        rollback=AsyncMock(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await aadd_messagetables([message], session)
+
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(message)
+    session.rollback.assert_awaited_once()
 
 
 @pytest.mark.usefixtures("client")

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -189,6 +189,21 @@ async def test_aadd_messagetables_finishes_rollback_when_cleanup_is_cancelled():
     session.rollback.assert_awaited_once()
 
 
+async def test_aadd_messagetables_keeps_cancelled_error_when_rollback_fails():
+    message = MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")
+    session = SimpleNamespace(
+        add=lambda _message: None,
+        commit=AsyncMock(side_effect=asyncio.CancelledError()),
+        refresh=AsyncMock(),
+        rollback=AsyncMock(side_effect=RuntimeError("rollback failed")),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await aadd_messagetables([message], session)
+
+    session.rollback.assert_awaited_once()
+
+
 @pytest.mark.usefixtures("client")
 def test_delete_messages():
     session_id = "new_session_id"


### PR DESCRIPTION
## Summary
- let `aadd_messagetables` propagate `asyncio.CancelledError` after rollback cleanup
- keep rollback cleanup running to completion if another cancellation arrives during cleanup
- log rollback cleanup failures without masking the original cancellation
- remove the recursive retry path that converted cancellation into `ValueError`
- add regression coverage for cancellation during commit, refresh, rollback cleanup, and rollback failure

Fixes #13827

## Tests
- `uv run pytest --timeout-method=thread src\backend\tests\unit\test_messages.py::test_aadd_messagetables src\backend\tests\unit\test_messages.py::test_aadd_messagetables_propagates_cancelled_error_from_commit src\backend\tests\unit\test_messages.py::test_aadd_messagetables_propagates_cancelled_error_from_refresh src\backend\tests\unit\test_messages.py::test_aadd_messagetables_finishes_rollback_when_cleanup_is_cancelled src\backend\tests\unit\test_messages.py::test_aadd_messagetables_keeps_cancelled_error_when_rollback_fails -q`
- `uv run ruff check src\backend\base\langflow\memory.py src\backend\tests\unit\test_messages.py`
- `uv run ruff format --check src\backend\base\langflow\memory.py src\backend\tests\unit\test_messages.py`
- `git diff --check`