### PR TITLE
test(frontend): harden model dropdown footer clicks in select-gpt-model

### DIFF
--- a/src/frontend/tests/utils/select-gpt-model.ts
+++ b/src/frontend/tests/utils/select-gpt-model.ts
@@ -37,8 +37,22 @@ const openModelDropdown = async (page: Page, model: Locator) => {
   await page.waitForSelector('[role="listbox"]', { timeout: 10000 });
 };
 
+// The model dropdown footer buttons ("Manage providers", "Refresh list") render
+// inside the in-canvas popover, which is drawn without a portal
+// (PopoverContentWithoutPortal). When the language-model node sits low on the
+// canvas the footer can be clipped, or shift while the model list settles, so a
+// plain click() fails Playwright's "visible, enabled and stable" actionability
+// check and times out. Nudge the button into view and dispatch the click
+// directly — the same workaround already used for the model option below.
+const clickModelDropdownFooter = async (page: Page, testId: string) => {
+  const button = page.getByTestId(testId);
+  await button.waitFor({ state: "attached", timeout: 10000 });
+  await button.scrollIntoViewIfNeeded().catch(() => {});
+  await button.dispatchEvent("click");
+};
+
 const enablePreferredOpenAiModel = async (page: Page) => {
-  await page.getByTestId("manage-model-providers").click();
+  await clickModelDropdownFooter(page, "manage-model-providers");
   await page.waitForSelector("text=Model providers", { timeout: 30000 });
 
   await page.getByTestId("provider-item-OpenAI").click();
@@ -101,7 +115,7 @@ export const selectGptModel = async (page: Page) => {
       modelName = await enablePreferredOpenAiModel(page);
       await openModelDropdown(page, model);
       if ((await page.getByTestId(`${modelName}-option`).count()) === 0) {
-        await page.getByTestId("refresh-model-list").click();
+        await clickModelDropdownFooter(page, "refresh-model-list");
         await openModelDropdown(page, model);
       }
     }


### PR DESCRIPTION
## Summary

Fixes intermittent timeouts in the `@release @starter-projects` Playwright tests (Document Q&A, Twitter Thread Generator, and any starter flow driven through `initialGPTsetup`). All failures share one signature at [`select-gpt-model.ts`](../blob/release-1.10.2/src/frontend/tests/utils/select-gpt-model.ts) clicking the `manage-model-providers` footer button:

```
locator.click: Timeout 20000ms exceeded
  waiting for getByTestId('manage-model-providers')
  locator resolved to <button data-testid="manage-model-providers" …>
  … waiting for element to be visible, enabled and stable
```

## Root cause

The model dropdown footer buttons (**Manage providers**, **Refresh list**) render inside the in-canvas model popover, which is drawn **without a portal** (`PopoverContentWithoutPortal`). When the language-model node sits low on the canvas, the footer is clipped or keeps shifting while the model list settles, so a plain `.click()` never satisfies Playwright's "visible, enabled and stable" actionability check and times out after 20s.

This path is only reached in the **"enable provider" fallback** — i.e. when a preferred OpenAI model is not yet in the dropdown for that test-worker. Because provider config is shared per worker, exactly **one** test per worker hits this fragile click; the rest find the model already enabled. That's why the failure looked flaky and shard-order dependent rather than deterministic.

This is **not** a product regression — the model-selection popover UI predates the recent `release-1.10.2` commits. The failures surfaced now because these tests only run when `OPENAI_API_KEY` is available (internal branches), so they had been skipping on fork PRs.

## Fix

Route both footer clicks through a `clickModelDropdownFooter()` helper that waits for the button, scrolls it into view, and dispatches the click directly — the same `dispatchEvent("click")` workaround already used a few lines below for the model-option selection.

## Test plan

- [x] `biome check` passes on the edited file
- [ ] `@release` starter-project shards (Document Q&A, Twitter Thread Generator) pass on CI
- [ ] No behavior change for the already-passing tests (helper is a strict superset of the previous click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when interacting with dropdown footer actions in the model selection flow.
  * Reduced timeout issues by making these buttons more dependable to click during automated UI interactions.
  * Updated model provider management and model list refresh actions to work more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->