### PR TITLE
fix: log missing optional deps as one-line warning during component discovery (main)

### DIFF
--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -146,3 +146,59 @@ class TestComponentLoading:
         with patch("importlib.import_module", side_effect=MaxRetryError(None, "", reason="Connection timeout")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when MaxRetryError occurs"
+
+    @pytest.mark.no_blockbuster
+    @pytest.mark.asyncio
+    async def test_process_single_module_missing_optional_dep_logs_single_warning(self):
+        """A ModuleNotFoundError during import is an expected condition (optional dependency absent).
+
+        It must produce a single-line warning without a traceback, not an error with exc_info
+        (e.g. litellm/toolguard are deliberately excluded from Python 3.14 images).
+        """
+        from unittest.mock import MagicMock, patch
+
+        from lfx.interface.components import _process_single_module
+
+        mock_logger = MagicMock()
+        missing_dep = ModuleNotFoundError("No module named 'litellm'", name="litellm")
+        with (
+            patch("lfx.interface.components.logger", mock_logger),
+            patch("importlib.import_module", side_effect=missing_dep),
+        ):
+            result = _process_single_module("lfx.components.crewai.crewai")
+
+        assert result is None, "Should return None when the optional dependency is missing"
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_called_once()
+        args, kwargs = mock_logger.warning.call_args
+        message = args[0]
+        assert "lfx.components.crewai.crewai" in message
+        assert "litellm" in message
+        assert "exc_info" not in kwargs, "Missing optional dependency must not log a traceback"
+
+    @pytest.mark.no_blockbuster
+    @pytest.mark.asyncio
+    async def test_process_single_module_unexpected_import_error_logs_traceback(self):
+        """Any non-ModuleNotFoundError import failure (syntax error, real bug) must stay loud.
+
+        It should be logged at error level with the full traceback (exc_info=True).
+        """
+        from unittest.mock import MagicMock, patch
+
+        from lfx.interface.components import _process_single_module
+
+        mock_logger = MagicMock()
+        with (
+            patch("lfx.interface.components.logger", mock_logger),
+            patch("importlib.import_module", side_effect=RuntimeError("boom during import")),
+        ):
+            result = _process_single_module("lfx.components.test_module")
+
+        assert result is None, "Should return None when an unexpected exception occurs"
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_called_once()
+        args, kwargs = mock_logger.error.call_args
+        message = args[0]
+        assert "lfx.components.test_module" in message
+        assert "boom during import" in message
+        assert kwargs.get("exc_info") is True, "Unexpected import failures must keep the full traceback"

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -591,6 +591,12 @@ def _process_single_module(modname: str) -> tuple[str, dict] | None:
     """
     try:
         module = importlib.import_module(modname)
+    except ModuleNotFoundError as e:
+        # Expected when a component's optional dependency isn't installed (e.g. litellm and
+        # toolguard are excluded on Python 3.14 images), so a one-line warning is enough --
+        # a full traceback per affected module would flood startup logs for a normal condition.
+        logger.warning(f"Skipping component module {modname}: missing optional dependency ({e.name or e})")
+        return None
     except Exception as e:  # noqa: BLE001
         # Catch all exceptions during import to prevent component failures from crashing startup
         # TODO: Surface these errors to the UI in a friendly manner


### PR DESCRIPTION
## Summary

Python 3.14 Docker images deliberately exclude `litellm` and `toolguard` (gated `python_version < '3.14'` in `src/lfx/pyproject.toml`), so six core component modules fail to import at startup:

- `lfx/components/crewai/{crewai,hierarchical_crew,sequential_crew}.py` (via `lfx/base/agents/crewai/crew.py` → `import litellm`)
- `lfx/components/models_and_agents/policies/{guard_sync_utils,llm_wrapper,tool_invoker}.py` (`from toolguard...`)

`_process_single_module` in `src/lfx/src/lfx/interface/components.py` logged each of these at **error** level with `exc_info=True`, producing a full rich traceback (with locals) per module — hundreds of lines of startup noise for an expected condition.

This PR catches `ModuleNotFoundError` separately and logs a single-line warning without a traceback:

```
Skipping component module lfx.components.crewai.crewai: missing optional dependency (litellm)
```

Any other import failure (syntax error, real bug) still logs at error level with the full traceback, and the return value (`None`, module skipped) is unchanged in both cases. The component-instantiation failure path further down already aggregates into a single-line warning, so no change was needed there.

## Test plan

- [x] New test: `ModuleNotFoundError` during import → single `logger.warning` without `exc_info`, no `logger.error`
- [x] New test: any other exception during import → `logger.error` with `exc_info=True`, no warning
- [x] Existing `test_process_single_module_exception_handling` still passes (plain `ImportError` and other exception types stay on the loud error path)
- [x] `make format_backend` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Forward-port of #13941 (release-1.11.0) to main. Same commit, applied cleanly — `_process_single_module` and the touched test file are identical on both branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component loading when an optional dependency is missing, so the app now skips that module cleanly instead of treating it as a hard error.
  * Logging is now more accurate: missing modules generate a brief warning, while unexpected import failures still produce an error with full details.
* **Tests**
  * Added unit coverage for both missing-dependency and unexpected-import failure cases to verify the new logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->