### PR TITLE
fix(ci): stop nightly Group 3 timeout and db-migration superuser boot crash

### DIFF
--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -322,6 +322,15 @@ jobs:
                 - "7860:7860"
               environment:  # pragma: allowlist secret
                 - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow  # pragma: allowlist secret
+                # The published Docker image ships secure-by-default: its Dockerfile bakes
+                # LANGFLOW_AUTO_LOGIN=false and there is no built-in superuser password (#13822).
+                # This migration test authenticates via GET /api/v1/auto_login, which requires
+                # AUTO_LOGIN=true, so pin it here (overriding the image ENV) to keep that token
+                # flow working and ensure boot never lands in the "Username and password must be
+                # set" branch. The explicit superuser credentials are a fallback for that branch.
+                - LANGFLOW_AUTO_LOGIN=true
+                - LANGFLOW_SUPERUSER=langflow  # pragma: allowlist secret
+                - LANGFLOW_SUPERUSER_PASSWORD=langflow  # pragma: allowlist secret
               depends_on:
                 postgres:
                   condition: service_healthy

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3650,7 +3650,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 535,
         "is_secret": false
       },
       {
@@ -3658,7 +3658,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 745,
         "is_secret": false
       }
     ],
@@ -10710,5 +10710,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-30T17:24:09Z"
+  "generated_at": "2026-07-01T16:16:08Z"
 }

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -463,7 +463,10 @@ def get_lifespan(*, fix_migration=False, version=None):
 
             # Start the delayed initialization as a background task
             # Allows the server to start first to avoid race conditions with MCP Server startup
-            mcp_init_task = asyncio.create_task(delayed_init_mcp_servers())
+            if get_settings_service().settings.skip_mcp_auto_init:
+                await logger.adebug("Skipping MCP server auto-initialization (skip_mcp_auto_init=True)")
+            else:
+                mcp_init_task = asyncio.create_task(delayed_init_mcp_servers())
 
             async def refresh_models_dev_periodically() -> None:
                 """Hydrate the models.dev catalog at startup and refresh daily.

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -65,6 +65,22 @@ def disable_models_dev_refresh():
     os.environ.pop("LANGFLOW_MODELS_DEV_REFRESH", None)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def disable_mcp_auto_init():
+    """Keep the MCP server auto-initialization out of tests.
+
+    Every app boot otherwise schedules a lifespan task (``delayed_init_mcp_servers``)
+    that, ~10s in, reconciles each project's MCP server config. For apikey/none projects
+    that reconciliation spawns ``uvx mcp-proxy`` and makes an outbound connect with no
+    bounded timeout, so on a slow/CI runner it hangs until the OS connect timeout (~127s),
+    inflating every app-fixture test by ~130s and pushing the heaviest test split past the
+    CI step timeout. Skipping it keeps the boot local and deterministic.
+    """
+    os.environ["LANGFLOW_SKIP_MCP_AUTO_INIT"] = "true"
+    yield
+    os.environ.pop("LANGFLOW_SKIP_MCP_AUTO_INIT", None)
+
+
 # TODO: Revert this to True once bb.functions[func].can_block_in("http/client.py", "_safe_read") is fixed
 @pytest.fixture(autouse=False)
 def blockbuster(request):

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -58,6 +58,15 @@ class McpSettings(BaseModel):
     add_projects_to_mcp_servers: bool = True
     """If set to True, newly created projects will be added to the user's MCP servers config automatically."""
 
+    skip_mcp_auto_init: bool = False
+    """If set to True, Langflow skips the background MCP server auto-initialization on startup.
+
+    The startup task reconciles every project's MCP server config, which for apikey/none
+    projects can spawn ``uvx mcp-proxy`` and open an outbound connection. On an offline or
+    firewalled host (or CI) that connect has no bounded timeout and blocks until the OS
+    connect timeout (~127s). Enable this in tests or air-gapped deployments to keep startup
+    local and deterministic."""
+
     # MCP Composer
     mcp_composer_enabled: bool = True
     """If set to False, Langflow will not start the MCP Composer service."""

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -83,6 +83,7 @@ EXPECTED_FIELDS = {
     "mcp_server_enabled",
     "mcp_server_enable_progress_notifications",
     "add_projects_to_mcp_servers",
+    "skip_mcp_auto_init",
     "mcp_composer_enabled",
     "mcp_composer_version",
     # TelemetrySettings
@@ -361,6 +362,7 @@ def test_yaml_round_trip():
         ("LANGFLOW_PROMETHEUS_ENABLED", "true", "prometheus_enabled", True),
         ("LANGFLOW_PROMETHEUS_PORT", "9999", "prometheus_port", 9999),
         ("LANGFLOW_MCP_SERVER_ENABLED", "false", "mcp_server_enabled", False),
+        ("LANGFLOW_SKIP_MCP_AUTO_INIT", "true", "skip_mcp_auto_init", True),
         ("LANGFLOW_DO_NOT_TRACK", "true", "do_not_track", True),
         ("LANGFLOW_DEV", "true", "dev", True),
         ("LANGFLOW_BACKEND_ONLY", "true", "backend_only", True),


### PR DESCRIPTION
## Summary

The 2026-07-01 nightly run surfaced **two independent failures**. This PR fixes both. Branched from and targeting `release-1.11.0`; cherry-pick the squash to `main` as needed.

### 1. Backend Unit Tests — Group 3 (py3.12 / 3.13) timed out at ~98%

**Symptom:** Group 3 crawled to ~97–98%, hit the 50-min/attempt step timeout, retried, and died identically. Only the slower 3.12/3.13 interpreters tipped over (3.10/3.11/3.14 finished just under the wall; the marginal version drifts over time).

**Root cause:** the per-test `client` fixture boots the whole app. Its lifespan schedules `delayed_init_mcp_servers()`, which for `apikey`/`none` projects spawns `uvx mcp-proxy` and makes an **unbounded outbound connect**. On the firewalled CI runner that connect hangs ~127 s (Linux `tcp_syn_retries`), so **every** app-fixture test cost ~130 s instead of the ~5 s recorded in `.test_durations` — a ~25× blowup that `pytest-split` cannot rebalance — overrunning the step timeout deterministically (so the retry fails the same way).

**Fix:**
- New `skip_mcp_auto_init` setting (`LANGFLOW_SKIP_MCP_AUTO_INIT`, default `False`) that guards the startup task in `main.py`.
- A session-autouse conftest fixture enables it for the unit-test suite — mirrors the existing `disable_models_dev_refresh`, which already solves the same class of "lifespan task hits the network mid-test".
- Also a supported escape hatch for offline/air-gapped deployments.

### 2. DB Migration Validation — Docker Compose (stable → nightly) boot crash

**Symptom:** the nightly container crashed on boot with `ValueError: Username and password must be set` (`username='langflow', password=''`). The pip/venv variant of the same nightly passed.

**Root cause (confirmed — *not* a version/pin skew):** the published Docker image now ships **secure-by-default**. `c6dbca308d` (#13822, "remove hardcoded default superuser password") added `ENV LANGFLOW_AUTO_LOGIN=false` to the release-1.11.0 Dockerfiles and dropped the built-in default password; `#13836` then pointed this test at the newly-pushed nightly `.devX` images. I inspected the `1.11.0.dev27` image config directly — it bakes `LANGFLOW_AUTO_LOGIN=false`. The migration compose provides no superuser password and authenticates via `GET /api/v1/auto_login`, so the nightly image boots into the `AUTO_LOGIN`-disabled branch with an empty password and hard-fails. The **pip/venv** variant passed because `python -m langflow run` uses the *code* default (`AUTO_LOGIN=true`), not the Dockerfile ENV — that, not gunicorn-vs-uvicorn, is the real venv-pass/docker-fail split.

**Fix:** pin `LANGFLOW_AUTO_LOGIN=true` in the compose (overriding the image ENV) so the `auto_login` token flow the test uses keeps working and boot can't reach the empty-password branch. Explicit `LANGFLOW_SUPERUSER`/`LANGFLOW_SUPERUSER_PASSWORD` are a fallback for the disabled branch.

> **Design follow-up (optional, maintainer call):** this fix forces `AUTO_LOGIN=true`, which means the migration test no longer exercises the image *as shipped* (secure-by-default `AUTO_LOGIN=false`). A more faithful variant would keep `AUTO_LOGIN=false`, set `LANGFLOW_SUPERUSER_PASSWORD`, and switch the two docker-compose token acquisitions from `/api/v1/auto_login` to `POST /api/v1/login`. Happy to do that in a follow-up if preferred.
>
> Separately worth noting: a user running the published image without `LANGFLOW_SUPERUSER_PASSWORD` now crash-loops with the same `ValueError` — presumably intended fail-fast, but the startup UX/docs may deserve a look (out of scope here).

## Changes
- `src/lfx/src/lfx/services/settings/groups/mcp.py` — add `skip_mcp_auto_init` setting
- `src/backend/base/langflow/main.py` — guard MCP auto-init scheduling
- `src/backend/tests/conftest.py` — session-autouse `disable_mcp_auto_init`
- `src/lfx/tests/unit/services/settings/test_settings_composition.py` — cover the new field (EXPECTED_FIELDS + env round-trip)
- `.github/workflows/db-migration-validation.yml` — pin auth env in the compose service

## Test plan
- [x] `test_settings_composition.py` passes (27/27), incl. the field-count assertion and env round-trip for the new setting
- [x] Previously-hanging `test_messages.py::test_aupdate_*` boot and pass locally (~17 s for 3 tests incl. per-test boots)
- [x] `ruff format` / `ruff check` clean; pre-commit (detect-secrets, etc.) green
- [ ] CI: Backend Unit Tests **Group 3** completes well under the step timeout on 3.12 and 3.13
- [ ] CI: **DB Migration Validation (Docker Compose)** boots the nightly image and passes

## Notes
- Intentionally does **not** refresh `.test_durations`: the recorded ~5 s is the correct real cost; re-recording under the stall would just re-encode the bug. Refresh after this lands and a clean Group 3 run records real durations.
- The heavier "make the `client` fixture session-scoped" performance win is deferred — higher risk to test isolation, and unnecessary once the boot no longer hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
