### PR TITLE
fix(docker): remove broken npm self-upgrade

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update \
     && NODE_VERSION="22.14.0" \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -105,8 +104,7 @@ RUN ARCH=$(dpkg --print-architecture) \
                     | head -1) \
     && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    | tar -xJ -C /usr/local --strip-components=1
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv


### PR DESCRIPTION
## Summary

- remove `npm install -g npm@latest` from the Docker builder and runtime stages
- keep the npm version bundled with Node.js, matching the current `release-1.11.0` Dockerfile

## Why

The Docker build now fails because npm 12 requires Node.js `^22.22.2`, while the builder stage pins Node.js 22.14.0. Node.js 22.14.0 already bundles npm 10.9.2, so the self-upgrade is unnecessary and makes the build depend on a moving incompatible npm release.

Observed failure: https://github.com/langflow-ai/langflow/actions/runs/29280281726/job/86919655324

## Validation

- reproduced the builder-stage Node.js install in `ghcr.io/astral-sh/uv:python3.14-trixie-slim`
- confirmed Node.js `v22.14.0` and bundled npm `10.9.2` run successfully without the self-upgrade
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the container build process by removing unnecessary global npm upgrades.
  * Continued using the npm version bundled with the installed Node.js runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->