### PR TITLE
fix(ci): keep core index check wheel-only

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -952,10 +952,8 @@ jobs:
         run: |
           core-test-env/bin/python - <<'PY'
           import importlib
-          import json
           import re
           from importlib.metadata import distributions, entry_points
-          from pathlib import Path
 
           from lfx.interface.components import _read_component_index
 
@@ -970,10 +968,12 @@ jobs:
 
           index = _read_component_index()
           assert index is not None, "Installed LFX rejected its bundled component index"
-          expected_index = json.loads(Path("src/lfx/src/lfx/_assets/component_index.json").read_text())
-          assert index["metadata"] == expected_index["metadata"], (
-            f"Unexpected component index metadata: {index['metadata']} "
-            f"!= {expected_index['metadata']}"
+          expected_metadata = {
+              "num_modules": len(index["entries"]),
+              "num_components": sum(len(components) for _, components in index["entries"]),
+          }
+          assert index["metadata"] == expected_metadata, (
+            f"Unexpected component index metadata: {index['metadata']} != {expected_metadata}"
           )
           for category, components in index["entries"]:
               for component_name, component in components.items():


### PR DESCRIPTION
## Summary

- keep the core-runtime verification independent of a source checkout
- derive expected component-index metadata from the wheel-bundled entries
- preserve the isolated indexed-import coverage

Fixes the failure in https://github.com/langflow-ai/langflow/actions/runs/29542552422/job/87773890440.

## Validation

- actionlint -shellcheck= .github/workflows/cross-platform-test.yml
- embedded Python syntax compilation
- current component-index metadata consistency (17 modules, 131 components)
- pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cross-platform validation to verify component-index metadata against the generated index contents.
  * Removed reliance on a separate reference metadata file during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->