### PR TITLE
fix: prevent MCP server config lost updates and stale cache across workers

### DIFF
--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -1,10 +1,11 @@
 import asyncio
 import json
-from collections import defaultdict
 from io import BytesIO
+from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, UploadFile
+from filelock import FileLock
 from lfx.base.agents.utils import safe_cache_get, safe_cache_set
 from lfx.base.mcp.util import update_tools
 
@@ -25,9 +26,48 @@ from langflow.services.storage.service import StorageService
 
 router = APIRouter(tags=["MCP"], prefix="/mcp")
 
-# Per-user locks to serialize update_server() calls and prevent lost updates
-# from the non-atomic read-modify-write cycle on the MCP config file.
-_update_server_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+def _get_mcp_lock_path(user_id: str) -> str:
+    """Get the lock file path for cross-process MCP update synchronization.
+
+    Uses a temporary directory that persists across process boundaries,
+    allowing Gunicorn workers and other replicas to coordinate.
+    """
+    # Use a stable, temp-friendly location for lock files
+    lock_dir = Path("/tmp/langflow-mcp-locks")
+    lock_dir.mkdir(exist_ok=True, parents=True)
+    return str(lock_dir / f"mcp_server_update_{user_id}.lock")
+
+
+class _MCPLockContext:
+    """Context manager for MCP server update synchronization.
+
+    Uses FileLock internally to coordinate across processes.
+    Can be mocked in tests.
+    """
+
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+        self.lock = None
+
+    async def __aenter__(self):
+        lock_path = _get_mcp_lock_path(self.user_id)
+        self.lock = FileLock(lock_path, timeout=30)
+
+        def _acquire():
+            return self.lock.acquire()
+
+        await asyncio.to_thread(_acquire)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self.lock:
+
+            def _release():
+                self.lock.release()
+
+            await asyncio.to_thread(_release)
+        return False
 
 
 def is_mcp_servers_locked(settings: object) -> bool:
@@ -332,7 +372,9 @@ async def update_server(
     delete: bool = False,
     merge_existing: bool = False,
 ):
-    async with _update_server_locks[str(current_user.id)]:
+    # Use a cross-process file lock to coordinate updates across Gunicorn workers
+    # (fixes b0: in-process asyncio.Lock doesn't protect across separate processes)
+    async with _MCPLockContext(str(current_user.id)):
         server_list = await get_server_list(current_user, session, storage_service, settings_service)
 
         # Validate server name
@@ -358,11 +400,14 @@ async def update_server(
         )
 
         shared_component_cache_service = get_shared_component_cache_service()
-        # Clear the servers cache
+        # Clear ALL cache entries for this server, including those with hashed keys
+        # (fixes b1: cache keys include SHA256 hash of headers+timeout, so bare name lookup fails)
         servers = safe_cache_get(shared_component_cache_service, "servers", {})
         if isinstance(servers, dict):
-            if server_name in servers:
-                del servers[server_name]
+            # Remove all entries that match this server (bare name or hashed variants)
+            keys_to_delete = [k for k in servers.keys() if k == server_name or k.startswith(f"{server_name}:")]
+            for key in keys_to_delete:
+                del servers[key]
             safe_cache_set(shared_component_cache_service, "servers", servers)
 
         return await get_server(

--- a/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
@@ -48,7 +48,7 @@ class FakeSession:
     def __init__(self):
         self._db: dict[str, object] = {}
 
-    async def exec(self, stmt):
+    async def exec(self, _stmt):
         return FakeResult([])
 
     def add(self, obj):
@@ -102,7 +102,6 @@ def session():
     return FakeSession()
 
 
-@pytest.mark.asyncio
 async def test_b1_cache_invalidation_clears_hashed_keys(session, storage_service, settings_service, current_user):
     """Cache invalidation must clear all cache entries, including those with hashed keys.
 
@@ -112,7 +111,7 @@ async def test_b1_cache_invalidation_clears_hashed_keys(session, storage_service
     """
     cache_updates = []
 
-    def mock_safe_cache_get(cache, key, default=None):
+    def mock_safe_cache_get(_cache, key, default=None):
         # Simulate having a "servers" dict with both bare and hashed keys
         if key == "servers":
             return {
@@ -122,7 +121,7 @@ async def test_b1_cache_invalidation_clears_hashed_keys(session, storage_service
             }
         return default
 
-    def mock_safe_cache_set(cache, key, value):
+    def mock_safe_cache_set(_cache, key, value):
         cache_updates.append((key, value))
 
     config_state = {"mcpServers": {"my_server": {"command": "new"}}}
@@ -183,7 +182,6 @@ async def test_b1_cache_invalidation_clears_hashed_keys(session, storage_service
     assert "other_server" in servers_update, "Other servers should remain"
 
 
-@pytest.mark.asyncio
 async def test_b0_distributed_lock_protects_concurrent_updates(
     session, storage_service, settings_service, current_user
 ):
@@ -222,7 +220,7 @@ async def test_b0_distributed_lock_protects_concurrent_updates(
 
     # Mock the lock context with proper synchronization
     class MockLockContext:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *_args, **_kwargs):
             self.lock = lock
 
         async def __aenter__(self):

--- a/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
@@ -1,12 +1,11 @@
 """Tests for MCP bugs b0, b1: concurrent updates and cache key mismatch on invalidation."""
+
 import asyncio
 import uuid
-from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-
 from langflow.api.v2.mcp import update_server
 
 
@@ -104,9 +103,7 @@ def session():
 
 
 @pytest.mark.asyncio
-async def test_b1_cache_invalidation_clears_hashed_keys(
-    session, storage_service, settings_service, current_user
-):
+async def test_b1_cache_invalidation_clears_hashed_keys(session, storage_service, settings_service, current_user):
     """Cache invalidation must clear all cache entries, including those with hashed keys.
 
     Bug b1: Cache invalidation deletes using bare server_name, but actual cache key
@@ -179,9 +176,7 @@ async def test_b1_cache_invalidation_clears_hashed_keys(
 
     assert servers_update is not None, "Cache should have been updated for servers"
     # Hashed key should be cleared
-    assert "my_server:abc123def" not in servers_update, (
-        "Hashed cache key 'my_server:abc123def' should be cleared"
-    )
+    assert "my_server:abc123def" not in servers_update, "Hashed cache key 'my_server:abc123def' should be cleared"
     # Bare key should be cleared
     assert "my_server" not in servers_update, "Bare server key should be cleared"
     # Other servers untouched

--- a/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_bugs_fix.py
@@ -1,0 +1,278 @@
+"""Tests for MCP bugs b0, b1: concurrent updates and cache key mismatch on invalidation."""
+import asyncio
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from langflow.api.v2.mcp import update_server
+
+
+class FakeStorageService:
+    """Minimal stub for storage interactions."""
+
+    def __init__(self):
+        self._store: dict[str, bytes] = {}
+
+    async def save_file(self, flow_id: str, file_name: str, data: bytes, *, append: bool = False):
+        key = f"{flow_id}/{file_name}"
+        if append and key in self._store:
+            self._store[key] += data
+        else:
+            self._store[key] = data
+
+    async def get_file_size(self, flow_id: str, file_name: str):
+        return len(self._store.get(f"{flow_id}/{file_name}", b""))
+
+    async def delete_file(self, flow_id: str, file_name: str):
+        self._store.pop(f"{flow_id}/{file_name}", None)
+
+
+class FakeResult:
+    """Helper for Session.exec return."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class FakeSession:
+    """Minimal async session stub."""
+
+    def __init__(self):
+        self._db: dict[str, object] = {}
+
+    async def exec(self, stmt):
+        return FakeResult([])
+
+    def add(self, obj):
+        self._db[str(obj)] = obj
+
+    async def commit(self):
+        return
+
+    async def refresh(self, obj):  # noqa: ARG002
+        return
+
+    async def delete(self, obj):
+        self._db.pop(str(obj), None)
+
+    async def flush(self):
+        return
+
+
+class FakeSettings:
+    """Fake settings for tests."""
+
+    max_file_size_upload: int = 10  # MB
+
+
+@pytest.fixture
+def current_user():
+    """Create a fake user."""
+
+    class User(SimpleNamespace):
+        id: str
+        is_superuser: bool = False
+
+    return User(id=str(uuid.uuid4()))
+
+
+@pytest.fixture
+def storage_service():
+    """Create a fake storage service."""
+    return FakeStorageService()
+
+
+@pytest.fixture
+def settings_service():
+    """Create a fake settings service."""
+    return SimpleNamespace(settings=FakeSettings())
+
+
+@pytest.fixture
+def session():
+    """Create a fake session."""
+    return FakeSession()
+
+
+@pytest.mark.asyncio
+async def test_b1_cache_invalidation_clears_hashed_keys(
+    session, storage_service, settings_service, current_user
+):
+    """Cache invalidation must clear all cache entries, including those with hashed keys.
+
+    Bug b1: Cache invalidation deletes using bare server_name, but actual cache key
+    includes SHA256 hash of headers+timeout (mcp_component.py:160-185).
+    Expected: All cache entries for a server are cleared, including hashed variants.
+    """
+    cache_updates = []
+
+    def mock_safe_cache_get(cache, key, default=None):
+        # Simulate having a "servers" dict with both bare and hashed keys
+        if key == "servers":
+            return {
+                "my_server": {"config": "old"},
+                "my_server:abc123def": {"config": "old_with_headers"},
+                "other_server": {"config": "data"},
+            }
+        return default
+
+    def mock_safe_cache_set(cache, key, value):
+        cache_updates.append((key, value))
+
+    config_state = {"mcpServers": {"my_server": {"command": "new"}}}
+
+    async def mock_get_server_list(*_args, **_kwargs):
+        return config_state
+
+    async def mock_upload_server_config(new_config, *_args, **_kwargs):
+        config_state["mcpServers"] = dict(new_config["mcpServers"])
+
+    async def mock_get_server(name, *_args, **kwargs):
+        server_list = kwargs.get("server_list", {})
+        return server_list.get("mcpServers", {}).get(name)
+
+    # Mock the lock context
+    class MockLockContext:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    with patch.multiple(
+        "langflow.api.v2.mcp",
+        get_server_list=mock_get_server_list,
+        upload_server_config=mock_upload_server_config,
+        get_server=mock_get_server,
+        _MCPLockContext=MockLockContext,
+        get_shared_component_cache_service=MagicMock(return_value=SimpleNamespace()),
+        safe_cache_get=mock_safe_cache_get,
+        safe_cache_set=mock_safe_cache_set,
+    ):
+        await update_server(
+            "my_server",
+            {"command": "new"},
+            current_user,
+            session,
+            storage_service,
+            settings_service,
+        )
+
+    # Find the cache update for servers
+    servers_update = None
+    for key, value in cache_updates:
+        if key == "servers":
+            servers_update = value
+            break
+
+    assert servers_update is not None, "Cache should have been updated for servers"
+    # Hashed key should be cleared
+    assert "my_server:abc123def" not in servers_update, (
+        "Hashed cache key 'my_server:abc123def' should be cleared"
+    )
+    # Bare key should be cleared
+    assert "my_server" not in servers_update, "Bare server key should be cleared"
+    # Other servers untouched
+    assert "other_server" in servers_update, "Other servers should remain"
+
+
+@pytest.mark.asyncio
+async def test_b0_distributed_lock_protects_concurrent_updates(
+    session, storage_service, settings_service, current_user
+):
+    """Concurrent updates use a distributed lock to prevent lost writes.
+
+    Bug b0: In-process asyncio.Lock doesn't coordinate across Gunicorn workers.
+    Expected: Distributed file lock serializes updates even across processes.
+
+    Note: this does not cover cross-worker cache staleness (a separate, narrower
+    issue in the tool-connection cache keyed in mcp_component.py, which self-heals
+    via that cache's existing TTL) — only the config-file lost-update race.
+    """
+    import copy
+
+    # Shared mutable config state
+    config_state = {"mcpServers": {"server_a": {"command": "echo", "args": ["a"]}}}
+    update_order = []
+
+    # Simulate a distributed lock with an asyncio.Lock for testing
+    lock = asyncio.Lock()
+
+    async def mock_get_server_list(*_args, **_kwargs):
+        result = copy.deepcopy(config_state)
+        await asyncio.sleep(0)  # Yield to allow interleaving
+        return result
+
+    async def mock_upload_server_config(new_config, *_args, **_kwargs):
+        # Record when each write happens (to verify ordering by lock)
+        update_order.append(list(new_config["mcpServers"].keys()))
+        await asyncio.sleep(0)  # Yield
+        config_state["mcpServers"] = dict(new_config["mcpServers"])
+
+    async def mock_get_server(name, *_args, **kwargs):
+        server_list = kwargs.get("server_list", {})
+        return server_list.get("mcpServers", {}).get(name)
+
+    # Mock the lock context with proper synchronization
+    class MockLockContext:
+        def __init__(self, *args, **kwargs):
+            self.lock = lock
+
+        async def __aenter__(self):
+            await self.lock.acquire()
+            return self
+
+        async def __aexit__(self, *args):
+            self.lock.release()
+            return False
+
+    with patch.multiple(
+        "langflow.api.v2.mcp",
+        get_server_list=mock_get_server_list,
+        upload_server_config=mock_upload_server_config,
+        get_server=mock_get_server,
+        _MCPLockContext=MockLockContext,
+        get_shared_component_cache_service=MagicMock(return_value=SimpleNamespace()),
+        safe_cache_get=MagicMock(return_value={}),
+        safe_cache_set=MagicMock(),
+    ):
+        # Run concurrent updates - they should serialize due to the lock
+        await asyncio.gather(
+            update_server(
+                "server_b",
+                {"command": "echo", "args": ["b"]},
+                current_user,
+                session,
+                storage_service,
+                settings_service,
+            ),
+            update_server(
+                "server_c",
+                {"command": "echo", "args": ["c"]},
+                current_user,
+                session,
+                storage_service,
+                settings_service,
+            ),
+        )
+
+    # All servers should be preserved (lock prevents lost updates)
+    assert "server_a" in config_state["mcpServers"], "server_a should be preserved"
+    assert "server_b" in config_state["mcpServers"], "server_b should be preserved"
+    assert "server_c" in config_state["mcpServers"], "server_c should be preserved"
+
+    # Lock ensures writes are serialized (one after the other)
+    # Each write should have all previously written servers plus the new one
+    assert len(update_order) >= 2, "Multiple writes should have occurred"

--- a/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
@@ -346,7 +346,7 @@ async def test_concurrent_update_server_should_not_lose_servers(
     lock = asyncio.Lock()
 
     class MockLockContext:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *_args, **_kwargs):
             self.lock = lock
 
         async def __aenter__(self):

--- a/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
@@ -342,11 +342,27 @@ async def test_concurrent_update_server_should_not_lose_servers(
         server_list = kwargs.get("server_list", {})
         return server_list.get("mcpServers", {}).get(name)
 
+    # Mock the lock context with proper synchronization to prevent lost updates
+    lock = asyncio.Lock()
+
+    class MockLockContext:
+        def __init__(self, *args, **kwargs):
+            self.lock = lock
+
+        async def __aenter__(self):
+            await self.lock.acquire()
+            return self
+
+        async def __aexit__(self, *args):
+            self.lock.release()
+            return False
+
     with patch.multiple(
         "langflow.api.v2.mcp",
         get_server_list=mock_get_server_list,
         upload_server_config=mock_upload_server_config,
         get_server=mock_get_server,
+        _MCPLockContext=MockLockContext,
         get_shared_component_cache_service=MagicMock(return_value=SimpleNamespace()),
         safe_cache_get=MagicMock(return_value={}),
         safe_cache_set=MagicMock(),


### PR DESCRIPTION
Fixes #13970 (partially — see note below).

`update_server()` used an in-process `asyncio.Lock` to guard its read-modify-write cycle on the MCP config file, which does nothing to prevent lost updates when multiple Gunicorn workers handle requests concurrently — one worker's write could silently clobber another's. Switched to a cross-process file lock (`filelock`, already a dependency) so updates from any worker serialize correctly.

Also fixed cache invalidation on update: the cache key for a server includes a hash of its headers/timeout, but invalidation only ever deleted the bare server name, so entries with custom headers or timeouts were never cleared and kept serving stale config.

**Note on scope:** the issue also describes a third symptom — different workers reporting divergent server lists. I traced this to a separate cache (the tool-connection cache in `mcp_component.py`, keyed by server name + headers/timeout hash) that has no cross-worker invalidation signal. Fixing that properly needs either a shared cache backend or a version-stamped cache key, which felt like a bigger change than this PR should bundle in. It self-heals via that cache's existing TTL in the meantime. Happy to follow up with that separately if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving MCP server changes by preventing simultaneous updates from overwriting each other.
  * Updated cache handling so server changes now refresh all related entries, including alternate cached variants, ensuring users see the latest server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->