### PR TITLE
fix: false duplicate-distribution extension errors from lib64 symlink aliasing in ubi Docker images (forward-port)

### DIFF
--- a/src/lfx/src/lfx/extension/loader/_plugins.py
+++ b/src/lfx/src/lfx/extension/loader/_plugins.py
@@ -299,6 +299,12 @@ def _resolve_distribution_roots(
     ``(winning_root, list_of_all_manifest_paths)``.  When the list has more
     than one entry, the canonical name was claimed by multiple distributions
     and the caller may surface ``duplicate-distribution`` warnings.
+
+    Manifest paths that are merely different spellings of one physical file
+    collapse to a single entry: RHEL-family venvs symlink ``lib64 -> lib``
+    and put both spellings on ``sys.path``, so
+    ``importlib.metadata.distributions()`` yields every distribution twice.
+    Only physically distinct manifests count as duplicates.
     """
     if distributions is None:
         distributions = importlib_metadata.distributions()
@@ -315,10 +321,32 @@ def _resolve_distribution_roots(
 
     resolved: dict[str, tuple[Path, list[Path]]] = {}
     for canonical, manifests in intermediate.items():
-        sorted_manifests = sorted(manifests, key=str)
+        sorted_manifests = _dedupe_aliased_manifests(sorted(manifests, key=str))
         winner = sorted_manifests[0].parent
         resolved[canonical] = (winner, sorted_manifests)
     return resolved
+
+
+def _dedupe_aliased_manifests(sorted_manifests: list[Path]) -> list[Path]:
+    """Collapse manifest paths that resolve to the same physical file.
+
+    Input must be pre-sorted; the first spelling of each physical manifest
+    is kept, so winner selection and error messages keep using the
+    unresolved on-``sys.path`` spelling.  A path that fails to resolve
+    (``OSError``) falls back to its raw spelling and is compared as-is.
+    """
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for manifest in sorted_manifests:
+        try:
+            identity = manifest.resolve()
+        except OSError:
+            identity = manifest
+        if identity in seen:
+            continue
+        seen.add(identity)
+        unique.append(manifest)
+    return unique
 
 
 def manifest_owning_distributions(

--- a/src/lfx/tests/unit/extension/loader/test_load_installed.py
+++ b/src/lfx/tests/unit/extension/loader/test_load_installed.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from lfx.extension import (
     SLOT_OFFICIAL,
     load_installed_extensions,
@@ -99,6 +100,47 @@ def test_duplicate_distribution_emits_warning(tmp_path: Path) -> None:
     assert err.hint  # AC: fix-hint payload
     # Winner's components still load -- only the conflict status changes.
     assert result.components, "Winner's components should still be loaded"
+
+
+def test_symlink_aliased_manifest_paths_are_not_duplicates(tmp_path: Path) -> None:
+    """Two sys.path spellings of ONE physical manifest must not emit duplicate-distribution.
+
+    RHEL-family (ubi) venvs create ``lib64`` as a symlink to ``lib`` and put
+    both spellings on ``sys.path``, so ``importlib.metadata.distributions()``
+    yields every installed distribution twice.  Both manifest paths resolve
+    to the same file, so the loader collapses them to one clean load instead
+    of a false ``duplicate-distribution`` error.  Physically distinct
+    manifests still error -- see
+    :func:`test_duplicate_distribution_emits_warning`.
+    """
+    lib_root = tmp_path / "lib"
+    make_installed_extension(lib_root, "lfx-pilot")
+    _populate_bundle(lib_root, "lfx-pilot")
+    lib64_root = tmp_path / "lib64"
+    try:
+        lib64_root.symlink_to(lib_root, target_is_directory=True)
+    except OSError:
+        pytest.skip("platform does not permit creating symlinks")
+
+    dist_lib = FakeDist(
+        name="lfx-pilot",
+        root=lib_root,
+        files=[Path("lfx-pilot") / "extension.json"],
+    )
+    dist_lib64 = FakeDist(
+        name="lfx-pilot",
+        root=lib64_root,
+        files=[Path("lfx-pilot") / "extension.json"],
+    )
+
+    results = load_installed_extensions(distributions=[dist_lib, dist_lib64])
+    assert len(results) == 1
+    result = results[0]
+    assert result.ok, [e.code for e in result.errors]
+    assert all(e.code != "duplicate-distribution" for e in result.errors)
+    # The lexicographically-first spelling (lib < lib64) is the winner.
+    assert result.source_path == (lib_root / "lfx-pilot").resolve()
+    assert result.components, "Aliased spellings must still load the winner's components"
 
 
 def test_no_installed_extensions_returns_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
Forward-port of #13943 to main (clean cherry-pick of e574e94679; the extension loader files are identical on both branches).

## Problem

Since #13893, the ubi10-based nightly Docker images log 16 `duplicate-distribution` extension errors at startup — one for every installed `lfx-*` bundle — even though nothing is actually duplicated.

RHEL-family venvs create `lib64` as a symlink to `lib` and put **both** path spellings on `sys.path`, so `importlib.metadata.distributions()` yields every installed distribution twice. `_resolve_distribution_roots` collected both manifest-path spellings under one canonical distribution name, so every manifest-shipping bundle tripped the `len(manifests) > 1` duplicate check in `load_installed_extensions` and logged a false error.

Verified in the running nightly container: all 16 reported duplicates are 2 path spellings resolving to 1 unique realpath, so this change eliminates all of them.

## Fix

In `_resolve_distribution_roots`, collapse manifest paths whose `Path.resolve()` is identical (an `OSError` during resolution falls back to comparing the raw path) before the duplicate check. The lexicographically-first *unresolved* spelling is kept, so winner selection and error messages are unchanged. Two physically distinct manifests still report `duplicate-distribution`.

## Test plan

- [x] New unit test: two fake distributions with the same canonical name whose manifest paths differ in spelling but resolve to the same file (via a `lib64 -> lib` symlink) load cleanly with zero `duplicate-distribution` errors
- [x] Existing `test_duplicate_distribution_emits_warning` still passes: two physically distinct manifests keep erroring
- [x] New test fails without the loader change (red/green verified)
- [x] `cd src/lfx && uv sync --dev && uv run pytest tests/unit/extension/` passes (the only failures are 4 pre-existing local-env failures in `test_bundle_api_changelog_script.py` caused by commit signing being unavailable in the sandbox, unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installed extension detection so manifests that point to the same physical file are no longer treated as duplicates.
  * Reduced false `duplicate-distribution` errors when the same manifest is reached through different filesystem paths.
  * Continued loading the selected extension normally after path deduplication.

* **Tests**
  * Added coverage for aliased manifest paths to verify only one extension is loaded and the expected manifest is chosen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->