### PR TITLE
fix(agents): preserve structured tool output artifacts

### DIFF
--- a/src/frontend/src/components/core/chatComponents/ToolOutputDisplay.tsx
+++ b/src/frontend/src/components/core/chatComponents/ToolOutputDisplay.tsx
@@ -80,6 +80,19 @@ function FormattedOutput({ value }: { value: JSONValue }) {
 
 type Tab = "result" | "metadata";
 
+function isMcpCallToolResultArtifact(
+  value: JSONValue | undefined,
+): value is Record<string, JSONValue> {
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Array.isArray(value.content) &&
+    typeof value.isError === "boolean"
+  );
+}
+
 /** Tab control sized for the inside of a tool-call card. Matches the
  * underline-on-active pattern used across assistant-ui / Claude /
  * ChatGPT — quiet by default, the active tab gets a 2px underline in
@@ -118,9 +131,10 @@ function TabButton({
  *   - LangChain ToolMessage envelope with non-standard metadata keys
  *     (additional_kwargs, response_metadata, type, ...) gets a 2-tab UI:
  *     "Result" prefers the structured `.artifact` and falls back to the
- *     model-facing `.content`; "Metadata" shows the rest of the envelope
- *     as pretty JSON. Plumbing keys (name, id, tool_call_id, status) are
- *     suppressed because the accordion trigger already surfaces them.
+ *     model-facing `.content`. MCP `CallToolResult` artifacts are protocol
+ *     envelopes, so their readable content stays in Result and the raw
+ *     artifact stays in Metadata. Plumbing keys (name, id, tool_call_id,
+ *     status) are suppressed because the accordion trigger surfaces them.
  *   - Anything else (simple string, plain dict, unwrappable envelope)
  *     falls through to FormattedOutput directly under the eyebrow —
  *     no tabs, just the body. */
@@ -137,17 +151,20 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
     );
   }
 
-  const result = output.artifact ?? output.content;
+  const artifact = output.artifact;
+  const isMcpArtifact = isMcpCallToolResultArtifact(artifact);
+  const result = artifact != null && !isMcpArtifact ? artifact : output.content;
   // Strip the standard ToolMessage plumbing keys from the metadata view —
   // the accordion trigger already shows tool name and status, and id /
   // tool_call_id aren't useful in the UI. What remains is the actually
   // interesting custom metadata (additional_kwargs, response_metadata,
-  // type, custom fields). Artifact is the primary result, so don't duplicate
-  // it in the Metadata tab.
+  // type, custom fields). Component artifacts are the primary result, while
+  // raw MCP protocol artifacts remain metadata behind readable content.
   const metadata = Object.fromEntries(
-    Object.entries(output).filter(
-      ([k]) => !TOOL_MESSAGE_KEYS_PLUS_CONTENT.has(k),
-    ),
+    Object.entries(output).filter(([key, value]) => {
+      if (key === "artifact") return value != null && isMcpArtifact;
+      return !TOOL_MESSAGE_KEYS_PLUS_CONTENT.has(key);
+    }),
   );
   const hasMetadata = Object.keys(metadata).length > 0;
 
@@ -205,12 +222,12 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
   );
 }
 
-// `content` and `artifact` belong in the Result tab; the rest of the
-// canonical plumbing fields aren't worth exposing — keep this set local
-// rather than re-exporting yet another constant.
+// `content` belongs in the Result tab; the canonical plumbing fields aren't
+// worth exposing — keep this set local rather than re-exporting another
+// constant. Artifact routing depends on whether it is component data or an
+// MCP protocol envelope, so it is handled separately above.
 const TOOL_MESSAGE_KEYS_PLUS_CONTENT = new Set([
   "content",
-  "artifact",
   "name",
   "id",
   "tool_call_id",

--- a/src/frontend/src/components/core/chatComponents/ToolOutputDisplay.tsx
+++ b/src/frontend/src/components/core/chatComponents/ToolOutputDisplay.tsx
@@ -116,10 +116,10 @@ function TabButton({
  * eyebrow so the section is unambiguous next to the "Arguments" block
  * above it. Routes by shape:
  *   - LangChain ToolMessage envelope with non-standard metadata keys
- *     (additional_kwargs, response_metadata, artifact, type, ...) gets
- *     a 2-tab UI: "Result" shows the inner `.content` rendered through
- *     FormattedOutput, "Metadata" shows the rest of the envelope as
- *     pretty JSON. Plumbing keys (name, id, tool_call_id, status) are
+ *     (additional_kwargs, response_metadata, type, ...) gets a 2-tab UI:
+ *     "Result" prefers the structured `.artifact` and falls back to the
+ *     model-facing `.content`; "Metadata" shows the rest of the envelope
+ *     as pretty JSON. Plumbing keys (name, id, tool_call_id, status) are
  *     suppressed because the accordion trigger already surfaces them.
  *   - Anything else (simple string, plain dict, unwrappable envelope)
  *     falls through to FormattedOutput directly under the eyebrow —
@@ -137,12 +137,13 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
     );
   }
 
-  const content = output.content;
+  const result = output.artifact ?? output.content;
   // Strip the standard ToolMessage plumbing keys from the metadata view —
   // the accordion trigger already shows tool name and status, and id /
   // tool_call_id aren't useful in the UI. What remains is the actually
   // interesting custom metadata (additional_kwargs, response_metadata,
-  // artifact, type, custom fields).
+  // type, custom fields). Artifact is the primary result, so don't duplicate
+  // it in the Metadata tab.
   const metadata = Object.fromEntries(
     Object.entries(output).filter(
       ([k]) => !TOOL_MESSAGE_KEYS_PLUS_CONTENT.has(k),
@@ -151,11 +152,11 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
   const hasMetadata = Object.keys(metadata).length > 0;
 
   // If after stripping plumbing there's no meaningful metadata left,
-  // drop the tabs and render content directly.
+  // drop the tabs and render the result directly.
   if (!hasMetadata) {
     return (
       <ToolSection eyebrow="Output">
-        <FormattedOutput value={content} />
+        <FormattedOutput value={result} />
       </ToolSection>
     );
   }
@@ -190,7 +191,7 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
             transition={{ duration: 0.08, ease: "easeOut" }}
           >
             {tab === "result" ? (
-              <FormattedOutput value={content} />
+              <FormattedOutput value={result} />
             ) : (
               <SimplifiedCodeTabComponent
                 language="json"
@@ -204,11 +205,12 @@ export function ToolOutputDisplay({ output }: { output: JSONValue }) {
   );
 }
 
-// `content` belongs in its own tab; the rest of the canonical plumbing
-// fields aren't worth exposing — keep this set local rather than
-// re-exporting yet another constant.
+// `content` and `artifact` belong in the Result tab; the rest of the
+// canonical plumbing fields aren't worth exposing — keep this set local
+// rather than re-exporting yet another constant.
 const TOOL_MESSAGE_KEYS_PLUS_CONTENT = new Set([
   "content",
+  "artifact",
   "name",
   "id",
   "tool_call_id",

--- a/src/frontend/src/components/core/chatComponents/__tests__/ContentDisplay.test.tsx
+++ b/src/frontend/src/components/core/chatComponents/__tests__/ContentDisplay.test.tsx
@@ -47,7 +47,11 @@ jest.mock("@/components/common/genericIconComponent", () => ({
 }));
 jest.mock("@/components/core/codeTabsComponent", () => ({
   __esModule: true,
-  default: () => <div data-testid="code-tabs" />,
+  default: ({ code, language }: { code: string; language: string }) => (
+    <pre data-language={language} data-testid="code-tabs">
+      {code}
+    </pre>
+  ),
 }));
 jest.mock("../DurationDisplay", () => ({
   __esModule: true,
@@ -355,6 +359,39 @@ describe("ContentDisplay", () => {
       expect(tabs[1]).toHaveAttribute("aria-selected", "false");
       // Body of the Result tab renders the inner string, not a JSON dump.
       expect(screen.getByText("the body")).toBeInTheDocument();
+    });
+
+    it("renders a structured ToolMessage artifact instead of lossy string content", () => {
+      const tool = {
+        type: "tool_use",
+        name: "search_documents",
+        tool_input: {},
+        output: {
+          content:
+            "                                                text\n" +
+            "0  Thanks to the high-quality document conversion...",
+          artifact: [
+            {
+              text: "Thanks to the high-quality document conversion...",
+              source: "docling.pdf",
+            },
+          ],
+          additional_kwargs: {},
+          response_metadata: {},
+          type: "tool",
+          name: "search_documents",
+          tool_call_id: "toolu_xyz",
+          status: "success",
+        },
+      } as unknown as ContentBlockItem;
+
+      render(<ContentDisplay content={tool} chatId="t-t-artifact" />);
+
+      const result = screen.getByTestId("code-tabs");
+      expect(result).toHaveAttribute("data-language", "json");
+      expect(result).toHaveTextContent('"source": "docling.pdf"');
+      expect(result).not.toHaveTextContent("0 Thanks to");
+      expect(screen.getAllByRole("tab")).toHaveLength(2);
     });
 
     it("renders the error body in a destructive-toned panel", () => {

--- a/src/frontend/src/components/core/chatComponents/__tests__/ContentDisplay.test.tsx
+++ b/src/frontend/src/components/core/chatComponents/__tests__/ContentDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type {
   CitationContent,
   ContentBlockItem,
@@ -392,6 +392,38 @@ describe("ContentDisplay", () => {
       expect(result).toHaveTextContent('"source": "docling.pdf"');
       expect(result).not.toHaveTextContent("0 Thanks to");
       expect(screen.getAllByRole("tab")).toHaveLength(2);
+    });
+
+    it("keeps MCP content as the result and its protocol artifact in metadata", async () => {
+      const tool = {
+        type: "tool_use",
+        name: "mcp_search",
+        tool_input: {},
+        output: {
+          content: "readable MCP output",
+          artifact: {
+            meta: null,
+            content: [{ type: "text", text: "readable MCP output" }],
+            structuredContent: null,
+            isError: false,
+          },
+          additional_kwargs: {},
+          response_metadata: {},
+          type: "tool",
+          name: "mcp_search",
+          tool_call_id: "toolu_mcp",
+          status: "success",
+        },
+      } as unknown as ContentBlockItem;
+
+      render(<ContentDisplay content={tool} chatId="t-t-mcp-artifact" />);
+
+      expect(screen.getByText("readable MCP output")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("tab", { name: "Metadata" }));
+      const metadata = await screen.findByTestId("code-tabs");
+      expect(metadata).toHaveTextContent('"artifact": {');
+      expect(metadata).toHaveTextContent('"isError": false');
     });
 
     it("renders the error body in a destructive-toned panel", () => {

--- a/src/lfx/src/lfx/base/tools/component_tool.py
+++ b/src/lfx/src/lfx/base/tools/component_tool.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import asyncio
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
+
+# LangChain resolves these annotations at runtime to inject config and callback managers.
+from langchain_core.callbacks import AsyncCallbackManagerForToolRun, CallbackManagerForToolRun  # noqa: TC002
+from langchain_core.runnables import RunnableConfig  # noqa: TC002
 from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools.structured import StructuredTool
+from typing_extensions import override
 
 from lfx.base.tools.constants import TOOL_OUTPUT_NAME
 from lfx.log.logger import logger
@@ -27,6 +32,39 @@ if TYPE_CHECKING:
     from lfx.schema.dotdict import dotdict
 
 TOOL_TYPES_SET = {"Tool", "BaseTool", "StructuredTool"}
+
+
+class ComponentStructuredTool(StructuredTool):
+    """StructuredTool that keeps JSON-safe component results as LangChain artifacts."""
+
+    response_format: Literal["content_and_artifact"] = "content_and_artifact"
+
+    @staticmethod
+    def _content_and_artifact(content: Any) -> tuple[Any, Any | None]:
+        artifact = None if isinstance(content, str) else serialize(content)
+        return content, artifact
+
+    @override
+    def _run(
+        self,
+        *args: Any,
+        config: RunnableConfig,
+        run_manager: CallbackManagerForToolRun | None = None,
+        **kwargs: Any,
+    ) -> tuple[Any, Any | None]:
+        content = super()._run(*args, config=config, run_manager=run_manager, **kwargs)
+        return self._content_and_artifact(content)
+
+    @override
+    async def _arun(
+        self,
+        *args: Any,
+        config: RunnableConfig,
+        run_manager: AsyncCallbackManagerForToolRun | None = None,
+        **kwargs: Any,
+    ) -> tuple[Any, Any | None]:
+        content = await super()._arun(*args, config=config, run_manager=run_manager, **kwargs)
+        return self._content_and_artifact(content)
 
 
 def _get_input_type(input_: InputTypes):
@@ -358,7 +396,7 @@ class ComponentToolkit:
             event_manager = self.component.get_event_manager()
             if asyncio.iscoroutinefunction(output_method):
                 tools.append(
-                    StructuredTool(
+                    ComponentStructuredTool(
                         name=formatted_name,
                         description=build_description(self.component, output),
                         coroutine=_build_output_async_function(
@@ -376,7 +414,7 @@ class ComponentToolkit:
                 )
             else:
                 tools.append(
-                    StructuredTool(
+                    ComponentStructuredTool(
                         name=formatted_name,
                         description=build_description(self.component, output),
                         func=_build_output_function(self.component, output_method, event_manager, TOOL_OUTPUT_NAME),

--- a/src/lfx/src/lfx/base/tools/component_tool.py
+++ b/src/lfx/src/lfx/base/tools/component_tool.py
@@ -63,6 +63,10 @@ class ComponentStructuredTool(StructuredTool):
         run_manager: AsyncCallbackManagerForToolRun | None = None,
         **kwargs: Any,
     ) -> tuple[Any, Any | None]:
+        if self.coroutine is None:
+            # StructuredTool falls back to self._run, which already returns the
+            # content-and-artifact tuple. Wrapping it again would nest the tuple.
+            return await super()._arun(*args, config=config, run_manager=run_manager, **kwargs)
         content = await super()._arun(*args, config=config, run_manager=run_manager, **kwargs)
         return self._content_and_artifact(content)
 

--- a/src/lfx/tests/unit/custom/component/test_tool_dataframe_return.py
+++ b/src/lfx/tests/unit/custom/component/test_tool_dataframe_return.py
@@ -105,7 +105,6 @@ def test_agent_tool_preserves_dataframe_as_artifact():
     ]
 
 
-@pytest.mark.asyncio
 async def test_sync_agent_tool_preserves_dataframe_as_artifact_when_awaited():
     """Async agent execution of a sync tool must not wrap the response tuple twice."""
     component = DataFrameProducerComponent()
@@ -126,6 +125,17 @@ async def test_sync_agent_tool_preserves_dataframe_as_artifact_when_awaited():
         {"col1": 2, "col2": "b"},
         {"col1": 3, "col2": "c"},
     ]
+
+
+async def test_sync_tool_arun_returns_dataframe_not_wrapped_tuple():
+    """Direct arun calls on sync tools must preserve the legacy raw-result contract."""
+    component = DataFrameProducerComponent()
+    table_tool = next(t for t in ComponentToolkit(component=component).get_tools() if t.name == "get_table")
+
+    result = await table_tool.arun({"query": "test"})
+
+    assert isinstance(result, pd.DataFrame), f"Expected pandas DataFrame, got {type(result).__name__}: {result!r}"
+    assert result["col1"].tolist() == [1, 2, 3]
 
 
 def test_tool_returns_text_for_message():
@@ -193,7 +203,6 @@ async def test_tool_handles_positional_args_async():
     assert "my_async_query" in result
 
 
-@pytest.mark.asyncio
 async def test_async_agent_tool_preserves_dataframe_as_artifact():
     """Async component tools must preserve structured output under the same Agent contract."""
     component = AsyncTextComponent()

--- a/src/lfx/tests/unit/custom/component/test_tool_dataframe_return.py
+++ b/src/lfx/tests/unit/custom/component/test_tool_dataframe_return.py
@@ -8,6 +8,7 @@ This allows agents like OpenDsStar to use the DataFrame natively with
 
 import pandas as pd
 import pytest
+from langchain_core.messages import ToolMessage
 from lfx.base.tools.component_tool import ComponentToolkit
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import MessageTextInput
@@ -52,8 +53,12 @@ class AsyncTextComponent(Component):
     ]
 
     outputs = [
+        Output(display_name="Table", name="table", method="get_table"),
         Output(display_name="Text", name="text", method="get_text"),
     ]
+
+    async def get_table(self) -> DataFrame:
+        return DataFrame(pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}))
 
     async def get_text(self) -> Message:
         return Message(text=f"async query was: {self.query}")
@@ -74,6 +79,53 @@ def test_tool_returns_dataframe_not_list():
     assert list(result.columns) == ["col1", "col2"]
     assert len(result) == 3
     assert result["col1"].tolist() == [1, 2, 3]
+
+
+def test_agent_tool_preserves_dataframe_as_artifact():
+    """Agent tool calls must keep structured rows instead of only a lossy DataFrame string."""
+    component = DataFrameProducerComponent()
+    table_tool = next(t for t in ComponentToolkit(component=component).get_tools() if t.name == "get_table")
+
+    result = table_tool.invoke(
+        {
+            "name": "get_table",
+            "args": {"query": "test"},
+            "id": "call-sync-table",
+            "type": "tool_call",
+        }
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert isinstance(result.content, str)
+    assert "col1" in result.content
+    assert result.artifact == [
+        {"col1": 1, "col2": "a"},
+        {"col1": 2, "col2": "b"},
+        {"col1": 3, "col2": "c"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sync_agent_tool_preserves_dataframe_as_artifact_when_awaited():
+    """Async agent execution of a sync tool must not wrap the response tuple twice."""
+    component = DataFrameProducerComponent()
+    table_tool = next(t for t in ComponentToolkit(component=component).get_tools() if t.name == "get_table")
+
+    result = await table_tool.ainvoke(
+        {
+            "name": "get_table",
+            "args": {"query": "test"},
+            "id": "call-awaited-sync-table",
+            "type": "tool_call",
+        }
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.artifact == [
+        {"col1": 1, "col2": "a"},
+        {"col1": 2, "col2": "b"},
+        {"col1": 3, "col2": "c"},
+    ]
 
 
 def test_tool_returns_text_for_message():
@@ -139,3 +191,28 @@ async def test_tool_handles_positional_args_async():
 
     assert isinstance(result, str)
     assert "my_async_query" in result
+
+
+@pytest.mark.asyncio
+async def test_async_agent_tool_preserves_dataframe_as_artifact():
+    """Async component tools must preserve structured output under the same Agent contract."""
+    component = AsyncTextComponent()
+    table_tool = next(t for t in ComponentToolkit(component=component).get_tools() if t.name == "get_table")
+
+    result = await table_tool.ainvoke(
+        {
+            "name": "get_table",
+            "args": {"query": "test"},
+            "id": "call-async-table",
+            "type": "tool_call",
+        }
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert isinstance(result.content, str)
+    assert "col1" in result.content
+    assert result.artifact == [
+        {"col1": 1, "col2": "a"},
+        {"col1": 2, "col2": "b"},
+        {"col1": 3, "col2": "c"},
+    ]


### PR DESCRIPTION
## Summary

- preserve JSON-safe component tool results in `ToolMessage.artifact` while retaining model-readable `content`
- keep direct tool invocation behavior unchanged, including native DataFrame returns
- render a non-null artifact as the primary Result in the playground instead of the flattened content string

## Context

Follow-up to #13391. LangGraph supplies a tool call id when invoking component-backed tools, so LangChain wraps the result in a `ToolMessage`. With the default content-only response format, structured values such as DataFrames are stringified into `content` and `artifact` remains null. That loses the structured document chunks both through `response.content_blocks` and in the playground Result view.

## Testing

- 150 related `lfx` tests passed
- 28 `ContentDisplay` Jest tests passed
- focused Ruff and Biome checks passed
- repository pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now prioritize structured artifacts for clearer, more accurate display.
  * Structured outputs, including tables, preserve their data for viewing and downstream use.
  * Result and Metadata tabs now present artifact data without duplicating it as metadata.

* **Bug Fixes**
  * Improved display of structured tool output, preventing loss of fields or fallback to less informative text.
  * Consistent behavior is now provided for both synchronous and asynchronous tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->