### PR TITLE
ci: surface nightly Group 3 stall via 90s pytest thread-timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,8 +186,15 @@ ignore-regex = '.*(Stati Uniti|Tense=Pres).*'
 
 
 [tool.pytest.ini_options]
-timeout = 150
-timeout_method = "signal"
+# DIAGNOSTIC (temporary): lowered from 150 and switched from "signal" to "thread" to identify the
+# nightly Backend Unit Tests Group 3 stall. Group 3 app-boot ("client" fixture) tests hang ~127s on
+# a firewalled outbound connect (Linux tcp_syn_retries); at timeout=150 that stall finished just
+# under the cap, so the per-test timeout never fired and the group silently accumulated until the
+# 50-min step wall. A 90s cap fires below the ~127s stall, and timeout_method="thread" dumps ALL
+# thread stacks (faulthandler) — naming the exact blocking call even when it is a leaked background
+# task. Revert to timeout=150 / timeout_method="signal" once the stall is identified and bounded.
+timeout = 90
+timeout_method = "thread"
 minversion = "6.0"
 testpaths = ["src/backend/tests", "src/lfx/tests", "src/bundles/*/tests"]
 console_output_style = "progress"


### PR DESCRIPTION
## Problem

Nightly **Backend Unit Tests Group 3** hangs at ~97–98%, hits the 50-min step wall, retries, and fails identically (e.g. [run 28539916502](https://github.com/langflow-ai/langflow/actions/runs/28539916502): py3.11/3.12/3.13 Group 3 hung while 3.10/3.14 passed). The recent `skip_mcp_auto_init` fix (#13933) is present in the failing run and **engages correctly**, but a 5-agent investigation showed it guards a *write-only* path (`init_mcp_servers → update_server` writes a config file; no socket), so it never removed the actual app-boot stall.

## Why the hang is *silent* (the key finding)

There is already a `timeout = 150` / `timeout_method = "signal"` in `[tool.pytest.ini_options]`. The Group 3 app-boot (`client` fixture) tests stall ~127s on a firewalled outbound connect (Linux `tcp_syn_retries`) — **just under the 150s cap** — so the per-test timeout never fires. Each stalling test slowly completes at ~127s and the group silently accumulates until the 50-min wall. `signal` method also wouldn't dump a leaked background task's stack.

## Change

```toml
timeout = 90            # was 150 — fires below the ~127s stall
timeout_method = "thread"   # was "signal" — dumps ALL thread stacks (faulthandler)
```

On the next Group 3 run, the first stalling test trips at 90s and prints a full faulthandler stack of every thread in the worker, naming the exact `file:line` of the blocking connect. With `-x` the job then fails fast **with a traceback** instead of grinding to the wall.

This is a **diagnostic / temporary** change (see inline comment). Once the stall is named, the fix is a bounded `asyncio.wait_for(...)` around that connect (prime suspect: the unbounded `streamablehttp_client(...)` at `src/lfx/src/lfx/base/mcp/util.py:1370`, which is not wrapped in `wait_for` and retries 3×), after which the timeout is reverted to 150/`signal` and `.test_durations` is refreshed on a clean run.

## Blast radius

Repo-global pytest config, so PR CI backend unit tests also get the 90s cap during the diagnostic window. Temporary, and arguably a useful safety net (no legitimate unit test should exceed 90s; `api_key_required` tests are excluded from the nightly).

## Test plan

- [ ] Dispatch a Nightly Build (or let PR CI run) and confirm Group 3 emits a faulthandler thread-stack dump naming the blocking call.
- [ ] Confirm no legitimate (non-stalling) unit test is falsely failed by the 90s cap.
- [ ] Follow-up PR: bound the identified connect with `asyncio.wait_for`, revert this diagnostic, then refresh `.test_durations`.

Companion PR opens the same change against `release-1.11.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test timeout settings to better handle intermittent long-running test runs.
  * Adjusted timeout enforcement to improve reliability during backend test execution.
  * Added a note clarifying the temporary testing change and the ongoing investigation into stalled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->