### PR TITLE
fix(ci): backport nightly Group 3 timeout + db-migration boot fix to main (#13933)

### DIFF
--- a/.github/workflows/db-migration-validation.yml
+++ b/.github/workflows/db-migration-validation.yml
@@ -322,6 +322,15 @@ jobs:
                 - "7860:7860"
               environment:  # pragma: allowlist secret
                 - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow  # pragma: allowlist secret
+                # The published Docker image ships secure-by-default: its Dockerfile bakes
+                # LANGFLOW_AUTO_LOGIN=false and there is no built-in superuser password (#13822).
+                # This migration test authenticates via GET /api/v1/auto_login, which requires
+                # AUTO_LOGIN=true, so pin it here (overriding the image ENV) to keep that token
+                # flow working and ensure boot never lands in the "Username and password must be
+                # set" branch. The explicit superuser credentials are a fallback for that branch.
+                - LANGFLOW_AUTO_LOGIN=true
+                - LANGFLOW_SUPERUSER=langflow  # pragma: allowlist secret
+                - LANGFLOW_SUPERUSER_PASSWORD=langflow  # pragma: allowlist secret
               depends_on:
                 postgres:
                   condition: service_healthy

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2837,7 +2837,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 531,
         "is_secret": false
       },
       {
@@ -2845,7 +2845,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 741,
         "is_secret": false
       }
     ],
@@ -9287,5 +9287,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-24T03:30:55Z"
+  "generated_at": "2026-07-01T16:38:59Z"
 }

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -452,7 +452,10 @@ def get_lifespan(*, fix_migration=False, version=None):
 
             # Start the delayed initialization as a background task
             # Allows the server to start first to avoid race conditions with MCP Server startup
-            mcp_init_task = asyncio.create_task(delayed_init_mcp_servers())
+            if get_settings_service().settings.skip_mcp_auto_init:
+                await logger.adebug("Skipping MCP server auto-initialization (skip_mcp_auto_init=True)")
+            else:
+                mcp_init_task = asyncio.create_task(delayed_init_mcp_servers())
 
             async def refresh_models_dev_periodically() -> None:
                 """Hydrate the models.dev catalog at startup and refresh daily.

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -65,6 +65,22 @@ def disable_models_dev_refresh():
     os.environ.pop("LANGFLOW_MODELS_DEV_REFRESH", None)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def disable_mcp_auto_init():
+    """Keep the MCP server auto-initialization out of tests.
+
+    Every app boot otherwise schedules a lifespan task (``delayed_init_mcp_servers``)
+    that, ~10s in, reconciles each project's MCP server config. For apikey/none projects
+    that reconciliation spawns ``uvx mcp-proxy`` and makes an outbound connect with no
+    bounded timeout, so on a slow/CI runner it hangs until the OS connect timeout (~127s),
+    inflating every app-fixture test by ~130s and pushing the heaviest test split past the
+    CI step timeout. Skipping it keeps the boot local and deterministic.
+    """
+    os.environ["LANGFLOW_SKIP_MCP_AUTO_INIT"] = "true"
+    yield
+    os.environ.pop("LANGFLOW_SKIP_MCP_AUTO_INIT", None)
+
+
 # TODO: Revert this to True once bb.functions[func].can_block_in("http/client.py", "_safe_read") is fixed
 @pytest.fixture(autouse=False)
 def blockbuster(request):

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -58,6 +58,15 @@ class McpSettings(BaseModel):
     add_projects_to_mcp_servers: bool = True
     """If set to True, newly created projects will be added to the user's MCP servers config automatically."""
 
+    skip_mcp_auto_init: bool = False
+    """If set to True, Langflow skips the background MCP server auto-initialization on startup.
+
+    The startup task reconciles every project's MCP server config, which for apikey/none
+    projects can spawn ``uvx mcp-proxy`` and open an outbound connection. On an offline or
+    firewalled host (or CI) that connect has no bounded timeout and blocks until the OS
+    connect timeout (~127s). Enable this in tests or air-gapped deployments to keep startup
+    local and deterministic."""
+
     # MCP Composer
     mcp_composer_enabled: bool = True
     """If set to False, Langflow will not start the MCP Composer service."""

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -83,6 +83,7 @@ EXPECTED_FIELDS = {
     "mcp_server_enabled",
     "mcp_server_enable_progress_notifications",
     "add_projects_to_mcp_servers",
+    "skip_mcp_auto_init",
     "mcp_composer_enabled",
     "mcp_composer_version",
     # TelemetrySettings
@@ -357,6 +358,7 @@ def test_yaml_round_trip():
         ("LANGFLOW_PROMETHEUS_ENABLED", "true", "prometheus_enabled", True),
         ("LANGFLOW_PROMETHEUS_PORT", "9999", "prometheus_port", 9999),
         ("LANGFLOW_MCP_SERVER_ENABLED", "false", "mcp_server_enabled", False),
+        ("LANGFLOW_SKIP_MCP_AUTO_INIT", "true", "skip_mcp_auto_init", True),
         ("LANGFLOW_DO_NOT_TRACK", "true", "do_not_track", True),
         ("LANGFLOW_DEV", "true", "dev", True),
         ("LANGFLOW_BACKEND_ONLY", "true", "backend_only", True),


### PR DESCRIPTION
## Summary

Backport of #13933 (merged to `release-1.11.0`) to `main`. Two nightly CI fixes:

### 1. Backend Unit Tests — Group 3 (py3.12/3.13) timeout — **needed on main**

The per-test `client` fixture boots the app; its lifespan schedules `delayed_init_mcp_servers()`, whose per-project `uvx mcp-proxy` registration makes an **unbounded outbound connect** that hangs ~127 s (Linux `tcp_syn_retries`) on the firewalled CI runner. Every app-fixture test cost ~130 s — a ~25× blowup vs the ~5 s recorded in `.test_durations` — overrunning the 50-min/attempt step timeout, retrying, and failing identically. Fixed with a `skip_mcp_auto_init` setting (`LANGFLOW_SKIP_MCP_AUTO_INIT`), a guard on the startup task in `main.py`, and a session-autouse conftest fixture enabling it for the unit suite (mirrors `disable_models_dev_refresh`). main runs the same app-boot tests, so it's exposed to the same hang.

### 2. db-migration-validation compose auth — **harmless consistency on main**

Pins `LANGFLOW_AUTO_LOGIN=true` + explicit superuser creds in the compose. On `release-1.11.0` the published image bakes `ENV LANGFLOW_AUTO_LOGIN=false` (#13822), which caused a `Username and password must be set` boot crash in the migration test; **main's Dockerfiles do not set that**, so on main this is a no-op consistency / forward-proofing change (keeps the workflow identical across branches, and robust if that Dockerfile hardening is later forward-ported).

## Validation (on this main-based branch)
- [x] Cherry-pick applied cleanly except `.secrets.baseline` (auto-regenerated line numbers)
- [x] `get_settings_service` import + `mcp_init_task = None` init + None-safe cleanup all present on main
- [x] `test_settings_composition.py` — 27/27 (incl. field-count + env round-trip)
- [x] `test_messages.py::test_aupdate_*` boot and pass
- [x] `ruff` / pre-commit green

Cherry-picked from f342655cf1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to skip automatic MCP server initialization at startup, helping avoid slow or blocking startup behavior in restricted environments.

* **Bug Fixes**
  * Improved migration validation so authentication is configured explicitly during container-based checks.
  * Ensured test runs disable MCP auto-initialization by default for more reliable and isolated execution.

* **Tests**
  * Updated coverage to verify the new startup setting and its environment variable mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->