### PR TITLE
fix(frontend): stop assistant 'New' pill from shifting on hover

### DIFF
--- a/src/frontend/src/components/core/canvasControlsComponent/CanvasControls.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/CanvasControls.tsx
@@ -165,10 +165,10 @@ const CanvasControls = ({
                   // pinned open; otherwise it falls back to the hover-only
                   // behavior so power users still see it as a hint without
                   // it being intrusive.
-                  className={`absolute -top-4 -left-1 z-10 flex items-center gap-0.5 rounded bg-accent-assistant-brand px-1 py-0.5 text-[9px] font-medium leading-none text-white transition-all duration-200 ${
+                  className={`absolute -top-4 -left-1 z-10 flex items-center gap-0.5 rounded bg-accent-assistant-brand px-1 py-0.5 text-[9px] font-medium leading-none text-white transition-opacity duration-200 ${
                     onboardingActive
-                      ? "opacity-100 scale-100"
-                      : "opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100"
+                      ? "opacity-100"
+                      : "opacity-0 group-hover:opacity-100"
                   }`}
                 >
                   <ForwardedIconComponent


### PR DESCRIPTION
## Summary

Hovering the assistant button in the canvas controls bar made the "New" discovery pill visibly shift: it animated `scale-90 → scale-100` with `transition-all`, so the pill text slid outward while growing and read as the whole controls bar wiggling.

## Fix

The pill is absolutely positioned, so all perceived movement came from the scale transform — not real layout. This drops the scale animation and fades the pill in place:

- `transition-all` → `transition-opacity`
- removed `scale-90` / `scale-100` from both the onboarding-pinned and hover states

Hover states no longer change size or position of anything in the bar.

## Validation

- `npx jest src/components/core/canvasControlsComponent` — 71/71 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the assistant discovery pill animation to use a smoother fade-in and fade-out effect.
  * Removed the scaling effect while preserving existing visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->