### PR TITLE
fix: thin single focus border on global-variable input

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -163,8 +163,7 @@ const getAnchorClassName = (
     editNode && "min-h-7 p-0 px-1",
     editNode && disabled && "min-h-5 border-muted",
     disabled && "bg-muted text-muted",
-    isFocused &&
-      "border-foreground ring-1 ring-foreground hover:border-foreground",
+    isFocused && "border-foreground hover:border-foreground",
   );
 };
 

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -1240,7 +1240,7 @@ input[type="password"]::-ms-clear {
     @apply top-[-23px];
   }
   .popover-input {
-    @apply h-fit w-fit flex-1 border-none bg-transparent p-0 shadow-none outline-none ring-0 ring-offset-0 placeholder:text-muted-foreground focus:border-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50;
+    @apply h-fit w-fit flex-1 border-none bg-transparent p-0 shadow-none outline-none ring-0 ring-offset-0 placeholder:text-muted-foreground focus:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50;
   }
 
   .beta-badge {


### PR DESCRIPTION
Fixes the focus border on global-variable inputs (fields with the globe
icon, e.g. "Match Text"), which rendered as a **doubled** and **thicker**
border than every other input in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated popover input focus visuals for a cleaner, simpler appearance.
  * Removed the extra focus ring effect and adjusted keyboard-focus styling to match the updated design.
  * Kept layout, disabled, and placeholder behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->