### PR TITLE
fix(security): close remaining indirect code bypasses (1.10.3)

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -5,6 +5,7 @@ Never executes the code. Called AFTER code extraction, BEFORE returning to user.
 """
 
 import ast
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 # Dangerous function calls that should never appear in component code
@@ -358,6 +359,20 @@ class _SecurityChecker(ast.NodeVisitor):
         if violation := self._opaque_reference_violation(node):
             self.violations.append(violation)
 
+    def visit_Return(self, node: ast.Return):
+        if node.value is not None:
+            self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
+    def visit_Yield(self, node: ast.Yield):
+        if node.value is not None:
+            self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom):
+        self._check_opaque_reference(node.value)
+        self.generic_visit(node)
+
     def _bind_name(self, name: str, values: frozenset[str]) -> None:
         if values:
             self.module_aliases[name] = values
@@ -366,13 +381,15 @@ class _SecurityChecker(ast.NodeVisitor):
             self.module_aliases.pop(name, None)
             self.shadowed_aliases.add(name)
 
-    def _bind_assignment_target(self, target: ast.AST, value: ast.AST) -> None:
-        """Apply assignment aliasing, including matching tuple/list unpacking."""
-        if isinstance(target, ast.Name):
-            self._bind_name(target.id, self._resolved_assignment_value(value))
-        elif isinstance(target, ast.Starred):
-            self._bind_assignment_target(target.value, value)
-        elif isinstance(target, (ast.Tuple, ast.List)):
+    def _iter_assignment_leaves(self, target: ast.AST, value: ast.AST) -> Iterator[tuple[ast.AST, ast.AST]]:
+        """Pair assignment target leaves with the values bound to them."""
+        if isinstance(target, (ast.Name, ast.Attribute, ast.Subscript)):
+            yield target, value
+            return
+        if isinstance(target, ast.Starred):
+            yield from self._iter_assignment_leaves(target.value, value)
+            return
+        if isinstance(target, (ast.Tuple, ast.List)):
             if isinstance(value, (ast.Tuple, ast.List)):
                 starred_index = next(
                     (
@@ -384,31 +401,44 @@ class _SecurityChecker(ast.NodeVisitor):
                 )
                 if starred_index is None and len(target.elts) == len(value.elts):
                     for target_element, value_element in zip(target.elts, value.elts, strict=True):
-                        self._bind_assignment_target(target_element, value_element)
+                        yield from self._iter_assignment_leaves(target_element, value_element)
                     return
                 if starred_index is not None and len(value.elts) >= len(target.elts) - 1:
                     for target_element, value_element in zip(
                         target.elts[:starred_index], value.elts[:starred_index], strict=True
                     ):
-                        self._bind_assignment_target(target_element, value_element)
+                        yield from self._iter_assignment_leaves(target_element, value_element)
 
                     trailing_count = len(target.elts) - starred_index - 1
                     if trailing_count:
                         for target_element, value_element in zip(
                             target.elts[-trailing_count:], value.elts[-trailing_count:], strict=True
                         ):
-                            self._bind_assignment_target(target_element, value_element)
+                            yield from self._iter_assignment_leaves(target_element, value_element)
 
                     remaining_end = len(value.elts) - trailing_count if trailing_count else len(value.elts)
                     remaining_values = ast.List(
                         elts=value.elts[starred_index:remaining_end],
                         ctx=ast.Load(),
                     )
-                    self._bind_assignment_target(target.elts[starred_index], remaining_values)
+                    yield from self._iter_assignment_leaves(target.elts[starred_index], remaining_values)
                     return
 
             for target_element in target.elts:
-                self._bind_assignment_target(target_element, value)
+                yield from self._iter_assignment_leaves(target_element, value)
+
+    def _check_assignment_value(self, target: ast.AST, value: ast.AST) -> None:
+        """Check assignment values that cannot remain visible to alias tracking."""
+        for target_leaf, value_leaf in self._iter_assignment_leaves(target, value):
+            if isinstance(target_leaf, ast.Name) and self._resolved_assignment_value(value_leaf):
+                continue
+            self._check_opaque_reference(value_leaf)
+
+    def _bind_assignment_target(self, target: ast.AST, value: ast.AST) -> None:
+        """Apply assignment aliasing, including matching tuple/list unpacking."""
+        for target_leaf, value_leaf in self._iter_assignment_leaves(target, value):
+            if isinstance(target_leaf, ast.Name):
+                self._bind_name(target_leaf.id, self._resolved_assignment_value(value_leaf))
 
     def _bind_iterated_target(self, target: ast.AST, iterable: ast.AST) -> None:
         """Bind a loop target to every statically visible iterable value."""
@@ -519,14 +549,9 @@ class _SecurityChecker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         self.visit(node.value)
-        if isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)) and any(
-            isinstance(target, ast.Name) for target in node.targets
-        ):
-            self._check_opaque_reference(node.value)
         for target in node.targets:
             self.visit(target)
-            if isinstance(target, (ast.Attribute, ast.Subscript)):
-                self._check_opaque_reference(node.value)
+            self._check_assignment_value(target, node.value)
             self._bind_assignment_target(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
@@ -534,19 +559,13 @@ class _SecurityChecker(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             self.visit(node.target)
-            if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
-                self._check_opaque_reference(node.value)
-            if isinstance(node.target, (ast.Attribute, ast.Subscript)):
-                self._check_opaque_reference(node.value)
+            self._check_assignment_value(node.target, node.value)
             self._bind_assignment_target(node.target, node.value)
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         self.visit(node.value)
         self.visit(node.target)
-        if isinstance(node.target, ast.Name) and isinstance(node.value, (ast.List, ast.Tuple, ast.Set, ast.Dict)):
-            self._check_opaque_reference(node.value)
-        if isinstance(node.target, (ast.Attribute, ast.Subscript)):
-            self._check_opaque_reference(node.value)
+        self._check_assignment_value(node.target, node.value)
         self._bind_assignment_target(node.target, node.value)
 
     def visit_AugAssign(self, node: ast.AugAssign):
@@ -679,6 +698,7 @@ class _SecurityChecker(ast.NodeVisitor):
             self._check_opaque_reference(default)
         enclosing_state = self._snapshot_alias_state()
         self._shadow_arguments(node.args)
+        self._check_opaque_reference(node.body)
         self.visit(node.body)
         self._restore_alias_state(enclosing_state)
 

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -609,7 +609,7 @@ module = object()
 
 def bind_locally():
     module = os
-    return module
+    return None
 
 module.system('not the os module')
 """
@@ -712,6 +712,17 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "import os\ngetattr(os if True else object(), 'system')('id')",
             "import os\ndef run(module):\n    module.system('id')\nrun([module for module in (os,)][0])",
             "import os\ndef run(module):\n    module.system('id')\nrun(next(module for module in (os,)))",
+            "def expose():\n    return exec\nexpose()(\"print('unsafe')\")",
+            "import os\ndef expose():\n    return os\nexpose().system('id')",
+            "def expose():\n    yield exec\nnext(expose())(\"print('unsafe')\")",
+            "import os\ndef expose():\n    yield from (os,)\nnext(expose()).system('id')",
+            "(lambda: exec)()(\"print('unsafe')\")",
+            "import os\nmodule = os if flag else object()\nmodule.system('id')",
+            "import os\nmodule = [os][0]\nmodule.system('id')",
+            "import os\nmodule = [item for item in (os,)][0]\nmodule.system('id')",
+            "import os\n(module,) = ([os][0],)\nmodule.system('id')",
+            "import os\nif module := [os][0]:\n    module.system('id')",
+            "import os\nmodule: object = os if flag else object()\nmodule.system('id')",
         ],
         ids=[
             "function-argument",
@@ -729,6 +740,17 @@ class TestScanCodeSecurityIndirectReferenceBypass:
             "conditional-expression-in-getattr",
             "list-comprehension-as-argument",
             "generator-expression-as-argument",
+            "returned-builtin",
+            "returned-module",
+            "yielded-builtin",
+            "yielded-module",
+            "lambda-returned-builtin",
+            "conditional-assignment",
+            "subscript-assignment",
+            "comprehension-assignment",
+            "nested-unpacking-assignment",
+            "named-expression-assignment",
+            "annotated-assignment",
         ],
     )
     def test_should_detect_indirect_dangerous_reference(self, code):
@@ -776,6 +798,8 @@ class IndirectCommandComponent(Component):
             "dangerous = exec\ndangerous = print\ndangerous('safe')",
             "import os\nmodule = os\nconsume([module for module in (object(),)])",
             "import os\nconsume(getattr(os, 'path'))",
+            "import requests\ndef expose():\n    return requests\nexpose().get('https://example.com')",
+            "import os\n(module,) = (os.path,)\nmodule.join('a', 'b')",
         ],
         ids=[
             "ordinary-object-method",
@@ -788,6 +812,8 @@ class IndirectCommandComponent(Component):
             "dangerous-alias-rebound",
             "comprehension-target-shadows-restricted-module",
             "safe-getattr-result-as-argument",
+            "returned-safe-module",
+            "unpacked-safe-module-attribute",
         ],
     )
     def test_should_allow_safe_indirect_reference(self, code):


### PR DESCRIPTION
## Summary

- reject dangerous callables and restricted modules returned or yielded from generated component code
- scan unresolved assignment expressions before their targets are shadowed
- add regressions for conditional, subscript, comprehension, nested-unpacking, named-expression, and annotated assignments

Follow-up to #14121 and the confirmed CodeRabbit findings on #14125. The `getattr(os.system, "__call__")` variant does not require this backport because `release-1.10.3` already blocks it.

## Validation

- `test_code_security.py`: 173 passed
- `test_flow_run.py`: 22 passed
- Ruff check and format: passed
- pre-commit hooks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code security scanning for indirect or hidden references in returns, generators, lambdas, assignments, unpacking, comprehensions, and conditional expressions.
  * Strengthened alias tracking to prevent dangerous references from bypassing validation.
  * Corrected handling of safe local return values.

* **Tests**
  * Expanded coverage for unsafe indirect-reference patterns and verified safe references remain allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->