### PR TITLE
feat: add scoped authorization visibility prefilter

### DIFF
--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -72,7 +72,7 @@ from langflow.services.authorization import (
     DeploymentAction,
     ensure_deployment_permission,
     filter_visible_resources,
-    visible_id_prefilter,
+    visible_scope_prefilter,
 )
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import _resolve_authz_domain
@@ -690,10 +690,10 @@ async def list_deployments(
     # before the prefilter could widen anything. ``load_from_provider`` lists via
     # the owner's live provider connection, so it always requires an owned account
     # and never consults the prefilter.
-    visible_deployment_ids = (
+    visibility_scope = (
         None
         if load_from_provider
-        else await visible_id_prefilter(
+        else await visible_scope_prefilter(
             current_user,
             resource_type="deployment",
             domain=_resolve_authz_domain(None, project_id),
@@ -709,7 +709,7 @@ async def list_deployments(
     # provider account by id alone so a shared deployment under another user's
     # provider account can be listed; the (owner ⊕ visible) union below still
     # governs which rows actually surface.
-    if visible_deployment_ids:
+    if visibility_scope is not None and visibility_scope.has_cross_user_access:
         provider_account = await get_shared_listing_provider_account_or_404(provider_id=provider_id, db=session)
     else:
         provider_account = await get_owned_provider_account_or_404(
@@ -748,7 +748,7 @@ async def list_deployments(
             deployment_type=deployment_type,
             flow_version_ids=effective_flow_version_ids,
             project_id=project_id,
-            allowed_ids=visible_deployment_ids,
+            visibility_scope=visibility_scope,
         )
     # Per-deployment authorization filter. Mirrors GET /flows/ and GET /projects/:
     # the coarse READ check above gates whether the caller can list deployments
@@ -758,7 +758,7 @@ async def list_deployments(
     # skip the per-row enforce. ``total`` may overcount denied items only on this
     # fallback path. ``rows_with_counts`` is ``list[tuple[Deployment, int,
     # list[...]]]`` so the key/domain extractors operate on the first element.
-    if visible_deployment_ids is None:
+    if visibility_scope is None:
         rows_with_counts = await filter_visible_resources(
             current_user,
             resource_type="deployment",

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -50,8 +50,8 @@ from langflow.services.authorization import (
     FlowAction,
     ensure_flow_permission,
     filter_visible_resources,
-    restrict_to_owned_or_visible,
-    visible_id_prefilter,
+    restrict_to_owned_or_visible_scope,
+    visible_scope_prefilter,
 )
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import _resolve_authz_domain
@@ -172,10 +172,15 @@ async def read_flows(
         # owner-scoped query to (owned ⊕ visible) in SQL and skip the per-row
         # in-memory filter below. OSS pass-through returns None → the query stays
         # owner-scoped and ``filter_visible_resources`` runs unchanged.
-        visible_flow_ids = await visible_id_prefilter(current_user, resource_type="flow", act=FlowAction.READ)
-        if visible_flow_ids is not None:
-            stmt = restrict_to_owned_or_visible(
-                select(Flow), id_column=Flow.id, owner_clause=owned_clause, visible_ids=visible_flow_ids
+        visibility_scope = await visible_scope_prefilter(current_user, resource_type="flow", act=FlowAction.READ)
+        if visibility_scope is not None:
+            stmt = restrict_to_owned_or_visible_scope(
+                select(Flow),
+                id_column=Flow.id,
+                owner_clause=owned_clause,
+                workspace_column=Flow.workspace_id,
+                project_column=Flow.folder_id,
+                visibility=visibility_scope,
             )
         else:
             stmt = select(Flow).where(fallback_clause)
@@ -200,7 +205,7 @@ async def read_flows(
             # rows in memory (per-flow domain_extractor). When the prefilter is
             # active the SQL union above is already authoritative, so skip the
             # per-row enforce to avoid an N+1.
-            if visible_flow_ids is None:
+            if visibility_scope is None:
                 flows = await filter_visible_resources(
                     current_user,
                     resource_type="flow",
@@ -232,7 +237,7 @@ async def read_flows(
         # was applied before pagination, so ``page.total`` is accurate; the OSS
         # fallback narrows ``page.items`` in memory and ``page.total`` may
         # overcount denied rows (unchanged from before).
-        if visible_flow_ids is None:
+        if visibility_scope is None:
             page.items = await filter_visible_resources(
                 current_user,
                 resource_type="flow",

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -82,6 +82,8 @@ from langflow.services.database.utils import require_non_empty
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from lfx.services.authorization.base import ResourceVisibilityScope
+
     from langflow.api.utils import DbSession
     from langflow.services.database.models.flow_version_deployment_attachment.model import (
         FlowVersionDeploymentAttachment,
@@ -884,6 +886,7 @@ async def list_deployments_synced(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     allowed_ids: list[UUID] | None = None,
+    visibility_scope: ResourceVisibilityScope | None = None,
 ) -> tuple[list[tuple[Deployment, int, list[tuple[UUID, str | None]]]], int, dict[str, dict[str, Any]]]:
     """Return a page of deployments, deleting any DB rows the provider doesn't recognise.
 
@@ -916,6 +919,7 @@ async def list_deployments_synced(
             flow_version_ids=flow_version_ids,
             project_id=project_id,
             allowed_ids=allowed_ids,
+            visibility_scope=visibility_scope,
         )
         if not batch:
             break
@@ -998,6 +1002,7 @@ async def list_deployments_synced(
         flow_version_ids=flow_version_ids,
         project_id=project_id,
         allowed_ids=allowed_ids,
+        visibility_scope=visibility_scope,
     )
     return accepted, total, provider_data_by_resource_key
 

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -38,8 +38,9 @@ from langflow.services.authorization import (
     ProjectAction,
     ensure_project_permission,
     filter_visible_resources,
-    restrict_to_owned_or_visible,
-    visible_id_prefilter,
+    resource_visible_in_scope,
+    restrict_to_owned_or_visible_scope,
+    visible_scope_prefilter,
 )
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
 from langflow.services.authorization.utils import _resolve_authz_domain
@@ -229,10 +230,15 @@ async def read_projects(
         # project ids the caller may read, widen the owner-scoped query to
         # (owned ⊕ visible) in SQL and skip the per-row in-memory filter below.
         # OSS pass-through returns None → owner-scoped query + filter unchanged.
-        visible_project_ids = await visible_id_prefilter(current_user, resource_type="project", act=ProjectAction.READ)
-        if visible_project_ids is not None:
-            stmt = restrict_to_owned_or_visible(
-                select(Folder), id_column=Folder.id, owner_clause=owned_clause, visible_ids=visible_project_ids
+        visibility_scope = await visible_scope_prefilter(current_user, resource_type="project", act=ProjectAction.READ)
+        if visibility_scope is not None:
+            stmt = restrict_to_owned_or_visible_scope(
+                select(Folder),
+                id_column=Folder.id,
+                owner_clause=owned_clause,
+                workspace_column=Folder.workspace_id,
+                project_column=Folder.id,
+                visibility=visibility_scope,
             )
         else:
             stmt = select(Folder).where(or_(owned_clause, Folder.user_id == None))  # noqa: E711
@@ -244,7 +250,7 @@ async def read_projects(
         # (projects are the resource itself, so the domain falls back to
         # workspace or ``*``). When the prefilter is active the SQL union is
         # already authoritative — skip the per-row enforce to avoid an N+1.
-        if visible_project_ids is None:
+        if visibility_scope is None:
             projects = await filter_visible_resources(
                 current_user,
                 resource_type="project",
@@ -324,8 +330,8 @@ async def read_project(
         # query / set-filter the eager-loaded collection to (owned ⊕ visible) and
         # skip the per-row enforce; None keeps the in-memory fallback. The flows
         # all live in this project, so a single project-scoped domain applies.
-        visible_flow_ids = (
-            await visible_id_prefilter(
+        visibility_scope = (
+            await visible_scope_prefilter(
                 current_user,
                 resource_type="flow",
                 domain=_resolve_authz_domain(project.workspace_id, project_id),
@@ -340,15 +346,17 @@ async def read_project(
             stmt = select(Flow).where(Flow.folder_id == project_id)
             if not treat_as_shared:
                 stmt = stmt.where(Flow.user_id == current_user.id)
-            elif visible_flow_ids is not None:
+            elif visibility_scope is not None:
                 # Shared project with a concrete prefilter: widen to
                 # (owned ⊕ visible) at the DB layer so ``page.total`` reflects the
                 # prefilter and no per-row enforce runs.
-                stmt = restrict_to_owned_or_visible(
+                stmt = restrict_to_owned_or_visible_scope(
                     stmt,
                     id_column=Flow.id,
                     owner_clause=Flow.user_id == current_user.id,
-                    visible_ids=visible_flow_ids,
+                    workspace_column=Flow.workspace_id,
+                    project_column=Flow.folder_id,
+                    visibility=visibility_scope,
                 )
 
             if Flow.updated_at is not None:
@@ -377,7 +385,7 @@ async def read_project(
             # available the SQL union above already narrowed the page (and
             # ``page.total``); this fallback path's ``page.total`` may overcount
             # when items are dropped — same caveat as ``read_flows``.
-            if treat_as_shared and visible_flow_ids is None:
+            if treat_as_shared and visibility_scope is None:
                 paginated_flows.items = await filter_visible_resources(
                     current_user,
                     resource_type="flow",
@@ -397,14 +405,21 @@ async def read_project(
             # regardless of finer-grained policy engine rules the plugin may
             # have. OSS pass-through returns the input list unchanged, so this
             # has no effect on default OSS installs.
-            if visible_flow_ids is not None:
+            if visibility_scope is not None:
                 # Eager-loaded ``project.flows`` constrained to (owned ⊕ visible)
                 # by set membership — the same union as the SQL prefilter, applied
                 # in memory because the relationship is already materialized
                 # (still no per-row enforce, so no N+1).
-                allowed_flow_ids = set(visible_flow_ids)
                 visible_flows = [
-                    flow for flow in project.flows if flow.id in allowed_flow_ids or flow.user_id == current_user.id
+                    flow
+                    for flow in project.flows
+                    if flow.user_id == current_user.id
+                    or resource_visible_in_scope(
+                        resource_id=flow.id,
+                        workspace_id=flow.workspace_id,
+                        project_id=flow.folder_id,
+                        visibility=visibility_scope,
+                    )
                 ]
             else:
                 visible_flows = await filter_visible_resources(

--- a/src/backend/base/langflow/services/authorization/__init__.py
+++ b/src/backend/base/langflow/services/authorization/__init__.py
@@ -28,8 +28,11 @@ from langflow.services.authorization.guards import (
 )
 from langflow.services.authorization.listing import (
     filter_visible_resources,
+    resource_visible_in_scope,
     restrict_to_owned_or_visible,
+    restrict_to_owned_or_visible_scope,
     visible_id_prefilter,
+    visible_scope_prefilter,
 )
 from langflow.services.authorization.service import LangflowAuthorizationService
 
@@ -57,7 +60,10 @@ __all__ = [
     "filter_visible_resources",
     "requires_flow_permission",
     "requires_resource_permission",
+    "resource_visible_in_scope",
     "restrict_to_owned_or_visible",
+    "restrict_to_owned_or_visible_scope",
     "should_apply_owner_override",
     "visible_id_prefilter",
+    "visible_scope_prefilter",
 ]

--- a/src/backend/base/langflow/services/authorization/listing.py
+++ b/src/backend/base/langflow/services/authorization/listing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from lfx.services.authorization.base import ResourceVisibilityScope
 from sqlalchemy import Select
 from sqlmodel import col, or_
 
@@ -149,6 +150,46 @@ async def visible_id_prefilter(
     )
 
 
+async def visible_scope_prefilter(
+    user: User | UserRead,
+    *,
+    resource_type: str,
+    domain: str = "*",
+    act: FlowAction | str = FlowAction.READ,
+) -> ResourceVisibilityScope | None:
+    """Return a compact SQL visibility scope, or ``None`` for the OSS fallback.
+
+    Unlike :func:`visible_id_prefilter`, this hook can represent global,
+    workspace, and project wildcard grants without materializing every matching
+    resource UUID. The base service adapts legacy concrete-ID plugins.
+    """
+    settings = get_settings_service()
+    if not settings.auth_settings.AUTHZ_ENABLED:
+        return None
+    authz = get_authorization_service()
+    get_visibility = getattr(authz, "get_resource_visibility", None)
+    if get_visibility is not None:
+        return await get_visibility(
+            user_id=getattr(user, "id", None),
+            resource_type=resource_type,
+            domain=domain,
+            act=_coerce_action(act),
+            context=_auth_context(user),
+        )
+
+    # Compatibility for duck-typed services that predate the new base method.
+    visible_ids = await authz.list_visible_resource_ids(
+        user_id=getattr(user, "id", None),
+        resource_type=resource_type,
+        domain=domain,
+        act=_coerce_action(act),
+        context=_auth_context(user),
+    )
+    if visible_ids is None:
+        return None
+    return ResourceVisibilityScope(resource_ids=tuple(visible_ids))
+
+
 def restrict_to_owned_or_visible(
     stmt: StatementT,
     *,
@@ -180,3 +221,42 @@ def restrict_to_owned_or_visible(
     only when that returned a concrete list (``None`` keeps today's behavior).
     """
     return stmt.where(or_(col(id_column).in_(list(visible_ids)), owner_clause))
+
+
+def restrict_to_owned_or_visible_scope(
+    stmt: StatementT,
+    *,
+    id_column: InstrumentedAttribute,
+    owner_clause: ColumnElement[bool],
+    visibility: ResourceVisibilityScope,
+    workspace_column: InstrumentedAttribute | None = None,
+    project_column: InstrumentedAttribute | None = None,
+) -> StatementT:
+    """Apply owner, concrete-ID, workspace, and project visibility before pagination."""
+    if visibility.all_resources:
+        return stmt
+
+    clauses: list[ColumnElement[bool]] = [owner_clause]
+    if visibility.resource_ids:
+        clauses.append(col(id_column).in_(visibility.resource_ids))
+    if workspace_column is not None and visibility.workspace_ids:
+        clauses.append(col(workspace_column).in_(visibility.workspace_ids))
+    if project_column is not None and visibility.project_ids:
+        clauses.append(col(project_column).in_(visibility.project_ids))
+    return stmt.where(or_(*clauses))
+
+
+def resource_visible_in_scope(
+    *,
+    resource_id: UUID,
+    visibility: ResourceVisibilityScope,
+    workspace_id: UUID | None = None,
+    project_id: UUID | None = None,
+) -> bool:
+    """Evaluate a compact visibility scope for an already-loaded resource."""
+    return bool(
+        visibility.all_resources
+        or resource_id in visibility.resource_ids
+        or (workspace_id is not None and workspace_id in visibility.workspace_ids)
+        or (project_id is not None and project_id in visibility.project_ids)
+    )

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from lfx.services.adapters.deployment.schema import DeploymentType
+    from lfx.services.authorization.base import ResourceVisibilityScope
     from sqlalchemy.sql.selectable import CTE
     from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -322,32 +323,39 @@ async def update_deployment_metadata_batch(
     (await db.exec(stmt)).all()
 
 
-def _scope_to_owner_or_allowed(stmt: StmtT, *, user_id: UUID, allowed_ids: list[UUID] | None) -> StmtT:
-    """Scope a deployment query to owner rows, optionally widened by ``allowed_ids``.
+def _scope_to_owner_or_allowed(
+    stmt: StmtT,
+    *,
+    user_id: UUID,
+    allowed_ids: list[UUID] | None,
+    visibility_scope: ResourceVisibilityScope | None = None,
+) -> StmtT:
+    """Scope a deployment query to owner rows plus concrete or domain grants.
 
-    ``allowed_ids is None`` (OSS default) → owner-only (``user_id == user_id``),
-    byte-for-byte the prior behavior. A list → the union of owner rows and
-    ``allowed_ids`` (deployment ids a registered authorization plugin reports
-    the caller may read). Centralized so the page query and its count apply the
-    identical predicate — a drift would make pagination totals disagree with the
-    rows returned.
+    No scope and ``allowed_ids is None`` preserves the OSS owner-only behavior.
+    ``visibility_scope`` represents concrete, workspace, project, or global
+    grants without expanding wildcards to resource UUIDs. ``allowed_ids`` stays
+    as a compatibility adapter for older plugins and callers.
 
-    The list branch delegates to
-    :func:`langflow.services.authorization.restrict_to_owned_or_visible` so the
-    ``(owner ⊕ visible-ids)`` union lives in one place; the import is lazy to
-    match the rest of this module's authorization access and keep import order
-    cycle-free. The ``None`` branch stays here so the OSS default never emits a
-    degenerate ``IN ()`` term.
+    Centralizing this predicate ensures the page and count queries cannot drift.
+    Imports stay lazy to avoid authorization/database import cycles.
     """
-    if allowed_ids is None:
+    if visibility_scope is None and allowed_ids is None:
         return stmt.where(Deployment.user_id == user_id)
-    from langflow.services.authorization.listing import restrict_to_owned_or_visible
+    from lfx.services.authorization.base import ResourceVisibilityScope
 
-    return restrict_to_owned_or_visible(
+    from langflow.services.authorization.listing import restrict_to_owned_or_visible_scope
+
+    if visibility_scope is None:
+        visibility_scope = ResourceVisibilityScope(resource_ids=tuple(allowed_ids or ()))
+
+    return restrict_to_owned_or_visible_scope(
         stmt,
         id_column=Deployment.id,
         owner_clause=Deployment.user_id == user_id,
-        visible_ids=allowed_ids,
+        workspace_column=Deployment.workspace_id,
+        project_column=Deployment.project_id,
+        visibility=visibility_scope,
     )
 
 
@@ -361,6 +369,7 @@ async def list_deployments_page(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     allowed_ids: list[UUID] | None = None,
+    visibility_scope: ResourceVisibilityScope | None = None,
 ) -> list[tuple[Deployment, int, list[tuple[UUID, str | None]]]]:
     """Return a page of deployments with attachment counts and matched attachments.
 
@@ -368,11 +377,9 @@ async def list_deployments_page(
     pairs for attachments that matched the ``flow_version_ids`` filter (empty
     list when no filter is active).
 
-    ``allowed_ids`` is the DB-layer authorization prefilter. When ``None`` (OSS
-    default) the page is owner-scoped exactly as before. When a list, the page
-    is widened to the union of owner rows and ``allowed_ids`` (rows a registered
-    authorization plugin reports the caller may read) — see
-    ``langflow.services.authorization.restrict_to_owned_or_visible``.
+    ``visibility_scope`` is the preferred DB-layer authorization prefilter;
+    ``allowed_ids`` remains its concrete-ID compatibility form. With neither,
+    the page is owner-scoped exactly as before.
     """
     if offset < 0:
         msg = "offset must be greater than or equal to 0"
@@ -403,7 +410,12 @@ async def list_deployments_page(
         .outerjoin(attachment_counts_subquery, attachment_counts_subquery.c.deployment_id == Deployment.id)
         .where(Deployment.deployment_provider_account_id == deployment_provider_account_id)
     )
-    stmt = _scope_to_owner_or_allowed(stmt, user_id=user_id, allowed_ids=allowed_ids)
+    stmt = _scope_to_owner_or_allowed(
+        stmt,
+        user_id=user_id,
+        allowed_ids=allowed_ids,
+        visibility_scope=visibility_scope,
+    )
     if project_id is not None:
         stmt = stmt.where(Deployment.project_id == project_id)
     if flow_version_ids:
@@ -543,17 +555,22 @@ async def count_deployments_by_provider(
     flow_version_ids: list[UUID] | None = None,
     project_id: UUID | None = None,
     allowed_ids: list[UUID] | None = None,
+    visibility_scope: ResourceVisibilityScope | None = None,
 ) -> int:
     """Count deployments for a provider account.
 
-    ``allowed_ids`` mirrors ``list_deployments_page``: ``None`` counts owner rows
-    only (OSS default); a list counts the owner ⊕ ``allowed_ids`` union so the
-    pagination total reflects the same authorization prefilter as the page.
+    Authorization arguments mirror ``list_deployments_page`` so pagination
+    totals use exactly the same owner-plus-visible predicate as the page.
     """
     stmt = select(func.count(Deployment.id)).where(
         Deployment.deployment_provider_account_id == deployment_provider_account_id,
     )
-    stmt = _scope_to_owner_or_allowed(stmt, user_id=user_id, allowed_ids=allowed_ids)
+    stmt = _scope_to_owner_or_allowed(
+        stmt,
+        user_id=user_id,
+        allowed_ids=allowed_ids,
+        visibility_scope=visibility_scope,
+    )
     if project_id is not None:
         stmt = stmt.where(Deployment.project_id == project_id)
     if flow_version_ids:

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -49,6 +49,7 @@ from lfx.services.adapters.deployment.schema import (
     SnapshotItem,
     SnapshotListResult,
 )
+from lfx.services.authorization import ResourceVisibilityScope
 
 ROUTES_MODULE = "langflow.api.v1.deployments"
 HELPERS_MODULE = "langflow.api.v1.mappers.deployments.helpers"
@@ -818,8 +819,8 @@ class TestListDeploymentsSharedPrefilter:
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
-    @patch(f"{ROUTES_MODULE}.visible_id_prefilter", new_callable=AsyncMock)
-    async def test_concrete_prefilter_relaxes_provider_gate_and_threads_allowed_ids(
+    @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
+    async def test_concrete_prefilter_relaxes_provider_gate_and_threads_visibility_scope(
         self,
         mock_prefilter,
         mock_get_owned_pa,
@@ -832,9 +833,9 @@ class TestListDeploymentsSharedPrefilter:
 
         Regression for the cross-user shared-deployment listing gap: a caller
         granted READ on a deployment under *another user's* provider account
-        used to 404 on the strict owner gate before the ``allowed_ids`` union
-        could surface the row. When ``visible_id_prefilter`` returns a concrete
-        list, the strict owner gate must be skipped, the relaxed (id-only) gate
+        used to 404 on the strict owner gate before the visibility union could
+        surface the row. When ``visible_scope_prefilter`` returns a concrete
+        scope, the strict owner gate must be skipped, the relaxed (id-only) gate
         must run, and the prefilter ids must be threaded into
         ``list_deployments_synced`` so the row is actually listed.
         """
@@ -844,7 +845,8 @@ class TestListDeploymentsSharedPrefilter:
         pa = _fake_provider_account()
         row = _fake_deployment_row(deployment_provider_account_id=pa.id, id=shared_id)
 
-        mock_prefilter.return_value = [shared_id]
+        scope = ResourceVisibilityScope(resource_ids=(shared_id,))
+        mock_prefilter.return_value = scope
         mock_get_shared_pa.return_value = pa
         mock_resolve_adapter.return_value = AsyncMock()
         mapper = MagicMock()
@@ -875,9 +877,9 @@ class TestListDeploymentsSharedPrefilter:
         # reader); the relaxed id-only gate resolves the foreign provider account.
         mock_get_owned_pa.assert_not_awaited()
         mock_get_shared_pa.assert_awaited_once()
-        # The prefilter ids are threaded into the synced query as allowed_ids so
+        # The prefilter scope is threaded into the synced query so
         # the (owner ⊕ visible) union actually constrains the page + total.
-        assert mock_synced.await_args.kwargs["allowed_ids"] == [shared_id]
+        assert mock_synced.await_args.kwargs["visibility_scope"] == scope
         assert result.total == 1
         assert result.deployments[0].id == shared_id
 
@@ -887,7 +889,7 @@ class TestListDeploymentsSharedPrefilter:
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
-    @patch(f"{ROUTES_MODULE}.visible_id_prefilter", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
     async def test_none_prefilter_keeps_strict_owner_gate(
         self,
         mock_prefilter,
@@ -899,7 +901,7 @@ class TestListDeploymentsSharedPrefilter:
     ):
         """OSS / no-plugin path (prefilter declines → None) keeps the owner gate.
 
-        The relaxed id-only fetch must never run, and ``allowed_ids`` stays
+        The relaxed id-only fetch must never run, and ``visibility_scope`` stays
         ``None`` so the listing remains owner-scoped exactly as before.
         """
         from langflow.api.v1.deployments import list_deployments
@@ -924,7 +926,7 @@ class TestListDeploymentsSharedPrefilter:
 
         mock_get_owned_pa.assert_awaited_once()
         mock_get_shared_pa.assert_not_awaited()
-        assert mock_synced.await_args.kwargs["allowed_ids"] is None
+        assert mock_synced.await_args.kwargs["visibility_scope"] is None
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.list_deployments_synced", new_callable=AsyncMock)
@@ -932,7 +934,7 @@ class TestListDeploymentsSharedPrefilter:
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
-    @patch(f"{ROUTES_MODULE}.visible_id_prefilter", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
     async def test_empty_prefilter_keeps_strict_owner_gate(
         self,
         mock_prefilter,
@@ -952,7 +954,8 @@ class TestListDeploymentsSharedPrefilter:
 
         pa = _fake_provider_account()
 
-        mock_prefilter.return_value = []
+        scope = ResourceVisibilityScope()
+        mock_prefilter.return_value = scope
         mock_get_owned_pa.return_value = pa
         mock_resolve_adapter.return_value = AsyncMock()
         mapper = MagicMock()
@@ -970,9 +973,9 @@ class TestListDeploymentsSharedPrefilter:
 
         mock_get_owned_pa.assert_awaited_once()
         mock_get_shared_pa.assert_not_awaited()
-        # The (empty) prefilter is still threaded through as allowed_ids so the
+        # The (empty) prefilter is still threaded through as visibility_scope so the
         # union stays authoritative and the per-row in-memory filter is skipped.
-        assert mock_synced.await_args.kwargs["allowed_ids"] == []
+        assert mock_synced.await_args.kwargs["visibility_scope"] == scope
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/services/authorization/test_route_guard_regressions.py
+++ b/src/backend/tests/unit/services/authorization/test_route_guard_regressions.py
@@ -138,41 +138,41 @@ def test_read_project_paginated_branch_filters_via_filter_visible_resources(proj
 
 
 def test_read_flows_wires_db_layer_prefilter(flows_routes):
-    """read_flows must call ``visible_id_prefilter`` so an EE plugin can prefilter at the DB.
+    """read_flows must call ``visible_scope_prefilter`` so an EE plugin can prefilter at the DB.
 
-    Without this the plugin's ``list_visible_resource_ids`` override has no
+    Without this the plugin's ``get_resource_visibility`` override has no
     effect on the listing — every candidate row is fetched and filtered in
     memory, defeating the hook at large-tenant scale.
     """
     func = flows_routes["read_flows"]
-    assert _calls(func, "visible_id_prefilter"), "read_flows must consult visible_id_prefilter"
+    assert _calls(func, "visible_scope_prefilter"), "read_flows must consult visible_scope_prefilter"
 
 
 def test_read_projects_wires_db_layer_prefilter(projects_routes):
-    """read_projects must call ``visible_id_prefilter`` (DB-layer prefilter)."""
+    """read_projects must call ``visible_scope_prefilter`` (DB-layer prefilter)."""
     func = projects_routes["read_projects"]
-    assert _calls(func, "visible_id_prefilter"), "read_projects must consult visible_id_prefilter"
+    assert _calls(func, "visible_scope_prefilter"), "read_projects must consult visible_scope_prefilter"
 
 
 def test_read_project_wires_db_layer_prefilter(projects_routes):
-    """read_project (flows-in-project) must call ``visible_id_prefilter`` too."""
+    """read_project (flows-in-project) must call ``visible_scope_prefilter`` too."""
     func = projects_routes["read_project"]
-    assert _calls(func, "visible_id_prefilter"), "read_project must consult visible_id_prefilter"
+    assert _calls(func, "visible_scope_prefilter"), "read_project must consult visible_scope_prefilter"
 
 
 def test_list_deployments_threads_prefilter_into_synced_query(deployments_routes):
     """list_deployments must consult the prefilter AND thread it into the synced query.
 
-    Passing ``allowed_ids`` into ``list_deployments_synced`` is what pushes the
+    Passing ``visibility_scope`` into ``list_deployments_synced`` is what pushes the
     prefilter down to both the page query and its count, so pagination totals
     reflect the constraint instead of overcounting denied rows.
     """
     func = deployments_routes["list_deployments"]
-    assert _calls(func, "visible_id_prefilter"), "list_deployments must consult visible_id_prefilter"
+    assert _calls(func, "visible_scope_prefilter"), "list_deployments must consult visible_scope_prefilter"
     synced_calls = _calls(func, "list_deployments_synced")
     assert synced_calls, "list_deployments must call list_deployments_synced"
-    assert any(_has_keyword(call, "allowed_ids") for call in synced_calls), (
-        "list_deployments must thread allowed_ids into list_deployments_synced so the "
+    assert any(_has_keyword(call, "visibility_scope") for call in synced_calls), (
+        "list_deployments must thread visibility_scope into list_deployments_synced so the "
         "page query and its total share the prefilter"
     )
 
@@ -183,9 +183,9 @@ def test_list_deployments_relaxes_provider_gate_on_prefilter(deployments_routes)
     A shared deployment lives under its *owner's* provider account, so the strict
     ``get_owned_provider_account_or_404`` 404s a cross-user reader before the
     ``(owner ⊕ visible)`` prefilter union can surface the row. When
-    ``visible_id_prefilter`` returns a concrete list, the handler must resolve the
+    ``visible_scope_prefilter`` returns cross-user visibility, the handler must resolve the
     provider account by id alone (``get_shared_listing_provider_account_or_404``)
-    so ``allowed_ids`` can actually widen cross-user shared listing — while the
+    so ``visibility_scope`` can actually widen cross-user shared listing — while the
     OSS / no-plugin path keeps the strict owner gate.
     """
     func = deployments_routes["list_deployments"]

--- a/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
@@ -49,6 +49,19 @@ async def test_visible_scope_prefilter_forwards_structured_scope(monkeypatch, fa
     ]
 
 
+@pytest.mark.anyio
+async def test_visible_scope_prefilter_adapts_legacy_concrete_id_service(monkeypatch, fake_user):
+    install_settings(monkeypatch, authz_enabled=True)
+    visible_ids = [uuid4(), uuid4()]
+    service = _StubAuthorizationService(visible_ids=visible_ids)
+    install_authz(monkeypatch, service)
+
+    result = await visible_scope_prefilter(fake_user, resource_type="flow", act="read")
+
+    assert result == ResourceVisibilityScope(resource_ids=tuple(visible_ids))
+    assert len(service.visible_calls) == 1
+
+
 def test_scope_predicate_unions_owner_explicit_workspace_and_project_grants():
     owner_id = uuid4()
     scope = ResourceVisibilityScope(

--- a/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
@@ -1,0 +1,95 @@
+"""Structured DB prefilter coverage for scoped authorization grants."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from langflow.services.authorization.listing import (
+    restrict_to_owned_or_visible_scope,
+    visible_scope_prefilter,
+)
+from langflow.services.database.models.flow.model import Flow
+from lfx.services.authorization.base import ResourceVisibilityScope
+from sqlmodel import select
+
+from ._common import _StubAuthorizationService, install_authz, install_settings
+
+
+class _ScopedAuthorizationService(_StubAuthorizationService):
+    def __init__(self, scope: ResourceVisibilityScope | None) -> None:
+        super().__init__()
+        self.scope = scope
+
+    async def get_resource_visibility(self, **kwargs) -> ResourceVisibilityScope | None:
+        self.visible_calls.append(kwargs)
+        return self.scope
+
+
+@pytest.mark.anyio
+async def test_visible_scope_prefilter_forwards_structured_scope(monkeypatch, fake_user):
+    install_settings(monkeypatch, authz_enabled=True)
+    workspace_id = uuid4()
+    project_id = uuid4()
+    scope = ResourceVisibilityScope(workspace_ids=(workspace_id,), project_ids=(project_id,))
+    service = _ScopedAuthorizationService(scope)
+    install_authz(monkeypatch, service)
+
+    result = await visible_scope_prefilter(fake_user, resource_type="flow", act="read")
+
+    assert result == scope
+    assert service.visible_calls == [
+        {
+            "user_id": fake_user.id,
+            "resource_type": "flow",
+            "domain": "*",
+            "act": "read",
+            "context": {"is_superuser": False},
+        }
+    ]
+
+
+def test_scope_predicate_unions_owner_explicit_workspace_and_project_grants():
+    owner_id = uuid4()
+    scope = ResourceVisibilityScope(
+        resource_ids=(uuid4(),),
+        workspace_ids=(uuid4(),),
+        project_ids=(uuid4(),),
+    )
+
+    constrained = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == owner_id,
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=scope,
+    )
+
+    sql = str(constrained)
+    assert "flow.user_id =" in sql
+    assert "flow.id IN" in sql
+    assert "flow.workspace_id IN" in sql
+    assert "flow.folder_id IN" in sql
+    assert sql.count(" OR ") == 3
+
+
+def test_global_scope_does_not_emit_an_unbounded_id_list():
+    constrained = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == uuid4(),
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=ResourceVisibilityScope(all_resources=True),
+    )
+
+    sql = str(constrained)
+    assert "flow.id IN" not in sql
+    assert "flow.user_id =" not in sql
+
+
+def test_scope_reports_cross_user_access_without_resource_enumeration():
+    assert ResourceVisibilityScope().has_cross_user_access is False
+    assert ResourceVisibilityScope(all_resources=True).has_cross_user_access is True
+    assert ResourceVisibilityScope(workspace_ids=(uuid4(),)).has_cross_user_access is True

--- a/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
@@ -1,10 +1,10 @@
-"""DB-layer tests for the deployment authz prefilter (``allowed_ids``).
+"""DB-layer tests for deployment authorization prefilters.
 
 ``list_deployments_page`` / ``count_deployments_by_provider`` gain an
-``allowed_ids`` parameter so a registered authorization plugin can widen the
-owner-scoped listing to the union of owner rows and the ids it reports visible —
-all in one SQL statement (no per-row enforce, so no N+1). ``None`` preserves the
-owner-only behavior exactly.
+``allowed_ids`` compatibility parameter and a structured ``visibility_scope``
+so a registered authorization plugin can widen the owner-scoped listing with
+concrete, workspace, project, or global grants in one SQL statement (no per-row
+enforce and no wildcard UUID expansion). ``None`` preserves owner-only behavior.
 
 The rows here deliberately seed foreign-owned deployments under the requester's
 provider account so the union semantics are observable at the DB layer (the
@@ -24,6 +24,7 @@ from langflow.services.database.models.deployment_provider_account.schemas impor
 from langflow.services.database.models.folder.model import Folder
 from langflow.services.database.models.user.model import User
 from lfx.services.adapters.deployment.schema import DeploymentType
+from lfx.services.authorization import ResourceVisibilityScope
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -31,7 +32,8 @@ async def _seed(async_session: AsyncSession):
     """Seed one provider account (owned by ``owner``) plus owned + foreign rows."""
     owner = User(username=f"owner-{uuid4()}", password=f"hashed-{uuid4()}", is_active=True)
     other = User(username=f"other-{uuid4()}", password=f"hashed-{uuid4()}", is_active=True)
-    project = Folder(name=f"project-{uuid4()}", user_id=owner.id)
+    project = Folder(name=f"project-{uuid4()}", user_id=owner.id, workspace_id=uuid4())
+    hidden_project = Folder(name=f"project-{uuid4()}", user_id=other.id, workspace_id=uuid4())
     provider = DeploymentProviderAccount(
         user_id=owner.id,
         name=f"provider-{uuid4()}",
@@ -40,22 +42,23 @@ async def _seed(async_session: AsyncSession):
         provider_url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
         api_key="encrypted-api-key",  # pragma: allowlist secret
     )
-    async_session.add_all([owner, other, project, provider])
+    async_session.add_all([owner, other, project, hidden_project, provider])
     await async_session.commit()
 
-    def _mk(user_id):
+    def _mk(user_id, target_project):
         return Deployment(
             user_id=user_id,
-            project_id=project.id,
+            workspace_id=target_project.workspace_id,
+            project_id=target_project.id,
             deployment_provider_account_id=provider.id,
             resource_key=f"rk-{uuid4()}",
             display_name=f"dep-{uuid4()}",
             deployment_type=DeploymentType.AGENT,
         )
 
-    owned = _mk(owner.id)
-    foreign_visible = _mk(other.id)
-    foreign_hidden = _mk(other.id)
+    owned = _mk(owner.id, project)
+    foreign_visible = _mk(other.id, project)
+    foreign_hidden = _mk(other.id, hidden_project)
     async_session.add_all([owned, foreign_visible, foreign_hidden])
     await async_session.commit()
     return owner, provider, owned, foreign_visible, foreign_hidden
@@ -159,3 +162,37 @@ async def test_count_deployments_by_provider_reflects_allowed_ids(async_session:
     # An empty visible set degrades to owner-only (owner-override invariant),
     # never to zero.
     assert empty_allowed == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope_kind", ["workspace", "project", "global"])
+async def test_structured_scope_keeps_page_and_total_consistent(async_session: AsyncSession, scope_kind: str):
+    """Domain/global grants are applied in SQL to both rows and pagination total."""
+    owner, provider, owned, foreign_visible, foreign_hidden = await _seed(async_session)
+    if scope_kind == "workspace":
+        scope = ResourceVisibilityScope(workspace_ids=(owned.workspace_id,))
+        expected = {owned.id, foreign_visible.id}
+    elif scope_kind == "project":
+        scope = ResourceVisibilityScope(project_ids=(owned.project_id,))
+        expected = {owned.id, foreign_visible.id}
+    else:
+        scope = ResourceVisibilityScope(all_resources=True)
+        expected = {owned.id, foreign_visible.id, foreign_hidden.id}
+
+    rows = await list_deployments_page(
+        async_session,
+        user_id=owner.id,
+        deployment_provider_account_id=provider.id,
+        offset=0,
+        limit=20,
+        visibility_scope=scope,
+    )
+    total = await count_deployments_by_provider(
+        async_session,
+        user_id=owner.id,
+        deployment_provider_account_id=provider.id,
+        visibility_scope=scope,
+    )
+
+    assert {deployment.id for deployment, _count, _matched in rows} == expected
+    assert total == len(expected)

--- a/src/lfx/src/lfx/services/authorization/__init__.py
+++ b/src/lfx/src/lfx/services/authorization/__init__.py
@@ -1,6 +1,6 @@
 """LFX authorization service package (abstract base + default no-op allow-all implementation)."""
 
-from lfx.services.authorization.base import BaseAuthorizationService
+from lfx.services.authorization.base import BaseAuthorizationService, ResourceVisibilityScope
 from lfx.services.authorization.service import AuthorizationService
 
-__all__ = ["AuthorizationService", "BaseAuthorizationService"]
+__all__ = ["AuthorizationService", "BaseAuthorizationService", "ResourceVisibilityScope"]

--- a/src/lfx/src/lfx/services/authorization/base.py
+++ b/src/lfx/src/lfx/services/authorization/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 from uuid import UUID as _UUID
 
@@ -31,6 +32,27 @@ class AuthzContext(TypedDict, total=False):
     api_key_id: _UUID | None
     api_key_source: str | None
     external_provider: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceVisibilityScope:
+    """Compact SQL-prefilter contract for resource-list authorization.
+
+    ``resource_ids`` represents concrete grants such as user/team shares.
+    ``workspace_ids`` and ``project_ids`` represent wildcard role grants at
+    those domains without expanding them to every resource UUID. A global
+    wildcard is represented by ``all_resources``.
+    """
+
+    all_resources: bool = False
+    resource_ids: tuple[UUID, ...] = ()
+    workspace_ids: tuple[UUID, ...] = ()
+    project_ids: tuple[UUID, ...] = ()
+
+    @property
+    def has_cross_user_access(self) -> bool:
+        """Return whether the scope can widen an owner-only query."""
+        return bool(self.all_resources or self.resource_ids or self.workspace_ids or self.project_ids)
 
 
 class BaseAuthorizationService(Service, abc.ABC):
@@ -121,6 +143,33 @@ class BaseAuthorizationService(Service, abc.ABC):
         """
         _ = (user_id, resource_type, domain, act, context)
         return None
+
+    async def get_resource_visibility(
+        self,
+        *,
+        user_id: UUID,
+        resource_type: str,
+        domain: str = "*",
+        act: str = "read",
+        context: dict[str, Any] | None = None,
+    ) -> ResourceVisibilityScope | None:
+        """Return a compact visibility scope, or ``None`` to decline SQL prefiltering.
+
+        The default adapts the original concrete-ID hook so existing plugins
+        remain source-compatible. Plugins with global or domain-wildcard grants
+        should override this method and return ``all_resources`` or domain IDs
+        instead of enumerating every resource row.
+        """
+        visible_ids = await self.list_visible_resource_ids(
+            user_id=user_id,
+            resource_type=resource_type,
+            domain=domain,
+            act=act,
+            context=context,
+        )
+        if visible_ids is None:
+            return None
+        return ResourceVisibilityScope(resource_ids=tuple(visible_ids))
 
     async def get_effective_permissions(
         self,


### PR DESCRIPTION
## Summary

- add a backward-compatible `ResourceVisibilityScope` authorization contract for concrete, workspace, project, and global grants
- apply owner-plus-visible predicates to flow, project, and deployment queries before pagination
- keep the existing concrete-ID plugin hook working while avoiding wildcard expansion to every resource UUID
- use the same deployment predicate for page rows and totals

## Why

Enterprise scoped RBAC cannot represent a global, workspace, or project wildcard through `list_visible_resource_ids()` without loading every matching resource. This seam lets registered authorization plugins return compact scopes that OSS list routes translate directly into SQL.

The OSS pass-through behavior is unchanged: when no plugin supplies a prefilter, queries remain owner-scoped and retain the existing in-memory fallback.

## Testing

- `uv run --frozen pytest -q src/backend/tests/unit/services/authorization src/backend/tests/unit/api/v1/test_deployment_route_handlers.py` — 306 passed
- `uv run --frozen pytest -q src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py` — 7 passed
- Enterprise compatibility typecheck and production Vite build against this branch

Refs LE-1826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Resource listings now apply visibility rules consistently across deployments, flows, and projects.
  * Pagination totals and displayed results remain aligned for shared, workspace-scoped, project-scoped, and globally visible resources.
  * Listing performance improves by applying visibility constraints during database queries where supported.
* **Bug Fixes**
  * Preserved compatibility with existing authorization providers while improving shared-resource access handling.
* **Tests**
  * Added coverage for visibility scopes, authorization fallbacks, and consistent deployment counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->