### PR TITLE
ci: pin third-party actions (wretry.action, jest-coverage-comment) to full commit SHAs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -254,7 +254,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push to Docker Hub
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
         with:
           action: docker/build-push-action@v6
           with: |
@@ -274,7 +274,7 @@ jobs:
           password: ${{ secrets.TEMP_GHCR_TOKEN}}
 
       - name: Build and push to Github Container Registry
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
         with:
           action: docker/build-push-action@v6
           with: |
@@ -361,7 +361,7 @@ jobs:
         run: sleep 120
 
       - name: Build and push ${{ matrix.component }}
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
         with:
           action: docker/build-push-action@v6
           with: |

--- a/.github/workflows/jest_test.yml
+++ b/.github/workflows/jest_test.yml
@@ -55,7 +55,7 @@ jobs:
           require_tests: true
 
       - name: Add Jest Coverage PR Comment
-        uses: MishaKav/jest-coverage-comment@main
+        uses: MishaKav/jest-coverage-comment@58072a21b8b7f84d36a6e21b5d9a0cad08bc9d75 # main
         if: github.event_name == 'pull_request'
         with:
           coverage-summary-path: src/frontend/coverage/jest/coverage-summary.json


### PR DESCRIPTION
### What

Pin the third-party actions currently referenced by mutable tags to their current commit SHA (tag kept
in a trailing comment):

| Action | Pinned to | Where |
|---|---|---|
| `Wandalen/wretry.action@master` | `e94c43b…` | `docker-build.yml` (×3) |
| `MishaKav/jest-coverage-comment@main` | `58072a2…` | `jest_test.yml` |

### Why

`@master`/`@main` are moving references — whatever they point to at run time runs in the job. The
`docker-build.yml` uses of `wretry.action` run in a job that has just logged in to **DockerHub and
GHCR** ([lines 253-282](https://github.com/langflow-ai/langflow/blob/def832f409c01f0acd3937b9317dde03d0273552/.github/workflows/docker-build.yml#L253-L282)) and does `push: true`:

```yaml
- uses: docker/login-action@...      # DOCKERHUB_TOKEN
- uses: Wandalen/wretry.action@master
  with: { action: docker/build-push-action@..., with: "push: true ..." }
```

If that action's `master` were moved (compromise or an accidental change), the new code would run with
Langflow's registry push credentials — the class of issue behind the 2025 `tj-actions/changed-files`
incident, here with image-push access.

### Scope / safety

- Behaviour unchanged — each SHA is the current tip of that action's default branch.
- Only third-party actions are touched; `actions/*` and first-party refs are left as-is.
  Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable). Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the credential exposure, and the pinned SHAs myself.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and security of automated Docker image builds and test coverage reporting by pinning workflow actions to specific versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->