### PR TITLE
fix(api): enforce sync-only output_ids across modes and correct documented auth status code

### DIFF
--- a/docs/docs/API-Reference/workflows-api.mdx
+++ b/docs/docs/API-Reference/workflows-api.mdx
@@ -504,7 +504,7 @@ The API uses standard HTTP status codes to indicate success or failure:
 |-------------|-------------|
 | `200 OK` | Request successful. |
 | `400 Bad Request` | Invalid request parameters. |
-| `401 Unauthorized` | Invalid or missing API key. |
+| `403 Forbidden` | Invalid or missing API key. |
 | `404 Not Found` | Flow not found or developer API disabled. |
 | `422 Unprocessable Entity` | Unknown `stream_protocol` or unsupported field for the selected mode. |
 | `500 Internal Server Error` | Server error during execution. |

--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -70,6 +70,7 @@ from langflow.api.v2.workflow_reconstruction import reconstruct_workflow_respons
 from langflow.api.v2.workflow_validation import (
     _enforce_flow_data_override_owner,
     _flow_not_found_privacy_exception,
+    _reject_sync_only_fields,
     _reject_unsupported_sync_fields,
     _validate_flow_data_for_execution,
 )
@@ -223,6 +224,7 @@ async def authorize_flow_action(
 def _apply_execution_gates(parsed, flow, current_user: UserRead) -> None:
     """The langflow request gates that run before a flow executes."""
     _reject_unsupported_sync_fields(parsed)
+    _reject_sync_only_fields(parsed)
     try:
         _enforce_flow_data_override_owner(parsed, flow, current_user)
     except HTTPException as exc:

--- a/src/backend/base/langflow/api/v2/workflow_validation.py
+++ b/src/backend/base/langflow/api/v2/workflow_validation.py
@@ -50,6 +50,27 @@ def _reject_unsupported_sync_fields(parsed: ParsedWorkflowRun) -> None:
         )
 
 
+def _reject_sync_only_fields(parsed: ParsedWorkflowRun) -> None:
+    """Reject sync-only request fields in stream/background mode.
+
+    ``output_ids`` only drives answer selection on the inline sync path; other
+    modes would silently ignore it, which reads as success to the caller.
+    """
+    if parsed.mode == "sync" or not parsed.output_ids:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail={
+            "error": "Unsupported request fields for mode",
+            "code": "MODE_UNSUPPORTED_FIELDS",
+            "message": f"mode='{parsed.mode}' does not support request fields: output_ids. "
+            "Output selection via output_ids only applies to mode='sync'.",
+            "fields": ["output_ids"],
+        },
+    )
+
+
 def _enforce_flow_data_override_owner(parsed: ParsedWorkflowRun, flow: FlowRead, current_user: UserRead) -> None:
     """Only the flow owner may execute caller-supplied graph data."""
     if parsed.data is None or flow.user_id == current_user.id:

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -897,11 +897,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -909,7 +909,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Content Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Content Aggregator.json
@@ -1467,11 +1467,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1479,7 +1479,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -444,11 +444,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Deep Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Deep Research Agent.json
@@ -1224,11 +1224,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1236,7 +1236,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -1966,11 +1966,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1978,7 +1978,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2720,11 +2720,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2732,7 +2732,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1358,11 +1358,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1370,7 +1370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "pydantic",
@@ -1310,11 +1310,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1322,7 +1322,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -269,7 +269,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "pydantic",
@@ -1230,11 +1230,11 @@
                 "dependencies": [
                   {
                     "name": "astrapy",
-                    "version": "2.3.0"
+                    "version": "2.3.1"
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx_datastax",
@@ -2486,11 +2486,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2498,7 +2498,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -3246,11 +3246,11 @@
                 "dependencies": [
                   {
                     "name": "astrapy",
-                    "version": "2.3.0"
+                    "version": "2.3.1"
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx_datastax",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -430,11 +430,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -442,7 +442,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -1856,11 +1856,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1868,7 +1868,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -740,11 +740,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -752,7 +752,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -877,11 +877,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -889,7 +889,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -723,11 +723,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -735,7 +735,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Multi Agent Flow.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Multi Agent Flow.json
@@ -712,11 +712,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -724,7 +724,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -1466,11 +1466,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1478,7 +1478,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2220,11 +2220,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2232,7 +2232,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -407,7 +407,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "pydantic",
@@ -1089,11 +1089,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1101,7 +1101,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -757,11 +757,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -769,7 +769,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -695,11 +695,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -707,7 +707,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -424,11 +424,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -436,7 +436,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -249,11 +249,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -261,7 +261,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -992,11 +992,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1004,7 +1004,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2217,11 +2217,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2229,7 +2229,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -724,11 +724,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -736,7 +736,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -720,11 +720,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -732,7 +732,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -453,7 +453,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "lfx",
@@ -1094,7 +1094,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -985,7 +985,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   },
                   {
                     "name": "pydantic",
@@ -1667,11 +1667,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1679,7 +1679,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2421,11 +2421,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2433,7 +2433,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -3175,11 +3175,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -3187,7 +3187,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1411,11 +1411,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1423,7 +1423,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2041,11 +2041,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2053,7 +2053,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4
@@ -2671,11 +2671,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -2683,7 +2683,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -1009,11 +1009,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1021,7 +1021,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1672,11 +1672,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -1684,7 +1684,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -505,11 +505,11 @@
                 "dependencies": [
                   {
                     "name": "langchain",
-                    "version": "1.3.11"
+                    "version": "1.3.13"
                   },
                   {
                     "name": "langgraph",
-                    "version": "1.2.8"
+                    "version": "1.2.9"
                   },
                   {
                     "name": "lfx",
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.4.8"
+                    "version": "1.4.9"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/tests/unit/api/v2/test_workflow_agui.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_agui.py
@@ -268,6 +268,29 @@ class TestAGUIModeDispatch:
         assert detail["code"] == "SYNC_MODE_UNSUPPORTED_FIELDS"
         assert detail["fields"] == ["data", "files", "start_component_id", "stop_component_id"]
 
+    @pytest.mark.parametrize("mode", ["stream", "background"])
+    async def test_non_sync_modes_reject_output_ids(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        empty_flow,
+        mode: str,
+    ):
+        """output_ids is sync-only; other modes must 422 instead of silently ignoring it."""
+        body = _agui_body(empty_flow, mode=mode)
+        body["output_ids"] = ["chat-output-1"]
+
+        response = await client.post(
+            "api/v2/workflows",
+            json=body,
+            headers={"x-api-key": created_api_key.api_key},
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail["code"] == "MODE_UNSUPPORTED_FIELDS"
+        assert detail["fields"] == ["output_ids"]
+
 
 class TestV2WorkflowAdmission:
     """Route-level admission checks before workflow execution dispatch."""

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -4824,7 +4824,7 @@
               "dependencies": [
                 {
                   "name": "json_repair",
-                  "version": "0.30.3"
+                  "version": "0.61.4"
                 },
                 {
                   "name": "lfx",
@@ -6893,7 +6893,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -7575,7 +7575,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -13693,7 +13693,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -14330,7 +14330,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -14338,7 +14338,7 @@
                 },
                 {
                   "name": "langchain",
-                  "version": "1.3.11"
+                  "version": "1.3.13"
                 }
               ],
               "total_dependencies": 3
@@ -14957,7 +14957,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -16747,7 +16747,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -17145,7 +17145,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -17398,7 +17398,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -18149,7 +18149,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -20326,11 +20326,11 @@
               "dependencies": [
                 {
                   "name": "langchain",
-                  "version": "1.3.11"
+                  "version": "1.3.13"
                 },
                 {
                   "name": "langgraph",
-                  "version": "1.2.8"
+                  "version": "1.2.9"
                 },
                 {
                   "name": "lfx",
@@ -20338,7 +20338,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 }
               ],
               "total_dependencies": 4
@@ -21752,7 +21752,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -23911,7 +23911,7 @@
               "dependencies": [
                 {
                   "name": "json_repair",
-                  "version": "0.30.3"
+                  "version": "0.61.4"
                 },
                 {
                   "name": "lfx",
@@ -23919,7 +23919,7 @@
                 },
                 {
                   "name": "jq",
-                  "version": "1.11.0"
+                  "version": "1.12.0"
                 }
               ],
               "total_dependencies": 3
@@ -24966,7 +24966,7 @@
                 },
                 {
                   "name": "json_repair",
-                  "version": "0.30.3"
+                  "version": "0.61.4"
                 }
               ],
               "total_dependencies": 2
@@ -25404,7 +25404,7 @@
                 },
                 {
                   "name": "json_repair",
-                  "version": "0.30.3"
+                  "version": "0.61.4"
                 },
                 {
                   "name": "lfx",
@@ -25412,7 +25412,7 @@
                 },
                 {
                   "name": "jq",
-                  "version": "1.11.0"
+                  "version": "1.12.0"
                 }
               ],
               "total_dependencies": 4
@@ -26626,7 +26626,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -27069,7 +27069,7 @@
               "dependencies": [
                 {
                   "name": "json_repair",
-                  "version": "0.30.3"
+                  "version": "0.61.4"
                 },
                 {
                   "name": "lfx",
@@ -27077,7 +27077,7 @@
                 },
                 {
                   "name": "jq",
-                  "version": "1.11.0"
+                  "version": "1.12.0"
                 }
               ],
               "total_dependencies": 3
@@ -29180,7 +29180,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -29306,7 +29306,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "lfx",
@@ -29496,7 +29496,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -29712,7 +29712,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -29882,7 +29882,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -30065,7 +30065,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -30304,7 +30304,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -30514,7 +30514,7 @@
                 },
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -30855,7 +30855,7 @@
               "dependencies": [
                 {
                   "name": "langchain_core",
-                  "version": "1.4.8"
+                  "version": "1.4.9"
                 },
                 {
                   "name": "pydantic",
@@ -31463,6 +31463,6 @@
     "num_components": 130,
     "num_modules": 17
   },
-  "sha256": "407dd854fc80584f0f213f9c190b977ae91ec0c7b7075df799db663c0c6aa24c",
+  "sha256": "72d484d68b9913f31014cb305ba6736c462b42ebb2a1a5251e303c5cc6cf8853",
   "version": "1.11.0"
 }


### PR DESCRIPTION
QA on the v2 workflows API surfaced two low-severity contract inconsistencies. This fixes both.

**`output_ids` was silently ignored outside sync mode.** The request gates only enforced one direction: fields the sync path can't execute (`data`, `files`, `start/stop_component_id`) return 422, but the sync-only `output_ids` field sailed through in stream and background mode and was silently ignored, returning 200. Added the inverse guard in `workflow_validation.py`, wired into `_apply_execution_gates` so all three modes are covered. New parametrized test proves stream and background now return 422 with a structured `MODE_UNSUPPORTED_FIELDS` body (was 200 on both before the fix).

**Docs documented 401 for missing/invalid API key; the platform returns 403.** `_auth_error_to_http` deliberately maps missing/invalid credentials to 403 across all endpoints (401 is reserved for invalid/expired tokens), so the v2 workflows error table was wrong on the docs side. Corrected the table to 403 rather than changing shared auth behavior.

Tests: `test_workflow_agui.py` 72 passed (2 new), `test_workflow.py` 28 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests using `output_ids` with streaming or background execution modes now return a clear validation error instead of being silently accepted.
  * Updated API documentation to identify invalid or missing API keys as `403 Forbidden`.

* **Tests**
  * Added coverage to verify `output_ids` is rejected for unsupported execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->