### PR TITLE
docs: document ComponentInputsPayload and ComponentIndexPayload on telemetry page

### DIFF
--- a/docs/docs/Develop/contributing-telemetry.mdx
+++ b/docs/docs/Develop/contributing-telemetry.mdx
@@ -113,3 +113,25 @@ This telemetry event is sent for various lifecycle operations on deployment reso
 - **DeploymentSuccess**: Boolean value indicating whether the operation was successful.
 - **DeploymentErrorMessage**: Error message details if the operation was unsuccessful.
 - **WxoTenantId**: A unique identifier for the tenant, populated only for `watsonx-orchestrate` deployments, used to understand multi-tenant usage patterns without collecting personal information.
+
+### Component inputs
+
+This telemetry event transmits the inputs provided to components during flow execution.
+
+- **ComponentRunId**: A unique identifier for the component run.
+- **ComponentId**: A unique identifier for the component itself.
+- **ComponentName**: The name of the component.
+- **ComponentInputs**: A dictionary mapping input names to their configured input values.
+- **ChunkIndex**: The index of the split chunk (used if the payload is split to respect size limits).
+- **TotalChunks**: The total number of chunks.
+
+### Component index
+
+This telemetry event is sent to track the loading metrics of components.
+
+- **IndexSource**: The source of the component index, which can be "builtin", "cache", or "dynamic".
+- **NumModules**: The number of modules loaded.
+- **NumComponents**: The number of components indexed.
+- **DevMode**: Boolean indicating whether developer mode is active.
+- **FilteredModules**: Comma-separated list of filtered modules, if any.
+- **LoadTimeMs**: Time taken in milliseconds to load the component index.


### PR DESCRIPTION
Resolves #14024.

### Description
Currently, the contributing telemetry documentation does not list all telemetry events that Langflow collects, omitting `ComponentInputsPayload` and `ComponentIndexPayload` which are defined in `schema.py`.

### Changes
- Added documentation for `Component inputs` (`ComponentInputsPayload`) explaining that it sends component inputs during flow execution along with field details.
- Added documentation for `Component index` (`ComponentIndexPayload`) detailing the loading metrics collected during component indexing.
- Kept the telemetry document fully aligned and complete with the actual implementation schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded telemetry documentation to include tenant identification details.
  * Added descriptions of telemetry collected for component inputs, including run metadata and chunking information.
  * Documented component indexing metrics, such as component counts, data sources, filtering details, and load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->