### PR TITLE
test(mcp): isolate timeout tests from SSRF validation

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_timeout_configuration.py
@@ -181,8 +181,11 @@ class TestMCPTimeoutConfiguration:
             mock_client_class.assert_called_once_with(tool_execution_timeout=250)
 
     @pytest.mark.asyncio
-    async def test_update_tools_passes_timeout_to_http_client(self):
+    async def test_update_tools_passes_timeout_to_http_client(self, monkeypatch):
         """Test that update_tools passes timeout when creating MCPStreamableHttpClient."""
+        # The placeholder host is not resolvable; this test exercises timeout plumbing, not URL
+        # safety (which has its own SSRF tests), so disable SSRF validation here.
+        monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")
         server_config = {
             "mode": "Streamable_HTTP",
             "url": "http://test-server",
@@ -336,9 +339,13 @@ class TestMCPTimeoutBehavior:
             assert initial_client._tool_execution_timeout == 250
 
     @pytest.mark.asyncio
-    async def test_mcp_sse_client_receives_timeout(self):
+    async def test_mcp_sse_client_receives_timeout(self, monkeypatch):
         """Test that mcp_sse_client (backward compatibility alias) receives timeout."""
         from lfx.base.mcp.util import update_tools
+
+        # The placeholder host is not resolvable; this test exercises timeout plumbing, not URL
+        # safety (which has its own SSRF tests), so disable SSRF validation here.
+        monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")
 
         # Create an SSE client (which is actually a StreamableHttpClient)
         sse_client = MCPStreamableHttpClient(tool_execution_timeout=100)


### PR DESCRIPTION
## Summary
- disable SSRF validation only in the two MCP timeout-plumbing tests that use an intentionally unresolvable placeholder host
- align the release-1.10.3 tests with the existing release-1.11.0 adjustment
- leave production SSRF enforcement unchanged

## Context
The Python 3.14 unit-test job on #14039 failed after the release security backport because http://test-server is now validated and cannot resolve. The first failure masked a second test using the same placeholder.

## Testing
- Python 3.14: 19 tests passed in test_mcp_timeout_configuration.py
- focused two-test regression run passed
- Ruff check and format check passed
- pre-commit passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MCP timeout configuration tests to run reliably with SSRF protection disabled.
  * Continued validating that tool execution timeout values are correctly propagated to MCP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->