### PR TITLE
fix(security): harden component code module access

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -41,6 +41,7 @@ DANGEROUS_DUNDER_ATTRS: set[str] = {
 # Langflow's variable/secret service, never raw process env.
 DANGEROUS_ATTRIBUTE_READS: list[tuple[str, str, str]] = [
     ("os", "environ", "os.environ is forbidden — use Langflow's variable/secret service"),
+    ("sys", "modules", "sys.modules is forbidden in components"),
 ]
 
 # Dangerous attribute calls: (module, method, violation_message)
@@ -134,6 +135,7 @@ RESTRICTED_IMPORT_NAMES: dict[str, set[str]] = {
         "dup2",
         "dup",
     },
+    "sys": {"modules"},
 }
 
 
@@ -296,6 +298,7 @@ class _SecurityChecker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call):
         self._check_name_call(node)
         self._check_attribute_call(node)
+        self._check_getattr_access(node)
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
@@ -329,6 +332,42 @@ class _SecurityChecker(ast.NodeVisitor):
 
         for mod, method, message in DANGEROUS_ATTR_CALLS:
             if module_name == mod and method_name == method:
+                self.violations.append(message)
+                return
+
+    def _check_getattr_access(self, node: ast.Call):
+        """Check reflective access to restricted module members.
+
+        ``getattr`` is common in legitimate components, so it stays allowed for
+        ordinary objects and safe module attributes. On modules with restricted
+        members, a dynamic attribute name is rejected because it could resolve to
+        one of those members at runtime.
+        """
+        if not (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+        ):
+            return
+
+        module_name = self.module_aliases.get(node.args[0].id, node.args[0].id)
+        try:
+            attr_node = node.args[1]
+        except IndexError:
+            return
+        if not (isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str)):
+            if module_name in _DANGEROUS_CALL_MEMBERS or module_name in _DANGEROUS_READ_MEMBERS:
+                self.violations.append(f"Dynamic getattr() access on module '{module_name}' is forbidden in components")
+            return
+
+        attr_name = attr_node.value
+        for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
+            if module_name == mod and attr_name == attr:
+                self.violations.append(message)
+                return
+        for mod, method, message in DANGEROUS_ATTR_CALLS:
+            if module_name == mod and attr_name == method:
                 self.violations.append(message)
                 return
 

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -183,6 +183,8 @@ def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]
 
 _DANGEROUS_CALL_MEMBERS, _DANGEROUS_READ_MEMBERS = _build_dangerous_members()
 
+_AliasState = tuple[dict[str, frozenset[str]], set[str]]
+
 
 def _collect_imports(tree: ast.AST) -> tuple[dict[str, str], set[str]]:
     """Map local binding names to canonical modules; collect ``import *`` modules.
@@ -219,17 +221,88 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def __init__(self, module_aliases: dict[str, str] | None = None, wildcard_modules: set[str] | None = None):
         self.violations: list[str] = []
-        # local-name -> canonical module (e.g. {"o": "os"}); falls back to the
-        # name itself so unaliased ``os.system()`` still matches.
-        self.module_aliases: dict[str, str] = module_aliases or {}
+        # local-name -> possible canonical module values. A set is needed when
+        # control-flow branches bind the same name differently.
+        self.module_aliases: dict[str, frozenset[str]] = {
+            name: frozenset({module}) for name, module in (module_aliases or {}).items()
+        }
+        # Names explicitly rebound to non-module values must not fall back to
+        # their spelling (e.g. ``os = object(); os.system()`` is not os.system).
+        self.shadowed_aliases: set[str] = set()
         # modules pulled in via ``from <mod> import *``.
         self.wildcard_modules: set[str] = wildcard_modules or set()
+
+    def _resolved_names(self, name: str) -> frozenset[str]:
+        """Return possible canonical values for a local name."""
+        if name in self.shadowed_aliases:
+            return frozenset()
+        return self.module_aliases.get(name, frozenset({name}))
+
+    def _resolved_assignment_value(self, node: ast.AST) -> frozenset[str]:
+        """Resolve a simple Name/Attribute RHS without executing it."""
+        if isinstance(node, ast.Name):
+            return self._resolved_names(node.id)
+        parts = _dotted_parts(node)
+        if not parts:
+            return frozenset()
+        return frozenset(".".join([root, *parts[1:]]) for root in self._resolved_names(parts[0]))
+
+    def _bind_name(self, name: str, values: frozenset[str]) -> None:
+        if values:
+            self.module_aliases[name] = values
+            self.shadowed_aliases.discard(name)
+        else:
+            self.module_aliases.pop(name, None)
+            self.shadowed_aliases.add(name)
+
+    def _bind_assignment_target(self, target: ast.AST, value: ast.AST) -> None:
+        """Apply assignment aliasing, including matching tuple/list unpacking."""
+        if isinstance(target, ast.Name):
+            self._bind_name(target.id, self._resolved_assignment_value(value))
+        elif isinstance(target, ast.Starred):
+            self._bind_assignment_target(target.value, value)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            if isinstance(value, (ast.Tuple, ast.List)) and len(target.elts) == len(value.elts):
+                for target_element, value_element in zip(target.elts, value.elts, strict=True):
+                    self._bind_assignment_target(target_element, value_element)
+            else:
+                for target_element in target.elts:
+                    self._bind_assignment_target(target_element, value)
+
+    def _snapshot_alias_state(self) -> _AliasState:
+        return self.module_aliases.copy(), self.shadowed_aliases.copy()
+
+    def _restore_alias_state(self, state: _AliasState) -> None:
+        aliases, shadowed = state
+        self.module_aliases = aliases.copy()
+        self.shadowed_aliases = shadowed.copy()
+
+    def _merge_alias_states(self, states: list[_AliasState]) -> None:
+        """Conservatively retain every module value reachable from a branch."""
+        names = set().union(*(set(aliases) | shadowed for aliases, shadowed in states))
+        merged_aliases: dict[str, frozenset[str]] = {}
+        merged_shadowed: set[str] = set()
+        for name in names:
+            possible_values: set[str] = set()
+            for aliases, shadowed in states:
+                if name in aliases:
+                    possible_values.update(aliases[name])
+                elif name not in shadowed:
+                    possible_values.add(name)
+            if possible_values:
+                merged_aliases[name] = frozenset(possible_values)
+            else:
+                merged_shadowed.add(name)
+        self.module_aliases = merged_aliases
+        self.shadowed_aliases = merged_shadowed
 
     def visit_Import(self, node: ast.Import):
         for alias in node.names:
             module = alias.name.split(".")[0]
             if module in DANGEROUS_IMPORTS or _is_dangerous_submodule(alias.name):
                 self.violations.append(f"Import of '{alias.name}' is forbidden in components")
+            binding = alias.asname or module
+            self._bind_name(binding, frozenset({module}))
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
@@ -252,37 +325,141 @@ class _SecurityChecker(ast.NodeVisitor):
                 if _is_dangerous_submodule(f"{node.module}.{alias.name}"):
                     self.violations.append(f"Import of '{node.module}.{alias.name}' is forbidden in components")
 
+        for alias in node.names:
+            if alias.name != "*":
+                binding = alias.asname or alias.name
+                self._bind_name(binding, frozenset({f"{node.module}.{alias.name}"}))
+
         return self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign):
+        self.visit(node.value)
+        for target in node.targets:
+            self.visit(target)
+            self._bind_assignment_target(target, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign):
+        self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+            self.visit(node.target)
+            self._bind_assignment_target(node.target, node.value)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        self.visit(node.value)
+        self.visit(node.target)
+        self._bind_assignment_target(node.target, node.value)
+
+    def visit_AugAssign(self, node: ast.AugAssign):
+        self.visit(node.target)
+        self.visit(node.value)
+        if isinstance(node.target, ast.Name):
+            self._bind_name(node.target.id, frozenset())
+
+    def visit_If(self, node: ast.If):
+        """Merge aliases from both possible branches instead of trusting visit order."""
+        self.visit(node.test)
+        before_branches = self._snapshot_alias_state()
+        branch_states: list[_AliasState] = []
+        for branch in (node.body, node.orelse):
+            self._restore_alias_state(before_branches)
+            for statement in branch:
+                self.visit(statement)
+            branch_states.append(self._snapshot_alias_state())
+        self._merge_alias_states(branch_states)
+
+    def _shadow_arguments(self, arguments: ast.arguments) -> None:
+        positional = [*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs]
+        for argument in positional:
+            self._bind_name(argument.arg, frozenset())
+        if arguments.vararg:
+            self._bind_name(arguments.vararg.arg, frozenset())
+        if arguments.kwarg:
+            self._bind_name(arguments.kwarg.arg, frozenset())
+
+    def _visit_function_definition(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        # Decorators, defaults, and annotations are evaluated in the enclosing
+        # scope; the function body receives an isolated alias state.
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self.visit(node.args)
+        if node.returns:
+            self.visit(node.returns)
+        for type_parameter in getattr(node, "type_params", ()):
+            self.visit(type_parameter)
+
+        enclosing_state = self._snapshot_alias_state()
+        self._bind_name(node.name, frozenset())
+        self._shadow_arguments(node.args)
+        for statement in node.body:
+            self.visit(statement)
+        self._restore_alias_state(enclosing_state)
+        self._bind_name(node.name, frozenset())
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self._visit_function_definition(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self._visit_function_definition(node)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        self.visit(node.args)
+        enclosing_state = self._snapshot_alias_state()
+        self._shadow_arguments(node.args)
+        self.visit(node.body)
+        self._restore_alias_state(enclosing_state)
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+        for type_parameter in getattr(node, "type_params", ()):
+            self.visit(type_parameter)
+
+        enclosing_state = self._snapshot_alias_state()
+        for statement in node.body:
+            self.visit(statement)
+        self._restore_alias_state(enclosing_state)
+        self._bind_name(node.name, frozenset())
 
     def visit_Attribute(self, node: ast.Attribute):
         """Check attribute access: dunder escapes, os.environ, urllib.request, ..."""
         if node.attr in DANGEROUS_DUNDER_ATTRS:
             self.violations.append(f"Access to '{node.attr}' is forbidden in components (sandbox escape)")
         elif isinstance(node.value, ast.Name):
-            module_name = self.module_aliases.get(node.value.id, node.value.id)
-            for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
-                if module_name == mod and node.attr == attr:
-                    self.violations.append(message)
+            for module_name in self._resolved_names(node.value.id):
+                violation = next(
+                    (
+                        message
+                        for mod, attr, message in DANGEROUS_ATTRIBUTE_READS
+                        if module_name == mod and node.attr == attr
+                    ),
+                    None,
+                )
+                if violation:
+                    self.violations.append(violation)
                     break
         # Dotted access to a blocked submodule (``urllib.request`` / ``http.client``),
         # which a bare ``import urllib`` / ``import http`` makes reachable at runtime
         # without an explicit submodule import. Alias-resolved on the root name.
-        if self._is_dangerous_submodule_access(node):
-            dotted = self._resolved_dotted(node)
+        if dotted := self._dangerous_submodule_access(node):
             self.violations.append(f"Access to '{dotted}' is forbidden in components")
         self.generic_visit(node)
 
-    def _resolved_dotted(self, node: ast.Attribute) -> str | None:
-        """Dotted name of an attribute chain, with the root name alias-resolved."""
+    def _resolved_dotted(self, node: ast.Attribute) -> frozenset[str]:
+        """Possible dotted names of an attribute chain, with its root alias-resolved."""
         parts = _dotted_parts(node)
         if not parts:
-            return None
-        return ".".join([self.module_aliases.get(parts[0], parts[0]), *parts[1:]])
+            return frozenset()
+        return frozenset(".".join([root, *parts[1:]]) for root in self._resolved_names(parts[0]))
 
-    def _is_dangerous_submodule_access(self, node: ast.Attribute) -> bool:
+    def _dangerous_submodule_access(self, node: ast.Attribute) -> str | None:
         # Exact match (not prefix): the ``urllib.request`` node itself is visited
         # within ``urllib.request.urlopen``, so matching exactly avoids double-flagging.
-        return self._resolved_dotted(node) in DANGEROUS_SUBMODULES
+        return next((name for name in sorted(self._resolved_dotted(node)) if name in DANGEROUS_SUBMODULES), None)
 
     def visit_Name(self, node: ast.Name):
         """Catch wildcard-imported reads (``from os import *``; ``environ[...]``)."""
@@ -324,13 +501,13 @@ class _SecurityChecker(ast.NodeVisitor):
         if not isinstance(node.func.value, ast.Name):
             return
 
-        module_name = self.module_aliases.get(node.func.value.id, node.func.value.id)
         method_name = node.func.attr
 
-        for mod, method, message in DANGEROUS_ATTR_CALLS:
-            if module_name == mod and method_name == method:
-                self.violations.append(message)
-                return
+        for module_name in self._resolved_names(node.func.value.id):
+            for mod, method, message in DANGEROUS_ATTR_CALLS:
+                if module_name == mod and method_name == method:
+                    self.violations.append(message)
+                    return
 
 
 def scan_code_security(code: str) -> SecurityScanResult:

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -78,7 +78,12 @@ DANGEROUS_ATTR_CALLS: list[tuple[str, str, str]] = [
 DANGEROUS_IMPORTS: set[str] = {
     "subprocess",
     "shutil",
+    # Native FFI modules can load arbitrary shared libraries. Include the
+    # lower-level backends so blocking only the public frontends is not bypassable.
     "ctypes",
+    "_ctypes",
+    "cffi",
+    "_cffi_backend",
     "pickle",
     "shelve",
     "marshal",

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -206,7 +206,7 @@ def _collect_imports(tree: ast.AST) -> tuple[dict[str, str], set[str]]:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.asname:
-                    aliases[alias.asname] = alias.name.split(".")[0]
+                    aliases[alias.asname] = alias.name
                 else:
                     top = alias.name.split(".")[0]
                     aliases[top] = top
@@ -269,12 +269,42 @@ class _SecurityChecker(ast.NodeVisitor):
         elif isinstance(target, ast.Starred):
             self._bind_assignment_target(target.value, value)
         elif isinstance(target, (ast.Tuple, ast.List)):
-            if isinstance(value, (ast.Tuple, ast.List)) and len(target.elts) == len(value.elts):
-                for target_element, value_element in zip(target.elts, value.elts, strict=True):
-                    self._bind_assignment_target(target_element, value_element)
-            else:
-                for target_element in target.elts:
-                    self._bind_assignment_target(target_element, value)
+            if isinstance(value, (ast.Tuple, ast.List)):
+                starred_index = next(
+                    (
+                        index
+                        for index, target_element in enumerate(target.elts)
+                        if isinstance(target_element, ast.Starred)
+                    ),
+                    None,
+                )
+                if starred_index is None and len(target.elts) == len(value.elts):
+                    for target_element, value_element in zip(target.elts, value.elts, strict=True):
+                        self._bind_assignment_target(target_element, value_element)
+                    return
+                if starred_index is not None and len(value.elts) >= len(target.elts) - 1:
+                    for target_element, value_element in zip(
+                        target.elts[:starred_index], value.elts[:starred_index], strict=True
+                    ):
+                        self._bind_assignment_target(target_element, value_element)
+
+                    trailing_count = len(target.elts) - starred_index - 1
+                    if trailing_count:
+                        for target_element, value_element in zip(
+                            target.elts[-trailing_count:], value.elts[-trailing_count:], strict=True
+                        ):
+                            self._bind_assignment_target(target_element, value_element)
+
+                    remaining_end = len(value.elts) - trailing_count if trailing_count else len(value.elts)
+                    remaining_values = ast.List(
+                        elts=value.elts[starred_index:remaining_end],
+                        ctx=ast.Load(),
+                    )
+                    self._bind_assignment_target(target.elts[starred_index], remaining_values)
+                    return
+
+            for target_element in target.elts:
+                self._bind_assignment_target(target_element, value)
 
     def _snapshot_alias_state(self) -> _AliasState:
         return self.module_aliases.copy(), self.shadowed_aliases.copy()
@@ -309,7 +339,8 @@ class _SecurityChecker(ast.NodeVisitor):
             if module in DANGEROUS_IMPORTS or _is_dangerous_submodule(alias.name):
                 self.violations.append(f"Import of '{alias.name}' is forbidden in components")
             binding = alias.asname or module
-            self._bind_name(binding, frozenset({module}))
+            imported_name = alias.name if alias.asname else module
+            self._bind_name(binding, frozenset({imported_name}))
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
@@ -374,6 +405,37 @@ class _SecurityChecker(ast.NodeVisitor):
                 self.visit(statement)
             branch_states.append(self._snapshot_alias_state())
         self._merge_alias_states(branch_states)
+
+    def _visit_loop(self, node: ast.For | ast.AsyncFor | ast.While) -> None:
+        """Merge zero-iteration and loop-body alias states conservatively."""
+        before_loop = self._snapshot_alias_state()
+        if isinstance(node, ast.While):
+            self.visit(node.test)
+        else:
+            self.visit(node.iter)
+            self.visit(node.target)
+
+        for statement in node.body:
+            self.visit(statement)
+        after_body = self._snapshot_alias_state()
+        self._merge_alias_states([before_loop, after_body])
+
+        if node.orelse:
+            before_else = self._snapshot_alias_state()
+            for statement in node.orelse:
+                self.visit(statement)
+            after_else = self._snapshot_alias_state()
+            # The else suite is skipped when a loop exits through break.
+            self._merge_alias_states([before_else, after_else])
+
+    def visit_For(self, node: ast.For):
+        self._visit_loop(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor):
+        self._visit_loop(node)
+
+    def visit_While(self, node: ast.While):
+        self._visit_loop(node)
 
     def _shadow_arguments(self, arguments: ast.arguments) -> None:
         positional = [*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs]
@@ -527,7 +589,7 @@ class _SecurityChecker(ast.NodeVisitor):
         """
         if not (
             isinstance(node.func, ast.Name)
-            and node.func.id == "getattr"
+            and "getattr" in self._resolved_names(node.func.id)
             and node.args
             and isinstance(node.args[0], ast.Name)
         ):

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -7,6 +7,7 @@ Tests cover:
 - Edge cases (syntax errors, empty code)
 """
 
+import pytest
 from langflow.agentic.helpers.code_security import scan_code_security
 
 
@@ -185,6 +186,31 @@ class TestScanCodeSecurityDangerousImports:
         code = "import ctypes"
         result = scan_code_security(code)
         assert result.is_safe is False
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import _ctypes",
+            "from _ctypes import dlopen",
+            "import cffi",
+            "from cffi import FFI",
+            "import cffi.api",
+            "import _cffi_backend",
+        ],
+        ids=[
+            "ctypes-backend",
+            "ctypes-backend-from",
+            "cffi",
+            "cffi-from",
+            "cffi-submodule",
+            "cffi-backend",
+        ],
+    )
+    def test_should_detect_native_ffi_imports(self, code):
+        """Native FFI entry points can load arbitrary shared libraries."""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("forbidden" in violation for violation in result.violations)
 
     def test_should_detect_from_subprocess_import(self):
         """From subprocess import run should be detected."""

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -506,6 +506,91 @@ class TestScanCodeSecurityAliasAndWildcardBypass:
         assert result.is_safe is True
 
 
+class TestScanCodeSecurityAssignmentAliasBypass:
+    """Assignment aliases of imported modules must retain their security policy."""
+
+    def test_should_detect_os_assignment_alias_call(self):
+        result = scan_code_security("import os\nmodule = os\nmodule.system('id')")
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_detect_transitive_assignment_alias_call(self):
+        result = scan_code_security("import os as imported\nfirst = imported\nsecond = first\nsecond.getenv('SECRET')")
+        assert result.is_safe is False
+        assert any("os.getenv()" in violation for violation in result.violations)
+
+    def test_should_detect_chained_assignment_alias_call(self):
+        result = scan_code_security("import os\nfirst = second = os\nsecond.putenv('KEY', 'value')")
+        assert result.is_safe is False
+        assert any("os.putenv()" in violation for violation in result.violations)
+
+    def test_should_detect_annotated_assignment_alias_read(self):
+        result = scan_code_security("import os\nmodule: object = os\nsecret = module.environ['SECRET']")
+        assert result.is_safe is False
+        assert any("os.environ" in violation for violation in result.violations)
+
+    def test_should_detect_destructured_assignment_alias_call(self):
+        result = scan_code_security("import os\n(module,) = (os,)\nmodule.system('id')")
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_detect_named_expression_alias_call(self):
+        result = scan_code_security("import os\nif module := os:\n    module.system('id')")
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_detect_assignment_alias_dotted_submodule(self):
+        result = scan_code_security("import urllib\nmodule = urllib\nmodule.request.urlopen('http://x')")
+        assert result.is_safe is False
+        assert any("urllib.request" in violation for violation in result.violations)
+
+    def test_should_allow_assignment_alias_of_safe_module(self):
+        result = scan_code_security("import requests\nclient = requests\nclient.get('https://api.example.com')")
+        assert result.is_safe is True
+
+    def test_should_allow_assignment_of_safe_module_attribute(self):
+        result = scan_code_security("import os\npath_module = os.path\npath_module.join('a', 'b')")
+        assert result.is_safe is True
+
+    def test_should_allow_alias_rebound_to_safe_value(self):
+        code = "import os\nmodule = os\nmodule = object()\nmodule.system('not the os module')"
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+    def test_should_not_leak_safe_local_shadow_into_later_function(self):
+        code = """
+import os
+
+def safe_function():
+    os = object()
+    return os
+
+def dangerous_function():
+    os.system('id')
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_not_leak_local_module_alias_into_outer_scope(self):
+        code = """
+import os
+module = object()
+
+def bind_locally():
+    module = os
+    return module
+
+module.system('not the os module')
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+    def test_should_allow_parameter_shadowing_module_name(self):
+        result = scan_code_security("import os\ndef use_safe_object(os):\n    os.system('not the os module')")
+        assert result.is_safe is True
+
+
 class TestScanCodeSecurityDottedSubmoduleAccess:
     """Bare-package imports must not reach a blocked submodule via dotted access.
 

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -506,6 +506,50 @@ class TestScanCodeSecurityAliasAndWildcardBypass:
         assert result.is_safe is True
 
 
+class TestScanCodeSecurityRuntimeModuleBypass:
+    """Runtime module lookup and reflection must not bypass dangerous calls."""
+
+    def test_should_detect_sys_modules_attribute_call(self):
+        result = scan_code_security("sys.modules['os'].system('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_getattr_from_sys_modules(self):
+        result = scan_code_security("getattr(sys.modules['os'], 'system')('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_aliased_sys_modules_access(self):
+        result = scan_code_security("import sys as runtime\nruntime.modules['os'].system('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_imported_sys_modules_access(self):
+        result = scan_code_security("from sys import modules\nmodules['os'].system('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_reflective_dangerous_call(self):
+        result = scan_code_security("import os\ngetattr(os, 'system')('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_dynamic_reflective_module_access(self):
+        result = scan_code_security("import os\nvalue = getattr(os, self.method_name)")
+        assert result.is_safe is False
+
+    def test_should_detect_reflective_sys_modules_access(self):
+        result = scan_code_security("getattr(sys, 'modules')['os'].system('id')")
+        assert result.is_safe is False
+
+    def test_should_allow_safe_sys_attribute(self):
+        result = scan_code_security("import sys\nversion = sys.version_info")
+        assert result.is_safe is True
+
+    def test_should_allow_reflective_safe_module_attribute(self):
+        result = scan_code_security("import os\npath_module = getattr(os, 'path')")
+        assert result.is_safe is True
+
+    def test_should_allow_dynamic_getattr_on_ordinary_objects(self):
+        result = scan_code_security("field = 'value'\nvalue = getattr(self, field, None)")
+        assert result.is_safe is True
+
+
 class TestScanCodeSecurityDottedSubmoduleAccess:
     """Bare-package imports must not reach a blocked submodule via dotted access.
 

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -496,10 +496,9 @@ class TestScanCodeSecurityAliasAndWildcardBypass:
         result = scan_code_security("import os as o\nk = o.getenv('SECRET')")
         assert result.is_safe is False
 
-    def test_should_detect_dotted_alias_os_path(self):
-        """`import os.path as p` still binds top-level `os`; p.system() is os.system()."""
-        result = scan_code_security("import os.path as p\np.system('id')")
-        assert result.is_safe is False
+    def test_should_allow_dotted_import_alias_safe_attribute(self):
+        result = scan_code_security("import os.path as path_module\ngetattr(path_module, attribute_name, None)")
+        assert result.is_safe is True
 
     # --- wildcard import bypass: `from os import *; <restricted>()` ---
 
@@ -560,6 +559,11 @@ class TestScanCodeSecurityAssignmentAliasBypass:
         assert result.is_safe is False
         assert any("os.system()" in violation for violation in result.violations)
 
+    def test_should_detect_starred_destructured_assignment_alias_call(self):
+        result = scan_code_security("import os\nmodule, *rest = (os,)\nmodule.system('id')")
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
     def test_should_detect_named_expression_alias_call(self):
         result = scan_code_security("import os\nif module := os:\n    module.system('id')")
         assert result.is_safe is False
@@ -616,6 +620,44 @@ module.system('not the os module')
         result = scan_code_security("import os\ndef use_safe_object(os):\n    os.system('not the os module')")
         assert result.is_safe is True
 
+    def test_should_detect_alias_after_zero_iteration_for_loop(self):
+        code = """
+import os
+module = os
+for _ in ():
+    module = object()
+module.system('id')
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_detect_alias_after_zero_iteration_async_for_loop(self):
+        code = """
+import os
+
+async def run():
+    module = os
+    async for _ in empty():
+        module = object()
+    module.system('id')
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    def test_should_detect_alias_after_zero_iteration_while_loop(self):
+        code = """
+import os
+module = os
+while False:
+    module = object()
+module.system('id')
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
 
 class TestScanCodeSecurityRuntimeModuleBypass:
     """Runtime module lookup and reflection must not bypass dangerous calls."""
@@ -638,6 +680,10 @@ class TestScanCodeSecurityRuntimeModuleBypass:
 
     def test_should_detect_reflective_dangerous_call(self):
         result = scan_code_security("import os\ngetattr(os, 'system')('id')")
+        assert result.is_safe is False
+
+    def test_should_detect_reflective_dangerous_call_through_getattr_alias(self):
+        result = scan_code_security("import os\nreflect = getattr\nreflect(os, 'system')('id')")
         assert result.is_safe is False
 
     def test_should_detect_dynamic_reflective_module_access(self):

--- a/src/backend/tests/unit/agentic/services/test_flow_run.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_run.py
@@ -275,6 +275,17 @@ class TestRunWorkingFlowSecurityGate:
         assert "error" in out
         bg.assert_not_awaited()
 
+    @pytest.mark.parametrize("code", ["import _ctypes", "from cffi import FFI"], ids=["ctypes", "cffi"])
+    @pytest.mark.asyncio
+    async def test_should_refuse_native_ffi_imports_before_graph_build(self, code: str):
+        evil = self._flow_with_code(code)
+        with patch(f"{MODULE}.build_graph_from_data", new_callable=AsyncMock) as bg:
+            out = await run_working_flow(flow_data=evil, flow_id="flow-1", user_id="u1")
+
+        assert "error" in out
+        assert "unsafe" in out["error"].lower()
+        bg.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_should_run_normally_when_code_is_safe(self):
         safe = self._flow_with_code("from math import isqrt\n\nclass C:\n    pass")


### PR DESCRIPTION
## Summary
- block reflective access to restricted module members in generated component code
- compose reflective checks with assignment-alias and native-FFI hardening
- preserve ordinary `getattr` use and safe rebinding

## Testing
- 120 scanner tests passed
- 5 flow security-gate tests passed
- combined direct/import/assignment reflection repros passed
- Ruff, formatting, and pre-commit passed

## Merge order
Merge #14041, then #14040, then this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Expanded code scanning to block additional native/FFI-related imports and restricted reflective module access.
  * Hardened protection against bypasses using aliases, conditional assignments, and shadowed names.
  * Improved detection of dangerous attribute access patterns (including module-qualified and dynamic `getattr` cases).
* **Bug Fixes**
  * Unsafe flows are now consistently rejected before any graph building or execution when prohibited patterns are detected.
* **Tests**
  * Added/updated coverage for native imports, aliasing bypass attempts, runtime module access attempts, and confirmed safe reflective access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->