### PR TITLE
chore: release lfx to docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1332,6 +1332,61 @@ jobs:
         run: |
           cd src/lfx && uv publish dist/*.whl
 
+  call_docker_build_lfx:
+    name: Call Docker Build Workflow for LFX
+    if: |
+      always() &&
+      !cancelled() &&
+      inputs.release_lfx &&
+      needs.publish-lfx.result == 'success'
+    needs: [publish-lfx, determine-lfx-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag }}
+      - name: Set up QEMU
+        if: ${{ !inputs.dry_run }}
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: ${{ !inputs.dry_run }}
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Prepare Docker metadata
+        if: ${{ !inputs.dry_run }}
+        id: lfx_docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            langflowai/lfx
+          tags: |
+            type=raw,value=${{ needs.determine-lfx-version.outputs.version }}
+            type=raw,value=latest,enable=${{ !inputs.pre_release }}
+          labels: |
+            org.opencontainers.image.title=LFX
+            org.opencontainers.image.description=Langflow Executor - CLI tool for running Langflow AI workflows
+            org.opencontainers.image.vendor=Langflow
+            org.opencontainers.image.version=${{ needs.determine-lfx-version.outputs.version }}
+      - name: Publish LFX Docker image to Docker Hub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/lfx/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.lfx_docker_meta.outputs.tags }}
+          labels: ${{ steps.lfx_docker_meta.outputs.labels }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   call_docker_build_base:
     name: Call Docker Build Workflow for Langflow Base
     if: ${{ inputs.build_docker_base }}


### PR DESCRIPTION
release lfx to docker hub. Might not work as expected but basic boiler plate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to automatically publish the LFX container image for supported architectures.
  * Added support for versioned image tags and the `latest` tag for non-pre-release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->