### PR TITLE
perf: batch deployment pruning

### DIFF
--- a/src/backend/base/langflow/alembic/versions/a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
+++ b/src/backend/base/langflow/alembic/versions/a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
@@ -1,0 +1,121 @@
+"""Rewrite deployment-family SQLite timestamps; drop now() server defaults
+
+Phase: EXPAND
+
+Bug
+---
+On SQLite, ``func.now()`` / ``datetime('now')`` store second-level precision
+(``YYYY-MM-DD HH:MM:SS``). When that same value is loaded into Python and
+SQLAlchemy later sends it as a query parameter, it is formatted with
+microsecond precision (``...SS.ffffff``). Comparisons then fail when one
+side is the stored ORM column value (still second-level text) and the
+other is SQLAlchemy's DateTime formatting of a previously loaded ORM
+datetime used as a parameter — even if both represent the same
+wall-clock second.
+
+An app-only fix (normalize the value in every query, cast/format in SQL,
+special-case whole-second equality) would have to live in every reader
+forever, and would still leave mixed formats (``YYYY-MM-DD HH:MM:SS`` and
+``...SS.ffffff``) in the table. Rewriting once through
+``DateTime(timezone=True)``, plus changing the deployment-family models to
+write UTC via Column ``default`` / ``onupdate`` (with no
+``server_default=func.now()``; Field stays ``default=None``), makes what
+is stored match what SQLAlchemy sends later, so ordinary
+equality/ordering work without per-query workarounds, and keeps a single
+predictable storage format for timestamps.
+
+This migration:
+1. On SQLite: re-reads each timestamp as ``DateTime(timezone=True)`` and
+   writes it back through the same type (idempotent).
+2. On all dialects: drops ``server_default`` / ``DEFAULT CURRENT_TIMESTAMP``
+   from these columns so the DB schema matches the models (ORM must supply
+   Python UTC; raw inserts must too).
+
+No-op data rewrite on PostgreSQL (real timestamp comparisons).
+
+Revision ID: a8f3c2d1e4b5
+Revises: 247308ce2598
+Create Date: 2026-07-09 23:20:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "a8f3c2d1e4b5"  # pragma: allowlist secret
+down_revision: str | None = "247308ce2598"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES_AND_COLUMNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("deployment", ("created_at", "updated_at")),
+    ("deployment_provider_account", ("created_at", "updated_at")),
+    ("flow_version_deployment_attachment", ("created_at", "updated_at")),
+)
+
+
+def _rewrite_table_timestamps(conn, table_name: str, column_names: tuple[str, ...]) -> None:
+    if not migration.table_exists(table_name, conn):
+        return
+    # Leave ``id`` untyped so SQLite's CHAR/BLOB UUID storage round-trips as-is.
+    columns = [sa.column("id")]
+    columns.extend(
+        sa.column(name, sa.DateTime(timezone=True))
+        for name in column_names
+        if migration.column_exists(table_name, name, conn)
+    )
+    if len(columns) == 1:
+        return
+
+    table = sa.table(table_name, *columns)
+    timestamp_cols = [c for c in columns if c.name != "id"]
+    rows = conn.execute(sa.select(table.c.id, *timestamp_cols)).all()
+    params = [
+        {"b_id": row.id, **{col.name: getattr(row, col.name) for col in timestamp_cols}}
+        for row in rows
+        if not all(getattr(row, col.name) is None for col in timestamp_cols)
+    ]
+    if not params:
+        return
+    # One executemany: DateTime bind formatting still runs per parameter set.
+    stmt = (
+        sa.update(table)
+        .where(table.c.id == sa.bindparam("b_id"))
+        .values(**{col.name: sa.bindparam(col.name) for col in timestamp_cols})
+    )
+    conn.execute(stmt, params)
+
+
+def _drop_timestamp_server_defaults(conn, table_name: str, column_names: tuple[str, ...]) -> None:
+    if not migration.table_exists(table_name, conn):
+        return
+    existing = [name for name in column_names if migration.column_exists(table_name, name, conn)]
+    if not existing:
+        return
+    # Single batch_alter_table so SQLite recreates the table once for all columns.
+    with op.batch_alter_table(table_name) as batch_op:
+        for name in existing:
+            batch_op.alter_column(
+                name,
+                existing_type=sa.DateTime(timezone=True),
+                existing_nullable=False,
+                server_default=None,
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "sqlite":
+        for table_name, column_names in _TABLES_AND_COLUMNS:
+            _rewrite_table_timestamps(conn, table_name, column_names)
+    for table_name, column_names in _TABLES_AND_COLUMNS:
+        _drop_timestamp_server_defaults(conn, table_name, column_names)
+
+
+def downgrade() -> None:
+    # Format normalization is forward-only; padded microsecond strings remain valid.
+    # Restoring server_default=func.now() would reintroduce the SQLite whole-second bug.
+    pass

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -942,9 +942,10 @@ async def list_deployments_synced(
         provider_data_by_resource_key.update(deployment_mapper.extract_list_item_provider_data(provider_view))
         provider_metadata_by_resource_key.update(deployment_mapper.extract_metadata_for_list(provider_view))
 
+        last_row = batch[-1][0]
+        cursor_created_at = last_row.created_at
+        cursor_exclude_id = last_row.id
         for row, attached_count, matched_flow_versions in batch:
-            cursor_created_at = row.created_at
-            cursor_exclude_id = row.id
             if row.resource_key not in known:
                 # Provider `known` is type-filtered; skip other local types instead of deleting as stale.
                 if deployment_type is not None and row.deployment_type != deployment_type:

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -891,8 +891,8 @@ async def list_deployments_synced(
     """Return a page of deployments, batch-deleting DB rows the provider doesn't recognise.
 
     Each round fetches a candidate window so one provider lookup reconciles
-    stale rows beyond the page. Refill rounds seek after the last processed row,
-    so concurrent deletes do not shift a numeric offset under the loop.
+    stale rows beyond the page. Refill rounds seek after the last processed row
+    to avoid corruption to the offset under concurrent deletes.
 
     ``allowed_ids`` is the DB-layer authorization prefilter, threaded into both
     the page query and the total count so a registered authorization plugin can

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -892,7 +892,9 @@ async def list_deployments_synced(
 
     Each round fetches a candidate window so one provider lookup reconciles
     stale rows beyond the page. Refill rounds seek after the last processed row
-    to avoid corruption to the offset under concurrent deletes.
+    to avoid offset drift under concurrent deletes. After provider sync finishes,
+    any remaining page slots are backfilled from local rows without another
+    provider check (they may be stale).
 
     ``allowed_ids`` is the DB-layer authorization prefilter, threaded into both
     the page query and the total count so a registered authorization plugin can
@@ -915,46 +917,57 @@ async def list_deployments_synced(
     for _ in range(max_sync_rounds):
         if len(accepted) >= size:
             break
-        batch = await list_deployments_page(
-            db,
-            user_id=user_id,
-            deployment_provider_account_id=provider_id,
-            offset=initial_offset if not cursor_created_at else None,
-            limit=sync_batch_size,
-            flow_version_ids=flow_version_ids,
-            project_id=project_id,
-            allowed_ids=allowed_ids,
-            cursor_created_at=cursor_created_at,
-            cursor_exclude_id=cursor_exclude_id,
-        )
-        if not batch:
-            break
+        try:
+            batch = await list_deployments_page(
+                db,
+                user_id=user_id,
+                deployment_provider_account_id=provider_id,
+                offset=initial_offset if cursor_created_at is None else None,
+                limit=sync_batch_size,
+                flow_version_ids=flow_version_ids,
+                project_id=project_id,
+                deployment_type=deployment_type,
+                allowed_ids=allowed_ids,
+                cursor_created_at=cursor_created_at,
+                cursor_exclude_id=cursor_exclude_id,
+            )
+            if not batch:
+                break
 
-        known, provider_view = await fetch_provider_resource_keys(
-            deployment_adapter=deployment_adapter,
-            user_id=user_id,
-            provider_id=provider_id,
-            db=db,
-            resource_keys=[row.resource_key for row, _, _ in batch],
-            deployment_type=deployment_type,
-        )
-        provider_bindings.extend(deployment_mapper.extract_snapshot_bindings(provider_view))
-        provider_data_by_resource_key.update(deployment_mapper.extract_list_item_provider_data(provider_view))
-        provider_metadata_by_resource_key.update(deployment_mapper.extract_metadata_for_list(provider_view))
+            known, provider_view = await fetch_provider_resource_keys(
+                deployment_adapter=deployment_adapter,
+                user_id=user_id,
+                provider_id=provider_id,
+                db=db,
+                resource_keys=[row.resource_key for row, _, _ in batch],
+                deployment_type=deployment_type,
+            )
+            provider_bindings.extend(deployment_mapper.extract_snapshot_bindings(provider_view))
+            provider_data_by_resource_key.update(deployment_mapper.extract_list_item_provider_data(provider_view))
+            provider_metadata_by_resource_key.update(deployment_mapper.extract_metadata_for_list(provider_view))
 
-        last_row = batch[-1][0]
-        cursor_created_at = last_row.created_at
-        cursor_exclude_id = last_row.id
-        for row, attached_count, matched_flow_versions in batch:
-            if row.resource_key not in known:
-                # Provider `known` is type-filtered; skip other local types instead of deleting as stale.
-                if deployment_type is not None and row.deployment_type != deployment_type:
+            last_row = batch[-1][0]
+            cursor_created_at = last_row.created_at
+            cursor_exclude_id = last_row.id
+            for row, attached_count, matched_flow_versions in batch:
+                if row.resource_key not in known:
+                    # Page rows are already type-filtered in SQL when deployment_type
+                    # is set, so provider-unknown rows are safe to prune as stale.
+                    stale_deployment_owner_pairs.append(DeploymentOwnerPair(owner_id=row.user_id, deployment_id=row.id))
                     continue
-                stale_deployment_owner_pairs.append(DeploymentOwnerPair(owner_id=row.user_id, deployment_id=row.id))
-                continue
-            if len(accepted) < size:
-                accepted.append((row, attached_count, matched_flow_versions))
-                accepted_deployment_ids.append(row.id)
+                if len(accepted) < size:
+                    accepted.append((row, attached_count, matched_flow_versions))
+                    accepted_deployment_ids.append(row.id)
+        except Exception:  # noqa: BLE001
+            # Keep the list path alive: return whatever earlier rounds accepted
+            # and still prune confirmed stales once below.
+            logger.warning(
+                "Deployment list sync round failed for provider %s; continuing with %d accepted row(s)",
+                provider_id,
+                len(accepted),
+                exc_info=True,
+            )
+            break
 
     if stale_deployment_owner_pairs:
         logger.warning(
@@ -964,7 +977,7 @@ async def list_deployments_synced(
         )
         await delete_deployments_by_owner_and_ids(db, deployment_owner_pairs=stale_deployment_owner_pairs)
 
-    # Phase 2: metadata and binding-level sync.
+    # Phase 2: metadata and binding-level sync (provider-confirmed rows only).
     if accepted:
         metadata_updates: list[DeploymentMetadataUpdate] = []
         for row, _attached_count, _matched in accepted:
@@ -982,7 +995,8 @@ async def list_deployments_synced(
 
     # Remove stale local attachments based on provider bindings, then recount.
     # Best-effort - provider or DB failures should not block the list response.
-    if accepted:
+    # Only provider-confirmed IDs: backfill rows below are not binding-synced.
+    if accepted_deployment_ids:
         try:
             async with db.begin_nested():
                 await delete_unbound_attachments(
@@ -1005,12 +1019,40 @@ async def list_deployments_synced(
                 exc_info=True,
             )
 
+    # Pad the response page from local rows after all provider sync is done.
+    # These rows may be stale and are not metadata/binding-synced above.
+    remaining = size - len(accepted)
+    if remaining > 0:
+        try:
+            backfill_batch = await list_deployments_page(
+                db,
+                user_id=user_id,
+                deployment_provider_account_id=provider_id,
+                offset=initial_offset if cursor_created_at is None else None,
+                limit=remaining,
+                flow_version_ids=flow_version_ids,
+                project_id=project_id,
+                deployment_type=deployment_type,
+                allowed_ids=allowed_ids,
+                cursor_created_at=cursor_created_at,
+                cursor_exclude_id=cursor_exclude_id,
+            )
+            accepted.extend(backfill_batch)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Deployment list backfill failed for provider %s; returning %d accepted row(s)",
+                provider_id,
+                len(accepted),
+                exc_info=True,
+            )
+
     total = await count_deployments_by_provider(
         db,
         user_id=user_id,
         deployment_provider_account_id=provider_id,
         flow_version_ids=flow_version_ids,
         project_id=project_id,
+        deployment_type=deployment_type,
         allowed_ids=allowed_ids,
     )
     return accepted, total, provider_data_by_resource_key

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -46,8 +46,10 @@ from langflow.initial_setup.setup import get_or_create_default_folder
 from langflow.services.adapters.deployment.context import deployment_provider_scope
 from langflow.services.database.models.deployment.crud import (
     DeploymentMetadataUpdate,
+    DeploymentOwnerPair,
     count_deployments_by_provider,
     delete_deployment_by_id,
+    delete_deployments_by_owner_and_ids,
     list_deployments_page,
     update_deployment_metadata,
     update_deployment_metadata_batch,
@@ -78,6 +80,7 @@ from langflow.services.database.models.flow_version_deployment_attachment.crud i
 )
 from langflow.services.database.models.folder.model import Folder
 from langflow.services.database.utils import require_non_empty
+from langflow.services.deps import get_settings_service
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -885,25 +888,30 @@ async def list_deployments_synced(
     project_id: UUID | None = None,
     allowed_ids: list[UUID] | None = None,
 ) -> tuple[list[tuple[Deployment, int, list[tuple[UUID, str | None]]]], int, dict[str, dict[str, Any]]]:
-    """Return a page of deployments, deleting any DB rows the provider doesn't recognise.
+    """Return a page of deployments, batch-deleting DB rows the provider doesn't recognise.
 
-    Fetches DB rows in batches, sends each batch's resource keys to the
-    provider for validation, deletes stale rows inline, and syncs
-    provider-owned display metadata for rows that still exist. The cursor
-    does not advance for deleted rows (deletion shifts subsequent offsets down).
+    Each round fetches a candidate window so one provider lookup reconciles
+    stale rows beyond the page. Refill rounds seek after the last processed row,
+    so concurrent deletes do not shift a numeric offset under the loop.
 
     ``allowed_ids`` is the DB-layer authorization prefilter, threaded into both
     the page query and the total count so a registered authorization plugin can
     constrain the listing to (owner ⊕ visible) rows without a per-row enforce.
     ``None`` (OSS default) keeps the listing owner-scoped exactly as before.
     """
+    settings = get_settings_service().settings
+    sync_batch_size = settings.deployment_list_sync_batch_size
+    max_sync_rounds = settings.deployment_list_sync_max_rounds
+
     accepted: list[tuple[Deployment, int, list[tuple[UUID, str | None]]]] = []
     accepted_deployment_ids: list[UUID] = []
     provider_bindings: list[ProviderSnapshotBinding] = []
     provider_data_by_resource_key: dict[str, dict[str, Any]] = {}
     provider_metadata_by_resource_key: dict[str, dict[str, Any]] = {}
-    cursor = page_offset(page, size)
-    max_sync_rounds = 2  # Initial pass + one refill pass.
+    stale_deployment_owner_pairs: list[DeploymentOwnerPair] = []
+    initial_offset = page_offset(page, size)
+    cursor_created_at = None
+    cursor_exclude_id = None
     for _ in range(max_sync_rounds):
         if len(accepted) >= size:
             break
@@ -911,11 +919,13 @@ async def list_deployments_synced(
             db,
             user_id=user_id,
             deployment_provider_account_id=provider_id,
-            offset=cursor,
-            limit=size - len(accepted),
+            offset=initial_offset if not cursor_created_at else None,
+            limit=sync_batch_size,
             flow_version_ids=flow_version_ids,
             project_id=project_id,
             allowed_ids=allowed_ids,
+            cursor_created_at=cursor_created_at,
+            cursor_exclude_id=cursor_exclude_id,
         )
         if not batch:
             break
@@ -933,22 +943,25 @@ async def list_deployments_synced(
         provider_metadata_by_resource_key.update(deployment_mapper.extract_metadata_for_list(provider_view))
 
         for row, attached_count, matched_flow_versions in batch:
+            cursor_created_at = row.created_at
+            cursor_exclude_id = row.id
             if row.resource_key not in known:
                 # Provider `known` is type-filtered; skip other local types instead of deleting as stale.
                 if deployment_type is not None and row.deployment_type != deployment_type:
-                    cursor += 1
                     continue
-                logger.warning(
-                    "Deployment %s (resource_key=%s) not found on provider %s — deleting stale row",
-                    row.id,
-                    row.resource_key,
-                    provider_id,
-                )
-                await delete_deployment_by_id(db, user_id=row.user_id, deployment_id=row.id)
+                stale_deployment_owner_pairs.append(DeploymentOwnerPair(owner_id=row.user_id, deployment_id=row.id))
                 continue
-            accepted.append((row, attached_count, matched_flow_versions))
-            accepted_deployment_ids.append(row.id)
-            cursor += 1
+            if len(accepted) < size:
+                accepted.append((row, attached_count, matched_flow_versions))
+                accepted_deployment_ids.append(row.id)
+
+    if stale_deployment_owner_pairs:
+        logger.warning(
+            "Deleting %d stale deployment row(s) not found on provider %s",
+            len(stale_deployment_owner_pairs),
+            provider_id,
+        )
+        await delete_deployments_by_owner_and_ids(db, deployment_owner_pairs=stale_deployment_owner_pairs)
 
     # Phase 2: metadata and binding-level sync.
     if accepted:

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from lfx.log.logger import logger
-from sqlalchemy import Select, column, values
+from sqlalchemy import Select, column, or_, tuple_, values
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, delete, func, select, update
 
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
 # Preserves the concrete statement type (scalar count select vs. multi-column
 # page select) through the authz scoping helper below.
 StmtT = TypeVar("StmtT", bound=Select[Any])
+
+
+class DeploymentOwnerPair(NamedTuple):
+    owner_id: UUID
+    deployment_id: UUID
 
 
 @dataclass(frozen=True, slots=True)
@@ -356,11 +361,13 @@ async def list_deployments_page(
     *,
     user_id: UUID,
     deployment_provider_account_id: UUID,
-    offset: int,
     limit: int,
+    offset: int | None = None,
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     allowed_ids: list[UUID] | None = None,
+    cursor_created_at: datetime | None = None,
+    cursor_exclude_id: UUID | None = None,
 ) -> list[tuple[Deployment, int, list[tuple[UUID, str | None]]]]:
     """Return a page of deployments with attachment counts and matched attachments.
 
@@ -373,12 +380,22 @@ async def list_deployments_page(
     is widened to the union of owner rows and ``allowed_ids`` (rows a registered
     authorization plugin reports the caller may read) — see
     ``langflow.services.authorization.restrict_to_owned_or_visible``.
+
+    Use ``offset`` for the first page. Use ``cursor_created_at`` and
+    ``cursor_exclude_id`` together for follow-up keyset reads; cursor reads must
+    not also pass ``offset``.
     """
-    if offset < 0:
+    if offset is not None and offset < 0:
         msg = "offset must be greater than or equal to 0"
         raise ValueError(msg)
     if limit <= 0:
         msg = "limit must be greater than 0"
+        raise ValueError(msg)
+    if (cursor_created_at is None) != (cursor_exclude_id is None):
+        msg = "cursor_created_at and cursor_exclude_id must be provided together"
+        raise ValueError(msg)
+    if cursor_created_at and offset is not None:
+        msg = "offset cannot be used with cursor_created_at and cursor_exclude_id"
         raise ValueError(msg)
     attachment_counts_subquery = (
         select(
@@ -406,6 +423,15 @@ async def list_deployments_page(
     stmt = _scope_to_owner_or_allowed(stmt, user_id=user_id, allowed_ids=allowed_ids)
     if project_id is not None:
         stmt = stmt.where(Deployment.project_id == project_id)
+    if cursor_created_at:
+        stmt = stmt.where(
+            or_(
+                # older deployments
+                col(Deployment.created_at) < cursor_created_at,
+                # Same age but different deployments
+                (col(Deployment.created_at) == cursor_created_at) & (col(Deployment.id) < cursor_exclude_id),
+            )
+        )
     if flow_version_ids:
         matched_deployments_subquery = (
             select(FlowVersionDeploymentAttachment.deployment_id)
@@ -420,7 +446,10 @@ async def list_deployments_page(
             matched_deployments_subquery,
             matched_deployments_subquery.c.deployment_id == Deployment.id,
         )
-    stmt = stmt.order_by(col(Deployment.created_at).desc(), col(Deployment.id).desc()).offset(offset).limit(limit)
+    stmt = stmt.order_by(col(Deployment.created_at).desc(), col(Deployment.id).desc())
+    if offset is not None:
+        stmt = stmt.offset(offset)
+    stmt = stmt.limit(limit)
     rows = (await db.exec(stmt)).all()
     deployment_rows = [(deployment, int(attached_count or 0)) for deployment, attached_count in rows]
     if not flow_version_ids or not deployment_rows:
@@ -678,3 +707,42 @@ async def delete_deployments_by_ids(
             deployment_ids,
         )
     return int(result.rowcount or 0)
+
+
+async def delete_deployments_by_owner_and_ids(
+    db: AsyncSession,
+    *,
+    deployment_owner_pairs: list[DeploymentOwnerPair],
+) -> int:
+    """Delete owner-scoped deployment rows; return the number of deployment rows deleted."""
+    if not deployment_owner_pairs:
+        return 0
+
+    await db.exec(
+        delete(FlowVersionDeploymentAttachment).where(
+            tuple_(
+                FlowVersionDeploymentAttachment.user_id,
+                FlowVersionDeploymentAttachment.deployment_id,
+            ).in_(deployment_owner_pairs),
+        )
+    )
+
+    result = await db.exec(
+        delete(Deployment).where(
+            tuple_(
+                Deployment.user_id,
+                Deployment.id,
+            ).in_(deployment_owner_pairs),
+        )
+    )
+    if result.rowcount is None:
+        msg = (
+            "DELETE rowcount was None for deployments=%s -- "
+            "database driver may not support rowcount for DELETE statements"
+        )
+        await logger.aerror(
+            msg,
+            deployment_owner_pairs,
+        )
+        raise RuntimeError(msg % deployment_owner_pairs)
+    return result.rowcount

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from lfx.log.logger import logger
-from sqlalchemy import Select, column, or_, tuple_, values
+from sqlalchemy import Select, and_, column, or_, tuple_, values
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, delete, func, select, update
 
@@ -34,6 +34,21 @@ StmtT = TypeVar("StmtT", bound=Select[Any])
 class DeploymentOwnerPair(NamedTuple):
     owner_id: UUID
     deployment_id: UUID
+
+
+class UnknownDeleteCount:
+    """Sentinel returned when DELETE rowcount is not a usable integer."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "UnknownDeleteCount()"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNKNOWN_DELETE_COUNT = UnknownDeleteCount()
 
 
 @dataclass(frozen=True, slots=True)
@@ -365,6 +380,7 @@ async def list_deployments_page(
     offset: int | None = None,
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
+    deployment_type: DeploymentType | None = None,
     allowed_ids: list[UUID] | None = None,
     cursor_created_at: datetime | None = None,
     cursor_exclude_id: UUID | None = None,
@@ -381,9 +397,13 @@ async def list_deployments_page(
     authorization plugin reports the caller may read) — see
     ``langflow.services.authorization.restrict_to_owned_or_visible``.
 
+    ``deployment_type`` optionally restricts the page to one local deployment
+    type. When set, callers that also type-filter the provider can treat
+    provider-unknown rows as stale without a Python type skip.
+
     Use ``offset`` for the first page. Use ``cursor_created_at`` and
     ``cursor_exclude_id`` together for follow-up keyset reads; cursor reads must
-    not also pass ``offset``.
+    not also pass ``offset``. Exactly one of those modes is required.
     """
     if offset is not None and offset < 0:
         msg = "offset must be greater than or equal to 0"
@@ -394,8 +414,11 @@ async def list_deployments_page(
     if (cursor_created_at is None) != (cursor_exclude_id is None):
         msg = "cursor_created_at and cursor_exclude_id must be provided together"
         raise ValueError(msg)
-    if cursor_created_at and offset is not None:
+    if cursor_created_at is not None and offset is not None:
         msg = "offset cannot be used with cursor_created_at and cursor_exclude_id"
+        raise ValueError(msg)
+    if offset is None and cursor_created_at is None:
+        msg = "either offset or cursor_created_at/cursor_exclude_id is required"
         raise ValueError(msg)
     attachment_counts_subquery = (
         select(
@@ -423,13 +446,17 @@ async def list_deployments_page(
     stmt = _scope_to_owner_or_allowed(stmt, user_id=user_id, allowed_ids=allowed_ids)
     if project_id is not None:
         stmt = stmt.where(Deployment.project_id == project_id)
-    if cursor_created_at:
+    if deployment_type is not None:
+        stmt = stmt.where(Deployment.deployment_type == deployment_type)
+    if cursor_created_at is not None:
+        # DESC keyset: seek strictly after (created_at, id) cursor.
         stmt = stmt.where(
             or_(
-                # older deployments
                 col(Deployment.created_at) < cursor_created_at,
-                # Same age but different deployments
-                (col(Deployment.created_at) == cursor_created_at) & (col(Deployment.id) < cursor_exclude_id),
+                and_(
+                    col(Deployment.created_at) == cursor_created_at,
+                    col(Deployment.id) < cursor_exclude_id,
+                ),
             )
         )
     if flow_version_ids:
@@ -571,6 +598,7 @@ async def count_deployments_by_provider(
     deployment_provider_account_id: UUID,
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
+    deployment_type: DeploymentType | None = None,
     allowed_ids: list[UUID] | None = None,
 ) -> int:
     """Count deployments for a provider account.
@@ -578,6 +606,7 @@ async def count_deployments_by_provider(
     ``allowed_ids`` mirrors ``list_deployments_page``: ``None`` counts owner rows
     only (OSS default); a list counts the owner ⊕ ``allowed_ids`` union so the
     pagination total reflects the same authorization prefilter as the page.
+    ``deployment_type``, when set, counts only rows of that local type.
     """
     stmt = select(func.count(Deployment.id)).where(
         Deployment.deployment_provider_account_id == deployment_provider_account_id,
@@ -585,6 +614,8 @@ async def count_deployments_by_provider(
     stmt = _scope_to_owner_or_allowed(stmt, user_id=user_id, allowed_ids=allowed_ids)
     if project_id is not None:
         stmt = stmt.where(Deployment.project_id == project_id)
+    if deployment_type is not None:
+        stmt = stmt.where(Deployment.deployment_type == deployment_type)
     if flow_version_ids:
         matched_deployments_subquery = (
             select(FlowVersionDeploymentAttachment.deployment_id)
@@ -713,8 +744,13 @@ async def delete_deployments_by_owner_and_ids(
     db: AsyncSession,
     *,
     deployment_owner_pairs: list[DeploymentOwnerPair],
-) -> int:
-    """Delete owner-scoped deployment rows; return the number of deployment rows deleted."""
+) -> int | UnknownDeleteCount:
+    """Delete owner-scoped deployment rows.
+
+    Returns:
+        The deleted row count when the driver reports an ``int`` rowcount;
+        otherwise ``UNKNOWN_DELETE_COUNT``.
+    """
     if not deployment_owner_pairs:
         return 0
 
@@ -735,14 +771,15 @@ async def delete_deployments_by_owner_and_ids(
             ).in_(deployment_owner_pairs),
         )
     )
-    if result.rowcount is None:
-        msg = (
-            "DELETE rowcount was None for deployments=%s -- "
-            "database driver may not support rowcount for DELETE statements"
-        )
-        await logger.aerror(
-            msg,
-            deployment_owner_pairs,
-        )
-        raise RuntimeError(msg % deployment_owner_pairs)
-    return result.rowcount
+    # Prefer isinstance over ``is not None``: some drivers may return non-int
+    # sentinels, and inventing a count from those would be misleading.
+    if isinstance(result.rowcount, int):
+        return result.rowcount
+
+    await logger.aerror(
+        "DELETE rowcount was not an int for deployments=%s (got %r) -- "
+        "database driver may not support rowcount for DELETE statements",
+        deployment_owner_pairs,
+        result.rowcount,
+    )
+    return UNKNOWN_DELETE_COUNT

--- a/src/backend/base/langflow/services/database/models/deployment/model.py
+++ b/src/backend/base/langflow/services/database/models/deployment/model.py
@@ -7,10 +7,14 @@ from lfx.services.adapters.deployment.schema import DeploymentType
 from pydantic import field_validator
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, UniqueConstraint
-from sqlmodel import Column, DateTime, Field, Relationship, SQLModel, func
+from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 
 from langflow.schema.serialize import UUIDstr
-from langflow.services.database.utils import validate_non_empty_string, validate_non_empty_string_preserve_value
+from langflow.services.database.utils import (
+    utc_now,
+    validate_non_empty_string,
+    validate_non_empty_string_preserve_value,
+)
 
 if TYPE_CHECKING:
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
@@ -112,13 +116,19 @@ class Deployment(SQLModel, table=True):  # type: ignore[call-arg]
             index=True,
         ),
     )
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     user: "User" = Relationship(back_populates="deployments")

--- a/src/backend/base/langflow/services/database/models/deployment_provider_account/model.py
+++ b/src/backend/base/langflow/services/database/models/deployment_provider_account/model.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from pydantic import field_validator, model_validator
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, UniqueConstraint
-from sqlmodel import Column, DateTime, Field, Relationship, SQLModel, func
+from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 from typing_extensions import Self
 
 from langflow.schema.serialize import UUIDstr
@@ -17,6 +17,7 @@ from langflow.services.database.models.deployment_provider_account.utils import 
 )
 from langflow.services.database.utils import (
     normalize_string_or_none,
+    utc_now,
     validate_non_empty_string,
 )
 
@@ -97,13 +98,19 @@ class DeploymentProviderAccount(SQLModel, table=True):  # type: ignore[call-arg]
     # MUST be stored encrypted; the CRUD layer encrypts via auth_utils before writing
     # and the Read schema intentionally excludes this field.
     api_key: str = Field(description="Provider credential material. Stored encrypted; never returned in API responses.")
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     user: "User" = Relationship(back_populates="deployment_provider_accounts")

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/model.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/model.py
@@ -6,9 +6,9 @@ from uuid import UUID, uuid4
 from pydantic import ValidationInfo, field_validator
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import validates
-from sqlmodel import Column, DateTime, Field, SQLModel, func
+from sqlmodel import Column, DateTime, Field, SQLModel
 
-from langflow.services.database.utils import validate_non_empty_string
+from langflow.services.database.utils import utc_now, validate_non_empty_string
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -39,13 +39,19 @@ class FlowVersionDeploymentAttachment(SQLModel, table=True):  # type: ignore[cal
             "Links this Langflow flow version to its provider-side resource."
         ),
     )
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     # Primary enforcement is in CRUD helpers (require_non_empty at write boundary).

--- a/src/backend/base/langflow/services/database/utils.py
+++ b/src/backend/base/langflow/services/database/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -12,6 +13,18 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 if TYPE_CHECKING:
     from langflow.services.database.service import DatabaseService
+
+
+def utc_now() -> datetime:
+    """Return timezone-aware UTC now for ORM timestamp columns.
+
+    Prefer Column ``default`` / ``onupdate`` with this over
+    ``server_default=func.now()``: on SQLite, ``func.now()`` stores
+    second-level precision. When that value is loaded into Python and
+    SQLAlchemy later sends it as a query parameter, it is formatted with
+    microseconds — stored column text vs the parameter then diverge.
+    """
+    return datetime.now(timezone.utc)
 
 
 async def initialize_database(*, fix_migration: bool = False) -> None:

--- a/src/backend/tests/integration/test_deployments_integration.py
+++ b/src/backend/tests/integration/test_deployments_integration.py
@@ -18,6 +18,7 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentType,
     ItemResult,
 )
+from sqlalchemy import text
 
 pytestmark = pytest.mark.noclient
 
@@ -217,6 +218,129 @@ async def test_list_deployments_db_mode_syncs_display_name(async_session, active
                 deployment_beta.display_name,
                 deployment_gamma.display_name,
             } == {"Agent Alpha", "Agent Beta", "Agent Gamma"}
+
+
+@pytest.mark.asyncio
+async def test_list_deployments_db_mode_filters_by_deployment_type(async_session, active_user):
+    """Type-scoped DB list returns/prunes only matching local types; other types stay untouched."""
+    with patch("langflow.services.utils.FEATURE_FLAGS.wxo_deployments", new=True):
+        register_builtin_adapters()
+
+        project_a = Folder(name=f"project-a-{uuid4()}", user_id=active_user.id)
+        async_session.add(project_a)
+        await async_session.commit()
+
+        provider_account = await create_provider_account(
+            async_session,
+            user_id=active_user.id,
+            name=f"provider-{uuid4()}",
+            provider_key="watsonx-orchestrate",
+            provider_url="https://api.example.com",
+            provider_tenant_id="tenant-1",
+            api_key="secret",  # pragma: allowlist secret
+        )
+
+        agent_known = await create_deployment(
+            async_session,
+            user_id=active_user.id,
+            project_id=project_a.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key=f"rk-agent-known-{uuid4()}",
+            display_name="Agent Known",
+            deployment_type=DeploymentType.AGENT,
+        )
+        agent_stale = await create_deployment(
+            async_session,
+            user_id=active_user.id,
+            project_id=project_a.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key=f"rk-agent-stale-{uuid4()}",
+            display_name="Agent Stale",
+            deployment_type=DeploymentType.AGENT,
+        )
+        other_type = await create_deployment(
+            async_session,
+            user_id=active_user.id,
+            project_id=project_a.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key=f"rk-other-{uuid4()}",
+            display_name="Other Type",
+            deployment_type=DeploymentType.AGENT,
+        )
+        # Second local type outside the enum catalog so filtering is observable
+        # without expanding DeploymentType for production.
+        await async_session.execute(
+            text("UPDATE deployment SET deployment_type = :deployment_type WHERE id = :id"),
+            {"deployment_type": "other", "id": other_type.id.hex},
+        )
+        await async_session.commit()
+        # Avoid ORM refresh of a value outside DeploymentType.
+        async_session.expunge(other_type)
+
+        provider_items_by_resource_key = {
+            agent_known.resource_key: _provider_deployment(
+                agent_known.resource_key,
+                "tech-known",
+                display_name="Agent Known Synced",
+                description="",
+            ),
+        }
+
+        async def mock_fetch_provider_resource_keys(*args, **kwargs):  # noqa: ARG001
+            resource_keys = kwargs.get("resource_keys", [])
+            # Type-scoped sync must only ask the provider about matching local rows.
+            assert set(resource_keys) <= {agent_known.resource_key, agent_stale.resource_key}
+            assert other_type.resource_key not in resource_keys
+            assert kwargs.get("deployment_type") is DeploymentType.AGENT
+            known = {key for key in resource_keys if key in provider_items_by_resource_key}
+            return known, DeploymentListResult(deployments=[provider_items_by_resource_key[key] for key in known])
+
+        with (
+            patch(
+                "langflow.api.v1.mappers.deployments.helpers.fetch_provider_resource_keys",
+                new_callable=AsyncMock,
+                side_effect=mock_fetch_provider_resource_keys,
+            ),
+            patch(
+                "langflow.api.v1.deployments.resolve_deployment_adapter",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "langflow.api.v1.deployments.get_deployment_mapper",
+                return_value=_NoSnapshotBindingMapper(),
+            ),
+            patch(
+                "langflow.api.v1.mappers.deployments.helpers.get_settings_service",
+                return_value=SimpleNamespace(
+                    settings=SimpleNamespace(
+                        deployment_list_sync_batch_size=500,
+                        deployment_list_sync_max_rounds=2,
+                    )
+                ),
+            ),
+        ):
+            response = await list_deployments(
+                provider_id=provider_account.id,
+                session=async_session,
+                current_user=active_user,
+                # size=1 avoids a short-page backfill; this test is about type
+                # filtering + prune, not keyset refill behavior.
+                params=SimpleNamespace(page=1, size=1),
+                deployment_type=DeploymentType.AGENT,
+                load_from_provider=False,
+            )
+
+        assert response.total == 1
+        assert [item.resource_key for item in response.deployments] == [agent_known.resource_key]
+        await async_session.commit()
+
+        assert await get_deployment_db(async_session, user_id=active_user.id, deployment_id=agent_known.id) is not None
+        assert await get_deployment_db(async_session, user_id=active_user.id, deployment_id=agent_stale.id) is None
+        other_still_present = await async_session.execute(
+            text("SELECT 1 FROM deployment WHERE id = :id AND deployment_type = 'other'"),
+            {"id": other_type.id.hex},
+        )
+        assert other_still_present.first() is not None
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/alembic/test_a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
+++ b/src/backend/tests/unit/alembic/test_a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
@@ -1,0 +1,104 @@
+"""Tests for deployment timestamp rewrite / server_default drop migration."""
+
+import importlib
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+_MIGRATION = importlib.import_module("langflow.alembic.versions.a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps")
+
+
+def test_sqlite_timestamp_rewrite_pads_whole_second_strings():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE deployment (id BLOB PRIMARY KEY, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO deployment (id, created_at, updated_at) VALUES "
+                "(:id, '2026-07-09 21:00:00', '2026-07-09 21:00:00')"
+            ),
+            {"id": b"\x01" * 16},
+        )
+        _MIGRATION._rewrite_table_timestamps(conn, "deployment", ("created_at", "updated_at"))
+        row = conn.execute(sa.text("SELECT quote(created_at), quote(updated_at) FROM deployment")).one()
+        assert row[0] == "'2026-07-09 21:00:00.000000'"
+        assert row[1] == "'2026-07-09 21:00:00.000000'"
+
+
+def test_sqlite_timestamp_rewrite_preserves_existing_fractional_seconds():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE deployment (id BLOB PRIMARY KEY, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO deployment (id, created_at, updated_at) VALUES "
+                "(:id, '2026-07-09 21:00:00.123456', '2026-07-09 21:00:00.654321')"
+            ),
+            {"id": b"\x02" * 16},
+        )
+        _MIGRATION._rewrite_table_timestamps(conn, "deployment", ("created_at", "updated_at"))
+        row = conn.execute(sa.text("SELECT quote(created_at), quote(updated_at) FROM deployment")).one()
+        assert row[0] == "'2026-07-09 21:00:00.123456'"
+        assert row[1] == "'2026-07-09 21:00:00.654321'"
+
+
+def test_drop_timestamp_server_defaults_clears_sqlite_current_timestamp(monkeypatch):
+    """batch_alter_table must remove DEFAULT CURRENT_TIMESTAMP from timestamp columns."""
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+    from sqlalchemy import inspect
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE deployment ("
+                "id BLOB PRIMARY KEY, "
+                "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+            )
+        )
+        before = {c["name"]: c.get("default") for c in inspect(conn).get_columns("deployment")}
+        assert before["created_at"] == "CURRENT_TIMESTAMP"
+        assert before["updated_at"] == "CURRENT_TIMESTAMP"
+
+        ops = Operations(MigrationContext.configure(conn))
+        monkeypatch.setattr(_MIGRATION, "op", ops)
+        _MIGRATION._drop_timestamp_server_defaults(conn, "deployment", ("created_at", "updated_at"))
+
+        after = {c["name"]: c.get("default") for c in inspect(conn).get_columns("deployment")}
+        assert after["created_at"] is None
+        assert after["updated_at"] is None
+        ddl = conn.execute(sa.text("SELECT sql FROM sqlite_master WHERE name='deployment'")).scalar()
+        assert ddl is not None
+        assert "DEFAULT" not in ddl.upper()
+
+
+def test_upgrade_skips_data_rewrite_on_non_sqlite(monkeypatch):
+    """upgrade() must not rewrite rows on PostgreSQL (schema default drop still runs)."""
+
+    class _FakeConn:
+        dialect = type("D", (), {"name": "postgresql"})()
+
+    calls: list[tuple] = []
+
+    def _fake_rewrite(conn, table_name, column_names):  # noqa: ARG001
+        calls.append(("rewrite", table_name))
+
+    def _fake_drop(conn, table_name, column_names):  # noqa: ARG001
+        calls.append(("drop", table_name))
+
+    monkeypatch.setattr(_MIGRATION.op, "get_bind", lambda: _FakeConn())
+    monkeypatch.setattr(_MIGRATION, "_rewrite_table_timestamps", _fake_rewrite)
+    monkeypatch.setattr(_MIGRATION, "_drop_timestamp_server_defaults", _fake_drop)
+    _MIGRATION.upgrade()
+    assert all(kind == "drop" for kind, _ in calls)
+    assert {name for _, name in calls} == {
+        "deployment",
+        "deployment_provider_account",
+        "flow_version_deployment_attachment",
+    }

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -612,13 +612,13 @@ class TestListDeploymentsSynced:
         mock_count.assert_awaited_once()
 
     @pytest.mark.asyncio
-    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=1)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
     @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
-    async def test_mismatched_type_not_in_known_skips_without_deleting(
+    async def test_forwards_deployment_type_to_page_count_and_provider(
         self,
         mock_list,
         mock_fetch,
@@ -627,23 +627,15 @@ class TestListDeploymentsSynced:
         mock_count_attachments,
         mock_count,
     ):
-        """Row not in known but with a different local type is skipped, not deleted.
+        """Type-scoped lists push deployment_type into DB page/count and provider lookup."""
+        from langflow.api.v1.mappers.deployments.helpers import DeploymentType, list_deployments_synced
 
-        The provider was filtered by type, so absence only means the type didn't
-        match — the resource may still exist on the provider.
-        """
         row_match = _mock_deployment_row("rk-1", deployment_type="agent")
-        row_other = _mock_deployment_row("rk-2", deployment_type="other")
-        mock_list.side_effect = [
-            [(row_match, 0, []), (row_other, 0, [])],
-            [],
-        ]
-        # Provider filtered by "agent" — only rk-1 returned
+        mock_list.side_effect = [[(row_match, 0, [])], []]
         mock_fetch.return_value = ({"rk-1"}, _mock_provider_view([SimpleNamespace(id="rk-1")]))
         mock_count_attachments.return_value = {row_match.id: 0}
         db = _mock_async_db()
-
-        from langflow.api.v1.mappers.deployments.helpers import DeploymentType, list_deployments_synced
+        deployment_type = DeploymentType("agent")
 
         accepted, _, _ = await list_deployments_synced(
             deployment_adapter=AsyncMock(),
@@ -653,15 +645,16 @@ class TestListDeploymentsSynced:
             db=db,
             page=1,
             size=10,
-            deployment_type=DeploymentType("agent"),
+            deployment_type=deployment_type,
         )
 
-        assert len(accepted) == 1
-        assert accepted[0][0] is row_match
-        # rk-2 was NOT deleted — just skipped
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-1"]
+        assert mock_list.call_args_list[0].kwargs["deployment_type"] is deployment_type
+        assert mock_list.call_args_list[1].kwargs["deployment_type"] is deployment_type  # backfill
+        assert mock_fetch.await_args.kwargs["deployment_type"] is deployment_type
+        assert mock_count.await_args.kwargs["deployment_type"] is deployment_type
         mock_delete.assert_not_awaited()
         mock_delete_unbound.assert_awaited_once()
-        mock_count.assert_awaited_once()
 
     @pytest.mark.asyncio
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
@@ -757,7 +750,7 @@ class TestListDeploymentsSynced:
         """Only two sync rounds run: initial fetch + one refill."""
         stale_1 = _mock_deployment_row("rk-stale-1")
         stale_2 = _mock_deployment_row("rk-stale-2")
-        mock_list.side_effect = [[(stale_1, 0, [])], [(stale_2, 0, [])]]
+        mock_list.side_effect = [[(stale_1, 0, [])], [(stale_2, 0, [])], []]
         mock_fetch.return_value = (set(), None)  # never known
         db = AsyncMock()
 
@@ -775,18 +768,73 @@ class TestListDeploymentsSynced:
         )
 
         assert accepted == []
-        assert mock_list.call_count == 2
-        first_call, second_call = mock_list.call_args_list
+        assert mock_list.call_count == 3  # two sync rounds + empty backfill probe
+        first_call, second_call, backfill_call = mock_list.call_args_list
         assert first_call.kwargs["offset"] == 0
         assert second_call.kwargs["offset"] is None
         assert first_call.kwargs["cursor_created_at"] is None
         assert first_call.kwargs["cursor_exclude_id"] is None
         assert second_call.kwargs["cursor_created_at"] == stale_1.created_at
         assert second_call.kwargs["cursor_exclude_id"] == stale_1.id
+        assert backfill_call.kwargs["cursor_created_at"] == stale_2.created_at
+        assert backfill_call.kwargs["cursor_exclude_id"] == stale_2.id
         mock_delete.assert_awaited_once_with(
             db,
             deployment_owner_pairs=[(stale_1.user_id, stale_1.id), (stale_2.user_id, stale_2.id)],
         )
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=1)
+    @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_continues_list_path_when_later_provider_round_fails(
+        self,
+        mock_list,
+        mock_fetch,
+        mock_delete,
+        mock_delete_unbound,
+        mock_count_attachments,
+        mock_count,
+    ):
+        """A failed refill logs and stops rounds; earlier work completes and backfill may fill the page."""
+        good = _mock_deployment_row("rk-good")
+        stale = _mock_deployment_row("rk-stale")
+        refill = _mock_deployment_row("rk-refill")
+        # Round 2 lists refill then fails provider check before advancing the cursor,
+        # so backfill re-reads from after `stale` and can include refill unverified.
+        mock_list.side_effect = [[(good, 0, []), (stale, 0, [])], [(refill, 0, [])], [(refill, 2, [])]]
+        mock_fetch.side_effect = [
+            ({"rk-good"}, _mock_provider_view([SimpleNamespace(id="rk-good")])),
+            RuntimeError("provider unavailable"),
+        ]
+        mock_count_attachments.return_value = {good.id: 0}
+        db = _mock_async_db()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, _, _ = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=2,
+            deployment_type=None,
+        )
+
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-good", "rk-refill"]
+        assert accepted[1][1] == 2
+        mock_delete.assert_awaited_once_with(
+            db,
+            deployment_owner_pairs=[(stale.user_id, stale.id)],
+        )
+        mock_delete_unbound.assert_awaited_once()
+        assert mock_delete_unbound.await_args.kwargs["deployment_ids"] == [good.id]
         mock_count.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -917,7 +965,7 @@ class TestListDeploymentsSynced:
             deployment_type=None,
         )
 
-        assert mock_list.call_args.kwargs["limit"] == 42
+        assert mock_list.call_args_list[0].kwargs["limit"] == 42
         mock_fetch.assert_not_awaited()
         mock_count.assert_awaited_once()
 
@@ -930,7 +978,7 @@ class TestListDeploymentsSynced:
         """The configured max_sync_rounds caps the number of sync rounds."""
         self._sync_settings.deployment_list_sync_max_rounds = 3
         stale_rows = [_mock_deployment_row(f"rk-stale-{i}") for i in range(3)]
-        mock_list.side_effect = [[(row, 0, [])] for row in stale_rows]
+        mock_list.side_effect = [[(row, 0, [])] for row in stale_rows] + [[]]
         mock_fetch.return_value = (set(), None)
         db = AsyncMock()
 
@@ -948,7 +996,7 @@ class TestListDeploymentsSynced:
         )
 
         assert accepted == []
-        assert mock_list.call_count == 3
+        assert mock_list.call_count == 4  # three sync rounds + empty backfill probe
         assert mock_list.call_args_list[0].kwargs["offset"] == 0
         assert mock_list.call_args_list[1].kwargs["offset"] is None
         assert mock_list.call_args_list[2].kwargs["offset"] is None
@@ -958,6 +1006,8 @@ class TestListDeploymentsSynced:
         assert mock_list.call_args_list[1].kwargs["cursor_exclude_id"] == stale_rows[0].id
         assert mock_list.call_args_list[2].kwargs["cursor_created_at"] == stale_rows[1].created_at
         assert mock_list.call_args_list[2].kwargs["cursor_exclude_id"] == stale_rows[1].id
+        assert mock_list.call_args_list[3].kwargs["cursor_created_at"] == stale_rows[2].created_at
+        assert mock_list.call_args_list[3].kwargs["cursor_exclude_id"] == stale_rows[2].id
         mock_delete.assert_awaited_once_with(
             db,
             deployment_owner_pairs=[(row.user_id, row.id) for row in stale_rows],
@@ -983,8 +1033,8 @@ class TestListDeploymentsSynced:
         """When the DB tracks fewer rows than the candidate batch, all are synced in one round."""
         owner = uuid4()
         rows = [_mock_deployment_row(f"rk-{i}", user_id=owner) for i in range(3)]
-        # DB returns all 3 in one call, then nothing — no padding, no second fetch.
-        mock_list.side_effect = [[(r, 0, []) for r in rows], []]
+        # DB returns all 3 in one call, then empty sync refill + empty backfill probe.
+        mock_list.side_effect = [[(r, 0, []) for r in rows], [], []]
         mock_fetch.return_value = (
             {r.resource_key for r in rows},
             _mock_provider_view([SimpleNamespace(id=r.resource_key) for r in rows]),
@@ -1007,7 +1057,7 @@ class TestListDeploymentsSynced:
 
         assert [row.resource_key for row, _, _ in accepted] == ["rk-0", "rk-1", "rk-2"]
         assert total == 3
-        assert mock_list.call_count == 2  # one candidate fetch + one empty refill probe
+        assert mock_list.call_count == 3  # candidate fetch + empty sync refill + empty backfill
         mock_delete.assert_not_awaited()
         mock_delete_unbound.assert_awaited_once()
         mock_count.assert_awaited_once()
@@ -1054,6 +1104,64 @@ class TestListDeploymentsSynced:
         assert [row.resource_key for row, _, _ in accepted] == ["rk-good"]
         mock_delete.assert_awaited_once_with(db, deployment_owner_pairs=[(owner, stale.id)])
         mock_delete_unbound.assert_awaited_once()
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
+    @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_backfills_page_with_unverified_local_rows_after_sync_rounds(
+        self,
+        mock_list,
+        mock_fetch,
+        mock_delete,
+        mock_delete_unbound,
+        mock_count_attachments,
+        mock_count,
+    ):
+        """When sync rounds leave the page short, local rows backfill without provider checks."""
+        self._sync_settings.deployment_list_sync_max_rounds = 1
+        owner = uuid4()
+        good = _mock_deployment_row("rk-good", user_id=owner)
+        stale = _mock_deployment_row("rk-stale", user_id=owner)
+        backfill = _mock_deployment_row("rk-backfill", user_id=owner)
+        mock_list.side_effect = [
+            [(good, 0, []), (stale, 0, [])],  # sync round
+            [(backfill, 3, [])],  # unverified backfill
+        ]
+        mock_fetch.return_value = ({"rk-good"}, _mock_provider_view([SimpleNamespace(id="rk-good")]))
+        mock_count_attachments.return_value = {good.id: 0}
+        db = _mock_async_db()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, _, provider_data = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=2,
+            deployment_type=None,
+        )
+
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-good", "rk-backfill"]
+        assert accepted[1][1] == 3  # backfill keeps local attachment count
+        assert "rk-backfill" not in provider_data
+        mock_delete.assert_awaited_once_with(db, deployment_owner_pairs=[(owner, stale.id)])
+        # Binding sync runs before backfill, so only provider-confirmed rows are targeted.
+        mock_delete_unbound.assert_awaited_once()
+        assert mock_delete_unbound.await_args.kwargs["deployment_ids"] == [good.id]
+        assert mock_list.call_count == 2
+        backfill_call = mock_list.call_args_list[1]
+        assert backfill_call.kwargs["offset"] is None
+        assert backfill_call.kwargs["cursor_created_at"] == stale.created_at
+        assert backfill_call.kwargs["cursor_exclude_id"] == stale.id
+        assert backfill_call.kwargs["limit"] == 1
         mock_count.assert_awaited_once()
 
 
@@ -2912,6 +3020,26 @@ class TestDeploymentCrud:
         assert "deployment.id" in statement_text
 
     @pytest.mark.asyncio
+    async def test_list_deployments_page_applies_deployment_type_filter(self):
+        from langflow.api.v1.mappers.deployments.helpers import DeploymentType
+        from langflow.services.database.models.deployment.crud import list_deployments_page
+
+        db = _CaptureDb(_FakeAllResult([]))
+
+        rows = await list_deployments_page(
+            db,
+            user_id=uuid4(),
+            deployment_provider_account_id=uuid4(),
+            offset=0,
+            limit=10,
+            deployment_type=DeploymentType.AGENT,
+        )
+
+        assert rows == []
+        statement_text = str(db.statements[0]).lower()
+        assert "deployment_type" in statement_text
+
+    @pytest.mark.asyncio
     async def test_list_deployments_page_rejects_offset_with_seek_cursor(self):
         from langflow.services.database.models.deployment.crud import list_deployments_page
 
@@ -2924,6 +3052,18 @@ class TestDeploymentCrud:
                 limit=10,
                 cursor_created_at=datetime.now(timezone.utc),
                 cursor_exclude_id=uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_page_requires_offset_or_seek_cursor(self):
+        from langflow.services.database.models.deployment.crud import list_deployments_page
+
+        with pytest.raises(ValueError, match="either offset or cursor_created_at"):
+            await list_deployments_page(
+                _CaptureDb(_FakeAllResult([])),
+                user_id=uuid4(),
+                deployment_provider_account_id=uuid4(),
+                limit=10,
             )
 
     @pytest.mark.asyncio
@@ -2948,6 +3088,23 @@ class TestDeploymentCrud:
         assert "delete from deployment" in deployment_delete
         assert "user_id" in deployment_delete
         assert "id" in deployment_delete
+
+    @pytest.mark.asyncio
+    async def test_delete_deployments_by_owner_and_ids_unknown_rowcount(self):
+        from langflow.services.database.models.deployment.crud import (
+            UNKNOWN_DELETE_COUNT,
+            delete_deployments_by_owner_and_ids,
+        )
+
+        db = _CaptureDb(SimpleNamespace(rowcount=None))
+
+        deleted = await delete_deployments_by_owner_and_ids(
+            db,
+            deployment_owner_pairs=[(uuid4(), uuid4())],
+        )
+
+        assert deleted is UNKNOWN_DELETE_COUNT
+        assert not isinstance(deleted, int)
 
 
 class TestFlowVersionDeploymentAttachmentCrud:

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -2,11 +2,12 @@
 
 Covers:
 - fetch_provider_resource_keys: ID-only matching, error handling
-- list_deployments_synced: cursor-based sync with inline stale-row deletion
+- list_deployments_synced: candidate-batch sync with batched stale-row deletion
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -72,6 +73,7 @@ def _mock_deployment_row(
     deployment_type: str | None = None,
     *,
     user_id: UUID | None = None,
+    created_at: datetime | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=uuid4(),
@@ -81,6 +83,7 @@ def _mock_deployment_row(
         deployment_type=deployment_type,
         deployment_provider_account_id=uuid4(),
         user_id=user_id or uuid4(),
+        created_at=created_at or datetime.now(timezone.utc),
     )
 
 
@@ -342,6 +345,18 @@ class TestFetchProviderResourceKeys:
 
 
 class TestListDeploymentsSynced:
+    @pytest.fixture(autouse=True)
+    def _mock_settings_service(self):
+        self._sync_settings = SimpleNamespace(
+            deployment_list_sync_batch_size=500,
+            deployment_list_sync_max_rounds=2,
+        )
+        with patch(
+            f"{MODULE}.get_settings_service",
+            return_value=SimpleNamespace(settings=self._sync_settings),
+        ):
+            yield
+
     @pytest.mark.asyncio
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
@@ -394,7 +409,7 @@ class TestListDeploymentsSynced:
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=1)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
-    @patch(f"{MODULE}.delete_deployment_by_id", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
     async def test_deletes_stale_rows(
@@ -406,7 +421,7 @@ class TestListDeploymentsSynced:
         mock_count_attachments,
         mock_count,
     ):
-        """Rows not recognised by the provider are deleted."""
+        """Rows not recognised by the provider are batch-deleted."""
         uid = uuid4()
         stale_row = _mock_deployment_row("rk-stale", user_id=uid)
         good_row = _mock_deployment_row("rk-good", user_id=uid)
@@ -441,8 +456,7 @@ class TestListDeploymentsSynced:
         assert provider_data_by_resource_key == {}
         mock_delete.assert_awaited_once_with(
             db,
-            user_id=uid,
-            deployment_id=stale_row.id,
+            deployment_owner_pairs=[(uid, stale_row.id)],
         )
         mock_delete_unbound.assert_awaited_once()
         mock_count.assert_awaited_once()
@@ -451,7 +465,7 @@ class TestListDeploymentsSynced:
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
-    @patch(f"{MODULE}.delete_deployment_by_id", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
     async def test_merges_list_item_provider_data_across_refill_rounds(
@@ -509,7 +523,7 @@ class TestListDeploymentsSynced:
             "rk-1": {"environments": ["draft"]},
             "rk-2": {"environments": ["live"]},
         }
-        mock_delete.assert_awaited_once()
+        mock_delete.assert_awaited_once_with(db, deployment_owner_pairs=[(owner_id, stale_row.id)])
         mock_delete_unbound.assert_awaited_once()
         mock_count.assert_awaited_once()
 
@@ -574,8 +588,8 @@ class TestListDeploymentsSynced:
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
-    async def test_empty_batch_stops_loop(self, mock_list, mock_fetch, mock_count):
-        """An empty batch from the DB ends the loop."""
+    async def test_empty_batch_skips_provider_sync(self, mock_list, mock_fetch, mock_count):
+        """An empty batch from the DB ends the loop without calling the provider."""
         mock_list.return_value = []
 
         from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
@@ -601,7 +615,7 @@ class TestListDeploymentsSynced:
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
-    @patch(f"{MODULE}.delete_deployment_by_id", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
     async def test_mismatched_type_not_in_known_skips_without_deleting(
@@ -653,10 +667,10 @@ class TestListDeploymentsSynced:
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
-    @patch(f"{MODULE}.delete_deployment_by_id", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
-    async def test_cursor_does_not_advance_on_delete(
+    async def test_refill_uses_seek_cursor_when_cleanup_is_deferred(
         self,
         mock_list,
         mock_fetch,
@@ -665,12 +679,10 @@ class TestListDeploymentsSynced:
         mock_count_attachments,
         mock_count,
     ):
-        """When a stale row is deleted the cursor stays put (offset doesn't increment)."""
+        """Refill rounds seek after collected stale rows instead of advancing an offset."""
         stale = _mock_deployment_row("rk-stale")
         good = _mock_deployment_row("rk-good")
 
-        # First batch: stale row only. Cursor should stay at 0 for next fetch.
-        # Second batch: good row at the same offset (because deletion shifted it).
         mock_list.side_effect = [
             [(stale, 0, [])],
             [(good, 0, [])],
@@ -696,12 +708,16 @@ class TestListDeploymentsSynced:
             deployment_type=None,
         )
 
-        # Both list_deployments_page calls should use offset=0
-        offsets = [call.kwargs["offset"] for call in mock_list.call_args_list[:2]]
-        assert offsets == [0, 0], f"Expected cursor to stay at 0 after deletion, got offsets={offsets}"
+        first_call, second_call = mock_list.call_args_list[:2]
+        assert first_call.kwargs["offset"] == 0
+        assert first_call.kwargs["cursor_created_at"] is None
+        assert first_call.kwargs["cursor_exclude_id"] is None
+        assert second_call.kwargs["offset"] is None
+        assert second_call.kwargs["cursor_created_at"] == stale.created_at
+        assert second_call.kwargs["cursor_exclude_id"] == stale.id
         assert len(accepted) == 1
         assert accepted[0][0] is good
-        mock_delete.assert_awaited_once()
+        mock_delete.assert_awaited_once_with(db, deployment_owner_pairs=[(stale.user_id, stale.id)])
         mock_delete_unbound.assert_awaited_once()
         mock_count.assert_awaited_once()
 
@@ -727,20 +743,23 @@ class TestListDeploymentsSynced:
         )
 
         assert mock_list.call_args.kwargs["offset"] == 5
+        assert mock_list.call_args.kwargs["cursor_created_at"] is None
+        assert mock_list.call_args.kwargs["cursor_exclude_id"] is None
         mock_fetch.assert_not_awaited()
         mock_count.assert_awaited_once()
 
     @pytest.mark.asyncio
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
-    @patch(f"{MODULE}.delete_deployment_by_id", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
     @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
     @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
     async def test_stops_after_one_refill(self, mock_list, mock_fetch, mock_delete, mock_count):
         """Only two sync rounds run: initial fetch + one refill."""
-        stale = _mock_deployment_row("rk-stale")
-        # Always return a stale row — the function should still stop after 2 rounds.
-        mock_list.return_value = [(stale, 0, [])]
+        stale_1 = _mock_deployment_row("rk-stale-1")
+        stale_2 = _mock_deployment_row("rk-stale-2")
+        mock_list.side_effect = [[(stale_1, 0, [])], [(stale_2, 0, [])]]
         mock_fetch.return_value = (set(), None)  # never known
+        db = AsyncMock()
 
         from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
 
@@ -749,7 +768,7 @@ class TestListDeploymentsSynced:
             deployment_mapper=_NoSnapshotBindingMapper(),
             user_id=uuid4(),
             provider_id=uuid4(),
-            db=AsyncMock(),
+            db=db,
             page=1,
             size=2,
             deployment_type=None,
@@ -757,7 +776,17 @@ class TestListDeploymentsSynced:
 
         assert accepted == []
         assert mock_list.call_count == 2
-        assert mock_delete.await_count == 2
+        first_call, second_call = mock_list.call_args_list
+        assert first_call.kwargs["offset"] == 0
+        assert second_call.kwargs["offset"] is None
+        assert first_call.kwargs["cursor_created_at"] is None
+        assert first_call.kwargs["cursor_exclude_id"] is None
+        assert second_call.kwargs["cursor_created_at"] == stale_1.created_at
+        assert second_call.kwargs["cursor_exclude_id"] == stale_1.id
+        mock_delete.assert_awaited_once_with(
+            db,
+            deployment_owner_pairs=[(stale_1.user_id, stale_1.id), (stale_2.user_id, stale_2.id)],
+        )
         mock_count.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -813,6 +842,219 @@ class TestListDeploymentsSynced:
         assert mock_list.call_args.kwargs["project_id"] == project_id
         assert mock_count.call_args.kwargs["project_id"] == project_id
         mock_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=1)
+    @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_deletes_stale_rows_in_one_call(
+        self,
+        mock_list,
+        mock_fetch,
+        mock_delete,
+        mock_delete_unbound,
+        mock_count_attachments,
+        mock_count,
+    ):
+        """Stale ids from multiple owners are deleted through one helper call."""
+        owner_a = uuid4()
+        owner_b = uuid4()
+        stale_a1 = _mock_deployment_row("rk-a1", user_id=owner_a)
+        stale_a2 = _mock_deployment_row("rk-a2", user_id=owner_a)
+        stale_b1 = _mock_deployment_row("rk-b1", user_id=owner_b)
+        good = _mock_deployment_row("rk-good", user_id=owner_a)
+        mock_list.side_effect = [
+            [(stale_a1, 0, []), (stale_a2, 0, []), (stale_b1, 0, []), (good, 0, [])],
+            [],
+        ]
+        mock_fetch.return_value = ({"rk-good"}, _mock_provider_view([SimpleNamespace(id="rk-good")]))
+        mock_count_attachments.return_value = {good.id: 0}
+        db = _mock_async_db()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, _, _ = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=10,
+            deployment_type=None,
+        )
+
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-good"]
+        mock_delete.assert_awaited_once_with(
+            db,
+            deployment_owner_pairs=[(owner_a, stale_a1.id), (owner_a, stale_a2.id), (owner_b, stale_b1.id)],
+        )
+        mock_delete_unbound.assert_awaited_once()
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_candidate_batch_size_from_settings(self, mock_list, mock_fetch, mock_count):
+        """The configured candidate batch size is forwarded as the page query limit."""
+        self._sync_settings.deployment_list_sync_batch_size = 42
+        mock_list.return_value = []
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=BaseDeploymentMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=AsyncMock(),
+            page=1,
+            size=10,
+            deployment_type=None,
+        )
+
+        assert mock_list.call_args.kwargs["limit"] == 42
+        mock_fetch.assert_not_awaited()
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_max_sync_rounds_from_settings(self, mock_list, mock_fetch, mock_delete, mock_count):
+        """The configured max_sync_rounds caps the number of sync rounds."""
+        self._sync_settings.deployment_list_sync_max_rounds = 3
+        stale_rows = [_mock_deployment_row(f"rk-stale-{i}") for i in range(3)]
+        mock_list.side_effect = [[(row, 0, [])] for row in stale_rows]
+        mock_fetch.return_value = (set(), None)
+        db = AsyncMock()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, _, _ = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=2,
+            deployment_type=None,
+        )
+
+        assert accepted == []
+        assert mock_list.call_count == 3
+        assert mock_list.call_args_list[0].kwargs["offset"] == 0
+        assert mock_list.call_args_list[1].kwargs["offset"] is None
+        assert mock_list.call_args_list[2].kwargs["offset"] is None
+        assert mock_list.call_args_list[0].kwargs["cursor_created_at"] is None
+        assert mock_list.call_args_list[0].kwargs["cursor_exclude_id"] is None
+        assert mock_list.call_args_list[1].kwargs["cursor_created_at"] == stale_rows[0].created_at
+        assert mock_list.call_args_list[1].kwargs["cursor_exclude_id"] == stale_rows[0].id
+        assert mock_list.call_args_list[2].kwargs["cursor_created_at"] == stale_rows[1].created_at
+        assert mock_list.call_args_list[2].kwargs["cursor_exclude_id"] == stale_rows[1].id
+        mock_delete.assert_awaited_once_with(
+            db,
+            deployment_owner_pairs=[(row.user_id, row.id) for row in stale_rows],
+        )
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=3)
+    @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_syncs_all_available_candidates_when_db_has_fewer_than_batch_size(
+        self,
+        mock_list,
+        mock_fetch,
+        mock_delete,
+        mock_delete_unbound,
+        mock_count_attachments,
+        mock_count,
+    ):
+        """When the DB tracks fewer rows than the candidate batch, all are synced in one round."""
+        owner = uuid4()
+        rows = [_mock_deployment_row(f"rk-{i}", user_id=owner) for i in range(3)]
+        # DB returns all 3 in one call, then nothing — no padding, no second fetch.
+        mock_list.side_effect = [[(r, 0, []) for r in rows], []]
+        mock_fetch.return_value = (
+            {r.resource_key for r in rows},
+            _mock_provider_view([SimpleNamespace(id=r.resource_key) for r in rows]),
+        )
+        mock_count_attachments.return_value = {r.id: 0 for r in rows}
+        db = _mock_async_db()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, total, _ = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=10,
+            deployment_type=None,
+        )
+
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-0", "rk-1", "rk-2"]
+        assert total == 3
+        assert mock_list.call_count == 2  # one candidate fetch + one empty refill probe
+        mock_delete.assert_not_awaited()
+        mock_delete_unbound.assert_awaited_once()
+        mock_count.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=2)
+    @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.delete_unbound_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.delete_deployments_by_owner_and_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.fetch_provider_resource_keys", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployments_page", new_callable=AsyncMock)
+    async def test_stale_rows_beyond_page_boundary_are_batch_deleted(
+        self,
+        mock_list,
+        mock_fetch,
+        mock_delete,
+        mock_delete_unbound,
+        mock_count_attachments,
+        mock_count,
+    ):
+        """Stale rows past the accepted page are still collected and batch-deleted."""
+        owner = uuid4()
+        good = _mock_deployment_row("rk-good", user_id=owner)
+        stale = _mock_deployment_row("rk-stale", user_id=owner)
+        # Candidate window of 2 rows; page size 1 so only `good` is accepted.
+        mock_list.side_effect = [[(good, 0, []), (stale, 0, [])], []]
+        mock_fetch.return_value = ({"rk-good"}, _mock_provider_view([SimpleNamespace(id="rk-good")]))
+        mock_count_attachments.return_value = {good.id: 0}
+        db = _mock_async_db()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployments_synced
+
+        accepted, _, _ = await list_deployments_synced(
+            deployment_adapter=AsyncMock(),
+            deployment_mapper=_NoSnapshotBindingMapper(),
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            db=db,
+            page=1,
+            size=1,
+            deployment_type=None,
+        )
+
+        assert [row.resource_key for row, _, _ in accepted] == ["rk-good"]
+        mock_delete.assert_awaited_once_with(db, deployment_owner_pairs=[(owner, stale.id)])
+        mock_delete_unbound.assert_awaited_once()
+        mock_count.assert_awaited_once()
 
 
 class _FakeMapper(BaseDeploymentMapper):
@@ -2115,6 +2357,18 @@ class TestWxoResolveRollbackUpdate:
 
 
 class TestListDeploymentsSyncedBindingPhase:
+    @pytest.fixture(autouse=True)
+    def _mock_settings_service(self):
+        self._sync_settings = SimpleNamespace(
+            deployment_list_sync_batch_size=500,
+            deployment_list_sync_max_rounds=2,
+        )
+        with patch(
+            f"{MODULE}.get_settings_service",
+            return_value=SimpleNamespace(settings=self._sync_settings),
+        ):
+            yield
+
     @pytest.mark.asyncio
     @patch(f"{MODULE}.count_deployments_by_provider", new_callable=AsyncMock, return_value=1)
     @patch(f"{MODULE}.count_attachments_by_deployment_ids", new_callable=AsyncMock)
@@ -2619,6 +2873,81 @@ class _CaptureDb:
     async def exec(self, statement):
         self.statements.append(statement)
         return self._result
+
+
+class TestDeploymentCrud:
+    @pytest.mark.asyncio
+    async def test_list_deployments_page_requires_complete_seek_cursor(self):
+        from langflow.services.database.models.deployment.crud import list_deployments_page
+
+        with pytest.raises(ValueError, match="cursor_created_at and cursor_exclude_id"):
+            await list_deployments_page(
+                _CaptureDb(_FakeAllResult([])),
+                user_id=uuid4(),
+                deployment_provider_account_id=uuid4(),
+                offset=0,
+                limit=10,
+                cursor_created_at=datetime.now(timezone.utc),
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_page_applies_seek_cursor(self):
+        from langflow.services.database.models.deployment.crud import list_deployments_page
+
+        db = _CaptureDb(_FakeAllResult([]))
+
+        rows = await list_deployments_page(
+            db,
+            user_id=uuid4(),
+            deployment_provider_account_id=uuid4(),
+            limit=10,
+            cursor_created_at=datetime.now(timezone.utc),
+            cursor_exclude_id=uuid4(),
+        )
+
+        assert rows == []
+        assert len(db.statements) == 1
+        statement_text = str(db.statements[0]).lower()
+        assert "created_at" in statement_text
+        assert "deployment.id" in statement_text
+
+    @pytest.mark.asyncio
+    async def test_list_deployments_page_rejects_offset_with_seek_cursor(self):
+        from langflow.services.database.models.deployment.crud import list_deployments_page
+
+        with pytest.raises(ValueError, match="offset cannot be used"):
+            await list_deployments_page(
+                _CaptureDb(_FakeAllResult([])),
+                user_id=uuid4(),
+                deployment_provider_account_id=uuid4(),
+                offset=0,
+                limit=10,
+                cursor_created_at=datetime.now(timezone.utc),
+                cursor_exclude_id=uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_deployments_by_owner_and_ids_deletes_pairs_in_one_call(self):
+        from langflow.services.database.models.deployment.crud import delete_deployments_by_owner_and_ids
+
+        deployment_owner_pairs = [(uuid4(), uuid4()), (uuid4(), uuid4()), (uuid4(), uuid4())]
+        db = _CaptureDb(SimpleNamespace(rowcount=3))
+
+        deleted = await delete_deployments_by_owner_and_ids(
+            db,
+            deployment_owner_pairs=deployment_owner_pairs,
+        )
+
+        assert deleted == 3
+        assert len(db.statements) == 2
+        attachment_delete = str(db.statements[0]).lower()
+        deployment_delete = str(db.statements[1]).lower()
+        assert "delete from flow_version_deployment_attachment" in attachment_delete
+        assert "user_id" in attachment_delete
+        assert "deployment_id" in attachment_delete
+        assert "delete from deployment" in deployment_delete
+        assert "user_id" in deployment_delete
+        assert "id" in deployment_delete
 
 
 class TestFlowVersionDeploymentAttachmentCrud:

--- a/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
@@ -162,3 +162,29 @@ async def test_local_deployment_queries_filter_project_and_flow_versions(async_s
         deployment_provider_account_id=provider_account.id,
     )
     assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_stores_microsecond_precision_on_sqlite(async_session: AsyncSession):
+    """ORM creates must write DateTime bind strings, not SQLite whole-second now()."""
+    from sqlalchemy import text
+
+    user, provider_account, project_a, _project_b = await _seed_user_provider_and_projects(async_session)
+    dep = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-{uuid4()}",
+        display_name="Timed",
+        deployment_type=DeploymentType.AGENT,
+    )
+    await async_session.commit()
+    row = (
+        await async_session.execute(
+            text("SELECT quote(created_at), quote(updated_at) FROM deployment WHERE id = :id"),
+            {"id": dep.id.hex},
+        )
+    ).one()
+    assert "." in row[0], f"created_at missing fractional seconds: {row[0]}"
+    assert "." in row[1], f"updated_at missing fractional seconds: {row[1]}"

--- a/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
@@ -165,6 +165,70 @@ async def test_local_deployment_queries_filter_project_and_flow_versions(async_s
 
 
 @pytest.mark.asyncio
+async def test_local_deployment_queries_filter_deployment_type(async_session: AsyncSession):
+    """list/count honor deployment_type so type-scoped sync can prune safely."""
+    from sqlalchemy import text
+
+    user, provider_account, project_a, _project_b = await _seed_user_provider_and_projects(async_session)
+
+    dep_agent = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-agent-{uuid4()}",
+        display_name="Agent",
+        deployment_type=DeploymentType.AGENT,
+    )
+    dep_other = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-other-{uuid4()}",
+        display_name="Other",
+        deployment_type=DeploymentType.AGENT,
+    )
+    # Seed a second local type outside the enum catalog so filtering is observable
+    # without expanding DeploymentType for production.
+    await async_session.execute(
+        text("UPDATE deployment SET deployment_type = :deployment_type WHERE id = :id"),
+        {"deployment_type": "other", "id": dep_other.id.hex},
+    )
+    await async_session.commit()
+    async_session.expunge(dep_other)
+
+    page = await list_deployments_page(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        offset=0,
+        limit=10,
+        deployment_type=DeploymentType.AGENT,
+    )
+    count = await count_deployments_by_provider(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        deployment_type=DeploymentType.AGENT,
+    )
+    assert count == 1
+    assert [row.id for row, _, _ in page] == [dep_agent.id]
+
+    unfiltered_count = await count_deployments_by_provider(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+    )
+    assert unfiltered_count == 2
+    other_still_present = await async_session.execute(
+        text("SELECT 1 FROM deployment WHERE id = :id AND deployment_type = 'other'"),
+        {"id": dep_other.id.hex},
+    )
+    assert other_still_present.first() is not None
+
+
+@pytest.mark.asyncio
 async def test_create_deployment_stores_microsecond_precision_on_sqlite(async_session: AsyncSession):
     """ORM creates must write DateTime bind strings, not SQLite whole-second now()."""
     from sqlalchemy import text
@@ -188,3 +252,149 @@ async def test_create_deployment_stores_microsecond_precision_on_sqlite(async_se
     ).one()
     assert "." in row[0], f"created_at missing fractional seconds: {row[0]}"
     assert "." in row[1], f"updated_at missing fractional seconds: {row[1]}"
+
+
+@pytest.mark.asyncio
+async def test_list_deployments_page_keyset_tiebreaks_on_identical_created_at(
+    async_session: AsyncSession,
+):
+    """Identical created_at values require the id tie-break for the next page."""
+    from datetime import datetime, timezone
+
+    from langflow.services.database.models.deployment.model import Deployment
+    from sqlmodel import col, update
+
+    user, provider_account, project_a, _project_b = await _seed_user_provider_and_projects(async_session)
+
+    newer = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-newer-{uuid4()}",
+        display_name="Newer",
+        deployment_type=DeploymentType.AGENT,
+    )
+    older = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-older-{uuid4()}",
+        display_name="Older",
+        deployment_type=DeploymentType.AGENT,
+    )
+    same_second = datetime(2026, 7, 9, 21, 0, 0, tzinfo=timezone.utc)
+    await async_session.execute(
+        update(Deployment).where(col(Deployment.id).in_([newer.id, older.id])).values(created_at=same_second)
+    )
+    await async_session.commit()
+    async_session.expunge(newer)
+    async_session.expunge(older)
+
+    page1 = await list_deployments_page(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        offset=0,
+        limit=1,
+    )
+    assert len(page1) == 1
+    cursor_row = page1[0][0]
+    assert cursor_row.created_at is not None
+    assert cursor_row.created_at.microsecond == 0
+
+    page2 = await list_deployments_page(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        limit=1,
+        cursor_created_at=cursor_row.created_at,
+        cursor_exclude_id=cursor_row.id,
+    )
+    assert len(page2) == 1
+    assert page2[0][0].id != cursor_row.id
+    assert {page1[0][0].id, page2[0][0].id} == {newer.id, older.id}
+
+
+@pytest.mark.asyncio
+async def test_list_deployments_page_keyset_after_rewriting_whole_second_sqlite_strings(
+    async_session: AsyncSession,
+):
+    """Legacy whole-second SQLite strings must keyset correctly after DateTime rewrite."""
+    import importlib
+
+    from sqlalchemy import text
+
+    mig = importlib.import_module("langflow.alembic.versions.a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps")
+
+    user, provider_account, project_a, _project_b = await _seed_user_provider_and_projects(async_session)
+
+    newer = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-newer-{uuid4()}",
+        display_name="Newer",
+        deployment_type=DeploymentType.AGENT,
+    )
+    older = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-older-{uuid4()}",
+        display_name="Older",
+        deployment_type=DeploymentType.AGENT,
+    )
+    # Reproduce the historical SQLite store shape (no fractional seconds).
+    await async_session.execute(
+        text("UPDATE deployment SET created_at = '2026-07-09 21:00:00' WHERE id IN (:a, :b)"),
+        {"a": newer.id.hex, "b": older.id.hex},
+    )
+    await async_session.commit()
+
+    raw = (
+        await async_session.execute(
+            text("SELECT quote(created_at) FROM deployment WHERE id = :id"),
+            {"id": newer.id.hex},
+        )
+    ).one()
+    assert raw[0] == "'2026-07-09 21:00:00'"
+
+    # Without rewrite, keyset would re-include the cursor via string '<'.
+    conn = await async_session.connection()
+    await conn.run_sync(
+        lambda sync_conn: mig._rewrite_table_timestamps(sync_conn, "deployment", ("created_at", "updated_at"))
+    )
+    await async_session.commit()
+    async_session.expunge(newer)
+    async_session.expunge(older)
+
+    rewritten = (
+        await async_session.execute(
+            text("SELECT quote(created_at) FROM deployment WHERE id = :id"),
+            {"id": newer.id.hex},
+        )
+    ).one()
+    assert rewritten[0] == "'2026-07-09 21:00:00.000000'"
+
+    page1 = await list_deployments_page(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        offset=0,
+        limit=1,
+    )
+    cursor_row = page1[0][0]
+    page2 = await list_deployments_page(
+        async_session,
+        user_id=user.id,
+        deployment_provider_account_id=provider_account.id,
+        limit=1,
+        cursor_created_at=cursor_row.created_at,
+        cursor_exclude_id=cursor_row.id,
+    )
+    assert page2[0][0].id != cursor_row.id
+    assert {page1[0][0].id, page2[0][0].id} == {newer.id, older.id}

--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -98,6 +98,32 @@ class RuntimeSettings(BaseModel):
     via the `lfx.executors` entry-point group can be selected by setting this to their kind.
     """
 
+    deployment_list_sync_batch_size: int = Field(default=500, ge=1)
+    """Max local deployment rows checked against the provider in one list request.
+
+    The deployment list endpoint in Langflow, GET /api/v1/deployments,
+    prunes any local DB rows representing deployments that have been deleted
+    in the provider. This can involve multiple provider API calls before
+    filling the page size requested to Langflow, because deployments might
+    have been pruned. If each provider API call only uses the
+    page-size-requested-to-langflow many deployments, then the number of
+    provider requests (bounded by deployment_list_sync_max_rounds) can be high
+    and result in a slow API response from Langflow to the requestor. Thus, it
+    is recommended to make the batch size larger than the requested page size
+    to Langflow to reduce the number of provider API calls.
+    """
+
+    deployment_list_sync_max_rounds: int = Field(default=2, ge=1)
+    """Max provider validation rounds used to fill one deployment-list response.
+
+    When GET /api/v1/deployments checks local deployment rows against a provider,
+    some rows might be pruned before they can be returned to the requestor.
+    If enough rows are pruned, Langflow can make another provider API call
+    using the next local DB rows after the last checked deployment.
+    This setting limits how many of those provider API calls Langflow can make
+    while trying to fill a single requested page.
+    """
+
     @field_validator("event_delivery", mode="before")
     @classmethod
     def set_event_delivery(cls, value, info):

--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -111,6 +111,10 @@ class RuntimeSettings(BaseModel):
     and result in a slow API response from Langflow to the requestor. Thus, it
     is recommended to make the batch size larger than the requested page size
     to Langflow to reduce the number of provider API calls.
+
+    Do not set this above the provider API's limit for ID-filtered list calls.
+    watsonx Orchestrate docs do not currently document such a limit; keep the
+    value within whatever limit your provider enforces in practice.
     """
 
     deployment_list_sync_max_rounds: int = Field(default=2, ge=1)

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -181,6 +181,8 @@ EXPECTED_FIELDS = {
     "redis_queue_polling_watchdog_interval_s",
     "max_ingestion_timeout_secs",
     "executor_kind",
+    "deployment_list_sync_batch_size",
+    "deployment_list_sync_max_rounds",
     # UiSettings
     "embedded_mode",
     "hide_getting_started_progress",


### PR DESCRIPTION
prune stale deployments in a single db call instead of per-round and per-owner
