### PR TITLE
fix(lfx): isolate component tool message suppression

### DIFF
--- a/src/lfx/src/lfx/base/tools/component_tool.py
+++ b/src/lfx/src/lfx/base/tools/component_tool.py
@@ -106,6 +106,7 @@ def _build_output_function(
         # Create an isolated copy to prevent race conditions when this
         # tool is invoked concurrently by an agent (GitHub issue #8791)
         comp = deepcopy(component)
+        comp.send_message = send_message_noop  # type: ignore[method-assign, assignment]
         local_method = getattr(comp, method_name, output_method)
         build_started = False
         result = None
@@ -140,7 +141,7 @@ def _build_output_function(
         # removing the model_dump() call here because it is not serializable
         return serialize(result)
 
-    return _patch_send_message_decorator(component, output_function)
+    return output_function
 
 
 def _build_output_async_function(
@@ -162,6 +163,7 @@ def _build_output_async_function(
         # Create an isolated copy to prevent race conditions when this
         # tool is invoked concurrently by an agent (GitHub issue #8791)
         comp = deepcopy(component)
+        comp.send_message = send_message_noop  # type: ignore[method-assign, assignment]
         local_method = getattr(comp, method_name, output_method)
         build_started = False
         result = None
@@ -195,7 +197,7 @@ def _build_output_async_function(
         # removing the model_dump() call here because it is not serializable
         return serialize(result)
 
-    return _patch_send_message_decorator(component, output_function)
+    return output_function
 
 
 def _format_tool_name(name: str):

--- a/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
+++ b/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
@@ -1,15 +1,17 @@
-"""Test for GitHub issue #8791: Race condition when component-tool is invoked concurrently.
+"""Tests for race conditions when component tools are invoked concurrently.
 
 When an Agent invokes the same component-based tool multiple times concurrently,
 the same component instance is reused, causing inputs to be overwritten between
 concurrent invocations (data corruption).
 """
 
+import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 
-from lfx.base.tools.component_tool import ComponentToolkit
+import pytest
+from lfx.base.tools.component_tool import ComponentToolkit, send_message_noop
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import DataInput, MessageTextInput
 from lfx.io import Output
@@ -50,6 +52,110 @@ class SlowLabelComponent(Component):
                 "label_after": self.label,
             }
         )
+
+
+class OrderedSyncComponent(Component):
+    inputs = []
+    outputs = [Output(display_name="Result", name="result", method="process")]
+
+    first_started = threading.Event()
+    second_started = threading.Event()
+    finish_first = threading.Event()
+    finish_second = threading.Event()
+    call_lock = threading.Lock()
+    call_number = 0
+
+    def process(self) -> Data:
+        with self.call_lock:
+            current = self.call_number
+            type(self).call_number += 1
+
+        if current == 0:
+            self.first_started.set()
+            assert self.second_started.wait(timeout=5)
+            assert self.finish_first.wait(timeout=5)
+        else:
+            self.second_started.set()
+            assert self.finish_second.wait(timeout=5)
+
+        return Data(data={"send_message_is_noop": self.send_message is send_message_noop})
+
+
+class OrderedAsyncComponent(Component):
+    inputs = []
+    outputs = [Output(display_name="Result", name="result", method="process")]
+
+    first_started: asyncio.Event
+    second_started: asyncio.Event
+    finish_first: asyncio.Event
+    finish_second: asyncio.Event
+    call_number = 0
+
+    async def process(self) -> Data:
+        current = self.call_number
+        type(self).call_number += 1
+
+        if current == 0:
+            self.first_started.set()
+            await asyncio.wait_for(self.second_started.wait(), timeout=5)
+            await asyncio.wait_for(self.finish_first.wait(), timeout=5)
+        else:
+            self.second_started.set()
+            await asyncio.wait_for(self.finish_second.wait(), timeout=5)
+
+        return Data(data={"send_message_is_noop": self.send_message is send_message_noop})
+
+
+def test_sync_tool_calls_do_not_patch_shared_send_message():
+    component = OrderedSyncComponent()
+    original_send_message = component.send_message
+    component_type = type(component)
+    component_type.first_started = threading.Event()
+    component_type.second_started = threading.Event()
+    component_type.finish_first = threading.Event()
+    component_type.finish_second = threading.Event()
+    component_type.call_number = 0
+    tool = ComponentToolkit(component=component).get_tools()[0]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(tool.invoke, {})
+        assert component_type.first_started.wait(timeout=5)
+        second = executor.submit(tool.invoke, {})
+        assert component_type.second_started.wait(timeout=5)
+        component_type.finish_first.set()
+        first_result = first.result(timeout=5)
+        component_type.finish_second.set()
+        second_result = second.result(timeout=5)
+
+    assert first_result["send_message_is_noop"] is True
+    assert second_result["send_message_is_noop"] is True
+    assert component.send_message == original_send_message
+
+
+@pytest.mark.asyncio
+async def test_async_tool_calls_do_not_patch_shared_send_message():
+    component = OrderedAsyncComponent()
+    original_send_message = component.send_message
+    component_type = type(component)
+    component_type.first_started = asyncio.Event()
+    component_type.second_started = asyncio.Event()
+    component_type.finish_first = asyncio.Event()
+    component_type.finish_second = asyncio.Event()
+    component_type.call_number = 0
+    tool = ComponentToolkit(component=component).get_tools()[0]
+
+    first = asyncio.create_task(tool.ainvoke({}))
+    await asyncio.wait_for(component_type.first_started.wait(), timeout=5)
+    second = asyncio.create_task(tool.ainvoke({}))
+    await asyncio.wait_for(component_type.second_started.wait(), timeout=5)
+    component_type.finish_first.set()
+    first_result = await asyncio.wait_for(first, timeout=5)
+    component_type.finish_second.set()
+    second_result = await asyncio.wait_for(second, timeout=5)
+
+    assert first_result["send_message_is_noop"] is True
+    assert second_result["send_message_is_noop"] is True
+    assert component.send_message == original_send_message
 
 
 def test_should_isolate_inputs_when_tool_invoked_concurrently():


### PR DESCRIPTION
## Summary

- apply `send_message_noop` to each invocation's deep-copied component instead of mutating the shared source component
- return the sync and async output functions directly, removing the shared-state restore race from the production path
- add deterministic `ComponentToolkit` regressions for both sync and async completion interleavings

Fixes #14088

## Why

The old wrapper temporarily replaced `component.send_message` around every call. If call B started while call A held the patch, B captured the no-op as its original method; when A completed before B, B restored that stale no-op permanently.

Each output function already creates an isolated component copy. Installing the no-op on that copy keeps message suppression scoped to the invocation and leaves the shared component untouched. The tests force the problematic order: first call starts, second call starts, first finishes, then second finishes.

## Testing

- Original issue reproduction on `release-1.11.0` `9155ed6`: `send_message_is_noop=True`, followed by the expected assertion failure.
- New sync and async regressions before the fix: `2 failed`.
- New sync and async regressions after the fix: `2 passed`.
- Direct `ComponentToolkit` regression set: `31 passed`.
- Full `src/lfx/tests/unit/custom/component` directory: `104 passed, 1 skipped`.
- `ruff format --check` and `ruff check` on both changed files: passed.
- `git diff --check`: passed.

AI-assisted analysis, implementation, and test authoring were reviewed through deterministic red/green tests and the broader component suite.

From Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent tool execution so simultaneous calls no longer interfere with a component’s message-sending behavior.
  * Ensured each tool invocation safely suppresses UI messages without altering the component’s shared behavior after execution.

* **Tests**
  * Added coverage for concurrent synchronous and asynchronous tool calls to verify consistent results and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->