### PR TITLE
fix(mcp): forward extra advertised input fields as tweaks during tool execution

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -310,7 +310,15 @@ async def handle_call_tool(
             )
 
         session_id = processed_inputs.pop("session_id", None) or str(uuid4())
-        input_request = SimplifiedAPIRequest(input_value=processed_inputs.get("input_value", ""), session_id=session_id)
+        input_value = processed_inputs.pop("input_value", "")
+        # Forward remaining advertised fields as tweaks so the published MCP schema
+        # matches actual execution behaviour (issue #14002).
+        extra_tweaks = dict(processed_inputs) if processed_inputs else None
+        input_request = SimplifiedAPIRequest(
+            input_value=input_value,
+            session_id=session_id,
+            tweaks=extra_tweaks,
+        )
 
         async def send_progress_updates(progress_token):
             try:

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -532,3 +532,47 @@ def test_json_schema_from_flow_preserves_flow_defined_session_id(monkeypatch):
     # The flow's own definition wins — the reserved injection must not clobber it.
     assert schema["properties"]["session_id"]["description"] == custom_session_id_property["description"]
     assert "session_id" in schema["required"]
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_forwards_extra_fields_as_tweaks(monkeypatch):
+    """Extra advertised fields (beyond input_value/session_id) must be forwarded as tweaks.
+
+    Regression test for issue #14002: MCP tools advertise multiple input fields
+    but previously only passed input_value during execution.
+    """
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={
+            "input_value": "hello",
+            "backend_token": "secret-tok",
+            "backend_url": "https://backend.example.com",
+        },
+    )
+
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    assert forwarded_request.input_value == "hello"
+    # tweaks is stored as a Tweaks model; compare its root dict for clarity.
+    tweaks_dict = (
+        forwarded_request.tweaks.root if hasattr(forwarded_request.tweaks, "root") else dict(forwarded_request.tweaks)
+    )
+    assert tweaks_dict == {
+        "backend_token": "secret-tok",
+        "backend_url": "https://backend.example.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_tweaks_none_when_no_extra_fields(monkeypatch):
+    """When only input_value (and optionally session_id) are supplied, tweaks must be None.
+
+    Ensures backward compatibility: existing MCP calls with only input_value are
+    not affected by the issue #14002 fix.
+    """
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+    )
+
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    assert forwarded_request.tweaks is None

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -534,7 +534,6 @@ def test_json_schema_from_flow_preserves_flow_defined_session_id(monkeypatch):
     assert "session_id" in schema["required"]
 
 
-@pytest.mark.asyncio
 async def test_handle_call_tool_forwards_extra_fields_as_tweaks(monkeypatch):
     """Extra advertised fields (beyond input_value/session_id) must be forwarded as tweaks.
 
@@ -562,7 +561,6 @@ async def test_handle_call_tool_forwards_extra_fields_as_tweaks(monkeypatch):
     }
 
 
-@pytest.mark.asyncio
 async def test_handle_call_tool_tweaks_none_when_no_extra_fields(monkeypatch):
     """When only input_value (and optionally session_id) are supplied, tweaks must be None.
 


### PR DESCRIPTION
## Summary

Fixes #14002

When a flow is exposed as an MCP tool, `json_schema_from_flow()` advertises all visible input-node fields (e.g. `backend_token`, `backend_url`) in the tool's `inputSchema`. However, `handle_call_tool()` was constructing `SimplifiedAPIRequest` with only `input_value` and `session_id`, silently discarding every other argument supplied by the MCP client.

**Root cause:** `handle_call_tool` (line 313) called `processed_inputs.get("input_value", "")` without removing `input_value`, and never forwarded the remaining keys.

**Fix:** Pop `input_value` and `session_id` from `processed_inputs` first, then pass the remaining keys as `tweaks` to `SimplifiedAPIRequest`.

`process_tweaks` already handles a flat `{field_name: value}` dict and applies it to every node whose template contains a matching field. Nodes that don't have that field skip it silently (`apply_tweaks`, `if tweak_name not in template_data: continue`), so the change is safe for all existing flows.

## Changes

- `src/backend/base/langflow/api/v1/mcp_utils.py` — 8 lines changed in `handle_call_tool`
- `src/backend/tests/unit/api/v1/test_mcp_utils.py` — 2 new tests added

## Test plan

- [x] `uv run pytest src/backend/tests/unit/api/v1/test_mcp_utils.py -v` — 21/21 pass
- [x] `test_handle_call_tool_forwards_extra_fields_as_tweaks` — extra fields arrive as tweaks
- [x] `test_handle_call_tool_tweaks_none_when_no_extra_fields` — backward-compatible: tweaks is `None` when only `input_value` is supplied
- [ ] Manual: create a flow with a custom input field, expose it via MCP, call the tool with that field — verify it reaches the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool calls now correctly forward additional input fields as execution settings.
  * Tool calls containing only the primary input continue to work without additional settings.

* **Tests**
  * Added coverage for forwarding extra tool inputs and preserving existing behavior when none are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->