### PR TITLE
fix(security): require docker run for MCP stdio

### DIFF
--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -742,6 +742,18 @@ class TestMCPCommandInjectionSecurity:
         error_msg = str(exc_info.value)
         assert "not allowed" in error_msg.lower()
 
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["cp", "other:/run/secrets/token", "/workspace/token"],
+            ["inspect", "other"],
+            ["network", "connect", "shared", "other"],
+        ],
+    )
+    def test_docker_non_run_subcommands_rejected(self, args):
+        with pytest.raises(ValidationError, match="not allowed"):
+            MCPServerConfig(command="docker", args=args)
+
     def test_docker_net_host_rejected(self):
         """Test that docker --net=host is rejected."""
         with pytest.raises(ValidationError) as exc_info:

--- a/src/lfx/src/lfx/base/mcp/source_policy.py
+++ b/src/lfx/src/lfx/base/mcp/source_policy.py
@@ -598,7 +598,9 @@ def _is_clustered_short_flag(flag: str, target: str, allowed_prefixes: frozenset
 
 
 def _validate_docker_args(args: list[str], *, hardened: bool) -> None:
-    if hardened and (not args or args[0].lower() != "run"):
+    # Docker is allowlisted only as an isolated MCP server launcher. Other
+    # subcommands operate on the shared daemon and bypass the run-argument policy.
+    if not args or args[0].lower() != "run":
         _raise_disallowed("docker", args[0] if args else "<missing run subcommand>")
 
     for index, arg in enumerate(args):

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -62,6 +62,7 @@ def test_package_manager_configuration_namespaces_are_reserved(env_var):
         ("sh", ["-c", "uvx --default-index https://packages.example.invalid/simple mcp-server"]),
         ("bash", ["-lc", "npx --registry=https://packages.example.invalid @example/mcp-server"]),
         ("cmd", ["/c", "docker", "run", "--mount", "type=bind,source=/,target=/host", "mcp-server"]),
+        ("sh", ["-c", "docker cp other:/run/secrets/token /workspace/token"]),
         ("sh", ["-c", "true; uvx --index-url https://packages.example.invalid/simple mcp-server"]),
         ("sh", ["-c", "exec uvx --index-url https://packages.example.invalid/simple mcp-server"]),
     ],
@@ -92,6 +93,20 @@ def test_source_redirects_and_docker_host_access_are_rejected(command, args):
 )
 def test_trusted_registry_packages_and_isolated_docker_args_are_allowed(command, args):
     _validate_policy(command, args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["cp", "other:/run/secrets/token", "/workspace/token"],
+        ["inspect", "other"],
+        ["network", "connect", "shared", "other"],
+    ],
+)
+def test_docker_requires_run_subcommand_by_default(args):
+    with pytest.raises(ValueError, match=r"not allowed"):
+        validate_mcp_stdio_source_policy("docker", args, docker_hardening=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Backport of #14122 to `release-1.11.0`.

- require every MCP stdio Docker configuration to use the `run` subcommand
- preserve the existing lenient and hardened argument checks after the subcommand gate
- add regression coverage for direct policy calls, shell wrappers, and the backend API model

## Backport notes

Cherry-picked merged commit `c726bd26808e77cd45ae475cfa35e15ca209fb7b`. The backend test conflict was resolved by retaining the newer `release-1.11.0` command-specific allowlist coverage and adding only the missing non-`run` Docker regression cases.

## Validation

- original `docker cp` validator reproducer is rejected
- isolated `docker run --rm -i mcp-image` remains accepted
- `121 passed` — `src/backend/tests/unit/test_mcp_command_injection_security.py`
- `108 passed` — `src/lfx/tests/unit/mcp/test_stdio_source_policy.py` in an isolated LFX environment
- Ruff check and format verification passed for all changed files
- repository pre-commit hooks passed during the cherry-pick


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted Docker-based MCP commands to the `run` subcommand.
  * Blocked Docker operations such as copying files, inspecting containers, and connecting networks.
  * Prevented attempts to copy host secrets through Docker commands.

* **Tests**
  * Added coverage confirming unauthorized Docker subcommands and secret-copy paths are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->