### PR TITLE
feat(a2a): implement tasks/cancel with a durable terminal state

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -26,6 +26,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import httpx
+from a2a.server.agent_execution.active_task import TERMINAL_TASK_STATES
 from a2a.server.context import ServerCallContext
 from a2a.server.owner_resolver import resolve_user_scope
 from a2a.server.request_handlers import DefaultRequestHandler
@@ -33,7 +34,7 @@ from a2a.server.routes.common import DefaultServerCallContextBuilder
 from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from a2a.server.tasks import BasePushNotificationSender, InMemoryPushNotificationConfigStore, TaskStore
 from a2a.types import a2a_pb2 as pb
-from a2a.utils.errors import InvalidParamsError, TaskNotFoundError
+from a2a.utils.errors import InvalidParamsError, TaskNotCancelableError, TaskNotFoundError
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from google.protobuf.json_format import MessageToDict, ParseDict
 from lfx.graph.checkpoint.schema import GraphCheckpoint
@@ -490,9 +491,20 @@ class _DurableCancelHandler(DefaultRequestHandler):
         if await _TASK_STORE.get(params.id, context) is None:
             raise TaskNotFoundError
         task = await super().on_cancel_task(params, context)
-        if task is not None and task.status.state != pb.TaskState.TASK_STATE_CANCELED:
-            task.status.state = pb.TaskState.TASK_STATE_CANCELED
-            await _TASK_STORE.save(task, context)
+        if task is None:
+            return None
+        if task.status.state in TERMINAL_TASK_STATES:
+            # Already terminal: done if it's CANCELED. Otherwise the run finished (a registry-resident
+            # task in the async-cleanup window, or one a stream subscriber still pins) and the SDK
+            # returned it terminal-but-uncanceled instead of raising. Match the SDK's cold path and
+            # refuse, rather than clobbering a real COMPLETED/FAILED with CANCELED in the store.
+            if task.status.state != pb.TaskState.TASK_STATE_CANCELED:
+                raise TaskNotCancelableError
+            return task
+        # Non-terminal: the SDK left a parked (input-required) task unchanged, so force terminal
+        # CANCELED into the returned task and the durable store.
+        task.status.state = pb.TaskState.TASK_STATE_CANCELED
+        await _TASK_STORE.save(task, context)
         return task
 
 

--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -33,7 +33,7 @@ from a2a.server.routes.common import DefaultServerCallContextBuilder
 from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from a2a.server.tasks import BasePushNotificationSender, InMemoryPushNotificationConfigStore, TaskStore
 from a2a.types import a2a_pb2 as pb
-from a2a.utils.errors import InvalidParamsError
+from a2a.utils.errors import InvalidParamsError, TaskNotFoundError
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response, status
 from google.protobuf.json_format import MessageToDict, ParseDict
 from lfx.graph.checkpoint.schema import GraphCheckpoint
@@ -402,6 +402,19 @@ def _is_terminal_cancel(blob: dict[str, Any] | None) -> bool:
     return bool(blob) and (blob.get("status") or {}).get("state") == "TASK_STATE_CANCELED"
 
 
+def _task_scope(context: ServerCallContext) -> str:
+    """Owner key for the durable task store, scoped to the flow.
+
+    ``resolve_user_scope`` returns '' for every anonymous public caller, so without the flow it
+    keys all public flows' tasks together and a caller could read or cancel another flow's task by
+    id through a different flow's endpoint. Folding the path ``flow_id`` into the key makes such a
+    cross-flow lookup miss. Falls back to the plain owner scope when no flow_id is on the context.
+    """
+    owner = resolve_user_scope(context)
+    flow_id = (getattr(context, "state", None) or {}).get("flow_id")
+    return f"{flow_id}\x00{owner}" if flow_id else owner
+
+
 class DurableTaskStore(TaskStore):
     """DB-backed A2A task store keyed by ``(task_id, owner)``.
 
@@ -412,10 +425,12 @@ class DurableTaskStore(TaskStore):
     """
 
     async def save(self, task: pb.Task, context: ServerCallContext) -> None:
-        owner = resolve_user_scope(context)
+        owner = _task_scope(context)
         blob: dict[str, Any] = MessageToDict(task)
         async with session_scope() as session:
-            row = await session.get(A2ATask, (task.id, owner))
+            # Lock the row so a completion racing a cancel can't read stale state and then clobber
+            # the terminal CANCELED (Postgres row lock; a no-op on SQLite, which serializes writers).
+            row = await session.get(A2ATask, (task.id, owner), with_for_update=True)
             if row is None:
                 session.add(A2ATask(id=task.id, owner=owner, task=blob))
             elif _is_terminal_cancel(row.task) and not _is_terminal_cancel(blob):
@@ -426,7 +441,7 @@ class DurableTaskStore(TaskStore):
                 row.task = blob  # fresh dict reference flags the JSON column dirty
 
     async def get(self, task_id: str, context: ServerCallContext) -> pb.Task | None:
-        owner = resolve_user_scope(context)
+        owner = _task_scope(context)
         async with session_scope_readonly() as session:  # pure read, no commit
             row = await session.get(A2ATask, (task_id, owner))
             blob = row.task if row is not None else None
@@ -463,6 +478,12 @@ class _DurableCancelHandler(DefaultRequestHandler):
     """
 
     async def on_cancel_task(self, params, context: ServerCallContext):
+        # The in-memory ActiveTaskRegistry is keyed by task id only, not flow, so without this a
+        # cancel could reach a task created under a different flow's endpoint. Gate on the
+        # flow-scoped store: a task this flow can't see is "not found" here (and we never reveal
+        # that it exists under another flow).
+        if await _TASK_STORE.get(params.id, context) is None:
+            raise TaskNotFoundError
         task = await super().on_cancel_task(params, context)
         if task is not None and task.status.state != pb.TaskState.TASK_STATE_CANCELED:
             task.status.state = pb.TaskState.TASK_STATE_CANCELED

--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -411,10 +411,13 @@ def _task_scope(context: ServerCallContext) -> str:
     keys all public flows' tasks together and a caller could read or cancel another flow's task by
     id through a different flow's endpoint. Folding the path ``flow_id`` into the key makes such a
     cross-flow lookup miss. Falls back to the plain owner scope when no flow_id is on the context.
+
+    Delimited by ':' like ``_push_config_scope``: the flow_id prefix is a UUID (no ':'), so the key
+    is unambiguous, and it avoids a NUL byte that Postgres text columns reject at write time.
     """
     owner = resolve_user_scope(context)
     flow_id = (getattr(context, "state", None) or {}).get("flow_id")
-    return f"{flow_id}\x00{owner}" if flow_id else owner
+    return f"{flow_id}:{owner}" if flow_id else owner
 
 
 class DurableTaskStore(TaskStore):

--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -397,6 +397,11 @@ class A2ACheckpointStore(CheckpointStore):
         raise NotImplementedError
 
 
+def _is_terminal_cancel(blob: dict[str, Any] | None) -> bool:
+    """True when a stored task blob is in the terminal CANCELED state (MessageToDict enum name)."""
+    return bool(blob) and (blob.get("status") or {}).get("state") == "TASK_STATE_CANCELED"
+
+
 class DurableTaskStore(TaskStore):
     """DB-backed A2A task store keyed by ``(task_id, owner)``.
 
@@ -413,6 +418,10 @@ class DurableTaskStore(TaskStore):
             row = await session.get(A2ATask, (task.id, owner))
             if row is None:
                 session.add(A2ATask(id=task.id, owner=owner, task=blob))
+            elif _is_terminal_cancel(row.task) and not _is_terminal_cancel(blob):
+                # tasks/cancel already made this task terminal; a run that completes on this worker
+                # after the cancel must not clobber CANCELED with a non-cancel state. Terminal is final.
+                return
             else:
                 row.task = blob  # fresh dict reference flags the JSON column dirty
 
@@ -435,6 +444,30 @@ class DurableTaskStore(TaskStore):
     async def delete(self, task_id: str, context: ServerCallContext) -> None:
         # ponytail: no mounted path calls delete this slice.
         raise NotImplementedError
+
+
+# Shared durable task store: read/written by the SDK handler and by _DurableCancelHandler, which
+# forces a terminal CANCELED into it so tasks/cancel works for parked tasks and can't be lost to an
+# event-queue close.
+_TASK_STORE = DurableTaskStore()
+
+
+class _DurableCancelHandler(DefaultRequestHandler):
+    """Make tasks/cancel terminal, including for parked tasks the SDK won't touch.
+
+    The V2 handler only preempts a *live* producer (ActiveTask.cancel no-ops once the producer has
+    finished), so cancelling a parked input-required task returns it unchanged, and cancelling a live
+    run whose queue closed can leave it stuck 'working'. After delegating (which still preempts a live
+    producer same-worker), force CANCELED into the returned task and the durable store so the state is
+    terminal for both cases. A run on another worker still can't be preempted (LE-1699).
+    """
+
+    async def on_cancel_task(self, params, context: ServerCallContext):
+        task = await super().on_cancel_task(params, context)
+        if task is not None and task.status.state != pb.TaskState.TASK_STATE_CANCELED:
+            task.status.state = pb.TaskState.TASK_STATE_CANCELED
+            await _TASK_STORE.save(task, context)
+        return task
 
 
 # One shared httpx client sends webhooks; a short timeout so a slow/hostile webhook
@@ -464,9 +497,9 @@ async def close_push_client() -> None:
 # default in-memory QueueManager); a terminal or cross-worker task returns a spec error
 # and tasks/get covers terminal reads. Push configs are in-memory per-worker; durable
 # cross-worker re-attach and push delivery are a later slice.
-_HANDLER = DefaultRequestHandler(
+_HANDLER = _DurableCancelHandler(
     agent_executor=FlowAgentExecutor(_run_flow, _resume_flow),
-    task_store=DurableTaskStore(),
+    task_store=_TASK_STORE,
     agent_card=pb.AgentCard(capabilities=pb.AgentCapabilities(streaming=True, push_notifications=True)),
     push_config_store=_PUSH_CONFIG_STORE,
     push_sender=_PUSH_SENDER,
@@ -474,8 +507,8 @@ _HANDLER = DefaultRequestHandler(
 _DISPATCHER = JsonRpcDispatcher(
     request_handler=_HANDLER,
     context_builder=_FlowContextBuilder(),
-    # routes spec method names: message/send, message/stream, tasks/get, tasks/resubscribe,
-    # tasks/pushNotificationConfig/{set,get,list,delete}
+    # routes spec method names: message/send, message/stream, tasks/get, tasks/cancel,
+    # tasks/resubscribe, tasks/pushNotificationConfig/{set,get,list,delete}
     enable_v0_3_compat=True,
 )
 

--- a/src/backend/base/langflow/api/v1/a2a_executor.py
+++ b/src/backend/base/langflow/api/v1/a2a_executor.py
@@ -116,5 +116,8 @@ class FlowAgentExecutor(AgentExecutor):
         await updater.complete()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
-        # ponytail: synchronous message/send runs aren't cancelable; tasks/cancel is out of scope.
-        raise NotImplementedError
+        # The durable terminal CANCELED is written by the request handler (see a2a.py); here we only
+        # emit the terminal cancel event so a live message/stream subscriber sees it. Must not raise:
+        # the SDK marks the task FAILED if agent cancel raises. Only invoked for a live producer; a
+        # parked (finished) task's cancel is handled entirely in the handler.
+        await TaskUpdater(event_queue, context.task_id, context.context_id).cancel()

--- a/src/backend/base/langflow/api/v1/a2a_executor.py
+++ b/src/backend/base/langflow/api/v1/a2a_executor.py
@@ -142,6 +142,8 @@ class FlowAgentExecutor(AgentExecutor):
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
         # The durable terminal CANCELED is written by the request handler (see a2a.py); here we only
         # emit the terminal cancel event so a live message/stream subscriber sees it. Must not raise:
-        # the SDK marks the task FAILED if agent cancel raises. Only invoked for a live producer; a
-        # parked (finished) task's cancel is handled entirely in the handler.
-        await TaskUpdater(event_queue, context.task_id, context.context_id).cancel()
+        # the SDK marks the task FAILED if agent cancel raises, so suppress a failed emit (e.g. an
+        # already-closed queue). Only invoked for a live producer; a parked (finished) task's cancel
+        # is handled entirely in the handler.
+        with contextlib.suppress(Exception):
+            await TaskUpdater(event_queue, context.task_id, context.context_id).cancel()

--- a/src/backend/base/langflow/api/v1/a2a_executor.py
+++ b/src/backend/base/langflow/api/v1/a2a_executor.py
@@ -12,6 +12,8 @@ compat adapter wired up in ``a2a.py``.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from uuid import UUID
@@ -88,6 +90,15 @@ class FlowAgentExecutor(AgentExecutor):
                 response = await self._resume_flow(UUID(flow_id), context.task_id, text)
             else:
                 response = await self._run_flow(UUID(flow_id), context.task_id, text, context.context_id)
+        except asyncio.CancelledError:
+            # tasks/cancel preempted this live run (the SDK cancels the producer task). Emit a
+            # terminal CANCELED on this producer's OWN queue before it closes, so the original
+            # message/send / message/stream consumer gets a terminal event instead of hanging on the
+            # last 'working' state, then propagate the cancellation (never swallow it, or the task
+            # won't wind down). The durable store is set to CANCELED by the request handler.
+            with contextlib.suppress(Exception):
+                await updater.cancel()
+            raise
         except Exception:
             # Unexpected build/timeout/system failures become a failed Task, not a 500.
             # The endpoint is unauthenticated, so don't hand the caller raw exception

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -1213,3 +1213,44 @@ async def test_durable_store_roundtrips_on_real_migrated_db():
             return "other"
 
     assert await DurableTaskStore().get(task_id, ServerCallContext(user=_Other())) is None
+
+
+# --- tasks/cancel ----------------------------------------------------------
+
+
+@pytest.mark.usefixtures("a2a_flag_on")
+async def test_cancel_input_required_task(client: AsyncClient, active_user, human_input_flow_data):
+    """tasks/cancel transitions a parked input-required task to canceled, durably."""
+    flow_id = await _create_flow(active_user.id, data=human_input_flow_data)
+
+    paused = (await _jsonrpc(client, flow_id, "message/send", _text_message("start"))).json()["result"]
+    assert paused["status"]["state"] == "input-required"
+    task_id = paused["id"]
+
+    canceled = (await _jsonrpc(client, flow_id, "tasks/cancel", {"id": task_id})).json()["result"]
+    assert canceled["status"]["state"] == "canceled"
+
+    # Durably persisted: tasks/get reads canceled back from the store.
+    got = (await _jsonrpc(client, flow_id, "tasks/get", {"id": task_id})).json()["result"]
+    assert got["status"]["state"] == "canceled"
+
+
+@pytest.mark.usefixtures("client")
+async def test_durable_store_wont_clobber_terminal_cancel():
+    """A run completing on the same worker after a cancel must not overwrite terminal CANCELED."""
+    from a2a.server.context import ServerCallContext
+    from a2a.types import a2a_pb2 as pb
+    from langflow.api.v1.a2a import DurableTaskStore
+
+    store = DurableTaskStore()
+    ctx = ServerCallContext()
+    tid = uuid.uuid4().hex
+
+    await store.save(pb.Task(id=tid, context_id="c", status=pb.TaskStatus(state=pb.TaskState.TASK_STATE_CANCELED)), ctx)
+    # A late completion is ignored once the task is terminally canceled.
+    await store.save(
+        pb.Task(id=tid, context_id="c", status=pb.TaskStatus(state=pb.TaskState.TASK_STATE_COMPLETED)), ctx
+    )
+
+    got = await store.get(tid, ctx)
+    assert got.status.state == pb.TaskState.TASK_STATE_CANCELED

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -842,7 +842,10 @@ async def test_resume_via_other_flow_is_rejected(client: AsyncClient, active_use
             _text_message("Approve", message_id="m2", context_id=context_id, task_id=task_id),
         )
     ).json()
-    assert via_b.get("result", {}).get("status", {}).get("state") != "completed"
+    # The flow-scoped store misses flow A's task, so the SDK returns a JSON-RPC error (not found),
+    # not a result. Assert the error envelope, not just "didn't complete" (which any state satisfies).
+    assert "error" in via_b
+    assert "result" not in via_b
 
     # Flow A's task is untouched and still resumable through flow A.
     resumed = (
@@ -1365,6 +1368,50 @@ async def test_cancel_input_required_task(client: AsyncClient, active_user, huma
     assert got["status"]["state"] == "canceled"
 
 
+@pytest.mark.usefixtures("a2a_flag_on")
+async def test_cancel_wont_flip_a_completed_task(client: AsyncClient, active_user, echo_flow_data):
+    """A run that already finished must not be rewritten to canceled by a racing tasks/cancel."""
+    from a2a.server.agent_execution.active_task import ActiveTask
+    from a2a.server.tasks.task_manager import TaskManager
+    from langflow.api.v1.a2a import _HANDLER
+
+    flow_id = await _create_flow(active_user.id, data=echo_flow_data)
+    done = (await _jsonrpc(client, flow_id, "message/send", _text_message("hi"))).json()["result"]
+    assert done["status"]["state"] == "completed"
+    task_id, context_id = done["id"], done["contextId"]
+
+    # Reproduce the race window: the finished task is still resident in the ActiveTaskRegistry
+    # (the async cleanup hasn't run, or a stream subscriber pins it), so tasks/cancel hits the
+    # registry-HIT path where ActiveTask.cancel returns the terminal task unchanged instead of the
+    # already-correct registry-miss path that raises. Seed a finished ActiveTask exactly as
+    # get_or_create builds one; it reads the completed task back through the request's context.
+    registry = _HANDLER._active_task_registry
+    task_manager = TaskManager(
+        task_store=registry._task_store, context=None, task_id=task_id, context_id=context_id, initial_message=None
+    )
+    active_task = ActiveTask(
+        agent_executor=registry._agent_executor,
+        task_id=task_id,
+        task_manager=task_manager,
+        push_sender=registry._push_sender,
+        on_cleanup=registry._on_active_task_cleanup,
+    )
+    active_task._is_finished.set()
+    active_task._task_created.set()
+    registry._active_tasks[task_id] = active_task
+    try:
+        # Not cancelable: expect a JSON-RPC error (TaskNotCancelableError), not a canceled result.
+        resp = (await _jsonrpc(client, flow_id, "tasks/cancel", {"id": task_id})).json()
+        assert "error" in resp
+        assert "result" not in resp
+
+        # The durable terminal state is untouched.
+        got = (await _jsonrpc(client, flow_id, "tasks/get", {"id": task_id})).json()["result"]
+        assert got["status"]["state"] == "completed"
+    finally:
+        registry._active_tasks.pop(task_id, None)
+
+
 @pytest.mark.usefixtures("client")
 async def test_durable_store_wont_clobber_terminal_cancel():
     """A run completing on the same worker after a cancel must not overwrite terminal CANCELED."""
@@ -1407,9 +1454,12 @@ async def test_cancel_is_scoped_to_the_path_flow(client: AsyncClient, active_use
     assert paused["status"]["state"] == "input-required"
     task_id = paused["id"]
 
-    # Same task id, sent to flow B: must not reach flow A's task (flow B can't see it).
+    # Same task id, sent to flow B: the flow-scoped gate makes it "not found", so flow B gets a
+    # JSON-RPC error with no result. Assert that (not just "not canceled"), or a full disclosure of
+    # flow A's task through flow B's endpoint would still pass the check.
     via_b = (await _jsonrpc(client, flow_b, "tasks/cancel", {"id": task_id})).json()
-    assert via_b.get("result", {}).get("status", {}).get("state") != "canceled"
+    assert "error" in via_b
+    assert "result" not in via_b
 
     # Flow A's task is untouched by the cross-flow attempt.
     got = (await _jsonrpc(client, flow_a, "tasks/get", {"id": task_id})).json()["result"]
@@ -1449,6 +1499,9 @@ async def test_execute_emits_canceled_when_run_is_cancelled():
     run.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await run
+    # The cancellation must propagate (the comment says never swallow it), so the task ends cancelled
+    # rather than returning normally. Without this, swallowing the CancelledError would still pass.
+    assert run.cancelled()
 
     states = []
     while True:

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -1386,6 +1386,17 @@ async def test_durable_store_wont_clobber_terminal_cancel():
     assert got.status.state == pb.TaskState.TASK_STATE_CANCELED
 
 
+async def test_task_scope_key_is_postgres_safe():
+    """The flow-scoped store key must fold in the flow but carry no NUL byte (Postgres rejects NUL)."""
+    from a2a.server.context import ServerCallContext
+    from langflow.api.v1.a2a import _task_scope
+
+    flow_id = uuid.uuid4().hex
+    key = _task_scope(ServerCallContext(state={"flow_id": flow_id}))
+    assert "\x00" not in key
+    assert flow_id in key
+
+
 @pytest.mark.usefixtures("a2a_flag_on")
 async def test_cancel_is_scoped_to_the_path_flow(client: AsyncClient, active_user, human_input_flow_data):
     """A task can't be cancelled through a different flow's endpoint: the store is flow-scoped."""

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -716,14 +716,15 @@ async def test_unmatched_decision_re_parks_task(client: AsyncClient, active_user
 
 @pytest.mark.usefixtures("a2a_flag_on")
 async def test_resume_via_other_flow_is_rejected(client: AsyncClient, active_user, human_input_flow_data):
-    """A task parked under one flow cannot be resumed through a different flow's endpoint."""
+    """A task parked under one flow can't be resumed or completed through a different flow's endpoint."""
     flow_a = await _create_flow(active_user.id, data=human_input_flow_data)
     flow_b = await _create_flow(active_user.id, data=human_input_flow_data)
 
     paused = (await _jsonrpc(client, flow_a, "message/send", _text_message("start"))).json()["result"]
     task_id, context_id = paused["id"], paused["contextId"]
 
-    # Same task id, but sent to flow B: must not run flow A's graph.
+    # Same task id, sent to flow B: the flow-scoped store means flow B can't address flow A's task,
+    # so it can't complete it (never runs flow A's graph as flow A's owner).
     via_b = (
         await _jsonrpc(
             client,
@@ -731,9 +732,19 @@ async def test_resume_via_other_flow_is_rejected(client: AsyncClient, active_use
             "message/send",
             _text_message("Approve", message_id="m2", context_id=context_id, task_id=task_id),
         )
-    ).json()["result"]
+    ).json()
+    assert via_b.get("result", {}).get("status", {}).get("state") != "completed"
 
-    assert via_b["status"]["state"] == "failed"
+    # Flow A's task is untouched and still resumable through flow A.
+    resumed = (
+        await _jsonrpc(
+            client,
+            flow_a,
+            "message/send",
+            _text_message("Approve", message_id="m3", context_id=context_id, task_id=task_id),
+        )
+    ).json()["result"]
+    assert resumed["status"]["state"] == "completed"
 
 
 # --- apikey auth enforcement ----------------------------------------------
@@ -1254,3 +1265,68 @@ async def test_durable_store_wont_clobber_terminal_cancel():
 
     got = await store.get(tid, ctx)
     assert got.status.state == pb.TaskState.TASK_STATE_CANCELED
+
+
+@pytest.mark.usefixtures("a2a_flag_on")
+async def test_cancel_is_scoped_to_the_path_flow(client: AsyncClient, active_user, human_input_flow_data):
+    """A task can't be cancelled through a different flow's endpoint: the store is flow-scoped."""
+    flow_a = await _create_flow(active_user.id, data=human_input_flow_data)
+    flow_b = await _create_flow(active_user.id, data=human_input_flow_data)
+
+    paused = (await _jsonrpc(client, flow_a, "message/send", _text_message("start"))).json()["result"]
+    assert paused["status"]["state"] == "input-required"
+    task_id = paused["id"]
+
+    # Same task id, sent to flow B: must not reach flow A's task (flow B can't see it).
+    via_b = (await _jsonrpc(client, flow_b, "tasks/cancel", {"id": task_id})).json()
+    assert via_b.get("result", {}).get("status", {}).get("state") != "canceled"
+
+    # Flow A's task is untouched by the cross-flow attempt.
+    got = (await _jsonrpc(client, flow_a, "tasks/get", {"id": task_id})).json()["result"]
+    assert got["status"]["state"] == "input-required"
+
+
+async def test_execute_emits_canceled_when_run_is_cancelled():
+    """A cancelled live run emits a terminal CANCELED on its own queue, so the consumer can't hang."""
+    import asyncio
+    import contextlib
+    from uuid import uuid4
+
+    from a2a.server.agent_execution import RequestContext
+    from a2a.server.context import ServerCallContext
+    from a2a.server.events import EventQueue
+    from a2a.types import a2a_pb2 as pb
+    from langflow.api.v1.a2a_executor import FlowAgentExecutor
+
+    started = asyncio.Event()
+
+    async def blocking_run(*_args):
+        started.set()
+        await asyncio.Event().wait()  # runs until cancelled
+
+    async def _no_resume(*_args):
+        pytest.fail("resume must not be called")
+
+    executor = FlowAgentExecutor(blocking_run, _no_resume)
+    queue = EventQueue()
+    ctx = RequestContext(
+        call_context=ServerCallContext(state={"flow_id": str(uuid4())}),
+        task_id=uuid4().hex,
+        context_id="c",
+    )
+    run = asyncio.create_task(executor.execute(ctx, queue))
+    await asyncio.wait_for(started.wait(), timeout=5)
+    run.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await run
+
+    states = []
+    while True:
+        try:
+            event = await asyncio.wait_for(queue.dequeue_event(), timeout=0.5)
+        except TimeoutError:
+            break
+        state = getattr(getattr(event, "status", None), "state", None)
+        if state is not None:
+            states.append(state)
+    assert pb.TaskState.TASK_STATE_CANCELED in states


### PR DESCRIPTION
tasks/cancel was unimplemented (the executor's cancel raised NotImplementedError). Two things made the naive fix wrong, both caught by tests:

- The SDK's V2 request handler only preempts a *live* producer. A parked input-required task has already finished its producer, so the SDK's `on_cancel_task` no-ops and returns the task unchanged.
- A live run whose event queue closes as its producer is cancelled can drop the CANCELED event, leaving the task stuck `working`.

So a `_DurableCancelHandler` overrides `on_cancel_task`: it delegates (still preempts a live producer on the same worker), then forces a terminal CANCELED into the durable store and the returned task, covering both cases. `DurableTaskStore.save` also won't let a run that completes after the cancel clobber a terminal CANCELED. `executor.cancel` is now just the stream cancel event (it must not raise, or the SDK marks the task failed).

Cross-worker preemption of a running flow is out of scope: the producer registry and queues are per-process, so a cancel on another worker marks the store CANCELED but can't stop the other worker's run. That needs the shared cancel signal from the async/durable execution path.

Tests: a parked input-required task is canceled end-to-end and reads back canceled from the store, and the store won't overwrite a terminal CANCELED with a later completion.
