### PR TITLE
feat(a2a): add an owner-scoped agent registry endpoint

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -34,7 +34,7 @@ from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from a2a.server.tasks import BasePushNotificationSender, InMemoryPushNotificationConfigStore, TaskStore
 from a2a.types import a2a_pb2 as pb
 from a2a.utils.errors import InvalidParamsError
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from google.protobuf.json_format import MessageToDict, ParseDict
 from lfx.graph.checkpoint.schema import GraphCheckpoint
 from lfx.graph.checkpoint.store import CheckpointStore
@@ -480,7 +480,10 @@ _DISPATCHER = JsonRpcDispatcher(
 )
 
 
-@router.get("/agents")
+# The flag guard is a route dependency so it runs BEFORE the CurrentActiveUser auth dependency
+# (FastAPI resolves decorator dependencies first): a disabled route must look unmounted (404) to an
+# anonymous caller, not leak a 403 from auth resolving ahead of an in-body flag check.
+@router.get("/agents", dependencies=[Depends(_require_a2a_enabled)])
 async def list_a2a_agents(request: Request, session: DbSession, current_user: CurrentActiveUser) -> list[dict]:
     """List the caller's own A2A-published agent flows, each with its agent-card URL.
 
@@ -489,7 +492,6 @@ async def list_a2a_agents(request: Request, session: DbSession, current_user: Cu
     agents, so this enumerates only the calling user's agents. Each ``cardUrl`` is the public
     discovery entry point an orchestrator fetches per agent.
     """
-    _require_a2a_enabled()
     base = str(request.base_url).rstrip("/")
     flows = (
         await session.exec(select(Flow).where(Flow.user_id == current_user.id, Flow.flow_type == FlowType.AGENT))

--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -52,7 +52,7 @@ from lfx.utils.ssrf_transport import create_ssrf_protected_client
 from lfx.workflow.converters import parse_workflow_run_request, run_response_to_workflow_response
 from sqlmodel import select
 
-from langflow.api.utils import DbSession
+from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.utils.flow_utils import compute_virtual_flow_id, scope_session_to_namespace
 from langflow.api.v1.a2a_executor import FlowAgentExecutor
 from langflow.api.v1.a2a_utils import (
@@ -478,6 +478,33 @@ _DISPATCHER = JsonRpcDispatcher(
     # tasks/pushNotificationConfig/{set,get,list,delete}
     enable_v0_3_compat=True,
 )
+
+
+@router.get("/agents")
+async def list_a2a_agents(request: Request, session: DbSession, current_user: CurrentActiveUser) -> list[dict]:
+    """List the caller's own A2A-published agent flows, each with its agent-card URL.
+
+    Authenticated and owner-scoped, mirroring the MCP-projects catalog: a public cross-user
+    directory would strip the per-flow card's unguessable-id obscurity and expose other users'
+    agents, so this enumerates only the calling user's agents. Each ``cardUrl`` is the public
+    discovery entry point an orchestrator fetches per agent.
+    """
+    _require_a2a_enabled()
+    base = str(request.base_url).rstrip("/")
+    flows = (
+        await session.exec(select(Flow).where(Flow.user_id == current_user.id, Flow.flow_type == FlowType.AGENT))
+    ).all()
+    # a2a_enabled is bool|None; filter truthiness in Python, matching the card route's gate.
+    return [
+        {
+            "id": str(flow.id),
+            "name": flow.name,
+            "description": flow.description,
+            "cardUrl": f"{base}/api/v1/a2a/{flow.id}/.well-known/agent-card.json",
+        }
+        for flow in flows
+        if flow.a2a_enabled
+    ]
 
 
 @router.get("/{flow_id}/.well-known/agent-card.json")

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -299,6 +299,26 @@ async def test_malformed_overrides_fall_back_to_defaults(client: AsyncClient, ac
     assert "examples" not in body["skills"][0]
 
 
+# --- agent registry (owner-scoped listing) ---------------------------------
+
+
+@pytest.mark.usefixtures("a2a_flag_on")
+async def test_list_agents_is_owner_scoped(client: AsyncClient, active_user, logged_in_headers, flow_data):
+    """GET /a2a/agents lists only the caller's own agent + a2a_enabled flows, each with a card URL."""
+    enabled = await _create_flow(active_user.id, data=flow_data)  # agent + a2a_enabled: included
+    await _create_flow(active_user.id, data=flow_data, a2a_enabled=False)  # excluded: a2a disabled
+    await _create_flow(active_user.id, data=flow_data, flow_type=FlowType.WORKFLOW)  # excluded: not an agent
+    other = await _create_other_user()
+    await _create_flow(other, data=flow_data)  # excluded: another user's agent
+
+    resp = await client.get("api/v1/a2a/agents", headers=logged_in_headers)
+
+    assert resp.status_code == 200
+    agents = resp.json()
+    assert [a["id"] for a in agents] == [str(enabled)]
+    assert agents[0]["cardUrl"].endswith(f"/api/v1/a2a/{enabled}/.well-known/agent-card.json")
+
+
 # --- JSON-RPC message/send + tasks/get -------------------------------------
 
 _ECHO_FLOW = Path(__file__).parents[3] / "data" / "chat_echo_no_llm.json"

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -319,6 +319,12 @@ async def test_list_agents_is_owner_scoped(client: AsyncClient, active_user, log
     assert agents[0]["cardUrl"].endswith(f"/api/v1/a2a/{enabled}/.well-known/agent-card.json")
 
 
+async def test_list_agents_flag_off_returns_404(client: AsyncClient):
+    """The registry looks unmounted (404) when the flag is off, before auth runs (no 403 leak)."""
+    response = await client.get("api/v1/a2a/agents")
+    assert response.status_code == 404
+
+
 # --- JSON-RPC message/send + tasks/get -------------------------------------
 
 _ECHO_FLOW = Path(__file__).parents[3] / "data" / "chat_echo_no_llm.json"


### PR DESCRIPTION
Discovery today is one card per flow URL: an orchestrator has to know each flow id up front. This adds `GET /api/v1/a2a/agents`, which lists the caller's own A2A-published agent flows (agent-typed + a2a_enabled), each with its agent-card URL, so agents can be enumerated.

Auth model: authenticated and owner-scoped, mirroring the MCP-projects catalog. A public cross-user directory would strip the per-flow card's unguessable-id obscurity and expose every user's agents, so the registry lists only the calling user's agents. The per-flow card itself stays public (unchanged), it's just no longer the only way to find an agent.

Test: the listing returns only the caller's agent + a2a_enabled flows (a disabled flow, a non-agent flow, and another user's agent are all excluded) with the correct card URL.
