### PR TITLE
fix(security): block indirect component code bypasses

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -190,6 +190,18 @@ def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]
 
 _DANGEROUS_CALL_MEMBERS, _DANGEROUS_READ_MEMBERS = _build_dangerous_members()
 
+# Modules with a mix of allowed and forbidden members may be used directly so
+# legitimate operations such as ``os.path.join`` remain available. They must
+# not, however, be passed through an opaque boundary where this scanner can no
+# longer relate the eventual member access back to the module.
+_RESTRICTED_MODULE_REFERENCES: set[str] = {
+    *_DANGEROUS_CALL_MEMBERS,
+    *_DANGEROUS_READ_MEMBERS,
+    *(prefix.split(".")[0] for prefix in DANGEROUS_SUBMODULES),
+    "builtins",
+    "__builtins__",
+}
+
 _AliasState = tuple[dict[str, frozenset[str]], set[str]]
 
 
@@ -253,6 +265,51 @@ class _SecurityChecker(ast.NodeVisitor):
         if not parts:
             return frozenset()
         return frozenset(".".join([root, *parts[1:]]) for root in self._resolved_names(parts[0]))
+
+    @staticmethod
+    def _dangerous_callable_message(resolved_name: str) -> str | None:
+        """Return the violation for a resolved builtin or module callable."""
+        if resolved_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[resolved_name]
+
+        module_name, separator, member_name = resolved_name.rpartition(".")
+        if separator and module_name in {"builtins", "__builtins__"} and member_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[member_name]
+
+        return next(
+            (message for mod, method, message in DANGEROUS_ATTR_CALLS if resolved_name == f"{mod}.{method}"),
+            None,
+        )
+
+    def _opaque_reference_violation(self, node: ast.AST) -> str | None:
+        """Reject dangerous values crossing a boundary alias tracking cannot follow."""
+        if isinstance(node, ast.Starred):
+            return self._opaque_reference_violation(node.value)
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return next(
+                (violation for item in node.elts if (violation := self._opaque_reference_violation(item))), None
+            )
+        if isinstance(node, ast.Dict):
+            items = [*node.keys, *node.values]
+            return next(
+                (
+                    violation
+                    for item in items
+                    if item is not None and (violation := self._opaque_reference_violation(item))
+                ),
+                None,
+            )
+
+        for resolved_name in self._resolved_assignment_value(node):
+            if resolved_name in _RESTRICTED_MODULE_REFERENCES:
+                return f"Indirect reference to restricted module '{resolved_name}' is forbidden in components"
+            if violation := self._dangerous_callable_message(resolved_name):
+                return violation
+        return None
+
+    def _check_opaque_reference(self, node: ast.AST) -> None:
+        if violation := self._opaque_reference_violation(node):
+            self.violations.append(violation)
 
     def _bind_name(self, name: str, values: frozenset[str]) -> None:
         if values:
@@ -415,8 +472,14 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         self.visit(node.value)
+        if isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)) and any(
+            isinstance(target, ast.Name) for target in node.targets
+        ):
+            self._check_opaque_reference(node.value)
         for target in node.targets:
             self.visit(target)
+            if isinstance(target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
@@ -424,16 +487,25 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             self.visit(node.target)
+            if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+                self._check_opaque_reference(node.value)
+            if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(node.target, node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         self.visit(node.value)
         self.visit(node.target)
+        if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+            self._check_opaque_reference(node.value)
+        if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+            self._check_opaque_reference(node.value)
         self._bind_assignment_target(node.target, node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign):
         self.visit(node.target)
         self.visit(node.value)
+        self._check_opaque_reference(node.value)
         if isinstance(node.target, ast.Name):
             self._bind_name(node.target.id, frozenset())
 
@@ -537,6 +609,8 @@ class _SecurityChecker(ast.NodeVisitor):
             self.visit(node.returns)
         for type_parameter in getattr(node, "type_params", ()):
             self.visit(type_parameter)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
 
         enclosing_state = self._snapshot_alias_state()
         self._bind_name(node.name, frozenset())
@@ -554,6 +628,8 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda):
         self.visit(node.args)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
         enclosing_state = self._snapshot_alias_state()
         self._shadow_arguments(node.args)
         self.visit(node.body)
@@ -624,6 +700,13 @@ class _SecurityChecker(ast.NodeVisitor):
         self._check_name_call(node)
         self._check_attribute_call(node)
         self._check_getattr_access(node)
+        resolved_call_names = self._resolved_assignment_value(node.func)
+        # getattr is explicitly modeled below, including dynamic access to
+        # restricted modules. Passing the module as its first argument is not
+        # itself an opaque escape and safe members such as os.path must remain usable.
+        if "getattr" not in resolved_call_names:
+            for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
+                self._check_opaque_reference(argument)
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
@@ -634,9 +717,10 @@ class _SecurityChecker(ast.NodeVisitor):
         if not isinstance(node.func, ast.Name):
             return
         name = node.func.id
-        if name in DANGEROUS_CALLS:
-            self.violations.append(DANGEROUS_CALLS[name])
-            return
+        for resolved_name in self._resolved_names(name):
+            if violation := self._dangerous_callable_message(resolved_name):
+                self.violations.append(violation)
+                return
         for mod in self.wildcard_modules:
             if name in _DANGEROUS_CALL_MEMBERS.get(mod, ()):
                 self.violations.append(f"Use of '{name}()' (via 'from {mod} import *') is forbidden in components")
@@ -655,6 +739,9 @@ class _SecurityChecker(ast.NodeVisitor):
         method_name = node.func.attr
 
         for module_name in self._resolved_names(node.func.value.id):
+            if module_name in {"builtins", "__builtins__"} and method_name in DANGEROUS_CALLS:
+                self.violations.append(DANGEROUS_CALLS[method_name])
+                return
             for mod, method, message in DANGEROUS_ATTR_CALLS:
                 if module_name == mod and method_name == method:
                     self.violations.append(message)
@@ -683,9 +770,7 @@ class _SecurityChecker(ast.NodeVisitor):
             return
         if not (isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str)):
             dangerous_modules = sorted(
-                module_name
-                for module_name in module_names
-                if module_name in _DANGEROUS_CALL_MEMBERS or module_name in _DANGEROUS_READ_MEMBERS
+                module_name for module_name in module_names if module_name in _RESTRICTED_MODULE_REFERENCES
             )
             if dangerous_modules:
                 self.violations.append(
@@ -694,6 +779,11 @@ class _SecurityChecker(ast.NodeVisitor):
             return
 
         attr_name = attr_node.value
+        if any(module_name in {"builtins", "__builtins__"} for module_name in module_names) and (
+            violation := DANGEROUS_CALLS.get(attr_name)
+        ):
+            self.violations.append(violation)
+            return
         for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
             if mod in module_names and attr_name == attr:
                 self.violations.append(message)

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -691,6 +691,98 @@ module.system('id')
         assert any("os.system()" in violation for violation in result.violations)
 
 
+class TestScanCodeSecurityIndirectReferenceBypass:
+    """Restricted modules and builtins must stay restricted through indirection."""
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import os\ndef run(module):\n    module.system('id')\nrun(os)",
+            "import os\ndef run(module=os):\n    module.system('id')\nrun()",
+            "import os\nmodules = {}\nmodules['os'] = os\nmodules['os'].system('id')",
+            "import os\nmodules = [os]\nmodules[0].system('id')",
+            "import os\nclass Holder:\n    pass\nholder = Holder()\nholder.module = os\nholder.module.system('id')",
+            "dangerous = exec\ndangerous(\"import os\\nos.system('id')\")",
+            "import builtins\nbuiltins.exec(\"import os\\nos.system('id')\")",
+            'import builtins\ngetattr(builtins, "exec")("import os\\nos.system(\'id\')")',
+            "import builtins\nvars(builtins)[\"eval\"](\"__import__('os').system('id')\")",
+            "import os\ndangerous = os.system\ndangerous('id')",
+            "import os\nmodule = os\ndef run(value):\n    value.system('id')\nrun(module)",
+        ],
+        ids=[
+            "function-argument",
+            "function-default",
+            "dict-entry",
+            "list-entry",
+            "object-attribute",
+            "builtin-alias",
+            "builtins-attribute",
+            "builtins-getattr",
+            "builtins-vars",
+            "module-callable-alias",
+            "module-alias-as-argument",
+        ],
+    )
+    def test_should_detect_indirect_dangerous_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    def test_should_detect_indirection_in_component_shaped_code(self):
+        code = """
+import os
+from lfx.custom import Component
+from lfx.io import Output
+from lfx.schema import Message
+
+class IndirectCommandComponent(Component):
+    outputs = [Output(name="result", display_name="Result", method="run_command")]
+
+    def run_command(self) -> Message:
+        def invoke(module):
+            module.system("id")
+
+        invoke(os)
+        return Message(text="done")
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            (
+                "class Client:\n"
+                "    def system(self, value):\n"
+                "        return value\n"
+                "client = Client()\n"
+                "def run(obj):\n"
+                "    obj.system('status')\n"
+                "run(client)"
+            ),
+            "import os\nmodules = [os.path]\npath = modules[0].join('a', 'b')",
+            "import requests\nclass Holder:\n    pass\nholder = Holder()\nholder.client = requests\nholder.client.get('https://example.com')",
+            "import builtins\nsize = builtins.len([1, 2, 3])",
+            'import builtins\nsize = getattr(builtins, "len")([1, 2, 3])',
+            "import os\ndef join(path_module=os.path):\n    return path_module.join('a', 'b')\njoin()",
+            "import os\ndef join(path_module):\n    return path_module.join('a', 'b')\njoin(os.path)",
+            "dangerous = exec\ndangerous = print\ndangerous('safe')",
+        ],
+        ids=[
+            "ordinary-object-method",
+            "safe-module-member-in-list",
+            "safe-module-in-attribute",
+            "safe-builtin-attribute",
+            "safe-builtin-getattr",
+            "safe-module-member-default",
+            "safe-module-member-argument",
+            "dangerous-alias-rebound",
+        ],
+    )
+    def test_should_allow_safe_indirect_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+
 class TestScanCodeSecurityRuntimeModuleBypass:
     """Runtime module lookup and reflection must not bypass dangerous calls."""
 

--- a/src/backend/tests/unit/agentic/services/test_flow_run.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_run.py
@@ -275,6 +275,16 @@ class TestRunWorkingFlowSecurityGate:
         assert "error" in out
         bg.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_should_refuse_indirect_module_call_before_graph_build(self):
+        evil = self._flow_with_code("import os\ndef run(module):\n    module.system('id')\nrun(os)")
+        with patch(f"{MODULE}.build_graph_from_data", new_callable=AsyncMock) as bg:
+            out = await run_working_flow(flow_data=evil, flow_id="flow-1", user_id="u1")
+
+        assert "error" in out
+        assert "unsafe" in out["error"].lower()
+        bg.assert_not_awaited()
+
     @pytest.mark.parametrize("code", ["import _ctypes", "from cffi import FFI"], ids=["ctypes", "cffi"])
     @pytest.mark.asyncio
     async def test_should_refuse_native_ffi_imports_before_graph_build(self, code: str):


### PR DESCRIPTION
## Summary

- fail closed when restricted modules or callables cross scanner-opaque arguments, defaults, containers, or attribute/subscript assignments
- detect rebound dangerous builtins and builtins module access
- keep safe os.path, ordinary object methods, safe builtins, and alias rebinding working
- verify the assistant run-flow gate rejects indirect unsafe code before graph construction

## Test plan

- 176 focused agentic security/run-flow tests passed
- Ruff check and format check passed for all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scanning to detect restricted modules and dangerous built-ins when accessed indirectly through aliases, containers, attributes, assignments, function defaults, or helper calls.
  * Prevented unsafe flows from running when dangerous operations are hidden behind indirect module references.
  * Preserved support for safe indirect references and ordinary objects with similarly named methods.

* **Tests**
  * Added regression coverage for indirect unsafe references and safe indirection scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->