### PR TITLE
fix: preserve OpenSearch JWT global variables

### DIFF
--- a/src/backend/tests/unit/components/bundles/elastic/test_opensearch_auth.py
+++ b/src/backend/tests/unit/components/bundles/elastic/test_opensearch_auth.py
@@ -1,0 +1,71 @@
+"""JWT authentication regressions shared by both OpenSearch components."""
+
+from typing import Any
+
+import pytest
+from lfx_bundles.elastic.opensearch import OpenSearchVectorStoreComponent
+from lfx_bundles.elastic.opensearch_multimodal import OpenSearchVectorStoreComponentMultimodalMultiEmbedding
+from pydantic import SecretStr
+
+_TEST_JWT = "header.payload.signature"  # pragma: allowlist secret
+_COMPONENT_CLASSES = (
+    pytest.param(OpenSearchVectorStoreComponent, id="opensearch"),
+    pytest.param(OpenSearchVectorStoreComponentMultimodalMultiEmbedding, id="opensearch-multimodal"),
+)
+
+
+@pytest.mark.parametrize("component_class", _COMPONENT_CLASSES)
+def test_jwt_token_default_is_blank(component_class: type[Any]) -> None:
+    jwt_input = next(input_ for input_ in component_class().inputs if input_.name == "jwt_token")
+
+    assert jwt_input.value == ""
+    assert jwt_input.load_from_db is False
+
+
+@pytest.mark.parametrize("component_class", _COMPONENT_CLASSES)
+def test_jwt_auth_without_token_raises(component_class: type[Any]) -> None:
+    component = component_class()
+    component.set_attributes({"auth_mode": "jwt"})
+
+    with pytest.raises(ValueError, match="no jwt_token was provided"):
+        component._build_auth_kwargs()
+
+
+@pytest.mark.parametrize("component_class", _COMPONENT_CLASSES)
+async def test_jwt_global_named_like_old_default_survives_refresh(component_class: type[Any]) -> None:
+    component = component_class()
+    fresh_node = component.to_frontend_node()["data"]["node"]
+    saved_node = component_class().to_frontend_node()["data"]["node"]
+    saved_node["template"]["jwt_token"].update(value="JWT", load_from_db=True)
+
+    refreshed = await component.update_frontend_node(fresh_node, saved_node)
+
+    assert refreshed["template"]["jwt_token"]["value"] == "JWT"
+    assert refreshed["template"]["jwt_token"]["load_from_db"] is True
+
+
+@pytest.mark.parametrize("component_class", _COMPONENT_CLASSES)
+@pytest.mark.parametrize(
+    "runtime_token",
+    [_TEST_JWT, SecretStr(_TEST_JWT)],
+    ids=["literal", "credential-global"],
+)
+@pytest.mark.parametrize("bearer_prefix", [False, True], ids=["raw", "bearer"])
+def test_jwt_auth_header(
+    component_class: type[Any],
+    runtime_token: str | SecretStr,
+    *,
+    bearer_prefix: bool,
+) -> None:
+    component = component_class()
+    component.set_attributes(
+        {
+            "auth_mode": "jwt",
+            "jwt_token": runtime_token,
+            "jwt_header": "Authorization",
+            "bearer_prefix": bearer_prefix,
+        }
+    )
+
+    expected = f"Bearer {_TEST_JWT}" if bearer_prefix else _TEST_JWT
+    assert component._build_auth_kwargs() == {"headers": {"Authorization": expected}}

--- a/src/backend/tests/unit/components/bundles/elastic/test_opensearch_multimodal.py
+++ b/src/backend/tests/unit/components/bundles/elastic/test_opensearch_multimodal.py
@@ -350,48 +350,45 @@ class TestOpenSearchMultimodalComponent(ComponentTestBaseWithoutClient):
         assert len(models) == 2
 
     def test_authentication_basic(self, component_class):
-        """Test component configuration with basic authentication."""
+        """Test basic authentication configuration."""
         component = component_class().set(
             opensearch_url="http://localhost:9200",
             index_name="test_index",
             embedding=MockEmbeddings(),
-            auth_mode="Basic Authentication",
+            auth_mode="basic",
             username="test_user",
             password="test_password",  # pragma: allowlist secret  # noqa: S106
         )
 
-        # Verify auth settings
-        assert component.auth_mode == "Basic Authentication"
-        assert component.username == "test_user"
-        assert component.password == "test_password"  # pragma: allowlist secret  # noqa: S105
+        assert component._build_auth_kwargs() == {"http_auth": ("test_user", "test_password")}
 
     def test_authentication_jwt(self, component_class):
-        """Test component configuration with JWT authentication."""
+        """Test JWT authentication without a Bearer prefix."""
         component = component_class().set(
             opensearch_url="http://localhost:9200",
             index_name="test_index",
             embedding=MockEmbeddings(),
-            auth_mode="JWT Token",
+            auth_mode="jwt",
             jwt_token="test_jwt_token",  # pragma: allowlist secret  # noqa: S106
+            jwt_header="Authorization",
+            bearer_prefix=False,
         )
 
-        # Verify JWT settings
-        assert component.auth_mode == "JWT Token"
-        assert component.jwt_token == "test_jwt_token"  # pragma: allowlist secret  # noqa: S105
+        assert component._build_auth_kwargs() == {"headers": {"Authorization": "test_jwt_token"}}
 
-    def test_authentication_bearer(self, component_class):
-        """Test component configuration with Bearer token authentication."""
+    def test_authentication_jwt_with_bearer_prefix(self, component_class):
+        """Test JWT authentication with a Bearer prefix."""
         component = component_class().set(
             opensearch_url="http://localhost:9200",
             index_name="test_index",
             embedding=MockEmbeddings(),
-            auth_mode="Bearer Token",
-            bearer_token="test_bearer_token",  # pragma: allowlist secret  # noqa: S106
+            auth_mode="jwt",
+            jwt_token="test_jwt_token",  # pragma: allowlist secret  # noqa: S106
+            jwt_header="Authorization",
+            bearer_prefix=True,
         )
 
-        # Verify Bearer settings
-        assert component.auth_mode == "Bearer Token"
-        assert component.bearer_token == "test_bearer_token"  # pragma: allowlist secret  # noqa: S105
+        assert component._build_auth_kwargs() == {"headers": {"Authorization": "Bearer test_jwt_token"}}
 
     def test_default_auth_mode_and_bearer_prefix_inputs(self, component_class):
         """Test default auth-mode related input values for new instances."""

--- a/src/backend/tests/unit/template/utils/test_update_template_field.py
+++ b/src/backend/tests/unit/template/utils/test_update_template_field.py
@@ -1,0 +1,143 @@
+import pytest
+from lfx.template import utils as template_utils
+
+
+@pytest.mark.parametrize(
+    ("rebuilt_load_from_db", "saved_load_from_db"),
+    [(False, True), (True, False)],
+)
+def test_update_template_field_preserves_explicit_load_from_db_for_equal_values(
+    *,
+    rebuilt_load_from_db: bool,
+    saved_load_from_db: bool,
+) -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "JWT",
+            "load_from_db": rebuilt_load_from_db,
+        }
+    }
+    previous_value = {
+        "type": "str",
+        "value": "JWT",
+        "load_from_db": saved_load_from_db,
+    }
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"]["load_from_db"] is saved_load_from_db
+
+
+@pytest.mark.parametrize("saved_load_from_db", [False, True])
+def test_update_template_field_preserves_explicit_load_from_db_for_changed_values(
+    *,
+    saved_load_from_db: bool,
+) -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "",
+            "load_from_db": not saved_load_from_db,
+        }
+    }
+    previous_value = {
+        "type": "str",
+        "value": "OPENSEARCH_JWT",
+        "load_from_db": saved_load_from_db,
+    }
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"]["value"] == "OPENSEARCH_JWT"
+    assert new_template["jwt_token"]["load_from_db"] is saved_load_from_db
+
+
+def test_update_template_field_keeps_rebuilt_load_from_db_when_saved_state_is_missing() -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "JWT",
+            "load_from_db": True,
+        }
+    }
+    previous_value = {"type": "str", "value": "JWT"}
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"]["load_from_db"] is True
+
+
+def test_update_template_field_uses_false_for_changed_value_without_saved_load_from_db() -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "",
+            "load_from_db": True,
+        }
+    }
+    previous_value = {"type": "str", "value": "JWT"}
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"]["value"] == "JWT"
+    assert new_template["jwt_token"]["load_from_db"] is False
+
+
+def test_update_template_field_does_not_add_load_from_db_to_unsupported_field() -> None:
+    new_template = {"jwt_token": {"type": "str", "value": "JWT"}}
+    previous_value = {
+        "type": "str",
+        "value": "JWT",
+        "load_from_db": True,
+    }
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert "load_from_db" not in new_template["jwt_token"]
+
+
+def test_update_template_field_ignores_mismatched_types() -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "",
+            "load_from_db": False,
+        }
+    }
+    previous_value = {
+        "type": "int",
+        "value": "JWT",
+        "load_from_db": True,
+    }
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"] == {
+        "type": "str",
+        "value": "",
+        "load_from_db": False,
+    }
+
+
+def test_update_template_field_ignores_none_value() -> None:
+    new_template = {
+        "jwt_token": {
+            "type": "str",
+            "value": "",
+            "load_from_db": False,
+        }
+    }
+    previous_value = {
+        "type": "str",
+        "value": None,
+        "load_from_db": True,
+    }
+
+    template_utils.update_template_field(new_template, "jwt_token", previous_value)
+
+    assert new_template["jwt_token"] == {
+        "type": "str",
+        "value": "",
+        "load_from_db": False,
+    }

--- a/src/bundles/lfx-bundles/src/lfx_bundles/elastic/opensearch.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/elastic/opensearch.py
@@ -207,7 +207,7 @@ class OpenSearchVectorStoreComponent(LCVectorStoreComponent):
         SecretStrInput(
             name="jwt_token",
             display_name="JWT Token",
-            value="JWT",
+            value="",
             load_from_db=False,
             show=False,
             info=(

--- a/src/bundles/lfx-bundles/src/lfx_bundles/elastic/opensearch_multimodal.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/elastic/opensearch_multimodal.py
@@ -304,7 +304,7 @@ class OpenSearchVectorStoreComponentMultimodalMultiEmbedding(LCVectorStoreCompon
         SecretStrInput(
             name="jwt_token",
             display_name="JWT Token",
-            value="JWT",
+            value="",
             load_from_db=False,
             show=False,
             info=(

--- a/src/lfx/src/lfx/template/utils.py
+++ b/src/lfx/src/lfx/template/utils.py
@@ -39,12 +39,15 @@ def update_template_field(new_template, key, previous_value_dict) -> None:
         return
 
     if "value" in previous_value_dict and previous_value_dict["value"] is not None:
-        # if the new value is different, this means the default value has been changed
-        # so we need to update the value in the template_field
-        # and set other parameters to the new ones as well
-        if template_field.get("value") != previous_value_dict["value"]:
+        previous_value = previous_value_dict["value"]
+        value_changed = template_field.get("value") != previous_value
+        has_explicit_load_from_db = "load_from_db" in template_field and "load_from_db" in previous_value_dict
+
+        # Preserve the saved value and its explicit literal/global source mode together.
+        # When that mode is absent, retain the existing behavior for changed values.
+        if value_changed or has_explicit_load_from_db:
             template_field["load_from_db"] = previous_value_dict.get("load_from_db", False)
-        template_field["value"] = previous_value_dict["value"]
+        template_field["value"] = previous_value
 
     if previous_value_dict.get("file_path"):
         file_path_value = get_file_path_value(previous_value_dict["file_path"])


### PR DESCRIPTION
## Summary

- preserve explicit `load_from_db` state during template refresh when a saved value matches the rebuilt default
- default JWT inputs to blank in both OpenSearch components instead of treating `JWT` as a credential placeholder
- add shared JWT coverage for regular and multimodal OpenSearch, including credential globals and Bearer-prefix behavior
- update existing multimodal auth tests to exercise the actual `basic` and `jwt` modes

## Root cause

Both OpenSearch JWT inputs defaulted to `value="JWT"` with `load_from_db=false`. A global variable named `JWT` was saved with the same value and `load_from_db=true`. Template refresh only restored the saved database-loading flag when the values differed, so the flag silently reverted to `false` and OpenSearch sent the literal token `JWT`.

## Impact

Global credential references now remain database-backed across component refreshes, even when their name matches a component default. New OpenSearch nodes also require an explicit JWT instead of accepting the placeholder. Existing saved literal and global values remain preserved.

## Validation

- 68 passed, 4 skipped across the OpenSearch auth, multimodal, and template utility suites
- Ruff checks passed for all changed files
- repository pre-commit suite passed, including secret detection