### PR TITLE
fix(security): compare API keys in constant time

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1115,7 +1115,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 117,
         "is_secret": true
       }
     ],
@@ -6689,7 +6689,7 @@
         "filename": "src/lfx/src/lfx/cli/serve_app.py",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 51,
         "is_secret": true
       }
     ],

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -25,6 +25,11 @@ def hash_api_key(api_key: str) -> str:
     return hashlib.sha256(api_key.encode()).hexdigest()
 
 
+def _api_keys_match(provided: str, expected: str) -> bool:
+    """Compare API keys without content-dependent short-circuiting."""
+    return secrets.compare_digest(provided.encode(), expected.encode())
+
+
 def _is_expired(expires_at: datetime.datetime | None) -> bool:
     if expires_at is None:
         return False
@@ -163,11 +168,11 @@ async def _check_key_from_db(session: AsyncSession, api_key: str, settings_servi
             continue
 
         # decrypt_api_key returns "" on failure (never raises for decryption errors)
-        if stored_value == api_key:
+        if _api_keys_match(api_key, stored_value):
             matched = True
         else:
             candidate = auth_utils.decrypt_api_key(stored_value)
-            matched = candidate == api_key
+            matched = _api_keys_match(api_key, candidate)
 
         if matched:
             if _is_expired(api_key_obj.expires_at):
@@ -196,8 +201,7 @@ async def _check_key_from_env(session: AsyncSession, api_key: str, settings_serv
     if not env_api_key:
         return None
 
-    # Compare the provided API key with the environment variable
-    if api_key != env_api_key:
+    if not _api_keys_match(api_key, env_api_key):
         return None
 
     # Return the superuser for authorization purposes

--- a/src/backend/tests/unit/services/database/models/api_key/test_crud.py
+++ b/src/backend/tests/unit/services/database/models/api_key/test_crud.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import secrets
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -133,10 +135,16 @@ async def test_check_key_fallback_for_legacy_keys(async_session, mock_settings, 
         "langflow.services.database.models.api_key.crud.auth_utils.decrypt_api_key",
         lambda val, **_kwargs: val,
     )
+    compare_digest = MagicMock(wraps=secrets.compare_digest)
+    monkeypatch.setattr(
+        "langflow.services.database.models.api_key.crud.secrets.compare_digest",
+        compare_digest,
+    )
 
     result = await _check_key_from_db(async_session, plaintext, mock_settings)
     assert result is not None
     assert result.id == user.id
+    compare_digest.assert_called_once_with(plaintext.encode(), plaintext.encode())
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/test_api_key_source.py
+++ b/src/backend/tests/unit/test_api_key_source.py
@@ -5,6 +5,7 @@ This module tests the check_key function behavior when:
 - API_KEY_SOURCE='env': Validates against LANGFLOW_API_KEY environment variable
 """
 
+import secrets
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -214,15 +215,22 @@ class TestCheckKeyFromEnv:
         """Valid API key matching env var should return the superuser."""
         monkeypatch.setenv("LANGFLOW_API_KEY", "sk-test-env-key")
 
-        with patch(
-            "langflow.services.database.models.user.crud.get_user_by_username",
-            new_callable=AsyncMock,
-        ) as mock_get_user:
+        with (
+            patch(
+                "langflow.services.database.models.user.crud.get_user_by_username",
+                new_callable=AsyncMock,
+            ) as mock_get_user,
+            patch(
+                "langflow.services.database.models.api_key.crud.secrets.compare_digest",
+                wraps=secrets.compare_digest,
+            ) as compare_digest,
+        ):
             mock_get_user.return_value = mock_superuser
 
             result = await _check_key_from_env(mock_session, "sk-test-env-key", mock_settings_service_env)
 
             assert result == mock_superuser
+            compare_digest.assert_called_once_with(b"sk-test-env-key", b"sk-test-env-key")
             mock_get_user.assert_called_once_with(mock_session, "langflow")
 
     @pytest.mark.asyncio

--- a/src/lfx/src/lfx/cli/serve_app.py
+++ b/src/lfx/src/lfx/cli/serve_app.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import secrets
 import time
 import traceback
 import uuid
@@ -69,7 +70,7 @@ def verify_api_key(
 
     try:
         expected_key = get_api_key()
-        if provided_key != expected_key:
+        if not secrets.compare_digest(provided_key.encode(), expected_key.encode()):
             raise HTTPException(status_code=401, detail="Invalid API key")
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/lfx/tests/unit/cli/test_serve_app.py
+++ b/src/lfx/tests/unit/cli/test_serve_app.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import secrets
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -940,8 +941,10 @@ class TestSecurityFunctions:
     def test_verify_api_key_with_query_param(self):
         """Test API key verification with query parameter."""
         with patch.dict(os.environ, {"LANGFLOW_API_KEY": "test-key-123"}):  # pragma: allowlist secret
-            result = verify_api_key("test-key-123", None)
+            with patch("lfx.cli.serve_app.secrets.compare_digest", wraps=secrets.compare_digest) as compare_digest:
+                result = verify_api_key("test-key-123", None)
             assert result == "test-key-123"
+            compare_digest.assert_called_once_with(b"test-key-123", b"test-key-123")
 
     def test_verify_api_key_with_header_param(self):
         """Test API key verification with header parameter."""


### PR DESCRIPTION
## Summary

- compare the `lfx serve` shared API key with `secrets.compare_digest`
- use the same constant-time control for environment-backed and legacy database API keys
- preserve existing Unicode, case-sensitive, whitespace, and special-character behavior by comparing UTF-8 bytes
- add regression assertions at each affected authentication boundary

Refs LE-1534 and LE-1536.

## Security context

Static triage confirmed ordinary string equality on these credential paths, but did not establish a remotely exploitable timing signal. This defense-in-depth change removes content-dependent short-circuit comparison without changing accepted keys or error semantics.

## Validation

- pre-fix regression failed because the affected paths did not call `compare_digest`
- 35 passed: backend API-key source and CRUD suites on `release-1.10.3`
- 6 passed: isolated `lfx` serve security suite on `release-1.10.3`
- Ruff check and format verification passed
- repository commit hooks, including detect-secrets, passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved API key verification by using timing-resistant comparisons across supported authentication paths, helping reduce information leakage during authentication.

* **Tests**
  * Added coverage confirming timing-resistant API key comparisons are used for database, environment-variable, and CLI authentication.
  * Updated secret-scan metadata to reflect current line locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->