### PR TITLE
fix: correct deprecated model settings behavior

### DIFF
--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -393,16 +393,17 @@ async def _get_enabled_models(session: DbSession, current_user: CurrentActiveUse
     return set()
 
 
-def _build_model_default_flags() -> dict[str, bool]:
+def _build_model_default_flags(all_models_by_provider: list[dict] | None = None) -> dict[str, bool]:
     """Build a map of model names to their default flag status.
 
     Returns:
         Dictionary mapping model names to whether they are default models
     """
-    all_models_by_provider = get_unified_models_detailed(
-        include_unsupported=True,
-        include_deprecated=True,
-    )
+    if all_models_by_provider is None:
+        all_models_by_provider = get_unified_models_detailed(
+            include_unsupported=True,
+            include_deprecated=True,
+        )
 
     is_default_model = {}
     for provider_dict in all_models_by_provider:
@@ -611,13 +612,39 @@ async def update_enabled_models(
     disabled_models = await _get_disabled_models(session=session, current_user=current_user)
     explicitly_enabled_models = await _get_enabled_models(session=session, current_user=current_user)
 
+    all_models_by_provider = get_unified_models_detailed(
+        include_unsupported=True,
+        include_deprecated=True,
+    )
     # Build map of model names to their default flag
-    is_default_model = _build_model_default_flags()
+    is_default_model = _build_model_default_flags(all_models_by_provider)
+
+    unavailable_models: dict[tuple[str, str], str] = {}
+    for provider_dict in all_models_by_provider:
+        provider = provider_dict.get("provider")
+        if not isinstance(provider, str):
+            continue
+        for model in provider_dict.get("models", []):
+            model_name = model.get("model_name")
+            if not isinstance(model_name, str):
+                continue
+            metadata = model.get("metadata", {})
+            if metadata.get("deprecated", False):
+                unavailable_models[(provider, model_name)] = "deprecated"
+            elif metadata.get("not_supported", False):
+                unavailable_models[(provider, model_name)] = "not supported"
 
     # Update model sets based on user requests
     # For any model being enabled, validate the provider credentials
     for update in updates:
         if update.enabled:
+            unavailable_reason = unavailable_models.get((update.provider, update.model_id))
+            if unavailable_reason:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot enable {unavailable_reason} model: {update.model_id}",
+                )
+
             from lfx.base.models.unified_models import get_all_variables_for_provider, validate_model_provider_key
 
             # Get variables from DB or environment

--- a/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
@@ -366,6 +366,19 @@ async def test_enabled_providers_reflects_models_endpoint(client: AsyncClient, o
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_cannot_enable_deprecated_model(client: AsyncClient, logged_in_headers):
+    """Deprecated models cannot be persisted as explicitly enabled."""
+    response = await client.post(
+        "api/v1/models/enabled_models",
+        json=[{"provider": "OpenAI", "model_id": "gpt-3.5-turbo", "enabled": True}],
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Cannot enable deprecated model: gpt-3.5-turbo"
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_security_credential_value_never_exposed_in_variables_endpoint(
     client: AsyncClient, openai_credential, logged_in_headers
 ):

--- a/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
@@ -320,6 +320,26 @@ describe("ModelSelection", () => {
       );
     });
 
+    it("should not allow deprecated models to be enabled", async () => {
+      const user = userEvent.setup();
+      const onModelToggle = jest.fn();
+      render(
+        <ModelSelection
+          {...defaultProps}
+          availableModels={withDeprecated}
+          modelType="llm"
+          onModelToggle={onModelToggle}
+        />,
+      );
+
+      await user.click(screen.getByTestId("llm-deprecated-summary"));
+      const deprecatedToggle = screen.getByTestId("llm-toggle-gpt-old");
+      expect(deprecatedToggle).toBeDisabled();
+
+      await user.click(deprecatedToggle);
+      expect(onModelToggle).not.toHaveBeenCalled();
+    });
+
     it("should pluralize 'model' correctly for a single deprecated row", () => {
       const single: Model[] = [
         { model_name: "gpt-4o", metadata: { model_type: "llm", icon: "Bot" } },

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -146,6 +146,10 @@ const ModelRow = ({
       {isEnabledModel && (
         <Switch
           checked={enabled}
+          disabled={
+            model.metadata?.deprecated === true ||
+            model.metadata?.not_supported === true
+          }
           onCheckedChange={(checked) => onToggle(model.model_name, checked)}
           data-testid={`${testIdPrefix}-toggle-${model.model_name}`}
           aria-label={

--- a/src/lfx/src/lfx/base/models/models_dev_catalog.py
+++ b/src/lfx/src/lfx/base/models/models_dev_catalog.py
@@ -57,12 +57,9 @@ _DATED_SNAPSHOT_RE = re.compile(r"-(?:\d{4}-\d{2}-\d{2}|\d{8}|preview-\d{2}-\d{2
 
 # Threshold for auto-deprecating models that haven't shipped a new version in
 # a long time. models.dev has no deprecation field, and providers rarely
-# formally deprecate models even after they ship a successor — but a model
-# that hasn't been touched in 30 months is overwhelmingly legacy in practice
-# (catches gpt-4 / gpt-4-turbo / text-embedding-ada-002 today, leaves
-# gpt-4o / text-embedding-3-small/large active). Tuned conservatively so
-# current embeddings (~28 months old) survive; nudge down only if successor
-# adoption is verified.
+# formally deprecate models even after they ship a successor. Apply this only
+# to language models: embedding release cadences are slower, and age alone
+# does not mean that a provider has deprecated an embedding model.
 _AGE_DEPRECATION_DAYS = 900
 
 MODELS_DEV_URL = "https://models.dev/api.json"
@@ -229,15 +226,16 @@ def _is_embedding_family(model_dict: dict[str, Any]) -> bool:
 
 
 def _is_aged_out(model_dict: dict[str, Any], now: datetime) -> bool:
-    """Return True if the model is older than ``_AGE_DEPRECATION_DAYS`` days.
+    """Return True if a language model is older than ``_AGE_DEPRECATION_DAYS`` days.
 
     Prefers ``release_date`` (when the model functionally shipped) over
     ``last_updated`` (which tracks catalog-curator edits like typo fixes, not
-    new model versions). The combination of preferring release_date and the
-    900-day threshold correctly catches ``gpt-4`` / ``gpt-4-turbo`` (924d from
-    their 2023-11 release) while keeping ``text-embedding-3-large`` (844d
-    from its 2024-01 release) active.
+    new model versions). Embedding models are excluded because their age does
+    not indicate provider deprecation.
     """
+    if _is_embedding_family(model_dict):
+        return False
+
     raw = model_dict.get("release_date") or model_dict.get("last_updated")
     epoch = _release_date_to_epoch(raw)
     if epoch == 0:
@@ -285,7 +283,7 @@ def _translate_model_entry(
     ``deprecated`` kwarg (which lets callers forward the static-list
     curation that models.dev itself doesn't surface):
       * dated-snapshot id (:data:`_DATED_SNAPSHOT_RE`);
-      * stale ``last_updated`` / ``release_date`` per :data:`_AGE_DEPRECATION_DAYS`.
+      * stale LLM ``last_updated`` / ``release_date`` per :data:`_AGE_DEPRECATION_DAYS`.
     ``now`` is injected for testability — defaults to the current UTC time.
     """
     now = now or datetime.now(tz=timezone.utc)
@@ -357,8 +355,8 @@ def apply_models_dev_overrides(
     preserves the static-list curation by name: any model that was already
     flagged deprecated in the bundled ``*_constants.py`` lists keeps that flag
     after the override. Dated-snapshot ids
-    (e.g. ``claude-opus-4-5-20251101``, ``gpt-4o-2024-05-13``) and rows whose
-    most recent date is older than :data:`_AGE_DEPRECATION_DAYS` are also
+    (e.g. ``claude-opus-4-5-20251101``, ``gpt-4o-2024-05-13``) and language
+    models whose most recent date is older than :data:`_AGE_DEPRECATION_DAYS` are also
     auto-flagged in :func:`_translate_model_entry`. ``now`` is forwarded for
     testability.
     """

--- a/src/lfx/tests/unit/base/models/test_models_dev_catalog.py
+++ b/src/lfx/tests/unit/base/models/test_models_dev_catalog.py
@@ -454,6 +454,12 @@ def test_apply_overrides_preserves_static_deprecated_flag():
         {"provider": "OpenAI", "name": "gpt-4o", "tool_calling": True, "deprecated": False},
         {"provider": "OpenAI", "name": "gpt-3.5-turbo", "tool_calling": True, "deprecated": True},
         {"provider": "OpenAI", "name": "gpt-4.5-preview", "tool_calling": True, "deprecated": True},
+        {
+            "provider": "OpenAI",
+            "name": "text-embedding-legacy",
+            "model_type": "embeddings",
+            "deprecated": True,
+        },
     ]
     snapshot = {
         "openai": {
@@ -465,6 +471,11 @@ def test_apply_overrides_preserves_static_deprecated_flag():
                 # New model not in our static list — should default to
                 # non-deprecated unless dated-snapshot.
                 "gpt-6": {"id": "gpt-6", "tool_call": True},
+                "text-embedding-legacy": {
+                    "id": "text-embedding-legacy",
+                    "family": "text-embedding",
+                    "release_date": "2020-01-01",
+                },
             },
         }
     }
@@ -475,6 +486,7 @@ def test_apply_overrides_preserves_static_deprecated_flag():
     assert by_name["gpt-3.5-turbo"]["deprecated"] is True
     assert by_name["gpt-4.5-preview"]["deprecated"] is True
     assert by_name["gpt-6"]["deprecated"] is False
+    assert by_name["text-embedding-legacy"]["deprecated"] is True
 
 
 def test_apply_overrides_marks_embedding_family_as_embeddings_model_type():
@@ -517,37 +529,37 @@ def test_apply_overrides_marks_embedding_family_as_embeddings_model_type():
     assert by_name["voyage-3-embedding"]["model_type"] == "embeddings"
 
 
-def test_apply_overrides_auto_deprecates_stale_models():
-    """Models with last_updated older than ~30 months are auto-deprecated.
+def test_apply_overrides_auto_deprecates_stale_language_models_only():
+    """Language models older than ~30 months are auto-deprecated.
 
-    Catches gpt-4 / gpt-4-turbo / text-embedding-ada-002 today; leaves
-    gpt-4o / text-embedding-3-* / current Claudes active.
+    Embedding models remain active regardless of age unless the provider's
+    static catalog explicitly marks them deprecated.
     """
     from lfx.base.models.models_dev_catalog import apply_models_dev_overrides
 
-    fixed_now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    fixed_now = datetime(2026, 7, 14, tzinfo=timezone.utc)
     snapshot = {
         "openai": {
             "id": "openai",
             "models": {
-                # 2023-11 → 924 days as of 2026-05-18 → deprecated
+                # 2023-11 → older than 900 days → deprecated
                 "gpt-4": {"id": "gpt-4", "release_date": "2023-11-06", "last_updated": "2024-04-09"},
                 "gpt-4-turbo": {"id": "gpt-4-turbo", "release_date": "2023-11-06", "last_updated": "2024-04-09"},
-                # 2022-12 → very old → deprecated
+                # 2022-12 → very old, but embeddings are exempt from the age heuristic
                 "text-embedding-ada-002": {
                     "id": "text-embedding-ada-002",
                     "family": "text-embedding",
                     "release_date": "2022-12-15",
                     "last_updated": "2022-12-15",
                 },
-                # 2024-01-25 → 844 days → still active under the 900d threshold
+                # 2024-01-25 → over 900 days, but still active because it is an embedding
                 "text-embedding-3-large": {
                     "id": "text-embedding-3-large",
                     "family": "text-embedding",
                     "release_date": "2024-01-25",
                     "last_updated": "2024-01-25",
                 },
-                # 2024-08 → 650 days → active
+                # 2024-05 → newer than 900 days → active
                 "gpt-4o": {"id": "gpt-4o", "release_date": "2024-05-13", "last_updated": "2024-08-06"},
                 # No date at all → not auto-deprecated (insufficient signal)
                 "gpt-future": {"id": "gpt-future"},
@@ -560,7 +572,7 @@ def test_apply_overrides_auto_deprecates_stale_models():
 
     assert by_name["gpt-4"]["deprecated"] is True
     assert by_name["gpt-4-turbo"]["deprecated"] is True
-    assert by_name["text-embedding-ada-002"]["deprecated"] is True
+    assert by_name["text-embedding-ada-002"]["deprecated"] is False
     assert by_name["text-embedding-3-large"]["deprecated"] is False
     assert by_name["gpt-4o"]["deprecated"] is False
     assert by_name["gpt-future"]["deprecated"] is False


### PR DESCRIPTION
## Summary

- disable model-provider switches for deprecated and unsupported models
- reject API attempts to persist those models as explicitly enabled
- limit age-based auto-deprecation to language models so embeddings do not become deprecated solely because they cross the 900-day threshold

## Root cause

The settings UI allowed deprecated models to enter its optimistic toggle queue, and the update endpoint accepted and persisted that state. A later `GET /enabled_models` always returned deprecated models as disabled, so the next refetch appeared to undo the user's toggle.

Separately, the models.dev fallback marks catalog entries older than 900 days as deprecated. That heuristic also applied to embeddings. The OpenAI `text-embedding-3-*` models reached that threshold in July 2026 even though age alone is not a reliable deprecation signal for embedding models.

Explicit catalog deprecations remain unchanged, including provider-specific embedding models that are known to be unavailable.

## Validation

- `uv run pytest tests/unit/base/models/test_models_dev_catalog.py -q` (23 passed)
- `uv run pytest src/backend/tests/unit/api/v1/test_models_enabled_providers.py -k cannot_enable_deprecated_model -q` (1 passed)
- `npm test -- src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx --runInBand` (26 passed)
- focused Ruff and Biome checks
- pre-commit hooks
- live models.dev smoke test confirms all three OpenAI embedding models remain non-deprecated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deprecated and unsupported models are now clearly disabled in model selection.
  * Attempts to enable unavailable models are rejected with an explanatory error.

* **Bug Fixes**
  * Model availability status is applied consistently across the model catalog.
  * Automatic age-based deprecation now applies only to stale language models, while embedding models retain their intended status.
  * Existing static deprecation flags for embedding models are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->