### PR TITLE
fix(security): backport indirect component code bypass protections

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -5,6 +5,7 @@ Never executes the code. Called AFTER code extraction, BEFORE returning to user.
 """
 
 import ast
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 # Dangerous function calls that should never appear in component code
@@ -363,6 +364,20 @@ class _SecurityChecker(ast.NodeVisitor):
         if violation := self._opaque_reference_violation(node):
             self.violations.append(violation)
 
+    def visit_Return(self, node: ast.Return):
+        if node.value is not None:
+            self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
+    def visit_Yield(self, node: ast.Yield):
+        if node.value is not None:
+            self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom):
+        self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
     def _bind_name(self, name: str, values: frozenset[str]) -> None:
         if values:
             self.module_aliases[name] = values
@@ -376,13 +391,15 @@ class _SecurityChecker(ast.NodeVisitor):
                 if scope_depth == self._alias_scope_depth:
                     states.append(state)
 
-    def _bind_assignment_target(self, target: ast.AST, value: ast.AST) -> None:
-        """Apply assignment aliasing, including matching tuple/list unpacking."""
-        if isinstance(target, ast.Name):
-            self._bind_name(target.id, self._resolved_assignment_value(value))
-        elif isinstance(target, ast.Starred):
-            self._bind_assignment_target(target.value, value)
-        elif isinstance(target, (ast.Tuple, ast.List)):
+    def _iter_assignment_leaves(self, target: ast.AST, value: ast.AST) -> Iterator[tuple[ast.AST, ast.AST]]:
+        """Pair assignment target leaves with the values bound to them."""
+        if isinstance(target, (ast.Name, ast.Attribute, ast.Subscript)):
+            yield target, value
+            return
+        if isinstance(target, ast.Starred):
+            yield from self._iter_assignment_leaves(target.value, value)
+            return
+        if isinstance(target, (ast.Tuple, ast.List)):
             if isinstance(value, (ast.Tuple, ast.List)):
                 starred_index = next(
                     (
@@ -394,31 +411,44 @@ class _SecurityChecker(ast.NodeVisitor):
                 )
                 if starred_index is None and len(target.elts) == len(value.elts):
                     for target_element, value_element in zip(target.elts, value.elts, strict=True):
-                        self._bind_assignment_target(target_element, value_element)
+                        yield from self._iter_assignment_leaves(target_element, value_element)
                     return
                 if starred_index is not None and len(value.elts) >= len(target.elts) - 1:
                     for target_element, value_element in zip(
                         target.elts[:starred_index], value.elts[:starred_index], strict=True
                     ):
-                        self._bind_assignment_target(target_element, value_element)
+                        yield from self._iter_assignment_leaves(target_element, value_element)
 
                     trailing_count = len(target.elts) - starred_index - 1
                     if trailing_count:
                         for target_element, value_element in zip(
                             target.elts[-trailing_count:], value.elts[-trailing_count:], strict=True
                         ):
-                            self._bind_assignment_target(target_element, value_element)
+                            yield from self._iter_assignment_leaves(target_element, value_element)
 
                     remaining_end = len(value.elts) - trailing_count if trailing_count else len(value.elts)
                     remaining_values = ast.List(
                         elts=value.elts[starred_index:remaining_end],
                         ctx=ast.Load(),
                     )
-                    self._bind_assignment_target(target.elts[starred_index], remaining_values)
+                    yield from self._iter_assignment_leaves(target.elts[starred_index], remaining_values)
                     return
 
             for target_element in target.elts:
-                self._bind_assignment_target(target_element, value)
+                yield from self._iter_assignment_leaves(target_element, value)
+
+    def _check_assignment_value(self, target: ast.AST, value: ast.AST) -> None:
+        """Check assignment values that cannot remain visible to alias tracking."""
+        for target_leaf, value_leaf in self._iter_assignment_leaves(target, value):
+            if isinstance(target_leaf, ast.Name) and self._resolved_assignment_value(value_leaf):
+                continue
+            self._check_opaque_reference(value_leaf)
+
+    def _bind_assignment_target(self, target: ast.AST, value: ast.AST) -> None:
+        """Apply assignment aliasing, including matching tuple/list unpacking."""
+        for target_leaf, value_leaf in self._iter_assignment_leaves(target, value):
+            if isinstance(target_leaf, ast.Name):
+                self._bind_name(target_leaf.id, self._resolved_assignment_value(value_leaf))
 
     def _bind_iterated_target(self, target: ast.AST, iterable: ast.AST) -> None:
         """Bind a loop target to every statically visible iterable value."""
@@ -529,14 +559,9 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         self.visit(node.value)
-        if isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)) and any(
-            isinstance(target, ast.Name) for target in node.targets
-        ):
-            self._check_opaque_reference(node.value)
         for target in node.targets:
             self.visit(target)
-            if isinstance(target, (ast.Attribute, ast.Subscript)):
-                self._check_opaque_reference(node.value)
+            self._check_assignment_value(target, node.value)
             self._bind_assignment_target(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
@@ -544,19 +569,13 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             self.visit(node.target)
-            if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
-                self._check_opaque_reference(node.value)
-            if isinstance(node.target, (ast.Attribute, ast.Subscript)):
-                self._check_opaque_reference(node.value)
+            self._check_assignment_value(node.target, node.value)
             self._bind_assignment_target(node.target, node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         self.visit(node.value)
         self.visit(node.target)
-        if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
-            self._check_opaque_reference(node.value)
-        if isinstance(node.target, (ast.Attribute, ast.Subscript)):
-            self._check_opaque_reference(node.value)
+        self._check_assignment_value(node.target, node.value)
         self._bind_assignment_target(node.target, node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign):
@@ -757,6 +776,7 @@ class _SecurityChecker(ast.NodeVisitor):
         self._alias_scope_depth += 1
         try:
             self._shadow_arguments(node.args)
+            self._check_opaque_reference(node.body)
             self.visit(node.body)
         finally:
             self._alias_scope_depth -= 1
@@ -906,6 +926,10 @@ class _SecurityChecker(ast.NodeVisitor):
             return False
 
         module_names = self._resolved_receiver_names(node.args[0])
+        for receiver_name in module_names:
+            if violation := self._dangerous_callable_message(receiver_name):
+                self.violations.append(violation)
+                return True
         try:
             attr_node = node.args[1]
         except IndexError:

--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -191,6 +191,18 @@ def _build_dangerous_members() -> tuple[dict[str, set[str]], dict[str, set[str]]
 
 _DANGEROUS_CALL_MEMBERS, _DANGEROUS_READ_MEMBERS = _build_dangerous_members()
 
+# Modules with a mix of allowed and forbidden members may be used directly so
+# legitimate operations such as ``os.path.join`` remain available. They must
+# not, however, be passed through an opaque boundary where this scanner can no
+# longer relate the eventual member access back to the module.
+_RESTRICTED_MODULE_REFERENCES: set[str] = {
+    *_DANGEROUS_CALL_MEMBERS,
+    *_DANGEROUS_READ_MEMBERS,
+    *(prefix.split(".")[0] for prefix in DANGEROUS_SUBMODULES),
+    "builtins",
+    "__builtins__",
+}
+
 _AliasState = tuple[dict[str, frozenset[str]], set[str]]
 
 
@@ -251,13 +263,105 @@ class _SecurityChecker(ast.NodeVisitor):
         return self.module_aliases.get(name, frozenset({name}))
 
     def _resolved_assignment_value(self, node: ast.AST) -> frozenset[str]:
-        """Resolve a simple Name/Attribute RHS without executing it."""
+        """Resolve a statically identifiable reference RHS without executing it."""
         if isinstance(node, ast.Name):
             return self._resolved_names(node.id)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and "getattr" in self._resolved_names(node.func.id)
+            and node.args
+        ):
+            try:
+                attr_node = node.args[1]
+            except IndexError:
+                return frozenset()
+            if isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str):
+                return frozenset(
+                    f"{base_name}.{attr_node.value}" for base_name in self._resolved_assignment_value(node.args[0])
+                )
         parts = _dotted_parts(node)
         if not parts:
             return frozenset()
         return frozenset(".".join([root, *parts[1:]]) for root in self._resolved_names(parts[0]))
+
+    @staticmethod
+    def _dangerous_callable_message(resolved_name: str) -> str | None:
+        """Return the violation for a resolved builtin or module callable."""
+        if resolved_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[resolved_name]
+
+        module_name, separator, member_name = resolved_name.rpartition(".")
+        if separator and module_name in {"builtins", "__builtins__"} and member_name in DANGEROUS_CALLS:
+            return DANGEROUS_CALLS[member_name]
+
+        return next(
+            (message for mod, method, message in DANGEROUS_ATTR_CALLS if resolved_name == f"{mod}.{method}"),
+            None,
+        )
+
+    def _opaque_reference_violation(self, node: ast.AST) -> str | None:
+        """Reject dangerous values crossing a boundary alias tracking cannot follow."""
+        if isinstance(node, ast.Starred):
+            return self._opaque_reference_violation(node.value)
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return next(
+                (violation for item in node.elts if (violation := self._opaque_reference_violation(item))), None
+            )
+        if isinstance(node, ast.Dict):
+            items = [*node.keys, *node.values]
+            return next(
+                (
+                    violation
+                    for item in items
+                    if item is not None and (violation := self._opaque_reference_violation(item))
+                ),
+                None,
+            )
+
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            expressions = (node.key, node.value) if isinstance(node, ast.DictComp) else (node.elt,)
+            enclosing_state = self._snapshot_alias_state()
+            try:
+                for generator in node.generators:
+                    if violation := self._opaque_reference_violation(generator.iter):
+                        return violation
+                    self._bind_iterated_target(generator.target, generator.iter)
+                    for condition in generator.ifs:
+                        if violation := self._opaque_reference_violation(condition):
+                            return violation
+                return next(
+                    (
+                        violation
+                        for expression in expressions
+                        if (violation := self._opaque_reference_violation(expression))
+                    ),
+                    None,
+                )
+            finally:
+                self._restore_alias_state(enclosing_state)
+
+        resolved_names = self._resolved_assignment_value(node)
+        for resolved_name in resolved_names:
+            if resolved_name in _RESTRICTED_MODULE_REFERENCES:
+                return f"Indirect reference to restricted module '{resolved_name}' is forbidden in components"
+            if violation := self._dangerous_callable_message(resolved_name):
+                return violation
+        if resolved_names:
+            return None
+
+        return next(
+            (
+                violation
+                for child in ast.iter_child_nodes(node)
+                if (violation := self._opaque_reference_violation(child))
+            ),
+            None,
+        )
+
+    def _check_opaque_reference(self, node: ast.AST) -> None:
+        if violation := self._opaque_reference_violation(node):
+            self.violations.append(violation)
 
     def _bind_name(self, name: str, values: frozenset[str]) -> None:
         if values:
@@ -425,8 +529,14 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         self.visit(node.value)
+        if isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)) and any(
+            isinstance(target, ast.Name) for target in node.targets
+        ):
+            self._check_opaque_reference(node.value)
         for target in node.targets:
             self.visit(target)
+            if isinstance(target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
@@ -434,16 +544,25 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             self.visit(node.target)
+            if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+                self._check_opaque_reference(node.value)
+            if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+                self._check_opaque_reference(node.value)
             self._bind_assignment_target(node.target, node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         self.visit(node.value)
         self.visit(node.target)
+        if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
+            self._check_opaque_reference(node.value)
+        if isinstance(node.target, (ast.Attribute, ast.Subscript)):
+            self._check_opaque_reference(node.value)
         self._bind_assignment_target(node.target, node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign):
         self.visit(node.target)
         self.visit(node.value)
+        self._check_opaque_reference(node.value)
         if isinstance(node.target, ast.Name):
             self._bind_name(node.target.id, frozenset())
 
@@ -609,6 +728,8 @@ class _SecurityChecker(ast.NodeVisitor):
             self.visit(node.returns)
         for type_parameter in getattr(node, "type_params", ()):
             self.visit(type_parameter)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
 
         enclosing_state = self._snapshot_alias_state()
         self._alias_scope_depth += 1
@@ -630,6 +751,8 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Lambda(self, node: ast.Lambda):
         self.visit(node.args)
+        for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
+            self._check_opaque_reference(default)
         enclosing_state = self._snapshot_alias_state()
         self._alias_scope_depth += 1
         try:
@@ -711,7 +834,14 @@ class _SecurityChecker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call):
         self._check_name_call(node)
         self._check_attribute_call(node)
-        self._check_getattr_access(node)
+        getattr_arguments_validated = self._check_getattr_access(node)
+        resolved_call_names = self._resolved_assignment_value(node.func)
+        # getattr is explicitly modeled below, including dynamic access to
+        # restricted modules. Passing the module as its first argument is not
+        # itself an opaque escape and safe members such as os.path must remain usable.
+        exempt_getattr_arguments = 2 if "getattr" in resolved_call_names and getattr_arguments_validated else 0
+        for argument in (*node.args[exempt_getattr_arguments:], *(keyword.value for keyword in node.keywords)):
+            self._check_opaque_reference(argument)
         self.generic_visit(node)
 
     def _check_name_call(self, node: ast.Call):
@@ -722,9 +852,10 @@ class _SecurityChecker(ast.NodeVisitor):
         if not isinstance(node.func, ast.Name):
             return
         name = node.func.id
-        if name in DANGEROUS_CALLS:
-            self.violations.append(DANGEROUS_CALLS[name])
-            return
+        for resolved_name in self._resolved_names(name):
+            if violation := self._dangerous_callable_message(resolved_name):
+                self.violations.append(violation)
+                return
         for mod in self.wildcard_modules:
             if name in _DANGEROUS_CALL_MEMBERS.get(mod, ()):
                 self.violations.append(f"Use of '{name}()' (via 'from {mod} import *') is forbidden in components")
@@ -743,18 +874,22 @@ class _SecurityChecker(ast.NodeVisitor):
         method_name = node.func.attr
 
         for module_name in self._resolved_names(node.func.value.id):
+            if module_name in {"builtins", "__builtins__"} and method_name in DANGEROUS_CALLS:
+                self.violations.append(DANGEROUS_CALLS[method_name])
+                return
             for mod, method, message in DANGEROUS_ATTR_CALLS:
                 if module_name == mod and method_name == method:
                     self.violations.append(message)
                     return
 
-    def _check_getattr_access(self, node: ast.Call):
+    def _check_getattr_access(self, node: ast.Call) -> bool:
         """Check reflective access to restricted module members.
 
         ``getattr`` is common in legitimate components, so it stays allowed for
         ordinary objects and safe module attributes. On modules with restricted
         members, a dynamic attribute name is rejected because it could resolve to
-        one of those members at runtime.
+        one of those members at runtime. Returns whether the object and attribute
+        arguments were fully validated here.
         """
         if isinstance(node.func, ast.Name):
             function_names = self._resolved_names(node.func.id)
@@ -768,34 +903,38 @@ class _SecurityChecker(ast.NodeVisitor):
             and node.args
             and isinstance(node.args[0], (ast.Name, ast.Attribute))
         ):
-            return
+            return False
 
         module_names = self._resolved_receiver_names(node.args[0])
         try:
             attr_node = node.args[1]
         except IndexError:
-            return
+            return False
         if not (isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str)):
             dangerous_modules = sorted(
-                module_name
-                for module_name in module_names
-                if module_name in _DANGEROUS_CALL_MEMBERS or module_name in _DANGEROUS_READ_MEMBERS
+                module_name for module_name in module_names if module_name in _RESTRICTED_MODULE_REFERENCES
             )
             if dangerous_modules:
                 self.violations.append(
                     f"Dynamic getattr() access on module '{dangerous_modules[0]}' is forbidden in components"
                 )
-            return
+            return True
 
         attr_name = attr_node.value
+        if any(module_name in {"builtins", "__builtins__"} for module_name in module_names) and (
+            violation := DANGEROUS_CALLS.get(attr_name)
+        ):
+            self.violations.append(violation)
+            return True
         for mod, attr, message in DANGEROUS_ATTRIBUTE_READS:
             if mod in module_names and attr_name == attr:
                 self.violations.append(message)
-                return
+                return True
         for mod, method, message in DANGEROUS_ATTR_CALLS:
             if mod in module_names and attr_name == method:
                 self.violations.append(message)
-                return
+                return True
+        return True
 
 
 def scan_code_security(code: str) -> SecurityScanResult:

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -626,7 +626,7 @@ module = object()
 
 def bind_locally():
     module = os
-    return module
+    return None
 
 module.system('not the os module')
 """
@@ -820,9 +820,9 @@ module.getenv('not the os module')
 import os
 module = object()
 try:
-    def deferred():
-        module = os
-        return module
+        def deferred():
+            module = os
+            return None
 finally:
     module.getenv('not the os module')
 """
@@ -882,6 +882,18 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "import os\ngetattr(os if True else object(), 'system')('id')",
             "import os\ndef run(module):\n    module.system('id')\nrun([module for module in (os,)][0])",
             "import os\ndef run(module):\n    module.system('id')\nrun(next(module for module in (os,)))",
+            "def expose():\n    return exec\nexpose()(\"print('unsafe')\")",
+            "import os\ndef expose():\n    return os\nexpose().system('id')",
+            "def expose():\n    yield exec\nnext(expose())(\"print('unsafe')\")",
+            "import os\ndef expose():\n    yield from (os,)\nnext(expose()).system('id')",
+            "(lambda: exec)()(\"print('unsafe')\")",
+            "import os\nmodule = os if flag else object()\nmodule.system('id')",
+            "import os\nmodule = [os][0]\nmodule.system('id')",
+            "import os\nmodule = [item for item in (os,)][0]\nmodule.system('id')",
+            "import os\n(module,) = ([os][0],)\nmodule.system('id')",
+            "import os\nif module := [os][0]:\n    module.system('id')",
+            "import os\nmodule: object = os if flag else object()\nmodule.system('id')",
+            "import os\ngetattr(os.system, '__call__')('id')",
         ],
         ids=[
             "function-argument",
@@ -899,6 +911,18 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "conditional-expression-in-getattr",
             "list-comprehension-as-argument",
             "generator-expression-as-argument",
+            "returned-builtin",
+            "returned-module",
+            "yielded-builtin",
+            "yielded-module",
+            "lambda-returned-builtin",
+            "conditional-assignment",
+            "subscript-assignment",
+            "comprehension-assignment",
+            "nested-unpacking-assignment",
+            "named-expression-assignment",
+            "annotated-assignment",
+            "getattr-dangerous-callable-receiver",
         ],
     )
     def test_should_detect_indirect_dangerous_reference(self, code):
@@ -962,6 +986,9 @@ class IndirectCommandComponent(Component):
             'import builtins\nsize = getattr(builtins, "len")([1, 2, 3])',
             "dangerous = exec\ndangerous = print\ndangerous('safe')",
             "import os\nmodule = os\nconsume([module for module in (object(),)])",
+            "import requests\ndef expose():\n    return requests\nexpose().get('https://example.com')",
+            "import os\n(module,) = (os.path,)\nmodule.join('a', 'b')",
+            "import os\ngetattr(os.path.join, '__call__')('a', 'b')",
         ],
         ids=[
             "ordinary-object-method",
@@ -970,6 +997,9 @@ class IndirectCommandComponent(Component):
             "safe-builtin-getattr",
             "dangerous-alias-rebound",
             "comprehension-target-shadows-restricted-module",
+            "returned-safe-module",
+            "unpacked-safe-module-attribute",
+            "getattr-safe-callable-receiver",
         ],
     )
     def test_should_allow_safe_indirect_reference(self, code):

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -861,6 +861,122 @@ except* TypeError:
         assert any("os.getenv()" in violation for violation in result.violations)
 
 
+class TestScanCodeSecurityIndirectReferenceBypass:
+    """Restricted modules and builtins must stay restricted through indirection."""
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import os\ndef run(module):\n    module.system('id')\nrun(os)",
+            "import os\ndef run(module=os):\n    module.system('id')\nrun()",
+            "import os\nmodules = {}\nmodules['os'] = os\nmodules['os'].system('id')",
+            "import os\nmodules = [os]\nmodules[0].system('id')",
+            "import os\nclass Holder:\n    pass\nholder = Holder()\nholder.module = os\nholder.module.system('id')",
+            "dangerous = exec\ndangerous(\"import os\\nos.system('id')\")",
+            "import builtins\nbuiltins.exec(\"import os\\nos.system('id')\")",
+            'import builtins\ngetattr(builtins, "exec")("import os\\nos.system(\'id\')")',
+            "import builtins\nvars(builtins)[\"eval\"](\"__import__('os').system('id')\")",
+            "import os\ndangerous = os.system\ndangerous('id')",
+            "import os\nmodule = os\ndef run(value):\n    value.system('id')\nrun(module)",
+            "import os\ndef run(module):\n    module.system('id')\nrun(os if True else object())",
+            "import os\ngetattr(os if True else object(), 'system')('id')",
+            "import os\ndef run(module):\n    module.system('id')\nrun([module for module in (os,)][0])",
+            "import os\ndef run(module):\n    module.system('id')\nrun(next(module for module in (os,)))",
+        ],
+        ids=[
+            "function-argument",
+            "function-default",
+            "dict-entry",
+            "list-entry",
+            "object-attribute",
+            "builtin-alias",
+            "builtins-attribute",
+            "builtins-getattr",
+            "builtins-vars",
+            "module-callable-alias",
+            "module-alias-as-argument",
+            "conditional-expression-as-argument",
+            "conditional-expression-in-getattr",
+            "list-comprehension-as-argument",
+            "generator-expression-as-argument",
+        ],
+    )
+    def test_should_detect_indirect_dangerous_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    def test_should_detect_indirection_in_component_shaped_code(self):
+        code = """
+import os
+from lfx.custom import Component
+from lfx.io import Output
+from lfx.schema import Message
+
+class IndirectCommandComponent(Component):
+    outputs = [Output(name="result", display_name="Result", method="run_command")]
+
+    def run_command(self) -> Message:
+        def invoke(module):
+            module.system("id")
+
+        invoke(os)
+        return Message(text="done")
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "import os\nmodules = [os.path]\npath = modules[0].join('a', 'b')",
+            "import os\ndef join(path_module=os.path):\n    return path_module.join('a', 'b')\njoin()",
+            "import os\ndef join(path_module):\n    return path_module.join('a', 'b')\njoin(os.path)",
+            "import os\nconsume(getattr(os, 'path'))",
+        ],
+        ids=[
+            "module-reexport-in-list",
+            "module-reexport-default",
+            "module-reexport-argument",
+            "getattr-module-reexport-argument",
+        ],
+    )
+    def test_should_preserve_restricted_module_reexport_boundary(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.path" in violation for violation in result.violations)
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            (
+                "class Client:\n"
+                "    def system(self, value):\n"
+                "        return value\n"
+                "client = Client()\n"
+                "def run(obj):\n"
+                "    obj.system('status')\n"
+                "run(client)"
+            ),
+            "import requests\nclass Holder:\n    pass\nholder = Holder()\nholder.client = requests\nholder.client.get('https://example.com')",
+            "import builtins\nsize = builtins.len([1, 2, 3])",
+            'import builtins\nsize = getattr(builtins, "len")([1, 2, 3])',
+            "dangerous = exec\ndangerous = print\ndangerous('safe')",
+            "import os\nmodule = os\nconsume([module for module in (object(),)])",
+        ],
+        ids=[
+            "ordinary-object-method",
+            "safe-module-in-attribute",
+            "safe-builtin-attribute",
+            "safe-builtin-getattr",
+            "dangerous-alias-rebound",
+            "comprehension-target-shadows-restricted-module",
+        ],
+    )
+    def test_should_allow_safe_indirect_reference(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+
 class TestScanCodeSecurityRuntimeModuleBypass:
     """Runtime module lookup and reflection must not bypass dangerous calls."""
 

--- a/src/backend/tests/unit/agentic/services/test_flow_run.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_run.py
@@ -275,6 +275,16 @@ class TestRunWorkingFlowSecurityGate:
         assert "error" in out
         bg.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_should_refuse_indirect_module_call_before_graph_build(self):
+        evil = self._flow_with_code("import os\ndef run(module):\n    module.system('id')\nrun(os)")
+        with patch(f"{MODULE}.build_graph_from_data", new_callable=AsyncMock) as bg:
+            out = await run_working_flow(flow_data=evil, flow_id="flow-1", user_id="u1")
+
+        assert "error" in out
+        assert "unsafe" in out["error"].lower()
+        bg.assert_not_awaited()
+
     @pytest.mark.parametrize("code", ["import _ctypes", "from cffi import FFI"], ids=["ctypes", "cffi"])
     @pytest.mark.asyncio
     async def test_should_refuse_native_ffi_imports_before_graph_build(self, code: str):


### PR DESCRIPTION
## Summary

- Backport the merged security hardening from #14121 to `release-1.11.0`.
- Reject restricted modules and dangerous callables hidden behind call arguments, defaults, containers, conditional expressions, comprehensions, and reflective `getattr` access.
- Refuse unsafe component code before graph construction.
- Preserve `release-1.11.0`'s stricter `os.path.os` module re-export boundary.

## Why

The opaque-reference resolver only followed simple names, attributes, and literal containers. Restricted modules could therefore cross an untracked boundary through expressions such as conditional expressions or comprehensions and later reach dangerous members.

This backport is based on merged commit `536a0a2f6aca5680140de04ec24684535b54ae46`. Its tests are adapted to the newer release-line policy that treats `os.path` as restricted when it crosses an opaque boundary because it re-exports the `os` module.

## Impact

Generated component code using these indirection patterns is rejected by the security scanner, and flow execution stops before graph construction. Direct safe `os.path` operations remain supported.

## Validation

- `uv run --no-sync pytest src/backend/tests/unit/agentic/helpers/test_code_security.py src/backend/tests/unit/agentic/services/test_flow_run.py::TestRunWorkingFlowSecurityGate` — 188 passed
- Ruff check — passed
- Ruff format check — passed
- Repository pre-commit hooks, including detect-secrets — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened code scanning to detect restricted modules, built-ins, and dangerous calls even when accessed indirectly.
  * Improved protection against sandbox-escape attempts through aliases, collections, attributes, comprehensions, defaults, and helper functions.
  * Preserved support for safe indirect references and validated reflective attribute access.

* **Bug Fixes**
  * Unsafe indirect code is now blocked before flow execution begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->