### PR TITLE
fix: return 403 instead of 404 on denied flow DELETE when the flow is readable

### DIFF
--- a/src/backend/base/langflow/api/v1/authz_route_dependencies.py
+++ b/src/backend/base/langflow/api/v1/authz_route_dependencies.py
@@ -14,6 +14,7 @@ from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.database.models.flow.model import Flow, FlowCreate
 
 _FLOW_WRITE_DENIED_DETAIL = "You don't have permission to edit this flow."
+_FLOW_DELETE_DENIED_DETAIL = "You don't have permission to delete this flow."
 
 
 async def _get_authorized_flow(
@@ -37,7 +38,7 @@ async def _get_authorized_flow(
             folder_id=flow.folder_id,
         )
     except HTTPException as exc:
-        if act == FlowAction.WRITE and exc.status_code == status.HTTP_403_FORBIDDEN:
+        if act in (FlowAction.WRITE, FlowAction.DELETE) and exc.status_code == status.HTTP_403_FORBIDDEN:
             try:
                 await ensure_flow_permission(
                     current_user,
@@ -49,7 +50,8 @@ async def _get_authorized_flow(
                 )
             except HTTPException as read_exc:
                 raise deny_to_404(read_exc, detail="Flow not found") from read_exc
-            raise HTTPException(status_code=403, detail=_FLOW_WRITE_DENIED_DETAIL) from exc
+            denied_detail = _FLOW_WRITE_DENIED_DETAIL if act == FlowAction.WRITE else _FLOW_DELETE_DENIED_DETAIL
+            raise HTTPException(status_code=403, detail=denied_detail) from exc
         raise deny_to_404(exc, detail="Flow not found") from exc
     return flow
 
@@ -68,7 +70,7 @@ async def get_authorized_flow_for_write(
     current_user: CurrentActiveUser,
     session: DbSession,
 ) -> Flow:
-    """Return a flow the caller may write (404 when denied or missing)."""
+    """Return a flow the caller may write (403 when readable but not writable, 404 otherwise)."""
     return await _get_authorized_flow(FlowAction.WRITE, flow_id=flow_id, current_user=current_user, session=session)
 
 
@@ -77,7 +79,7 @@ async def get_authorized_flow_for_delete(
     current_user: CurrentActiveUser,
     session: DbSession,
 ) -> Flow:
-    """Return a flow the caller may delete (404 when denied or missing)."""
+    """Return a flow the caller may delete (403 when readable but not deletable, 404 otherwise)."""
     return await _get_authorized_flow(FlowAction.DELETE, flow_id=flow_id, current_user=current_user, session=session)
 
 

--- a/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
+++ b/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
@@ -9,7 +9,7 @@ and exercise the *real* flow routes over HTTP, validating that:
 * the per-route guards (``ensure_flow_permission`` via the ``Authorized*Flow``
   dependencies) actually gate read/write/delete/create/execute by role,
 * cross-user denials are masked as 404 (not 403) on fetch routes, while
-  write denials on readable flows return an explicit 403,
+  write and delete denials on readable flows return an explicit 403,
 * the share-aware fetch + ``authz_share`` rows grant cross-user access, and
 * domain resolution (``_resolve_authz_domain``) scopes a domain-bound grant.
 
@@ -115,8 +115,10 @@ async def test_viewer_can_read_and_execute_but_not_write_delete_or_create(client
         patch = await client.patch(f"api/v1/flows/{flow_id}", headers=headers, json={"name": f"x_{uuid4().hex}"})
         assert patch.status_code == 403
         assert patch.json()["detail"] == "You don't have permission to edit this flow."
-        # delete -> denied, masked as 404
-        assert (await client.delete(f"api/v1/flows/{flow_id}", headers=headers)).status_code == 404
+        # delete -> denied, but the flow is readable so return a delete-permission 403.
+        delete = await client.delete(f"api/v1/flows/{flow_id}", headers=headers)
+        assert delete.status_code == 403
+        assert delete.json()["detail"] == "You don't have permission to delete this flow."
         # create -> denied; 403 is correct here (no existing resource UUID to protect)
         create = await client.post(
             "api/v1/flows/", headers=headers, json={"name": f"new_{uuid4().hex}", "data": {"nodes": [], "edges": []}}
@@ -140,8 +142,10 @@ async def test_developer_can_write_and_create_but_not_delete(client):
             "api/v1/flows/", headers=headers, json={"name": f"dev_{uuid4().hex}", "data": {"nodes": [], "edges": []}}
         )
         assert create.status_code == 201, create.text
-        # delete -> denied (developer lacks flow:delete) -> 404
-        assert (await client.delete(f"api/v1/flows/{flow_id}", headers=headers)).status_code == 404
+        # delete -> denied (developer lacks flow:delete) but readable -> 403
+        delete = await client.delete(f"api/v1/flows/{flow_id}", headers=headers)
+        assert delete.status_code == 403
+        assert delete.json()["detail"] == "You don't have permission to delete this flow."
 
 
 async def test_admin_has_full_flow_access(client):
@@ -184,6 +188,7 @@ async def test_share_grants_cross_user_access_and_absence_is_404(client):
         assert (
             await client.patch(f"api/v1/flows/{flow_id}", headers=bob_headers, json={"name": "x"})
         ).status_code == 404
+        assert (await client.delete(f"api/v1/flows/{flow_id}", headers=bob_headers)).status_code == 404
         assert (await client.post(f"api/v1/build/{flow_id}/flow", headers=bob_headers, json={})).status_code == 404
 
     # Alice grants Bob an admin-level share (read + write + execute).
@@ -231,6 +236,12 @@ async def test_read_only_share_allows_get_but_denies_write_and_execute(client):
         patch = await client.patch(f"api/v1/flows/{flow_id}", headers=bob_headers, json={"name": "nope"})
         assert patch.status_code == 403
         assert patch.json()["detail"] == "You don't have permission to edit this flow."
+        # delete is likewise denied on a readable flow -> delete-permission 403,
+        # matching the write behavior (LE-1738 B9: a flow the caller can GET must
+        # not flip to 404 on a denied DELETE).
+        delete = await client.delete(f"api/v1/flows/{flow_id}", headers=bob_headers)
+        assert delete.status_code == 403
+        assert delete.json()["detail"] == "You don't have permission to delete this flow."
         # execute is modeled independently from write — a read-level share must
         # not grant build either -> deny -> 404
         build = await client.post(f"api/v1/build/{flow_id}/flow", headers=bob_headers, json={})


### PR DESCRIPTION
## Summary

Fixes QA bug **B9** from LE-1738: for a flow the caller can `GET` (200), a denied `PATCH` correctly returned an explicit 403, but a denied `DELETE` returned 404. The two mutation verbs now behave consistently.

Root cause: the read-visibility recheck in `_get_authorized_flow` (`src/backend/base/langflow/api/v1/authz_route_dependencies.py`) special-cased only `FlowAction.WRITE` before falling through to the `deny_to_404` mask, so a delete denial was always masked as 404 even when the flow was readable.

## Changes

- Extend the 403-recheck branch to `act in (FlowAction.WRITE, FlowAction.DELETE)`, keeping the existing semantics: re-check `FlowAction.READ`; if READ is denied too, mask as 404 to preserve UUID privacy; if READ passes, raise an explicit 403.
- Add `_FLOW_DELETE_DENIED_DETAIL = "You don't have permission to delete this flow."` alongside `_FLOW_WRITE_DENIED_DETAIL`, selected per action.
- Update the stale docstrings on `get_authorized_flow_for_write` / `get_authorized_flow_for_delete`.

## Tests

Extended `src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py` next to the existing write-deny assertions:

- viewer/developer delete-deny on a readable flow now asserts **403** with the delete-permission detail (was 404),
- no-share cross-user DELETE still asserts the **404** UUID-privacy mask,
- read-only share: denied DELETE asserts **403** with the delete detail, matching the PATCH behavior.

`uv run pytest src/backend/tests/unit/services/authorization/` — 215 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow authorization responses for write and delete actions.
  * Users with read access but insufficient write or delete permissions now receive a clear 403 error.
  * Requests for inaccessible flows continue to return 404, helping prevent unauthorized resource discovery.
  * Updated permission messaging to identify whether write or delete access is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->