### PR TITLE
fix: preserve non-config StrInput values in convert_kwargs

### DIFF
--- a/src/lfx/src/lfx/interface/initialize/loading.py
+++ b/src/lfx/src/lfx/interface/initialize/loading.py
@@ -97,16 +97,22 @@ def convert_params_to_sets(params):
 
 
 def convert_kwargs(params):
-    # Loop through items to avoid repeated lookups
     items_to_remove = []
+
     for key, value in params.items():
-        if ("kwargs" in key or "config" in key) and isinstance(value, str):
+        # Only parse actual kwargs/config fields.
+        # Avoid matching names like "tube_config_name".
+        should_parse_json = key in {
+            "kwargs",
+            "config",
+        } or key.endswith(("_kwargs", "_config"))
+
+        if should_parse_json and isinstance(value, str):
             try:
                 params[key] = orjson.loads(value)
             except orjson.JSONDecodeError:
                 items_to_remove.append(key)
 
-    # Remove invalid keys outside the loop to avoid modifying dict during iteration
     for key in items_to_remove:
         params.pop(key, None)
 

--- a/src/lfx/tests/unit/interface/test_loading_custom_component_code_param.py
+++ b/src/lfx/tests/unit/interface/test_loading_custom_component_code_param.py
@@ -100,3 +100,25 @@ def test_reuse_path_custom_params_pop_code_none_safe():
     custom_params = loading.get_params({"foo": 1})
     custom_params.pop("code", None)
     assert custom_params == {"foo": 1}
+
+
+def test_convert_kwargs_preserves_non_config_field_names():
+    """Fields that merely contain 'config' in their name should not be treated as JSON."""
+    params = {
+        "tube_config_name": "test1223",
+    }
+
+    result = loading.convert_kwargs(params)
+
+    assert result["tube_config_name"] == "test1223"
+
+
+def test_convert_kwargs_removes_invalid_json_kwargs():
+    """Actual kwargs fields containing invalid JSON should still be removed."""
+    params = {
+        "kwargs": "not-json",
+    }
+
+    result = loading.convert_kwargs(params)
+
+    assert "kwargs" not in result


### PR DESCRIPTION
**## Summary**

This fixes an issue where `convert_kwargs()` treated any parameter whose name contained `"config"` as a JSON field.

For example, a `StrInput` named `tube_config_name` was incorrectly processed as JSON. Since values such as `"test1223"` are not valid JSON, the field was removed from the parameters, causing the component to receive `None` at runtime.

**## Root Cause**

The previous implementation used substring matching:


if ("kwargs" in key or "config" in key):


This matched fields such as:

- `tube_config_name`
- `my_config_name`

even though they are plain string inputs and not configuration objects.

## Fix

Restrict JSON parsing to actual configuration fields only:

- `kwargs`
- `config`
- `*_kwargs`
- `*_config`

This prevents unrelated `StrInput` fields from being parsed or removed while preserving the existing behavior for legitimate configuration fields.

## Validation

Verified using a custom component with:

- `StrInput(name="tube_config_name")`
- Input value: `test1223`

**Before this change:**


self.tube_config_name = None





self.tube_config_name = 'test1223'


The user-provided value is now preserved correctly during flow execution.

**<img width="521" height="169" alt="Screenshot 2026-07-14 202327" src="https://github.com/user-attachments/assets/a8e323c8-0022-4dc0-b0d1-91cb4c6d9bf0" />**

<img width="527" height="214" alt="Screenshot 2026-07-14 202309" src="https://github.com/user-attachments/assets/314dfb5c-ef4d-499e-818c-3f7fbf80b55d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration and keyword argument values during initialization.
  * Prevented unrelated fields containing “config” or “kwargs” in their names from being incorrectly parsed as JSON.
  * Invalid JSON values in recognized configuration fields continue to be safely excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->