### PR TITLE
feat(a2a): emit and consume DataPart so the application/json contract is real

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a_executor.py
+++ b/src/backend/base/langflow/api/v1/a2a_executor.py
@@ -12,11 +12,12 @@ compat adapter wired up in ``a2a.py``.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from uuid import UUID
 
-from a2a.helpers.proto_helpers import new_text_part
+from a2a.helpers.proto_helpers import get_data_parts, new_data_part, new_text_part
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
@@ -33,22 +34,27 @@ RunFlow = Callable[[UUID, str, str, str | None], Awaitable[WorkflowExecutionResp
 ResumeFlow = Callable[[UUID, str, str], Awaitable[WorkflowExecutionResponse]]
 
 
-def _answer_texts(response: WorkflowExecutionResponse) -> list[str]:
-    """The run's text answer(s) for the A2A artifact.
+def _answer_parts(response: WorkflowExecutionResponse) -> list[pb.Part]:
+    """The run's answer as A2A artifact parts: text for string channels, data for the rest.
 
-    SINGLE is the canonical agent shape (one ChatOutput); preserve its text,
-    including an intentional "". A multi-output agent flow resolves to MULTIPLE
-    with the answers in ``outputs`` (output.text is None), so emit each text
-    channel rather than silently dropping them. NONE/NON_STRING have no string
-    text channel, so there's nothing to return.
+    SINGLE is the canonical agent shape (one ChatOutput); preserve its text, including an
+    intentional "". Otherwise read each ``outputs`` channel: a string message/text becomes a
+    text part, and anything else that carries content (a ``data``-typed output, or a non-string
+    payload) becomes an ``application/json`` data part, so a structured / data-only flow emits
+    its JSON instead of being silently dropped to an empty text answer. The card already
+    advertises ``application/json`` output, so this makes that contract real.
     """
     if response.output.reason == OutputReason.SINGLE:
-        return [response.output.text or ""]
-    return [
-        output.content
-        for output in response.outputs.values()
-        if output.type in {"message", "text"} and isinstance(output.content, str)
-    ]
+        return [new_text_part(response.output.text or "")]
+    parts: list[pb.Part] = []
+    for output in response.outputs.values():
+        if output.content is None:
+            continue
+        if output.type in {"message", "text"} and isinstance(output.content, str):
+            parts.append(new_text_part(output.content))
+        else:
+            parts.append(new_data_part(output.content, media_type="application/json"))
+    return parts
 
 
 class FlowAgentExecutor(AgentExecutor):
@@ -83,6 +89,13 @@ class FlowAgentExecutor(AgentExecutor):
         await updater.start_work()
 
         text = context.get_user_input()
+        if not text and context.message is not None:
+            # A caller can send structured input as DataPart(s) with no text. The flow input is
+            # a text channel, so serialize the data to JSON so it reaches the flow rather than
+            # being dropped. Plain-text input is untouched (the common case).
+            data = get_data_parts(context.message.parts)
+            if data:
+                text = json.dumps(data[0] if len(data) == 1 else data)
         try:
             if resuming:
                 response = await self._resume_flow(UUID(flow_id), context.task_id, text)
@@ -111,7 +124,7 @@ class FlowAgentExecutor(AgentExecutor):
             await updater.failed(updater.new_agent_message([new_text_part(detail)]))
             return
 
-        parts = [new_text_part(answer) for answer in _answer_texts(response)]
+        parts = _answer_parts(response)
         await updater.add_artifact(parts or [new_text_part("")], name="result")
         await updater.complete()
 

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -1086,13 +1086,14 @@ def _response(*, output, outputs=None):
     return WorkflowExecutionResponse(flow_id="f", status=JobStatus.COMPLETED, output=output, outputs=outputs or {})
 
 
-def test_answer_texts_resolves_each_output_reason():
-    """SINGLE keeps its text (even ""); MULTIPLE recovers every text channel; NONE is empty."""
-    from langflow.api.v1.a2a_executor import _answer_texts
+def test_answer_parts_resolves_each_output_reason():
+    """SINGLE keeps its text (even ""); MULTIPLE recovers every text channel; NONE emits nothing."""
+    from a2a.helpers.proto_helpers import get_data_parts, get_text_parts
+    from langflow.api.v1.a2a_executor import _answer_parts
     from lfx.schema.workflow import ComponentOutput, JobStatus, OutputReason, WorkflowOutput
 
     single = _response(output=WorkflowOutput(reason=OutputReason.SINGLE, text=""))
-    assert _answer_texts(single) == [""]
+    assert get_text_parts(_answer_parts(single)) == [""]
 
     multi = _response(
         output=WorkflowOutput(reason=OutputReason.MULTIPLE),
@@ -1101,10 +1102,11 @@ def test_answer_texts_resolves_each_output_reason():
             "b": ComponentOutput(type="text", status=JobStatus.COMPLETED, content="y"),
         },
     )
-    assert _answer_texts(multi) == ["x", "y"]
+    assert get_text_parts(_answer_parts(multi)) == ["x", "y"]
+    assert get_data_parts(_answer_parts(multi)) == []
 
     none = _response(output=WorkflowOutput(reason=OutputReason.NONE))
-    assert _answer_texts(none) == []
+    assert _answer_parts(none) == []
 
 
 # --- durable task store ----------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -7,6 +7,7 @@ object, the served card is revalidated against the a2a-sdk model, and message/se
 runs a real echo flow through the v2 surface.
 """
 
+import json
 import uuid
 from pathlib import Path
 
@@ -372,6 +373,74 @@ async def test_message_send_runs_flow_and_returns_completed_task(client: AsyncCl
     assert result["kind"] == "task"
     assert result["status"]["state"] == "completed"
     assert result["artifacts"][0]["parts"][0]["text"] == "hello a2a"
+
+
+# --- DataPart (structured application/json I/O) ----------------------------
+
+
+def _data_message(data, message_id="m1"):
+    """A message whose sole part is a structured DataPart (no text)."""
+    return {"message": {"role": "user", "parts": [{"kind": "data", "data": data}], "messageId": message_id}}
+
+
+def test_answer_parts_emits_data_for_structured_output():
+    """A data-typed / non-string output emits an application/json data part, not an empty text answer."""
+    from a2a.helpers.proto_helpers import get_data_parts, get_text_parts
+    from langflow.api.v1.a2a_executor import _answer_parts
+    from lfx.schema.workflow import (
+        ComponentOutput,
+        JobStatus,
+        OutputReason,
+        WorkflowExecutionResponse,
+        WorkflowOutput,
+    )
+
+    response = WorkflowExecutionResponse(
+        flow_id="f",
+        status=JobStatus.COMPLETED,
+        output=WorkflowOutput(reason=OutputReason.NONE),
+        outputs={
+            "c1": ComponentOutput(type="text", status=JobStatus.COMPLETED, content="hi"),
+            "c2": ComponentOutput(type="data", status=JobStatus.COMPLETED, content={"answer": "42"}),
+        },
+    )
+
+    parts = _answer_parts(response)
+
+    # The string channel stays text; the structured channel round-trips as a data part.
+    assert get_text_parts(parts) == ["hi"]
+    assert get_data_parts(parts) == [{"answer": "42"}]
+
+
+def test_answer_parts_single_stays_text():
+    """The canonical single-answer shape stays a text part (no regression)."""
+    from a2a.helpers.proto_helpers import get_data_parts, get_text_parts
+    from langflow.api.v1.a2a_executor import _answer_parts
+    from lfx.schema.workflow import JobStatus, OutputReason, WorkflowExecutionResponse, WorkflowOutput
+
+    response = WorkflowExecutionResponse(
+        flow_id="f",
+        status=JobStatus.COMPLETED,
+        output=WorkflowOutput(reason=OutputReason.SINGLE, text="hello"),
+    )
+
+    parts = _answer_parts(response)
+
+    assert get_text_parts(parts) == ["hello"]
+    assert get_data_parts(parts) == []
+
+
+@pytest.mark.usefixtures("a2a_flag_on")
+async def test_message_send_consumes_data_part_input(client: AsyncClient, active_user, echo_flow_data):
+    """A DataPart-only message (no text) reaches the flow as JSON; the echo flow returns it verbatim."""
+    flow_id = await _create_flow(active_user.id, data=echo_flow_data)
+
+    response = await _jsonrpc(client, flow_id, "message/send", _data_message({"foo": "bar"}))
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"]["state"] == "completed"
+    assert result["artifacts"][0]["parts"][0]["text"] == json.dumps({"foo": "bar"})
 
 
 @pytest.mark.usefixtures("a2a_flag_on")


### PR DESCRIPTION
The agent card advertises application/json input and output modes, but the executor emitted text-only Parts. A structured (data-typed or non-string) output was silently dropped to an empty text answer, so the advertised contract wasn't real.

This emits an `application/json` data part for data-typed / non-string outputs, while string message/text channels stay text parts and the canonical single-answer shape is unchanged. On the input side, a DataPart-only message (no text) is serialized to JSON so it reaches the text-shaped flow input instead of being dropped.

Tests: `_answer_parts` emits a data part for a structured output and keeps a single answer as text, and a DataPart-only message/send reaches the echo flow as JSON and comes back verbatim.
