### PR TITLE
feat: add LoopQuest human-in-the-loop tool component

### DIFF
--- a/src/backend/tests/unit/components/tools/test_loopquest.py
+++ b/src/backend/tests/unit/components/tools/test_loopquest.py
@@ -22,11 +22,18 @@ def test_build_task_body_defaults():
 
 def test_build_task_body_grounding_and_gate():
     body = build_task_body(
-        content="x", module="grounding", mode="gate", timeout_seconds=3600,
-        claim="Flood is covered.", source="Policy excludes flood.",
+        content="x",
+        module="grounding",
+        mode="gate",
+        timeout_seconds=3600,
+        claim="Flood is covered.",
+        source="Policy excludes flood.",
     )
     assert body["payload"] == {
-        "content": "x", "body": "x", "claim": "Flood is covered.", "source": "Policy excludes flood.",
+        "content": "x",
+        "body": "x",
+        "claim": "Flood is covered.",
+        "source": "Policy excludes flood.",
     }
     assert body["timeout_seconds"] == 3600
     assert body["on_timeout"] == "escalate"

--- a/src/backend/tests/unit/components/tools/test_loopquest.py
+++ b/src/backend/tests/unit/components/tools/test_loopquest.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+from lfx.components.tools.loopquest import LoopQuestComponent
+from lfx.components.tools.loopquest_core import build_task_body, verdict_to_string
+
+
+def test_loopquest_initialization():
+    component = LoopQuestComponent()
+    assert component.display_name == "LoopQuest Human Review"
+    assert component.name == "LoopQuestHumanReview"
+    assert component.icon == "LoopQuest"
+
+
+def test_build_task_body_defaults():
+    body = build_task_body(content="ship it?")
+    assert body["module"] == "swiper"
+    assert body["mode"] == "gate"
+    assert body["payload"] == {"content": "ship it?", "body": "ship it?"}
+    assert body["source"] == "langflow"
+    assert "timeout_seconds" not in body
+
+
+def test_build_task_body_grounding_and_gate():
+    body = build_task_body(
+        content="x", module="grounding", mode="gate", timeout_seconds=3600,
+        claim="Flood is covered.", source="Policy excludes flood.",
+    )
+    assert body["payload"] == {
+        "content": "x", "body": "x", "claim": "Flood is covered.", "source": "Policy excludes flood.",
+    }
+    assert body["timeout_seconds"] == 3600
+    assert body["on_timeout"] == "escalate"
+
+
+def test_verdict_to_string():
+    assert verdict_to_string({"status": "pending"}) is None
+    assert "APPROVED" in verdict_to_string({"status": "reviewed", "verdict": True})
+    flagged = verdict_to_string({"status": "reviewed", "verdict": False, "verdict_reason": "PII leak"})
+    assert "FLAGGED" in flagged
+    assert "PII leak" in flagged
+    assert "ESCALATED" in verdict_to_string({"status": "escalated"})
+
+
+def test_build_tool_returns_named_tool():
+    component = LoopQuestComponent()
+    component.api_key = "lq_test"
+    tool = component.build_tool()
+    assert tool.name == "request_human_review"
+
+
+@patch("lfx.components.tools.loopquest.time.sleep", return_value=None)
+@patch("lfx.components.tools.loopquest.httpx")
+def test_review_gate_returns_verdict(mock_httpx, _mock_sleep):
+    mock_httpx.HTTPError = Exception
+    created = MagicMock()
+    created.json.return_value = {"id": "t1"}
+    polled = MagicMock()
+    polled.json.return_value = {"status": "reviewed", "verdict": True}
+    mock_httpx.post.return_value = created
+    mock_httpx.get.return_value = polled
+
+    component = LoopQuestComponent()
+    component.api_key = "lq_test"
+    component.game = "swiper"
+    component.mode = "gate"
+    component.poll_seconds = 1
+    component.max_wait_seconds = 10
+    component.timeout_seconds = 3600
+
+    result = component._review("send the refund?")
+    assert "APPROVED" in result
+
+
+@patch("lfx.components.tools.loopquest.httpx")
+def test_review_monitor_does_not_wait(mock_httpx):
+    mock_httpx.HTTPError = Exception
+    created = MagicMock()
+    created.json.return_value = {"id": "t9"}
+    mock_httpx.post.return_value = created
+
+    component = LoopQuestComponent()
+    component.api_key = "lq_test"
+    component.game = "swiper"
+    component.mode = "monitor"
+    component.timeout_seconds = 3600
+    component.max_wait_seconds = 300
+    component.poll_seconds = 5
+
+    result = component._review("fyi only")
+    assert "monitor mode" in result
+    mock_httpx.get.assert_not_called()

--- a/src/lfx/src/lfx/components/tools/__init__.py
+++ b/src/lfx/src/lfx/components/tools/__init__.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from lfx.components.files_and_knowledge.filesystem import FileSystemToolComponent
 
     from .calculator import CalculatorToolComponent
+    from .loopquest import LoopQuestComponent
     from .python_repl import PythonREPLToolComponent
     from .search_api import SearchAPIComponent
     from .searxng import SearXNGToolComponent
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
 _dynamic_imports = {
     "CalculatorToolComponent": "calculator",
+    "LoopQuestComponent": "loopquest",
     # FileSystemToolComponent was moved to files_and_knowledge; forward it here
     # so existing flows / imports referencing lfx.components.tools keep working.
     "FileSystemToolComponent": ("filesystem", "files_and_knowledge"),
@@ -38,6 +40,7 @@ _dynamic_imports = {
 __all__ = [
     "CalculatorToolComponent",
     "FileSystemToolComponent",
+    "LoopQuestComponent",
     "PythonREPLToolComponent",
     "SearXNGToolComponent",
     "SearchAPIComponent",

--- a/src/lfx/src/lfx/components/tools/loopquest.py
+++ b/src/lfx/src/lfx/components/tools/loopquest.py
@@ -38,22 +38,40 @@ class LoopQuestComponent(LCToolComponent):
     inputs = [
         SecretStrInput(name="api_key", display_name="LoopQuest API Key", required=True, info="Workspaces → API keys."),
         MessageTextInput(
-            name="base_url", display_name="Base URL", value=DEFAULT_BASE_URL, advanced=True,
+            name="base_url",
+            display_name="Base URL",
+            value=DEFAULT_BASE_URL,
+            advanced=True,
             info="Only change this for a self-hosted LoopQuest deployment.",
         ),
-        DropdownInput(name="game", display_name="Game", options=GAMES, value="swiper", info="How the reviewer sees the item."),
         DropdownInput(
-            name="mode", display_name="Mode", options=["gate", "monitor"], value="gate",
+            name="game", display_name="Game", options=GAMES, value="swiper", info="How the reviewer sees the item."
+        ),
+        DropdownInput(
+            name="mode",
+            display_name="Mode",
+            options=["gate", "monitor"],
+            value="gate",
             info="Gate blocks until a human decides. Monitor creates the review and returns immediately.",
         ),
         MessageTextInput(name="content", display_name="Content", info="The item to review (used when run directly)."),
         MessageTextInput(name="title", display_name="Title", advanced=True),
         MessageTextInput(name="claim", display_name="Claim", advanced=True, info="Grounding only."),
         MessageTextInput(name="source", display_name="Source text", advanced=True, info="Grounding only."),
-        IntInput(name="timeout_seconds", display_name="Gate timeout (seconds)", value=3600, advanced=True,
-                 info="Server-side fail-closed timeout (30–2592000). On timeout it escalates."),
-        IntInput(name="max_wait_seconds", display_name="Max wait (seconds)", value=300, advanced=True,
-                 info="How long this component blocks polling for a verdict."),
+        IntInput(
+            name="timeout_seconds",
+            display_name="Gate timeout (seconds)",
+            value=3600,
+            advanced=True,
+            info="Server-side fail-closed timeout (30–2592000). On timeout it escalates.",
+        ),
+        IntInput(
+            name="max_wait_seconds",
+            display_name="Max wait (seconds)",
+            value=300,
+            advanced=True,
+            info="How long this component blocks polling for a verdict.",
+        ),
         IntInput(name="poll_seconds", display_name="Poll interval (seconds)", value=5, advanced=True),
     ]
 
@@ -63,7 +81,9 @@ class LoopQuestComponent(LCToolComponent):
     def _headers(self) -> dict:
         return {"authorization": f"Bearer {self.api_key}", "content-type": "application/json"}
 
-    def _review(self, content: str, title: str | None = None, claim: str | None = None, source: str | None = None) -> str:
+    def _review(
+        self, content: str, title: str | None = None, claim: str | None = None, source: str | None = None
+    ) -> str:
         if not self.api_key:
             msg = "LoopQuest API Key is missing. Please configure it on the component."
             raise ToolException(msg)
@@ -73,8 +93,15 @@ class LoopQuestComponent(LCToolComponent):
         poll = max(1, int(self.poll_seconds or 5))
         mode = self.mode or "gate"
         body = build_task_body(
-            content=content, module=self.game or "swiper", mode=mode, title=title, claim=claim,
-            source=source, timeout_seconds=timeout_seconds, on_timeout="escalate", review_source="langflow",
+            content=content,
+            module=self.game or "swiper",
+            mode=mode,
+            title=title,
+            claim=claim,
+            source=source,
+            timeout_seconds=timeout_seconds,
+            on_timeout="escalate",
+            review_source="langflow",
         )
         base = self._base_url()
         headers = self._headers()

--- a/src/lfx/src/lfx/components/tools/loopquest.py
+++ b/src/lfx/src/lfx/components/tools/loopquest.py
@@ -1,0 +1,121 @@
+import time
+
+import httpx
+from langchain_core.tools import StructuredTool, ToolException
+from pydantic import BaseModel, Field
+
+from lfx.base.langchain_utilities.model import LCToolComponent
+from lfx.field_typing import Tool
+from lfx.inputs.inputs import DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+
+try:  # packaged in the monorepo
+    from lfx.components.tools.loopquest_core import build_task_body, verdict_to_string
+except ImportError:  # standalone / tests
+    from loopquest_core import build_task_body, verdict_to_string
+
+DEFAULT_BASE_URL = "https://loopquest.tomphillips.uk"
+GAMES = ["swiper", "versus", "sorter", "detective", "fixer", "redact", "grounding"]
+
+
+class LoopQuestReviewSchema(BaseModel):
+    content: str = Field(..., description="The output or decision a human should review.")
+    title: str | None = Field(None, description="Optional short heading for the reviewer.")
+    claim: str | None = Field(None, description="Grounding game only: the claim to verify.")
+    source: str | None = Field(None, description="Grounding game only: the source text to check the claim against.")
+
+
+class LoopQuestComponent(LCToolComponent):
+    display_name = "LoopQuest Human Review"
+    description = (
+        "Send the agent's output to a human for review and wait for their verdict (approve/flag) before continuing."
+    )
+    icon = "LoopQuest"
+    name = "LoopQuestHumanReview"
+    documentation = "https://loopquest.tomphillips.uk/docs"
+
+    inputs = [
+        SecretStrInput(name="api_key", display_name="LoopQuest API Key", required=True, info="Workspaces → API keys."),
+        MessageTextInput(
+            name="base_url", display_name="Base URL", value=DEFAULT_BASE_URL, advanced=True,
+            info="Only change this for a self-hosted LoopQuest deployment.",
+        ),
+        DropdownInput(name="game", display_name="Game", options=GAMES, value="swiper", info="How the reviewer sees the item."),
+        DropdownInput(
+            name="mode", display_name="Mode", options=["gate", "monitor"], value="gate",
+            info="Gate blocks until a human decides. Monitor creates the review and returns immediately.",
+        ),
+        MessageTextInput(name="content", display_name="Content", info="The item to review (used when run directly)."),
+        MessageTextInput(name="title", display_name="Title", advanced=True),
+        MessageTextInput(name="claim", display_name="Claim", advanced=True, info="Grounding only."),
+        MessageTextInput(name="source", display_name="Source text", advanced=True, info="Grounding only."),
+        IntInput(name="timeout_seconds", display_name="Gate timeout (seconds)", value=3600, advanced=True,
+                 info="Server-side fail-closed timeout (30–2592000). On timeout it escalates."),
+        IntInput(name="max_wait_seconds", display_name="Max wait (seconds)", value=300, advanced=True,
+                 info="How long this component blocks polling for a verdict."),
+        IntInput(name="poll_seconds", display_name="Poll interval (seconds)", value=5, advanced=True),
+    ]
+
+    def _base_url(self) -> str:
+        return (self.base_url or DEFAULT_BASE_URL).rstrip("/")
+
+    def _headers(self) -> dict:
+        return {"authorization": f"Bearer {self.api_key}", "content-type": "application/json"}
+
+    def _review(self, content: str, title: str | None = None, claim: str | None = None, source: str | None = None) -> str:
+        if not self.api_key:
+            msg = "LoopQuest API Key is missing. Please configure it on the component."
+            raise ToolException(msg)
+        # Clamp to positive values — a 0/negative poll interval would tight-loop.
+        timeout_seconds = max(1, int(self.timeout_seconds or 3600))
+        max_wait = max(1, int(self.max_wait_seconds or 300))
+        poll = max(1, int(self.poll_seconds or 5))
+        mode = self.mode or "gate"
+        body = build_task_body(
+            content=content, module=self.game or "swiper", mode=mode, title=title, claim=claim,
+            source=source, timeout_seconds=timeout_seconds, on_timeout="escalate", review_source="langflow",
+        )
+        base = self._base_url()
+        headers = self._headers()
+        try:
+            created = httpx.post(f"{base}/api/v1/tasks", json=body, headers=headers, timeout=30)
+            created.raise_for_status()
+            task_id = created.json().get("id")
+            if not task_id:
+                return "Failed to create the review task."
+            if mode != "gate":
+                return f"Review task {task_id} created (monitor mode) — not waiting for a verdict."
+
+            deadline = time.monotonic() + max_wait
+            while time.monotonic() < deadline:
+                time.sleep(poll)
+                try:
+                    res = httpx.get(f"{base}/api/v1/tasks/{task_id}", headers=headers, timeout=30)
+                    res.raise_for_status()
+                    verdict = verdict_to_string(res.json())
+                    if verdict:
+                        self.status = verdict
+                        return verdict
+                except httpx.HTTPError:
+                    logger.debug("Transient error polling LoopQuest task %s", task_id, exc_info=True)
+            return "No human verdict within the wait window — treat as NOT approved (fail closed)."
+        except httpx.HTTPError as exc:
+            msg = f"Error contacting LoopQuest: {exc}"
+            raise ToolException(msg) from exc
+
+    def run_model(self) -> list[Data]:
+        verdict = self._review(self.content, self.title, self.claim, self.source)
+        self.status = verdict
+        return [Data(data={"result": verdict})]
+
+    def build_tool(self) -> Tool:
+        return StructuredTool.from_function(
+            name="request_human_review",
+            description=(
+                "Send content to a human reviewer and wait for their verdict. "
+                "Use before any consequential or irreversible action."
+            ),
+            func=self._review,
+            args_schema=LoopQuestReviewSchema,
+        )

--- a/src/lfx/src/lfx/components/tools/loopquest_core.py
+++ b/src/lfx/src/lfx/components/tools/loopquest_core.py
@@ -1,5 +1,6 @@
 """Pure helpers for the LoopQuest Langflow component — no Langflow imports, so
-they can be unit-tested in isolation."""
+they can be unit-tested in isolation.
+"""
 
 from __future__ import annotations
 

--- a/src/lfx/src/lfx/components/tools/loopquest_core.py
+++ b/src/lfx/src/lfx/components/tools/loopquest_core.py
@@ -1,0 +1,56 @@
+"""Pure helpers for the LoopQuest Langflow component — no Langflow imports, so
+they can be unit-tested in isolation."""
+
+from __future__ import annotations
+
+
+def build_task_body(
+    *,
+    content: str,
+    module: str = "swiper",
+    mode: str = "gate",
+    title: str | None = None,
+    claim: str | None = None,
+    source: str | None = None,
+    timeout_seconds: int | None = None,
+    on_timeout: str | None = "escalate",
+    review_source: str = "langflow",
+) -> dict:
+    """Build the POST /api/v1/tasks body from the tool call + component config."""
+    payload: dict = {"content": content, "body": content}
+    if claim:
+        payload["claim"] = claim
+    if source:
+        payload["source"] = source
+
+    body: dict = {
+        "module": module or "swiper",
+        "mode": mode or "gate",
+        "payload": payload,
+        "card": {"title": title or "Review", "body": content},
+        "source": review_source,
+    }
+    if timeout_seconds:
+        body["timeout_seconds"] = timeout_seconds
+    if on_timeout:
+        body["on_timeout"] = on_timeout
+    return body
+
+
+def verdict_to_string(task: dict) -> str | None:
+    """Turn a polled task into a human-readable verdict, or None while pending."""
+    status = task.get("status")
+    if status == "reviewed":
+        verdict = task.get("verdict")
+        decision = "APPROVED" if verdict is True else "FLAGGED" if verdict is False else "RESOLVED"
+        parts = [f"Human review {decision}"]
+        if task.get("verdict_choice"):
+            parts.append(f"choice: {task['verdict_choice']}")
+        if task.get("verdict_reason"):
+            parts.append(f"reason: {task['verdict_reason']}")
+        if task.get("timed_out"):
+            parts.append("(auto-resolved on timeout)")
+        return " · ".join(parts)
+    if status == "escalated":
+        return "Human review ESCALATED — no automatic verdict; a person will follow up."
+    return None


### PR DESCRIPTION
## New tool component: LoopQuest Human Review

Adds a component for [LoopQuest](https://loopquest.tomphillips.uk) — a human-in-the-loop step for agents. Before a consequential action, the agent calls `request_human_review`; a person reviews it, and the verdict returns to the agent.

### How it works
Langflow flows can't natively pause, so the component runs a **blocking gate**: it creates a review task in `gate` mode (`POST /api/v1/tasks`) and polls `GET /api/v1/tasks/{id}` until it resolves (or a fail-closed timeout escalates), then returns a readable verdict string. A **Monitor** mode creates the review and returns immediately.

### Files
- `src/lfx/src/lfx/components/tools/loopquest.py` — the `LCToolComponent`; `build_tool` returns a `StructuredTool` (`request_human_review`), and `run_model` supports direct use.
- `src/lfx/src/lfx/components/tools/loopquest_core.py` — pure helpers (task body + verdict formatting), unit-tested in the source repo.
- `src/lfx/src/lfx/components/tools/__init__.py` — registers `LoopQuestComponent` (TYPE_CHECKING import, `_dynamic_imports`, `__all__`).

### Config
Inputs: LoopQuest API key (SecretStr), game (swiper/versus/sorter/detective/fixer/redact/grounding), mode (gate/monitor), gate timeout, max wait, poll interval. The LLM supplies `content` (+ `title`, and `claim`/`source` for grounding). Intervals are clamped to ≥1s; requests are wrapped and transient poll errors ignored.

### Notes
- Auth is a Bearer API key; verifiable with `GET /api/v1/me`.
- Happy to provide a **dedicated, disposable test API key** for review — I'll share it privately (ping me) rather than posting a live credential here.
- If CI needs a lockfile/registry update beyond `tools/__init__.py`, flag it and I'll follow up.
- Docs: https://loopquest.tomphillips.uk/docs · OpenAPI: https://loopquest.tomphillips.uk/openapi.json
