### PR TITLE
fix(knowledge-base): align frontend chunk defaults with backend (issue #13884)

### DIFF
--- a/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/chunkDefaults.test.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/chunkDefaults.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+
+// ── Mocks (must precede component imports) ────────────────────────────────────
+
+const mockMutateAsync = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-create-knowledge-base",
+  () => ({
+    useCreateKnowledgeBase: () => ({
+      mutateAsync: mockMutateAsync,
+      isLoading: false,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-ingestion-job-status",
+  () => ({ useGetIngestionJobStatus: () => ({ data: null }) }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-ingestion-runs",
+  () => ({
+    useGetIngestionRuns: () => ({
+      data: { runs: [], total: 0, page: 1, limit: 10, total_pages: 0 },
+      isLoading: false,
+      isError: false,
+    }),
+  }),
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: jest.fn(), get: jest.fn() },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/knowledge_bases"),
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-model-providers", () => ({
+  useGetModelProviders: () => ({
+    data: [
+      {
+        provider: "OpenAI",
+        is_enabled: true,
+        icon: "OpenAI",
+        models: [
+          {
+            model_name: "text-embedding-3-small",
+            metadata: { model_type: "embeddings" },
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/stores/alertStore", () => {
+  const store = jest.fn((selector) => {
+    const state = {
+      setSuccessData: jest.fn(),
+      setErrorData: jest.fn(),
+    };
+    return typeof selector === "function" ? selector(state) : state;
+  });
+  return { __esModule: true, default: store };
+});
+
+interface MockModelInputProps {
+  value: { id: string; name: string }[];
+  handleOnNewValue: (val: { value: { id: string; name: string }[] }) => void;
+  options: { id: string; name: string }[];
+  placeholder?: string;
+}
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/modelInputComponent",
+  () => ({
+    __esModule: true,
+    default: ({
+      value,
+      handleOnNewValue,
+      options,
+      placeholder,
+    }: MockModelInputProps) => (
+      <div data-testid="mock-model-input">
+        <select
+          data-testid="embedding-model-select"
+          value={value?.[0]?.id || ""}
+          onChange={(e) => {
+            const selected = options?.find((o) => o.id === e.target.value);
+            if (selected) handleOnNewValue({ value: [selected] });
+          }}
+        >
+          <option value="">{placeholder || "Select..."}</option>
+          {options?.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    ),
+  }),
+);
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE } from "../constants";
+import KnowledgeBaseUploadModal from "../KnowledgeBaseUploadModal";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <TooltipProvider>{children}</TooltipProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+const addDummyFile = () => {
+  const fileInput = document.getElementById("file-input") as HTMLInputElement;
+  fireEvent.change(fileInput, {
+    target: {
+      files: [new File(["x"], "doc.txt", { type: "text/plain" })],
+    },
+  } as unknown as React.ChangeEvent<HTMLInputElement>);
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("chunk defaults (issue #13884)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMutateAsync.mockResolvedValue({ id: "kb1", name: "kb1" });
+  });
+
+  it("exports DEFAULT_CHUNK_SIZE=1000 and DEFAULT_CHUNK_OVERLAP=200", () => {
+    expect(DEFAULT_CHUNK_SIZE).toBe(1000);
+    expect(DEFAULT_CHUNK_OVERLAP).toBe(200);
+  });
+
+  it("shows 1000 and 200 as initial values for a new knowledge base", async () => {
+    render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+      wrapper: createWrapper(),
+    });
+
+    addDummyFile();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("kb-chunk-size-input")).not.toBeDisabled(),
+    );
+
+    expect(screen.getByTestId("kb-chunk-size-input")).toHaveValue(1000);
+    expect(screen.getByTestId("kb-chunk-overlap-input")).toHaveValue(200);
+  });
+});

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/constants.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/constants.ts
@@ -11,8 +11,8 @@ export const getStepDescriptions = (): Record<WizardStep, string> => ({
   2: i18n.t("knowledge.reviewDescription"),
 });
 
-export const DEFAULT_CHUNK_SIZE = 100;
-export const DEFAULT_CHUNK_OVERLAP = 0;
+export const DEFAULT_CHUNK_SIZE = 1000;
+export const DEFAULT_CHUNK_OVERLAP = 200;
 export const DEFAULT_SEPARATOR = "\\n";
 
 export const KB_INGEST_FORMATS: Record<string, string[]> = {


### PR DESCRIPTION
## Summary

Fixes #13884

The knowledge base creation dialog showed `chunk_size=100` and `chunk_overlap=0`, but after saving and refreshing the page, the "Ingest Files" dialog showed `chunk_size=1000` and `chunk_overlap=200`. This inconsistency confused users into thinking the values they set were not being respected.

**Root cause:** `constants.ts` defined frontend-only defaults that were out of sync with the backend:

| Location | chunk_size | chunk_overlap |
|---|---|---|
| Frontend `constants.ts` (before) | 100 | 0 |
| Backend `model.py` | 1000 | 200 |
| Backend `schema/knowledge_base.py` | 1000 | 200 |
| Backend `api/v1/knowledge_bases.py` | 1000 | 200 |

## Changes

- `src/frontend/src/modals/knowledgeBaseUploadModal/constants.ts` — 2 values corrected

`DEFAULT_CHUNK_SIZE` and `DEFAULT_CHUNK_OVERLAP` are the single source of truth for the frontend: they initialize the React state, populate the reset path, and serve as the null-fallback when hydrating an existing KB. Correcting them here fixes all three code paths at once.

## Test plan

- [ ] Create a new knowledge base → chunk size shows **1000**, overlap shows **200**
- [ ] Save without changing values → refresh → open "Ingest Files" → values still show **1000/200**
- [ ] Existing KBs created with the old defaults (100/0) are unaffected — their stored values load correctly via the `!= null` hydration path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated knowledge base upload defaults to use larger chunks with increased overlap, improving document processing configuration.

* **Tests**
  * Added coverage verifying the default chunk size and overlap values in the upload interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->