### PR TITLE
fix(security): protect Docling Serve outbound requests

### DIFF
--- a/src/bundles/docling/src/lfx_docling/components/docling/docling_remote.py
+++ b/src/bundles/docling/src/lfx_docling/components/docling/docling_remote.py
@@ -13,6 +13,7 @@ from lfx.base.data.docling_utils import coerce_docling_document
 from lfx.inputs import IntInput, NestedDictInput, StrInput, TableInput
 from lfx.inputs.inputs import FloatInput
 from lfx.schema import Data, DataFrame, dotdict
+from lfx.utils.ssrf_httpx import ssrf_protected_httpx_client_kwargs_for_url
 from lfx.utils.util import transform_localhost_url
 
 
@@ -292,9 +293,13 @@ class DoclingRemoteComponent(BaseFileComponent):
         transformed_url = transform_localhost_url(self.api_url)
         base_url = f"{transformed_url}/v1"
 
-        with httpx.Client(headers=self._process_headers()) as client:
+        with self._create_http_client(base_url) as client:
             result = self._poll_and_fetch_result(client, base_url, self.task_id)
             return [result] if result else []
+
+    def _create_http_client(self, base_url: str) -> httpx.Client:
+        client_kwargs, _ = ssrf_protected_httpx_client_kwargs_for_url(base_url)
+        return httpx.Client(headers=self._process_headers(), **client_kwargs)
 
     def load_files_base(self) -> list[Data]:
         """Load and process files, or poll an existing task if task_id is provided.
@@ -331,7 +336,7 @@ class DoclingRemoteComponent(BaseFileComponent):
 
         processed_data: list[Data | None] = []
         with (
-            httpx.Client(headers=self._process_headers()) as client,
+            self._create_http_client(base_url) as client,
             ThreadPoolExecutor(max_workers=self.max_concurrency) as executor,
         ):
             futures: list[tuple[int, Future]] = []

--- a/src/bundles/docling/tests/test_docling_remote.py
+++ b/src/bundles/docling/tests/test_docling_remote.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import httpx
 import pytest
@@ -18,6 +18,7 @@ from lfx_docling.components.docling.docling_remote import DoclingRemoteComponent
 
 from lfx.inputs import TableInput
 from lfx.schema import Data
+from lfx.utils.ssrf_transport import SSRFProtectedSyncTransport
 
 # isort: on
 
@@ -59,6 +60,14 @@ class _Client:
     def get(self, url: str) -> _Response:
         self.urls.append(url)
         return self.responses.pop(0)
+
+
+class _ContextClient:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
 
 
 def _input(name: str):
@@ -138,3 +147,100 @@ def test_poll_raises_later_4xx_before_json_parse(monkeypatch: pytest.MonkeyPatch
 
     assert pending_response.json_called is True
     assert not_found_response.json_called is False
+
+
+@pytest.mark.parametrize("request_path", ["task", "files"])
+def test_remote_request_paths_block_metadata_url_before_creating_client(
+    monkeypatch: pytest.MonkeyPatch, request_path: str
+) -> None:
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+
+    component = DoclingRemoteComponent()
+    component._attributes.update(
+        {
+            "api_url": "http://169.254.169.254/latest/meta-data",
+            "api_headers": [],
+            "docling_serve_opts": {},
+            "max_concurrency": 1,
+            "max_poll_timeout": 60,
+            "task_id": "task-1",
+        }
+    )
+
+    def fail_if_client_is_created(**_kwargs: Any) -> None:
+        msg = "HTTP client must not be created for a blocked URL"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(docling_remote.httpx, "Client", fail_if_client_is_created)
+
+    def invoke_request() -> None:
+        if request_path == "task":
+            component._process_task_id()
+        else:
+            component.process_files([])
+
+    with pytest.raises(ValueError, match=r"SSRF Protection: .*blocked IP address"):
+        invoke_request()
+
+
+def test_process_task_id_pins_public_docling_host_and_preserves_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setattr("lfx.utils.ssrf_protection.resolve_hostname", lambda _hostname: ["93.184.216.34"])
+
+    component = DoclingRemoteComponent()
+    component._attributes.update(
+        {
+            "api_url": "https://docling.example",
+            "api_headers": [{"key": "Authorization", "value": "Bearer token"}],
+            "max_poll_timeout": 60,
+            "task_id": "task-1",
+        }
+    )
+    client_kwargs: dict[str, Any] = {}
+
+    def capture_client(**kwargs: Any) -> _ContextClient:
+        client_kwargs.update(kwargs)
+        return _ContextClient()
+
+    expected = Data(data={"status": "success"})
+    monkeypatch.setattr(docling_remote.httpx, "Client", capture_client)
+    monkeypatch.setattr(component, "_poll_and_fetch_result", lambda *_args, **_kwargs: expected)
+
+    result = component._process_task_id()
+
+    assert result[0] is expected
+    assert client_kwargs["headers"] == {"Authorization": "Bearer token"}
+    assert client_kwargs["follow_redirects"] is False
+    assert isinstance(client_kwargs["transport"], SSRFProtectedSyncTransport)
+    assert client_kwargs["transport"].pinned_ips == {"docling.example": ["93.184.216.34"]}
+
+
+def test_process_task_id_allows_explicitly_allowlisted_internal_docling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "10.0.0.7")
+
+    component = DoclingRemoteComponent()
+    component._attributes.update(
+        {
+            "api_url": "http://10.0.0.7:5001",
+            "api_headers": [],
+            "max_poll_timeout": 60,
+            "task_id": "task-1",
+        }
+    )
+    client_kwargs: dict[str, Any] = {}
+
+    def capture_client(**kwargs: Any) -> _ContextClient:
+        client_kwargs.update(kwargs)
+        return _ContextClient()
+
+    expected = Data(data={"status": "success"})
+    monkeypatch.setattr(docling_remote.httpx, "Client", capture_client)
+    monkeypatch.setattr(component, "_poll_and_fetch_result", lambda *_args, **_kwargs: expected)
+
+    result = component._process_task_id()
+
+    assert result[0] is expected
+    assert client_kwargs == {"headers": {}, "follow_redirects": False}

--- a/src/bundles/docling/tests/test_docling_remote.py
+++ b/src/bundles/docling/tests/test_docling_remote.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 pytest.importorskip("docling_core")
 


### PR DESCRIPTION
## Summary

- validate Docling Serve URLs with the shared SSRF policy before creating an HTTP client
- pin validated public DNS addresses and disable automatic redirects
- preserve API headers and explicitly allowlisted internal Docling deployments

## Validation

- [x] Docling Remote component tests: 9 passed
- [x] Ruff formatting and lint checks
- [x] `uv build --package lfx-docling --wheel`
- [x] pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for remote Docling requests by blocking metadata-service addresses.
  * Added safer handling for public and explicitly allowlisted internal Docling hosts.
  * Preserved required request headers and connection settings during remote processing.

* **Tests**
  * Added coverage for secure URL validation, host resolution, allowlisting, and request configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->