### PR TITLE
fix: store deployment timestamps with microsecond precision on SQLite

### DIFF
--- a/src/backend/base/langflow/alembic/versions/a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
+++ b/src/backend/base/langflow/alembic/versions/a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
@@ -1,0 +1,121 @@
+"""Rewrite deployment-family SQLite timestamps; drop now() server defaults
+
+Phase: EXPAND
+
+Bug
+---
+On SQLite, ``func.now()`` / ``datetime('now')`` store second-level precision
+(``YYYY-MM-DD HH:MM:SS``). When that same value is loaded into Python and
+SQLAlchemy later sends it as a query parameter, it is formatted with
+microsecond precision (``...SS.ffffff``). Comparisons then fail when one
+side is the stored ORM column value (still second-level text) and the
+other is SQLAlchemy's DateTime formatting of a previously loaded ORM
+datetime used as a parameter — even if both represent the same
+wall-clock second.
+
+An app-only fix (normalize the value in every query, cast/format in SQL,
+special-case whole-second equality) would have to live in every reader
+forever, and would still leave mixed formats (``YYYY-MM-DD HH:MM:SS`` and
+``...SS.ffffff``) in the table. Rewriting once through
+``DateTime(timezone=True)``, plus changing the deployment-family models to
+write UTC via Column ``default`` / ``onupdate`` (with no
+``server_default=func.now()``; Field stays ``default=None``), makes what
+is stored match what SQLAlchemy sends later, so ordinary
+equality/ordering work without per-query workarounds, and keeps a single
+predictable storage format for timestamps.
+
+This migration:
+1. On SQLite: re-reads each timestamp as ``DateTime(timezone=True)`` and
+   writes it back through the same type (idempotent).
+2. On all dialects: drops ``server_default`` / ``DEFAULT CURRENT_TIMESTAMP``
+   from these columns so the DB schema matches the models (ORM must supply
+   Python UTC; raw inserts must too).
+
+No-op data rewrite on PostgreSQL (real timestamp comparisons).
+
+Revision ID: a8f3c2d1e4b5
+Revises: 247308ce2598
+Create Date: 2026-07-09 23:20:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "a8f3c2d1e4b5"  # pragma: allowlist secret
+down_revision: str | None = "247308ce2598"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES_AND_COLUMNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("deployment", ("created_at", "updated_at")),
+    ("deployment_provider_account", ("created_at", "updated_at")),
+    ("flow_version_deployment_attachment", ("created_at", "updated_at")),
+)
+
+
+def _rewrite_table_timestamps(conn, table_name: str, column_names: tuple[str, ...]) -> None:
+    if not migration.table_exists(table_name, conn):
+        return
+    # Leave ``id`` untyped so SQLite's CHAR/BLOB UUID storage round-trips as-is.
+    columns = [sa.column("id")]
+    columns.extend(
+        sa.column(name, sa.DateTime(timezone=True))
+        for name in column_names
+        if migration.column_exists(table_name, name, conn)
+    )
+    if len(columns) == 1:
+        return
+
+    table = sa.table(table_name, *columns)
+    timestamp_cols = [c for c in columns if c.name != "id"]
+    rows = conn.execute(sa.select(table.c.id, *timestamp_cols)).all()
+    params = [
+        {"b_id": row.id, **{col.name: getattr(row, col.name) for col in timestamp_cols}}
+        for row in rows
+        if not all(getattr(row, col.name) is None for col in timestamp_cols)
+    ]
+    if not params:
+        return
+    # One executemany: DateTime bind formatting still runs per parameter set.
+    stmt = (
+        sa.update(table)
+        .where(table.c.id == sa.bindparam("b_id"))
+        .values(**{col.name: sa.bindparam(col.name) for col in timestamp_cols})
+    )
+    conn.execute(stmt, params)
+
+
+def _drop_timestamp_server_defaults(conn, table_name: str, column_names: tuple[str, ...]) -> None:
+    if not migration.table_exists(table_name, conn):
+        return
+    existing = [name for name in column_names if migration.column_exists(table_name, name, conn)]
+    if not existing:
+        return
+    # Single batch_alter_table so SQLite recreates the table once for all columns.
+    with op.batch_alter_table(table_name) as batch_op:
+        for name in existing:
+            batch_op.alter_column(
+                name,
+                existing_type=sa.DateTime(timezone=True),
+                existing_nullable=False,
+                server_default=None,
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "sqlite":
+        for table_name, column_names in _TABLES_AND_COLUMNS:
+            _rewrite_table_timestamps(conn, table_name, column_names)
+    for table_name, column_names in _TABLES_AND_COLUMNS:
+        _drop_timestamp_server_defaults(conn, table_name, column_names)
+
+
+def downgrade() -> None:
+    # Format normalization is forward-only; padded microsecond strings remain valid.
+    # Restoring server_default=func.now() would reintroduce the SQLite whole-second bug.
+    pass

--- a/src/backend/base/langflow/services/database/models/deployment/model.py
+++ b/src/backend/base/langflow/services/database/models/deployment/model.py
@@ -7,10 +7,14 @@ from lfx.services.adapters.deployment.schema import DeploymentType
 from pydantic import field_validator
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, UniqueConstraint
-from sqlmodel import Column, DateTime, Field, Relationship, SQLModel, func
+from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 
 from langflow.schema.serialize import UUIDstr
-from langflow.services.database.utils import validate_non_empty_string, validate_non_empty_string_preserve_value
+from langflow.services.database.utils import (
+    utc_now,
+    validate_non_empty_string,
+    validate_non_empty_string_preserve_value,
+)
 
 if TYPE_CHECKING:
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
@@ -112,13 +116,19 @@ class Deployment(SQLModel, table=True):  # type: ignore[call-arg]
             index=True,
         ),
     )
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     user: "User" = Relationship(back_populates="deployments")

--- a/src/backend/base/langflow/services/database/models/deployment_provider_account/model.py
+++ b/src/backend/base/langflow/services/database/models/deployment_provider_account/model.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from pydantic import field_validator, model_validator
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import ForeignKey, UniqueConstraint
-from sqlmodel import Column, DateTime, Field, Relationship, SQLModel, func
+from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 from typing_extensions import Self
 
 from langflow.schema.serialize import UUIDstr
@@ -17,6 +17,7 @@ from langflow.services.database.models.deployment_provider_account.utils import 
 )
 from langflow.services.database.utils import (
     normalize_string_or_none,
+    utc_now,
     validate_non_empty_string,
 )
 
@@ -97,13 +98,19 @@ class DeploymentProviderAccount(SQLModel, table=True):  # type: ignore[call-arg]
     # MUST be stored encrypted; the CRUD layer encrypts via auth_utils before writing
     # and the Read schema intentionally excludes this field.
     api_key: str = Field(description="Provider credential material. Stored encrypted; never returned in API responses.")
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     user: "User" = Relationship(back_populates="deployment_provider_accounts")

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/model.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/model.py
@@ -6,9 +6,9 @@ from uuid import UUID, uuid4
 from pydantic import ValidationInfo, field_validator
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import validates
-from sqlmodel import Column, DateTime, Field, SQLModel, func
+from sqlmodel import Column, DateTime, Field, SQLModel
 
-from langflow.services.database.utils import validate_non_empty_string
+from langflow.services.database.utils import utc_now, validate_non_empty_string
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -39,13 +39,19 @@ class FlowVersionDeploymentAttachment(SQLModel, table=True):  # type: ignore[cal
             "Links this Langflow flow version to its provider-side resource."
         ),
     )
+    # Column-level Python default/onupdate (not server_default=func.now()):
+    # on SQLite, func.now() stores second-level precision. When that value is
+    # loaded into Python and SQLAlchemy later sends it as a query parameter,
+    # it is formatted with microseconds — stored column text vs the parameter
+    # then diverge. Field stays default=None so the ORM attribute is unset
+    # until flush; SQLAlchemy fills via Column default.
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, nullable=False),
     )
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False),
+        sa_column=Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False),
     )
 
     # Primary enforcement is in CRUD helpers (require_non_empty at write boundary).

--- a/src/backend/base/langflow/services/database/utils.py
+++ b/src/backend/base/langflow/services/database/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -12,6 +13,18 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 if TYPE_CHECKING:
     from langflow.services.database.service import DatabaseService
+
+
+def utc_now() -> datetime:
+    """Return timezone-aware UTC now for ORM timestamp columns.
+
+    Prefer Column ``default`` / ``onupdate`` with this over
+    ``server_default=func.now()``: on SQLite, ``func.now()`` stores
+    second-level precision. When that value is loaded into Python and
+    SQLAlchemy later sends it as a query parameter, it is formatted with
+    microseconds — stored column text vs the parameter then diverge.
+    """
+    return datetime.now(timezone.utc)
 
 
 async def initialize_database(*, fix_migration: bool = False) -> None:

--- a/src/backend/tests/unit/alembic/test_a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
+++ b/src/backend/tests/unit/alembic/test_a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps.py
@@ -1,0 +1,104 @@
+"""Tests for deployment timestamp rewrite / server_default drop migration."""
+
+import importlib
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+_MIGRATION = importlib.import_module("langflow.alembic.versions.a8f3c2d1e4b5_rewrite_deployment_sqlite_timestamps")
+
+
+def test_sqlite_timestamp_rewrite_pads_whole_second_strings():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE deployment (id BLOB PRIMARY KEY, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO deployment (id, created_at, updated_at) VALUES "
+                "(:id, '2026-07-09 21:00:00', '2026-07-09 21:00:00')"
+            ),
+            {"id": b"\x01" * 16},
+        )
+        _MIGRATION._rewrite_table_timestamps(conn, "deployment", ("created_at", "updated_at"))
+        row = conn.execute(sa.text("SELECT quote(created_at), quote(updated_at) FROM deployment")).one()
+        assert row[0] == "'2026-07-09 21:00:00.000000'"
+        assert row[1] == "'2026-07-09 21:00:00.000000'"
+
+
+def test_sqlite_timestamp_rewrite_preserves_existing_fractional_seconds():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE deployment (id BLOB PRIMARY KEY, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)")
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO deployment (id, created_at, updated_at) VALUES "
+                "(:id, '2026-07-09 21:00:00.123456', '2026-07-09 21:00:00.654321')"
+            ),
+            {"id": b"\x02" * 16},
+        )
+        _MIGRATION._rewrite_table_timestamps(conn, "deployment", ("created_at", "updated_at"))
+        row = conn.execute(sa.text("SELECT quote(created_at), quote(updated_at) FROM deployment")).one()
+        assert row[0] == "'2026-07-09 21:00:00.123456'"
+        assert row[1] == "'2026-07-09 21:00:00.654321'"
+
+
+def test_drop_timestamp_server_defaults_clears_sqlite_current_timestamp(monkeypatch):
+    """batch_alter_table must remove DEFAULT CURRENT_TIMESTAMP from timestamp columns."""
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+    from sqlalchemy import inspect
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE deployment ("
+                "id BLOB PRIMARY KEY, "
+                "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+            )
+        )
+        before = {c["name"]: c.get("default") for c in inspect(conn).get_columns("deployment")}
+        assert before["created_at"] == "CURRENT_TIMESTAMP"
+        assert before["updated_at"] == "CURRENT_TIMESTAMP"
+
+        ops = Operations(MigrationContext.configure(conn))
+        monkeypatch.setattr(_MIGRATION, "op", ops)
+        _MIGRATION._drop_timestamp_server_defaults(conn, "deployment", ("created_at", "updated_at"))
+
+        after = {c["name"]: c.get("default") for c in inspect(conn).get_columns("deployment")}
+        assert after["created_at"] is None
+        assert after["updated_at"] is None
+        ddl = conn.execute(sa.text("SELECT sql FROM sqlite_master WHERE name='deployment'")).scalar()
+        assert ddl is not None
+        assert "DEFAULT" not in ddl.upper()
+
+
+def test_upgrade_skips_data_rewrite_on_non_sqlite(monkeypatch):
+    """upgrade() must not rewrite rows on PostgreSQL (schema default drop still runs)."""
+
+    class _FakeConn:
+        dialect = type("D", (), {"name": "postgresql"})()
+
+    calls: list[tuple] = []
+
+    def _fake_rewrite(conn, table_name, column_names):  # noqa: ARG001
+        calls.append(("rewrite", table_name))
+
+    def _fake_drop(conn, table_name, column_names):  # noqa: ARG001
+        calls.append(("drop", table_name))
+
+    monkeypatch.setattr(_MIGRATION.op, "get_bind", lambda: _FakeConn())
+    monkeypatch.setattr(_MIGRATION, "_rewrite_table_timestamps", _fake_rewrite)
+    monkeypatch.setattr(_MIGRATION, "_drop_timestamp_server_defaults", _fake_drop)
+    _MIGRATION.upgrade()
+    assert all(kind == "drop" for kind, _ in calls)
+    assert {name for _, name in calls} == {
+        "deployment",
+        "deployment_provider_account",
+        "flow_version_deployment_attachment",
+    }

--- a/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_filters.py
@@ -162,3 +162,29 @@ async def test_local_deployment_queries_filter_project_and_flow_versions(async_s
         deployment_provider_account_id=provider_account.id,
     )
     assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_stores_microsecond_precision_on_sqlite(async_session: AsyncSession):
+    """ORM creates must write DateTime bind strings, not SQLite whole-second now()."""
+    from sqlalchemy import text
+
+    user, provider_account, project_a, _project_b = await _seed_user_provider_and_projects(async_session)
+    dep = await create_deployment(
+        async_session,
+        user_id=user.id,
+        project_id=project_a.id,
+        deployment_provider_account_id=provider_account.id,
+        resource_key=f"rk-{uuid4()}",
+        display_name="Timed",
+        deployment_type=DeploymentType.AGENT,
+    )
+    await async_session.commit()
+    row = (
+        await async_session.execute(
+            text("SELECT quote(created_at), quote(updated_at) FROM deployment WHERE id = :id"),
+            {"id": dep.id.hex},
+        )
+    ).one()
+    assert "." in row[0], f"created_at missing fractional seconds: {row[0]}"
+    assert "." in row[1], f"updated_at missing fractional seconds: {row[1]}"


### PR DESCRIPTION
On SQLite, ``func.now()`` / ``datetime('now')`` store second-level precision (``YYYY-MM-DD HH:MM:SS``). When that same value is loaded into Python and SQLAlchemy later sends it as a query parameter, it is formatted with microsecond precision (``...SS.ffffff``). Comparisons then fail when one side is the stored ORM column value (still second-level text) and the other is SQLAlchemy's DateTime formatting of a previously loaded ORM datetime used as a parameter — even if both represent the same wall-clock second.

Rewriting once through ``DateTime(timezone=True)``, plus changing the deployment-family models to write UTC via Column ``default`` / ``onupdate``, makes what is stored match what SQLAlchemy sends later, so ordinary equality/ordering work without per-query workarounds.