### PR TITLE
fix(auth): verify current password on password changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1717,7 +1717,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "a240a1757ef2e0abf3f252dccec6895fc90d6385",
         "is_verified": false,
-        "line_number": 7,
+        "line_number": 9,
         "is_secret": true
       },
       {
@@ -1725,7 +1725,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 124,
         "is_secret": true
       },
       {
@@ -1733,16 +1733,30 @@
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 136,
         "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_users.py",
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_verified": false,
+        "line_number": 203
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 220,
         "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_users.py",
+        "hashed_secret": "6c03ac0ea7241c3b2e2b7d54ff1db5f5539dc198",
+        "is_verified": false,
+        "line_number": 228
       }
     ],
     "src/backend/tests/unit/api/v2/test_files.py": [
@@ -2565,7 +2579,7 @@
         "filename": "src/backend/tests/unit/test_user.py",
         "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 212,
         "is_secret": true
       }
     ],
@@ -2651,7 +2665,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
         "is_verified": false,
-        "line_number": 763,
+        "line_number": 764,
         "is_secret": true
       },
       {
@@ -2659,7 +2673,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "3806954324550e26ef5de85d007f1746825a073c",
         "is_verified": false,
-        "line_number": 764,
+        "line_number": 765,
         "is_secret": true
       },
       {
@@ -2667,7 +2681,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 948,
+        "line_number": 949,
         "is_secret": true
       }
     ],
@@ -3077,23 +3091,21 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "f562caab01134c53120bd36dcda6d9d904760138",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "42174448e882bf43f51c70d0ed3f57d377bb74bb",
+        "is_verified": false,
+        "line_number": 1591
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "da5b4695b6132090955c121e932d6f9b833c0b1d",
-        "is_verified": false,
-        "line_number": 1643,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "d4f39052ccfaf9ef5b8fd360ed75d23cf12fa2c4",
-        "is_verified": false,
-        "line_number": 1644,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "bfc0c1d4d70399476ea81e40a48418ed9962832d",
         "is_verified": false,
         "line_number": 1645,
         "is_secret": true
@@ -3101,9 +3113,25 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "d4f39052ccfaf9ef5b8fd360ed75d23cf12fa2c4",
+        "is_verified": false,
+        "line_number": 1646,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "bfc0c1d4d70399476ea81e40a48418ed9962832d",
+        "is_verified": false,
+        "line_number": 1647,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "2a24f50d36559883d2bc391e4e99f9a7afd56ef9",
         "is_verified": false,
-        "line_number": 1666,
+        "line_number": 1668,
         "is_secret": true
       },
       {
@@ -3111,7 +3139,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fd0543de99a00bd6e67f3e522a18ed417089b6b4",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -3119,7 +3147,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fa4b98297401af5e6ab7a402330a12715e891325",
         "is_verified": false,
-        "line_number": 1811,
+        "line_number": 1813,
         "is_secret": true
       },
       {
@@ -3127,7 +3155,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9c46c22e7a8ff423706b990fc02c85e0d324f134",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -3135,7 +3163,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "91cde4236a3754b4b57733682edfc50571d954c6",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "is_secret": true
       },
       {
@@ -3143,7 +3171,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9625c6b66710b648d27ee284940849a6b5abf3f0",
         "is_verified": false,
-        "line_number": 1829,
+        "line_number": 1831,
         "is_secret": true
       },
       {
@@ -3151,7 +3179,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "370c53187d8e550db85edabdcb86547dab96e300",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -3159,7 +3187,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc57a2140542893b4c9396b6a7186b26351c6fe5",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1852,
         "is_secret": true
       },
       {
@@ -3167,7 +3195,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "d922d16c3bbc818b6fab4e8d2662fa361309fa9d",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2050,
         "is_secret": true
       },
       {
@@ -3175,7 +3203,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "8ea601e5cac549eef50d2743f915e4af54135789",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2051,
         "is_secret": true
       },
       {
@@ -3183,7 +3211,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e498ebe977c948f4d1b7eddd6bb77be398ed4d7c",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -3191,7 +3219,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "02e680473cb1ee7473e2cdb5b0b6c48cd8aae081",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2058,
         "is_secret": true
       },
       {
@@ -3199,7 +3227,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc50b2aac5d886516a06afb79b4931f4ee66422d",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -3343,9 +3371,23 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "4d5967896006c8a626ecef45e6312f6fc7d5b52f",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "2a2f556b3e73e091f1e21b95ae5bbca523ab1a2a",
+        "is_verified": false,
+        "line_number": 279
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1abaf3f0bb2d459a0fdefe08084901710603a6be",
         "is_verified": false,
-        "line_number": 287,
+        "line_number": 289,
         "is_secret": true
       },
       {
@@ -3353,7 +3395,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4a7c565d4c4430e3bb8fa6c560125d5eb37e7c3d",
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 374,
         "is_secret": true
       },
       {
@@ -3361,7 +3403,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 438,
+        "line_number": 440,
         "is_secret": true
       },
       {
@@ -3369,7 +3411,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c23d0f85d66cef95852d6a63811ab919de76b02a",
         "is_verified": false,
-        "line_number": 470,
+        "line_number": 472,
         "is_secret": true
       },
       {
@@ -3377,7 +3419,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "76b33d23eee6aaa96f11abb4cbf1e5abd66aa46d",
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 575,
         "is_secret": true
       },
       {
@@ -3385,7 +3427,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e9013532fd4966ed4b3aab1ae711b21f180e4c26",
         "is_verified": false,
-        "line_number": 574,
+        "line_number": 576,
         "is_secret": true
       },
       {
@@ -3393,7 +3435,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f16563f8a1751c141fd1c47148369ca1c380bb1",
         "is_verified": false,
-        "line_number": 613,
+        "line_number": 615,
         "is_secret": true
       },
       {
@@ -3401,7 +3443,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2c4e1babc2d1448dfcfdd24fb92068644227d6f1",
         "is_verified": false,
-        "line_number": 634,
+        "line_number": 636,
         "is_secret": true
       },
       {
@@ -3409,7 +3451,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "7ce9180d54b399cafbe6515ca2ca4710a6b9554c",
         "is_verified": false,
-        "line_number": 640,
+        "line_number": 642,
         "is_secret": true
       },
       {
@@ -3417,7 +3459,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "924cf2c6cefbba9e88dc676bd2575b7f21f9661e",
         "is_verified": false,
-        "line_number": 647,
+        "line_number": 649,
         "is_secret": true
       },
       {
@@ -3425,7 +3467,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "9d6bd29f94e1e565bd5de8f44c875638b26e85b6",
         "is_verified": false,
-        "line_number": 648,
+        "line_number": 650,
         "is_secret": true
       },
       {
@@ -3433,7 +3475,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8e77e1ff96d9be727f25fc393a48f767935660db",
         "is_verified": false,
-        "line_number": 1133,
+        "line_number": 1135,
         "is_secret": true
       },
       {
@@ -3441,7 +3483,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29538b53771fff5bad78e3a48a3a8f88c2f141d2",
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1426,
         "is_secret": true
       },
       {
@@ -3449,7 +3491,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8d24e5afd2e9b40d21e4300c893a486aab979795",
         "is_verified": false,
-        "line_number": 1425,
+        "line_number": 1427,
         "is_secret": true
       },
       {
@@ -3457,7 +3499,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ed05045c1666dd556d9a09f9eb6889f42a81aa5a",
         "is_verified": false,
-        "line_number": 1518,
+        "line_number": 1520,
         "is_secret": true
       },
       {
@@ -3465,7 +3507,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f616a4d4abc959d505a5b83f1b3fa1a6bce6b2e",
         "is_verified": false,
-        "line_number": 1520,
+        "line_number": 1522,
         "is_secret": true
       },
       {
@@ -3473,7 +3515,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1bbb8fd38e8fef4280c7218b961ae2ceeb83bbc9",
         "is_verified": false,
-        "line_number": 1521,
+        "line_number": 1523,
         "is_secret": true
       },
       {
@@ -3481,7 +3523,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "0b8eacdde75bb24c6f29adf660f50ca4d9846358",
         "is_verified": false,
-        "line_number": 1523,
+        "line_number": 1525,
         "is_secret": true
       },
       {
@@ -3489,7 +3531,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8cde7462c1ce55676dc45124068d844ad3b86dcf",
         "is_verified": false,
-        "line_number": 1544,
+        "line_number": 1546,
         "is_secret": true
       },
       {
@@ -3497,7 +3539,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "afbf9aed8c22c3faf4d92dccadabe324d49bc5a8",
         "is_verified": false,
-        "line_number": 1766,
+        "line_number": 1768,
         "is_secret": true
       },
       {
@@ -3505,7 +3547,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "651f66f27bbfaed040c836e22515162e20c4fa0d",
         "is_verified": false,
-        "line_number": 1780,
+        "line_number": 1782,
         "is_secret": true
       },
       {
@@ -3513,7 +3555,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e38ef0e653c39ce1a4dde13da87333c43ced6cab",
         "is_verified": false,
-        "line_number": 1864,
+        "line_number": 1866,
         "is_secret": true
       },
       {
@@ -3521,7 +3563,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "a3e4ec7cb1a57129b074bdd0b9403a008a7f0019",
         "is_verified": false,
-        "line_number": 1882,
+        "line_number": 1884,
         "is_secret": true
       }
     ],
@@ -3737,23 +3779,21 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "6848bf99f0e8cbaa9e3afe15724b0592761c9895",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "71e1d05cafdbe483092571dc8fa209cb4fb602d2",
+        "is_verified": false,
+        "line_number": 1591
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bd2d890bd01b9843827f1583db8f9ee99564f270",
-        "is_verified": false,
-        "line_number": 1643,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "b245ddc4e5dfcb57cba8d08000e59c5dc0809ceb",
-        "is_verified": false,
-        "line_number": 1644,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "443fd1115c9bd30afaac31a42fc192b86476f288",
         "is_verified": false,
         "line_number": 1645,
         "is_secret": true
@@ -3761,9 +3801,25 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "b245ddc4e5dfcb57cba8d08000e59c5dc0809ceb",
+        "is_verified": false,
+        "line_number": 1646,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "443fd1115c9bd30afaac31a42fc192b86476f288",
+        "is_verified": false,
+        "line_number": 1647,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "5c324bbf8f0a15d640a2ca93b4bb0183d106edd8",
         "is_verified": false,
-        "line_number": 1666,
+        "line_number": 1668,
         "is_secret": true
       },
       {
@@ -3771,7 +3827,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "49d8b438094e36554d1d2ec73dbc4adbdca1a891",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -3779,7 +3835,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bdd17febdd742a928650952ec63b0ab0d7eeddac",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -3787,7 +3843,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "15e4f8d5f1d2759b1e83f9082a8ce8e194eb5600",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "is_secret": true
       },
       {
@@ -3795,7 +3851,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "c8700cb4716f270e7c37191104366e7b1cadc9de",
         "is_verified": false,
-        "line_number": 1829,
+        "line_number": 1831,
         "is_secret": true
       },
       {
@@ -3803,7 +3859,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "60b0610326aa371e079775047f4e66c77aabb0a2",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -3811,7 +3867,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "0147f29ee8d8343d8d70f94b71b0053b268461e3",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1852,
         "is_secret": true
       },
       {
@@ -3819,7 +3875,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "3c89182cf4fc330080cfb2352105827a904d5691",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2050,
         "is_secret": true
       },
       {
@@ -3827,7 +3883,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "998c11b06dfd04593f289507da2b499cf4bca6e8",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2051,
         "is_secret": true
       },
       {
@@ -3835,7 +3891,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "ccaa726ee57e4ccdab0a28886273feee26d647ec",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -3843,7 +3899,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "2e329e7c25daa340c17b719f5371248f691de123",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2058,
         "is_secret": true
       },
       {
@@ -3851,7 +3907,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6e09157ed6a7516c860d26d0747fb229badf190a",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -4035,9 +4091,23 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "f924297673a9a6a8f9362349954b1e5273549e28",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "649624ecf03baa824fd2f66c653ef47a10159656",
+        "is_verified": false,
+        "line_number": 1591
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "89400786d11d1ee5d936d6cd1890e99e4e3aa54b",
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1647,
         "is_secret": true
       },
       {
@@ -4045,7 +4115,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "b1df0ac48f734b370fc58c591ef0772266f88bb4",
         "is_verified": false,
-        "line_number": 1666,
+        "line_number": 1668,
         "is_secret": true
       },
       {
@@ -4053,7 +4123,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "541b6268f8abceae80c498212280ee7136eba255",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -4061,7 +4131,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "ff959bbe348ba1b8176852cd2e3d6ba8dbf4062d",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -4069,7 +4139,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "73f311b6a3b5bb2b45eccad848db62d85ae37b58",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -4077,7 +4147,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7294ab5b6d4cf3ea2deab49cecb0a7baacd16447",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -4085,7 +4155,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "8dfdd0969287ef24a795d71e17f53f148d37d766",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -4239,7 +4309,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c0428438c20615c80570a0bd88158db6a5cc6003",
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1645,
         "is_secret": true
       },
       {
@@ -4247,7 +4317,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c22e6661861b4203426d47e3a1a50363c09c812e",
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1646,
         "is_secret": true
       },
       {
@@ -4255,7 +4325,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b360f8c2eb4e5aeab3a63c711ffe95b4fa24afde",
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1647,
         "is_secret": true
       },
       {
@@ -4263,7 +4333,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b6416594e1de4cfc0351c6562ab936519130f5b2",
         "is_verified": false,
-        "line_number": 1654,
+        "line_number": 1656,
         "is_secret": true
       },
       {
@@ -4271,7 +4341,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b7cd1a2885e8998336c89a87d4df110a6b66e2f2",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -4279,7 +4349,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "5e8bcadfaab440649c70e43a015503e9109a7bfa",
         "is_verified": false,
-        "line_number": 1811,
+        "line_number": 1813,
         "is_secret": true
       },
       {
@@ -4287,7 +4357,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "44ed46c9ee10a3a7308c6d1a5df4cb082c57b9e0",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -4295,7 +4365,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "20e6aa34a3dd984dd602c294ee85714b53a0a872",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "is_secret": true
       },
       {
@@ -4303,7 +4373,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b5426a913c9da60eff621ee15e0b195bf6aaa8da",
         "is_verified": false,
-        "line_number": 1829,
+        "line_number": 1831,
         "is_secret": true
       },
       {
@@ -4311,7 +4381,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "415c03a82cd5f390ad3e28dd82c88e36fb540548",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -4319,7 +4389,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "9e7ba6c71dc246eee615e88e31861a563e33b42d",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1852,
         "is_secret": true
       },
       {
@@ -4327,7 +4397,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "18a887dd97555ab726e7f4d4d999dedd236763eb",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2050,
         "is_secret": true
       },
       {
@@ -4335,7 +4405,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "e4777a4b7b9c6fd1911762e35405c0b6b80ae735",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2051,
         "is_secret": true
       },
       {
@@ -4343,7 +4413,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "8847d054d32b57b7a5633fed58444d7237209e24",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -4351,7 +4421,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "369cb27892790b429dacabb4ee12cdfd63d6c250",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2058,
         "is_secret": true
       },
       {
@@ -4359,7 +4429,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b9743a370a7e12046cbb762dda96137a0327fc28",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -4583,23 +4653,21 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "9fc16a99501e66da0391bf67c7a16b236b23bed9",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "6e40094f370649da3568ca1c747fb5a17575c2be",
+        "is_verified": false,
+        "line_number": 1591
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "924dffdc29e36152ac5c5ad72472d4012c453619",
-        "is_verified": false,
-        "line_number": 1643,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "3cf10d8f342037e71cf0fa4f902939cce046db88",
-        "is_verified": false,
-        "line_number": 1644,
-        "is_secret": true
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "83107836c3fbb4f7126e1c62127d867f2115c66e",
         "is_verified": false,
         "line_number": 1645,
         "is_secret": true
@@ -4607,9 +4675,25 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "3cf10d8f342037e71cf0fa4f902939cce046db88",
+        "is_verified": false,
+        "line_number": 1646,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "83107836c3fbb4f7126e1c62127d867f2115c66e",
+        "is_verified": false,
+        "line_number": 1647,
+        "is_secret": true
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "e5de519e1707a85ae531c311d440ee66c9d92013",
         "is_verified": false,
-        "line_number": 1666,
+        "line_number": 1668,
         "is_secret": true
       },
       {
@@ -4617,7 +4701,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "5e210e2b1f3abec2110bc9be8e64d7f330fa1077",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -4625,7 +4709,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f0b397ea447a3fa2ad71bf2275fef3c57c19ced",
         "is_verified": false,
-        "line_number": 1811,
+        "line_number": 1813,
         "is_secret": true
       },
       {
@@ -4633,7 +4717,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9a36a9b7c6bfc059b4f02372fff29d59a7d28956",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -4641,7 +4725,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "d041f1238574c9fda80f329a69df103dd0362201",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "is_secret": true
       },
       {
@@ -4649,7 +4733,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "cb9c85cb748ddd0400375630f5ec0206759ddb89",
         "is_verified": false,
-        "line_number": 1829,
+        "line_number": 1831,
         "is_secret": true
       },
       {
@@ -4657,7 +4741,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f426df5e9101c108190dccfd037a953d0d402f2",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -4665,7 +4749,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "01817544892d96dedca2ad884fa493fea87ba133",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1852,
         "is_secret": true
       },
       {
@@ -4673,7 +4757,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "187a0dc92fd69a86bd0e675941e7f1898e3b55e1",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2050,
         "is_secret": true
       },
       {
@@ -4681,7 +4765,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "685a15b5a75fafecd74ad06561f50711e97d7275",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2051,
         "is_secret": true
       },
       {
@@ -4689,7 +4773,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "47a5deeb29d9b4f9d88464d050560a7f7b294ddd",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -4697,7 +4781,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "32c3af10cab241e0b425cebc42831cbaa236f1c6",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2058,
         "is_secret": true
       },
       {
@@ -4705,7 +4789,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "4cb21cbeac2b9488b0fde6c6291caf37245c54c2",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -4859,7 +4943,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d370647062f8a9ebf57183122e6aacd46c2a7bda",
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1645,
         "is_secret": true
       },
       {
@@ -4867,7 +4951,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7d2d5daebdd522b7de7fab94e153cbea4620c369",
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1647,
         "is_secret": true
       },
       {
@@ -4875,7 +4959,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "74a3dd23222f2bc1888171506f585281009f79a4",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1679,
         "is_secret": true
       },
       {
@@ -4883,7 +4967,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "c10e8dbe79654ae8ed496c4c50f5e188b7924a4e",
         "is_verified": false,
-        "line_number": 1811,
+        "line_number": 1813,
         "is_secret": true
       },
       {
@@ -4891,7 +4975,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7223cfc50b72fe9b091b46275f561526aba9e705",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": true
       },
       {
@@ -4899,7 +4983,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "4aa9a3231780af9a37413cb7034ecdf72d43cfec",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1828,
         "is_secret": true
       },
       {
@@ -4907,7 +4991,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "68af7627d36cc6b923f5928a198165857f1ba5f1",
         "is_verified": false,
-        "line_number": 1829,
+        "line_number": 1831,
         "is_secret": true
       },
       {
@@ -4915,7 +4999,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7acd3659ef48c980ce4aef1d0f2f218ff25efc89",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1836,
         "is_secret": true
       },
       {
@@ -4923,7 +5007,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7443c6e0ef4c013461140fb1aa2a7a60b40a0b89",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1852,
         "is_secret": true
       },
       {
@@ -4931,7 +5015,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "3c274d81d83ceba5bfaaaf2ac4f6b0aedcf431a0",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2050,
         "is_secret": true
       },
       {
@@ -4939,7 +5023,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "583ddc85a613ceef2e54f9d2251113f3acef73a3",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2051,
         "is_secret": true
       },
       {
@@ -4947,7 +5031,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8494b7db80f8bfedeef8cc5697bed5339cd1a4ee",
         "is_verified": false,
-        "line_number": 2055,
+        "line_number": 2057,
         "is_secret": true
       },
       {
@@ -4955,7 +5039,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d45af2467cb991008a273eb0c4590fa9a96fc497",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2058,
         "is_secret": true
       },
       {
@@ -4963,7 +5047,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8da5daf1ef780fe5e37ae02bee48cbdb023c7101",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2068,
         "is_secret": true
       }
     ],
@@ -7244,5 +7328,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-06T22:15:18Z"
+  "generated_at": "2026-07-13T18:14:58Z"
 }

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -228,6 +228,11 @@ class UsersResponse(BaseModel):
     users: list[UserRead]
 
 
+class PasswordResetRequest(BaseModel):
+    current_password: str
+    password: str
+
+
 class ApiKeyResponse(BaseModel):
     id: str
     api_key: str

--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 from sqlmodel.sql.expression import SelectOfScalar
 
 from langflow.api.utils import CurrentActiveUser, DbSession
-from langflow.api.v1.schemas import UsersResponse
+from langflow.api.v1.schemas import PasswordResetRequest, UsersResponse
 from langflow.initial_setup.setup import get_or_create_default_folder
 from langflow.services.auth.utils import get_current_active_superuser, get_current_user_optional
 from langflow.services.database.models.user.crud import get_user_by_id, update_user
@@ -133,25 +133,25 @@ async def patch_user(
 @router.patch("/{user_id}/reset-password", response_model=UserRead)
 async def reset_password(
     user_id: UUID,
-    user_update: UserUpdate,
+    password_reset: PasswordResetRequest,
     user: CurrentActiveUser,
     session: DbSession,
 ) -> User:
-    """Reset a user's password."""
+    """Change the current user's password after verifying the existing password."""
     if user_id != user.id:
         raise HTTPException(status_code=404, detail="You can't change another user's password")
 
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    if user_update.password is None:
-        raise HTTPException(status_code=400, detail="Password is required for password reset")
-
     auth = get_auth_service()
-    if auth.verify_password(user_update.password, user.password):
+    if not auth.verify_password(password_reset.current_password, user.password):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
+
+    if auth.verify_password(password_reset.password, user.password):
         raise HTTPException(status_code=400, detail="You can't use your current password")
 
-    new_password = auth.get_password_hash(user_update.password)
+    new_password = auth.get_password_hash(password_reset.password)
     user.password = new_password
 
     await session.flush()

--- a/src/backend/tests/unit/api/v1/test_users.py
+++ b/src/backend/tests/unit/api/v1/test_users.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from fastapi import status
 from httpx import AsyncClient
 
@@ -198,7 +200,7 @@ async def test_patch_user(client: AsyncClient, logged_in_headers_super_user):
 
 async def test_reset_password(client: AsyncClient, logged_in_headers, active_user):
     id_ = str(active_user.id)
-    basic_case = {"username": "string", "password": "new_password"}
+    basic_case = {"current_password": "testpassword", "password": "new_password"}
     response = await client.patch(f"api/v1/users/{id_}/reset-password", json=basic_case, headers=logged_in_headers)
     result = response.json()
 
@@ -212,6 +214,63 @@ async def test_reset_password(client: AsyncClient, logged_in_headers, active_use
     assert "store_api_key" in result, "The result must have an 'store_api_key' key"
     assert "updated_at" in result, "The result must have an 'updated_at' key"
     assert "username" in result, "The result must have an 'username' key"
+
+    login_response = await client.post(
+        "api/v1/login",
+        data={"username": active_user.username, "password": "new_password"},
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+
+
+async def test_reset_password_rejects_incorrect_current_password(client: AsyncClient, logged_in_headers, active_user):
+    response = await client.patch(
+        f"api/v1/users/{active_user.id}/reset-password",
+        json={"current_password": "incorrect", "password": "new_password"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Current password is incorrect"}
+
+    login_response = await client.post(
+        "api/v1/login",
+        data={"username": active_user.username, "password": "testpassword"},
+    )
+    assert login_response.status_code == status.HTTP_200_OK
+
+
+async def test_reset_password_requires_current_password(client: AsyncClient, logged_in_headers, active_user):
+    response = await client.patch(
+        f"api/v1/users/{active_user.id}/reset-password",
+        json={"password": "new_password"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+async def test_reset_password_rejects_current_password_as_new_password(
+    client: AsyncClient, logged_in_headers, active_user
+):
+    response = await client.patch(
+        f"api/v1/users/{active_user.id}/reset-password",
+        json={"current_password": "testpassword", "password": "testpassword"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "You can't use your current password"}
+
+
+async def test_reset_password_cannot_target_another_user(client: AsyncClient, logged_in_headers):
+    response = await client.patch(
+        f"api/v1/users/{uuid4()}/reset-password",
+        json={"current_password": "testpassword", "password": "new_password"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "You can't change another user's password"}
 
 
 async def test_delete_user(client: AsyncClient, logged_in_headers_super_user):

--- a/src/backend/tests/unit/test_user.py
+++ b/src/backend/tests/unit/test_user.py
@@ -207,13 +207,14 @@ async def test_patch_user(client: AsyncClient, active_user, logged_in_headers):
 @pytest.mark.api_key_required
 async def test_patch_reset_password(client: AsyncClient, active_user, logged_in_headers):
     user_id = active_user.id
-    update_data = UserUpdate(
-        password="newpassword",  # noqa: S106
-    )
+    update_data = {
+        "current_password": "testpassword",
+        "password": "newpassword",
+    }
 
     response = await client.patch(
         f"/api/v1/users/{user_id}/reset-password",
-        json=update_data.model_dump(),
+        json=update_data,
         headers=logged_in_headers,
     )
     assert response.status_code == 200, response.json()

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -637,6 +637,7 @@ export const CONTROL_INPUT_STATE = {
 };
 
 export const CONTROL_PATCH_USER_STATE = {
+  currentPassword: "",
   password: "",
   cnfPassword: "",
   profilePicture: "",

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "Ihre geheimen Langflow-API-Schlüssel sind unten aufgeführt. Geben Sie Ihren API-Schlüssel nicht an andere weiter und machen Sie ihn nicht im Browser oder in anderem clientseitigen Code sichtbar.",
   "settings.confirmPasswordPlaceholder": "Bestätigungskennwort",
   "settings.confirmPasswordRequired": "Bitte bestätigen Sie Ihr Passwort",
+  "settings.currentPasswordPlaceholder": "Aktuelles Passwort",
+  "settings.currentPasswordRequired": "Bitte geben Sie Ihr aktuelles Passwort ein",
   "settings.dbProviders.active": "Aktiv",
   "settings.dbProviders.chromaDescription": "Chroma speichert Vektoren auf der Festplatte neben Langflow und ist standardmäßig aktiviert. Wenn Sie ihn hier auswählen, wird er zum Standardanbieter für neue Wissensdatenbanken.",
   "settings.dbProviders.chromaSelected": "Chroma ausgewählt",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -275,6 +275,8 @@
   "settings.confirmPasswordPlaceholder": "Confirm Password",
   "settings.passwordRequired": "Please enter your password",
   "settings.confirmPasswordRequired": "Please confirm your password",
+  "settings.currentPasswordPlaceholder": "Current Password",
+  "settings.currentPasswordRequired": "Please enter your current password",
   "settings.saveButton": "Save",
   "settings.languageTitle": "Language",
   "settings.languageDescription": "Choose the display language for the Langflow interface.",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "A continuación se muestran tus claves API secretas de Langflow. No compartas tu clave API con otras personas ni la expongas en el navegador o en otro código del lado del cliente.",
   "settings.confirmPasswordPlaceholder": "Confirmar contraseña",
   "settings.confirmPasswordRequired": "Confirma tu contraseña",
+  "settings.currentPasswordPlaceholder": "Contraseña actual",
+  "settings.currentPasswordRequired": "Introduce tu contraseña actual",
   "settings.dbProviders.active": "Activo",
   "settings.dbProviders.chromaDescription": "Chroma almacena los vectores en el disco junto a Langflow y está activado de forma predeterminada. Si lo seleccionas aquí, se convertirá en el proveedor predeterminado para las nuevas bases de conocimientos.",
   "settings.dbProviders.chromaSelected": "Chroma seleccionado",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "Vos clés API Langflow confidentielles sont répertoriées ci-dessous. Ne communiquez pas votre clé API à des tiers et ne la divulguez pas dans le navigateur ou dans tout autre code côté client.",
   "settings.confirmPasswordPlaceholder": "Confirmer le mot de passe",
   "settings.confirmPasswordRequired": "Veuillez confirmer votre mot de passe",
+  "settings.currentPasswordPlaceholder": "Mot de passe actuel",
+  "settings.currentPasswordRequired": "Veuillez saisir votre mot de passe actuel",
   "settings.dbProviders.active": "Actif",
   "settings.dbProviders.chromaDescription": "Chroma stocke les fichiers vectoriels sur le disque aux côtés de Langflow et est activé par défaut. Si vous le sélectionnez ici, il deviendra le fournisseur par défaut pour les nouvelles bases de connaissances.",
   "settings.dbProviders.chromaSelected": "Chroma sélectionné",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "秘密のLangflow APIキーは以下の通りです。 APIキーを他人と共有したり、ブラウザやその他のクライアントサイドのコード内で公開したりしないでください。",
   "settings.confirmPasswordPlaceholder": "パスワードの確認",
   "settings.confirmPasswordRequired": "パスワードの確認をお願いします",
+  "settings.currentPasswordPlaceholder": "現在のパスワード",
+  "settings.currentPasswordRequired": "現在のパスワードを入力してください",
   "settings.dbProviders.active": "アクティブ",
   "settings.dbProviders.chromaDescription": "Chromaは、Langflowと同じディスク上にベクトルを保存し、デフォルトで有効になっています。 ここでこれを選択すると、新しいナレッジベースのデフォルトのプロバイダーになります。",
   "settings.dbProviders.chromaSelected": "色を選択しました",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "Suas chaves secretas da API do Langflow estão listadas abaixo. Não compartilhe sua chave de API com outras pessoas nem a exponha no navegador ou em outro código do lado do cliente.",
   "settings.confirmPasswordPlaceholder": "Confirmar senha",
   "settings.confirmPasswordRequired": "Confirme sua senha",
+  "settings.currentPasswordPlaceholder": "Senha atual",
+  "settings.currentPasswordRequired": "Digite sua senha atual",
   "settings.dbProviders.active": "Ativo",
   "settings.dbProviders.chromaDescription": "O Chroma armazena vetores no disco junto com o Langflow e está ativado por padrão. Ao selecioná-lo aqui, ele se torna o provedor padrão para novas bases de conhecimento.",
   "settings.dbProviders.chromaSelected": "Chroma selecionado",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1587,6 +1587,8 @@
   "settings.apiPageParagraph": "您的 Langflow 私有 API 密钥如下所示。 请勿将您的 API 密钥分享给他人，也不要在浏览器或其他客户端代码中暴露该密钥。",
   "settings.confirmPasswordPlaceholder": "确认密码",
   "settings.confirmPasswordRequired": "请确认您的密码",
+  "settings.currentPasswordPlaceholder": "当前密码",
+  "settings.currentPasswordRequired": "请输入当前密码",
   "settings.dbProviders.active": "活动",
   "settings.dbProviders.chromaDescription": "Chroma 将矢量数据存储在 Langflow 旁边的磁盘上，并且默认处于启用状态。 在此处选中它，将使其成为新建知识库的默认提供程序。",
   "settings.dbProviders.chromaSelected": "已选择色相",

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
@@ -1,5 +1,6 @@
 import * as Form from "@radix-ui/react-form";
 import { useTranslation } from "react-i18next";
+import type { inputHandlerEventType } from "@/types/components";
 import InputComponent from "../../../../../../components/core/parameterRenderComponent/components/inputComponent";
 import { Button } from "../../../../../../components/ui/button";
 import {
@@ -12,16 +13,14 @@ import {
 } from "../../../../../../components/ui/card";
 
 type PasswordFormComponentProps = {
+  currentPassword: string;
   password: string;
   cnfPassword: string;
-  handleInput: (event: any) => void;
-  handlePatchPassword: (
-    password: string,
-    cnfPassword: string,
-    handleInput: any,
-  ) => void;
+  handleInput: (event: inputHandlerEventType) => void;
+  handlePatchPassword: () => void;
 };
 const PasswordFormComponent = ({
+  currentPassword,
   password,
   cnfPassword,
   handleInput,
@@ -32,7 +31,7 @@ const PasswordFormComponent = ({
     <>
       <Form.Root
         onSubmit={(event) => {
-          handlePatchPassword(password, cnfPassword, handleInput);
+          handlePatchPassword();
           event.preventDefault();
         }}
       >
@@ -44,7 +43,26 @@ const PasswordFormComponent = ({
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex w-full gap-4">
+            <div className="flex w-full flex-col gap-4 md:flex-row">
+              <Form.Field name="currentPassword" className="w-full">
+                <InputComponent
+                  id="currentPassword"
+                  onChange={(value) => {
+                    handleInput({
+                      target: { name: "currentPassword", value },
+                    });
+                  }}
+                  value={currentPassword}
+                  isForm
+                  password={true}
+                  required
+                  placeholder={t("settings.currentPasswordPlaceholder")}
+                  className="w-full"
+                />
+                <Form.Message match="valueMissing" className="field-invalid">
+                  {t("settings.currentPasswordRequired")}
+                </Form.Message>
+              </Form.Field>
               <Form.Field name="password" className="w-full">
                 <InputComponent
                   id="pasword"
@@ -54,6 +72,7 @@ const PasswordFormComponent = ({
                   value={password}
                   isForm
                   password={true}
+                  required
                   placeholder={t("settings.passwordPlaceholder")}
                   className="w-full"
                 />
@@ -72,6 +91,7 @@ const PasswordFormComponent = ({
                   value={cnfPassword}
                   isForm
                   password={true}
+                  required
                   placeholder={t("settings.confirmPasswordPlaceholder")}
                   className="w-full"
                 />

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -36,7 +36,7 @@ export const GeneralPage = () => {
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const { userData, setUserData } = useContext(AuthContext);
-  const { password, cnfPassword, profilePicture } = inputState;
+  const { currentPassword, password, cnfPassword, profilePicture } = inputState;
   const autoLogin = useAuthStore((state) => state.autoLogin);
 
   const { storeApiKey } = useContext(AuthContext);
@@ -56,11 +56,15 @@ export const GeneralPage = () => {
       return;
     }
 
-    if (password !== "") {
+    if (currentPassword !== "" && password !== "") {
       mutateResetPassword(
-        { user_id: userData!.id, password: { password } },
+        {
+          user_id: userData!.id,
+          password: { current_password: currentPassword, password },
+        },
         {
           onSuccess: () => {
+            handleInput({ target: { name: "currentPassword", value: "" } });
             handleInput({ target: { name: "password", value: "" } });
             handleInput({ target: { name: "cnfPassword", value: "" } });
             setSuccessData({ title: t("success.changesSaved") });
@@ -156,6 +160,7 @@ export const GeneralPage = () => {
 
         {!autoLogin && (
           <PasswordFormComponent
+            currentPassword={currentPassword}
             password={password}
             cnfPassword={cnfPassword}
             handleInput={handleInput}

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -196,8 +196,8 @@ export type changeUser = {
 };
 
 export type resetPasswordType = {
-  password?: string;
-  profile_image?: string;
+  current_password: string;
+  password: string;
 };
 
 export type Users = {

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -452,6 +452,7 @@ export type loginInputStateType = {
 };
 
 export type patchUserInputStateType = {
+  currentPassword: string;
   password: string;
   cnfPassword: string;
   profilePicture: string;


### PR DESCRIPTION
## Summary

- require users to confirm their current password before changing it
- preserve self-only account targeting and the existing password-reuse check
- update the Settings form/request contract and all locale files
- add positive and negative regression coverage

## Validation

- [x] owning users API module: 20 passed
- [x] focused password-change tests: 5 passed
- [x] legacy reset-password test: 1 passed
- [x] Ruff, Biome, and pre-commit hooks
- [x] frontend production build

## Scope note

This change does not introduce a new password-complexity policy because the release line has no established minimum-length or character-class standard. That remains a separate product decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Password changes now require the current password and a different new password.
  - Added validation for incorrect, missing, or reused passwords and unauthorized account targets.
  - Updated the settings form with a current-password field and responsive layout.
  - Added localized labels and validation messages in supported languages.

- **Bug Fixes**
  - Improved password reset security and clearer validation feedback.

- **Tests**
  - Expanded coverage for successful and rejected password reset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->