### PR TITLE
fix(mcp): forward advertised flow input fields

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -24,7 +24,7 @@ from sqlmodel import select
 from langflow.api.v1.endpoints import simple_run_flow
 from langflow.api.v1.run_validation import HITL_UNSUPPORTED_DETAIL, flow_requires_hitl
 from langflow.api.v1.schemas import SimplifiedAPIRequest
-from langflow.helpers.flow import json_schema_from_flow
+from langflow.helpers.flow import get_flow_input_tweaks, json_schema_from_flow
 from langflow.schema.message import Message
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.database.models import Flow
@@ -314,7 +314,13 @@ async def handle_call_tool(
             )
 
         session_id = processed_inputs.pop("session_id", None) or str(uuid4())
-        input_request = SimplifiedAPIRequest(input_value=processed_inputs.get("input_value", ""), session_id=session_id)
+        input_value = processed_inputs.pop("input_value", "")
+        tweaks = get_flow_input_tweaks(flow, processed_inputs) if processed_inputs else None
+        input_request = SimplifiedAPIRequest(
+            input_value=input_value,
+            session_id=session_id,
+            tweaks=tweaks or None,
+        )
 
         async def send_progress_updates(progress_token):
             try:

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -551,24 +551,43 @@ async def generate_unique_flow_name(flow_name, user_id, session):
         n += 1
 
 
-def json_schema_from_flow(flow: Flow) -> dict:
-    """Generate JSON schema from flow input nodes."""
+def _get_flow_input_nodes(flow: Flow) -> list[Vertex]:
     from lfx.graph.graph.base import Graph
 
-    # Get the flow's data which contains the nodes and their configurations
-    flow_data = flow.data or {}
+    graph = Graph.from_payload(flow.data or {})
+    return [vertex for vertex in graph.vertices if vertex.is_input]
 
-    graph = Graph.from_payload(flow_data)
-    input_nodes = [vertex for vertex in graph.vertices if vertex.is_input]
 
+def _is_mcp_input_field(field_data: Any) -> bool:
+    return isinstance(field_data, dict) and field_data.get("show", False) and not field_data.get("advanced", False)
+
+
+def get_flow_input_tweaks(flow: Flow, inputs: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map advertised MCP inputs to node-scoped flow tweaks."""
+    tweaks: dict[str, dict[str, Any]] = {}
+    for node in _get_flow_input_nodes(flow):
+        template = node.data["node"]["template"]
+        node_tweaks = {
+            field_name: inputs[field_name]
+            for field_name, field_data in template.items()
+            if field_name in inputs and _is_mcp_input_field(field_data)
+        }
+        if node_tweaks:
+            tweaks[node.id] = node_tweaks
+
+    return tweaks
+
+
+def json_schema_from_flow(flow: Flow) -> dict:
+    """Generate JSON schema from flow input nodes."""
     properties = {}
     required = []
-    for node in input_nodes:
+    for node in _get_flow_input_nodes(flow):
         node_data = node.data["node"]
         template = node_data["template"]
 
         for field_name, field_data in template.items():
-            if isinstance(field_data, dict) and field_data.get("show", False) and not field_data.get("advanced", False):
+            if _is_mcp_input_field(field_data):
                 field_type = field_data.get("type", "string")
                 properties[field_name] = {
                     "type": field_type,

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1230,11 +1230,11 @@
                 "dependencies": [
                   {
                     "name": "astrapy",
-                    "version": "2.3.0"
+                    "version": "2.3.1"
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx_datastax",
@@ -3246,11 +3246,11 @@
                 "dependencies": [
                   {
                     "name": "astrapy",
-                    "version": "2.3.0"
+                    "version": "2.3.1"
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx_datastax",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -453,7 +453,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -472,6 +472,79 @@ async def test_handle_call_tool_falls_back_when_session_id_blank(monkeypatch):
     assert forwarded_request.session_id != ""
 
 
+async def test_handle_call_tool_forwards_only_advertised_input_fields(monkeypatch):
+    """Advertised MCP arguments must reach only the input nodes that expose them."""
+
+    class _FakeNode:
+        def __init__(self, node_id, *, is_input, template):
+            self.id = node_id
+            self.is_input = is_input
+            self.data = {"node": {"template": template}}
+
+    class _FakeGraph:
+        def __init__(self):
+            self.vertices = [
+                _FakeNode(
+                    "input-a",
+                    is_input=True,
+                    template={
+                        "input_value": {"show": True, "advanced": False},
+                        "backend_token": {"show": True, "advanced": False},
+                        "enabled": {"show": True, "advanced": False},
+                        "hidden": {"show": False, "advanced": False},
+                        "advanced": {"show": True, "advanced": True},
+                    },
+                ),
+                _FakeNode(
+                    "input-b",
+                    is_input=True,
+                    template={
+                        "backend_token": {"show": True, "advanced": False},
+                        "backend_url": {"show": True, "advanced": False},
+                    },
+                ),
+                _FakeNode(
+                    "downstream",
+                    is_input=False,
+                    template={"backend_url": {"show": True, "advanced": False}},
+                ),
+            ]
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={
+            "input_value": "test request",
+            "session_id": "thread-1",
+            "backend_token": "example-token",
+            "backend_url": "https://backend.example.com",
+            "enabled": False,
+            "hidden": "must-not-forward",
+            "advanced": "must-not-forward",
+            "unknown": "must-not-forward",
+        },
+    )
+
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    assert forwarded_request.input_value == "test request"
+    assert forwarded_request.session_id == "thread-1"
+    assert forwarded_request.tweaks is not None
+    assert forwarded_request.tweaks.root == {
+        "input-a": {"backend_token": "example-token", "enabled": False},
+        "input-b": {
+            "backend_token": "example-token",
+            "backend_url": "https://backend.example.com",
+        },
+    }
+
+
 def test_json_schema_from_flow_includes_optional_session_id(monkeypatch):
     """json_schema_from_flow must advertise session_id so MCP clients can supply it."""
 


### PR DESCRIPTION
## Summary

- forward non-reserved MCP tool arguments as node-scoped flow tweaks
- derive execution mappings from the same visible, non-advanced input fields used by tool discovery
- ignore unknown, hidden, advanced, and same-named downstream fields while preserving falsey values
- keep `input_value` and `session_id` on their existing dedicated execution paths

Fixes #14002.

## Context

This supersedes #14016, which is currently conflicting with `release-1.11.0`. Thanks to @Juanmidev1 for the initial fix and regression coverage. This version builds from the current release head and scopes tweaks by input-node ID; flat tweaks would otherwise apply matching names to unrelated graph nodes and mishandle dict-valued fields.

When multiple input nodes advertise the same flattened field name, the submitted value is intentionally applied to each matching input node. A future schema change can introduce disambiguated names if separate values are needed.

## Test plan

- `src/backend/tests/unit/api/v1/test_mcp_utils.py`: 21 passed
- `src/backend/tests/unit/test_process.py -k tweak`: 24 passed, 1 deselected
- changed-lines coverage: 100% (20/20)
- pre-commit hooks: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP tool calls now forward only advertised flow input fields.
  * Advanced, hidden, and unsupported inputs are excluded from requests.
  * Session and input values are preserved while valid flow tweaks are applied.

* **Tests**
  * Added coverage verifying that only supported input fields are forwarded during MCP tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->