### PR TITLE
fix(security): protect SQL runtime configuration

### DIFF
--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -144,16 +144,23 @@ def apply_tweaks(node: dict[str, Any], node_tweaks: dict[str, Any]) -> None:
         logger.warning(f"Template data for node {node.get('id')} should be a dictionary")
         return
 
-    # Security: tweaks must never inject executable code or widen the code sandbox.
+    # Security: tweaks must never inject executable code, widen the code sandbox,
+    # or repoint a protected sink configured by the flow author.
     # The previous name-only block on "code" was bypassable because code-execution
     # components expose their code under other field names (python_code, tool_code,
     # filter_instruction) that serialize as plain "str". Refuse a tweak when the
     # field is code-typed, literally named "code", or is a code/sandbox input on a
     # code-execution component — while leaving benign fields (name, description,
     # data, ...) on those components tweakable.
-    from lfx.utils.flow_validation import CODE_EXECUTION_COMPONENT_TYPES, CODE_EXECUTION_FIELD_NAMES
+    from lfx.utils.flow_validation import (
+        CODE_EXECUTION_COMPONENT_TYPES,
+        CODE_EXECUTION_FIELD_NAMES,
+        PROTECTED_TWEAK_FIELDS_BY_COMPONENT,
+    )
 
-    is_code_exec_component = node.get("data", {}).get("type") in CODE_EXECUTION_COMPONENT_TYPES
+    component_type = node.get("data", {}).get("type")
+    is_code_exec_component = component_type in CODE_EXECUTION_COMPONENT_TYPES
+    protected_tweak_fields = PROTECTED_TWEAK_FIELDS_BY_COMPONENT.get(component_type, ())
     for tweak_name, tweak_value in node_tweaks.items():
         if tweak_name not in template_data:
             continue
@@ -164,6 +171,9 @@ def apply_tweaks(node: dict[str, Any], node_tweaks: dict[str, Any]) -> None:
             or (is_code_exec_component and tweak_name in CODE_EXECUTION_FIELD_NAMES)
         ):
             logger.warning(f"Security: refusing to override code field {tweak_name!r} via tweaks.")
+            continue
+        if tweak_name in protected_tweak_fields:
+            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
             continue
         if field_type == "NestedDict":
             value = validate_and_repair_json(tweak_value)

--- a/src/backend/tests/unit/test_process.py
+++ b/src/backend/tests/unit/test_process.py
@@ -499,6 +499,46 @@ def test_apply_tweaks_code_override_prevention():
     assert node["data"]["node"]["template"]["param1"]["value"] == "new_value"
 
 
+def test_apply_tweaks_blocks_sql_connection_and_query():
+    """A run caller cannot repoint the stored SQL sink or replace its query."""
+    from unittest.mock import call, patch
+
+    from langflow.processing.process import apply_tweaks
+
+    node = {
+        "id": "SQLComponent-test",
+        "data": {
+            "type": "SQLComponent",
+            "node": {
+                "template": {
+                    "database_url": {"value": "postgresql://stored/db", "type": "str"},
+                    "query": {"value": "SELECT 1", "type": "str"},
+                    "include_columns": {"value": True, "type": "bool"},
+                }
+            },
+        },
+    }
+
+    with patch("langflow.processing.process.logger") as mock_logger:
+        apply_tweaks(
+            node,
+            {
+                "database_url": "sqlite:////etc/passwd",
+                "query": "DROP TABLE users",
+                "include_columns": False,
+            },
+        )
+
+    template = node["data"]["node"]["template"]
+    assert template["database_url"]["value"] == "postgresql://stored/db"
+    assert template["query"]["value"] == "SELECT 1"
+    assert template["include_columns"]["value"] is False
+    assert mock_logger.warning.call_args_list == [
+        call("Security: refusing to override protected field 'database_url' via tweaks."),
+        call("Security: refusing to override protected field 'query' via tweaks."),
+    ]
+
+
 def test_apply_tweaks_code_only_prevention():
     """Test that only code tweaks are prevented when trying to override code alone."""
     from unittest.mock import patch

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -169,16 +169,23 @@ def apply_tweaks(node: dict[str, Any], node_tweaks: dict[str, Any]) -> None:
         logger.warning(f"Template data for node {node.get('id')} should be a dictionary")
         return
 
-    # Security: tweaks must never inject executable code or widen the code sandbox.
+    # Security: tweaks must never inject executable code, widen the code sandbox,
+    # or repoint a protected sink configured by the flow author.
     # The previous name-only block on "code" was bypassable because code-execution
     # components expose their code under other field names (python_code, tool_code,
     # filter_instruction) that serialize as plain "str". Refuse a tweak when the
     # field is code-typed, literally named "code", or is a code/sandbox input on a
     # code-execution component — while leaving benign fields (name, description,
     # data, ...) on those components tweakable.
-    from lfx.utils.flow_validation import CODE_EXECUTION_COMPONENT_TYPES, CODE_EXECUTION_FIELD_NAMES
+    from lfx.utils.flow_validation import (
+        CODE_EXECUTION_COMPONENT_TYPES,
+        CODE_EXECUTION_FIELD_NAMES,
+        PROTECTED_TWEAK_FIELDS_BY_COMPONENT,
+    )
 
-    is_code_exec_component = node.get("data", {}).get("type") in CODE_EXECUTION_COMPONENT_TYPES
+    component_type = node.get("data", {}).get("type")
+    is_code_exec_component = component_type in CODE_EXECUTION_COMPONENT_TYPES
+    protected_tweak_fields = PROTECTED_TWEAK_FIELDS_BY_COMPONENT.get(component_type, ())
     for tweak_name, tweak_value in node_tweaks.items():
         if tweak_name not in template_data:
             continue
@@ -189,6 +196,9 @@ def apply_tweaks(node: dict[str, Any], node_tweaks: dict[str, Any]) -> None:
             or (is_code_exec_component and tweak_name in CODE_EXECUTION_FIELD_NAMES)
         ):
             logger.warning(f"Security: refusing to override code field {tweak_name!r} via tweaks.")
+            continue
+        if tweak_name in protected_tweak_fields:
+            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
             continue
         if field_type == "NestedDict":
             value = validate_and_repair_json(tweak_value)

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -99,6 +99,16 @@ CODE_EXECUTION_FIELD_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# Component inputs that cross a privileged sink boundary and therefore must retain
+# the value stored by the flow author. SQLComponent uses these fields to select a
+# database and execute SQL with the server's filesystem access and database
+# credentials; allowing the Tweaks API to replace them would let a run caller
+# repoint that authority without editing the flow. Other SQLComponent options
+# remain tweakable.
+PROTECTED_TWEAK_FIELDS_BY_COMPONENT: Mapping[str, frozenset[str]] = {
+    "SQLComponent": frozenset({"database_url", "query"}),
+}
+
 # Component node ``type`` values that load and execute *another* saved flow by
 # id or name at build/run time. On the unauthenticated public path these are an
 # indirect code-execution primitive: a public wrapper flow with none of the

--- a/src/lfx/tests/unit/test_process.py
+++ b/src/lfx/tests/unit/test_process.py
@@ -3,13 +3,14 @@
 These mirror the langflow-side regression tests in
 ``src/backend/tests/unit/test_process.py`` so the two copies of ``apply_tweaks``
 (``langflow.processing.process`` used by the API and ``lfx.processing.process``)
-cannot drift. They guard the Tweaks-API code-injection gate (CWE-94): a tweak must
-never override an executable/sandbox input, while leaving benign fields tweakable.
+cannot drift. They guard Tweaks-API security boundaries: a tweak must never
+override an executable/sandbox input or repoint a protected sink, while leaving
+benign fields tweakable.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from lfx.processing.process import apply_tweaks
 from lfx.utils.flow_validation import CODE_EXECUTION_COMPONENT_TYPES, CODE_EXECUTION_FIELD_NAMES
@@ -27,6 +28,37 @@ def test_apply_tweaks_applies_ordinary_field():
     node = _template_node({"param1": {"value": "old", "type": "str"}})
     apply_tweaks(node, {"param1": "new"})
     assert node["data"]["node"]["template"]["param1"]["value"] == "new"
+
+
+def test_apply_tweaks_blocks_sql_connection_and_query():
+    """A run caller cannot repoint the stored SQL sink or replace its query."""
+    node = _template_node(
+        {
+            "database_url": {"value": "postgresql://stored/db", "type": "str"},
+            "query": {"value": "SELECT 1", "type": "str"},
+            "include_columns": {"value": True, "type": "bool"},
+        },
+        node_type="SQLComponent",
+    )
+
+    with patch("lfx.processing.process.logger") as mock_logger:
+        apply_tweaks(
+            node,
+            {
+                "database_url": "sqlite:////etc/passwd",
+                "query": "DROP TABLE users",
+                "include_columns": False,
+            },
+        )
+
+    template = node["data"]["node"]["template"]
+    assert template["database_url"]["value"] == "postgresql://stored/db"
+    assert template["query"]["value"] == "SELECT 1"
+    assert template["include_columns"]["value"] is False
+    assert mock_logger.warning.call_args_list == [
+        call("Security: refusing to override protected field 'database_url' via tweaks."),
+        call("Security: refusing to override protected field 'query' via tweaks."),
+    ]
 
 
 def test_apply_tweaks_blocks_code_named_field():


### PR DESCRIPTION
## Summary

- refuse Tweaks API overrides of SQLComponent database_url and query
- preserve ordinary SQL component tweaks and stored SQL execution behavior
- keep the backend and lfx processing implementations covered by mirrored regressions

## Validation

- `uv run pytest tests/unit/test_process.py tests/unit/utils/test_flow_validation.py` from `src/lfx` (86 passed)
- `uv run pytest src/backend/tests/unit/test_process.py` (26 passed)
- `uv run pytest src/backend/tests/unit/components/data_source/test_sql_executor.py` (7 passed, 4 skipped)
- `uv run ruff format --check` on changed files
- `uv run ruff check` on changed files
- pre-commit hooks, including secret detection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened Tweaks API protections for SQL components.
  - Prevented runtime overrides of protected database connection and query settings.
  - Preserved support for updating permitted options, such as included columns.
  - Added security warnings when protected fields are rejected.
- **Tests**
  - Added coverage confirming protected SQL settings remain unchanged while approved tweaks continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->