### PR TITLE
feat(models): add pluggable provider policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2253,7 +2253,7 @@
         "filename": "src/backend/tests/unit/services/variable/test_service.py",
         "hashed_secret": "30abc0a833efea23496b4d226fffa2f90c0855c0",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 48,
         "is_secret": false
       }
     ],
@@ -2451,7 +2451,7 @@
         "filename": "src/backend/tests/unit/test_unified_models.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 527,
+        "line_number": 549,
         "is_secret": false
       }
     ],
@@ -6637,7 +6637,7 @@
         "filename": "src/lfx/src/lfx/base/models/unified_models/model_catalog.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 498,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-16T15:57:06Z"
+  "generated_at": "2026-07-16T21:26:55Z"
 }

--- a/BUNDLE_API.md
+++ b/BUNDLE_API.md
@@ -493,6 +493,18 @@ the deserialize half is covered by
   provider-only extension with `DiscoveredExtension.bundle_name = None`, and
   `registry.Extension.bundle_name` is likewise now `str | None` (the
   `lfx extension list` BUNDLE column shows `—` for such extensions).
+- **Provider identity and static catalogs (additive).**  A `providers[]` entry
+  may now declare a stable lowercase `provider_id`, an independent
+  `display_name`, legacy `aliases`, and a dotted-path `catalog_loader`.  The
+  loader must return a flat list of model metadata rows; Langflow validates
+  model identities and stamps provider ownership before merging those rows
+  into the unified catalog.  Manifests that omit `provider_id` retain their
+  existing behavior through a deterministic ID derived from `name`.
+  `ProviderDescriptor` is the preferred public registry type and
+  `ProviderSpec` remains an alias for source compatibility.  The registry also
+  exposes an immutable generation-tagged snapshot plus an eager catalog
+  validation hook for deployment readiness.  Existing provider manifests are
+  unaffected and `BUNDLE_API_VERSION` remains `1`.
 - **New typed error codes (additive): `provider-invalid`, `provider-skipped`.**
   A malformed provider spec surfaces `provider-invalid`; a provider whose name
   collides with a built-in or already-loaded provider surfaces

--- a/docs/docs/Lfx/extensions-manifest.mdx
+++ b/docs/docs/Lfx/extensions-manifest.mdx
@@ -37,11 +37,14 @@ Use the `$schema` reference in your manifest so editors can autocomplete and val
 | `name` | string | yes | Human-readable display name shown in the Langflow palette. 1-200 chars. |
 | `description` | string \| null | no | Optional one-paragraph summary, max 2000 chars. |
 | `lfx` | object | yes | [Compatibility declaration](#lfx-compatibility-declaration) against the BUNDLE_API contract. |
-| `bundles` | array | yes | [Bundle list](#bundles). v0 accepts **exactly one** bundle. |
+| `bundles` | array | no | [Bundle list](#bundles). v0 accepts at most one bundle; omit it for a provider-only extension. |
+| `providers` | array | no | [Model providers](#providers) contributed to the unified model-provider registry. |
 | `capabilities` | object | no | [Optional capability flags](#capabilities). Defaults to all-false. |
 | `$schema` | string | no | Optional pointer to this JSON Schema; editors use it for autocomplete. |
 
 `additionalProperties: false` — any field not listed here is rejected with a typed error. Reserved names (`services`, `routes`, `hooks`, `starterProjects`, `userConfig`) are documented under [Deferred fields](#deferred-fields) and surface a more specific error code.
+
+An extension must declare at least one entry in either `bundles` or `providers`. It can declare both when one package contributes components and model providers.
 
 ## `lfx`: compatibility declaration
 
@@ -68,7 +71,66 @@ The runtime compares `str(BUNDLE_API_VERSION)` against this list. A mismatch fai
 | `name` | string | Bundle name; addressable as `ext:<bundle>:<Class>@<slot>`. Lowercase snake_case, starts with a letter, 2-64 chars. |
 | `path` | string | Path to the bundle directory, relative to the manifest. Must not start with `/` or contain `..`. |
 
-v0 enforces `minItems: 1, maxItems: 1`; multi-bundle extensions are rejected with `multi-bundle-deferred-in-this-milestone` and ship in a later epic.
+v0 enforces `maxItems: 1`; multi-bundle extensions are rejected with `multi-bundle-deferred-in-this-milestone` and ship in a later epic. The list can be empty when the extension declares at least one model provider.
+
+## `providers`
+
+A provider-only extension can add a provider without adding a component bundle:
+
+```json
+{
+  "$schema": "https://schemas.langflow.org/extension/v1.json",
+  "id": "lfx-acme-models",
+  "version": "0.1.0",
+  "name": "Acme Models",
+  "lfx": { "compat": ["1"] },
+  "providers": [
+    {
+      "name": "Acme",
+      "provider_id": "acme.models",
+      "display_name": "Acme Models",
+      "aliases": ["Acme Legacy"],
+      "metadata": {
+        "icon": "Bot",
+        "variables": [],
+        "mapping": {
+          "model_class": "ChatAcme",
+          "model_param": "model"
+        }
+      },
+      "api_key_required": false,
+      "model_class": {
+        "module": "langchain_acme",
+        "attr": "ChatAcme",
+        "install_hint": "langchain-acme"
+      },
+      "catalog_loader": "lfx_acme.catalog:load_models"
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | yes | Canonical provider name used by existing saved flows and provider selectors. |
+| `provider_id` | string | no | Stable lowercase machine identity used by policy and extension compatibility. Must match `^[a-z0-9][a-z0-9._-]*$`. Legacy manifests can omit it and receive a deterministic ID derived from `name`. |
+| `display_name` | string | no | User-facing label. It can change without changing `provider_id` or saved-flow identity. |
+| `aliases` | array of strings | no | Unique legacy names accepted when resolving the provider's stable identity. |
+| `metadata` | object | yes | Provider icon, variables, API documentation URL, and mapping. `mapping.model_class` must be non-empty. |
+| `model_class` | object | no | Lazy LLM class import with `module`, `attr`, and optional `install_hint`. Omit it when reusing an already-registered class. |
+| `embedding` | object | no | Optional embedding class import and parameter mapping. Includes `class_name`, `module`, `attr`, `param_mapping_key`, `param_mapping`, and optional `install_hint`. |
+| `api_key_required` | bool | no | Whether unified runtime helpers reject missing API-key credentials. Defaults to `true`. |
+| `live` | bool | no | Enables always-on live model discovery. Mutually exclusive with `conditional_live`. |
+| `conditional_live` | bool | no | Enables live discovery only when the provider has a custom endpoint configured. Mutually exclusive with `live`. |
+| `live_discovery` | string | no | Lazy `module:callable` that receives `(user_id, model_type)` and returns live model rows. |
+| `validator` | string | no | Lazy `module:callable` that validates `(provider, variables, model)` and raises on invalid credentials. |
+| `catalog_loader` | string | no | Lazy `module:callable` returning the provider's static model metadata rows. |
+
+`catalog_loader` must return a flat `list[dict]`. Every row requires a non-empty `name`; `model_type` can be `llm` or `embeddings` and defaults to `llm`. Langflow overwrites any supplied `provider` value with the descriptor's canonical `name`, supplies the provider icon when omitted, and rejects duplicate `(model_type, name)` identities. Deployments that require an extension catalog can call `validate_registered_provider_catalogs()` or `get_registry_snapshot(validate_catalogs=True)` during readiness.
+
+Providers that use ambient authentication or need no credentials should set `api_key_required` to `false`. They remain eligible for unified model options when `metadata.variables` is empty or contains only optional configuration fields.
+
+Built-in providers take precedence over extension declarations. A colliding provider is skipped without preventing other providers or components in the extension from loading.
 
 ## `capabilities`
 
@@ -127,6 +189,8 @@ The loader and validator both emit typed errors keyed by the manifest field that
 | `multi-bundle-deferred-in-this-milestone` | `bundles` has more than one entry. |
 | `path-escape` | A `bundles[].path` resolves outside the manifest root (typically a symlink). |
 | `bundle-path-not-found` | `bundles[].path` does not exist or is not a directory. |
+| `provider-invalid` | A provider descriptor or one of its lazy import paths is malformed. The invalid provider is skipped. |
+| `provider-skipped` | A provider name collides with a built-in or previously loaded provider. The existing provider wins. |
 
 Run `lfx extension validate <path>` to see every error as a structured object with `code`, `message`, `location`, `hint`, and `ref_url`.
 

--- a/src/backend/base/langflow/agentic/api/router.py
+++ b/src/backend/base/langflow/agentic/api/router.py
@@ -10,10 +10,11 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from lfx.base.models.provider_registry import is_api_key_optional
 from lfx.base.models.unified_models import (
     get_all_variables_for_provider,
-    get_model_provider_variable_mapping,
     get_provider_required_variable_keys,
+    get_provider_secret_variable_key,
     get_unified_models_detailed,
 )
 from lfx.log.logger import logger
@@ -47,7 +48,7 @@ class _AssistantContext:
 
     provider: str
     model_name: str
-    api_key_name: str
+    api_key_name: str | None
     session_id: str
     global_vars: dict[str, str]
     max_retries: int
@@ -63,7 +64,6 @@ async def _resolve_assistant_context(
     Raises:
         HTTPException: If provider is not configured or API key is missing.
     """
-    provider_variable_map = get_model_provider_variable_mapping()
     enabled_providers, _ = await get_enabled_providers_for_user(user_id, session)
 
     if not enabled_providers:
@@ -87,8 +87,8 @@ async def _resolve_assistant_context(
             detail=f"Provider '{provider}' is not configured. Available providers: {enabled_providers}",
         )
 
-    api_key_name = provider_variable_map.get(provider)
-    if not api_key_name:
+    api_key_name = get_provider_secret_variable_key(provider)
+    if not api_key_name and not is_api_key_optional(provider):
         raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
 
     model_name = request.model_name or get_default_model(provider, user_id=user_id) or ""

--- a/src/backend/base/langflow/agentic/services/provider_service.py
+++ b/src/backend/base/langflow/agentic/services/provider_service.py
@@ -6,12 +6,15 @@ from uuid import UUID
 
 from lfx.base.models.model_metadata import CONDITIONAL_LIVE_MODEL_PROVIDERS, LIVE_MODEL_PROVIDERS
 from lfx.base.models.model_utils import get_live_models_for_provider
+from lfx.base.models.provider_registry import is_api_key_optional
 from lfx.base.models.unified_models import (
     get_model_provider_variable_mapping,
+    get_model_providers,
     get_provider_required_variable_keys,
     get_unified_models_detailed,
 )
 from lfx.log.logger import logger
+from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
 from lfx.utils.secrets import secret_value_to_str
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -61,15 +64,36 @@ async def get_enabled_providers_for_user(
     all_variable_names = {var.name for var in all_variables}
 
     provider_variable_map = get_model_provider_variable_mapping()
+    registered_providers = get_model_providers()
+    provider_candidates = [
+        *provider_variable_map,
+        *(
+            provider
+            for provider in registered_providers
+            if provider not in provider_variable_map and is_api_key_optional(provider)
+        ),
+    ]
+    provider_policy = resolve_model_provider_policy(
+        user_id=user_id,
+        providers=[*registered_providers, *provider_candidates],
+        purpose=ModelProviderPolicyPurpose.USE,
+    )
 
     enabled_providers = []
     provider_status = {}
 
-    for provider in provider_variable_map:
+    for provider in provider_candidates:
+        if not provider_policy.allows(provider):
+            continue
         # Check if ALL required variables for this provider are present
         # in either database variables or environment variables
         required_keys = get_provider_required_variable_keys(provider)
-        is_enabled = all(key in all_variable_names or os.getenv(key) for key in required_keys)
+        provider_has_variables = provider in provider_variable_map
+        is_enabled = (
+            is_api_key_optional(provider)
+            if not provider_has_variables
+            else all(key in all_variable_names or os.getenv(key) for key in required_keys)
+        )
 
         provider_status[provider] = is_enabled
         if is_enabled:

--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -22,8 +22,14 @@ from lfx.base.knowledge_bases.ingestion_sources import (
     get_source_class,
     registered_sources,
 )
+from lfx.base.models.provider_registry import provider_id_for
 from lfx.base.vectorstores.chroma_security import chroma_client_create_collection_kwargs
 from lfx.log import logger
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyError,
+    ModelProviderPolicyPurpose,
+    require_model_provider,
+)
 from pydantic import BaseModel, Field
 
 from langflow.api.utils import CurrentActiveUser, ingestion_run_service, knowledge_base_service
@@ -76,6 +82,41 @@ from langflow.utils.kb_constants import (
 KB_METADATA_KEYS_VALUES_CAP = 50
 
 router = APIRouter(tags=["Knowledge Bases"], prefix="/knowledge_bases", include_in_schema=False)
+
+
+def _provider_identity(provider: str) -> str:
+    """Return a stable identity for comparison without exposing registry state."""
+    normalized = provider.strip()
+    return provider_id_for(normalized) or normalized.casefold()
+
+
+def _require_create_embedding_provider(
+    request: CreateKnowledgeBaseRequest,
+    current_user: CurrentActiveUser,
+) -> str:
+    """Validate both provider representations and enforce CONFIGURE policy."""
+    flat_provider = request.embedding_provider.strip()
+    selected_provider = None
+    if request.model_selection is not None:
+        selected_provider = knowledge_base_service.get_embedding_provider(request.model_selection)
+    if not flat_provider or (
+        selected_provider is not None
+        and (
+            selected_provider == "Unknown" or _provider_identity(flat_provider) != _provider_identity(selected_provider)
+        )
+    ):
+        raise HTTPException(status_code=404, detail="Model provider not found")
+
+    try:
+        require_model_provider(
+            user_id=current_user.id,
+            provider=flat_provider,
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
+    except ModelProviderPolicyError as exc:
+        # Treat unknown, blocked, and conflicting provider identities alike.
+        raise HTTPException(status_code=404, detail="Model provider not found") from exc
+    return flat_provider
 
 
 @dataclass(frozen=True)
@@ -709,6 +750,7 @@ async def create_knowledge_base(
 ) -> KnowledgeBaseInfo:
     """Create a new knowledge base with embedding configuration."""
     try:
+        embedding_provider = _require_create_embedding_provider(request, current_user)
         kb_root_path = KBStorageHelper.get_root_path()
         kb_user = current_user.username
         kb_name = request.name.strip().replace(" ", "_")
@@ -788,7 +830,7 @@ async def create_knowledge_base(
         backend_config_value = request.backend_config or {}
         embedding_metadata = {
             "id": str(kb_id),
-            "embedding_provider": request.embedding_provider,
+            "embedding_provider": embedding_provider,
             "embedding_model": request.embedding_model,
             "model_selection": request.model_selection,
             "created_at": datetime.now(timezone.utc).isoformat(),
@@ -827,7 +869,7 @@ async def create_knowledge_base(
             # when the request didn't carry one of its own.
             persisted_selection = request.model_selection or {
                 "name": request.embedding_model,
-                "provider": request.embedding_provider,
+                "provider": embedding_provider,
             }
             await knowledge_base_service.create_record(
                 user_id=current_user.id,
@@ -857,7 +899,7 @@ async def create_knowledge_base(
             id=str(kb_id),
             dir_name=kb_name,
             name=kb_name.replace("_", " "),
-            embedding_provider=request.embedding_provider,
+            embedding_provider=embedding_provider,
             embedding_model=request.embedding_model,
             size=0,
             words=0,

--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from lfx.base.models.model_metadata import EXPLICIT_ENABLE_ONLY_PROVIDERS
 from lfx.base.models.model_utils import inject_custom_enabled_models, replace_with_live_models
+from lfx.base.models.provider_registry import is_api_key_optional, provider_id_for
 from lfx.base.models.unified_models import (
     get_live_only_providers,
     get_model_provider_metadata,
@@ -19,11 +20,15 @@ from lfx.base.models.unified_models.credentials import (
     model_status_key,
     parse_model_status_key,
 )
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyError,
+    ModelProviderPolicyPurpose,
+    resolve_model_provider_policy,
+)
 from loguru import logger
 from pydantic import BaseModel, field_validator
 
 from langflow.api.utils import CurrentActiveUser, DbSession
-from langflow.services.auth.utils import get_current_active_user
 from langflow.services.authorization import VariableAction, ensure_variable_permission
 from langflow.services.deps import get_variable_service
 from langflow.services.variable.constants import GENERIC_TYPE
@@ -42,6 +47,26 @@ MAX_STRING_LENGTH = 200  # Maximum length for model IDs and provider names
 MAX_BATCH_UPDATE_SIZE = 100  # Maximum number of models that can be updated at once
 
 
+def _resolve_policy(current_user: CurrentActiveUser, purpose: ModelProviderPolicyPurpose):
+    return resolve_model_provider_policy(
+        user_id=current_user.id,
+        providers=get_model_providers(),
+        purpose=purpose,
+    )
+
+
+def _require_provider(
+    current_user: CurrentActiveUser,
+    provider: str,
+    purpose: ModelProviderPolicyPurpose,
+) -> None:
+    try:
+        _resolve_policy(current_user, purpose).require(provider)
+    except ModelProviderPolicyError as exc:
+        # Do not confirm whether a hidden provider is registered or merely blocked.
+        raise HTTPException(status_code=404, detail="Model provider not found") from exc
+
+
 def get_provider_from_variable_name(variable_name: str) -> str | None:
     """Get provider name from a model provider variable name.
 
@@ -51,10 +76,11 @@ def get_provider_from_variable_name(variable_name: str) -> str | None:
     Returns:
         The provider name (e.g., "OpenAI") or None if not a model provider variable
     """
-    provider_mapping = get_model_provider_variable_mapping()
-    # Reverse the mapping to get provider from variable name
-    for provider, var_name in provider_mapping.items():
-        if var_name == variable_name:
+    # Resolve against every declared provider variable, not just the primary
+    # API-key mapping. This remains dynamic so providers registered by an
+    # extension during startup participate without a process restart cache.
+    for provider in get_model_providers():
+        if any(variable.get("variable_key") == variable_name for variable in get_provider_all_variables(provider)):
             return provider
     return None
 
@@ -106,10 +132,11 @@ class ValidateProviderResponse(BaseModel):
     error: str | None = None
 
 
-@router.get("/providers", status_code=200, dependencies=[Depends(get_current_active_user)])
-async def list_model_providers() -> list[str]:
+@router.get("/providers", status_code=200)
+async def list_model_providers(current_user: CurrentActiveUser) -> list[str]:
     """Return available model providers."""
-    return get_model_providers()
+    policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.DISCOVER)
+    return policy.filter(get_model_providers())
 
 
 @router.get("", status_code=200)
@@ -134,7 +161,10 @@ async def list_models(
 
     Pass providers as repeated query params, e.g. `?provider=OpenAI&provider=Anthropic`.
     """
-    selected_providers: list[str] | None = provider
+    provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.DISCOVER)
+    selected_providers: list[str] | None = provider_policy.filter(provider) if provider is not None else None
+    if provider is not None and not selected_providers:
+        return []
     metadata_filters = {
         k: v
         for k, v in {
@@ -192,22 +222,25 @@ async def list_models(
         provider_metadata = get_model_provider_metadata()
         listed_providers = {provider_dict.get("provider") for provider_dict in filtered_models}
         for live_only_provider in get_live_only_providers():
+            if not provider_policy.allows(live_only_provider):
+                continue
             if live_only_provider in listed_providers:
                 continue
             if selected_providers and live_only_provider not in selected_providers:
                 continue
             filtered_models.append(
                 {
+                    **provider_metadata.get(live_only_provider, {}),
                     "provider": live_only_provider,
                     "models": [],
                     "num_models": 0,
-                    **provider_metadata.get(live_only_provider, {}),
                 }
             )
 
     # Run before status is computed so live-only providers appended here (e.g. IBM WatsonX,
     # whose static catalog is fully deprecated) still receive is_enabled/is_configured (#13735).
     configured_providers = {p for p, configured in provider_configured_status.items() if configured}
+    configured_providers = {provider for provider in configured_providers if provider_policy.allows(provider)}
     replace_with_live_models(filtered_models, current_user.id, configured_providers, model_type)
 
     # Merge free-text custom deployments into the catalog (honors list_models filters).
@@ -219,6 +252,9 @@ async def list_models(
         model_type=model_type,
         metadata_filters=metadata_filters or None,
     )
+    filtered_models = [
+        provider_data for provider_data in filtered_models if provider_policy.allows(provider_data.get("provider", ""))
+    ]
 
     # replace_with_live_models iterates every live-capable provider regardless of
     # the ?provider= filter, so it can append providers the caller excluded (e.g.
@@ -229,6 +265,7 @@ async def list_models(
 
     for provider_dict in filtered_models:
         prov_name = provider_dict.get("provider")
+        provider_dict["provider_id"] = provider_id_for(prov_name) if isinstance(prov_name, str) else None
         provider_dict["is_configured"] = provider_configured_status.get(prov_name, False)
         prov_models_status = enabled_models_map.get(prov_name, {})
         has_active_model = any(prov_models_status.values())
@@ -247,7 +284,7 @@ async def list_models(
 
 
 @router.get("/provider-variable-mapping", status_code=200)
-async def get_model_provider_mapping() -> dict[str, list[dict]]:
+async def get_model_provider_mapping(current_user: CurrentActiveUser) -> dict[str, list[dict]]:
     """Return provider variables mapping with full variable info.
 
     Each provider maps to a list of variable objects containing:
@@ -260,7 +297,8 @@ async def get_model_provider_mapping() -> dict[str, list[dict]]:
     - options: Predefined options for dropdowns
     """
     metadata = get_model_provider_metadata()
-    return {provider: meta.get("variables", []) for provider, meta in metadata.items()}
+    policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
+    return {provider: meta.get("variables", []) for provider, meta in metadata.items() if policy.allows(provider)}
 
 
 @router.get("/enabled_providers", status_code=200)
@@ -276,6 +314,7 @@ async def get_enabled_providers(
     API key validation is performed when credentials are saved, not on every read,
     to avoid latency from external API calls.
     """
+    provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
     variable_service = get_variable_service()
     try:
         if not isinstance(variable_service, DatabaseVariableService):
@@ -289,20 +328,33 @@ async def get_enabled_providers(
         # Build a set of all variable names we have
         all_variable_names = {var.name for var in all_variables}
 
-        # Get the provider-variable mapping
         provider_variable_map = get_model_provider_variable_mapping()
+        provider_candidates = [
+            *provider_variable_map,
+            *(
+                provider
+                for provider in get_model_providers()
+                if provider not in provider_variable_map and is_api_key_optional(provider)
+            ),
+        ]
 
         # Check which providers have all required variables saved
         enabled_providers = []
         provider_status = {}
 
-        for provider in provider_variable_map:
+        for provider in provider_candidates:
+            if not provider_policy.allows(provider):
+                continue
             # Get ALL variables for this provider
             provider_vars = get_provider_all_variables(provider)
 
             # Check if all REQUIRED variables are present
             required_vars = [v for v in provider_vars if v.get("required", False)]
-            all_required_present = all(v.get("variable_key") in all_variable_names for v in required_vars)
+            all_required_present = (
+                is_api_key_optional(provider)
+                if not provider_vars
+                else all(v.get("variable_key") in all_variable_names for v in required_vars)
+            )
 
             provider_status[provider] = all_required_present
             if all_required_present:
@@ -339,13 +391,15 @@ async def get_enabled_providers(
 @router.post("/validate-provider", status_code=200, response_model=ValidateProviderResponse)
 async def validate_provider(
     request: ValidateProviderRequest,
-    current_user: CurrentActiveUser,  # noqa: ARG001
+    current_user: CurrentActiveUser,
 ) -> ValidateProviderResponse:
     """Validate provider credentials before saving.
 
     This endpoint checks if the provided credentials are valid by attempting
     to connect to the provider. Use this for real-time validation in the UI.
     """
+    _require_provider(current_user, request.provider, ModelProviderPolicyPurpose.CONFIGURE)
+
     from lfx.base.models.unified_models import validate_model_provider_key
 
     try:
@@ -683,6 +737,7 @@ async def get_enabled_models(
     model_names: Annotated[list[str] | None, Query()] = None,
 ):
     """Get enabled models for the current user."""
+    provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
     all_models_by_provider = get_unified_models_detailed(
         include_unsupported=True,
         include_deprecated=True,
@@ -691,13 +746,25 @@ async def get_enabled_models(
     enabled_providers_result = await get_enabled_providers(session=session, current_user=current_user)
     provider_status = enabled_providers_result.get("provider_status", {})
 
-    configured_providers = {p for p, configured in provider_status.items() if configured}
+    all_models_by_provider = [
+        provider_data
+        for provider_data in all_models_by_provider
+        if provider_policy.allows(provider_data.get("provider", ""))
+    ]
+    configured_providers = {
+        provider for provider, configured in provider_status.items() if configured and provider_policy.allows(provider)
+    }
     replace_with_live_models(all_models_by_provider, current_user.id, configured_providers)
 
     # Get disabled and explicitly enabled models lists
     disabled_models = await _get_disabled_models(session=session, current_user=current_user)
     explicitly_enabled_models = await _get_enabled_models(session=session, current_user=current_user)
     inject_custom_enabled_models(all_models_by_provider, explicitly_enabled_models)
+    all_models_by_provider = [
+        provider_data
+        for provider_data in all_models_by_provider
+        if provider_policy.allows(provider_data.get("provider", ""))
+    ]
 
     enabled_models: dict[str, dict[str, bool]] = {}
     enabled_models_by_type: dict[str, dict[str, dict[str, bool]]] = {}
@@ -852,6 +919,7 @@ async def update_enabled_models(
     # For any model being enabled, validate the provider credentials
     for update in updates:
         if update.enabled:
+            _require_provider(current_user, update.provider, ModelProviderPolicyPurpose.CONFIGURE)
             unavailable_reason = unavailable_models.get((update.provider, update.model_id))
             if unavailable_reason:
                 raise HTTPException(
@@ -901,10 +969,21 @@ async def update_enabled_models(
         variable_service, session, current_user, ENABLED_MODELS_VAR, explicitly_enabled_models
     )
 
-    # Return the updated model status
+    # Cleanup of a now-hidden provider remains allowed, but the response must
+    # not echo hidden provider identities from persisted legacy state.
+    provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
+
+    def _visible_status_entries(entries: set[str]) -> list[str]:
+        visible = []
+        for entry in entries:
+            provider, _model_name, _model_type = parse_model_status_key(entry)
+            if provider is None or provider_policy.allows(provider):
+                visible.append(entry)
+        return visible
+
     return {
-        "disabled_models": list(disabled_models),
-        "enabled_models": list(explicitly_enabled_models),
+        "disabled_models": _visible_status_entries(disabled_models),
+        "enabled_models": _visible_status_entries(explicitly_enabled_models),
     }
 
 
@@ -966,6 +1045,9 @@ async def get_default_model(
                 ):
                     logger.warning("Invalid default model format for user %s", current_user.id)
                     return {"default_model": None}
+                policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.USE)
+                if not policy.allows(parsed_value["provider"]):
+                    return {"default_model": None}
                 return {"default_model": parsed_value}
     except ValueError:
         # Variable not found
@@ -981,6 +1063,7 @@ async def set_default_model(
     request: DefaultModelRequest,
 ):
     """Set the default model for the current user."""
+    _require_provider(current_user, request.provider, ModelProviderPolicyPurpose.USE)
     # Creating/updating the default-model Variable is a variable WRITE. Enforce
     # so the external access ceiling caps a "viewer"; the owner with no ceiling
     # fast-paths via owner-override.

--- a/src/backend/base/langflow/api/v1/variable.py
+++ b/src/backend/base/langflow/api/v1/variable.py
@@ -9,12 +9,15 @@ from lfx.base.models.unified_models import (
     get_model_provider_variable_mapping,
     validate_model_provider_key,
 )
+from lfx.services.model_provider_policy import ModelProviderPolicyPurpose
 from sqlalchemy.exc import NoResultFound
 
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.v1.models import (
     DISABLED_MODELS_VAR,
     ENABLED_MODELS_VAR,
+    _require_provider,
+    _resolve_policy,
     build_model_providers_by_name,
     get_provider_from_variable_name,
     normalize_model_status_entries,
@@ -29,7 +32,6 @@ from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
 from langflow.services.variable.service import DatabaseVariableService
 
 router = APIRouter(prefix="/variables", tags=["Variables"])
-model_provider_variable_mapping = get_model_provider_variable_mapping()
 logger = logging.getLogger(__name__)
 
 
@@ -151,21 +153,25 @@ async def create_variable(
     if not variable.value:
         raise HTTPException(status_code=400, detail="Variable value cannot be empty")
 
+    # Provider variables contributed by core or extensions are policy-gated
+    # before credential lookup, SDK import, validation, or persistence.
+    provider = get_provider_from_variable_name(variable.name)
+    if provider is not None:
+        _require_provider(current_user, provider, ModelProviderPolicyPurpose.CONFIGURE)
+
     if variable.name in await variable_service.list_variables(user_id=current_user.id, session=session):
         raise HTTPException(status_code=400, detail="Variable name already exists")
 
-    # Check if the variable is a reserved model provider variable
-    if variable.name in model_provider_variable_mapping.values():
-        provider = get_provider_from_variable_name(variable.name)
-        if provider is not None:
-            # Saved provider vars (e.g. OPENAI_BASE_URL) must reach the validator; run off the event loop.
-            provider_vars = await asyncio.to_thread(get_all_variables_for_provider, current_user.id, provider)
-            try:
-                await asyncio.to_thread(
-                    validate_model_provider_key, provider, {**provider_vars, variable.name: variable.value}
-                )
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=str(e)) from e
+    if provider is not None and variable.name == get_model_provider_variable_mapping().get(provider):
+        provider_vars = await asyncio.to_thread(get_all_variables_for_provider, current_user.id, provider)
+        try:
+            await asyncio.to_thread(
+                validate_model_provider_key,
+                provider,
+                {**provider_vars, variable.name: variable.value},
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
     try:
         return await variable_service.create_variable(
@@ -208,14 +214,21 @@ async def read_variables(
         all_variables = await variable_service.get_all(user_id=current_user.id, session=session)
 
         # Filter out internal variables (those starting and ending with __)
-        filtered_variables = [
-            var for var in all_variables if not (var.name and var.name.startswith("__") and var.name.endswith("__"))
-        ]
+        provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
+        filtered_variables = []
+        for var in all_variables:
+            if var.name and var.name.startswith("__") and var.name.endswith("__"):
+                continue
+            provider = get_provider_from_variable_name(var.name) if var.name else None
+            if provider is not None and not provider_policy.allows(provider):
+                continue
+            filtered_variables.append(var)
 
         # Mark model provider credentials - validation status is based on existence
         # (actual validation happens on create/update)
+        primary_provider_variables = set(get_model_provider_variable_mapping().values())
         for var in filtered_variables:
-            if var.name and var.name in model_provider_variable_mapping.values() and var.type == CREDENTIAL_TYPE:
+            if var.name and var.name in primary_provider_variables and var.type == CREDENTIAL_TYPE:
                 # Credential exists and was validated on save
                 var.is_valid = True
                 var.validation_error = None
@@ -270,17 +283,21 @@ async def update_variable(
         except HTTPException as exc:
             raise deny_to_404(exc, detail="Variable not found") from exc
 
-        # Validate API key if updating a model provider variable
-        if existing_variable.name in model_provider_variable_mapping.values() and variable.value:
-            provider = get_provider_from_variable_name(existing_variable.name)
-            if provider is not None:
+        # Validate provider variables using their effective post-update name.
+        # This closes the rename path from a generic variable into a hidden
+        # provider credential while still allowing rename/delete cleanup.
+        effective_name = variable.name or existing_variable.name
+        provider = get_provider_from_variable_name(effective_name)
+        if provider is not None:
+            _require_provider(current_user, provider, ModelProviderPolicyPurpose.CONFIGURE)
+            if variable.value and effective_name == get_model_provider_variable_mapping().get(provider):
                 # Run validation off the event loop; owner context (not caller) for share-aware updates.
                 provider_vars = await asyncio.to_thread(get_all_variables_for_provider, owner_id, provider)
                 try:
                     await asyncio.to_thread(
                         validate_model_provider_key,
                         provider,
-                        {**provider_vars, existing_variable.name: variable.value},
+                        {**provider_vars, effective_name: variable.value},
                     )
                 except ValueError as e:
                     raise HTTPException(status_code=400, detail=str(e)) from e
@@ -435,4 +452,11 @@ async def detect_env_vars(
         data = _validate_flow_or_422(version_id=version_id, data=version.data)
         candidate_keys.update(_collect_candidate_variable_keys_from_flow_data(data))
 
-    return DetectVarsResponse(variables=sorted(existing_variable_names.intersection(candidate_keys)))
+    provider_policy = _resolve_policy(current_user, ModelProviderPolicyPurpose.CONFIGURE)
+    visible_candidate_keys = {
+        variable_key
+        for variable_key in candidate_keys
+        if (provider := get_provider_from_variable_name(variable_key)) is None or provider_policy.allows(provider)
+    }
+
+    return DetectVarsResponse(variables=sorted(existing_variable_names.intersection(visible_candidate_keys)))

--- a/src/backend/base/langflow/services/factory.py
+++ b/src/backend/base/langflow/services/factory.py
@@ -76,8 +76,9 @@ def import_all_services_into_a_dict():
         try:
             service_name = ServiceType(service_type).value.replace("_service", "")
 
-            # Special handling for mcp_composer which is now in lfx module
-            if service_name == "mcp_composer":
+            # Shared services live in lfx so both the standalone runtime and
+            # the Langflow application use the same contract and instance.
+            if service_name in {"mcp_composer", "model_provider_policy"}:
                 module_name = f"lfx.services.{service_name}.service"
             else:
                 module_name = f"langflow.services.{service_name}.service"

--- a/src/backend/base/langflow/services/memory_base/preprocessing.py
+++ b/src/backend/base/langflow/services/memory_base/preprocessing.py
@@ -155,6 +155,9 @@ async def run_preprocessing(
         return PreprocessingResult(status="skipped", output_text="", raw_response="")
 
     provider = infer_llm_provider(preproc_model)
+    from lfx.services.model_provider_policy import require_model_provider
+
+    require_model_provider(user_id=user_id, provider=provider)
 
     # Resolve the provider's API key from the user's globally-configured
     # variables (or env). Required because we instantiate the component outside

--- a/src/backend/base/langflow/services/memory_base/service.py
+++ b/src/backend/base/langflow/services/memory_base/service.py
@@ -18,6 +18,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from lfx.base.models.unified_models import get_api_key_for_provider
+from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, require_model_provider
 from sqlmodel import col, select
 
 from langflow.services.base import Service
@@ -65,14 +66,27 @@ class PreprocessingValidationError(ValueError):
     """Raised when preprocessing is enabled but the provider API key is absent."""
 
 
-def _validate_preprocessing_api_key(user_id: uuid.UUID, preproc_model: str | None) -> None:
-    """Raise PreprocessingValidationError if the preprocessing provider API key is missing."""
+def _require_preprocessing_model_provider(user_id: uuid.UUID, preproc_model: str | None) -> str | None:
+    """Require CONFIGURE access for a supplied preprocessing model identity."""
     if not preproc_model:
-        return
+        return None
     try:
         provider = infer_llm_provider(preproc_model)
     except ValueError as exc:
         raise PreprocessingValidationError(str(exc)) from exc
+    require_model_provider(
+        user_id=user_id,
+        provider=provider,
+        purpose=ModelProviderPolicyPurpose.CONFIGURE,
+    )
+    return provider
+
+
+def _validate_preprocessing_api_key(user_id: uuid.UUID, preproc_model: str | None) -> None:
+    """Raise PreprocessingValidationError if the preprocessing provider API key is missing."""
+    provider = _require_preprocessing_model_provider(user_id, preproc_model)
+    if provider is None:
+        return
     api_key = get_api_key_for_provider(user_id, provider)
     if not api_key:
         msg = (
@@ -101,9 +115,21 @@ class MemoryBaseService(Service):
                 msg = f"Flow {payload.flow_id} not found"
                 raise PermissionError(msg)
 
-        # 1b. Validate preprocessing API key before touching the filesystem.
+        # 1b. Validate every supplied preprocessing identity even while the
+        # feature is disabled; enabling it additionally requires credentials.
         if payload.preprocessing:
             _validate_preprocessing_api_key(user_id, payload.preproc_model)
+        elif payload.preproc_model:
+            _require_preprocessing_model_provider(user_id, payload.preproc_model)
+
+        # 1c. Resolve and authorize the embedding provider before filesystem
+        # initialization or any persistence work.
+        embedding_provider = infer_embedding_provider(payload.embedding_model)
+        require_model_provider(
+            user_id=user_id,
+            provider=embedding_provider,
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
 
         # 2. Resolve username — needed for the KB path.
         async with session_scope() as db:
@@ -113,7 +139,6 @@ class MemoryBaseService(Service):
         kb_name = f"{sanitize_kb_name(payload.name)}_{uuid.uuid4().hex[:8]}"
 
         # 4. Create KB directory and embedding_metadata.json on disk.
-        embedding_provider = infer_embedding_provider(payload.embedding_model)
         await initialize_kb(
             kb_name=kb_name,
             kb_username=kb_username,
@@ -183,6 +208,13 @@ class MemoryBaseService(Service):
             mb = result.first()
             if mb is None:
                 return None
+
+            embedding_provider = infer_embedding_provider(mb.embedding_model)
+            require_model_provider(
+                user_id=user_id,
+                provider=embedding_provider,
+                purpose=ModelProviderPolicyPurpose.CONFIGURE,
+            )
 
             if mb.preprocessing:
                 _validate_preprocessing_api_key(user_id, mb.preproc_model)

--- a/src/backend/base/langflow/services/schema.py
+++ b/src/backend/base/langflow/services/schema.py
@@ -6,6 +6,7 @@ class ServiceType(str, Enum):
 
     AUTH_SERVICE = "auth_service"
     AUTHORIZATION_SERVICE = "authorization_service"
+    MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
     CACHE_SERVICE = "cache_service"
     SHARED_COMPONENT_CACHE_SERVICE = "shared_component_cache_service"
     SETTINGS_SERVICE = "settings_service"

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -567,6 +567,7 @@ def register_all_service_factories() -> None:
     service_manager = get_service_manager()
     from lfx.services.executor import factory as executor_factory
     from lfx.services.mcp_composer import factory as mcp_composer_factory
+    from lfx.services.model_provider_policy.service import ModelProviderPolicyService
     from lfx.services.settings import factory as settings_factory
 
     from langflow.services.auth import factory as auth_factory
@@ -622,6 +623,11 @@ def register_all_service_factories() -> None:
         ServiceType.AUTHORIZATION_SERVICE, LangflowAuthorizationService, override=True
     )
     service_manager.register_factory(authorization_factory.AuthorizationServiceFactory())
+    service_manager.register_service_class(
+        ServiceType.MODEL_PROVIDER_POLICY_SERVICE,
+        ModelProviderPolicyService,
+        override=True,
+    )
     service_manager.register_factory(mcp_composer_factory.MCPComposerServiceFactory())
     service_manager.register_factory(executor_factory.ExecutorServiceFactory())
     service_manager.set_factory_registered()

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -34,6 +34,7 @@ class DatabaseVariableService(VariableService, Service):
         # Import the provider mapping to set default_fields for known providers
         try:
             from lfx.base.models.unified_models import get_model_provider_metadata
+            from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
 
             # Build var_to_provider from all variables in metadata (not just primary)
             var_to_provider = {}
@@ -46,8 +47,14 @@ class DatabaseVariableService(VariableService, Service):
                         var_to_provider[var_key] = provider
                         var_to_info[var_key] = var
         except Exception:  # noqa: BLE001
-            var_to_provider = {}
-            var_to_info = {}
+            await logger.aexception("Could not resolve model-provider metadata; skipping environment variable import")
+            return
+        else:
+            provider_policy = resolve_model_provider_policy(
+                user_id=user_id,
+                providers=metadata,
+                purpose=ModelProviderPolicyPurpose.CONFIGURE,
+            )
 
         for var_name in self.settings_service.settings.variables_to_get_from_environment:
             # Check if session is still usable before processing each variable
@@ -57,6 +64,10 @@ class DatabaseVariableService(VariableService, Service):
                     "Some environment variables may not have been processed."
                 )
                 break
+
+            provider_name = var_to_provider.get(var_name)
+            if provider_name is not None and not provider_policy.allows(provider_name):
+                continue
 
             if var_name in os.environ and os.environ[var_name].strip():
                 value = os.environ[var_name].strip()

--- a/src/backend/tests/unit/agentic/api/test_iterations_limit_forwarding.py
+++ b/src/backend/tests/unit/agentic/api/test_iterations_limit_forwarding.py
@@ -33,8 +33,8 @@ def _provider_env():
             return_value=(["OpenAI"], {}),
         ),
         patch(
-            f"{_ROUTER}.get_model_provider_variable_mapping",
-            return_value={"OpenAI": "OPENAI_API_KEY"},
+            f"{_ROUTER}.get_provider_secret_variable_key",
+            return_value="OPENAI_API_KEY",
         ),
         patch(f"{_ROUTER}.get_default_model", return_value="gpt-4o"),
         patch(
@@ -64,6 +64,53 @@ async def test_absent_iterations_limit_leaves_global_vars_unbudgeted():
     ctx = await _resolve_assistant_context(_request(), uuid4(), session=session)
 
     assert "ITERATIONS_LIMIT" not in ctx.global_vars
+
+
+async def test_credentialless_extension_provider_resolves_without_api_key_name():
+    with (
+        patch(
+            f"{_ROUTER}.get_enabled_providers_for_user",
+            new_callable=AsyncMock,
+            return_value=(["AmbientAuthCo"], {"AmbientAuthCo": True}),
+        ),
+        patch(f"{_ROUTER}.get_provider_secret_variable_key", return_value=None),
+        patch(f"{_ROUTER}.is_api_key_optional", return_value=True),
+        patch(f"{_ROUTER}.get_default_model", return_value="ambient-chat"),
+        patch(f"{_ROUTER}.get_all_variables_for_provider", return_value={}),
+        patch(f"{_ROUTER}.get_provider_required_variable_keys", return_value=[]),
+    ):
+        ctx = await _resolve_assistant_context(
+            _request(provider="AmbientAuthCo"),
+            uuid4(),
+            session=AsyncMock(),
+        )
+
+    assert ctx.provider == "AmbientAuthCo"
+    assert ctx.api_key_name is None
+    assert ctx.global_vars["MODEL_NAME"] == "ambient-chat"
+
+
+async def test_base_url_only_provider_does_not_inject_connection_config_as_api_key():
+    with (
+        patch(
+            f"{_ROUTER}.get_enabled_providers_for_user",
+            new_callable=AsyncMock,
+            return_value=(["LocalCo"], {"LocalCo": True}),
+        ),
+        patch(f"{_ROUTER}.get_provider_secret_variable_key", return_value=None),
+        patch(f"{_ROUTER}.is_api_key_optional", return_value=True),
+        patch(f"{_ROUTER}.get_default_model", return_value="local-chat"),
+        patch(f"{_ROUTER}.get_all_variables_for_provider", return_value={"LOCALCO_BASE_URL": "http://local"}),
+        patch(f"{_ROUTER}.get_provider_required_variable_keys", return_value=["LOCALCO_BASE_URL"]),
+    ):
+        ctx = await _resolve_assistant_context(
+            _request(provider="LocalCo"),
+            uuid4(),
+            session=AsyncMock(),
+        )
+
+    assert ctx.api_key_name is None
+    assert ctx.global_vars["LOCALCO_BASE_URL"] == "http://local"
 
 
 async def test_non_streaming_execution_binds_the_iterations_context():

--- a/src/backend/tests/unit/agentic/services/test_provider_service.py
+++ b/src/backend/tests/unit/agentic/services/test_provider_service.py
@@ -228,6 +228,10 @@ class TestGetEnabledProvidersForUser:
                 "langflow.agentic.services.provider_service.get_model_provider_variable_mapping",
                 return_value={"Anthropic": "ANTHROPIC_API_KEY", "OpenAI": "OPENAI_API_KEY"},
             ),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_providers",
+                return_value=["Anthropic", "OpenAI"],
+            ),
             patch("langflow.agentic.services.provider_service.os.getenv", return_value=None),
         ):
             enabled, status = await get_enabled_providers_for_user("user-1", mock_session)
@@ -260,6 +264,10 @@ class TestGetEnabledProvidersForUser:
                 "langflow.agentic.services.provider_service.get_model_provider_variable_mapping",
                 return_value={"Anthropic": "ANTHROPIC_API_KEY", "OpenAI": "OPENAI_API_KEY"},
             ),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_providers",
+                return_value=["Anthropic", "OpenAI"],
+            ),
         ):
             enabled, status = await get_enabled_providers_for_user("user-1", mock_session)
 
@@ -284,6 +292,69 @@ class TestGetEnabledProvidersForUser:
 
         assert enabled_providers == []
         assert all(not v for v in provider_status.values())
+
+    @pytest.mark.asyncio
+    async def test_policy_hidden_provider_is_absent_from_enabled_and_status(self):
+        from langflow.services.variable.service import DatabaseVariableService
+
+        variables = []
+        for name in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            variable = MagicMock()
+            variable.name = name
+            variables.append(variable)
+        mock_db_service = MagicMock(spec=DatabaseVariableService)
+        mock_db_service.get_all = AsyncMock(return_value=variables)
+        policy = MagicMock()
+        policy.allows.side_effect = lambda provider: provider == "OpenAI"
+
+        with (
+            patch("langflow.agentic.services.provider_service.get_variable_service", return_value=mock_db_service),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_provider_variable_mapping",
+                return_value={"OpenAI": "OPENAI_API_KEY", "Anthropic": "ANTHROPIC_API_KEY"},
+            ),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_providers",
+                return_value=["OpenAI", "Anthropic"],
+            ),
+            patch(
+                "langflow.agentic.services.provider_service.get_provider_required_variable_keys",
+                side_effect=lambda provider: [f"{provider.upper()}_API_KEY"],
+            ),
+            patch("langflow.agentic.services.provider_service.resolve_model_provider_policy", return_value=policy),
+        ):
+            enabled, provider_status = await get_enabled_providers_for_user("user-1", MagicMock())
+
+        assert enabled == ["OpenAI"]
+        assert provider_status == {"OpenAI": True}
+
+    @pytest.mark.asyncio
+    async def test_credentialless_extension_provider_is_enabled(self):
+        from langflow.services.variable.service import DatabaseVariableService
+
+        mock_db_service = MagicMock(spec=DatabaseVariableService)
+        mock_db_service.get_all = AsyncMock(return_value=[])
+        policy = MagicMock()
+        policy.allows.return_value = True
+
+        with (
+            patch("langflow.agentic.services.provider_service.get_variable_service", return_value=mock_db_service),
+            patch("langflow.agentic.services.provider_service.get_model_provider_variable_mapping", return_value={}),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_providers",
+                return_value=["AmbientAuthCo"],
+            ),
+            patch("langflow.agentic.services.provider_service.is_api_key_optional", return_value=True),
+            patch(
+                "langflow.agentic.services.provider_service.get_provider_required_variable_keys",
+                return_value=[],
+            ),
+            patch("langflow.agentic.services.provider_service.resolve_model_provider_policy", return_value=policy),
+        ):
+            enabled, provider_status = await get_enabled_providers_for_user("user-1", MagicMock())
+
+        assert enabled == ["AmbientAuthCo"]
+        assert provider_status == {"AmbientAuthCo": True}
 
 
 class TestBugsAndEdgeCases:
@@ -379,6 +450,10 @@ class TestBugsAndEdgeCases:
             patch(
                 "langflow.agentic.services.provider_service.get_model_provider_variable_mapping",
                 return_value={"NoKeysProvider": None, "Anthropic": "ANTHROPIC_API_KEY"},
+            ),
+            patch(
+                "langflow.agentic.services.provider_service.get_model_providers",
+                return_value=["NoKeysProvider", "Anthropic"],
             ),
             patch(
                 "langflow.agentic.services.provider_service.get_provider_required_variable_keys",

--- a/src/backend/tests/unit/api/v1/test_detect_env_vars.py
+++ b/src/backend/tests/unit/api/v1/test_detect_env_vars.py
@@ -69,6 +69,54 @@ class TestDetectEnvVars:
         assert result.variables == ["MY_OPENAI_KEY"]
 
     @pytest.mark.asyncio
+    async def test_filters_hidden_provider_variable_names(self):
+        fv_id = uuid4()
+        version = _flow_version_with_data(
+            {
+                "nodes": [
+                    _node(
+                        {
+                            "hidden_provider_key": {
+                                "load_from_db": True,
+                                "value": "ANTHROPIC_API_KEY",
+                            },
+                            "generic_key": {
+                                "load_from_db": True,
+                                "value": "MY_GENERIC_KEY",
+                            },
+                        }
+                    )
+                ]
+            }
+        )
+
+        def _openai_only_policy(_current_user, purpose):
+            from lfx.services.model_provider_policy import ModelProviderPolicyPurpose
+
+            assert purpose is ModelProviderPolicyPurpose.CONFIGURE
+            return SimpleNamespace(allows=lambda provider: provider == "OpenAI")
+
+        with (
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["ANTHROPIC_API_KEY", "MY_GENERIC_KEY"]),
+            ),
+            patch(f"{MODULE}._resolve_policy", side_effect=_openai_only_policy),
+        ):
+            result = await detect_env_vars(
+                payload=DetectVarsRequest(flow_version_ids=[fv_id]),
+                session=AsyncMock(),
+                current_user=SimpleNamespace(id=uuid4()),
+            )
+
+        assert result.variables == ["MY_GENERIC_KEY"]
+
+    @pytest.mark.asyncio
     async def test_ignores_password_only_fields(self):
         fv_id = uuid4()
         version = _flow_version_with_data({"nodes": [_node({"api_key": {"password": True}})]})

--- a/src/backend/tests/unit/api/v1/test_models_live_only_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_live_only_providers.py
@@ -17,11 +17,24 @@ from lfx.base.models.provider_registry import ProviderSpec, register_provider
 
 _PROVIDER_NAME = "FakeLiveCo"
 _API_DOCS_URL = "https://fakeliveco.example/docs"
+_AMBIENT_PROVIDER_NAME = "AmbientAuthCo"
+_AMBIENT_MODEL_NAME = "ambient-chat"
 
 
 def fake_live_discovery(user_id, model_type):  # noqa: ARG001
     """Referenced by the ProviderSpec dotted path; never called while unconfigured."""
     return []
+
+
+def ambient_auth_catalog():
+    """Static catalog for a provider whose runtime uses ambient authentication."""
+    return [
+        {
+            "name": _AMBIENT_MODEL_NAME,
+            "model_type": "llm",
+            "default": True,
+        }
+    ]
 
 
 def _fakeliveco_spec() -> ProviderSpec:
@@ -49,6 +62,19 @@ def _fakeliveco_spec() -> ProviderSpec:
     )
 
 
+def _ambient_auth_spec() -> ProviderSpec:
+    return ProviderSpec(
+        name=_AMBIENT_PROVIDER_NAME,
+        metadata={
+            "icon": "Bot",
+            "variables": [],
+            "mapping": {"model_class": "ChatOpenAI", "model_param": "model"},
+        },
+        api_key_required=False,
+        catalog_loader=f"{__name__}:ambient_auth_catalog",
+    )
+
+
 def _unregister(name: str) -> None:
     """Remove a single provider registration.
 
@@ -59,9 +85,18 @@ def _unregister(name: str) -> None:
     MODEL_PROVIDER_METADATA.pop(name, None)
     if name in LIVE_MODEL_PROVIDERS:
         LIVE_MODEL_PROVIDERS.remove(name)
-    provider_registry._registered.pop(name, None)
+    descriptor = provider_registry._registered.pop(name, None)
+    if descriptor is not None:
+        provider_registry._registered_ids.pop(descriptor.canonical_id(), None)
+    for alias, registered_name in list(provider_registry._registered_aliases.items()):
+        if registered_name == name:
+            provider_registry._registered_aliases.pop(alias, None)
     provider_registry._live_discovery_cache.pop(name, None)
     provider_registry._validator_cache.pop(name, None)
+    provider_registry._catalog_cache.pop(name, None)
+    provider_registry._undo.metadata_keys.discard(name)
+    provider_registry._undo.live_names.discard(name)
+    provider_registry._generation += 1
     provider_registry._clear_derived_caches()
 
 
@@ -70,6 +105,13 @@ def fake_live_provider():
     assert register_provider(_fakeliveco_spec()) is True
     yield _PROVIDER_NAME
     _unregister(_PROVIDER_NAME)
+
+
+@pytest.fixture
+def ambient_auth_provider():
+    assert register_provider(_ambient_auth_spec()) is True
+    yield _AMBIENT_PROVIDER_NAME
+    _unregister(_AMBIENT_PROVIDER_NAME)
 
 
 async def _get_models(client: AsyncClient, headers: dict, params: dict | None = None) -> list[dict]:
@@ -119,3 +161,23 @@ async def test_non_live_metadata_providers_stay_hidden(client: AsyncClient, logg
     providers = {p["provider"] for p in await _get_models(client, logged_in_headers)}
     assert "Azure OpenAI" not in providers
     assert "Groq" not in providers
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_credentialless_extension_provider_is_enabled_and_offered(
+    client: AsyncClient,
+    logged_in_headers,
+    ambient_auth_provider,
+):
+    enabled_response = await client.get("api/v1/models/enabled_providers", headers=logged_in_headers)
+    options_response = await client.get("api/v1/model_options/language", headers=logged_in_headers)
+
+    assert enabled_response.status_code == status.HTTP_200_OK
+    assert enabled_response.json()["provider_status"][ambient_auth_provider] is True
+    assert ambient_auth_provider in enabled_response.json()["enabled_providers"]
+
+    assert options_response.status_code == status.HTTP_200_OK
+    assert any(
+        option["provider"] == ambient_auth_provider and option["name"] == _AMBIENT_MODEL_NAME
+        for option in options_response.json()
+    )

--- a/src/backend/tests/unit/api/v1/test_models_provider_policy.py
+++ b/src/backend/tests/unit/api/v1/test_models_provider_policy.py
@@ -1,0 +1,69 @@
+"""The model-provider policy must hide denied providers across shared OSS APIs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import status
+from lfx.base.models.provider_registry import provider_id_for
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyContext,
+    ModelProviderPolicySnapshot,
+)
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+def _openai_only_policy(*, user_id, providers, purpose):
+    candidate_ids = frozenset(filter(None, (provider_id_for(provider) for provider in providers)))
+    return ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id=user_id),
+        purpose=purpose,
+        candidate_provider_ids=candidate_ids,
+        allowed_provider_ids=frozenset({"openai"}) & candidate_ids,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restrict_to_openai(monkeypatch):
+    monkeypatch.setattr("langflow.api.v1.models.resolve_model_provider_policy", _openai_only_policy)
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_provider_reads_hide_denied_providers(client: AsyncClient, logged_in_headers):
+    providers_response = await client.get("api/v1/models/providers", headers=logged_in_headers)
+    models_response = await client.get("api/v1/models", headers=logged_in_headers)
+    mapping_response = await client.get("api/v1/models/provider-variable-mapping", headers=logged_in_headers)
+
+    assert providers_response.status_code == status.HTTP_200_OK
+    assert providers_response.json() == ["OpenAI"]
+
+    assert models_response.status_code == status.HTTP_200_OK
+    model_groups = models_response.json()
+    assert {group["provider"] for group in model_groups} == {"OpenAI"}
+    assert {group["provider_id"] for group in model_groups} == {"openai"}
+
+    assert mapping_response.status_code == status.HTTP_200_OK
+    assert set(mapping_response.json()) == {"OpenAI"}
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_denied_provider_mutations_return_non_enumerating_not_found(client: AsyncClient, logged_in_headers):
+    validate_response = await client.post(
+        "api/v1/models/validate-provider",
+        headers=logged_in_headers,
+        json={
+            "provider": "Anthropic",
+            "variables": {"ANTHROPIC_API_KEY": "test"},  # pragma: allowlist secret
+        },
+    )
+    default_response = await client.post(
+        "api/v1/models/default_model",
+        headers=logged_in_headers,
+        json={"provider": "Anthropic", "model_name": "claude-test", "model_type": "language"},
+    )
+
+    assert validate_response.status_code == status.HTTP_404_NOT_FOUND
+    assert default_response.status_code == status.HTTP_404_NOT_FOUND

--- a/src/backend/tests/unit/api/v1/test_models_provider_policy.py
+++ b/src/backend/tests/unit/api/v1/test_models_provider_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import status
@@ -26,6 +27,16 @@ def _openai_only_policy(*, user_id, providers, purpose):
     )
 
 
+def _allow_all_policy(*, user_id, providers, purpose):
+    candidate_ids = frozenset(provider_id_for(provider) or provider for provider in providers)
+    return ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id=user_id),
+        purpose=purpose,
+        candidate_provider_ids=candidate_ids,
+        allowed_provider_ids=candidate_ids,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _restrict_to_openai(monkeypatch):
     monkeypatch.setattr("langflow.api.v1.models.resolve_model_provider_policy", _openai_only_policy)
@@ -36,6 +47,11 @@ async def test_provider_reads_hide_denied_providers(client: AsyncClient, logged_
     providers_response = await client.get("api/v1/models/providers", headers=logged_in_headers)
     models_response = await client.get("api/v1/models", headers=logged_in_headers)
     mapping_response = await client.get("api/v1/models/provider-variable-mapping", headers=logged_in_headers)
+    denied_query_response = await client.get(
+        "api/v1/models",
+        headers=logged_in_headers,
+        params={"provider": "Anthropic"},
+    )
 
     assert providers_response.status_code == status.HTTP_200_OK
     assert providers_response.json() == ["OpenAI"]
@@ -47,10 +63,21 @@ async def test_provider_reads_hide_denied_providers(client: AsyncClient, logged_
 
     assert mapping_response.status_code == status.HTTP_200_OK
     assert set(mapping_response.json()) == {"OpenAI"}
+    assert denied_query_response.status_code == status.HTTP_200_OK
+    assert denied_query_response.json() == []
 
 
 @pytest.mark.usefixtures("active_user")
-async def test_denied_provider_mutations_return_non_enumerating_not_found(client: AsyncClient, logged_in_headers):
+async def test_denied_provider_mutations_return_non_enumerating_not_found(
+    client: AsyncClient, logged_in_headers, monkeypatch
+):
+    provider_validation_called = False
+
+    def _provider_validation(*_args, **_kwargs):
+        nonlocal provider_validation_called
+        provider_validation_called = True
+
+    monkeypatch.setattr("langflow.api.v1.variable.validate_model_provider_key", _provider_validation)
     validate_response = await client.post(
         "api/v1/models/validate-provider",
         headers=logged_in_headers,
@@ -64,6 +91,102 @@ async def test_denied_provider_mutations_return_non_enumerating_not_found(client
         headers=logged_in_headers,
         json={"provider": "Anthropic", "model_name": "claude-test", "model_type": "language"},
     )
+    variable_response = await client.post(
+        "api/v1/variables/",
+        headers=logged_in_headers,
+        json={
+            "name": "ANTHROPIC_API_KEY",
+            "value": "test",  # pragma: allowlist secret
+            "type": "Credential",
+            "default_fields": [],
+        },
+    )
+    enabled_response = await client.post(
+        "api/v1/models/enabled_models",
+        headers=logged_in_headers,
+        json=[{"provider": "Anthropic", "model_id": "claude-test", "enabled": True}],
+    )
 
     assert validate_response.status_code == status.HTTP_404_NOT_FOUND
     assert default_response.status_code == status.HTTP_404_NOT_FOUND
+    assert variable_response.status_code == status.HTTP_404_NOT_FOUND
+    assert enabled_response.status_code == status.HTTP_404_NOT_FOUND
+    assert provider_validation_called is False
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_dynamic_model_sources_cannot_reintroduce_denied_provider(
+    client: AsyncClient, logged_in_headers, monkeypatch
+):
+    from langflow.api.v1 import models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "get_enabled_providers",
+        AsyncMock(
+            return_value={
+                "enabled_providers": ["OpenAI", "Anthropic"],
+                "provider_status": {"OpenAI": True, "Anthropic": True},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        models_module,
+        "get_enabled_models",
+        AsyncMock(return_value={"enabled_models": {}, "enabled_models_by_type": {}}),
+    )
+    live_provider_sets = []
+
+    def _replace_with_live(groups, _user_id, configured_providers, *_args, **_kwargs):
+        live_provider_sets.append(set(configured_providers))
+        groups.append({"provider": "Anthropic", "models": [], "num_models": 0})
+
+    def _inject_custom(groups, *_args, **_kwargs):
+        groups.append(
+            {
+                "provider": "Anthropic",
+                "models": [{"model_name": "blocked-custom", "metadata": {"model_type": "llm"}}],
+                "num_models": 1,
+            }
+        )
+
+    monkeypatch.setattr(models_module, "replace_with_live_models", _replace_with_live)
+    monkeypatch.setattr(models_module, "inject_custom_enabled_models", _inject_custom)
+
+    response = await client.get("api/v1/models", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert {group["provider"] for group in response.json()} == {"OpenAI"}
+    assert live_provider_sets == [{"OpenAI"}]
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_hidden_provider_variables_are_omitted_but_can_be_deleted(
+    client: AsyncClient, logged_in_headers, monkeypatch
+):
+    monkeypatch.setattr("langflow.api.v1.models.resolve_model_provider_policy", _allow_all_policy)
+    existing_response = await client.get("api/v1/variables/", headers=logged_in_headers)
+    for variable in existing_response.json():
+        if variable["name"] == "ANTHROPIC_API_KEY":
+            await client.delete(f"api/v1/variables/{variable['id']}", headers=logged_in_headers)
+
+    monkeypatch.setattr("langflow.api.v1.variable.validate_model_provider_key", lambda *_args, **_kwargs: None)
+    create_response = await client.post(
+        "api/v1/variables/",
+        headers=logged_in_headers,
+        json={
+            "name": "ANTHROPIC_API_KEY",
+            "value": "test",  # pragma: allowlist secret
+            "type": "Credential",
+            "default_fields": [],
+        },
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED
+    variable_id = create_response.json()["id"]
+
+    monkeypatch.setattr("langflow.api.v1.models.resolve_model_provider_policy", _openai_only_policy)
+    hidden_response = await client.get("api/v1/variables/", headers=logged_in_headers)
+    delete_response = await client.delete(f"api/v1/variables/{variable_id}", headers=logged_in_headers)
+
+    assert "ANTHROPIC_API_KEY" not in {variable["name"] for variable in hidden_response.json()}
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -10,6 +10,11 @@ from langflow.services.database.models.variable.model import VariableUpdate
 from langflow.services.deps import get_settings_service
 from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
 from langflow.services.variable.service import DatabaseVariableService
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyContext,
+    ModelProviderPolicyPurpose,
+    ModelProviderPolicySnapshot,
+)
 from lfx.services.settings.constants import VARIABLES_TO_GET_FROM_ENVIRONMENT
 from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -66,6 +71,41 @@ async def test_initialize_user_variables__skipping_environment_variable_storage(
     service.settings_service.settings.store_environment_variables = False
     await service.initialize_user_variables(uuid4(), session=session)
     assert True
+
+
+async def test_initialize_user_variables_skips_policy_hidden_provider_before_validation(
+    service,
+    session: AsyncSession,
+    monkeypatch,
+):
+    user_id = uuid4()
+    monkeypatch.setattr(
+        service.settings_service.settings,
+        "variables_to_get_from_environment",
+        ["ANTHROPIC_API_KEY"],
+    )
+    snapshot = ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id=user_id),
+        purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        candidate_provider_ids=frozenset({"openai", "anthropic"}),
+        allowed_provider_ids=frozenset({"openai"}),
+    )
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"ANTHROPIC_API_KEY": "hidden-secret"},  # pragma: allowlist secret
+            clear=True,
+        ),
+        patch("lfx.services.model_provider_policy.resolve_model_provider_policy", return_value=snapshot),
+        patch(
+            "lfx.base.models.unified_models.validate_model_provider_key",
+            side_effect=AssertionError("hidden provider credential must not be validated"),
+        ),
+    ):
+        await service.initialize_user_variables(user_id=user_id, session=session)
+
+    assert await service.list_variables(user_id, session=session) == []
 
 
 async def test_get_variable(service, session: AsyncSession):

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -1,7 +1,7 @@
 import io
 import json
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -233,6 +233,113 @@ class TestKnowledgeBaseAPI:
         assert record.model_selection == model_selection
         metadata = json.loads((tmp_path / active_user.username / kb_name / "embedding_metadata.json").read_text())
         assert metadata["model_selection"] == model_selection
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_fresh_chroma_client")
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_create_legacy_request_without_model_selection(
+        self,
+        mock_root,
+        mock_fresh_client,
+        client: AsyncClient,
+        logged_in_headers,
+        active_user,
+        tmp_path,
+        monkeypatch,
+    ):
+        from langflow.api.v1 import knowledge_bases as kb_api
+
+        mock_fresh_client.return_value = MagicMock()
+        mock_root.return_value = tmp_path
+        policy_check = MagicMock()
+        monkeypatch.setattr(kb_api, "require_model_provider", policy_check)
+        kb_name = "Legacy_KB_No_Selection"
+
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": kb_name,
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+            },
+        )
+
+        assert response.status_code == 201
+        record = await knowledge_base_service.get_by_user_and_name(active_user.id, kb_name)
+        assert record is not None
+        assert record.model_selection == {
+            "name": "text-embedding-3-small",
+            "provider": "OpenAI",
+        }
+        policy_check.assert_called_once()
+
+    async def test_create_rejects_disagreeing_embedding_providers_before_storage_or_db(
+        self, client: AsyncClient, logged_in_headers, monkeypatch
+    ):
+        from langflow.api.v1 import knowledge_bases as kb_api
+
+        root_path = MagicMock()
+        guard = AsyncMock()
+        policy_check = MagicMock()
+        monkeypatch.setattr(kb_api.KBStorageHelper, "get_root_path", root_path)
+        monkeypatch.setattr(kb_api, "_guard_kb_action", guard)
+        monkeypatch.setattr(kb_api, "require_model_provider", policy_check)
+
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": "Spoofed Provider KB",
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+                "model_selection": {
+                    "name": "text-embedding-3-small",
+                    "provider": "Anthropic",
+                },
+            },
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Model provider not found"}
+        root_path.assert_not_called()
+        guard.assert_not_awaited()
+        policy_check.assert_not_called()
+
+    async def test_create_denied_embedding_provider_is_hidden_before_storage_or_db(
+        self, client: AsyncClient, logged_in_headers, monkeypatch
+    ):
+        from langflow.api.v1 import knowledge_bases as kb_api
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        root_path = MagicMock()
+        guard = AsyncMock()
+        policy_check = MagicMock(
+            side_effect=ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.CONFIGURE)
+        )
+        monkeypatch.setattr(kb_api.KBStorageHelper, "get_root_path", root_path)
+        monkeypatch.setattr(kb_api, "_guard_kb_action", guard)
+        monkeypatch.setattr(kb_api, "require_model_provider", policy_check)
+
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": "Denied Provider KB",
+                "embedding_provider": "Anthropic",
+                "embedding_model": "claude-embed",
+                "model_selection": {"name": "claude-embed", "provider": "Anthropic"},
+            },
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Model provider not found"}
+        root_path.assert_not_called()
+        guard.assert_not_awaited()
+        policy_check.assert_called_once_with(
+            user_id=ANY,
+            provider="Anthropic",
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
 
     async def test_create_knowledge_base_rejects_unknown_backend(self, client: AsyncClient, logged_in_headers):
         response = await client.post(

--- a/src/backend/tests/unit/test_memory_base_preprocessing.py
+++ b/src/backend/tests/unit/test_memory_base_preprocessing.py
@@ -348,6 +348,31 @@ class TestRunPreprocessing:
         llm_cls.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_policy_denial_happens_before_api_key_lookup(self):
+        from langflow.services.memory_base.preprocessing import run_preprocessing
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        key_lookup = MagicMock()
+        with (
+            patch("langflow.services.memory_base.preprocessing.infer_llm_provider", return_value="Anthropic"),
+            patch(
+                "lfx.services.model_provider_policy.require_model_provider",
+                side_effect=ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.USE),
+            ),
+            patch("langflow.services.memory_base.preprocessing.get_api_key_for_provider", key_lookup),
+            pytest.raises(ModelProviderPolicyError),
+        ):
+            await run_preprocessing(
+                messages=[_make_message(text="hello")],
+                preproc_model="claude-test",
+                preproc_instructions="Summarize.",
+                kill_phrase="NO_INGEST",
+                user_id=uuid.uuid4(),
+            )
+
+        key_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_normal_response_returns_ingested(self):
         from langflow.services.memory_base.preprocessing import run_preprocessing
 

--- a/src/backend/tests/unit/test_memory_bases.py
+++ b/src/backend/tests/unit/test_memory_bases.py
@@ -514,6 +514,129 @@ class TestMemoryBaseCreateFlowOwnership:
         assert exc_info.value.status_code == 404
 
 
+class TestMemoryBaseProviderPolicy:
+    """Provider policy must run before Memory Base filesystem or persistence work."""
+
+    @pytest.fixture
+    def service(self):
+        from langflow.services.memory_base.service import MemoryBaseService
+
+        return MemoryBaseService()
+
+    @staticmethod
+    def _fake_scope(mock_db):
+        class _FakeCtx:
+            async def __aenter__(self):
+                return mock_db
+
+            async def __aexit__(self, *_args):
+                pass
+
+        scope = MagicMock()
+        scope.return_value = _FakeCtx()
+        return scope
+
+    @staticmethod
+    def _db_returning(value):
+        result = MagicMock()
+        result.first.return_value = value
+        db = AsyncMock()
+        db.exec = AsyncMock(return_value=result)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_create_denied_embedding_provider_stops_before_initialize_or_persist(self, service):
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        user_id = uuid.uuid4()
+        payload = MemoryBaseCreate(name="mb", flow_id=uuid.uuid4(), embedding_model="denied-embed")
+        db = self._db_returning(object())
+        initialize = AsyncMock()
+        denial = ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.CONFIGURE)
+
+        with (
+            patch("langflow.services.memory_base.service.session_scope", self._fake_scope(db)),
+            patch("langflow.services.memory_base.service.infer_embedding_provider", return_value="Anthropic"),
+            patch("langflow.services.memory_base.service.require_model_provider", side_effect=denial) as require,
+            patch("langflow.services.memory_base.service.initialize_kb", initialize),
+            pytest.raises(ModelProviderPolicyError),
+        ):
+            await service.create(payload, user_id=user_id)
+
+        require.assert_called_once_with(
+            user_id=user_id,
+            provider="Anthropic",
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
+        initialize.assert_not_awaited()
+        db.add.assert_not_called()
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_denied_preproc_model_is_rejected_even_when_preprocessing_is_disabled(self, service):
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        user_id = uuid.uuid4()
+        payload = MemoryBaseCreate(
+            name="mb",
+            flow_id=uuid.uuid4(),
+            embedding_model="text-embedding-3-small",
+            preprocessing=False,
+            preproc_model="claude-test",
+        )
+        db = self._db_returning(object())
+        initialize = AsyncMock()
+        denial = ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.CONFIGURE)
+
+        def require_provider(*, provider, **_kwargs):
+            if provider == "Anthropic":
+                raise denial
+
+        with (
+            patch("langflow.services.memory_base.service.session_scope", self._fake_scope(db)),
+            patch("langflow.services.memory_base.service.infer_llm_provider", return_value="Anthropic"),
+            patch(
+                "langflow.services.memory_base.service.require_model_provider",
+                side_effect=require_provider,
+            ) as require,
+            patch("langflow.services.memory_base.service.initialize_kb", initialize),
+            pytest.raises(ModelProviderPolicyError),
+        ):
+            await service.create(payload, user_id=user_id)
+
+        assert require.call_args.kwargs["purpose"] is ModelProviderPolicyPurpose.CONFIGURE
+        initialize.assert_not_awaited()
+        db.add.assert_not_called()
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_denied_embedding_provider_stops_before_mutation_or_persist(self, service):
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        user_id = uuid.uuid4()
+        mb = _make_mb(user_id=user_id, threshold=10)
+        mb.embedding_model = "denied-embed"
+        db = self._db_returning(mb)
+        denial = ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.CONFIGURE)
+
+        with (
+            patch("langflow.services.memory_base.service.session_scope", self._fake_scope(db)),
+            patch("langflow.services.memory_base.service.infer_embedding_provider", return_value="Anthropic"),
+            patch("langflow.services.memory_base.service.require_model_provider", side_effect=denial) as require,
+            pytest.raises(ModelProviderPolicyError),
+        ):
+            await service.update(mb.id, user_id, MemoryBaseUpdate(threshold=99))
+
+        require.assert_called_once_with(
+            user_id=user_id,
+            provider="Anthropic",
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
+        assert mb.threshold == 10
+        db.add.assert_not_called()
+        db.commit.assert_not_awaited()
+
+
 class TestMemoryBaseGuardPassesRealKbIdentity:
     """The ID-bearing guards must pass the REAL kb identity, not actor-as-owner.
 
@@ -2302,6 +2425,30 @@ class TestPreprocessingApiKeyValidation:
         ):
             # Should not raise.
             _validate_preprocessing_api_key(uuid.uuid4(), "gpt-4o")
+
+    def test_policy_denial_happens_before_api_key_lookup(self):
+        from langflow.services.memory_base.service import _validate_preprocessing_api_key
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        key_lookup = MagicMock()
+        user_id = uuid.uuid4()
+        with (
+            patch("langflow.services.memory_base.service.infer_llm_provider", return_value="Anthropic"),
+            patch(
+                "langflow.services.memory_base.service.require_model_provider",
+                side_effect=ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.CONFIGURE),
+            ) as require,
+            patch("langflow.services.memory_base.service.get_api_key_for_provider", key_lookup),
+            pytest.raises(ModelProviderPolicyError),
+        ):
+            _validate_preprocessing_api_key(user_id, "claude-test")
+
+        require.assert_called_once_with(
+            user_id=user_id,
+            provider="Anthropic",
+            purpose=ModelProviderPolicyPurpose.CONFIGURE,
+        )
+        key_lookup.assert_not_called()
 
     def test_raises_when_provider_unknown(self):
         from langflow.services.memory_base.service import (

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -410,6 +410,28 @@ def test_get_all_provider_mapped_fields_is_cached():
     assert fields1 is fields2
 
 
+def test_api_key_optional_provider_with_only_optional_variables_is_enabled_without_values():
+    from lfx.base.models.unified_models import credentials
+
+    optional_variables = [
+        {
+            "variable_key": "AMBIENT_ENDPOINT",
+            "required": False,
+            "is_secret": False,
+        }
+    ]
+    with (
+        patch.object(credentials, "get_provider_all_variables", return_value=optional_variables),
+        patch("lfx.base.models.provider_registry.is_api_key_optional", return_value=True),
+    ):
+        enabled = credentials._validate_and_get_enabled_providers(
+            {},
+            {"AmbientAuthCo": "AMBIENT_ENDPOINT"},
+        )
+
+    assert enabled == {"AmbientAuthCo"}
+
+
 # ---------------------------------------------------------------------------
 # get_embeddings tests
 # ---------------------------------------------------------------------------
@@ -590,6 +612,55 @@ def test_get_embeddings_populates_available_models_from_all_configured_providers
     assert result.available_models["text-embedding-3-small"] is primary
     assert result.available_models["text-embedding-3-large"] is openai_secondary
     assert result.available_models["models/text-embedding-004"] is google_embedding
+
+
+@patch("lfx.base.models.unified_models.get_api_key_for_provider")
+@patch("lfx.base.models.unified_models.get_embedding_class")
+def test_get_embeddings_skips_policy_denied_secondary_provider_before_lookup(
+    mock_get_class, mock_get_api_key, monkeypatch
+):
+    from lfx.services.model_provider_policy import (
+        ModelProviderPolicyContext,
+        ModelProviderPolicyPurpose,
+        ModelProviderPolicySnapshot,
+    )
+
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.instantiation._get_configured_embedding_providers",
+        lambda _user_id, _selected_provider: ["OpenAI", "Google Generative AI"],
+    )
+    looked_up_providers = []
+
+    def _embedding_names_for_provider(provider, _user_id):
+        looked_up_providers.append(provider)
+        if provider == "Google Generative AI":
+            pytest.fail("policy-denied provider catalog must not be read")
+        return ["text-embedding-3-small"]
+
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.instantiation._get_provider_embedding_model_names",
+        _embedding_names_for_provider,
+    )
+    mock_get_api_key.return_value = "sk-test"
+    primary = MagicMock(name="primary")
+    mock_embedding_class = MagicMock(return_value=primary)
+    mock_get_class.return_value = mock_embedding_class
+    policy = ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id="user-1"),
+        purpose=ModelProviderPolicyPurpose.USE,
+        candidate_provider_ids=frozenset({"openai", "google-generative-ai"}),
+        allowed_provider_ids=frozenset({"openai"}),
+    )
+
+    result = get_embeddings(
+        [_make_openai_embedding_model()],
+        api_key="sk-test",  # pragma: allowlist secret
+        provider_policy=policy,
+    )
+
+    assert result.available_models == {"text-embedding-3-small": primary}
+    assert looked_up_providers == ["OpenAI"]
+    assert all(call.args[1] != "Google Generative AI" for call in mock_get_api_key.call_args_list)
 
 
 @pytest.mark.parametrize(
@@ -1012,6 +1083,59 @@ def test_handle_model_input_update_calls_apply_provider_config_when_model_select
         )
 
         mock_apply.assert_called_once_with(build_config, "OpenAI")
+
+
+def test_policy_refresh_clears_hidden_provider_fields_before_applying_allowed_default():
+    from lfx.services.model_provider_policy import (
+        ModelProviderPolicyContext,
+        ModelProviderPolicyPurpose,
+        ModelProviderPolicySnapshot,
+    )
+
+    component = _make_mock_component()
+    watsonx = [{"name": "watsonx-test", "provider": "IBM WatsonX", "metadata": {}}]
+    openai = [{"name": "gpt-test", "provider": "OpenAI", "metadata": {}}]
+    build_config = {
+        "model": _make_model_field(value=watsonx),
+        "api_key": {
+            "show": True,
+            "required": True,
+            "value": "WATSONX_APIKEY",
+            "load_from_db": True,
+        },
+        "project_id": {
+            "show": True,
+            "required": True,
+            "value": "WATSONX_PROJECT_ID",
+            "load_from_db": True,
+        },
+    }
+    snapshot = ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id=component.user_id),
+        purpose=ModelProviderPolicyPurpose.USE,
+        candidate_provider_ids=frozenset({"openai", "ibm-watsonx"}),
+        allowed_provider_ids=frozenset({"openai"}),
+    )
+
+    with (
+        patch("lfx.services.model_provider_policy.resolve_model_provider_policy", return_value=snapshot),
+        patch("lfx.base.models.unified_models.apply_provider_variable_config_to_build_config") as mock_apply,
+    ):
+        mock_apply.side_effect = lambda config, _provider: config
+        result = handle_model_input_update(
+            component,
+            build_config,
+            field_value="WATSONX_APIKEY",
+            field_name="api_key",
+            get_options_func=lambda user_id=None: openai,  # noqa: ARG005
+        )
+
+    assert result["model"]["value"] == openai
+    assert result["api_key"]["value"] == ""
+    assert result["api_key"]["load_from_db"] is False
+    assert result["project_id"]["value"] == ""
+    assert result["project_id"]["load_from_db"] is False
+    mock_apply.assert_called_once_with(build_config, "OpenAI")
 
 
 def test_handle_model_input_update_watsonx_embedding_shows_special_fields():

--- a/src/lfx/PLUGGABLE_SERVICES.md
+++ b/src/lfx/PLUGGABLE_SERVICES.md
@@ -260,6 +260,7 @@ Service keys **must** match `ServiceType` enum values exactly:
 
 - `database_service`
 - `auth_service`
+- `model_provider_policy_service`
 - `storage_service`
 - `cache_service`
 - `chat_service`
@@ -276,6 +277,60 @@ Service keys **must** match `ServiceType` enum values exactly:
 - `transaction_service`
 
 **Important:** `settings_service` is **not pluggable** and cannot be overridden. It is always created using the built-in factory and provides the foundational configuration for all other services.
+
+### Model-provider policy service
+
+`model_provider_policy_service` controls which registered providers are exposed through the unified model-provider surfaces. The built-in `ModelProviderPolicyService` allows every candidate provider, preserving the historical OSS behavior. A deployment can replace it with a subclass of `BaseModelProviderPolicyService`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Collection
+
+from lfx.services.model_provider_policy import (
+    BaseModelProviderPolicyService,
+    ModelProviderPolicyContext,
+    ModelProviderPolicyPurpose,
+)
+
+
+class AcmeModelProviderPolicyService(BaseModelProviderPolicyService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_ready()
+
+    def get_allowed_provider_ids(
+        self,
+        *,
+        context: ModelProviderPolicyContext,
+        candidate_provider_ids: frozenset[str],
+        purpose: ModelProviderPolicyPurpose,
+    ) -> Collection[str]:
+        deployment_ceiling = frozenset({"openai", "acme.models"})
+        # A later RBAC implementation can narrow this set using context.user_id,
+        # context.attributes, and purpose in the same batch decision.
+        return candidate_provider_ids & deployment_ceiling
+```
+
+The method receives stable provider IDs for both core and extension-contributed providers and returns the allowed subset. The base service rejects results that widen the candidate set and returns an immutable decision snapshot. Calls are synchronous so configuration and runtime paths can share one batch decision without introducing async work into model construction.
+
+`purpose` identifies the protected operation:
+
+- `discover` filters provider and model listings.
+- `configure` guards credentials, validation, and enabled-model changes.
+- `use` guards model selection, defaults, and runtime instantiation.
+
+Install the package that contains the implementation, then select it through deploy-time configuration:
+
+```toml
+# $LANGFLOW_CONFIG_DIR/lfx.toml
+[services]
+model_provider_policy_service = "acme_langflow.policy:AcmeModelProviderPolicyService"
+```
+
+The equivalent `pyproject.toml` section is `[tool.lfx.services]`. When both files exist, `lfx.toml` is preferred. Config-file registration has higher precedence than the built-in decorator; an `lfx.services` entry point alone does not replace the OSS default. The configured class must inherit `BaseModelProviderPolicyService`; service resolution fails closed for an incompatible implementation.
+
+This policy applies to shared unified model catalogs, configuration APIs, selectors, and runtime helpers. It does not hide provider-specific component classes from the component palette.
 
 ## Creating Custom Services
 

--- a/src/lfx/lfx.toml.example
+++ b/src/lfx/lfx.toml.example
@@ -21,6 +21,9 @@ cache_service = "langflow.services.cache.service:ThreadingInMemoryCache"
 auth_service = "langflow.services.auth.service:AuthService"
 session_service = "langflow.services.session.service:SessionService"
 
+# Model Provider Policy (optional; the built-in implementation allows every registered provider)
+# model_provider_policy_service = "acme_langflow.policy:AcmeModelProviderPolicyService"
+
 # Chat & Communication
 chat_service = "langflow.services.chat.service:ChatService"
 

--- a/src/lfx/src/lfx/base/models/model_metadata.py
+++ b/src/lfx/src/lfx/base/models/model_metadata.py
@@ -309,6 +309,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
     },
     "IBM WatsonX": {
         "provider_id": "ibm-watsonx",
+        "aliases": ["IBM watsonx.ai"],
         "icon": "WatsonxAI",
         "max_tokens_field_name": "max_tokens",
         "variables": [

--- a/src/lfx/src/lfx/base/models/model_metadata.py
+++ b/src/lfx/src/lfx/base/models/model_metadata.py
@@ -92,6 +92,7 @@ EXPLICIT_ENABLE_ONLY_PROVIDERS: frozenset[str] = frozenset({"Azure AI Foundry"})
 #
 MODEL_PROVIDER_METADATA: dict[str, Any] = {
     "OpenAI": {
+        "provider_id": "openai",
         "icon": "OpenAI",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -131,6 +132,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Anthropic": {
+        "provider_id": "anthropic",
         "icon": "Anthropic",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -157,6 +159,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Google Generative AI": {
+        "provider_id": "google-generative-ai",
         "icon": "GoogleGenerativeAI",
         "max_tokens_field_name": "max_output_tokens",
         "variables": [
@@ -183,6 +186,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Ollama": {
+        "provider_id": "ollama",
         "icon": "Ollama",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -209,6 +213,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Groq": {
+        "provider_id": "groq",
         "icon": "Groq",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -235,6 +240,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Azure OpenAI": {
+        "provider_id": "azure-openai",
         "icon": "Azure",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -261,6 +267,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "Azure AI Foundry": {
+        "provider_id": "azure-ai-foundry",
         "icon": "Azure",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -301,6 +308,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "IBM WatsonX": {
+        "provider_id": "ibm-watsonx",
         "icon": "WatsonxAI",
         "max_tokens_field_name": "max_tokens",
         "variables": [
@@ -365,6 +373,7 @@ MODEL_PROVIDER_METADATA: dict[str, Any] = {
         },
     },
     "OpenRouter": {
+        "provider_id": "openrouter",
         "icon": "OpenRouter",
         "max_tokens_field_name": "max_tokens",
         "base_url": "https://openrouter.ai/api/v1",

--- a/src/lfx/src/lfx/base/models/provider_registry.py
+++ b/src/lfx/src/lfx/base/models/provider_registry.py
@@ -38,7 +38,8 @@ from __future__ import annotations
 import importlib
 import re
 import threading
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
@@ -56,13 +57,16 @@ from lfx.base.models.unified_models.class_registry import (
 from lfx.log.logger import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Sequence
 
 # Provider names that ship in core lfx.  Captured at import (before any bundle
 # can register) so collision detection never depends on registration order.
 _CORE_PROVIDER_NAMES: frozenset[str] = frozenset(MODEL_PROVIDER_METADATA)
 
 _PROVIDER_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_RESERVED_PROVIDER_METADATA_KEYS = frozenset(
+    {"provider", "name", "models", "num_models", "provider_id", "display_name", "aliases"}
+)
 
 ClassRef = tuple[str, str, str | None]
 """``(module_path, attribute_name, install_hint | None)`` -- the shape the lazy
@@ -101,7 +105,7 @@ class ProviderDescriptor:
     """
 
     name: str
-    metadata: dict
+    metadata: Mapping[str, Any]
     # Stable machine identity used by policy and extension compatibility.
     # ``name`` remains the legacy public selector stored in existing flows.
     provider_id: str | None = None
@@ -115,7 +119,9 @@ class ProviderDescriptor:
     # EMBEDDING_PROVIDER_CLASS_MAPPING[name] and the key into
     # _EMBEDDING_CLASS_IMPORTS; ``embedding_class`` supplies the import tuple
     # when that class is novel.  ``embedding_param_key``/``embedding_param_mapping``
-    # populate EMBEDDING_PARAM_MAPPINGS.
+    # populate EMBEDDING_PARAM_MAPPINGS. The mapping is always available under
+    # ``name`` because runtime consumers index it by the selected provider; an
+    # alternate key is retained as a compatibility alias for older manifests.
     embedding_class_name: str | None = None
     embedding_class: ClassRef | None = None
     embedding_param_key: str | None = None
@@ -232,9 +238,14 @@ def _validate_spec(spec: ProviderDescriptor) -> None:
     if not spec.name or not isinstance(spec.name, str):
         msg = "ProviderSpec.name must be a non-empty string"
         raise ValueError(msg)
-    if not isinstance(spec.metadata, dict):
-        msg = f"ProviderSpec.metadata for {spec.name!r} must be a dict"
+    if not isinstance(spec.metadata, Mapping):
+        msg = f"ProviderSpec.metadata for {spec.name!r} must be a mapping"
         raise ValueError(msg)  # noqa: TRY004 - spec validation surfaces uniformly as ValueError
+    reserved_metadata_keys = _RESERVED_PROVIDER_METADATA_KEYS.intersection(spec.metadata)
+    if reserved_metadata_keys:
+        keys = ", ".join(sorted(reserved_metadata_keys))
+        msg = f"ProviderDescriptor.metadata for {spec.name!r} contains reserved keys: {keys}"
+        raise ValueError(msg)
     if not spec.model_class_name():
         msg = f"ProviderSpec.metadata for {spec.name!r} must set mapping.model_class"
         raise ValueError(msg)
@@ -359,12 +370,20 @@ def register_provider(spec: ProviderDescriptor) -> bool:
                     f"conflicts with an existing import"
                 )
                 raise ValueError(msg)
-            if spec.embedding_param_key and spec.embedding_param_key in EMBEDDING_PARAM_MAPPINGS:
-                msg = (
-                    f"ProviderSpec {spec.name!r} embedding params {spec.embedding_param_key!r} "
-                    f"conflict with an existing mapping"
+            if spec.embedding_param_mapping is not None:
+                embedding_param_keys = {spec.name}
+                if spec.embedding_param_key:
+                    embedding_param_keys.add(spec.embedding_param_key)
+                conflicting_param_key = next(
+                    (key for key in embedding_param_keys if key in EMBEDDING_PARAM_MAPPINGS),
+                    None,
                 )
-                raise ValueError(msg)
+                if conflicting_param_key is not None:
+                    msg = (
+                        f"ProviderSpec {spec.name!r} embedding params {conflicting_param_key!r} "
+                        f"conflict with an existing mapping"
+                    )
+                    raise ValueError(msg)
 
         # --- metadata (C1) -------------------------------------------------
         metadata = dict(spec.metadata)
@@ -387,9 +406,13 @@ def register_provider(spec: ProviderDescriptor) -> bool:
             if spec.embedding_class and spec.embedding_class_name not in _EMBEDDING_CLASS_IMPORTS:
                 _EMBEDDING_CLASS_IMPORTS[spec.embedding_class_name] = spec.embedding_class
                 _undo.embedding_class_keys.add(spec.embedding_class_name)
-            if spec.embedding_param_key and spec.embedding_param_mapping is not None:
-                EMBEDDING_PARAM_MAPPINGS[spec.embedding_param_key] = dict(spec.embedding_param_mapping)
-                _undo.embedding_param_keys.add(spec.embedding_param_key)
+            if spec.embedding_param_mapping is not None:
+                embedding_param_keys = {spec.name}
+                if spec.embedding_param_key:
+                    embedding_param_keys.add(spec.embedding_param_key)
+                for embedding_param_key in embedding_param_keys:
+                    EMBEDDING_PARAM_MAPPINGS[embedding_param_key] = dict(spec.embedding_param_mapping)
+                    _undo.embedding_param_keys.add(embedding_param_key)
 
         # --- live-discovery gate (C2) -------------------------------------
         if spec.live and spec.name not in LIVE_MODEL_PROVIDERS:
@@ -554,13 +577,35 @@ def get_registry_snapshot(*, validate_catalogs: bool = False) -> ProviderRegistr
     if validate_catalogs:
         validate_registered_provider_catalogs()
     descriptors = {
-        provider_id: descriptor
+        provider_id: _freeze_descriptor(descriptor)
         for provider_id in _core_provider_ids() | _registered_ids
         if (descriptor := get_provider_descriptor(provider_id)) is not None
     }
     return ProviderRegistrySnapshot(
         generation=_generation,
         descriptors_by_id=MappingProxyType(descriptors),
+    )
+
+
+def _freeze_value(value: Any) -> Any:
+    """Recursively freeze manifest-owned containers for snapshot consumers."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
+
+
+def _freeze_descriptor(descriptor: ProviderDescriptor) -> ProviderDescriptor:
+    embedding_mapping = (
+        _freeze_value(descriptor.embedding_param_mapping) if descriptor.embedding_param_mapping is not None else None
+    )
+    return replace(
+        descriptor,
+        metadata=_freeze_value(descriptor.metadata),
+        embedding_param_mapping=embedding_mapping,
     )
 
 

--- a/src/lfx/src/lfx/base/models/provider_registry.py
+++ b/src/lfx/src/lfx/base/models/provider_registry.py
@@ -36,9 +36,11 @@ test seam.
 from __future__ import annotations
 
 import importlib
+import re
 import threading
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
 
 from lfx.base.models.model_metadata import (
     CONDITIONAL_LIVE_MODEL_PROVIDERS,
@@ -54,19 +56,40 @@ from lfx.base.models.unified_models.class_registry import (
 from lfx.log.logger import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping, Sequence
 
 # Provider names that ship in core lfx.  Captured at import (before any bundle
 # can register) so collision detection never depends on registration order.
 _CORE_PROVIDER_NAMES: frozenset[str] = frozenset(MODEL_PROVIDER_METADATA)
+
+_PROVIDER_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
 ClassRef = tuple[str, str, str | None]
 """``(module_path, attribute_name, install_hint | None)`` -- the shape the lazy
 class-import tables in ``class_registry`` expect."""
 
 
+def _derive_provider_id(name: str) -> str:
+    """Derive a compatibility ID for manifests that predate ``provider_id``."""
+    provider_id = re.sub(r"[^a-z0-9._-]+", "-", name.strip().lower()).strip("-._")
+    if not provider_id:
+        msg = f"Could not derive a provider_id from provider name {name!r}"
+        raise ValueError(msg)
+    return provider_id
+
+
 @dataclass(frozen=True)
-class ProviderSpec:
+class ProviderOrigin:
+    """Loader-owned provenance for an extension provider declaration."""
+
+    extension_id: str
+    extension_version: str
+    distribution: str | None = None
+    manifest_path: str | None = None
+
+
+@dataclass(frozen=True)
+class ProviderDescriptor:
     """A bundle-declared model provider, ready to merge into the core tables.
 
     ``metadata`` mirrors a single ``MODEL_PROVIDER_METADATA`` value (``icon``,
@@ -79,6 +102,11 @@ class ProviderSpec:
 
     name: str
     metadata: dict
+    # Stable machine identity used by policy and extension compatibility.
+    # ``name`` remains the legacy public selector stored in existing flows.
+    provider_id: str | None = None
+    display_name: str | None = None
+    aliases: tuple[str, ...] = ()
     # LLM chat class, keyed under metadata["mapping"]["model_class"].  Omit when
     # the provider reuses a class already in _MODEL_CLASS_IMPORTS (e.g. an
     # OpenAI-compatible provider reusing "ChatOpenAI").
@@ -105,10 +133,35 @@ class ProviderSpec:
     #   validator(provider, variables, model_name) -> None  (raises ValueError on failure)
     live_discovery: str | None = None
     validator: str | None = None
+    # Dotted-path ``module.path:attr`` callable returning a flat list of
+    # model-metadata rows. Provider ownership is stamped by the registry.
+    catalog_loader: str | None = None
+    # Filled by the extension loader, never by extension.json authors.
+    origin: ProviderOrigin | None = None
 
     def model_class_name(self) -> str | None:
         """Class name this provider's metadata references for its LLM."""
         return (self.metadata.get("mapping") or {}).get("model_class")
+
+    def canonical_id(self) -> str:
+        """Return the explicit provider ID or the legacy-compatible derived ID."""
+        return self.provider_id or _derive_provider_id(self.name)
+
+
+# Backward-compatible public name used by existing extension packages.
+ProviderSpec = ProviderDescriptor
+
+
+@dataclass(frozen=True)
+class ProviderRegistrySnapshot:
+    """Immutable point-in-time view consumed by policy/readiness layers."""
+
+    generation: int
+    descriptors_by_id: Mapping[str, ProviderDescriptor]
+
+    @property
+    def provider_ids(self) -> frozenset[str]:
+        return frozenset(self.descriptors_by_id)
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +169,14 @@ class ProviderSpec:
 # ---------------------------------------------------------------------------
 
 _lock = threading.RLock()
-_registered: dict[str, ProviderSpec] = {}
+_registered: dict[str, ProviderDescriptor] = {}
+_registered_ids: dict[str, str] = {}
+_registered_aliases: dict[str, str] = {}
 # Resolved-callable caches (dotted path -> callable), keyed by provider name.
 _live_discovery_cache: dict[str, Callable | None] = {}
 _validator_cache: dict[str, Callable | None] = {}
+_catalog_cache: dict[str, tuple[dict[str, Any], ...]] = {}
+_generation = 0
 
 
 @dataclass
@@ -143,7 +200,34 @@ _undo = _Undo()
 # ---------------------------------------------------------------------------
 
 
-def _validate_spec(spec: ProviderSpec) -> None:
+def _core_provider_ids() -> dict[str, str]:
+    """Return stable-id -> legacy-name mappings for providers shipped in core."""
+    return {
+        str(metadata.get("provider_id") or _derive_provider_id(name)): name
+        for name, metadata in MODEL_PROVIDER_METADATA.items()
+        if name in _CORE_PROVIDER_NAMES
+    }
+
+
+def _core_aliases() -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for provider_id, name in _core_provider_ids().items():
+        metadata = MODEL_PROVIDER_METADATA[name]
+        values = (name, provider_id, metadata.get("display_name"), *(metadata.get("aliases") or ()))
+        for value in values:
+            if isinstance(value, str) and value:
+                aliases[value.casefold()] = name
+    return aliases
+
+
+def _validate_callable_path(value: str, field_name: str, provider_name: str) -> None:
+    module_path, sep, attr = value.partition(":")
+    if not sep or not module_path or not attr:
+        msg = f"ProviderDescriptor {provider_name!r} {field_name} must be of the form 'module.path:attribute'"
+        raise ValueError(msg)
+
+
+def _validate_spec(spec: ProviderDescriptor) -> None:
     """Raise ``ValueError`` if *spec* is missing essentials needed to merge."""
     if not spec.name or not isinstance(spec.name, str):
         msg = "ProviderSpec.name must be a non-empty string"
@@ -158,8 +242,30 @@ def _validate_spec(spec: ProviderSpec) -> None:
         msg = f"ProviderSpec {spec.name!r} cannot be both live and conditional_live"
         raise ValueError(msg)
 
+    provider_id = spec.canonical_id()
+    if not _PROVIDER_ID_RE.fullmatch(provider_id):
+        msg = f"ProviderDescriptor.provider_id for {spec.name!r} must match ^[a-z0-9][a-z0-9._-]*$"
+        raise ValueError(msg)
+    if spec.display_name is not None and not spec.display_name.strip():
+        msg = f"ProviderDescriptor.display_name for {spec.name!r} must be non-empty"
+        raise ValueError(msg)
+    normalized_aliases: set[str] = set()
+    for alias in spec.aliases:
+        if not isinstance(alias, str) or not alias.strip():
+            msg = f"ProviderDescriptor.aliases for {spec.name!r} must contain non-empty strings"
+            raise ValueError(msg)
+        normalized = alias.casefold()
+        if normalized in normalized_aliases:
+            msg = f"ProviderDescriptor.aliases for {spec.name!r} contain a duplicate alias {alias!r}"
+            raise ValueError(msg)
+        normalized_aliases.add(normalized)
+    for field_name in ("live_discovery", "validator", "catalog_loader"):
+        value = getattr(spec, field_name)
+        if value is not None:
+            _validate_callable_path(value, field_name, spec.name)
 
-def register_provider(spec: ProviderSpec) -> bool:
+
+def register_provider(spec: ProviderDescriptor) -> bool:
     """Merge *spec* into the core provider tables in place.
 
     Returns ``True`` when the provider was registered, ``False`` when it was
@@ -169,19 +275,54 @@ def register_provider(spec: ProviderSpec) -> bool:
     """
     _validate_spec(spec)
 
+    global _generation  # noqa: PLW0603 - registry generation advances atomically with registration
+
     with _lock:
-        if spec.name in _CORE_PROVIDER_NAMES:
+        provider_id = spec.canonical_id()
+        core_aliases = _core_aliases()
+        identity_aliases = (spec.name, provider_id, spec.display_name, *spec.aliases)
+        normalized_identities = {
+            identity.casefold() for identity in identity_aliases if isinstance(identity, str) and identity
+        }
+
+        if spec.name in _CORE_PROVIDER_NAMES or spec.name.casefold() in core_aliases:
             logger.warning(
                 f"Extension tried to register model provider {spec.name!r}, which is a built-in "
                 f"provider; ignoring the bundle definition (core providers take precedence)."
             )
             return False
+        if provider_id in _core_provider_ids():
+            msg = (
+                f"ProviderDescriptor {spec.name!r} provider_id {provider_id!r} conflicts with "
+                f"built-in provider {_core_provider_ids()[provider_id]!r}"
+            )
+            raise ValueError(msg)
         if spec.name in _registered:
             logger.warning(
                 f"Model provider {spec.name!r} is already registered by another extension; "
                 f"ignoring the duplicate registration (first registration wins)."
             )
             return False
+        if provider_id in _registered_ids:
+            msg = (
+                f"ProviderDescriptor {spec.name!r} provider_id {provider_id!r} conflicts with "
+                f"registered provider {_registered_ids[provider_id]!r}"
+            )
+            raise ValueError(msg)
+        conflicting_core_alias = next((alias for alias in normalized_identities if alias in core_aliases), None)
+        if conflicting_core_alias is not None:
+            msg = (
+                f"ProviderDescriptor {spec.name!r} alias {conflicting_core_alias!r} conflicts with "
+                f"built-in provider {core_aliases[conflicting_core_alias]!r}"
+            )
+            raise ValueError(msg)
+        conflicting_alias = next((alias for alias in normalized_identities if alias in _registered_aliases), None)
+        if conflicting_alias is not None:
+            msg = (
+                f"ProviderDescriptor {spec.name!r} alias {conflicting_alias!r} conflicts with "
+                f"registered provider {_registered_aliases[conflicting_alias]!r}"
+            )
+            raise ValueError(msg)
 
         # Validate lazy-import + embedding keys before mutating any global table,
         # so a malformed spec is rejected wholesale (never partially applied) and
@@ -226,7 +367,12 @@ def register_provider(spec: ProviderSpec) -> bool:
                 raise ValueError(msg)
 
         # --- metadata (C1) -------------------------------------------------
-        MODEL_PROVIDER_METADATA[spec.name] = spec.metadata
+        metadata = dict(spec.metadata)
+        metadata["provider_id"] = provider_id
+        metadata["display_name"] = spec.display_name or spec.name
+        if spec.aliases:
+            metadata["aliases"] = list(spec.aliases)
+        MODEL_PROVIDER_METADATA[spec.name] = metadata
         _undo.metadata_keys.add(spec.name)
 
         # --- LLM class lazy-import (C3) ------------------------------------
@@ -254,8 +400,13 @@ def register_provider(spec: ProviderSpec) -> bool:
             _undo.conditional_live_names.add(spec.name)
 
         _registered[spec.name] = spec
+        _registered_ids[provider_id] = spec.name
+        for identity in normalized_identities:
+            _registered_aliases[identity] = spec.name
         _live_discovery_cache.pop(spec.name, None)
         _validator_cache.pop(spec.name, None)
+        _catalog_cache.pop(spec.name, None)
+        _generation += 1
         _clear_derived_caches()
 
     logger.debug(f"Registered bundle model provider {spec.name!r}")
@@ -347,6 +498,154 @@ def registered_provider_names() -> frozenset[str]:
     return frozenset(_registered)
 
 
+def provider_id_for(provider: str) -> str | None:
+    """Resolve a legacy name, display name, alias, or provider ID to its stable ID."""
+    if not isinstance(provider, str) or not provider:
+        return None
+
+    metadata = MODEL_PROVIDER_METADATA.get(provider)
+    if metadata is not None:
+        return str(metadata.get("provider_id") or _derive_provider_id(provider))
+
+    normalized = provider.casefold()
+    core_name = _core_aliases().get(normalized)
+    if core_name is not None:
+        core_metadata = MODEL_PROVIDER_METADATA[core_name]
+        return str(core_metadata.get("provider_id") or _derive_provider_id(core_name))
+
+    registered_name = _registered_aliases.get(normalized)
+    if registered_name is None:
+        return None
+    return _registered[registered_name].canonical_id()
+
+
+def provider_name_for_id(provider_id: str) -> str | None:
+    """Return the legacy public provider name for a stable provider ID."""
+    if not isinstance(provider_id, str) or not provider_id:
+        return None
+    core_name = _core_provider_ids().get(provider_id)
+    if core_name is not None:
+        return core_name
+    return _registered_ids.get(provider_id)
+
+
+def get_provider_descriptor(provider: str) -> ProviderDescriptor | None:
+    """Return a descriptor for a core or extension provider."""
+    provider_id = provider_id_for(provider)
+    if provider_id is None:
+        return None
+    name = provider_name_for_id(provider_id)
+    if name is None:
+        return None
+    registered = _registered.get(name)
+    if registered is not None:
+        return registered
+    return ProviderDescriptor(
+        name=name,
+        provider_id=provider_id,
+        display_name=str(MODEL_PROVIDER_METADATA[name].get("display_name") or name),
+        aliases=tuple(MODEL_PROVIDER_METADATA[name].get("aliases") or ()),
+        metadata=dict(MODEL_PROVIDER_METADATA[name]),
+    )
+
+
+def get_registry_snapshot(*, validate_catalogs: bool = False) -> ProviderRegistrySnapshot:
+    """Return an immutable registry snapshot after optional eager catalog validation."""
+    if validate_catalogs:
+        validate_registered_provider_catalogs()
+    descriptors = {
+        provider_id: descriptor
+        for provider_id in _core_provider_ids() | _registered_ids
+        if (descriptor := get_provider_descriptor(provider_id)) is not None
+    }
+    return ProviderRegistrySnapshot(
+        generation=_generation,
+        descriptors_by_id=MappingProxyType(descriptors),
+    )
+
+
+def _load_registered_catalog(provider: str) -> tuple[dict[str, Any], ...]:
+    if provider in _catalog_cache:
+        return _catalog_cache[provider]
+
+    spec = _registered.get(provider)
+    if spec is None or spec.catalog_loader is None:
+        _catalog_cache[provider] = ()
+        return ()
+
+    loader = _resolve_callable(spec.catalog_loader)
+    rows = loader()
+    if not isinstance(rows, list):
+        msg = f"Catalog loader for provider {provider!r} must return a list of model metadata rows"
+        raise TypeError(msg)
+
+    normalized_rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    provider_metadata = MODEL_PROVIDER_METADATA[provider]
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            msg = f"Catalog loader for provider {provider!r} returned non-dict row at index {index}"
+            raise TypeError(msg)
+        name = row.get("name")
+        if not isinstance(name, str) or not name.strip():
+            msg = f"Catalog loader for provider {provider!r} returned row {index} without a model name"
+            raise ValueError(msg)
+        model_type = row.get("model_type", "llm")
+        if model_type not in {"llm", "embeddings"}:
+            msg = (
+                f"Catalog loader for provider {provider!r} returned unsupported model_type "
+                f"{model_type!r} at row {index}"
+            )
+            raise ValueError(msg)
+        key = (model_type, name)
+        if key in seen:
+            msg = f"Catalog loader for provider {provider!r} returned duplicate model identity {key!r}"
+            raise ValueError(msg)
+        seen.add(key)
+
+        normalized = dict(row)
+        normalized["provider"] = provider
+        normalized["name"] = name.strip()
+        normalized["model_type"] = model_type
+        normalized.setdefault("icon", provider_metadata.get("icon", "Bot"))
+        normalized_rows.append(normalized)
+
+    result = tuple(normalized_rows)
+    _catalog_cache[provider] = result
+    return result
+
+
+def get_registered_model_catalogs() -> list[list[dict[str, Any]]]:
+    """Return validated static catalog groups contributed by provider extensions.
+
+    A bad optional extension is isolated from the shared catalog and logged. A
+    deployment that requires an extension should call
+    :func:`validate_registered_provider_catalogs` during readiness and fail
+    startup on the same error.
+    """
+    groups: list[list[dict[str, Any]]] = []
+    for provider in _registered:
+        try:
+            rows = _load_registered_catalog(provider)
+        except Exception as exc:  # noqa: BLE001 - extension import and execution are isolated here
+            logger.warning(f"Could not load static model catalog for provider {provider!r}: {exc}")
+            continue
+        if rows:
+            groups.append([dict(row) for row in rows])
+    return groups
+
+
+def validate_registered_provider_catalogs(providers: Sequence[str] | None = None) -> None:
+    """Eagerly validate provider catalogs for startup/readiness checks."""
+    selected = tuple(providers) if providers is not None else tuple(_registered)
+    for provider in selected:
+        name = provider_name_for_id(provider) or provider
+        if name not in _registered:
+            msg = f"Cannot validate catalog for unregistered extension provider {provider!r}"
+            raise ValueError(msg)
+        _load_registered_catalog(name)
+
+
 # ---------------------------------------------------------------------------
 # Test seam
 # ---------------------------------------------------------------------------
@@ -357,6 +656,8 @@ def clear() -> None:
 
     Intended for tests so a registered provider does not leak across cases.
     """
+    global _generation  # noqa: PLW0603 - test seam restores an empty extension generation
+
     with _lock:
         for key in _undo.metadata_keys:
             MODEL_PROVIDER_METADATA.pop(key, None)
@@ -375,8 +676,11 @@ def clear() -> None:
             if name in CONDITIONAL_LIVE_MODEL_PROVIDERS:
                 CONDITIONAL_LIVE_MODEL_PROVIDERS.remove(name)
         _registered.clear()
+        _registered_ids.clear()
+        _registered_aliases.clear()
         _live_discovery_cache.clear()
         _validator_cache.clear()
+        _catalog_cache.clear()
         _undo.metadata_keys.clear()
         _undo.model_class_keys.clear()
         _undo.embedding_class_keys.clear()
@@ -384,4 +688,5 @@ def clear() -> None:
         _undo.embedding_param_keys.clear()
         _undo.live_names.clear()
         _undo.conditional_live_names.clear()
+        _generation += 1
         _clear_derived_caches()

--- a/src/lfx/src/lfx/base/models/unified_models/__init__.py
+++ b/src/lfx/src/lfx/base/models/unified_models/__init__.py
@@ -41,6 +41,7 @@ from .provider_queries import (
     get_provider_for_model_name,
     get_provider_from_variable_key,
     get_provider_required_variable_keys,
+    get_provider_secret_variable_key,
     model_provider_metadata,
 )
 
@@ -69,6 +70,7 @@ __all__ = [
     "get_provider_for_model_name",
     "get_provider_from_variable_key",
     "get_provider_required_variable_keys",
+    "get_provider_secret_variable_key",
     "get_unified_models_detailed",
     "handle_model_input_update",
     "model_provider_metadata",

--- a/src/lfx/src/lfx/base/models/unified_models/build_config.py
+++ b/src/lfx/src/lfx/base/models/unified_models/build_config.py
@@ -229,6 +229,28 @@ def apply_provider_variable_config_to_build_config(
     return build_config
 
 
+def _filter_model_options_by_policy(user_id: Any, options: list[Any]):
+    """Filter provider-bearing options and return the decision snapshot used."""
+    from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+    from .provider_queries import get_model_providers
+
+    option_providers = {
+        option.get("provider") for option in options if isinstance(option, dict) and option.get("provider")
+    }
+    policy = resolve_model_provider_policy(
+        user_id=user_id,
+        providers=[*get_model_providers(), *option_providers],
+        purpose=ModelProviderPolicyPurpose.USE,
+    )
+    visible_options = [
+        option
+        for option in options
+        if not isinstance(option, dict) or not option.get("provider") or policy.allows(option["provider"])
+    ]
+    return visible_options, policy
+
+
 def update_model_options_in_build_config(
     component: Any,
     build_config: dict,
@@ -257,8 +279,16 @@ def update_model_options_in_build_config(
 
     # If component has static options, skip the refresh logic entirely
     if component.cache.get(static_options_cache_key, False):
-        # Static options - don't override them
-        # Just handle the visibility logic and return
+        static_options = build_config.get(model_field_name, {}).get("options") or []
+        visible_options, provider_policy = _filter_model_options_by_policy(component.user_id, static_options)
+        build_config[model_field_name]["options"] = visible_options
+        current_value = build_config.get(model_field_name, {}).get("value")
+        if isinstance(current_value, list) and current_value and isinstance(current_value[0], dict):
+            current_provider = current_value[0].get("provider")
+            if current_provider and not provider_policy.allows(current_provider):
+                build_config[model_field_name]["value"] = [visible_options[0]] if visible_options else None
+
+        # Static options remain the source; policy only narrows their visibility.
         if field_value == "connect_other_models":
             # User explicitly selected "Connect other models", show the handle
             if cache_key_prefix == "embedding_model_options":
@@ -307,7 +337,9 @@ def update_model_options_in_build_config(
 
     # Use cached results
     cached = component.cache.get(cache_key, {"options": []})
-    build_config[model_field_name]["options"] = cached["options"]
+    cached_options = cached.get("options", [])
+    visible_options, provider_policy = _filter_model_options_by_policy(component.user_id, cached_options)
+    build_config[model_field_name]["options"] = visible_options
 
     # Sticky-default: if the currently saved value references a model that
     # isn't in the freshly-fetched options list (e.g. an imported flow whose
@@ -328,10 +360,14 @@ def update_model_options_in_build_config(
         saved_name = saved["name"]
         saved_provider = saved.get("provider", "")
         options_list = build_config[model_field_name]["options"]
+        saved_provider_allowed = bool(saved_provider) and provider_policy.allows(saved_provider)
         already_present = any(
             opt.get("name") == saved_name and opt.get("provider", "") == saved_provider for opt in options_list
         )
-        if not already_present:
+        if not saved_provider_allowed:
+            logger.debug("Dropping saved model from policy-hidden provider %s", saved_provider)
+            build_config[model_field_name]["value"] = None
+        elif not already_present:
             # When the ModelInput declares filters (e.g. Agent passes
             # ``filters={"tool_calling": True}``) and the saved selection
             # exists in the catalog but doesn't satisfy them, the regular
@@ -362,7 +398,7 @@ def update_model_options_in_build_config(
     # non-model field (like api_key) is cleared or set to a global variable.
     current_model_value = build_config.get(model_field_name, {}).get("value")
     if not current_model_value:
-        options = cached.get("options", [])
+        options = visible_options
         if options:
             # Determine model type based on cache_key_prefix
             model_type = "embeddings" if cache_key_prefix == "embedding_model_options" else "language"
@@ -476,6 +512,15 @@ def handle_model_input_update(
     """Full update_build_config lifecycle for any component with a ModelInput."""
     from lfx.base.models import unified_models as unified_models_module
 
+    def _selected_provider() -> str | None:
+        selection = build_config.get(model_field_name, {}).get("value")
+        if isinstance(selection, list) and selection and isinstance(selection[0], dict):
+            provider = selection[0].get("provider")
+            return provider if isinstance(provider, str) and provider else None
+        return None
+
+    selected_provider_before_refresh = _selected_provider()
+
     # If get_options_func is not provided, derive one from the declarative
     # ``filters`` dict on the ModelInput (e.g. Agent declares
     # ``filters={"tool_calling": True}``). The cache prefix is namespaced by
@@ -516,11 +561,13 @@ def handle_model_input_update(
         field_value=field_value,
         model_field_name=model_field_name,
     )
+    selected_provider_after_refresh = _selected_provider()
+    provider_changed_during_refresh = selected_provider_before_refresh != selected_provider_after_refresh
 
     # When the user directly edits a provider-specific field (e.g. api_key),
     # skip the provider reset/re-population so their value is preserved.
     provider_mapped_fields = _get_all_provider_mapped_fields()
-    if field_name in provider_mapped_fields:
+    if field_name in provider_mapped_fields and not provider_changed_during_refresh:
         return build_config
 
     # If the model field is in connection mode (user chose "Connect other models"),
@@ -537,8 +584,11 @@ def handle_model_input_update(
         if value_missing:
             # If the current value is not in the options (e.g. user switched to a model that
             # is no longer available), reset to avoid confusion so the user can pick a valid one.
-            option_names = {opt["name"] for opt in options}
-            value_is_valid = bool(field_value) and field_value[0]["name"] in option_names
+            value_is_valid = bool(field_value) and any(
+                option.get("name") == field_value[0].get("name")
+                and option.get("provider") == field_value[0].get("provider")
+                for option in options
+            )
 
             # If the value is invalid, reset to the first option if available, otherwise empty.
             build_config[model_field_name]["value"] = field_value if value_is_valid else [options[0]] if options else ""
@@ -558,6 +608,9 @@ def handle_model_input_update(
             field_config = build_config[field]
             field_config["show"] = False
             field_config["required"] = False
+            if provider_changed_during_refresh:
+                field_config["value"] = ""
+                field_config["load_from_db"] = False
 
     # Step 3: Show/configure the right fields for the selected provider
     # Use field_value when the user actively changed the model selection;

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -19,7 +19,9 @@ from lfx.utils.ssrf_protection import validate_connector_url_for_ssrf
 
 from .provider_queries import (
     get_model_provider_variable_mapping,
+    get_model_providers,
     get_provider_all_variables,
+    get_provider_secret_variable_key,
 )
 
 MODEL_STATUS_KEY_SEPARATOR = "::"
@@ -126,6 +128,14 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
 
     if api_key and api_key.strip():
         var_name = api_key.strip()
+        # A malformed or legacy component can point its api_key field at any
+        # global variable name. Never reinterpret declared non-secret provider
+        # configuration (for example, a base URL) as bearer credentials.
+        if any(
+            variable.get("variable_key") == var_name and not variable.get("is_secret")
+            for variable in get_provider_all_variables(provider)
+        ):
+            return None
         # Names that look like env/global variables (e.g. MY_OPENAI_API_KEY): resolve from env/DB
         if var_name.replace("_", "").isalnum() and var_name[0].isalpha():
             resolved = _resolve_var_name(var_name)
@@ -138,8 +148,7 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
         return var_name
 
     # Get primary variable (first required secret) from provider metadata
-    provider_variable_map = get_model_provider_variable_mapping()
-    variable_name = provider_variable_map.get(provider)
+    variable_name = get_provider_secret_variable_key(provider)
     if not variable_name:
         return None
 
@@ -295,6 +304,7 @@ def _validate_and_get_enabled_providers(
 
     settings_service = get_settings_service()
     enabled = set()
+    from lfx.base.models.provider_registry import is_api_key_optional
 
     for provider in provider_variable_map:
         provider_vars = get_provider_all_variables(provider)
@@ -345,9 +355,10 @@ def _validate_and_get_enabled_providers(
                 all_required_present = False
 
         if not provider_vars:
-            enabled.add(provider)
-        elif all_required_present and collected_values:
-            if skip_validation:
+            if is_api_key_optional(provider):
+                enabled.add(provider)
+        elif all_required_present and (collected_values or is_api_key_optional(provider)):
+            if skip_validation or not collected_values:
                 # Just check existence - validation was done on save
                 enabled.add(provider)
             else:
@@ -419,13 +430,34 @@ async def _fetch_enabled_providers_for_user(user_id: UUID | str) -> set[str]:
         all_var_names = {var.name for var in all_vars}
 
         provider_variable_map = get_model_provider_variable_mapping()
+        from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+        providers = get_model_providers()
+        provider_policy = resolve_model_provider_policy(
+            user_id=user_id,
+            providers=providers,
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+        from lfx.base.models.provider_registry import is_api_key_optional
+
+        provider_candidates = {
+            **provider_variable_map,
+            **{
+                provider: ""
+                for provider in providers
+                if provider not in provider_variable_map and is_api_key_optional(provider)
+            },
+        }
+        provider_candidates = {
+            provider: variable for provider, variable in provider_candidates.items() if provider_policy.allows(provider)
+        }
 
         # Build dict with raw Variable values (encrypted for secrets, plaintext for others)
         # We need to fetch raw Variable objects because VariableRead has value=None for credentials
         all_provider_variables = {}
         user_id_uuid = UUID(user_id) if isinstance(user_id, str) else user_id
 
-        for provider in provider_variable_map:
+        for provider in provider_candidates:
             # Get ALL variables for this provider (not just the primary one)
             provider_vars = get_provider_all_variables(provider)
 
@@ -452,7 +484,7 @@ async def _fetch_enabled_providers_for_user(user_id: UUID | str) -> set[str]:
                     continue
 
         # Use shared helper to validate and get enabled providers
-        return _validate_and_get_enabled_providers(all_provider_variables, provider_variable_map)
+        return _validate_and_get_enabled_providers(all_provider_variables, provider_candidates)
 
 
 def validate_model_provider_key(provider: str, variables: dict[str, str], model_name: str | None = None) -> None:

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
     from langchain_core.embeddings import Embeddings
 
+    from lfx.services.model_provider_policy import ModelProviderPolicySnapshot
+
 
 def _env_if_allowed(key: str) -> str | None:
     """Return ``os.environ.get(key)`` unless the active request disables env fallback.
@@ -86,6 +88,7 @@ def get_llm(
     watsonx_project_id=None,
     ollama_base_url=None,
     overrides: dict[str, Any] | None = None,
+    provider_policy: ModelProviderPolicySnapshot | None = None,
 ) -> Any:
     # Resolve helpers via package namespace so tests patching
     # lfx.base.models.unified_models.<name> keep working.
@@ -119,6 +122,37 @@ def get_llm(
     provider = model.get("provider")
     metadata = model.get("metadata", {})
 
+    if not isinstance(provider, str) or not provider:
+        msg = (
+            "The selected model is missing a provider. Please reselect a model from the dropdown "
+            "so the component knows which provider to use."
+        )
+        raise ValueError(msg)
+    if provider_policy is None:
+        from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+        from .provider_queries import get_model_providers
+
+        provider_policy = resolve_model_provider_policy(
+            user_id=user_id,
+            providers=(*get_model_providers(), provider),
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+    provider_policy.require(provider)
+
+    # Policy is evaluated against the submitted identity, then all runtime
+    # wiring for a known provider is resolved from its canonical registry
+    # entry. Stored flow metadata is not authoritative for class or parameter
+    # names: trusting it would let an allowed provider instantiate a denied
+    # provider's client. Unknown legacy providers retain the historical
+    # metadata fallback under the OSS allow-all policy.
+    from lfx.base.models.provider_registry import provider_id_for, provider_name_for_id
+
+    provider_id = provider_id_for(provider)
+    canonical_provider = provider_name_for_id(provider_id) if provider_id is not None else None
+    provider_is_known = canonical_provider is not None
+    provider = canonical_provider or provider
+
     # Stored selections sourced from ``get_unified_models_detailed`` (e.g. the
     # ``GET /api/v1/models`` catalog the frontend uses to augment its dropdown
     # right after a provider is configured, before the backend repopulates
@@ -133,10 +167,14 @@ def get_llm(
     # though the dropdown, connection test, and standalone component all work.
     from lfx.base.models.model_metadata import get_provider_param_mapping
 
-    provider_param_mapping = get_provider_param_mapping(provider) if provider else {}
+    provider_param_mapping = get_provider_param_mapping(provider)
 
     # Get model class and parameter names from metadata
-    api_key_param = metadata.get("api_key_param") or provider_param_mapping.get("api_key_param", "api_key")
+    api_key_param = (
+        provider_param_mapping.get("api_key_param", "api_key")
+        if provider_is_known
+        else metadata.get("api_key_param") or "api_key"
+    )
 
     # Capture the user-supplied api_key BEFORE resolution so we can name
     # it back in the error message if it was a Global Variable reference
@@ -210,7 +248,11 @@ def get_llm(
     # carries the raw ``create_model_metadata`` fields, so we have to derive
     # ``model_class`` from the provider mapping that
     # ``get_language_model_options`` would have used.
-    model_class_name = metadata.get("model_class") or provider_param_mapping.get("model_class")
+    model_class_name = (
+        provider_param_mapping.get("model_class")
+        if provider_is_known
+        else metadata.get("model_class") or provider_param_mapping.get("model_class")
+    )
     if not model_class_name:
         msg = f"No model class defined for {model_name}"
         raise ValueError(msg)
@@ -219,7 +261,11 @@ def get_llm(
     # (``get_language_model_options`` re-keys it to ``model_name_param``); fall
     # back to it so e.g. IBM WatsonX resolves to ``model_id`` rather than the
     # generic ``model``.
-    model_name_param = metadata.get("model_name_param") or provider_param_mapping.get("model_param", "model")
+    model_name_param = (
+        provider_param_mapping.get("model_param", "model")
+        if provider_is_known
+        else metadata.get("model_name_param") or provider_param_mapping.get("model_param", "model")
+    )
 
     # Reasoning models commonly reject sampling parameters such as
     # ``temperature``. Catalog metadata marks these with ``reasoning: True``;
@@ -250,10 +296,13 @@ def get_llm(
             if max_tokens_int >= 1:
                 # Look up provider-specific field name from model metadata first,
                 # then fall back to provider metadata, then default to "max_tokens"
-                max_tokens_param = metadata.get("max_tokens_field_name")
-                if not max_tokens_param:
-                    provider_meta = model_provider_metadata.get(provider, {})
-                    max_tokens_param = provider_meta.get("max_tokens_field_name", "max_tokens")
+                provider_meta = model_provider_metadata.get(provider, {})
+                max_tokens_param = (
+                    provider_meta.get("max_tokens_field_name", "max_tokens")
+                    if provider_is_known
+                    else metadata.get("max_tokens_field_name")
+                    or provider_meta.get("max_tokens_field_name", "max_tokens")
+                )
                 kwargs[max_tokens_param] = max_tokens_int
         except (TypeError, ValueError):
             pass  # Skip invalid max_tokens (e.g. empty string from form input)
@@ -266,9 +315,15 @@ def get_llm(
     if provider in {"IBM WatsonX", "IBM watsonx.ai"}:
         # For watsonx, url and project_id are required parameters
         # Try database first, then component values, then environment variables
-        url_param = metadata.get("url_param") or provider_param_mapping.get("url_param", "url")
-        project_id_param = metadata.get("project_id_param") or provider_param_mapping.get(
-            "project_id_param", "project_id"
+        url_param = (
+            provider_param_mapping.get("url_param", "url")
+            if provider_is_known
+            else metadata.get("url_param") or provider_param_mapping.get("url_param", "url")
+        )
+        project_id_param = (
+            provider_param_mapping.get("project_id_param", "project_id")
+            if provider_is_known
+            else metadata.get("project_id_param") or provider_param_mapping.get("project_id_param", "project_id")
         )
 
         # Get all provider variables from database
@@ -304,7 +359,11 @@ def get_llm(
         # else: neither provided - let ChatWatsonx handle it (will fail with its own error)
     elif provider == "Ollama":
         # For Ollama, handle custom base_url with database > component > env var fallback
-        base_url_param = metadata.get("base_url_param", "base_url")
+        base_url_param = (
+            provider_param_mapping.get("base_url_param", "base_url")
+            if provider_is_known
+            else metadata.get("base_url_param", "base_url")
+        )
 
         # Get all provider variables from database
         provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
@@ -526,9 +585,18 @@ def _compose_embedding_kwargs(
     ollama_base_url: str | None = None,
 ) -> tuple[type, dict[str, Any]] | None:
     """Build kwargs for a provider/model pair. Returns None when credentials are missing."""
-    from lfx.base.models.provider_registry import is_api_key_optional, is_registered
+    from lfx.base.models.provider_registry import (
+        is_api_key_optional,
+        is_registered,
+        provider_id_for,
+        provider_name_for_id,
+    )
 
     metadata = metadata or {}
+    provider_id = provider_id_for(provider)
+    canonical_provider = provider_name_for_id(provider_id) if provider_id is not None else None
+    provider_is_known = canonical_provider is not None
+    provider = canonical_provider or provider
     api_key_override = component_api_key if provider == selected_provider else None
     api_key = unified_models_module.get_api_key_for_provider(user_id, provider, api_key_override)
     if not api_key and provider != "Ollama" and not is_api_key_optional(provider):
@@ -536,11 +604,19 @@ def _compose_embedding_kwargs(
     if not api_key and is_api_key_optional(provider):
         api_key = "EMPTY"  # pragma: allowlist secret
 
-    embedding_class_name = metadata.get("embedding_class") or EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+    embedding_class_name = (
+        EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+        if provider_is_known
+        else metadata.get("embedding_class") or EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+    )
     if not embedding_class_name:
         return None
 
-    param_mapping: dict[str, str] = metadata.get("param_mapping") or EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+    param_mapping: dict[str, str] = (
+        EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+        if provider_is_known
+        else metadata.get("param_mapping") or EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+    )
     if not param_mapping:
         return None
 
@@ -705,11 +781,14 @@ def _build_available_embedding_models(
     watsonx_truncate_input_tokens: int | None,
     watsonx_input_text: bool | None,
     ollama_base_url: str | None,
+    provider_policy: ModelProviderPolicySnapshot,
 ) -> dict[str, Embeddings]:
     """Build embedding instances for every enabled embedding model on configured providers."""
     available_models: dict[str, Embeddings] = {primary_model_name: primary_instance}
 
     for provider in _get_configured_embedding_providers(user_id, selected_provider):
+        if not provider_policy.allows(provider):
+            continue
         provider_metadata = metadata if provider == selected_provider else {}
         for model_name in _get_provider_embedding_model_names(provider, user_id):
             if model_name in available_models:
@@ -770,6 +849,7 @@ def get_embeddings(
     watsonx_truncate_input_tokens=None,
     watsonx_input_text=None,
     ollama_base_url=None,
+    provider_policy: ModelProviderPolicySnapshot | None = None,
 ) -> Any:
     """Instantiate an embeddings model from a model selection dict.
 
@@ -804,6 +884,28 @@ def get_embeddings(
     model_name = model_dict.get("name")
     provider = model_dict.get("provider")
     metadata = model_dict.get("metadata", {})
+
+    if not isinstance(provider, str) or not provider:
+        msg = "The selected embedding model is missing a provider"
+        raise ValueError(msg)
+    if provider_policy is None:
+        from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+        from .provider_queries import get_model_providers
+
+        provider_policy = resolve_model_provider_policy(
+            user_id=user_id,
+            providers=(*get_model_providers(), provider),
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+    provider_policy.require(provider)
+
+    from lfx.base.models.provider_registry import provider_id_for, provider_name_for_id
+
+    provider_id = provider_id_for(provider)
+    canonical_provider = provider_name_for_id(provider_id) if provider_id is not None else None
+    provider_is_known = canonical_provider is not None
+    provider = canonical_provider or provider
 
     # --- resolve API key for the selected provider ---------------------------
     api_key = unified_models_module.get_api_key_for_provider(user_id, provider, api_key)
@@ -849,7 +951,11 @@ def get_embeddings(
         ollama_base_url=ollama_base_url,
     )
     if composed is None:
-        embedding_class_name = metadata.get("embedding_class") or EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+        embedding_class_name = (
+            EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+            if provider_is_known
+            else metadata.get("embedding_class") or EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+        )
         if not embedding_class_name:
             msg = (
                 f"No embedding class defined in metadata for {model_name} (provider: {provider}). "
@@ -857,7 +963,11 @@ def get_embeddings(
             )
             raise ValueError(msg)
         unified_models_module.get_embedding_class(embedding_class_name)
-        param_mapping = metadata.get("param_mapping") or EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+        param_mapping = (
+            EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+            if provider_is_known
+            else metadata.get("param_mapping") or EMBEDDING_PARAM_MAPPINGS.get(provider, {})
+        )
         if not param_mapping:
             msg = (
                 f"Parameter mapping not found in metadata for model '{model_name}' (provider: {provider}). "
@@ -901,6 +1011,7 @@ def get_embeddings(
         watsonx_truncate_input_tokens=watsonx_truncate_input_tokens,
         watsonx_input_text=watsonx_input_text,
         ollama_base_url=ollama_base_url,
+        provider_policy=provider_policy,
     )
 
     return EmbeddingsWithModels(

--- a/src/lfx/src/lfx/base/models/unified_models/model_catalog.py
+++ b/src/lfx/src/lfx/base/models/unified_models/model_catalog.py
@@ -11,10 +11,12 @@ from lfx.utils.async_helpers import run_until_complete
 
 from .class_registry import EMBEDDING_PARAM_MAPPINGS, EMBEDDING_PROVIDER_CLASS_MAPPING
 from .credentials import _fetch_enabled_providers_for_user, _get_model_status, model_status_contains
-from .provider_queries import get_models_detailed, model_provider_metadata
+from .provider_queries import get_model_providers, get_models_detailed, model_provider_metadata
 
 if TYPE_CHECKING:
     from uuid import UUID
+
+    from lfx.services.model_provider_policy import ModelProviderPolicySnapshot
 
 
 def get_unified_models_detailed(
@@ -129,10 +131,10 @@ def get_unified_models_detailed(
     # Format as requested
     return [
         {
+            **model_provider_metadata.get(prov, {}),
             "provider": prov,
             "models": models,
             "num_models": len(models),
-            **model_provider_metadata.get(prov, {}),
         }
         for prov, models in provider_map.items()
     ]
@@ -143,6 +145,7 @@ def get_language_model_options(
     *,
     tool_calling: bool | None = None,
     filters: dict[str, Any] | None = None,
+    provider_policy: ModelProviderPolicySnapshot | None = None,
 ) -> list[dict[str, Any]]:
     """Return available language model providers with their configuration.
 
@@ -164,6 +167,16 @@ def get_language_model_options(
         **metadata_filters,
     )
 
+    if provider_policy is None:
+        from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+        provider_policy = resolve_model_provider_policy(
+            user_id=user_id,
+            providers=get_model_providers(),
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+    all_models = [provider_data for provider_data in all_models if provider_policy.allows(provider_data["provider"])]
+
     # Get disabled and explicitly enabled models for this user if user_id is provided
     disabled_models: set[str] = set()
     explicitly_enabled_models: set[str] = set()
@@ -176,6 +189,7 @@ def get_language_model_options(
     if user_id:
         with contextlib.suppress(Exception):
             enabled_providers = run_until_complete(_fetch_enabled_providers_for_user(user_id))
+    enabled_providers = {provider for provider in enabled_providers if provider_policy.allows(provider)}
 
     # Replace static defaults with actual available models from configured instances
     if enabled_providers:
@@ -186,6 +200,7 @@ def get_language_model_options(
         model_type="llm",
         metadata_filters=metadata_filters or None,
     )
+    all_models = [provider_data for provider_data in all_models if provider_policy.allows(provider_data["provider"])]
 
     options = []
 
@@ -280,6 +295,8 @@ def get_language_model_options(
 
 def get_embedding_model_options(
     user_id: UUID | str | None = None,
+    *,
+    provider_policy: ModelProviderPolicySnapshot | None = None,
 ) -> list[dict[str, Any]]:
     """Return available embedding model providers with their configuration."""
     # Get all embedding models (excluding deprecated and unsupported by default)
@@ -288,6 +305,16 @@ def get_embedding_model_options(
         include_deprecated=False,
         include_unsupported=False,
     )
+
+    if provider_policy is None:
+        from lfx.services.model_provider_policy import ModelProviderPolicyPurpose, resolve_model_provider_policy
+
+        provider_policy = resolve_model_provider_policy(
+            user_id=user_id,
+            providers=get_model_providers(),
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+    all_models = [provider_data for provider_data in all_models if provider_policy.allows(provider_data["provider"])]
 
     # Get disabled and explicitly enabled models for this user if user_id is provided
     disabled_models: set[str] = set()
@@ -301,6 +328,7 @@ def get_embedding_model_options(
     if user_id:
         with contextlib.suppress(Exception):
             enabled_providers = run_until_complete(_fetch_enabled_providers_for_user(user_id))
+    enabled_providers = {provider for provider in enabled_providers if provider_policy.allows(provider)}
 
     # Replace static defaults with actual available models from configured instances
     if enabled_providers:
@@ -312,6 +340,7 @@ def get_embedding_model_options(
             model_provider_metadata,
         )
     inject_custom_enabled_models(all_models, explicitly_enabled_models, model_type="embeddings")
+    all_models = [provider_data for provider_data in all_models if provider_policy.allows(provider_data["provider"])]
 
     options = []
 

--- a/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
+++ b/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
@@ -90,25 +90,44 @@ def get_models_detailed() -> list[list[dict]]:
 MODELS_DETAILED = _STATIC_MODELS_DETAILED
 
 
+def get_provider_secret_variable_key(provider: str) -> str | None:
+    """Return the provider's primary secret variable, never connection config.
+
+    Required secrets take precedence over optional secrets. Providers with no
+    declared secret (for example, a local API-key-optional endpoint configured
+    only by base URL) intentionally return ``None``.
+    """
+    variables = model_provider_metadata.get(provider, {}).get("variables", [])
+    required_secret = next(
+        (
+            variable.get("variable_key")
+            for variable in variables
+            if variable.get("required") and variable.get("is_secret")
+        ),
+        None,
+    )
+    if required_secret is not None:
+        return required_secret
+    return next((variable.get("variable_key") for variable in variables if variable.get("is_secret")), None)
+
+
 @lru_cache(maxsize=1)
 def get_model_provider_variable_mapping() -> dict[str, str]:
-    """Return primary (first required secret) variable for each provider.
+    """Return one primary variable for each provider.
 
-    Backward-compatible helper used in many callers that still expect a single
-    provider-level variable key.
+    This broad, backward-compatible mapping is used by provider UI and
+    enablement callers that need a representative variable even when a
+    provider has no secret. API-key resolution must instead use
+    :func:`get_provider_secret_variable_key`.
     """
     result = {}
     for provider, meta in model_provider_metadata.items():
         variables = meta.get("variables", [])
-        # Prefer a required secret (the canonical API key); then any secret
-        # (an *optional* API key, e.g. a local OpenAI-compatible server like
-        # vLLM whose VLLM_API_KEY is optional); only then fall back to the first
-        # variable. Without the "any secret" step the mapping would point at the
-        # first required *non-secret* connection field (e.g. a base URL), which
-        # get_api_key_for_provider would then resolve and send as the API key.
-        chosen = next((v["variable_key"] for v in variables if v.get("required") and v.get("is_secret")), None)
-        if chosen is None:
-            chosen = next((v["variable_key"] for v in variables if v.get("is_secret")), None)
+        # Prefer a required secret (the canonical API key), then any optional
+        # secret. Providers with no secret retain their first connection field
+        # for backward-compatible UI/enablement behavior; credential resolution
+        # deliberately uses get_provider_secret_variable_key directly.
+        chosen = get_provider_secret_variable_key(provider)
         if chosen is None and variables:
             chosen = variables[0]["variable_key"]
         if chosen is not None:

--- a/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
+++ b/src/lfx/src/lfx/base/models/unified_models/provider_queries.py
@@ -71,10 +71,15 @@ def get_models_detailed() -> list[list[dict]]:
     # invalidate_catalog_cache).
     from lfx.base.models.models_dev_catalog import apply_models_dev_overrides, get_active_snapshot
 
+    # Provider-only extensions can contribute a static catalog without editing
+    # this core list. Import lazily to avoid a cycle during registry mutation.
+    from lfx.base.models.provider_registry import get_registered_model_catalogs
+
+    active_catalog = [*_STATIC_MODELS_DETAILED, *get_registered_model_catalogs()]
     snapshot = get_active_snapshot()
     if snapshot is None:
-        return _STATIC_MODELS_DETAILED
-    return apply_models_dev_overrides(_STATIC_MODELS_DETAILED, snapshot)
+        return active_catalog
+    return apply_models_dev_overrides(active_catalog, snapshot)
 
 
 # NOTE: ``MODELS_DETAILED`` is a back-compat binding for callers that imported

--- a/src/lfx/src/lfx/components/agentics/helpers/llm_setup.py
+++ b/src/lfx/src/lfx/components/agentics/helpers/llm_setup.py
@@ -11,6 +11,7 @@ from lfx.components.agentics.constants import (
 )
 from lfx.components.agentics.helpers.llm_factory import create_llm
 from lfx.components.agentics.helpers.model_config import validate_model_selection
+from lfx.services.model_provider_policy import require_model_provider
 
 if TYPE_CHECKING:
     from crewai import LLM
@@ -34,6 +35,7 @@ def prepare_llm_from_component(component: Component) -> LLM:
         ValueError: If model is not selected or required API key is missing for the provider.
     """
     model_name, provider = validate_model_selection(component.model)
+    require_model_provider(user_id=component.user_id, provider=provider)
     api_key = get_api_key_for_provider(component.user_id, provider, component.api_key)
 
     if not api_key and provider != PROVIDER_OLLAMA:

--- a/src/lfx/src/lfx/extension/loader/_orchestrator.py
+++ b/src/lfx/src/lfx/extension/loader/_orchestrator.py
@@ -274,14 +274,17 @@ def _register_manifest_providers(
 
     # Lazy import: keeps the loader importable without pulling in the model
     # stack at module-import time and avoids any cycle through lfx.base.models.
-    from lfx.base.models.provider_registry import ProviderSpec, register_provider
+    from lfx.base.models.provider_registry import ProviderDescriptor, ProviderOrigin, register_provider
 
     for entry in manifest.providers:
         try:
             embedding = entry.embedding
-            spec = ProviderSpec(
+            spec = ProviderDescriptor(
                 name=entry.name,
                 metadata=dict(entry.metadata),
+                provider_id=entry.provider_id,
+                display_name=entry.display_name,
+                aliases=tuple(entry.aliases),
                 model_class=(
                     (entry.model_class.module, entry.model_class.attr, entry.model_class.install_hint)
                     if entry.model_class
@@ -296,6 +299,13 @@ def _register_manifest_providers(
                 conditional_live=entry.conditional_live,
                 live_discovery=entry.live_discovery,
                 validator=entry.validator,
+                catalog_loader=entry.catalog_loader,
+                origin=ProviderOrigin(
+                    extension_id=manifest.id,
+                    extension_version=manifest.version,
+                    distribution=result.distribution,
+                    manifest_path=str(source.path),
+                ),
             )
             if not register_provider(spec):
                 result.warnings.append(

--- a/src/lfx/src/lfx/extension/manifest.py
+++ b/src/lfx/src/lfx/extension/manifest.py
@@ -86,6 +86,8 @@ BUNDLE_NAME_RE: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
 """Bundle names use snake_case so they can be addressed in the registry as
 ``ext:<bundle>:<Class>@<slot>`` without quoting."""
 
+_PROVIDER_ID_RE: re.Pattern[str] = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
 _SEMVER_RE: re.Pattern[str] = re.compile(
     r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
     r"(?:-(?:[0-9A-Za-z-]+)(?:\.[0-9A-Za-z-]+)*)?"
@@ -299,6 +301,26 @@ class ProviderManifestEntry(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, protected_namespaces=())
 
     name: StrictStr = Field(..., min_length=1, max_length=120, description="Canonical provider name, e.g. 'vLLM'.")
+    provider_id: StrictStr | None = Field(
+        default=None,
+        min_length=1,
+        max_length=120,
+        pattern=_PROVIDER_ID_RE.pattern,
+        description=(
+            "Stable machine identity used by policy, e.g. 'openai' or 'acme.watsonx'. "
+            "Omit only for legacy manifests; Langflow then derives an ID from name."
+        ),
+    )
+    display_name: StrictStr | None = Field(
+        default=None,
+        min_length=1,
+        max_length=120,
+        description="Optional user-facing label; changing it does not change provider_id or saved-flow identity.",
+    )
+    aliases: tuple[StrictStr, ...] = Field(
+        default=(),
+        description="Legacy provider names accepted when resolving stable provider identity.",
+    )
     metadata: dict[str, Any] = Field(
         ...,
         description="MODEL_PROVIDER_METADATA value: icon, variables, mapping (with model_class), api_docs_url, etc.",
@@ -327,6 +349,29 @@ class ProviderManifestEntry(BaseModel):
         min_length=1,
         description="Dotted-path callable 'module:attr' validating credentials: (provider, variables, model) -> None.",
     )
+    catalog_loader: StrictStr | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Dotted-path callable 'module:attr' returning a flat list of static model metadata rows. "
+            "Langflow stamps provider ownership and validates model identities."
+        ),
+    )
+
+    @field_validator("aliases")
+    @classmethod
+    def _aliases_are_unique_and_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: set[str] = set()
+        for alias in value:
+            if not alias.strip():
+                msg = "provider.aliases must contain non-empty strings"
+                raise ValueError(msg)
+            folded = alias.casefold()
+            if folded in normalized:
+                msg = f"provider.aliases contains duplicate alias {alias!r}"
+                raise ValueError(msg)
+            normalized.add(folded)
+        return value
 
     @field_validator("metadata")
     @classmethod

--- a/src/lfx/src/lfx/mcp/flow_builder_tools/mutate_tools.py
+++ b/src/lfx/src/lfx/mcp/flow_builder_tools/mutate_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 from lfx.custom import Component
+from lfx.graph.flow_builder.component import _coerce_model_value as fb_coerce_model_value
 from lfx.graph.flow_builder.component import add_component as fb_add_component
 from lfx.graph.flow_builder.component import configure_component as fb_configure
 from lfx.graph.flow_builder.component import remove_component as fb_remove_component
@@ -18,6 +19,11 @@ from lfx.graph.flow_builder.layout import layout_flow
 from lfx.io import MessageTextInput, Output
 from lfx.log.logger import logger
 from lfx.schema import Data
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyError,
+    ModelProviderPolicyPurpose,
+    resolve_model_provider_policy,
+)
 
 from ._state import (
     _emit,
@@ -169,6 +175,53 @@ def _reconcile_source_selected_output(flow: dict, source_id: str, source_output:
         _emit("select_output", component_id=source_id, output_name=outputs[0].get("name", ""))
 
 
+def _current_policy_user_id() -> str | None:
+    """Return the request user when lfx is hosted by Langflow."""
+    try:
+        from langflow.agentic.services.user_components_context import current_user_id
+    except ImportError:
+        return None
+    return current_user_id()
+
+
+def _model_providers_in_params(flow: dict, component_id: str, params: dict) -> set[str]:
+    """Extract provider names from model-typed fields without mutating the flow."""
+    node = _find_node(flow, component_id)
+    if node is None:
+        return set()
+    template = node.get("data", {}).get("node", {}).get("template", {})
+    providers: set[str] = set()
+    for field_name, value in params.items():
+        field = template.get(field_name)
+        if not isinstance(field, dict) or field.get("type") != "model":
+            continue
+        normalized = fb_coerce_model_value(value)
+        if not isinstance(normalized, list):
+            continue
+        for entry in normalized:
+            if not isinstance(entry, dict):
+                continue
+            provider = entry.get("provider")
+            if isinstance(provider, str) and provider.strip():
+                providers.add(provider.strip())
+    return providers
+
+
+def _require_allowed_model_providers(providers: set[str]) -> None:
+    """Require USE policy before model values reach configuration or catalogs."""
+    if not providers:
+        return
+    from lfx.base.models.unified_models import get_model_providers
+
+    policy = resolve_model_provider_policy(
+        user_id=_current_policy_user_id(),
+        providers=[*get_model_providers(), *providers],
+        purpose=ModelProviderPolicyPurpose.USE,
+    )
+    for provider in providers:
+        policy.require(provider)
+
+
 class ConnectComponents(Component):
     display_name = "Connect Components"
     description = "Connect an output of one component to an input of another."
@@ -246,6 +299,12 @@ class ConfigureComponent(Component):
                     return Data(data={"error": f"params must be a JSON object, got {type(params).__name__}"})
             except json.JSONDecodeError:
                 return Data(data={"error": f'Invalid JSON in params: {raw!r}. Use format: {{"key": "value"}}'})
+
+        try:
+            _require_allowed_model_providers(_model_providers_in_params(flow, self.component_id, params))
+        except ModelProviderPolicyError as e:
+            logger.warning("configure_component blocked by model-provider policy: %s", e)
+            return Data(data={"error": str(e)})
 
         # Deterministic review gate (Bug B): editing a TEXT field on a pre-existing
         # component is surfaced as a reviewable diff; model/number/bool still apply live.
@@ -330,6 +389,8 @@ def _mirror_model_value_into_options(flow: dict, component_id: str, params: dict
 
 def _resolve_default_model_name(provider: str) -> str | None:
     """Return the provider's catalog default model name, or None if unknown."""
+    _require_allowed_model_providers({provider})
+
     from lfx.base.models.unified_models import get_unified_models_detailed
 
     detailed = get_unified_models_detailed(

--- a/src/lfx/src/lfx/services/deps.py
+++ b/src/lfx/src/lfx/services/deps.py
@@ -68,6 +68,18 @@ def get_service(service_type: ServiceType, default=None):
         return None
 
 
+def get_model_provider_policy_service():
+    """Return the configured model-provider policy service or fail closed."""
+    from lfx.services.model_provider_policy.base import BaseModelProviderPolicyService
+    from lfx.services.model_provider_policy.service import ModelProviderPolicyService  # noqa: F401
+
+    service = get_service(ServiceType.MODEL_PROVIDER_POLICY_SERVICE)
+    if not isinstance(service, BaseModelProviderPolicyService) or not service.ready:
+        msg = "A valid, ready model_provider_policy_service is required"
+        raise TypeError(msg)
+    return service
+
+
 def get_db_service() -> DatabaseServiceProtocol:
     """Retrieves the database service instance.
 

--- a/src/lfx/src/lfx/services/manager.py
+++ b/src/lfx/src/lfx/services/manager.py
@@ -421,6 +421,12 @@ class ServiceManager:
             expected_bases[ServiceType.AUTHORIZATION_SERVICE] = BaseAuthorizationService
         except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
             logger.debug(f"BaseAuthorizationService unavailable; entry-point validation skipped: {exc}")
+        try:
+            from lfx.services.model_provider_policy.base import BaseModelProviderPolicyService
+
+            expected_bases[ServiceType.MODEL_PROVIDER_POLICY_SERVICE] = BaseModelProviderPolicyService
+        except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
+            logger.debug(f"BaseModelProviderPolicyService unavailable; entry-point validation skipped: {exc}")
 
         for ep in eps:
             try:
@@ -492,7 +498,20 @@ class ServiceManager:
             object_key=service_key,
         )
         if service_class is None:
+            if service_type == ServiceType.MODEL_PROVIDER_POLICY_SERVICE:
+                msg = (
+                    "Configured model provider policy service could not be loaded; "
+                    "refusing to start with the OSS allow-all fallback"
+                )
+                raise RuntimeError(msg)
             return
+
+        if service_type == ServiceType.MODEL_PROVIDER_POLICY_SERVICE:
+            from lfx.services.model_provider_policy.base import BaseModelProviderPolicyService
+
+            if not isinstance(service_class, type) or not issubclass(service_class, BaseModelProviderPolicyService):
+                msg = "Configured model provider policy service must subclass BaseModelProviderPolicyService"
+                raise RuntimeError(msg)
 
         self.register_service_class(service_type, service_class, override=True)
         logger.debug(f"Registered service from config: {service_key} -> {service_path}")

--- a/src/lfx/src/lfx/services/model_provider_policy/__init__.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/__init__.py
@@ -1,0 +1,22 @@
+"""Pluggable policy contract for unified model providers."""
+
+from lfx.services.model_provider_policy.base import (
+    BaseModelProviderPolicyService,
+    ModelProviderPolicyContext,
+    ModelProviderPolicyError,
+    ModelProviderPolicyPurpose,
+    ModelProviderPolicySnapshot,
+)
+from lfx.services.model_provider_policy.service import ModelProviderPolicyService
+from lfx.services.model_provider_policy.utils import require_model_provider, resolve_model_provider_policy
+
+__all__ = [
+    "BaseModelProviderPolicyService",
+    "ModelProviderPolicyContext",
+    "ModelProviderPolicyError",
+    "ModelProviderPolicyPurpose",
+    "ModelProviderPolicyService",
+    "ModelProviderPolicySnapshot",
+    "require_model_provider",
+    "resolve_model_provider_policy",
+]

--- a/src/lfx/src/lfx/services/model_provider_policy/base.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/base.py
@@ -1,0 +1,143 @@
+"""Stable model-provider policy contract shared by OSS and Enterprise."""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from lfx.services.base import Service
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from uuid import UUID
+
+
+def _freeze_context_value(value: Any) -> Any:
+    """Recursively freeze request attributes captured by a policy snapshot."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_context_value(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_context_value(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze_context_value(item) for item in value)
+    return value
+
+
+class ModelProviderPolicyPurpose(str, Enum):
+    """Why the caller needs access to a provider."""
+
+    DISCOVER = "discover"
+    CONFIGURE = "configure"
+    USE = "use"
+
+
+@dataclass(frozen=True)
+class ModelProviderPolicyContext:
+    """Principal and request attributes available to future RBAC policies."""
+
+    user_id: UUID | str | None = None
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "attributes", _freeze_context_value(self.attributes))
+
+
+class ModelProviderPolicyError(PermissionError):
+    """A provider is not usable under the resolved policy snapshot."""
+
+    code = "policy_blocked"
+
+    def __init__(self, provider_id: str, purpose: ModelProviderPolicyPurpose) -> None:
+        self.provider_id = provider_id
+        self.purpose = purpose
+        super().__init__("The requested model provider is not available")
+
+
+@dataclass(frozen=True)
+class ModelProviderPolicySnapshot:
+    """Immutable decision set for one context, purpose, and candidate catalog."""
+
+    context: ModelProviderPolicyContext
+    purpose: ModelProviderPolicyPurpose
+    candidate_provider_ids: frozenset[str]
+    allowed_provider_ids: frozenset[str]
+
+    def __post_init__(self) -> None:
+        candidates = frozenset(self.candidate_provider_ids)
+        allowed = frozenset(self.allowed_provider_ids)
+        if not allowed.issubset(candidates):
+            msg = "allowed_provider_ids must be a subset of candidate_provider_ids"
+            raise ValueError(msg)
+        object.__setattr__(self, "candidate_provider_ids", candidates)
+        object.__setattr__(self, "allowed_provider_ids", allowed)
+
+    @staticmethod
+    def _stable_id(provider: str) -> str:
+        from lfx.base.models.provider_registry import provider_id_for
+
+        return provider_id_for(provider) or provider
+
+    def allows(self, provider: str) -> bool:
+        """Return whether a legacy name, alias, or stable ID is allowed."""
+        return self._stable_id(provider) in self.allowed_provider_ids
+
+    def filter(self, providers: Collection[str]) -> list[str]:
+        """Filter provider names without changing their order or representation."""
+        return [provider for provider in providers if self.allows(provider)]
+
+    def require(self, provider: str) -> None:
+        """Raise a reason-coded error when a provider is not allowed."""
+        if not self.allows(provider):
+            raise ModelProviderPolicyError(self._stable_id(provider), self.purpose)
+
+
+class BaseModelProviderPolicyService(Service, abc.ABC):
+    """Policy plugin point; implementations evaluate stable provider IDs."""
+
+    name = ServiceType.MODEL_PROVIDER_POLICY_SERVICE.value
+
+    @abc.abstractmethod
+    def get_allowed_provider_ids(
+        self,
+        *,
+        context: ModelProviderPolicyContext,
+        candidate_provider_ids: frozenset[str],
+        purpose: ModelProviderPolicyPurpose,
+    ) -> Collection[str]:
+        """Return the candidate IDs allowed for this context and purpose."""
+
+    def resolve(
+        self,
+        *,
+        context: ModelProviderPolicyContext,
+        candidate_provider_ids: frozenset[str],
+        purpose: ModelProviderPolicyPurpose,
+    ) -> ModelProviderPolicySnapshot:
+        """Resolve one immutable decision snapshot.
+
+        Enterprise implementations can intersect a deployment ceiling with a
+        single batch RBAC evaluation in ``get_allowed_provider_ids``. The base
+        method validates that a plugin can never widen the candidate set.
+        """
+        candidates = frozenset(candidate_provider_ids)
+        allowed = frozenset(
+            self.get_allowed_provider_ids(
+                context=context,
+                candidate_provider_ids=candidates,
+                purpose=purpose,
+            )
+        )
+        return ModelProviderPolicySnapshot(
+            context=context,
+            purpose=purpose,
+            candidate_provider_ids=candidates,
+            allowed_provider_ids=allowed,
+        )
+
+    async def teardown(self) -> None:
+        """No resources are owned by the base policy service."""

--- a/src/lfx/src/lfx/services/model_provider_policy/service.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/service.py
@@ -1,0 +1,38 @@
+"""Default OSS model-provider policy (allow all)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lfx.log.logger import logger
+from lfx.services import register_service
+from lfx.services.model_provider_policy.base import BaseModelProviderPolicyService
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from lfx.services.model_provider_policy.base import ModelProviderPolicyContext, ModelProviderPolicyPurpose
+
+
+@register_service(ServiceType.MODEL_PROVIDER_POLICY_SERVICE)
+class ModelProviderPolicyService(BaseModelProviderPolicyService):
+    """OSS default that preserves the historical allow-all behavior."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_ready()
+        logger.debug("Model provider policy service initialized (allow all)")
+
+    @property
+    def name(self) -> str:
+        return ServiceType.MODEL_PROVIDER_POLICY_SERVICE.value
+
+    def get_allowed_provider_ids(
+        self,
+        *,
+        context: ModelProviderPolicyContext,  # noqa: ARG002
+        candidate_provider_ids: frozenset[str],
+        purpose: ModelProviderPolicyPurpose,  # noqa: ARG002
+    ) -> Collection[str]:
+        return candidate_provider_ids

--- a/src/lfx/src/lfx/services/model_provider_policy/utils.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/utils.py
@@ -1,0 +1,54 @@
+"""Provider-name normalization and policy-service resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.base.models.provider_registry import provider_id_for
+from lfx.services.model_provider_policy.base import ModelProviderPolicyContext, ModelProviderPolicyPurpose
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from lfx.services.model_provider_policy.base import ModelProviderPolicySnapshot
+
+
+def resolve_model_provider_policy(
+    *,
+    user_id,
+    providers: Iterable[str],
+    purpose: ModelProviderPolicyPurpose,
+    attributes: Mapping[str, Any] | None = None,
+) -> ModelProviderPolicySnapshot:
+    """Resolve a policy snapshot for provider names from any catalog surface."""
+    from lfx.services.deps import get_model_provider_policy_service
+
+    # Preserve the OSS runtime's historical behavior for legacy or malformed
+    # saved selections: registered names resolve to stable IDs, while unknown
+    # names remain candidates that the allow-all default can pass through to
+    # the existing validation path. Restrictive policies can still omit them.
+    candidate_ids = frozenset(provider_id_for(provider) or provider for provider in providers)
+    service = get_model_provider_policy_service()
+    return service.resolve(
+        context=ModelProviderPolicyContext(user_id=user_id, attributes=attributes or {}),
+        candidate_provider_ids=candidate_ids,
+        purpose=purpose,
+    )
+
+
+def require_model_provider(
+    *,
+    user_id,
+    provider: str,
+    purpose: ModelProviderPolicyPurpose = ModelProviderPolicyPurpose.USE,
+    attributes: Mapping[str, Any] | None = None,
+) -> ModelProviderPolicySnapshot:
+    """Require one provider before any secret lookup or network-capable import."""
+    snapshot = resolve_model_provider_policy(
+        user_id=user_id,
+        providers=[provider],
+        purpose=purpose,
+        attributes=attributes,
+    )
+    snapshot.require(provider)
+    return snapshot

--- a/src/lfx/src/lfx/services/schema.py
+++ b/src/lfx/src/lfx/services/schema.py
@@ -8,6 +8,7 @@ from enum import Enum
 class ServiceType(str, Enum):
     AUTH_SERVICE = "auth_service"
     AUTHORIZATION_SERVICE = "authorization_service"
+    MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
     DATABASE_SERVICE = "database_service"
     STORAGE_SERVICE = "storage_service"
     SETTINGS_SERVICE = "settings_service"

--- a/src/lfx/tests/unit/base/models/test_build_config_sticky_default.py
+++ b/src/lfx/tests/unit/base/models/test_build_config_sticky_default.py
@@ -266,6 +266,38 @@ def test_sticky_default_unchanged_when_no_filters_declared():
     assert injected["metadata"].get("not_enabled_locally") is True
 
 
+def test_sticky_default_drops_policy_hidden_provider_and_uses_allowed_default():
+    from lfx.base.models.unified_models import build_config as bc
+    from lfx.services.model_provider_policy import (
+        ModelProviderPolicyContext,
+        ModelProviderPolicyPurpose,
+        ModelProviderPolicySnapshot,
+    )
+
+    openai_option = _llm_option("gpt-4o", provider="OpenAI")
+    saved_value = [{"name": "claude-opus-4-7", "provider": "Anthropic", "metadata": {}}]
+    build_config = {"model": {"value": saved_value, "options": []}}
+    snapshot = ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id="u-1"),
+        purpose=ModelProviderPolicyPurpose.USE,
+        candidate_provider_ids=frozenset({"openai", "anthropic"}),
+        allowed_provider_ids=frozenset({"openai"}),
+    )
+
+    with patch("lfx.services.model_provider_policy.resolve_model_provider_policy", return_value=snapshot):
+        result = bc.update_model_options_in_build_config(
+            component=_component(),
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=lambda user_id=None: [openai_option],  # noqa: ARG005
+            field_name=None,
+            field_value=None,
+        )
+
+    assert {(option["provider"], option["name"]) for option in result["model"]["options"]} == {("OpenAI", "gpt-4o")}
+    assert result["model"]["value"] == [openai_option]
+
+
 def test_saved_model_passes_filters_returns_true_for_unknown_models():
     """Unknown models conservatively pass the filter.
 

--- a/src/lfx/tests/unit/base/models/test_provider_registry.py
+++ b/src/lfx/tests/unit/base/models/test_provider_registry.py
@@ -25,6 +25,7 @@ from lfx.base.models.unified_models import (
     get_model_provider_metadata,
     get_model_provider_variable_mapping,
     get_model_providers,
+    get_models_detailed,
     validate_model_provider_key,
 )
 from lfx.base.models.unified_models.class_registry import (
@@ -54,6 +55,28 @@ def fake_validator(provider, variables, model_name):
 
 _LIVE_DISCOVERY_PATH = f"{__name__}:fake_live_discovery"
 _VALIDATOR_PATH = f"{__name__}:fake_validator"
+
+
+def fake_catalog_loader():
+    """Return rows whose provider ownership must be stamped by the registry."""
+    return [
+        {
+            "provider": "Untrusted manifest value",
+            "name": "fake-chat-1",
+            "icon": "FakeCo",
+            "default": True,
+            "model_type": "llm",
+        },
+        {
+            "name": "fake-embed-1",
+            "icon": "FakeCo",
+            "default": True,
+            "model_type": "embeddings",
+        },
+    ]
+
+
+_CATALOG_LOADER_PATH = f"{__name__}:fake_catalog_loader"
 
 
 def _fakeco_metadata() -> dict:
@@ -105,6 +128,53 @@ def test_register_adds_metadata_and_appears_in_accessors():
     assert "FakeCo" in get_model_provider_metadata()
     # Appears even though FakeCo ships no static model catalog.
     assert "FakeCo" in get_model_providers()
+
+
+def test_register_exposes_stable_identity_display_name_and_aliases():
+    register_provider(
+        _fakeco_spec(
+            provider_id="fakeco.enterprise",
+            display_name="FakeCo Enterprise",
+            aliases=("fake-co", "FakeCo Legacy"),
+        )
+    )
+
+    assert provider_registry.provider_id_for("FakeCo") == "fakeco.enterprise"
+    assert provider_registry.provider_id_for("fake-co") == "fakeco.enterprise"
+    assert provider_registry.provider_id_for("FakeCo Legacy") == "fakeco.enterprise"
+    assert provider_registry.provider_name_for_id("fakeco.enterprise") == "FakeCo"
+    assert MODEL_PROVIDER_METADATA["FakeCo"]["provider_id"] == "fakeco.enterprise"
+    assert MODEL_PROVIDER_METADATA["FakeCo"]["display_name"] == "FakeCo Enterprise"
+
+
+def test_registered_catalog_loader_contributes_static_models():
+    register_provider(
+        _fakeco_spec(
+            provider_id="fakeco",
+            catalog_loader=_CATALOG_LOADER_PATH,
+        )
+    )
+
+    fakeco_groups = [
+        group for group in get_models_detailed() if group and all(row.get("provider") == "FakeCo" for row in group)
+    ]
+
+    assert len(fakeco_groups) == 1
+    assert [row["name"] for row in fakeco_groups[0]] == ["fake-chat-1", "fake-embed-1"]
+    assert {row["provider"] for row in fakeco_groups[0]} == {"FakeCo"}
+
+
+def test_duplicate_provider_id_is_rejected_even_when_names_differ():
+    register_provider(_fakeco_spec(provider_id="fakeco"))
+
+    with pytest.raises(ValueError, match="provider_id"):
+        register_provider(
+            ProviderSpec(
+                name="OtherCo",
+                provider_id="fakeco",
+                metadata={**_fakeco_metadata(), "icon": "OtherCo"},
+            )
+        )
 
 
 def test_variable_mapping_cache_refreshed_after_register():

--- a/src/lfx/tests/unit/base/models/test_provider_registry.py
+++ b/src/lfx/tests/unit/base/models/test_provider_registry.py
@@ -147,6 +147,21 @@ def test_register_exposes_stable_identity_display_name_and_aliases():
     assert MODEL_PROVIDER_METADATA["FakeCo"]["display_name"] == "FakeCo Enterprise"
 
 
+def test_registry_snapshot_deep_freezes_descriptor_payloads():
+    register_provider(_fakeco_spec(provider_id="fakeco"))
+
+    descriptor = provider_registry.get_registry_snapshot().descriptors_by_id["fakeco"]
+
+    with pytest.raises(TypeError):
+        descriptor.metadata["icon"] = "Spoofed"  # type: ignore[index]
+    variables = descriptor.metadata["variables"]
+    with pytest.raises(TypeError):
+        variables[0]["variable_key"] = "SPOOFED_KEY"  # type: ignore[index]
+
+    assert MODEL_PROVIDER_METADATA["FakeCo"]["icon"] == "FakeCo"
+    assert MODEL_PROVIDER_METADATA["FakeCo"]["variables"][0]["variable_key"] == "FAKECO_API_KEY"
+
+
 def test_registered_catalog_loader_contributes_static_models():
     register_provider(
         _fakeco_spec(
@@ -173,6 +188,16 @@ def test_duplicate_provider_id_is_rejected_even_when_names_differ():
                 name="OtherCo",
                 provider_id="fakeco",
                 metadata={**_fakeco_metadata(), "icon": "OtherCo"},
+            )
+        )
+
+
+@pytest.mark.parametrize("reserved_key", ["provider", "models", "num_models", "provider_id", "aliases"])
+def test_provider_metadata_cannot_override_identity_or_catalog_structure(reserved_key):
+    with pytest.raises(ValueError, match="reserved keys"):
+        register_provider(
+            _fakeco_spec(
+                metadata={**_fakeco_metadata(), reserved_key: "OpenAI"},
             )
         )
 
@@ -325,6 +350,23 @@ def _fakeco_metadata_with_base_url() -> dict:
     return meta
 
 
+def _fakeco_metadata_with_only_base_url() -> dict:
+    """Provider metadata with required connection config but no secret variable."""
+    meta = _fakeco_metadata()
+    meta["variables"] = [
+        {
+            "variable_name": "FakeCo Base URL",
+            "variable_key": "FAKECO_API_BASE",
+            "required": True,
+            "is_secret": False,
+            "is_list": False,
+            "options": [],
+            "langchain_param": "base_url",
+        }
+    ]
+    return meta
+
+
 def test_get_llm_applies_registered_provider_base_url(monkeypatch):
     from lfx.base.models import unified_models as um
     from lfx.base.models.unified_models.instantiation import get_llm
@@ -385,13 +427,18 @@ def test_get_llm_real_resolver_uses_placeholder_not_base_url(monkeypatch):
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
-    register_provider(_fakeco_spec(metadata=_fakeco_metadata_with_base_url(), api_key_required=False))
+    register_provider(_fakeco_spec(metadata=_fakeco_metadata_with_only_base_url(), api_key_required=False))
     monkeypatch.setenv("FAKECO_API_BASE", "http://vllm.example:8000")
-    monkeypatch.delenv("FAKECO_API_KEY", raising=False)
     monkeypatch.setattr(um, "get_model_class", lambda _name: FakeChat)
     # Base URL comes from the env via the connection handler; do NOT patch the
     # api-key resolver -- that is the path under test.
     monkeypatch.setattr(um, "get_all_variables_for_provider", lambda *_a, **_k: {})
+
+    # The broad mapping remains available to provider enablement/UI callers,
+    # but neither implicit nor explicit API-key lookup may consume it.
+    assert um.get_model_provider_variable_mapping()["FakeCo"] == "FAKECO_API_BASE"
+    assert um.get_api_key_for_provider(None, "FakeCo") is None
+    assert um.get_api_key_for_provider(None, "FakeCo", "FAKECO_API_BASE") is None
 
     model_selection = [{"name": "m1", "provider": "FakeCo", "metadata": {"model_class": "ChatOpenAI"}}]
     get_llm(model_selection, user_id=None)
@@ -457,6 +504,7 @@ def test_embedding_wiring_registered():
         )
     )
     assert EMBEDDING_PROVIDER_CLASS_MAPPING["FakeCo"] == "OpenAIEmbeddings"
+    assert EMBEDDING_PARAM_MAPPINGS["FakeCo"]["api_key"] == "api_key"  # pragma: allowlist secret
     assert EMBEDDING_PARAM_MAPPINGS["FakeCo Embeddings"]["api_key"] == "api_key"  # pragma: allowlist secret
 
 
@@ -542,6 +590,7 @@ def test_clear_restores_baseline():
     assert set(MODEL_PROVIDER_METADATA) == baseline_meta_keys
     assert list(LIVE_MODEL_PROVIDERS) == baseline_live
     assert "FakeCo" not in EMBEDDING_PROVIDER_CLASS_MAPPING
+    assert "FakeCo" not in EMBEDDING_PARAM_MAPPINGS
     assert "FakeCo Embeddings" not in EMBEDDING_PARAM_MAPPINGS
 
 

--- a/src/lfx/tests/unit/components/agentics/test_llm_setup.py
+++ b/src/lfx/tests/unit/components/agentics/test_llm_setup.py
@@ -111,3 +111,22 @@ class TestPrepareLlmFromComponent:
             prepare_llm_from_component(component)
 
         mock_create_llm.assert_not_called()
+
+    @patch("lfx.components.agentics.helpers.llm_setup.create_llm")
+    @patch("lfx.components.agentics.helpers.llm_setup.get_api_key_for_provider")
+    @patch("lfx.components.agentics.helpers.llm_setup.require_model_provider")
+    def test_policy_denial_happens_before_credential_lookup(
+        self,
+        mock_require_provider: MagicMock,
+        mock_get_api_key: MagicMock,
+        mock_create_llm: MagicMock,
+    ):
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        mock_require_provider.side_effect = ModelProviderPolicyError("openai", ModelProviderPolicyPurpose.USE)
+
+        with pytest.raises(ModelProviderPolicyError):
+            prepare_llm_from_component(_create_mock_component())
+
+        mock_get_api_key.assert_not_called()
+        mock_create_llm.assert_not_called()

--- a/src/lfx/tests/unit/extension/test_provider_extension.py
+++ b/src/lfx/tests/unit/extension/test_provider_extension.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from lfx.base.models import provider_registry
-from lfx.base.models.unified_models import get_model_providers
+from lfx.base.models.unified_models import get_model_providers, get_models_detailed
 from lfx.extension import load_extension
 from lfx.extension.manifest import ExtensionManifest
 
@@ -26,7 +26,12 @@ def fake_live_discovery(user_id, model_type):  # noqa: ARG001
     return [{"provider": "FakeCo", "name": f"fake-{model_type}", "icon": "FakeCo"}]
 
 
+def fake_catalog_loader():
+    return [{"name": "fake-static", "icon": "FakeCo", "default": True, "model_type": "llm"}]
+
+
 _LIVE_DISCOVERY_PATH = f"{__name__}:fake_live_discovery"
+_CATALOG_LOADER_PATH = f"{__name__}:fake_catalog_loader"
 
 
 def _provider_entry(**overrides) -> dict:
@@ -91,6 +96,30 @@ def test_provider_only_extension_registers_provider(tmp_path: Path):
     assert provider_registry.is_registered("FakeCo")
     assert "FakeCo" in get_model_providers()
     assert provider_registry.is_api_key_optional("FakeCo") is True
+
+
+def test_provider_manifest_registers_identity_aliases_and_static_catalog(tmp_path: Path):
+    manifest = {
+        "id": "lfx-fakeco",
+        "version": "0.1.0",
+        "name": "FakeCo Provider",
+        "lfx": {"compat": ["1"]},
+        "providers": [
+            _provider_entry(
+                provider_id="fakeco.enterprise",
+                display_name="FakeCo Enterprise",
+                aliases=["FakeCo Legacy"],
+                catalog_loader=_CATALOG_LOADER_PATH,
+            )
+        ],
+    }
+
+    result = load_extension(_write_manifest(tmp_path, manifest))
+
+    assert result.ok, (result.errors, result.warnings)
+    assert provider_registry.provider_id_for("FakeCo Legacy") == "fakeco.enterprise"
+    assert provider_registry.provider_name_for_id("fakeco.enterprise") == "FakeCo"
+    assert any(row["name"] == "fake-static" for group in get_models_detailed() for row in group)
 
 
 def test_loaded_provider_live_discovery_dispatches(tmp_path: Path):

--- a/src/lfx/tests/unit/inputs/test_model_input_static_options.py
+++ b/src/lfx/tests/unit/inputs/test_model_input_static_options.py
@@ -195,3 +195,40 @@ class TestModelInputStaticOptions:
 
         # Verify: Should treat empty list as dynamic and fetch global options
         assert result["model"]["options"] == global_options
+
+    def test_static_options_are_narrowed_and_blocked_selection_is_replaced(self, monkeypatch):
+        from lfx.services.model_provider_policy import (
+            ModelProviderPolicyContext,
+            ModelProviderPolicyPurpose,
+            ModelProviderPolicySnapshot,
+        )
+
+        component = MagicMock()
+        component.user_id = "test_user"
+        component.cache = {}
+        component.log = MagicMock()
+        openai = {"name": "gpt-test", "provider": "OpenAI"}
+        anthropic = {"name": "claude-test", "provider": "Anthropic"}
+        build_config = {"model": {"options": [openai, anthropic], "value": [anthropic]}}
+        snapshot = ModelProviderPolicySnapshot(
+            context=ModelProviderPolicyContext(user_id=component.user_id),
+            purpose=ModelProviderPolicyPurpose.USE,
+            candidate_provider_ids=frozenset({"openai", "anthropic"}),
+            allowed_provider_ids=frozenset({"openai"}),
+        )
+        monkeypatch.setattr(
+            "lfx.services.model_provider_policy.resolve_model_provider_policy",
+            lambda **_kwargs: snapshot,
+        )
+
+        result = update_model_options_in_build_config(
+            component=component,
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=lambda _user_id: [],
+            field_name=None,
+            field_value=None,
+        )
+
+        assert result["model"]["options"] == [openai]
+        assert result["model"]["value"] == [openai]

--- a/src/lfx/tests/unit/services/model_provider_policy/__init__.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the model-provider policy service contract."""

--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from lfx.base.models.unified_models import get_llm
+from lfx.services.model_provider_policy import (
+    ModelProviderPolicyContext,
+    ModelProviderPolicyError,
+    ModelProviderPolicyPurpose,
+    ModelProviderPolicyService,
+    ModelProviderPolicySnapshot,
+)
+
+
+def _restricted_snapshot(*allowed: str) -> ModelProviderPolicySnapshot:
+    return ModelProviderPolicySnapshot(
+        context=ModelProviderPolicyContext(user_id="user-1"),
+        purpose=ModelProviderPolicyPurpose.USE,
+        candidate_provider_ids=frozenset({"openai", "anthropic"}),
+        allowed_provider_ids=frozenset(allowed),
+    )
+
+
+def test_default_service_allows_every_candidate():
+    service = ModelProviderPolicyService()
+
+    snapshot = service.resolve(
+        context=ModelProviderPolicyContext(user_id="user-1"),
+        candidate_provider_ids=frozenset({"openai", "anthropic"}),
+        purpose=ModelProviderPolicyPurpose.USE,
+    )
+
+    assert snapshot.allowed_provider_ids == frozenset({"openai", "anthropic"})
+    assert snapshot.allows("OpenAI")
+    assert snapshot.allows("Anthropic")
+
+
+def test_snapshot_is_immutable_and_cannot_allow_non_candidates():
+    snapshot = _restricted_snapshot("openai")
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.purpose = ModelProviderPolicyPurpose.CONFIGURE  # type: ignore[misc]
+
+    with pytest.raises(ValueError, match="subset"):
+        ModelProviderPolicySnapshot(
+            context=ModelProviderPolicyContext(),
+            purpose=ModelProviderPolicyPurpose.DISCOVER,
+            candidate_provider_ids=frozenset({"openai"}),
+            allowed_provider_ids=frozenset({"openai", "anthropic"}),
+        )
+
+
+def test_runtime_denies_provider_before_credential_resolution(monkeypatch):
+    credential_lookup_called = False
+
+    def _credential_lookup(*_args, **_kwargs):
+        nonlocal credential_lookup_called
+        credential_lookup_called = True
+        return "secret"
+
+    monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", _credential_lookup)
+
+    with pytest.raises(ModelProviderPolicyError) as exc_info:
+        get_llm(
+            [{"name": "claude-test", "provider": "Anthropic", "metadata": {}}],
+            user_id="user-1",
+            provider_policy=_restricted_snapshot("openai"),
+        )
+
+    assert exc_info.value.code == "policy_blocked"
+    assert credential_lookup_called is False

--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from lfx.base.models.unified_models import get_llm
+from lfx.base.models.unified_models import get_embeddings, get_llm
 from lfx.services.model_provider_policy import (
     ModelProviderPolicyContext,
     ModelProviderPolicyError,
@@ -17,7 +18,7 @@ def _restricted_snapshot(*allowed: str) -> ModelProviderPolicySnapshot:
     return ModelProviderPolicySnapshot(
         context=ModelProviderPolicyContext(user_id="user-1"),
         purpose=ModelProviderPolicyPurpose.USE,
-        candidate_provider_ids=frozenset({"openai", "anthropic"}),
+        candidate_provider_ids=frozenset({"openai", "anthropic", "ollama"}),
         allowed_provider_ids=frozenset(allowed),
     )
 
@@ -36,6 +37,28 @@ def test_default_service_allows_every_candidate():
     assert snapshot.allows("Anthropic")
 
 
+def test_default_resolution_preserves_unknown_legacy_provider_names(monkeypatch):
+    from lfx.services.model_provider_policy import utils
+
+    service = ModelProviderPolicyService()
+    monkeypatch.setattr("lfx.services.deps.get_model_provider_policy_service", lambda: service)
+
+    snapshot = utils.resolve_model_provider_policy(
+        user_id="user-1",
+        providers=["Legacy Custom Provider"],
+        purpose=ModelProviderPolicyPurpose.USE,
+    )
+
+    assert snapshot.allows("Legacy Custom Provider")
+
+
+def test_watsonx_legacy_alias_resolves_to_stable_provider_id():
+    from lfx.base.models.provider_registry import provider_id_for
+
+    assert provider_id_for("IBM watsonx.ai") == "ibm-watsonx"
+    assert _restricted_snapshot("openai").allows("IBM watsonx.ai") is False
+
+
 def test_snapshot_is_immutable_and_cannot_allow_non_candidates():
     snapshot = _restricted_snapshot("openai")
 
@@ -49,6 +72,16 @@ def test_snapshot_is_immutable_and_cannot_allow_non_candidates():
             candidate_provider_ids=frozenset({"openai"}),
             allowed_provider_ids=frozenset({"openai", "anthropic"}),
         )
+
+
+def test_context_attributes_are_deeply_immutable():
+    attributes = {"roles": ["member"], "scope": {"workspace": "one"}}
+    context = ModelProviderPolicyContext(attributes=attributes)
+    attributes["roles"].append("admin")
+
+    assert context.attributes["roles"] == ("member",)
+    with pytest.raises(TypeError):
+        context.attributes["scope"]["workspace"] = "two"
 
 
 def test_runtime_denies_provider_before_credential_resolution(monkeypatch):
@@ -70,3 +103,261 @@ def test_runtime_denies_provider_before_credential_resolution(monkeypatch):
 
     assert exc_info.value.code == "policy_blocked"
     assert credential_lookup_called is False
+
+
+def test_embedding_runtime_denies_provider_before_credential_resolution(monkeypatch):
+    credential_lookup_called = False
+
+    def _credential_lookup(*_args, **_kwargs):
+        nonlocal credential_lookup_called
+        credential_lookup_called = True
+        return "secret"
+
+    monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", _credential_lookup)
+
+    with pytest.raises(ModelProviderPolicyError):
+        get_embeddings(
+            [{"name": "embed-test", "provider": "Anthropic", "metadata": {}}],
+            user_id="user-1",
+            provider_policy=_restricted_snapshot("openai"),
+        )
+
+    assert credential_lookup_called is False
+
+
+def test_known_llm_provider_ignores_spoofed_runtime_metadata(monkeypatch):
+    requested_classes = []
+    captured = {}
+
+    class _OllamaChatModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    def _get_model_class(class_name):
+        requested_classes.append(class_name)
+        return _OllamaChatModel
+
+    monkeypatch.setattr("lfx.base.models.unified_models.get_model_class", _get_model_class)
+    monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("lfx.base.models.unified_models.get_all_variables_for_provider", lambda *_args: {})
+
+    result = get_llm(
+        [
+            {
+                "name": "llama-test",
+                "provider": "Ollama",
+                "metadata": {
+                    "model_class": "ChatAnthropic",
+                    "model_name_param": "anthropic_model",
+                    "api_key_param": "anthropic_api_key",  # pragma: allowlist secret
+                    "base_url_param": "anthropic_base_url",
+                },
+            }
+        ],
+        user_id="user-1",
+        ollama_base_url="http://ollama.test",
+        provider_policy=_restricted_snapshot("ollama"),
+    )
+
+    assert isinstance(result, _OllamaChatModel)
+    assert requested_classes == ["ChatOllama"]
+    assert captured == {
+        "model": "llama-test",
+        "streaming": False,
+        "api_key": None,
+        "base_url": "http://ollama.test",
+    }
+
+
+def test_known_embedding_provider_ignores_spoofed_runtime_metadata(monkeypatch):
+    from lfx.base.models.unified_models import instantiation
+
+    requested_classes = []
+    captured = {}
+
+    class _OllamaEmbeddings:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    def _get_embedding_class(class_name):
+        requested_classes.append(class_name)
+        return _OllamaEmbeddings
+
+    monkeypatch.setattr("lfx.base.models.unified_models.get_embedding_class", _get_embedding_class)
+    monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("lfx.base.models.unified_models.get_all_variables_for_provider", lambda *_args: {})
+    monkeypatch.setattr(instantiation, "_get_configured_embedding_providers", lambda *_args: [])
+
+    result = get_embeddings(
+        [
+            {
+                "name": "nomic-embed-text",
+                "provider": "Ollama",
+                "metadata": {
+                    "embedding_class": "OpenAIEmbeddings",
+                    "param_mapping": {
+                        "model": "deployment",
+                        "api_key": "openai_api_key",  # pragma: allowlist secret
+                        "base_url": "openai_api_base",
+                    },
+                },
+            }
+        ],
+        user_id="user-1",
+        ollama_base_url="http://ollama.test",
+        provider_policy=_restricted_snapshot("ollama"),
+    )
+
+    assert isinstance(result.embeddings, _OllamaEmbeddings)
+    assert requested_classes == ["OllamaEmbeddings"]
+    assert captured == {"model": "nomic-embed-text", "base_url": "http://ollama.test"}
+
+
+def test_default_runtime_policy_preserves_unknown_legacy_llm_provider(monkeypatch):
+    """Unknown saved providers must reach the historical runtime validation path."""
+    from lfx.services import deps
+
+    captured = {}
+
+    class _LegacyChatModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(deps, "get_model_provider_policy_service", lambda: ModelProviderPolicyService())
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.get_api_key_for_provider",
+        lambda *_args, **_kwargs: "legacy-key",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.get_model_class",
+        lambda _class_name: _LegacyChatModel,
+    )
+
+    result = get_llm(
+        [
+            {
+                "name": "legacy-model",
+                "provider": "Legacy Custom Provider",
+                "metadata": {
+                    "model_class": "LegacyChatModel",
+                    "model_name_param": "model",
+                    "api_key_param": "api_key",  # pragma: allowlist secret
+                },
+            }
+        ],
+        user_id="user-1",
+    )
+
+    assert isinstance(result, _LegacyChatModel)
+    assert captured == {  # pragma: allowlist secret
+        "model": "legacy-model",
+        "streaming": False,
+        "api_key": "legacy-key",  # pragma: allowlist secret
+    }
+
+
+def test_default_runtime_policy_preserves_unknown_legacy_embedding_provider(monkeypatch):
+    """The allow-all default must not turn an old embedding selection into a policy denial."""
+    from lfx.base.models.unified_models import instantiation
+    from lfx.services import deps
+
+    captured = {}
+
+    class _LegacyEmbeddings:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(deps, "get_model_provider_policy_service", lambda: ModelProviderPolicyService())
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.get_api_key_for_provider",
+        lambda *_args, **_kwargs: "legacy-key",
+    )
+    monkeypatch.setattr(
+        "lfx.base.models.unified_models.get_embedding_class",
+        lambda _class_name: _LegacyEmbeddings,
+    )
+    monkeypatch.setattr(instantiation, "_get_provider_embedding_model_names", lambda *_args: [])
+
+    result = get_embeddings(
+        [
+            {
+                "name": "legacy-embedding-model",
+                "provider": "Legacy Custom Provider",
+                "metadata": {
+                    "embedding_class": "LegacyEmbeddings",
+                    "param_mapping": {
+                        "model": "model",
+                        "api_key": "api_key",  # pragma: allowlist secret
+                    },
+                },
+            }
+        ],
+        user_id=None,
+    )
+
+    assert isinstance(result.embeddings, _LegacyEmbeddings)
+    assert captured == {
+        "model": "legacy-embedding-model",
+        "api_key": "legacy-key",  # pragma: allowlist secret
+    }
+
+
+@pytest.mark.parametrize(
+    ("option_builder", "model_type", "openai_model"),
+    [
+        ("get_language_model_options", "llm", "gpt-test"),
+        ("get_embedding_model_options", "embeddings", "text-embedding-test"),
+    ],
+)
+def test_model_options_filter_denied_dynamic_sources(option_builder, model_type, openai_model):
+    from lfx.base.models.unified_models import model_catalog
+
+    catalog = [
+        {
+            "provider": "OpenAI",
+            "icon": "OpenAI",
+            "models": [{"model_name": openai_model, "metadata": {"default": True, "model_type": model_type}}],
+        },
+        {
+            "provider": "Anthropic",
+            "icon": "Anthropic",
+            "models": [{"model_name": "blocked-static", "metadata": {"default": True, "model_type": model_type}}],
+        },
+    ]
+    live_enabled_providers = []
+
+    def _replace_with_live_models(groups, _user_id, enabled_providers, *_args, **_kwargs):
+        live_enabled_providers.append(set(enabled_providers))
+        groups.append(
+            {
+                "provider": "Anthropic",
+                "models": [{"model_name": "blocked-live", "metadata": {"default": True, "model_type": model_type}}],
+            }
+        )
+
+    def _inject_custom(groups, *_args, **_kwargs):
+        groups.append(
+            {
+                "provider": "Anthropic",
+                "models": [{"model_name": "blocked-custom", "metadata": {"default": True, "model_type": model_type}}],
+            }
+        )
+
+    with (
+        patch.object(model_catalog, "get_unified_models_detailed", return_value=catalog),
+        patch.object(model_catalog, "_get_model_status", new=AsyncMock(return_value=(set(), set()))),
+        patch.object(
+            model_catalog,
+            "_fetch_enabled_providers_for_user",
+            new=AsyncMock(return_value={"OpenAI", "Anthropic"}),
+        ),
+        patch.object(model_catalog, "replace_with_live_models", side_effect=_replace_with_live_models),
+        patch.object(model_catalog, "inject_custom_enabled_models", side_effect=_inject_custom),
+    ):
+        options = getattr(model_catalog, option_builder)(
+            user_id="00000000-0000-0000-0000-000000000001",
+            provider_policy=_restricted_snapshot("openai"),
+        )
+
+    assert live_enabled_providers == [{"OpenAI"}]
+    assert {(option["provider"], option["name"]) for option in options} == {("OpenAI", openai_model)}

--- a/src/lfx/tests/unit/services/test_service_manager.py
+++ b/src/lfx/tests/unit/services/test_service_manager.py
@@ -5,6 +5,12 @@ from pathlib import Path
 import pytest
 from lfx.services.base import Service
 from lfx.services.manager import NoFactoryRegisteredError, ServiceManager
+from lfx.services.model_provider_policy import (
+    BaseModelProviderPolicyService,
+    ModelProviderPolicyContext,
+    ModelProviderPolicyPurpose,
+    ModelProviderPolicyService,
+)
 from lfx.services.schema import ServiceType
 from lfx.services.storage.local import LocalStorageService
 from lfx.services.telemetry.service import TelemetryService
@@ -12,6 +18,21 @@ from lfx.services.tracing.service import TracingService
 from lfx.services.variable.service import VariableService
 
 from .conftest import MockSessionService
+
+
+class DenyAllModelProviderPolicyService(BaseModelProviderPolicyService):
+    """Test plugin proving that deployment config replaces the OSS default."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_ready()
+
+    @property
+    def name(self) -> str:
+        return ServiceType.MODEL_PROVIDER_POLICY_SERVICE.value
+
+    def get_allowed_provider_ids(self, *, context, candidate_provider_ids, purpose):  # noqa: ARG002
+        return frozenset()
 
 
 @pytest.fixture
@@ -100,6 +121,60 @@ storage_service = "lfx.services.storage.local:LocalStorageService"
 
         assert ServiceType.STORAGE_SERVICE in service_manager.service_classes
         assert service_manager.service_classes[ServiceType.STORAGE_SERVICE] == LocalStorageService
+
+    def test_model_provider_policy_config_overrides_allow_all_default(self, service_manager, temp_config_dir):
+        service_manager.register_service_class(
+            ServiceType.MODEL_PROVIDER_POLICY_SERVICE,
+            ModelProviderPolicyService,
+            override=True,
+        )
+        (temp_config_dir / "lfx.toml").write_text(
+            f"""
+[services]
+model_provider_policy_service = "{__name__}:DenyAllModelProviderPolicyService"
+"""
+        )
+
+        service_manager.discover_plugins(temp_config_dir)
+        service = service_manager.get(ServiceType.MODEL_PROVIDER_POLICY_SERVICE)
+        snapshot = service.resolve(
+            context=ModelProviderPolicyContext(user_id="user-1"),
+            candidate_provider_ids=frozenset({"openai", "anthropic"}),
+            purpose=ModelProviderPolicyPurpose.USE,
+        )
+
+        assert isinstance(service, DenyAllModelProviderPolicyService)
+        assert snapshot.allowed_provider_ids == frozenset()
+
+    @pytest.mark.parametrize(
+        ("service_path", "error"),
+        [
+            (
+                "nonexistent.module:MissingModelProviderPolicyService",
+                "could not be loaded",
+            ),
+            (
+                "lfx.services.storage.local:LocalStorageService",
+                "must subclass BaseModelProviderPolicyService",
+            ),
+        ],
+    )
+    def test_invalid_explicit_model_provider_policy_fails_closed(
+        self,
+        service_manager,
+        temp_config_dir,
+        service_path,
+        error,
+    ):
+        (temp_config_dir / "lfx.toml").write_text(
+            f"""
+[services]
+model_provider_policy_service = "{service_path}"
+"""
+        )
+
+        with pytest.raises(RuntimeError, match=error):
+            service_manager.discover_plugins(temp_config_dir)
 
     def test_discover_multiple_services_from_config(self, service_manager, temp_config_dir):
         """Test discovering multiple real services from config."""

--- a/src/lfx/tests/unit/test_flow_builder_tools.py
+++ b/src/lfx/tests/unit/test_flow_builder_tools.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import json
 
+import pytest
 from lfx.mcp.flow_builder_tools import (
     AddComponent,
     BuildFlowFromSpec,
@@ -739,6 +740,68 @@ class TestConfigureComponentModelProviderOnly:
 
         value = _read_model_field_value(agent_id)
         assert value[0].get("name") == "claude-sonnet-4-5-20250929"
+
+
+class TestConfigureComponentModelProviderPolicy:
+    """Denied providers must never enter the MCP flow-builder model field."""
+
+    @staticmethod
+    def _deny_all_snapshot():
+        from lfx.services.model_provider_policy import (
+            ModelProviderPolicyContext,
+            ModelProviderPolicyPurpose,
+            ModelProviderPolicySnapshot,
+        )
+
+        return ModelProviderPolicySnapshot(
+            context=ModelProviderPolicyContext(user_id="user-1"),
+            purpose=ModelProviderPolicyPurpose.USE,
+            candidate_provider_ids=frozenset({"openai", "anthropic"}),
+            allowed_provider_ids=frozenset(),
+        )
+
+    def test_denied_provider_returns_generic_error_before_configure_default_or_mirror(self, monkeypatch):
+        from lfx.mcp.flow_builder_tools import ConfigureComponent, mutate_tools
+
+        agent_id = _make_agent_node_for_model_test()
+        original_value = copy.deepcopy(_read_model_field_value(agent_id))
+        snapshot = self._deny_all_snapshot()
+
+        monkeypatch.setattr(mutate_tools, "resolve_model_provider_policy", lambda **_kwargs: snapshot)
+
+        def fail_if_called(*_args, **_kwargs):
+            msg = "denied provider reached downstream model configuration work"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(mutate_tools, "fb_configure", fail_if_called)
+        monkeypatch.setattr(mutate_tools, "_resolve_default_model_name", fail_if_called)
+        monkeypatch.setattr(mutate_tools, "_mirror_model_value_into_options", fail_if_called)
+
+        cfg = ConfigureComponent()
+        cfg.set(component_id=agent_id, params='{"model": [{"provider": "Anthropic"}]}')
+        result = cfg.configure_component()
+
+        assert result.data == {"error": "The requested model provider is not available"}
+        assert _read_model_field_value(agent_id) == original_value
+
+    def test_default_resolution_denies_before_catalog_lookup(self, monkeypatch):
+        from lfx.base.models import unified_models
+        from lfx.mcp.flow_builder_tools import mutate_tools
+        from lfx.services.model_provider_policy import ModelProviderPolicyError
+
+        snapshot = self._deny_all_snapshot()
+        monkeypatch.setattr(mutate_tools, "resolve_model_provider_policy", lambda **_kwargs: snapshot)
+
+        def fail_if_called(*_args, **_kwargs):
+            msg = "denied provider reached the model catalog"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(unified_models, "get_unified_models_detailed", fail_if_called)
+
+        with pytest.raises(ModelProviderPolicyError) as exc_info:
+            mutate_tools._resolve_default_model_name("Anthropic")
+
+        assert str(exc_info.value) == "The requested model provider is not available"
 
 
 class TestConfigureComponentModelFieldSerializedSpec:


### PR DESCRIPTION
## Summary

- Add stable provider IDs, aliases, origin metadata, and static catalog loading so extension packages can contribute enterprise providers without OSS registry edits.
- Add a pluggable model-provider policy service with separate discover, configure, and use decisions. The context is deployment-wide today and carries user, workspace, role, and attribute seams for later RBAC policies.
- Enforce hidden-provider behavior server-side across unified model discovery and mutation APIs, variables and environment import, model selectors, Agentic, Knowledge Base, Memory Base, MCP configuration, and runtime model construction.
- Support credentialless providers and use authoritative registry wiring for known providers so saved metadata cannot redirect model classes or secret parameters.

## Architecture and compatibility

- OSS installs use an allow-all policy by default, preserving existing behavior.
- Enterprise can install provider-only extension packages and supply a policy implementation or deployment configuration separately.
- Denied providers are omitted from discovery and return generic not-found responses before validation, secret lookup, storage, or network work.
- Unknown legacy saved providers retain the historical runtime fallback path.
- Provider-specific component-class filtering and frontend changes are intentionally out of scope.

## Validation

- 347 LFX provider, model, extension, service, Agentic, and MCP tests passed on the rebased release head.
- 217 focused backend tests passed with 1 pre-existing xfail.
- Ruff check and format checks passed for all changed Python files.
- Bundle API changelog guard and all commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model-provider policies to control provider discovery, configuration, and usage.
  * Added stable provider identities, aliases, display names, and catalog support for extensions.
  * Added support for provider-only extensions and credentialless providers.
  * Improved model and embedding catalogs with policy-aware filtering and safer provider selection.

* **Bug Fixes**
  * Prevented unauthorized providers and credentials from appearing or being used.
  * Fixed API-key detection for providers using non-secret settings such as base URLs.
  * Improved knowledge-base and memory-provider validation before persistence or execution.

* **Documentation**
  * Updated extension manifest, provider registry, and policy-service documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->