### PR TITLE
feat: add langflow-base[services] extra for service backends

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -239,6 +239,12 @@ jobs:
             echo "Server terminated successfully"
           fi
 
+      - name: Test Langflow Base services extra wheel
+        run: |
+          # Clean-venv proof that [services] installs PostgreSQL/Celery/backends
+          # and that a bare langflow-base wheel keeps those extras opt-in.
+          make check_base_services_wheel
+
       # PyPI publishing moved to after cross-platform testing
 
       - name: Upload Artifact

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,7 +179,7 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 750,
+        "line_number": 756,
         "is_secret": false
       }
     ],
@@ -7246,5 +7246,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T20:58:07Z"
+  "generated_at": "2026-07-14T17:42:56Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_clic load_test_setup load_test_setup_basic load_test_list_flows load_test_run load_test_langflow_quick load_test_stress load_test_example load_test_clean load_test_remote_setup load_test_remote_run load_test_help docs docs_build docs_install api_examples_local api_examples_local_syntax
+.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_clic load_test_setup load_test_setup_basic load_test_list_flows load_test_run load_test_langflow_quick load_test_stress load_test_example load_test_clean load_test_remote_setup load_test_remote_run load_test_help docs docs_build docs_install api_examples_local api_examples_local_syntax check_base_services_wheel
 
 # Configurations
 VERSION=$(shell grep "^version" pyproject.toml | sed 's/.*\"\(.*\)\"$$/\1/')
@@ -343,6 +343,9 @@ endif
 
 build_langflow_base:
 	cd src/backend/base && uv build $(args)
+
+check_base_services_wheel: ## build base/lfx/sdk wheels and prove [services] + bare installs
+	@uv run python scripts/ci/check_base_services_wheel.py
 
 build_langflow_backup:
 	uv lock && uv build

--- a/docs/docs/Develop/install-custom-dependencies.mdx
+++ b/docs/docs/Develop/install-custom-dependencies.mdx
@@ -76,11 +76,26 @@ To install multiple extras, use commas to separate each dependency group:
 uv pip install "langflow-base[postgresql,openai]"
 ```
 
-To install all optional dependencies for `langflow-base`, use the `complete` extra:
+`langflow-base` exposes these aggregate extras for host and service dependencies:
+
+| Extra | What it installs | When to use it |
+| --- | --- | --- |
+| `complete` | Default host feature set (Redis, Chroma, tracing providers, MCP, Kubernetes variables, S3 storage, Watsonx clients, LiteLLM, and related host extras). **Does not** include PostgreSQL or Celery. | Default path. `pip install langflow` already installs `langflow-base[complete]`. |
+| `all` | Alias for `complete` (backward compatible). **Does not** include PostgreSQL or Celery. | Same as `complete`. |
+| `services` | Every concrete service backend and provider: PostgreSQL drivers, Celery, Redis, Chroma, S3, Kubernetes variables, all tracing providers, Watsonx deployment clients, plus runtime packages service code imports directly (`anyio`, `tenacity`, `dill`). | When you need the full service dependency surface without the host-only extras that live only in `complete`. |
 
 ```bash
+# Default host feature set (no PostgreSQL / Celery)
 uv pip install "langflow-base[complete]"
+
+# Every concrete service backend/provider (includes PostgreSQL + Celery)
+uv pip install "langflow-base[services]"
+
+# Host features + every service backend
+uv pip install "langflow-base[complete,services]"
 ```
+
+PostgreSQL and Celery stay opt-in relative to a normal Langflow install. Install them explicitly with `langflow-base[postgresql]`, `langflow-base[celery]`, `langflow-base[services]`, or `langflow-base[complete,services]`.
 
 ### Use a virtual environment to test custom dependencies
 

--- a/scripts/ci/check_base_services_wheel.py
+++ b/scripts/ci/check_base_services_wheel.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Prove ``langflow-base[services]`` installs every concrete service backend.
+
+Builds the ``langflow-base`` (and prerequisite ``lfx`` / ``langflow-sdk``) wheels,
+installs ``langflow-base[services]`` into a temporary venv, recursively imports
+``langflow.services.*``, and probes the third-party packages that ``[services]``
+must provide (PostgreSQL drivers, Redis, Chroma, S3, Celery, Kubernetes,
+tracing providers, Watsonx SDKs, plus anyio/tenacity/dill).
+
+A second bare-wheel install confirms ``[services]`` remains opt-in: those
+backend packages must be absent without the extra.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import textwrap
+import venv
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Distributions that ``langflow-base[services]`` must install on every Python.
+# Prefer metadata checks over imports for packages that need native libs
+# (psycopg needs libpq / psycopg-binary at import time).
+REQUIRED_DISTRIBUTIONS = (
+    "anyio",
+    "tenacity",
+    "dill",
+    "psycopg",
+    "psycopg2-binary",
+    "redis",
+    "chromadb",
+    "langchain-chroma",
+    "aioboto3",
+    "celery",
+    "asgiref",
+    "kubernetes",
+    "langfuse",
+    "langsmith",
+    "openinference-instrumentation-langchain",
+    # Always-on tracing / deployment providers declared by [services].
+    "arize-phoenix-otel",
+    "traceloop-sdk",
+    "openlayer",
+    "ibm-cloud-sdk-core",
+)
+
+# Distributions gated by environment markers on the matching base extras.
+# Each entry is (distribution_name, min_inclusive, max_exclusive) where None
+# means unbounded. Compared against sys.version_info[:2].
+MARKER_REQUIRED_DISTRIBUTIONS = (
+    ("langwatch", None, (3, 14)),
+    ("opik", None, (3, 14)),
+    ("ibm-watsonx-orchestrate-core", (3, 11), None),
+    ("ibm-watsonx-orchestrate-clients", (3, 11), None),
+)
+
+# Pure-Python (or self-contained) modules that must import cleanly when present.
+REQUIRED_IMPORTS = (
+    "anyio",
+    "tenacity",
+    "dill",
+    "redis",
+    "chromadb",
+    "langchain_chroma",
+    "aioboto3",
+    "celery",
+    "asgiref",
+    "kubernetes",
+    "langfuse",
+    "langsmith",
+    "openinference",
+    "traceloop",
+    "openlayer",
+    "ibm_cloud_sdk_core",
+)
+
+# Import names gated like MARKER_REQUIRED_DISTRIBUTIONS.
+MARKER_REQUIRED_IMPORTS = (
+    ("langwatch", None, (3, 14)),
+    ("opik", None, (3, 14)),
+    ("phoenix", None, None),  # pulled by arize-phoenix-otel
+    ("ibm_watsonx_orchestrate_core", (3, 11), None),
+    ("ibm_watsonx_orchestrate_clients", (3, 11), None),
+)
+
+# Host-only extras that live in ``[complete]`` but not ``[services]``.
+# They may be absent from a services-only install; treat as optional failures
+# during recursive ``langflow.services.*`` import.
+HOST_ONLY_OPTIONAL_MODULE_PREFIXES = (
+    "litellm",
+    "cassio",
+    "cassandra",
+    "toolguard",
+    "mcp",
+)
+
+
+def _services_probe_source() -> str:
+    return textwrap.dedent(
+        f"""\
+        import importlib
+        import importlib.metadata
+        import pkgutil
+        import sys
+
+        REQUIRED_DISTRIBUTIONS = {REQUIRED_DISTRIBUTIONS!r}
+        MARKER_REQUIRED_DISTRIBUTIONS = {MARKER_REQUIRED_DISTRIBUTIONS!r}
+        REQUIRED_IMPORTS = {REQUIRED_IMPORTS!r}
+        MARKER_REQUIRED_IMPORTS = {MARKER_REQUIRED_IMPORTS!r}
+        HOST_ONLY_OPTIONAL_MODULE_PREFIXES = {HOST_ONLY_OPTIONAL_MODULE_PREFIXES!r}
+
+        def _marker_matches(version_info, min_inclusive, max_exclusive):
+            if min_inclusive is not None and version_info < min_inclusive:
+                return False
+            if max_exclusive is not None and version_info >= max_exclusive:
+                return False
+            return True
+
+        version_info = sys.version_info[:2]
+        required_dists = list(REQUIRED_DISTRIBUTIONS)
+        for name, min_inclusive, max_exclusive in MARKER_REQUIRED_DISTRIBUTIONS:
+            if _marker_matches(version_info, min_inclusive, max_exclusive):
+                required_dists.append(name)
+
+        missing_dists = []
+        for name in required_dists:
+            try:
+                importlib.metadata.distribution(name)
+            except importlib.metadata.PackageNotFoundError:
+                missing_dists.append(name)
+        if missing_dists:
+            raise SystemExit(
+                "langflow-base[services] missing required distributions: "
+                + ", ".join(missing_dists)
+            )
+
+        required_imports = list(REQUIRED_IMPORTS)
+        for name, min_inclusive, max_exclusive in MARKER_REQUIRED_IMPORTS:
+            if _marker_matches(version_info, min_inclusive, max_exclusive):
+                required_imports.append(name)
+
+        missing_imports = []
+        for name in required_imports:
+            try:
+                importlib.import_module(name)
+            except ModuleNotFoundError as exc:
+                missing_imports.append(f"{{name}}: {{exc}}")
+        if missing_imports:
+            raise SystemExit(
+                "langflow-base[services] missing required imports:\\n  "
+                + "\\n  ".join(missing_imports)
+            )
+
+        # psycopg is installed but may need system libpq; confirm the package
+        # is present and that ImportError is only the native-driver gap.
+        try:
+            importlib.import_module("psycopg")
+        except ModuleNotFoundError as exc:
+            raise SystemExit(f"psycopg module missing: {{exc}}") from exc
+        except ImportError as exc:
+            if "pq wrapper" not in str(exc) and "libpq" not in str(exc):
+                raise SystemExit(f"unexpected psycopg ImportError: {{exc}}") from exc
+
+        # Provider modules gated off this interpreter may be absent; allow only those.
+        allowed_optional = list(HOST_ONLY_OPTIONAL_MODULE_PREFIXES)
+        for name, min_inclusive, max_exclusive in MARKER_REQUIRED_IMPORTS:
+            if not _marker_matches(version_info, min_inclusive, max_exclusive):
+                allowed_optional.append(name)
+        # ibm_watsonx umbrella prefix covers related SDK imports when gated off.
+        if version_info < (3, 11):
+            allowed_optional.extend(
+                (
+                    "ibm_cloud_sdk_core",
+                    "ibm_watsonx",
+                    "ibm_watsonx_orchestrate",
+                    "ibm_watsonx_orchestrate_clients",
+                    "ibm_watsonx_orchestrate_core",
+                )
+            )
+        if version_info >= (3, 14):
+            allowed_optional.extend(("langwatch", "opik"))
+
+        import langflow.services as services_pkg
+
+        pkg_paths = list(services_pkg.__path__)
+        unexpected = []
+        optional_failures = []
+        for module in pkgutil.walk_packages(pkg_paths, prefix="langflow.services."):
+            try:
+                importlib.import_module(module.name)
+            except ModuleNotFoundError as exc:
+                missing = getattr(exc, "name", None) or str(exc)
+                if any(
+                    missing == prefix or missing.startswith(prefix + ".")
+                    for prefix in allowed_optional
+                ):
+                    optional_failures.append((module.name, str(exc)))
+                else:
+                    unexpected.append((module.name, type(exc).__name__, str(exc)))
+            except Exception as exc:  # noqa: BLE001 - surface unexpected import regressions
+                unexpected.append((module.name, type(exc).__name__, str(exc)))
+
+        if unexpected:
+            details = "\\n".join(
+                f"  {{name}}: {{exc_name}}: {{message}}"
+                for name, exc_name, message in unexpected
+            )
+            raise SystemExit(f"Unexpected import failures:\\n{{details}}")
+        print(
+            f"services-wheel-ok dists={{len(required_dists)}} "
+            f"imports={{len(required_imports)}} "
+            f"optional_failures={{len(optional_failures)}}"
+        )
+        for name, message in optional_failures[:20]:
+            print(f"  optional-fail {{name}}: {{message}}")
+        """
+    )
+
+
+def _bare_probe_source() -> str:
+    return textwrap.dedent(
+        """\
+        import importlib.metadata
+
+        # These must remain opt-in via [services] / their own extras.
+        MUST_BE_ABSENT = ("celery", "psycopg", "psycopg2-binary")
+        present = []
+        for name in MUST_BE_ABSENT:
+            try:
+                importlib.metadata.distribution(name)
+            except importlib.metadata.PackageNotFoundError:
+                continue
+            present.append(name)
+        if present:
+            raise SystemExit(
+                f"Bare langflow-base unexpectedly provides: {present}. "
+                "These belong in [services] / [postgresql] / [celery]."
+            )
+        import langflow  # noqa: F401
+        print("bare-wheel-ok services-extras-absent")
+        """
+    )
+
+
+def _run(cmd: list[str], **kwargs) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True, **kwargs)  # noqa: S603 - argv list from trusted CI callers only
+
+
+def _install_wheels(pip: Path, wheels: list[Path], extra: str | None = None) -> None:
+    specs = [str(wheel) for wheel in wheels]
+    # Apply the extra only to the langflow-base wheel.
+    if extra:
+        specs = [
+            f"{wheel}[{extra}]" if "langflow_base-" in wheel.name or "langflow-base-" in wheel.name else str(wheel)
+            for wheel in wheels
+        ]
+    _run([str(pip), "install", *specs])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--outdir",
+        type=Path,
+        default=None,
+        help="Directory for built wheels (default: temporary directory)",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Reuse wheels already present in --outdir",
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="langflow-base-services-") as tmp:
+        outdir = args.outdir or Path(tmp) / "wheels"
+        outdir.mkdir(parents=True, exist_ok=True)
+
+        if not args.skip_build:
+            for package in ("langflow-sdk", "lfx", "langflow-base"):
+                _run(["uv", "build", "--package", package, "-o", str(outdir)], cwd=REPO_ROOT)
+
+        wheels = sorted(outdir.glob("*.whl"))
+        if not wheels:
+            print("No wheels found", file=sys.stderr)
+            return 1
+        if not any("langflow_base" in w.name or "langflow-base" in w.name for w in wheels):
+            print("langflow-base wheel missing", file=sys.stderr)
+            return 1
+
+        # --- [services] install ---
+        services_venv = Path(tmp) / "services-venv"
+        venv.create(services_venv, with_pip=True)
+        services_pip = services_venv / "bin" / "pip"
+        services_python = services_venv / "bin" / "python"
+        _run([str(services_pip), "install", "--upgrade", "pip"])
+        _install_wheels(services_pip, wheels, extra="services")
+        _run([str(services_python), "-c", _services_probe_source()])
+
+        # --- bare install (opt-in guard) ---
+        bare_venv = Path(tmp) / "bare-venv"
+        venv.create(bare_venv, with_pip=True)
+        bare_pip = bare_venv / "bin" / "pip"
+        bare_python = bare_venv / "bin" / "python"
+        _run([str(bare_pip), "install", "--upgrade", "pip"])
+        _install_wheels(bare_pip, wheels, extra=None)
+        _run([str(bare_python), "-c", _bare_probe_source()])
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -415,6 +415,13 @@ fastmcp = ["fastmcp>=3.2.0"]
 # AWS extras
 aioboto3 = ["aioboto3>=15.2.0,<16.0.0"]
 
+# Celery task backend (langflow.services.task) plus the asgiref bridge used by
+# langflow.worker to run async vertex builds inside Celery tasks.
+celery = [
+    "celery>=5.3.0,<6.0.0",
+    "asgiref>=3.8.0",
+]
+
 # Astra
 astrapy = ["astrapy>=2.1.0,<3.0.0"]
 
@@ -428,6 +435,34 @@ ibm-watsonx-clients = [
     "ibm-watsonx-orchestrate-clients~=2.12.0; python_version >= '3.11'",
 ]
 
+# Exhaustive concrete-service dependency surface: every backend/provider that
+# langflow.services.* may select at runtime. Opt-in -- not pulled by
+# langflow-base[complete] or by ``pip install langflow``. Use this when you need
+# PostgreSQL, Celery, and the full set of service backends without the host-only
+# extras that live only in [complete] (mcp, litellm, cassandra, toolguard).
+# Direct packages below are imported by service code but were previously only
+# transitive; keep them explicit so a clean wheel install cannot drop them.
+services = [
+    "anyio>=4.0.0",
+    "tenacity>=8.0.0",
+    "dill>=0.3.8",
+    "langflow-base[postgresql]",
+    "langflow-base[redis]",
+    "langflow-base[chroma]",
+    "langflow-base[aioboto3]",
+    "langflow-base[celery]",
+    "langflow-base[kubernetes]",
+    "langflow-base[langfuse]",
+    "langflow-base[langwatch]",
+    "langflow-base[langsmith]",
+    "langflow-base[arize]",
+    "langflow-base[openinference]",
+    "langflow-base[opik]",
+    "langflow-base[traceloop]",
+    "langflow-base[openlayer]",
+    "langflow-base[ibm-watsonx-clients]",
+]
+
 complete = [
     # langflow-base[complete] pulls the third-party libraries that
     # langflow-base's OWN code imports -- service backends (cache, knowledge
@@ -438,6 +473,11 @@ complete = [
     # re-declared here -- doing so re-pulled large, already-bundled stacks (and
     # torch) into every install. When adding a base extra, only list it here if
     # langflow-base itself imports it.
+    #
+    # Intentionally independent of [services]: complete does NOT include
+    # PostgreSQL or Celery so the default ``pip install langflow`` (which pins
+    # langflow-base[complete]) stays lean. Install langflow-base[services] or
+    # langflow-base[complete,services] when those backends are required.
 
     # Cache / state
     "langflow-base[redis]",
@@ -475,6 +515,8 @@ complete = [
     "langflow-base[litellm]",
 ]
 
+# Backward-compatible alias for [complete]. Does NOT include [services]
+# (PostgreSQL / Celery); install langflow-base[complete,services] for that union.
 all = [
     "langflow-base[complete]",
 ]

--- a/src/backend/tests/unit/test_langflow_base_services_extras.py
+++ b/src/backend/tests/unit/test_langflow_base_services_extras.py
@@ -1,0 +1,143 @@
+"""Extras-drift guard for ``langflow-base[services]`` / ``[complete]`` / ``[all]``.
+
+``src/backend/base/pyproject.toml`` defines:
+
+* ``services`` — exhaustive concrete-service backends/providers (opt-in)
+* ``complete`` — default host feature set pulled by ``pip install langflow``
+* ``all`` — backward-compatible alias for ``complete`` (does NOT include ``services``)
+
+These invariants must not drift by hand-edit: PostgreSQL and Celery must stay
+inside ``services`` but must NOT appear in ``complete`` or ``all``, and every
+service-owned backend/provider extra must remain referenced by ``services``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+# File lives at src/backend/tests/unit/… → parents[2] is src/backend.
+BASE_PYPROJECT = Path(__file__).resolve().parents[2] / "base" / "pyproject.toml"
+
+# Direct packages that service code imports but were previously only transitive.
+REQUIRED_DIRECT_PACKAGES = frozenset({"anyio", "tenacity", "dill"})
+
+# Service-owned backend/provider extras that ``services`` must reference.
+REQUIRED_SERVICE_EXTRAS = frozenset(
+    {
+        "postgresql",
+        "redis",
+        "chroma",
+        "aioboto3",
+        "celery",
+        "kubernetes",
+        "langfuse",
+        "langwatch",
+        "langsmith",
+        "arize",
+        "openinference",
+        "opik",
+        "traceloop",
+        "openlayer",
+        "ibm-watsonx-clients",
+    }
+)
+
+# Must stay out of the default ``pip install langflow`` / ``[complete]`` / ``[all]`` path.
+COMPLETE_MUST_NOT_INCLUDE = frozenset({"postgresql", "celery", "services"})
+
+
+def _load_optional() -> dict[str, list[str]]:
+    assert BASE_PYPROJECT.is_file(), f"pyproject.toml not found at {BASE_PYPROJECT}"
+    with BASE_PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["project"]["optional-dependencies"]
+
+
+def _package_name(spec: str) -> str:
+    for sep in ("[", " ", ";", "=", "<", ">", "!", "~"):
+        if sep in spec:
+            spec = spec.split(sep, 1)[0]
+    return spec.strip().lower()
+
+
+def _extra_refs(specs: list[str], package: str = "langflow-base") -> set[str]:
+    """Return referenced extras from ``package[extra]`` self-refs."""
+    prefix = f"{package}["
+    found: set[str] = set()
+    for spec in specs:
+        if not spec.startswith(prefix) or "]" not in spec:
+            continue
+        inner = spec[len(prefix) : spec.index("]")]
+        found.update(part.strip() for part in inner.split(",") if part.strip())
+    return found
+
+
+def test_services_extra_exists_and_includes_direct_packages() -> None:
+    optional = _load_optional()
+    assert "services" in optional, "Expected `services` optional-dependency group"
+    names = {_package_name(s) for s in optional["services"]}
+    missing = REQUIRED_DIRECT_PACKAGES - names
+    assert not missing, (
+        f"`services` is missing required direct packages: {sorted(missing)}. Current specs: {optional['services']}"
+    )
+
+
+def test_services_extra_references_every_service_backend() -> None:
+    optional = _load_optional()
+    refs = _extra_refs(optional["services"])
+    missing = REQUIRED_SERVICE_EXTRAS - refs
+    assert not missing, (
+        f"`services` is missing required backend/provider extras: {sorted(missing)}. Referenced: {sorted(refs)}"
+    )
+
+
+def test_celery_extra_includes_celery_and_asgiref() -> None:
+    optional = _load_optional()
+    assert "celery" in optional, "Expected `celery` optional-dependency group"
+    names = {_package_name(s) for s in optional["celery"]}
+    for required in ("celery", "asgiref"):
+        assert required in names, f"`celery` extra is missing `{required}`. Current specs: {optional['celery']}"
+
+
+def test_complete_remains_independent_of_services() -> None:
+    optional = _load_optional()
+    refs = _extra_refs(optional["complete"])
+    leaked = COMPLETE_MUST_NOT_INCLUDE & refs
+    assert not leaked, (
+        f"`complete` must not pull {sorted(leaked)}; "
+        f"those stay opt-in via `[services]` or `[complete,services]`. Referenced: {sorted(refs)}"
+    )
+    # Direct package names in complete (should not list postgresql/celery/services either).
+    names = {_package_name(s) for s in optional["complete"]}
+    for forbidden in ("postgresql", "celery", "psycopg", "psycopg2"):
+        assert forbidden not in names, f"`complete` must not declare `{forbidden}` directly"
+
+
+def test_all_remains_alias_for_complete() -> None:
+    """Backward compat: [all] must stay equivalent to [complete], not pull [services]."""
+    optional = _load_optional()
+    assert "all" in optional
+    refs = _extra_refs(optional["all"])
+    assert refs == {"complete"}, (
+        f"`all` must be exactly an alias for complete; got {sorted(refs)}. Specs: {optional['all']}"
+    )
+    leaked = COMPLETE_MUST_NOT_INCLUDE & refs
+    assert not leaked, f"`all` must not pull {sorted(leaked)}; keep PostgreSQL/Celery opt-in via `[services]`"
+
+
+def test_postgresql_and_celery_cannot_fall_out_of_services() -> None:
+    """Regression: the headline gaps that motivated `[services]`."""
+    optional = _load_optional()
+    refs = _extra_refs(optional["services"])
+    for required in ("postgresql", "celery"):
+        assert required in refs, (
+            f"`services` lost `{required}` — this was the gap vs `[complete]`. Referenced: {sorted(refs)}"
+        )
+    # Celery extra itself must exist so the self-ref resolves.
+    assert "celery" in optional
+    assert "postgresql" in optional

--- a/uv.lock
+++ b/uv.lock
@@ -529,6 +529,18 @@ wheels = [
 ]
 
 [[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1160,6 +1172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1591,6 +1612,27 @@ wheels = [
 ]
 
 [[package]]
+name = "celery"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -1962,6 +2004,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -7424,6 +7503,21 @@ wheels = [
 ]
 
 [[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[[package]]
 name = "kubernetes"
 version = "31.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8461,6 +8555,12 @@ arize = [
 assemblyai = [
     { name = "assemblyai" },
 ]
+celery = [
+    { name = "asgiref" },
+    { name = "celery" },
+]
+
+
 astrapy = [
     { name = "astrapy" },
 ]
@@ -8489,6 +8589,33 @@ cleanlab = [
 clickhouse = [
     { name = "clickhouse-connect" },
 ]
+services = [
+    { name = "aioboto3" },
+    { name = "anyio" },
+    { name = "arize-phoenix-otel" },
+    { name = "asgiref" },
+    { name = "celery" },
+    { name = "chromadb" },
+    { name = "dill" },
+    { name = "ibm-cloud-sdk-core" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
+    { name = "kubernetes" },
+    { name = "langchain-chroma" },
+    { name = "langfuse" },
+    { name = "langsmith" },
+    { name = "langwatch", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-langchain" },
+    { name = "openlayer" },
+    { name = "opik", marker = "python_full_version < '3.14'" },
+    { name = "pydantic" },
+    { name = "redis" },
+    { name = "sqlalchemy", extra = ["postgresql-psycopg", "postgresql-psycopg2binary"] },
+    { name = "tenacity" },
+    { name = "traceloop-sdk" },
+]
+
+
 complete = [
     { name = "aioboto3" },
     { name = "apscheduler" },
@@ -9068,8 +9195,28 @@ requires-dist = [
     { name = "yfinance", marker = "extra == 'yfinance'", specifier = "==0.2.50" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
+    { name = "anyio", marker = "extra == 'services'", specifier = ">=4.0.0" },
+    { name = "asgiref", marker = "extra == 'celery'", specifier = ">=3.8.0" },
+    { name = "celery", marker = "extra == 'celery'", specifier = ">=5.3.0,<6.0.0" },
+    { name = "dill", marker = "extra == 'services'", specifier = ">=0.3.8" },
+    { name = "langflow-base", extras = ["aioboto3"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["arize"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["celery"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["chroma"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["ibm-watsonx-clients"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["kubernetes"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["langfuse"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["langsmith"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["langwatch"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["openinference"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["openlayer"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["opik"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["postgresql"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["redis"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["traceloop"], marker = "extra == 'services'", editable = "src/backend/base" },
+    { name = "tenacity", marker = "extra == 'services'", specifier = ">=8.0.0" },
 ]
-provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "qdrant-vectors", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "smolagents", "opendsstar", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "toolguard", "langchain-huggingface", "langchain-unstructured", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "docling-chunking", "docling-image-description", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
+provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "qdrant-vectors", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "smolagents", "opendsstar", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "toolguard", "langchain-huggingface", "langchain-unstructured", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "docling-chunking", "docling-image-description", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "celery", "astrapy", "gassist", "ibm-watsonx-clients", "services", "complete", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -20418,6 +20565,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
create an extra in `langflow-base` containing all dependencies needed for langflow's service implementations and supported backends (e.g, postgres)