### PR TITLE
chore: restore Python 3.14 litellm gating lost in release-1.10.2 merge

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -110,11 +110,6 @@ dependencies = [
     "transformers>=5.6.0,<6.0.0",
 ]
 
-[tool.uv]
-override-dependencies = [
-    "litellm>=1.85.1,<2.0.0"
-]
-
 [dependency-groups]
 dev = [
     "asgi-lifespan>=2.1.0",
@@ -308,7 +303,12 @@ numexpr = ["numexpr>=2.10.2"]
 qianfan = ["qianfan==0.3.5"]
 pgvector = ["pgvector>=0.4.2"]
 litellm = [
-    "litellm>=1.85.1,<2.0.0",
+    # litellm has no Python 3.14-compatible release: every version from 1.83.8
+    # onward declares Requires-Python <3.14, so nothing satisfying our >=1.85.1
+    # floor installs on 3.14 (the newest 3.14-installable litellm is 1.83.7).
+    # Gate it off on 3.14 so `pip install langflow` resolves there instead of
+    # dead-ending; drop the marker once upstream ships a 3.14-compatible litellm.
+    "litellm>=1.85.1,<2.0.0; python_version < '3.14'",
     # Runtime deps from litellm[proxy] that langflow-ide hits when logging
     # to langfuse via litellm.proxy.proxy_server (issue #12228). The full
     # [proxy] extra pins boto3==1.43.1, which conflicts with our aioboto3
@@ -363,7 +363,11 @@ langchain-unstructured = ["langchain-unstructured~=1.0.0"]
 langchain-mcp-adapters = ["langchain-mcp-adapters>=0.1.14,<0.2.0"]
 
 # Additional monitoring
-opik = ["opik>=2.0.0,<3.0.0"]
+# Gated off 3.14: opik depends on litellm unconditionally, and litellm has no
+# 3.14-compatible release (see the litellm extra above), so allowing it on 3.14
+# would drag in an uninstallable / sub-floor litellm. Re-enable once upstream
+# litellm supports 3.14.
+opik = ["opik>=2.0.0,<3.0.0; python_version < '3.14'"]
 traceloop = ["traceloop-sdk>=0.43.1,<1.0.0"]
 openlayer = ["openlayer>=0.9.0,<1.0.0"]
 


### PR DESCRIPTION
## Why

The nightly build (which builds from the latest `release-*` branch, currently `release-1.11.0`) fails its three experimental Python 3.14 cross-platform install jobs — see [run 29174116911](https://github.com/langflow-ai/langflow/actions/runs/29174116911). The `langflow-base` wheel's `[complete]` extra requires `litellm` unconditionally, so on 3.14 uv selects litellm 1.92.0, which has no cp314 wheel and whose sdist build fails (its Rust bridge uses pyo3 0.23.5, which caps at Python 3.13):

```
error: the configured Python interpreter version (3.14) is newer than
PyO3's maximum supported version (3.13)
```

#13814 fixed this by gating litellm off 3.14, and that commit (ee60a50d) is in this branch's history — but the merge of `release-1.10.2` into `release-1.11.0` (9d4810c6) resolved the `src/backend/base/pyproject.toml` conflict against it, reverting three of its hunks while keeping the rest (altk/toolguard gating, the test skips, and the workspace-root uv override all survived; the test allow-list on this branch still documents litellm as 3.14-gated).

## What

Restore the reverted hunks, mirroring main's current state:

- gate the `litellm` extra with `python_version < '3.14'`
- gate the `opik` extra likewise (opik depends on litellm unconditionally)
- drop langflow-base's `[tool.uv] override-dependencies` block; the gated litellm override already lives at the workspace root (#13814 moved it there), and member-level overrides are ignored in a uv workspace anyway

## Verification

Reproduced the failing resolution with `uv pip compile` against this source tree (lfx + langflow-base[complete]):

- `--python-version 3.14`, before: selects the failing `litellm==1.92.0`; after: resolves cleanly with no litellm/opik/toolguard
- `--python-version 3.13`, after: still selects `litellm==1.92.0` / `opik==2.1.22` — stable-Python resolution unchanged

Regenerated wheel METADATA confirms every litellm path in `complete`/`all` now carries the `python_version < '3.14'` marker.

`uv.lock` is intentionally not regenerated: no CI job checks lock freshness, and the nightly tag job runs `uv lock` itself before building.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMEd9nQqA9q4YnDLw69hwK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python 3.14 compatibility by preventing unsupported optional integrations from being installed on that version.
  * Removed a build-time package override that could cause dependency resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->