### PR TITLE
fix(security): redact secret component inputs from traces

### DIFF
--- a/src/backend/tests/unit/test_credential_variable_leakage.py
+++ b/src/backend/tests/unit/test_credential_variable_leakage.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from lfx.components.input_output import TextInputComponent
 from lfx.custom import Component
-from lfx.inputs.inputs import SecretStrInput
+from lfx.inputs.inputs import IntInput, SecretStrInput, StrInput
 from lfx.interface.initialize.loading import update_params_with_load_from_db_fields
 from lfx.io import Output
 from lfx.schema.message import Message
@@ -149,6 +149,52 @@ async def test_credential_variable_in_password_field_preserves_runtime_string_co
     assert component._output_logs["output"][0].message == "**********"
     assert component.status == "**********"
     assert component.repr_value == "**********"
+
+
+@pytest.mark.asyncio
+async def test_secret_inputs_are_redacted_at_tracing_boundary_by_field_metadata():
+    """Secret input metadata, not field-name guesses, controls trace redaction."""
+
+    class _TraceSecretsComponent(Component):
+        display_name = "TraceSecretsTest"
+        name = "TraceSecretsTest"
+        inputs = [
+            SecretStrInput(name="aws_secret_access_key", display_name="AWS Secret Access Key"),
+            SecretStrInput(name="access_token", display_name="Access Token"),
+            IntInput(name="token_budget", display_name="Token Budget"),
+            StrInput(name="region", display_name="Region"),
+        ]
+        outputs = [Output(display_name="Output", name="output", method="build_output")]
+
+        def build_output(self) -> str:
+            return self.region
+
+    component = _TraceSecretsComponent(_user_id=str(uuid.uuid4()))
+    component.set_attributes(
+        {
+            "aws_secret_access_key": "aws-secret-sentinel",  # pragma: allowlist secret
+            "access_token": "token-secret-sentinel",  # pragma: allowlist secret
+            "token_budget": 4096,
+            "region": "us-west-2",
+        }
+    )
+
+    tracing_service = MagicMock()
+    trace_context = MagicMock()
+    trace_context.__aenter__ = AsyncMock(return_value=tracing_service)
+    trace_context.__aexit__ = AsyncMock(return_value=None)
+    tracing_service.trace_component.return_value = trace_context
+    component._tracing_service = tracing_service
+
+    await component._build_with_tracing()
+
+    traced_inputs = tracing_service.trace_component.call_args.args[2]
+    assert traced_inputs == {
+        "aws_secret_access_key": "**********",
+        "access_token": "**********",
+        "token_budget": 4096,
+        "region": "us-west-2",
+    }
 
 
 @pytest.mark.asyncio

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1233,19 +1233,28 @@ class Component(CustomComponent):
             setattr(self, output.name, output)
             self._outputs_map[output.name] = output
 
+    @staticmethod
+    def _get_trace_value(input_: Any) -> Any:
+        """Return an input value safe to send to tracing providers."""
+        if getattr(input_, "password", False):
+            return "**********"
+        return _mask_secret_value(input_.value)
+
     def get_trace_as_inputs(self):
         predefined_inputs = {
-            input_.name: input_.value
+            input_.name: self._get_trace_value(input_)
             for input_ in self.inputs
             if hasattr(input_, "trace_as_input") and input_.trace_as_input
         }
         # Runtime inputs
-        runtime_inputs = {name: input_.value for name, input_ in self._inputs.items() if hasattr(input_, "value")}
+        runtime_inputs = {
+            name: self._get_trace_value(input_) for name, input_ in self._inputs.items() if hasattr(input_, "value")
+        }
         return {**predefined_inputs, **runtime_inputs}
 
     def get_trace_as_metadata(self):
         return {
-            input_.name: input_.value
+            input_.name: self._get_trace_value(input_)
             for input_ in self.inputs
             if hasattr(input_, "trace_as_metadata") and input_.trace_as_metadata
         }


### PR DESCRIPTION
## Summary

- redact component inputs marked as password fields before invoking tracing providers
- preserve legitimate nonsecret inputs even when their names contain token-like terms
- apply the same metadata-driven handling to trace metadata

## Security

Addresses LE-1538. SecretStrInput values whose field names did not match the tracing services keyword list could previously be sent to configured tracing providers in cleartext.

## Validation

- backend credential-leakage and tracing suites: 24 passed
- isolated lfx custom-component suite: 7 passed, 1 xfailed
- focused regression failed before the fix and passes after it
- ruff check and ruff format --check passed on both changed files
- pre-commit hooks, including detect-secrets, passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive and password input values are now automatically masked in tracing data.
  * Non-sensitive input values, such as regions and configuration settings, remain visible for troubleshooting.
  * Improved protection against accidental credential exposure across traced component inputs and metadata.
  * Added regression coverage to verify secret fields are consistently redacted while non-secret fields remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->