### PR TITLE
fix(voice): enforce flow authorization on websocket

### DIFF
--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -17,7 +17,7 @@ import sqlalchemy
 import websockets
 from cryptography.fernet import InvalidToken
 from elevenlabs import ElevenLabs
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from lfx.log import logger
 from lfx.schema.schema import InputValueRequest
 from lfx.utils.secrets import secret_value_to_str
@@ -28,13 +28,16 @@ from websockets.asyncio.client import ClientConnection
 
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.v1.chat import build_flow_and_stream
+from langflow.api.v1.flows_helpers import _read_flow
 from langflow.memory import aadd_messagetables
 from langflow.schema.properties import Properties
 from langflow.services.auth.utils import get_current_user_for_websocket
-from langflow.services.database.models.flow.model import Flow
+from langflow.services.authorization import FlowAction, ensure_flow_permission
+from langflow.services.authorization.fetch import deny_to_404
+from langflow.services.database.models.flow.model import AccessTypeEnum, Flow
 from langflow.services.database.models.message.model import MessageTable
 from langflow.services.database.models.user.model import User
-from langflow.services.deps import get_variable_service, session_scope
+from langflow.services.deps import get_variable_service
 from langflow.utils.voice_utils import BYTES_PER_24K_FRAME, VAD_SAMPLE_RATE_16K, resample_24k_to_16k
 
 router = APIRouter(prefix="/voice", tags=["Voice"], include_in_schema=False)
@@ -496,15 +499,31 @@ message_tasks: dict[str, asyncio.Task] = {}
 last_sender_by_session: defaultdict[str, str | None] = defaultdict(lambda: None)
 
 
-async def get_flow_desc_from_db(flow_id: str) -> Flow:
-    async with session_scope() as session:
-        stmt = select(Flow).where(Flow.id == UUID(flow_id))
-        result = await session.exec(stmt)
-        flow = result.scalar_one_or_none()
-        if not flow:
-            msg = f"Flow with id {flow_id} not found"
-            raise ValueError(msg)
-        return flow.description
+async def _get_authorized_voice_flow(flow_id: str, current_user: CurrentActiveUser, session: DbSession) -> Flow:
+    """Load a voice flow with the same share-aware execute policy as standard builds."""
+    flow_uuid = UUID(flow_id)
+    flow = await _read_flow(session, flow_uuid, current_user.id)
+    if flow is None:
+        public_stmt = select(Flow).where(
+            Flow.id == flow_uuid,
+            Flow.access_type == AccessTypeEnum.PUBLIC,
+        )
+        flow = (await session.exec(public_stmt)).first()
+    if flow is None:
+        raise HTTPException(status_code=404, detail="Flow not found")
+
+    try:
+        await ensure_flow_permission(
+            current_user,
+            FlowAction.EXECUTE,
+            flow_id=flow_uuid,
+            flow_user_id=flow.user_id,
+            workspace_id=flow.workspace_id,
+            folder_id=flow.folder_id,
+        )
+    except HTTPException as exc:
+        raise deny_to_404(exc, detail="Flow not found") from exc
+    return flow
 
 
 async def get_or_create_elevenlabs_client(user_id=None, session=None):
@@ -740,10 +759,9 @@ async def flow_as_tool_websocket(
         current_user, openai_key = await authenticate_and_get_openai_key(session, current_user, client_websocket)
         if current_user is None or openai_key is None:
             return
-        # Resolve voice config only after authentication, scoped to this user.
-        voice_config = get_voice_config(session_id, current_user.id)
         try:
-            flow_description = await get_flow_desc_from_db(flow_id)
+            flow = await _get_authorized_voice_flow(flow_id, current_user, session)
+            flow_description = flow.description
             flow_tool = {
                 "name": "execute_flow",
                 "type": "function",
@@ -759,6 +777,10 @@ async def flow_as_tool_websocket(
             await client_websocket.send_json(err_msg)
             await logger.aerror(f"Failed to load flow: {e}")
             return
+
+        # Resolve voice config only after authentication and flow authorization,
+        # scoped to this user.
+        voice_config = get_voice_config(session_id, current_user.id)
 
         url = "wss://api.openai.com/v1/realtime?model=gpt-4o-mini-realtime-preview"
         headers = {

--- a/src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py
+++ b/src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py
@@ -1,0 +1,164 @@
+"""Authorization regression tests for the voice flow-as-tool WebSocket."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from langflow.api.v1 import voice_mode
+
+
+def _flow(*, owner_id, description="Authorized flow"):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=owner_id,
+        workspace_id=uuid4(),
+        folder_id=uuid4(),
+        description=description,
+    )
+
+
+class _DescriptionProbe:
+    def __init__(self, *, owner_id):
+        self.id = uuid4()
+        self.user_id = owner_id
+        self.workspace_id = uuid4()
+        self.folder_id = uuid4()
+        self.description_reads = 0
+
+    @property
+    def description(self):
+        self.description_reads += 1
+        return "private description"
+
+
+@pytest.mark.asyncio
+async def test_authorized_voice_flow_allows_owner(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    flow = _flow(owner_id=user.id)
+    session = SimpleNamespace()
+    read_flow = AsyncMock(return_value=flow)
+    ensure_permission = AsyncMock()
+    monkeypatch.setattr(voice_mode, "_read_flow", read_flow, raising=False)
+    monkeypatch.setattr(voice_mode, "ensure_flow_permission", ensure_permission, raising=False)
+
+    result = await voice_mode._get_authorized_voice_flow(str(flow.id), user, session)
+
+    assert result is flow
+    read_flow.assert_awaited_once_with(session, flow.id, user.id)
+    ensure_permission.assert_awaited_once_with(
+        user,
+        voice_mode.FlowAction.EXECUTE,
+        flow_id=flow.id,
+        flow_user_id=flow.user_id,
+        workspace_id=flow.workspace_id,
+        folder_id=flow.folder_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorized_voice_flow_allows_share_aware_fetch_when_guard_allows(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    foreign_flow = _flow(owner_id=uuid4())
+    session = SimpleNamespace()
+    read_flow = AsyncMock(return_value=foreign_flow)
+    ensure_permission = AsyncMock()
+    monkeypatch.setattr(voice_mode, "_read_flow", read_flow, raising=False)
+    monkeypatch.setattr(voice_mode, "ensure_flow_permission", ensure_permission, raising=False)
+
+    result = await voice_mode._get_authorized_voice_flow(str(foreign_flow.id), user, session)
+
+    assert result is foreign_flow
+    read_flow.assert_awaited_once_with(session, foreign_flow.id, user.id)
+    ensure_permission.assert_awaited_once_with(
+        user,
+        voice_mode.FlowAction.EXECUTE,
+        flow_id=foreign_flow.id,
+        flow_user_id=foreign_flow.user_id,
+        workspace_id=foreign_flow.workspace_id,
+        folder_id=foreign_flow.folder_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorized_voice_flow_preserves_public_flow_access(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    public_flow = _flow(owner_id=uuid4())
+    read_flow = AsyncMock(return_value=None)
+    ensure_permission = AsyncMock()
+    result = SimpleNamespace(first=lambda: public_flow)
+    session = SimpleNamespace(exec=AsyncMock(return_value=result))
+    monkeypatch.setattr(voice_mode, "_read_flow", read_flow, raising=False)
+    monkeypatch.setattr(voice_mode, "ensure_flow_permission", ensure_permission, raising=False)
+
+    authorized = await voice_mode._get_authorized_voice_flow(str(public_flow.id), user, session)
+
+    assert authorized is public_flow
+    session.exec.assert_awaited_once()
+    ensure_permission.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_voice_flow_uses_same_generic_404(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    read_flow = AsyncMock(return_value=None)
+    ensure_permission = AsyncMock()
+    result = SimpleNamespace(first=lambda: None)
+    session = SimpleNamespace(exec=AsyncMock(return_value=result))
+    monkeypatch.setattr(voice_mode, "_read_flow", read_flow)
+    monkeypatch.setattr(voice_mode, "ensure_flow_permission", ensure_permission)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await voice_mode._get_authorized_voice_flow(str(uuid4()), user, session)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Flow not found"
+    ensure_permission.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_denied_cross_user_websocket_reaches_no_description_connection_or_message_sink(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    foreign_flow = _DescriptionProbe(owner_id=uuid4())
+    websocket = SimpleNamespace(accept=AsyncMock(), send_json=AsyncMock())
+    legacy_description_sink = AsyncMock(return_value="private description")
+    connect = Mock(side_effect=AssertionError("external connection reached before authorization"))
+    add_message = AsyncMock()
+    get_voice_config = Mock()
+
+    monkeypatch.setattr(voice_mode, "get_current_user_for_websocket", AsyncMock(return_value=user))
+    monkeypatch.setattr(
+        voice_mode,
+        "authenticate_and_get_openai_key",
+        AsyncMock(return_value=(user, "test-openai-key")),
+    )
+    monkeypatch.setattr(voice_mode, "_read_flow", AsyncMock(return_value=foreign_flow), raising=False)
+    monkeypatch.setattr(
+        voice_mode,
+        "ensure_flow_permission",
+        AsyncMock(side_effect=HTTPException(status_code=403, detail="denied")),
+        raising=False,
+    )
+    # Pin the pre-fix unscoped description helper as an explicit sink: a deny
+    # must return before either this legacy path or the Flow.description field.
+    monkeypatch.setattr(voice_mode, "get_flow_desc_from_db", legacy_description_sink, raising=False)
+    monkeypatch.setattr(voice_mode, "get_voice_config", get_voice_config)
+    monkeypatch.setattr(voice_mode.websockets, "connect", connect)
+    monkeypatch.setattr(voice_mode, "add_message_to_db", add_message)
+
+    await voice_mode.flow_as_tool_websocket(
+        client_websocket=websocket,
+        flow_id=str(foreign_flow.id),
+        background_tasks=BackgroundTasks(),
+        session=SimpleNamespace(),
+        session_id="voice-session",
+    )
+
+    websocket.accept.assert_awaited_once()
+    websocket.send_json.assert_awaited_once_with({"error": "Failed to load flow: 404: Flow not found"})
+    assert foreign_flow.description_reads == 0
+    legacy_description_sink.assert_not_awaited()
+    get_voice_config.assert_not_called()
+    connect.assert_not_called()
+    add_message.assert_not_awaited()


### PR DESCRIPTION
## Summary
- authorize voice-mode flow execution before reading flow metadata or opening external connections
- preserve owner, public, and share-aware access paths
- return a generic not-found response for denied or missing flows

## Testing
- 43 focused voice authorization tests passed
- Ruff, formatting, and pre-commit passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for voice-enabled flows.
  * Restricted access to flows based on permissions while preserving approved shared and public access.
  * Standardized missing or unauthorized flow responses as generic not-found errors.
  * Prevented unauthorized requests from initiating voice connections or processing flow data.

* **Tests**
  * Added regression coverage for owner, shared, public, missing, and unauthorized flow access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->