### PR TITLE
fix(security): rate limit public flow builds (1.10.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,8 +131,9 @@ LANGFLOW_API_KEY_SOURCE=
 LANGFLOW_API_KEY=
 
 # Rate Limiting Configuration
-# Controls rate limiting for login endpoint to prevent brute force attacks
-# LANGFLOW_RATE_LIMIT_PER_MINUTE: Number of login attempts allowed per minute per IP
+# Controls rate limiting for login and public-flow build endpoints
+# LANGFLOW_RATE_LIMIT_PER_MINUTE: Number of login attempts or builds of each public flow
+# allowed per minute per IP
 # Values: positive integer (default: 5)
 # Example: LANGFLOW_RATE_LIMIT_PER_MINUTE=10
 LANGFLOW_RATE_LIMIT_PER_MINUTE=

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -60,6 +60,7 @@ from langflow.services.deps import (
     session_scope,
 )
 from langflow.services.job_queue.service import JobQueueNotFoundError, JobQueueService
+from langflow.services.rate_limit import check_rate_limit
 from langflow.services.telemetry.schema import ComponentPayload, PlaygroundPayload
 
 if TYPE_CHECKING:
@@ -808,6 +809,8 @@ async def build_public_tmp(
     Returns:
         Dict with job_id that can be used to poll for build status
     """
+    check_rate_limit(request, scope=f"public-build:{flow_id}")
+
     try:
         # Reject caller-supplied file references that aren't scoped to this
         # public flow's own storage namespace. Done before any flow lookup so

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -4,10 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
-from limits import parse
 from pydantic import BaseModel
-from slowapi.errors import RateLimitExceeded
-from slowapi.wrappers import Limit
 
 from langflow.api.utils import DbSession
 from langflow.api.v1.schemas import Token
@@ -16,7 +13,7 @@ from langflow.services.auth.exceptions import AuthenticationError
 from langflow.services.database.models.user.crud import get_user_by_id
 from langflow.services.database.models.user.model import UserRead
 from langflow.services.deps import get_auth_service, get_settings_service, get_variable_service
-from langflow.services.rate_limit import get_rate_limit_string
+from langflow.services.rate_limit import check_rate_limit
 
 router = APIRouter(tags=["Login"])
 
@@ -24,35 +21,6 @@ router = APIRouter(tags=["Login"])
 def get_limiter_from_app(request: Request):
     """Get the rate limiter from app state (initialized after settings load)."""
     return request.app.state.limiter
-
-
-def check_rate_limit(request: Request) -> None:
-    """Check and enforce rate limit for the request.
-
-    Retrieves the limiter from app.state (initialized after settings load in main.py)
-    and manually checks the rate limit using the limits library.
-
-    Raises:
-        RateLimitExceeded: If the rate limit is exceeded
-    """
-    limiter = get_limiter_from_app(request)
-
-    # Parse the rate limit string and check if limit is exceeded
-    limit_item = parse(get_rate_limit_string())
-    if not limiter._limiter.hit(limit_item, limiter._key_func(request)):  # noqa: SLF001
-        # Limit exceeded - raise RateLimitExceeded with proper wrapper
-        limit_wrapper = Limit(
-            limit=limit_item,
-            key_func=limiter._key_func,  # noqa: SLF001
-            scope=None,
-            per_method=False,
-            methods=None,
-            error_message=None,
-            exempt_when=None,
-            cost=1,
-            override_defaults=False,
-        )
-        raise RateLimitExceeded(limit_wrapper)
 
 
 class SessionResponse(BaseModel):

--- a/src/backend/base/langflow/services/rate_limit/__init__.py
+++ b/src/backend/base/langflow/services/rate_limit/__init__.py
@@ -7,6 +7,11 @@ key-based rate limiting with configurable storage backends.
 
 from __future__ import annotations
 
-from langflow.services.rate_limit.service import get_limiter_key, get_rate_limit_string, get_rate_limiter
+from langflow.services.rate_limit.service import (
+    check_rate_limit,
+    get_limiter_key,
+    get_rate_limit_string,
+    get_rate_limiter,
+)
 
-__all__ = ["get_limiter_key", "get_rate_limit_string", "get_rate_limiter"]
+__all__ = ["check_rate_limit", "get_limiter_key", "get_rate_limit_string", "get_rate_limiter"]

--- a/src/backend/base/langflow/services/rate_limit/service.py
+++ b/src/backend/base/langflow/services/rate_limit/service.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from limits import parse
 from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+from slowapi.wrappers import Limit
 
 from langflow.services.deps import get_settings_service
 
@@ -57,6 +60,40 @@ def get_rate_limiter() -> Limiter:
         )
 
     return _limiter
+
+
+def check_rate_limit(request: Request, *, scope: str | None = None) -> None:
+    """Enforce the configured rate limit for a request.
+
+    A scope creates a distinct counter namespace while retaining the configured
+    client-IP key. This lets public flows have independent build counters without
+    consuming the login-attempt counter for the same client.
+
+    Args:
+        request: FastAPI request whose app owns the configured limiter.
+        scope: Optional counter namespace, such as a public flow identifier.
+
+    Raises:
+        RateLimitExceeded: If the configured limit has been exceeded.
+    """
+    limiter = request.app.state.limiter
+    limit_item = parse(get_rate_limit_string())
+    client_key = limiter._key_func(request)  # noqa: SLF001
+    identifiers = (scope, client_key) if scope is not None else (client_key,)
+
+    if not limiter._limiter.hit(limit_item, *identifiers):  # noqa: SLF001
+        limit_wrapper = Limit(
+            limit=limit_item,
+            key_func=limiter._key_func,  # noqa: SLF001
+            scope=scope,
+            per_method=False,
+            methods=None,
+            error_message=None,
+            exempt_when=None,
+            cost=1,
+            override_defaults=False,
+        )
+        raise RateLimitExceeded(limit_wrapper)
 
 
 def get_client_ip(request: Request) -> str:

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -564,6 +564,56 @@ async def test_build_public_tmp_ignores_data_parameter(client, json_memory_chatb
 
 @pytest.mark.benchmark
 @pytest.mark.security
+async def test_build_public_tmp_rate_limits_each_client_and_flow(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """Anonymous builds are bounded without sharing counters across public flows."""
+
+    async def create_public_flow():
+        flow_data = json.loads(json_memory_chatbot_no_llm)
+        flow_data["id"] = str(uuid.uuid4())
+        flow_id = await create_flow(client, json.dumps(flow_data), logged_in_headers)
+        response = await client.patch(
+            f"api/v1/flows/{flow_id}",
+            json={"access_type": "PUBLIC"},
+            headers=logged_in_headers,
+        )
+        assert response.status_code == codes.OK
+        return flow_id
+
+    first_flow_id = await create_public_flow()
+    second_flow_id = await create_public_flow()
+    started_source_flow_ids = []
+
+    async def fake_start_flow_build(**kwargs):
+        started_source_flow_ids.append(kwargs["source_flow_id"])
+        return str(uuid.uuid4())
+
+    monkeypatch.setattr("langflow.api.v1.chat.start_flow_build", fake_start_flow_build)
+    monkeypatch.setattr("langflow.services.rate_limit.service.get_rate_limit_string", lambda: "2/minute")
+
+    client.cookies.clear()
+    client.cookies.set("client_id", "test-public-build-rate-limit-client")
+    request_kwargs = {
+        "json": {"inputs": {"session": "test_session"}},
+        "headers": {"Content-Type": "application/json"},
+    }
+
+    for _ in range(2):
+        response = await client.post(f"api/v1/build_public_tmp/{first_flow_id}/flow", **request_kwargs)
+        assert response.status_code == codes.OK
+
+    limited_response = await client.post(f"api/v1/build_public_tmp/{first_flow_id}/flow", **request_kwargs)
+    assert limited_response.status_code == codes.TOO_MANY_REQUESTS
+    assert limited_response.headers["Retry-After"] == "60"
+
+    other_flow_response = await client.post(f"api/v1/build_public_tmp/{second_flow_id}/flow", **request_kwargs)
+    assert other_flow_response.status_code == codes.OK
+    assert started_source_flow_ids == [first_flow_id, first_flow_id, second_flow_id]
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
 @pytest.mark.parametrize(
     "malicious_files",
     [

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -131,9 +131,9 @@ class SecuritySettings(BaseModel):
 
     # Rate Limiting
     rate_limit_enabled: bool = True
-    """Enable rate limiting for login endpoint. Set to False to disable (useful for testing)."""
+    """Enable rate limiting for login and public-flow build endpoints. Set to False to disable."""
     rate_limit_per_minute: int = 5
-    """Number of login attempts allowed per minute per IP."""
+    """Number of login attempts or builds of each public flow allowed per minute per IP."""
     rate_limit_storage_uri: str = "memory://"
     """Storage backend for rate limiting. Use 'memory://' for single-server or 'redis://host:port' for multi-server."""
     rate_limit_trust_proxy: bool = False


### PR DESCRIPTION
## Summary

- enforce the existing configurable IP rate limit before anonymous public-flow build work begins
- keep counters independent for each public flow and separate from login attempts
- document that the shared rate-limit settings also protect public-flow builds

## Security impact

Anonymous callers could repeatedly execute a public flow with the owners provider credentials, allowing unbounded cost amplification. Requests are now limited per public flow and client IP before database access, validation, or execution.

## Testing

- pre-fix regression: third same-flow request returned 200 instead of 429
- post-fix public-build tests: 24 passed
- login rate-limit tests: 14 passed
- Ruff check and format
- pre-commit hooks

Refs LE-1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to public-flow build requests, scoped per IP address and flow.
  * Requests exceeding the configured limit now receive a “Too Many Requests” response with retry guidance.

* **Documentation**
  * Updated rate-limit configuration descriptions to cover both login attempts and public-flow builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->