### PR TITLE
fix(ci): publish bundle deps before nightly main

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -644,6 +644,9 @@ jobs:
         with:
           enable-cache: false
           python-version: "3.13"
+      - name: Wait for bundle PyPI propagation
+        if: needs.publish-nightly-bundles.result == 'success'
+        run: sleep 120
       - name: Check direct bundle dependencies on PyPI
         run: |
           uv run --with packaging --no-project python - <<'PY'

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -253,6 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.verify.outputs.version }}
+      bundles-found: ${{ steps.build-bundles.outputs.bundles-found }}
     defaults:
       run:
         shell: bash
@@ -482,10 +483,155 @@ jobs:
         run: |
           make publish base=true
 
+  publish-nightly-bundles:
+    name: Publish Bundle Dependencies to PyPI
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-lfx]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.build-nightly-main.outputs.bundles-found == '1' && needs.test-cross-platform.result == 'success' && (needs.publish-nightly-lfx.result == 'success' || inputs.build_lfx == false) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.nightly_tag_release }}
+          persist-credentials: true
+      - name: Download bundles artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-nightly-bundles
+          path: bundles-dist
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          python-version: "3.13"
+      - name: Publish bundle dependencies to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(bundles-dist/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "No bundle wheels to publish."
+            exit 0
+          fi
+
+          publish_plan="$(mktemp)"
+          uv run --with packaging --no-project python - "${wheels[@]}" > "$publish_plan" <<'PY'
+          import email
+          import json
+          import sys
+          import tomllib
+          import urllib.error
+          import urllib.request
+          import zipfile
+          from pathlib import Path
+
+          from packaging.requirements import Requirement
+          from packaging.utils import canonicalize_name
+          from packaging.version import InvalidVersion, Version
+
+          root_order = {}
+          root_dependencies = tomllib.loads(Path("pyproject.toml").read_text())["project"].get("dependencies", [])
+          for index, dependency in enumerate(root_dependencies):
+            try:
+              requirement = Requirement(dependency)
+            except Exception:
+              continue
+            root_order.setdefault(canonicalize_name(requirement.name), index)
+
+          def read_wheel_metadata(path: Path) -> tuple[str, Version]:
+            with zipfile.ZipFile(path) as wheel:
+              metadata_path = next(name for name in wheel.namelist() if name.endswith(".dist-info/METADATA"))
+              metadata = email.message_from_bytes(wheel.read(metadata_path))
+            return canonicalize_name(metadata["Name"]), Version(metadata["Version"])
+
+          plan = []
+          for wheel_arg in sys.argv[1:]:
+            wheel_path = Path(wheel_arg)
+            name, version = read_wheel_metadata(wheel_path)
+            url = f"https://pypi.org/pypi/{name}/json"
+            try:
+              with urllib.request.urlopen(url, timeout=30) as response:
+                project = json.load(response)
+            except urllib.error.HTTPError as exc:
+              if exc.code != 404:
+                raise
+              print(f"Will publish new PyPI project {name} {version}: {wheel_path}", file=sys.stderr)
+              plan.append((0, root_order.get(name, 9999), name, str(wheel_path)))
+              continue
+
+            published_versions = set()
+            for version_text in project.get("releases", {}):
+              try:
+                published_versions.add(Version(version_text))
+              except InvalidVersion:
+                continue
+
+            if version in published_versions:
+              print(f"Skipping {name} {version}: already published.", file=sys.stderr)
+              continue
+
+            print(f"Will publish new version {name} {version}: {wheel_path}", file=sys.stderr)
+            plan.append((1, root_order.get(name, 9999), name, str(wheel_path)))
+
+          for _, _, _, wheel_path in sorted(plan):
+            print(wheel_path)
+          PY
+
+          if [ ! -s "$publish_plan" ]; then
+            echo "No bundle wheels need publishing."
+            exit 0
+          fi
+
+          mapfile -t wheels < "$publish_plan"
+          failed=0
+          pypi_publish_delay_seconds=60
+          pypi_publish_max_attempts=5
+          wheel_count=${#wheels[@]}
+          wheel_number=0
+          for wheel in "${wheels[@]}"; do
+            wheel_number=$((wheel_number + 1))
+            echo "Publishing $wheel"
+            attempt=1
+            published=0
+            while true; do
+              # Re-running a nightly without bumping bundle versions should be a no-op.
+              if err=$(uv publish "$wheel" 2>&1); then
+                echo "$err"
+                published=1
+                break
+              fi
+              echo "$err"
+              if echo "$err" | grep -qiE 'already exists|file already exists|HTTP 400|duplicate'; then
+                echo "Skipping $wheel: already published."
+                break
+              fi
+              if echo "$err" | grep -qiE 'HTTP 429|429 Too Many Requests|Too many new projects created'; then
+                if [ "$attempt" -lt "$pypi_publish_max_attempts" ]; then
+                  echo "PyPI rate limited $wheel; sleeping ${pypi_publish_delay_seconds}s before retry $((attempt + 1))/${pypi_publish_max_attempts}."
+                  sleep "$pypi_publish_delay_seconds"
+                  attempt=$((attempt + 1))
+                  continue
+                fi
+              fi
+              echo "Publish failed for $wheel"
+              failed=1
+              break
+            done
+            if [ "$published" = "1" ] && [ "$wheel_number" -lt "$wheel_count" ]; then
+              echo "Sleeping ${pypi_publish_delay_seconds}s before the next PyPI upload."
+              sleep "$pypi_publish_delay_seconds"
+            fi
+          done
+          if [ "$failed" = "1" ]; then
+            exit 1
+          fi
+
   check-nightly-main-pypi-dependencies:
     name: Check Main Nightly PyPI Dependencies
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-base]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' }}
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-base, publish-nightly-bundles]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' && (needs.publish-nightly-bundles.result == 'success' || needs.build-nightly-main.outputs.bundles-found != '1') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- publish built bundle wheels after cross-platform nightly wheel tests and after LFX is on PyPI
- make the main PyPI dependency guard wait for bundle publishing before checking direct lfx-* dependencies
- expose the bundle-artifact output from the main nightly build job so the publish job can skip cleanly if no bundles are built

## Validation
- git diff --check
- actionlint -shellcheck= -ignore 'input ".*" of workflow_call event has the default value' .github/workflows/release_nightly.yml
- reproduced current PyPI guard failure: lfx-bundles<2.0,>=1.1
- built src/bundles/lfx-bundles wheel and confirmed publish planning selects lfx_bundles-1.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly releases now publish bundle dependencies more reliably, reducing missed or duplicate package uploads.
  * Improved handling for already-published versions and temporary publishing throttling.

* **Chores**
  * Updated nightly release steps so downstream checks wait for bundle publishing only when bundle artifacts are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->