### PR TITLE
fix(security): isolate lfx serve request logs

### DIFF
--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import contextlib
+import contextvars
 import importlib.metadata as importlib_metadata
 import io
 import os
@@ -12,6 +13,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import uuid
 import zipfile
 from io import StringIO
@@ -59,6 +61,62 @@ _LANGFLOW_NAMESPACE_UUID = uuid.UUID("3c091057-e799-4e32-8ebc-27bc31e1108c")
 
 # Environment variable for GitHub token
 _GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
+
+
+class _ContextualTextStream:
+    """Route writes to a task-local stream while preserving a process fallback.
+
+    ``sys.stdout`` and ``sys.stderr`` are process globals, so replacing either
+    around an ``await`` lets concurrent requests overwrite one another's capture
+    target. A stable proxy keeps the process-global object unchanged while a
+    ContextVar selects the destination for the current request and any child
+    tasks (or context-propagating worker threads).
+    """
+
+    def __init__(self, fallback, *, context_name: str) -> None:
+        self._fallback = fallback
+        self._target: contextvars.ContextVar[Any | None] = contextvars.ContextVar(context_name, default=None)
+
+    def _current(self):
+        target = self._target.get()
+        return self._fallback if target is None else target
+
+    def activate(self, target) -> contextvars.Token[Any | None]:
+        return self._target.set(target)
+
+    def reset(self, token: contextvars.Token[Any | None]) -> None:
+        self._target.reset(token)
+
+    def write(self, data):
+        return self._current().write(data)
+
+    def flush(self) -> None:
+        self._current().flush()
+
+    def writelines(self, lines) -> None:
+        self._current().writelines(lines)
+
+    def __getattr__(self, name: str):
+        return getattr(self._current(), name)
+
+
+_STREAM_PROXY_LOCK = threading.Lock()
+
+
+def _ensure_contextual_streams() -> tuple[_ContextualTextStream, _ContextualTextStream]:
+    """Install stdout/stderr proxies once for the current process stream pair."""
+    with _STREAM_PROXY_LOCK:
+        stdout = sys.stdout
+        if not isinstance(stdout, _ContextualTextStream):
+            stdout = _ContextualTextStream(stdout, context_name="lfx_request_stdout")
+            sys.stdout = stdout
+
+        stderr = sys.stderr
+        if not isinstance(stderr, _ContextualTextStream):
+            stderr = _ContextualTextStream(stderr, context_name="lfx_request_stderr")
+            sys.stderr = stderr
+
+    return stdout, stderr
 
 
 def create_verbose_printer(*, verbose: bool):
@@ -332,23 +390,21 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
     # Create input request
     inputs = InputValueRequest(input_value=input_value) if input_value else None
 
-    # Capture output during execution
+    # Capture output during execution. The process-global streams remain stable
+    # proxies; only this request's ContextVars point at these buffers.
     captured_stdout = StringIO()
     captured_stderr = StringIO()
-
-    # Redirect stdout and stderr during graph execution
-    original_stdout = sys.stdout
-    original_stderr = sys.stderr
+    stdout_router, stderr_router = _ensure_contextual_streams()
 
     fallback_to_env_vars = resolve_fallback_to_env_vars()
 
     scope_vars = build_request_variables_from_global_vars(graph.context.get("request_variables"))
     scope_token = activate_request_variables(scope_vars or None)
     no_env_fallback_token = activate_no_env_fallback(disabled=bool(graph.context.get("no_env_fallback")))
+    stdout_token = stdout_router.activate(captured_stdout)
+    stderr_token = stderr_router.activate(captured_stderr)
 
     try:
-        sys.stdout = captured_stdout
-        sys.stderr = captured_stderr
         results = [result async for result in graph.async_start(inputs, fallback_to_env_vars=fallback_to_env_vars)]
     except Exception as exc:
         # Capture any error output that was written to stderr
@@ -358,11 +414,12 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
             exc.args = (f"{exc.args[0] if exc.args else str(exc)}\n\nCaptured stderr:\n{error_output}",)
         raise
     finally:
-        reset_no_env_fallback(no_env_fallback_token)
-        reset_request_variables(scope_token)
-        # Restore original stdout/stderr
-        sys.stdout = original_stdout
-        sys.stderr = original_stderr
+        try:
+            reset_no_env_fallback(no_env_fallback_token)
+            reset_request_variables(scope_token)
+        finally:
+            stderr_router.reset(stderr_token)
+            stdout_router.reset(stdout_token)
 
     # Get captured logs
     captured_logs = captured_stdout.getvalue() + captured_stderr.getvalue()

--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -63,6 +63,19 @@ _LANGFLOW_NAMESPACE_UUID = uuid.UUID("3c091057-e799-4e32-8ebc-27bc31e1108c")
 _GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 
 
+class _StreamCaptureBinding:
+    """Shared capture state inherited by child execution contexts."""
+
+    def __init__(self, target) -> None:
+        self.target = target
+        self.active = True
+
+    def deactivate(self) -> None:
+        """Stop routing writes and release the completed capture buffer."""
+        self.active = False
+        self.target = None
+
+
 class _ContextualTextStream:
     """Route writes to a task-local stream while preserving a process fallback.
 
@@ -75,17 +88,25 @@ class _ContextualTextStream:
 
     def __init__(self, fallback, *, context_name: str) -> None:
         self._fallback = fallback
-        self._target: contextvars.ContextVar[Any | None] = contextvars.ContextVar(context_name, default=None)
+        self._binding: contextvars.ContextVar[_StreamCaptureBinding | None] = contextvars.ContextVar(
+            context_name, default=None
+        )
 
     def _current(self):
-        target = self._target.get()
-        return self._fallback if target is None else target
+        binding = self._binding.get()
+        return self._fallback if binding is None or not binding.active else binding.target
 
-    def activate(self, target) -> contextvars.Token[Any | None]:
-        return self._target.set(target)
+    def activate(self, target) -> tuple[contextvars.Token[_StreamCaptureBinding | None], _StreamCaptureBinding]:
+        binding = _StreamCaptureBinding(target)
+        return self._binding.set(binding), binding
 
-    def reset(self, token: contextvars.Token[Any | None]) -> None:
-        self._target.reset(token)
+    def reset(
+        self,
+        activation: tuple[contextvars.Token[_StreamCaptureBinding | None], _StreamCaptureBinding],
+    ) -> None:
+        token, binding = activation
+        binding.deactivate()
+        self._binding.reset(token)
 
     def write(self, data):
         return self._current().write(data)

--- a/src/lfx/tests/unit/cli/test_common.py
+++ b/src/lfx/tests/unit/cli/test_common.py
@@ -280,6 +280,43 @@ class TestGraphExecution:
         assert process_stderr.getvalue() == "outside stderr\n"
 
     @pytest.mark.asyncio
+    async def test_execute_graph_with_capture_deactivates_outliving_child_capture(self):
+        """A child task that outlives its graph writes to the process streams."""
+        child_started = asyncio.Event()
+        release_child = asyncio.Event()
+        child_task = None
+
+        async def write_after_graph_returns():
+            child_started.set()
+            await release_child.wait()
+            sys.stdout.write("late child stdout\n")
+            sys.stderr.write("late child stderr\n")
+
+        async def mock_async_start(inputs, **kwargs):  # noqa: ARG001
+            nonlocal child_task
+            child_task = asyncio.create_task(write_after_graph_returns())
+            await child_started.wait()
+            sys.stdout.write("captured stdout\n")
+            sys.stderr.write("captured stderr\n")
+            yield MagicMock(results={"text": "ok"})
+
+        mock_graph = MagicMock()
+        mock_graph.context = {}
+        mock_graph.async_start = mock_async_start
+
+        process_stdout = StringIO()
+        process_stderr = StringIO()
+        with patch.object(sys, "stdout", process_stdout), patch.object(sys, "stderr", process_stderr):
+            _, logs = await execute_graph_with_capture(mock_graph, "test input")
+            release_child.set()
+            assert child_task is not None
+            await child_task
+
+        assert logs == "captured stdout\ncaptured stderr\n"
+        assert process_stdout.getvalue() == "late child stdout\n"
+        assert process_stderr.getvalue() == "late child stderr\n"
+
+    @pytest.mark.asyncio
     async def test_execute_graph_with_capture_success(self):
         """Test successful graph execution with output capture."""
         # Mock graph and async iterator

--- a/src/lfx/tests/unit/cli/test_common.py
+++ b/src/lfx/tests/unit/cli/test_common.py
@@ -1,9 +1,11 @@
 """Unit tests for LFX CLI common utilities."""
 
+import asyncio
 import os
 import socket
 import sys
 import uuid
+from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -201,6 +203,81 @@ class TestLoadGraph:
 
 class TestGraphExecution:
     """Test graph execution utilities."""
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_with_capture_keeps_concurrent_logs_request_local(self):
+        """Concurrent graph output must not cross request boundaries."""
+        first_entered = asyncio.Event()
+        second_entered = asyncio.Event()
+        first_finished = asyncio.Event()
+
+        def make_graph(label: str, wait_for: asyncio.Event, entered: asyncio.Event):
+            async def mock_async_start(inputs, **kwargs):  # noqa: ARG001
+                sys.stdout.write(f"{label}-stdout-before\n")
+                sys.stderr.write(f"{label}-stderr-before\n")
+                entered.set()
+                await wait_for.wait()
+                sys.stdout.write(f"{label}-stdout-after\n")
+                sys.stderr.write(f"{label}-stderr-after\n")
+                yield MagicMock(results={"text": label})
+
+            graph = MagicMock()
+            graph.context = {}
+            graph.async_start = mock_async_start
+            return graph
+
+        first_graph = make_graph("first-secret", second_entered, first_entered)
+        second_graph = make_graph("second-secret", first_finished, second_entered)
+
+        async def run_first():
+            try:
+                return await execute_graph_with_capture(first_graph, "first input")
+            finally:
+                first_finished.set()
+
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
+        try:
+            first_task = asyncio.create_task(run_first())
+            await first_entered.wait()
+            second_task = asyncio.create_task(execute_graph_with_capture(second_graph, "second input"))
+            (_, first_logs), (_, second_logs) = await asyncio.gather(first_task, second_task)
+        finally:
+            # The vulnerable implementation can restore the wrong request's
+            # StringIO globally. Keep the regression self-contained when it fails.
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+
+        assert "first-secret-stdout-before" in first_logs
+        assert "first-secret-stderr-after" in first_logs
+        assert "second-secret" not in first_logs
+        assert "second-secret-stdout-before" in second_logs
+        assert "second-secret-stderr-after" in second_logs
+        assert "first-secret" not in second_logs
+
+    @pytest.mark.asyncio
+    async def test_execute_graph_with_capture_preserves_single_request_logs(self):
+        """A normal request still receives both its stdout and stderr."""
+
+        async def mock_async_start(inputs, **kwargs):  # noqa: ARG001
+            sys.stdout.write("single stdout\n")
+            sys.stderr.write("single stderr\n")
+            yield MagicMock(results={"text": "ok"})
+
+        mock_graph = MagicMock()
+        mock_graph.context = {}
+        mock_graph.async_start = mock_async_start
+
+        process_stdout = StringIO()
+        process_stderr = StringIO()
+        with patch.object(sys, "stdout", process_stdout), patch.object(sys, "stderr", process_stderr):
+            _, logs = await execute_graph_with_capture(mock_graph, "test input")
+            sys.stdout.write("outside stdout\n")
+            sys.stderr.write("outside stderr\n")
+
+        assert logs == "single stdout\nsingle stderr\n"
+        assert process_stdout.getvalue() == "outside stdout\n"
+        assert process_stderr.getvalue() == "outside stderr\n"
 
     @pytest.mark.asyncio
     async def test_execute_graph_with_capture_success(self):


### PR DESCRIPTION
## Summary
- route lfx serve stdout and stderr through ContextVar-backed stream proxies
- keep graph requests concurrent while isolating each request's returned logs
- add a deterministic interleaving regression and single-request compatibility coverage

## Security impact
Addresses LE-1540. Concurrent lfx serve requests can no longer overwrite process-global capture targets or receive another request's component output.

## Testing
- full lfx unit suite: 4,802 passed, 27 skipped, 6 xfailed
- owning CLI modules: 125 passed
- full lfx Ruff check
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent graph execution so each request receives only its own captured standard output and error logs.
  * Prevented output written after execution completes from being incorrectly included in captured logs.
* **Tests**
  * Added regression coverage for concurrent log isolation and post-execution output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->