### PR TITLE
fix(voice): preserve public flow websocket access

### DIFF
--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -22,7 +22,7 @@ from lfx.log import logger
 from lfx.schema.schema import InputValueRequest
 from lfx.utils.secrets import secret_value_to_str
 from openai import OpenAI
-from sqlalchemy import select
+from sqlmodel import select
 from starlette.websockets import WebSocket, WebSocketDisconnect
 from websockets.asyncio.client import ClientConnection
 

--- a/src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py
+++ b/src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 import pytest
 from fastapi import BackgroundTasks, HTTPException
 from langflow.api.v1 import voice_mode
+from langflow.services.database.models.flow.model import AccessTypeEnum, Flow
+from langflow.services.deps import session_scope
 
 
 def _flow(*, owner_id, description="Authorized flow"):
@@ -97,6 +99,22 @@ async def test_authorized_voice_flow_preserves_public_flow_access(monkeypatch):
     assert authorized is public_flow
     session.exec.assert_awaited_once()
     ensure_permission.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_authorized_voice_flow_allows_public_flow_for_non_owner_with_real_session(flow, user_two):
+    async with session_scope() as session:
+        db_flow = await session.get(Flow, flow.id)
+        assert db_flow is not None
+        db_flow.access_type = AccessTypeEnum.PUBLIC
+        session.add(db_flow)
+        await session.flush()
+
+    async with session_scope() as session:
+        authorized = await voice_mode._get_authorized_voice_flow(str(flow.id), user_two, session)
+
+    assert authorized.id == flow.id
+    assert authorized.user_id == flow.user_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use SQLModel `select` for the public voice-flow lookup so `AsyncSession.exec(...).first()` returns a `Flow` instead of a row wrapper
- preserve `flow_as_tool` websocket access for authenticated non-owners of PUBLIC flows
- add a database-backed regression test with separate flow owner and caller users

## Root cause
PR #14043 added the public-flow fallback with SQLAlchemy `select` against a SQLModel `AsyncSession`. The query returned `Row(Flow,)`, so the authorization helper raised `AttributeError("user_id")` when it expected a `Flow`.

## Testing
- `uv run pytest src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py -q` (6 passed)
- `uv run ruff check src/backend/base/langflow/api/v1/voice_mode.py src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py`
- `uv run ruff format --check src/backend/base/langflow/api/v1/voice_mode.py src/backend/tests/unit/api/v1/test_voice_mode_flow_authz.py`
- pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice-mode access handling for publicly shared flows, allowing authorized non-owners to connect successfully.

* **Tests**
  * Added regression coverage for public-flow authorization using persisted session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->