### PR TITLE
feat(a2a): set the card protocolVersion explicitly instead of the sdk default

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a_utils.py
+++ b/src/backend/base/langflow/api/v1/a2a_utils.py
@@ -27,6 +27,13 @@ from langflow.utils.version import get_version_info
 A2A_APIKEY_SCHEME_NAME = "apiKey"  # pragma: allowlist secret
 A2A_APIKEY_HEADER = "x-api-key"  # pragma: allowlist secret
 
+# The A2A protocol version the server actually speaks: the JSON-RPC v0.3 surface served via the
+# a2a-sdk compat layer (JsonRpcDispatcher(enable_v0_3_compat=True) in a2a.py). Set explicitly on
+# the card instead of relying on the sdk's default, so an sdk bump can't silently change what we
+# advertise. The latest spec is on the 1.x line, but we serve 0.3 today, so 0.3 is the truthful
+# value; bump this when the server actually moves onto the 1.x protocol.
+A2A_PROTOCOL_VERSION = "0.3.0"
+
 # Served when a flow's graph can't be built; the card stays valid, the input
 # contract is just empty rather than 500ing the public discovery endpoint.
 _EMPTY_INPUT_SCHEMA = {"type": "object", "properties": {}, "required": []}
@@ -206,6 +213,7 @@ async def build_agent_card(flow: Flow, *, rpc_url: str, session: AsyncSession) -
         description=description,
         url=rpc_url,
         version=version,
+        protocol_version=A2A_PROTOCOL_VERSION,
         capabilities=capabilities,
         default_input_modes=["application/json"],
         default_output_modes=["application/json"],

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -15,6 +15,7 @@ import orjson
 import pytest
 from a2a.compat.v0_3 import types as a2a_types
 from httpx import AsyncClient
+from langflow.api.v1 import a2a_utils
 from langflow.helpers.flow import json_schema_from_flow
 from langflow.services.database.models import Folder
 from langflow.services.database.models.flow.model import Flow, FlowType
@@ -92,7 +93,9 @@ async def test_get_agent_card_returns_valid_card(client: AsyncClient, active_use
     assert response.status_code == 200
     body = response.json()
     assert body["url"].endswith(f"/api/v1/a2a/{flow_id}/jsonrpc")
-    assert body["protocolVersion"] == "0.3.0"
+    # protocolVersion is set explicitly from our constant (not the sdk default), so an sdk bump
+    # can't silently change it; it stays 0.3.0 while the server speaks the v0.3 compat protocol.
+    assert body["protocolVersion"] == a2a_utils.A2A_PROTOCOL_VERSION == "0.3.0"
     assert body["preferredTransport"] == "JSONRPC"
 
     # The card (minus the non-model inputSchema key) revalidates against the SDK model.


### PR DESCRIPTION
The agent card advertised its protocolVersion via the a2a-sdk compat default, so an sdk bump could silently change what we advertise. This pins it to an explicit `A2A_PROTOCOL_VERSION` constant that the card reads.

The value stays 0.3.0 on purpose: the server speaks the JSON-RPC v0.3 surface via `JsonRpcDispatcher(enable_v0_3_compat=True)`, so 0.3.0 is the truthful protocol version. The latest spec is on the 1.x line, but we don't serve that yet, and advertising 1.x while speaking 0.3 would be worse than a stale-but-honest version. When the server moves onto the 1.x protocol, bump the constant.

`preferredTransport` (JSONRPC) is already correct, so it's untouched.

Test: the served card's protocolVersion is asserted to equal the constant and 0.3.0, so a future bump has to update both deliberately.
