### PR TITLE
fix(security): default access token cookie to HttpOnly

### DIFF
--- a/docs/docs/Develop/api-keys-and-authentication.mdx
+++ b/docs/docs/Develop/api-keys-and-authentication.mdx
@@ -498,7 +498,7 @@ For a multi-tenant deployment served over HTTPS, harden the access-token cookie.
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
 | `LANGFLOW_ACCESS_SECURE` | Boolean | `False` | When `true`, the `access_token_lf` cookie is sent only over HTTPS. Recommended `true` for any HTTPS deployment. Leave `false` for plain-HTTP/localhost development, where a `Secure` cookie would not be sent. |
-| `LANGFLOW_ACCESS_HTTPONLY` | Boolean | `False` | When `true`, the `access_token_lf` cookie is not readable by JavaScript (mitigates token theft via XSS). The default is `false` because the bundled frontend currently reads this cookie in JavaScript; enabling `HttpOnly` requires a frontend that does not read the token directly. |
+| `LANGFLOW_ACCESS_HTTPONLY` | Boolean | `True` | When `true`, the `access_token_lf` cookie is not readable by JavaScript, mitigating token theft via XSS. The bundled frontend relies on browser-managed cookies and does not persist access or refresh tokens in JavaScript-readable storage. Set this to `false` only for a custom client that must read the cookie directly. |
 | `LANGFLOW_ACCESS_SAME_SITE` | String | `lax` | The `SameSite` attribute of the access-token cookie (`lax`, `strict`, or `none`). |
 
 The refresh-token cookie is already `HttpOnly` + `Secure` + `SameSite` by default.

--- a/src/backend/tests/unit/test_security_cors.py
+++ b/src/backend/tests/unit/test_security_cors.py
@@ -447,6 +447,7 @@ class TestRefreshTokenSecurity:
             # Current behavior: refresh token uses 'none' (allows cross-site)
             assert auth_settings.REFRESH_SAME_SITE == "none"  # Current: allows cross-site (less secure)
             assert auth_settings.ACCESS_SAME_SITE == "lax"  # Access token is already lax (good)
+            assert auth_settings.ACCESS_HTTPONLY is True
 
             # Warn about security implications
             warnings.warn(

--- a/src/frontend/src/contexts/__tests__/authContext-login-fix.test.tsx
+++ b/src/frontend/src/contexts/__tests__/authContext-login-fix.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { ReactNode, useContext } from "react";
 
 // Mock all dependencies
@@ -41,18 +41,26 @@ jest.mock("@/utils/local-storage-util", () => ({
 const mockSetIsAuthenticated = jest.fn();
 const mockSetIsAdmin = jest.fn();
 
-const mockAuthStore = (selector: any) => {
-  const state = {
-    setIsAuthenticated: mockSetIsAuthenticated,
-    setIsAdmin: mockSetIsAdmin,
-  };
-  return selector ? selector(state) : state;
+type MockAuthState = {
+  setIsAuthenticated: typeof mockSetIsAuthenticated;
+  setIsAdmin: typeof mockSetIsAdmin;
 };
 
-(mockAuthStore as any).getState = () => ({
+const getMockAuthState = (): MockAuthState => ({
   setIsAuthenticated: mockSetIsAuthenticated,
   setIsAdmin: mockSetIsAdmin,
 });
+
+const mockAuthStore = Object.assign(
+  <T,>(selector: (state: MockAuthState) => T): T => {
+    const state = {
+      setIsAuthenticated: mockSetIsAuthenticated,
+      setIsAdmin: mockSetIsAdmin,
+    };
+    return selector(state);
+  },
+  { getState: getMockAuthState },
+);
 
 jest.mock("@/stores/authStore", () => ({
   __esModule: true,
@@ -62,8 +70,13 @@ jest.mock("@/stores/authStore", () => ({
 const mockCheckHasStore = jest.fn();
 const mockFetchApiData = jest.fn();
 
+type MockStoreState = {
+  checkHasStore: typeof mockCheckHasStore;
+  fetchApiData: typeof mockFetchApiData;
+};
+
 jest.mock("@/stores/storeStore", () => ({
-  useStoreStore: (selector: any) => {
+  useStoreStore: <T,>(selector: (state: MockStoreState) => T): T => {
     const state = {
       checkHasStore: mockCheckHasStore,
       fetchApiData: mockFetchApiData,
@@ -148,12 +161,6 @@ describe("AuthContext - Login Fix for Race Condition", () => {
       mockCookiesInstance.get.mockImplementation((name) => {
         if (name === "access_token_lf") return accessToken;
         return null;
-      });
-
-      // Track when setIsAuthenticated is called
-      let authSetCallCount = 0;
-      mockSetIsAuthenticated.mockImplementation(() => {
-        authSetCallCount++;
       });
 
       // Start login
@@ -299,8 +306,14 @@ describe("AuthContext - Login Fix for Race Condition", () => {
         result.current.login(accessToken, "login", refreshToken);
       });
 
-      // Verify cookies were set BEFORE mutations started
-      expect(mockCookiesInstance.set).toHaveBeenCalledTimes(3); // access, auto_login, refresh
+      // Only the non-sensitive UI preference is written by JavaScript. The
+      // server owns both token cookies so they retain HttpOnly.
+      expect(mockCookiesInstance.set).toHaveBeenCalledTimes(1);
+      expect(mockCookiesInstance.set).toHaveBeenCalledWith(
+        "auto_login_lf",
+        "login",
+        expect.any(Object),
+      );
 
       // Advance timers to trigger the verifyAndProceed function
       act(() => {
@@ -364,7 +377,7 @@ describe("AuthContext - Login Fix for Race Condition", () => {
   });
 
   describe("Cookie Synchronization", () => {
-    it("should set all auth cookies during login", () => {
+    it("should leave token cookies server-owned during login", () => {
       const { result } = renderHook(() => useTestContext(), { wrapper });
 
       const accessToken = "access_token_123";
@@ -374,37 +387,30 @@ describe("AuthContext - Login Fix for Race Condition", () => {
         result.current.login(accessToken, "login", refreshToken);
       });
 
-      // Verify all cookies were set (with options parameter)
-      expect(mockCookiesInstance.set).toHaveBeenCalledWith(
-        "access_token_lf",
-        accessToken,
-        expect.any(Object),
-      );
       expect(mockCookiesInstance.set).toHaveBeenCalledWith(
         "auto_login_lf",
         "login",
         expect.any(Object),
       );
-      expect(mockCookiesInstance.set).toHaveBeenCalledWith(
-        "refresh_token_lf",
-        refreshToken,
-        expect.any(Object),
+      const setCallArgs = mockCookiesInstance.set.mock.calls.map(
+        (call) => call[0],
       );
+      expect(setCallArgs).not.toContain("access_token_lf");
+      expect(setCallArgs).not.toContain("refresh_token_lf");
     });
 
-    it("should not set refresh token cookie if not provided", () => {
+    it("should leave token cookies server-owned when refresh token is omitted", () => {
       const { result } = renderHook(() => useTestContext(), { wrapper });
 
       act(() => {
         result.current.login("access_token_123", "login");
       });
 
-      // Should only set access_token and auto_login cookies
       const setCallArgs = mockCookiesInstance.set.mock.calls.map(
         (call) => call[0],
       );
 
-      expect(setCallArgs).toContain("access_token_lf");
+      expect(setCallArgs).not.toContain("access_token_lf");
       expect(setCallArgs).toContain("auto_login_lf");
       expect(setCallArgs).not.toContain("refresh_token_lf");
     });
@@ -437,8 +443,8 @@ describe("AuthContext - Login Fix for Race Condition", () => {
         result.current.login(accessToken, "login", refreshToken);
       });
 
-      // Verify cookies set
-      expect(mockCookiesInstance.set).toHaveBeenCalledTimes(3);
+      // Only the auto-login UI preference is written by JavaScript.
+      expect(mockCookiesInstance.set).toHaveBeenCalledTimes(1);
 
       // Verify isAuthenticated NOT set yet
       expect(mockSetIsAuthenticated).not.toHaveBeenCalled();

--- a/src/frontend/src/contexts/authContext.tsx
+++ b/src/frontend/src/contexts/authContext.tsx
@@ -1,6 +1,5 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useState } from "react";
 import {
-  LANGFLOW_ACCESS_TOKEN,
   LANGFLOW_API_TOKEN,
   LANGFLOW_AUTO_LOGIN_OPTION,
   LANGFLOW_REFRESH_TOKEN,
@@ -9,7 +8,6 @@ import { useGetUserData } from "@/controllers/API/queries/auth";
 import { useGetGlobalVariablesMutation } from "@/controllers/API/queries/variables/use-get-mutation-global-variables";
 import useAuthStore from "@/stores/authStore";
 import { cookieManager } from "@/utils/cookie-manager";
-import { setLocalStorage } from "@/utils/local-storage-util";
 import { useStoreStore } from "../stores/storeStore";
 import type { Users } from "../types/api";
 import type { AuthContextType } from "../types/contexts/auth";
@@ -67,15 +65,11 @@ export function AuthProvider({ children }): React.ReactElement {
   function login(
     newAccessToken: string,
     autoLogin: string,
-    refreshToken?: string,
+    _refreshToken?: string,
   ) {
-    cookieManager.set(LANGFLOW_ACCESS_TOKEN, newAccessToken);
+    // The server owns both token cookies so their HttpOnly attributes cannot
+    // be downgraded by a JavaScript-written cookie with the same name.
     cookieManager.set(LANGFLOW_AUTO_LOGIN_OPTION, autoLogin);
-    setLocalStorage(LANGFLOW_ACCESS_TOKEN, newAccessToken);
-
-    if (refreshToken) {
-      cookieManager.set(LANGFLOW_REFRESH_TOKEN, refreshToken);
-    }
     setAccessToken(newAccessToken);
 
     let userLoaded = false;
@@ -130,7 +124,6 @@ export function AuthProvider({ children }): React.ReactElement {
 
   function clearAuthSession() {
     cookieManager.clearAuthCookies();
-    localStorage.removeItem(LANGFLOW_ACCESS_TOKEN);
     localStorage.removeItem(LANGFLOW_API_TOKEN);
     localStorage.removeItem(LANGFLOW_REFRESH_TOKEN);
     setAccessToken(null);

--- a/src/frontend/src/controllers/API/queries/auth/__tests__/use-post-refresh-access.test.ts
+++ b/src/frontend/src/controllers/API/queries/auth/__tests__/use-post-refresh-access.test.ts
@@ -49,7 +49,7 @@ describe("refresh token functionality", () => {
   });
 
   describe("successful token refresh", () => {
-    it("should call refresh API and set new refresh token cookie", async () => {
+    it("should call refresh API without replacing the server's HttpOnly cookies", async () => {
       const mockRefreshResponse = {
         access_token: "new-access-token",
         refresh_token: "new-refresh-token",
@@ -64,10 +64,7 @@ describe("refresh token functionality", () => {
       expect(mockApiPost).toHaveBeenCalledWith(
         expect.stringContaining("refresh"),
       );
-      expect(mockCookieManagerSet).toHaveBeenCalledWith(
-        "refresh_token_lf",
-        "new-refresh-token",
-      );
+      expect(mockCookieManagerSet).not.toHaveBeenCalled();
       expect(result).toEqual(mockRefreshResponse);
     });
 
@@ -113,7 +110,7 @@ describe("refresh token functionality", () => {
   });
 
   describe("cookie management", () => {
-    it("should use cookieManager for setting refresh token", async () => {
+    it("should leave the refresh cookie server-owned", async () => {
       const mockRefreshResponse = {
         access_token: "access-token",
         refresh_token: "refresh-token-xyz",
@@ -125,14 +122,10 @@ describe("refresh token functionality", () => {
       const refreshMutation = useRefreshAccessToken();
       await refreshMutation.mutate();
 
-      expect(mockCookieManagerSet).toHaveBeenCalledTimes(1);
-      expect(mockCookieManagerSet).toHaveBeenCalledWith(
-        "refresh_token_lf",
-        "refresh-token-xyz",
-      );
+      expect(mockCookieManagerSet).not.toHaveBeenCalled();
     });
 
-    it("should set refresh token cookie before returning response", async () => {
+    it("should return the response without writing token cookies", async () => {
       const mockRefreshResponse = {
         access_token: "access-token",
         refresh_token: "refresh-token-abc",
@@ -144,11 +137,7 @@ describe("refresh token functionality", () => {
       const refreshMutation = useRefreshAccessToken();
       const response = await refreshMutation.mutate();
 
-      // Verify cookie was set before response was returned
-      expect(mockCookieManagerSet).toHaveBeenCalledWith(
-        "refresh_token_lf",
-        "refresh-token-abc",
-      );
+      expect(mockCookieManagerSet).not.toHaveBeenCalled();
       expect(response).toEqual(mockRefreshResponse);
     });
   });

--- a/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
@@ -1,7 +1,6 @@
-import { IS_AUTO_LOGIN, LANGFLOW_REFRESH_TOKEN } from "@/constants/constants";
+import { IS_AUTO_LOGIN } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
 import type { useMutationFunctionType } from "@/types/api";
-import { cookieManager } from "@/utils/cookie-manager";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -22,8 +21,6 @@ export const useRefreshAccessToken: useMutationFunctionType<
 
   async function refreshAccess(): Promise<IRefreshAccessToken> {
     const res = await api.post<IRefreshAccessToken>(`${getURL("REFRESH")}`);
-    cookieManager.set(LANGFLOW_REFRESH_TOKEN, res.data.refresh_token);
-
     return res.data;
   }
 

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -121,7 +121,7 @@ class AuthSettings(BaseSettings):
     """The SameSite attribute of the access token cookie."""
     ACCESS_SECURE: bool = False
     """The Secure attribute of the access token cookie."""
-    ACCESS_HTTPONLY: bool = False
+    ACCESS_HTTPONLY: bool = True
     """The HttpOnly attribute of the access token cookie."""
 
     COOKIE_DOMAIN: str | None = None


### PR DESCRIPTION
## Summary

- default the access_token_lf cookie to HttpOnly
- stop the bundled frontend from rewriting access and refresh cookies in JavaScript
- stop persisting the access token in localStorage
- document the secure default and retain LANGFLOW_ACCESS_HTTPONLY=false as a custom-client escape hatch

## Security impact

The release branch set the access cookie without HttpOnly and then duplicated both token cookies from JavaScript. Any SPA XSS could therefore read and exfiltrate the bearer token, while the client-side writes could also downgrade the server's HttpOnly refresh cookie. The browser already sends these cookies with credentials and the request layer does not require JavaScript token reads.

## Compatibility

Plain-HTTP localhost continues to work because this does not change the Secure attribute. API clients still receive the existing token response body. Custom frontends that intentionally read the access cookie can opt out with LANGFLOW_ACCESS_HTTPONLY=false.

## Validation

- 16 focused frontend auth tests passed
- backend secure-default regression passed against the release worktree
- Ruff check and format passed
- Biome checks passed
- full repository commit hooks, including detect-secrets, passed

Jira: LE-1539