### PR TITLE
feat(a2a): enforce oauth folders via owner-scoped api key at the A2A transport

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -89,12 +89,14 @@ async def _enforce_a2a_auth(flow: Flow, request: Request) -> None:
     run under the owner's identity. Gate by the folder's ``auth_type``:
 
     - ``"none"`` / missing / no-folder -> public agent (the intended public A2A model).
-    - ``"apikey"`` -> require a valid langflow API key in ``x-api-key`` whose owner is the
-      flow owner. Accepting another user's valid key would let them trigger a run under the
-      owner's identity, so scope to ``flow.user_id``.
-    - anything else (e.g. ``"oauth"``, which A2A can't enforce yet) -> fail closed with 403.
-      The card advertises no scheme for it, but treating a *protected* folder as public would
-      expose an owner-identity run anonymously, so deny until that scheme lands.
+    - ``"apikey"`` / ``"oauth"`` -> require a valid langflow API key in ``x-api-key`` whose
+      owner is the flow owner. An oauth folder is fronted by an external OAuth broker (the dance
+      happens in front); the langflow transport itself still takes an owner-scoped api key,
+      exactly as the MCP transport does (``mcp_projects.verify_project_auth``), since credential
+      forwarding from the broker isn't available yet. Accepting another user's valid key would
+      let them trigger a run under the owner's identity, so scope to ``flow.user_id``.
+    - anything else (an auth type A2A doesn't understand) -> fail closed with 403: treating a
+      *protected* folder as public would expose an owner-identity run anonymously.
 
     Uses ``check_key`` directly, NOT ``api_key_security``: under AUTO_LOGIN the latter
     returns the superuser for a *missing* key, which would silently bypass this gate.
@@ -105,8 +107,8 @@ async def _enforce_a2a_auth(flow: Flow, request: Request) -> None:
         auth_type = await folder_auth_type(flow, session)
         if auth_type == "none":
             return  # public agent
-        if auth_type != "apikey":
-            # Protected folder with a scheme A2A can't enforce yet: fail closed, never public.
+        if auth_type not in ("apikey", "oauth"):
+            # Protected folder with a scheme A2A can't enforce: fail closed, never public.
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"A2A access is disabled for this agent: unsupported folder auth type {auth_type!r}.",

--- a/src/backend/base/langflow/api/v1/a2a_utils.py
+++ b/src/backend/base/langflow/api/v1/a2a_utils.py
@@ -147,7 +147,10 @@ async def resolve_card_security(
     Reflects what the JSON-RPC route enforces. Returns ``(None, None)`` when there
     is no API-key requirement.
     """
-    if await folder_auth_type(flow, session) == "apikey":
+    # apikey and oauth both require an owner-scoped x-api-key at the A2A transport: oauth is
+    # fronted by an external broker, but the transport itself still takes an api key (mirrors
+    # mcp_projects.verify_project_auth), so both advertise the same apiKey scheme.
+    if await folder_auth_type(flow, session) in ("apikey", "oauth"):
         scheme = a2a_types.SecurityScheme(
             a2a_types.APIKeySecurityScheme(
                 in_=a2a_types.In.header,
@@ -157,8 +160,7 @@ async def resolve_card_security(
         )
         return {A2A_APIKEY_SCHEME_NAME: scheme}, [{A2A_APIKEY_SCHEME_NAME: []}]
 
-    # "none" / missing / "oauth" -> advertise no security. oauth has no advertised
-    # scheme yet, so the route leaves it public until that scheme lands.
+    # "none" / missing -> advertise no security (public agent).
     return None, None
 
 

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -217,15 +217,26 @@ async def test_security_schemes_apikey(client: AsyncClient, active_user, flow_da
 
 
 @pytest.mark.usefixtures("a2a_flag_on")
-async def test_no_security_for_oauth_folder(client: AsyncClient, active_user, flow_data):
-    """OAuth is out of F2 scope, so no security is advertised."""
+async def test_security_schemes_oauth_folder(client: AsyncClient, active_user, flow_data):
+    """An oauth folder advertises the same x-api-key scheme as apikey.
+
+    The broker fronts the OAuth dance, but the A2A transport still takes an owner-scoped api
+    key (mirrors the MCP transport), so the card reflects that.
+    """
     folder_id = await _create_folder(active_user.id, auth_settings={"auth_type": "oauth"})
     flow_id = await _create_flow(active_user.id, data=flow_data, folder_id=folder_id)
 
     body = (await client.get(_card_url(flow_id))).json()
 
-    assert "securitySchemes" not in body
-    assert "security" not in body
+    assert body["securitySchemes"] == {
+        "apiKey": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "x-api-key",
+            "description": "API key passed in the x-api-key header.",
+        }
+    }
+    assert body["security"] == [{"apiKey": []}]
 
 
 @pytest.mark.usefixtures("a2a_flag_on")
@@ -802,15 +813,23 @@ async def test_none_folder_stays_public(client: AsyncClient, active_user, echo_f
 
 
 @pytest.mark.usefixtures("a2a_flag_on")
-async def test_oauth_folder_fails_closed(client: AsyncClient, active_user, echo_flow_data):
-    """A2A can't enforce oauth yet, so an oauth folder fails closed (403), never public.
+async def test_oauth_folder_requires_owner_key(client: AsyncClient, active_user, echo_flow_data):
+    """An oauth folder is reachable with an owner-scoped x-api-key, and 401s without one.
 
-    Otherwise a protected flow would run anonymously as its owner.
+    The broker fronts OAuth; the transport still requires a key (mirrors MCP), so oauth enforces
+    like apikey here, never public and no longer a blanket 403 that makes the agent unreachable.
     """
     folder_id = await _create_folder(active_user.id, auth_settings={"auth_type": "oauth"})
     flow_id = await _create_flow(active_user.id, data=echo_flow_data, folder_id=folder_id)
 
-    assert (await _jsonrpc(client, flow_id, "message/send", _text_message("hi"))).status_code == 403
+    # No key -> 401, not public and not the old 403-dead.
+    assert (await _jsonrpc(client, flow_id, "message/send", _text_message("hi"))).status_code == 401
+
+    # A valid owner key runs the flow.
+    key = await _create_api_key(active_user.id)
+    resp = await _jsonrpc(client, flow_id, "message/send", _text_message("hello oauth"), headers={"x-api-key": key})
+    assert resp.status_code == 200
+    assert resp.json()["result"]["status"]["state"] == "completed"
 
 
 @pytest.mark.usefixtures("a2a_flag_on")


### PR DESCRIPTION
An oauth folder previously failed closed with 403 on every A2A request, so its agent was unreachable. This makes oauth enforce like apikey at the A2A transport: an owner-scoped x-api-key is required, and the card advertises the apiKey scheme.

The reasoning: langflow doesn't validate external OAuth/OIDC tokens itself anywhere. OAuth folders are fronted by an external broker, and the MCP transport already requires an api key at the transport for oauth folders (see `mcp_projects.verify_project_auth`: "credential forwarding from the broker is not yet available; use an API key in the meantime"). So this mirrors that, the broker fronts the OAuth dance and the transport still takes a key. Genuinely unknown auth types still fail closed with 403.

Validating an externally-issued OIDC bearer inside langflow would be net-new machinery that doesn't exist today, and it belongs across MCP too, not just A2A. I left that as a separate track.

Tests: an oauth card advertises the apiKey scheme, an oauth folder 401s without a key and runs with the owner's key, and an unknown auth type (saml) still 403s.
