### PR TITLE
fix(frontend): anchor alert notifications flush to bottom corner

### DIFF
--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -663,7 +663,7 @@ input[type="password"]::-ms-clear {
   }
 
   .app-div {
-    @apply absolute bottom-20 left-5 flex flex-col-reverse;
+    @apply absolute bottom-4 left-4 flex flex-col-reverse;
   }
 
   .chat-input-modal-txtarea {


### PR DESCRIPTION
## Summary

Error/notice/success alerts floated ~80px above the bottom-left corner, leaving a large empty gap beneath them. The global alert container (`.app-div` in `applies.css`) used `bottom-20 left-5`; this changes it to `bottom-4 left-4` so alerts sit flush in the corner.

## Why

`bottom-20` was introduced in #11636 (Langflow Assistant panel) as clearance for a bottom-left trigger that no longer exists — canvas controls are `bottom-center` and the assistant is a side panel, so nothing anchors bottom-left today. The offset survived as dead space.

`bottom-4 left-4` matches the Playground page's own alert mount (`fixed bottom-4 left-4` in `src/pages/Playground/index.tsx`), so both alert surfaces now share the same corner placement.

## Scope / blast radius

`.app-div` has exactly one consumer: the `AlertDisplayArea` wrapper in `AppWrapperPage`. No other element uses the class, and no floating UI occupies the bottom-left corner, so there is no overlap risk.

## Validation

- `npx jest src/alerts` — 4/4 pass
- Grep audit: single `.app-div` usage; canvas controls confirmed `bottom-center`

## Screenshots

before
<img width="761" height="468" alt="image" src="https://github.com/user-attachments/assets/76f439d4-ef3b-46ba-bfd6-f4c55ea03cd3" />


After
<img width="481" height="372" alt="image" src="https://github.com/user-attachments/assets/126da3c8-f838-4351-9648-cdd4814e46ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the app panel positioning to sit closer to the bottom-left corner.
  * Improved consistency of the panel’s spacing within the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->