### PR TITLE
fix(security): block indirect component code bypasses

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -258,9 +258,23 @@ class _SecurityChecker(ast.NodeVisitor):
         return self.module_aliases.get(name, frozenset({name}))
 
     def _resolved_assignment_value(self, node: ast.AST) -> frozenset[str]:
-        """Resolve a simple Name/Attribute RHS without executing it."""
+        """Resolve a statically identifiable reference RHS without executing it."""
         if isinstance(node, ast.Name):
             return self._resolved_names(node.id)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and "getattr" in self._resolved_names(node.func.id)
+            and node.args
+        ):
+            try:
+                attr_node = node.args[1]
+            except IndexError:
+                return frozenset()
+            if isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str):
+                return frozenset(
+                    f"{base_name}.{attr_node.value}" for base_name in self._resolved_assignment_value(node.args[0])
+                )
         parts = _dotted_parts(node)
         if not parts:
             return frozenset()
@@ -300,12 +314,45 @@ class _SecurityChecker(ast.NodeVisitor):
                 None,
             )
 
-        for resolved_name in self._resolved_assignment_value(node):
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            expressions = (node.key, node.value) if isinstance(node, ast.DictComp) else (node.elt,)
+            enclosing_state = self._snapshot_alias_state()
+            try:
+                for generator in node.generators:
+                    if violation := self._opaque_reference_violation(generator.iter):
+                        return violation
+                    self._bind_iterated_target(generator.target, generator.iter)
+                    for condition in generator.ifs:
+                        if violation := self._opaque_reference_violation(condition):
+                            return violation
+                return next(
+                    (
+                        violation
+                        for expression in expressions
+                        if (violation := self._opaque_reference_violation(expression))
+                    ),
+                    None,
+                )
+            finally:
+                self._restore_alias_state(enclosing_state)
+
+        resolved_names = self._resolved_assignment_value(node)
+        for resolved_name in resolved_names:
             if resolved_name in _RESTRICTED_MODULE_REFERENCES:
                 return f"Indirect reference to restricted module '{resolved_name}' is forbidden in components"
             if violation := self._dangerous_callable_message(resolved_name):
                 return violation
-        return None
+        if resolved_names:
+            return None
+
+        return next(
+            (
+                violation
+                for child in ast.iter_child_nodes(node)
+                if (violation := self._opaque_reference_violation(child))
+            ),
+            None,
+        )
 
     def _check_opaque_reference(self, node: ast.AST) -> None:
         if violation := self._opaque_reference_violation(node):
@@ -699,14 +746,14 @@ class _SecurityChecker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call):
         self._check_name_call(node)
         self._check_attribute_call(node)
-        self._check_getattr_access(node)
+        getattr_arguments_validated = self._check_getattr_access(node)
         resolved_call_names = self._resolved_assignment_value(node.func)
         # getattr is explicitly modeled below, including dynamic access to
         # restricted modules. Passing the module as its first argument is not
         # itself an opaque escape and safe members such as os.path must remain usable.
-        if "getattr" not in resolved_call_names:
-            for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
-                self._check_opaque_reference(argument)
+        exempt_getattr_arguments = 2 if "getattr" in resolved_call_names and getattr_arguments_validated else 0
+        for argument in (*node.args[exempt_getattr_arguments:], *(keyword.value for keyword in node.keywords)):
+            self._check_opaque_reference(argument)
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
@@ -747,13 +794,14 @@ class _SecurityChecker(ast.NodeVisitor):
                     self.violations.append(message)
                     return
 
-    def _check_getattr_access(self, node: ast.Call):
+    def _check_getattr_access(self, node: ast.Call) -> bool:
         """Check reflective access to restricted module members.
 
         ``getattr`` is common in legitimate components, so it stays allowed for
         ordinary objects and safe module attributes. On modules with restricted
         members, a dynamic attribute name is rejected because it could resolve to
-        one of those members at runtime.
+        one of those members at runtime. Returns whether the object and attribute
+        arguments were fully validated here.
         """
         if not (
             isinstance(node.func, ast.Name)
@@ -761,13 +809,13 @@ class _SecurityChecker(ast.NodeVisitor):
             and node.args
             and isinstance(node.args[0], ast.Name)
         ):
-            return
+            return False
 
         module_names = self._resolved_names(node.args[0].id)
         try:
             attr_node = node.args[1]
         except IndexError:
-            return
+            return False
         if not (isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str)):
             dangerous_modules = sorted(
                 module_name for module_name in module_names if module_name in _RESTRICTED_MODULE_REFERENCES
@@ -776,22 +824,23 @@ class _SecurityChecker(ast.NodeVisitor):
                 self.violations.append(
                     f"Dynamic getattr() access on module '{dangerous_modules[0]}' is forbidden in components"
                 )
-            return
+            return True
 
         attr_name = attr_node.value
         if any(module_name in {"builtins", "__builtins__"} for module_name in module_names) and (
             violation := DANGEROUS_CALLS.get(attr_name)
         ):
             self.violations.append(violation)
-            return
+            return True
         for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
             if mod in module_names and attr_name == attr:
                 self.violations.append(message)
-                return
+                return True
         for mod, method, message in DANGEROUS_ATTR_CALLS:
             if mod in module_names and attr_name == method:
                 self.violations.append(message)
-                return
+                return True
+        return True
 
 
 def scan_code_security(code: str) -> SecurityScanResult:

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -190,6 +190,18 @@ def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]
 
 _DANGEROUS_CALL_MEMBERS, _DANGEROUS_READ_MEMBERS = _build_dangerous_members()
 
+# Modules with a mix of allowed and forbidden members may be used directly so
+# legitimate operations such as ``os.path.join`` remain available. They must
+# not, however, be passed through an opaque boundary where this scanner can no
+# longer relate the eventual member access back to the module.
+_RESTRICTED_MODULE_REFERENCES: set[str] = {
+    *_DANGEROUS_CALL_MEMBERS,
+    *_DANGEROUS_READ_MEMBERS,
+    *(prefix.split(".")[0] for prefix in DANGEROUS_SUBMODULES),
+    "builtins",
+    "__builtins__",
+}
+
 _AliasState = tuple[dict[str, frozenset[str]], set[str]]
 
 
@@ -253,6 +265,51 @@ class _SecurityChecker(ast.NodeVisitor):
         if not parts:
             return frozenset()
         return frozenset(".".join([root, *parts[1:]]) for root in self._resolved_names(parts[0]))
+
+    @staticmethod
+    def _dangerous_callable_message(resolved_name: str) -> str | None:
+        """Return the violation for a resolved builtin or module callable."""
+        if resolved_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[resolved_name]
+
+        module_name, separator, member_name = resolved_name.rpartition(".")
+        if separator and module_name in {"builtins", "__builtins__"} and member_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[member_name]
+
+        return next(
+            (message for mod, method, message in DANGEROUS_ATTR_CALLS if resolved_name == f"{mod}.{method}"),
+            None,
+        )
+
+    def _opaque_reference_violation(self, node: ast.AST) -> str | None:
+        """Reject dangerous values crossing a boundary alias tracking cannot follow."""
+        if isinstance(node, ast.Starred):
+            return self._opaque_reference_violation(node.value)
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return next(
+                (violation for item in node.elts if (violation := self._opaque_reference_violation(item))), None
+            )
+        if isinstance(node, ast.Dict):
+            items = [*node.keys, *node.values]
+            return next(
+                (
+                    violation
+                    for item in items
+                    if item is not None and (violation := self._opaque_reference_violation(item))
+                ),
+                None,
+            )
+
+        for resolved_name in self._resolved_assignment_value(node):
+            if resolved_name in _RESTRICTED_MODULE_REFERENCES:
+                return f"Indirect reference to restricted module '{resolved_name}' is forbidden in components"
+            if violation := self._dangerous_callable_message(resolved_name):
+                return violation
+        return None
+
+    def _check_opaque_reference(self, node: ast.AST) -> None:
+        if violation := self._opaque_reference_violation(node):
+            self.violations.append(violation)
 
     def _bind_name(self, name: str, values: frozenset[str]) -> None:
         if values:
@@ -415,8 +472,14 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         self.visit(node.value)
+        if isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)) and any(
+            isinstance(target, ast.Name) for target in node.targets
+        ):
+            self._check_opaque_reference(node.value)
         for target in node.targets:
             self.visit(target)
+            if isinstance(target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
@@ -424,16 +487,25 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             self.visit(node.target)
+            if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+                self._check_opaque_reference(node.value)
+            if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(node.target, node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         self.visit(node.value)
         self.visit(node.target)
+        if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+            self._check_opaque_reference(node.value)
+        if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+            self._check_opaque_reference(node.value)
         self._bind_assignment_target(node.target, node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign):
         self.visit(node.target)
         self.visit(node.value)
+        self._check_opaque_reference(node.value)
         if isinstance(node.target, ast.Name):
             self._bind_name(node.target.id, frozenset())
 
@@ -537,6 +609,8 @@ class _SecurityChecker(ast.NodeVisitor):
             self.visit(node.returns)
         for type_parameter in getattr(node, "type_params", ()):
             self.visit(type_parameter)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
 
         enclosing_state = self._snapshot_alias_state()
         self._bind_name(node.name, frozenset())
@@ -554,6 +628,8 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda):
         self.visit(node.args)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
         enclosing_state = self._snapshot_alias_state()
         self._shadow_arguments(node.args)
         self.visit(node.body)
@@ -624,6 +700,13 @@ class _SecurityChecker(ast.NodeVisitor):
         self._check_name_call(node)
         self._check_attribute_call(node)
         self._check_getattr_access(node)
+        resolved_call_names = self._resolved_assignment_value(node.func)
+        # getattr is explicitly modeled below, including dynamic access to
+        # restricted modules. Passing the module as its first argument is not
+        # itself an opaque escape and safe members such as os.path must remain usable.
+        if "getattr" not in resolved_call_names:
+            for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
+                self._check_opaque_reference(argument)
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
@@ -634,9 +717,10 @@ class _SecurityChecker(ast.NodeVisitor):
         if not isinstance(node.func, ast.Name):
             return
         name = node.func.id
-        if name in DANGEROUS_CALLS:
-            self.violations.append(DANGEROUS_CALLS[name])
-            return
+        for resolved_name in self._resolved_names(name):
+            if violation := self._dangerous_callable_message(resolved_name):
+                self.violations.append(violation)
+                return
         for mod in self.wildcard_modules:
             if name in _DANGEROUS_CALL_MEMBERS.get(mod, ()):
                 self.violations.append(f"Use of '{name}()' (via 'from {mod} import *') is forbidden in components")
@@ -655,6 +739,9 @@ class _SecurityChecker(ast.NodeVisitor):
         method_name = node.func.attr
 
         for module_name in self._resolved_names(node.func.value.id):
+            if module_name in {"builtins", "__builtins__"} and method_name in DANGEROUS_CALLS:
+                self.violations.append(DANGEROUS_CALLS[method_name])
+                return
             for mod, method, message in DANGEROUS_ATTR_CALLS:
                 if module_name == mod and method_name == method:
                     self.violations.append(message)
@@ -683,9 +770,7 @@ class _SecurityChecker(ast.NodeVisitor):
             return
         if not (isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str)):
             dangerous_modules = sorted(
-                module_name
-                for module_name in module_names
-                if module_name in _DANGEROUS_CALL_MEMBERS or module_name in _DANGEROUS_READ_MEMBERS
+                module_name for module_name in module_names if module_name in _RESTRICTED_MODULE_REFERENCES
             )
             if dangerous_modules:
                 self.violations.append(
@@ -694,6 +779,11 @@ class _SecurityChecker(ast.NodeVisitor):
             return
 
         attr_name = attr_node.value
+        if any(module_name in {"builtins", "__builtins__"} for module_name in module_names) and (
+            violation := DANGEROUS_CALLS.get(attr_name)
+        ):
+            self.violations.append(violation)
+            return
         for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
             if mod in module_names and attr_name == attr:
                 self.violations.append(message)

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -708,6 +708,10 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "import builtins\nvars(builtins)[\"eval\"](\"__import__('os').system('id')\")",
             "import os\ndangerous = os.system\ndangerous('id')",
             "import os\nmodule = os\ndef run(value):\n    value.system('id')\nrun(module)",
+            "import os\ndef run(module):\n    module.system('id')\nrun(os if True else object())",
+            "import os\ngetattr(os if True else object(), 'system')('id')",
+            "import os\ndef run(module):\n    module.system('id')\nrun([module for module in (os,)][0])",
+            "import os\ndef run(module):\n    module.system('id')\nrun(next(module for module in (os,)))",
         ],
         ids=[
             "function-argument",
@@ -721,6 +725,10 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "builtins-vars",
             "module-callable-alias",
             "module-alias-as-argument",
+            "conditional-expression-as-argument",
+            "conditional-expression-in-getattr",
+            "list-comprehension-as-argument",
+            "generator-expression-as-argument",
         ],
     )
     def test_should_detect_indirect_dangerous_reference(self, code):
@@ -766,6 +774,8 @@ class IndirectCommandComponent(Component):
             "import os\ndef join(path_module=os.path):\n    return path_module.join('a', 'b')\njoin()",
             "import os\ndef join(path_module):\n    return path_module.join('a', 'b')\njoin(os.path)",
             "dangerous = exec\ndangerous = print\ndangerous('safe')",
+            "import os\nmodule = os\nconsume([module for module in (object(),)])",
+            "import os\nconsume(getattr(os, 'path'))",
         ],
         ids=[
             "ordinary-object-method",
@@ -776,6 +786,8 @@ class IndirectCommandComponent(Component):
             "safe-module-member-default",
             "safe-module-member-argument",
             "dangerous-alias-rebound",
+            "comprehension-target-shadows-restricted-module",
+            "safe-getattr-result-as-argument",
         ],
     )
     def test_should_allow_safe_indirect_reference(self, code):

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -691,6 +691,98 @@ module.system('id')
         assert any("os.system()" in violation for violation in result.violations)
 
 
+class TestScanCodeSecurityIndirectReferenceBypass:
+    """Restricted modules and builtins must stay restricted through indirection."""
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import os\ndef run(module):\n    module.system('id')\nrun(os)",
+            "import os\ndef run(module=os):\n    module.system('id')\nrun()",
+            "import os\nmodules = {}\nmodules['os'] = os\nmodules['os'].system('id')",
+            "import os\nmodules = [os]\nmodules[0].system('id')",
+            "import os\nclass Holder:\n    pass\nholder = Holder()\nholder.module = os\nholder.module.system('id')",
+            "dangerous = exec\ndangerous(\"import os\\nos.system('id')\")",
+            "import builtins\nbuiltins.exec(\"import os\\nos.system('id')\")",
+            'import builtins\ngetattr(builtins, "exec")("import os\\nos.system(\'id\')")',
+            "import builtins\nvars(builtins)[\"eval\"](\"__import__('os').system('id')\")",
+            "import os\ndangerous = os.system\ndangerous('id')",
+            "import os\nmodule = os\ndef run(value):\n    value.system('id')\nrun(module)",
+        ],
+        ids=[
+            "function-argument",
+            "function-default",
+            "dict-entry",
+            "list-entry",
+            "object-attribute",
+            "builtin-alias",
+            "builtins-attribute",
+            "builtins-getattr",
+            "builtins-vars",
+            "module-callable-alias",
+            "module-alias-as-argument",
+        ],
+    )
+    def test_should_detect_indirect_dangerous_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    def test_should_detect_indirection_in_component_shaped_code(self):
+        code = """
+import os
+from lfx.custom import Component
+from lfx.io import Output
+from lfx.schema import Message
+
+class IndirectCommandComponent(Component):
+    outputs = [Output(name="result", display_name="Result", method="run_command")]
+
+    def run_command(self) -> Message:
+        def invoke(module):
+            module.system("id")
+
+        invoke(os)
+        return Message(text="done")
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            (
+                "class Client:\n"
+                "    def system(self, value):\n"
+                "        return value\n"
+                "client = Client()\n"
+                "def run(obj):\n"
+                "    obj.system('status')\n"
+                "run(client)"
+            ),
+            "import os\nmodules = [os.path]\npath = modules[0].join('a', 'b')",
+            "import requests\nclass Holder:\n    pass\nholder = Holder()\nholder.client = requests\nholder.client.get('https://example.com')",
+            "import builtins\nsize = builtins.len([1, 2, 3])",
+            'import builtins\nsize = getattr(builtins, "len")([1, 2, 3])',
+            "import os\ndef join(path_module=os.path):\n    return path_module.join('a', 'b')\njoin()",
+            "import os\ndef join(path_module):\n    return path_module.join('a', 'b')\njoin(os.path)",
+            "dangerous = exec\ndangerous = print\ndangerous('safe')",
+        ],
+        ids=[
+            "ordinary-object-method",
+            "safe-module-member-in-list",
+            "safe-module-in-attribute",
+            "safe-builtin-attribute",
+            "safe-builtin-getattr",
+            "safe-module-member-default",
+            "safe-module-member-argument",
+            "dangerous-alias-rebound",
+        ],
+    )
+    def test_should_allow_safe_indirect_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+
 class TestScanCodeSecurityRuntimeModuleBypass:
     """Runtime module lookup and reflection must not bypass dangerous calls."""
 

--- a/src/backend/tests/unit/agentic/services/test_flow_run.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_run.py
@@ -275,6 +275,16 @@ class TestRunWorkingFlowSecurityGate:
         assert "error" in out
         bg.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_should_refuse_indirect_module_call_before_graph_build(self):
+        evil = self._flow_with_code("import os\ndef run(module):\n    module.system('id')\nrun(os)")
+        with patch(f"{MODULE}.build_graph_from_data", new_callable=AsyncMock) as bg:
+            out = await run_working_flow(flow_data=evil, flow_id="flow-1", user_id="u1")
+
+        assert "error" in out
+        assert "unsafe" in out["error"].lower()
+        bg.assert_not_awaited()
+
     @pytest.mark.parametrize("code", ["import _ctypes", "from cffi import FFI"], ids=["ctypes", "cffi"])
     @pytest.mark.asyncio
     async def test_should_refuse_native_ffi_imports_before_graph_build(self, code: str):


### PR DESCRIPTION
## Summary

- fail closed when restricted modules or callables cross scanner-opaque arguments, defaults, containers, or attribute/subscript assignments
- detect rebound dangerous builtins and builtins module access
- keep safe os.path, ordinary object methods, safe builtins, and alias rebinding working
- verify the assistant run-flow gate rejects indirect unsafe code before graph construction

## Test plan

- 176 focused agentic security/run-flow tests passed
- Ruff check and format check passed for all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened code scanning to block indirect access to restricted modules and dangerous built-ins.
  * Improved detection across aliases, containers, attributes, function defaults, lambdas, assignments, and dynamic lookups.
  * Prevented unsafe flow code from executing before graph construction.

* **Bug Fixes**
  * Closed security bypasses involving obfuscated or indirect dangerous calls.
  * Preserved support for safe indirect references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->