### PR TITLE
fix(anthropic): rebuild compatibility model annotations

### DIFF
--- a/src/bundles/anthropic/pyproject.toml
+++ b/src/bundles/anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-anthropic"
-version = "0.1.1"
+version = "0.1.2"
 description = "Anthropic component(s) as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/anthropic/src/lfx_anthropic/anthropic_chat_model.py
+++ b/src/bundles/anthropic/src/lfx_anthropic/anthropic_chat_model.py
@@ -9,6 +9,7 @@ model construction.
 from typing import Any
 
 from langchain_anthropic import ChatAnthropic
+from pydantic import SecretStr
 
 
 def _ensure_thinking_field(payload: dict) -> None:
@@ -29,3 +30,8 @@ class ChatAnthropicThinkingCompat(ChatAnthropic):
         payload = super()._get_request_payload(*args, **kwargs)
         _ensure_thinking_field(payload)
         return payload
+
+
+# Pydantic resolves inherited forward annotations in the subclass module. Make
+# ChatAnthropic's SecretStr annotation available before the first construction.
+ChatAnthropicThinkingCompat.model_rebuild(_types_namespace={"SecretStr": SecretStr})

--- a/src/bundles/anthropic/src/lfx_anthropic/extension.json
+++ b/src/bundles/anthropic/src/lfx_anthropic/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.langflow.org/extension/v1.json",
   "id": "lfx-anthropic",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "Anthropic",
   "description": "Anthropic component(s) as a standalone Langflow Extension Bundle.",
   "lfx": {

--- a/src/bundles/anthropic/tests/test_anthropic_thinking_blocks.py
+++ b/src/bundles/anthropic/tests/test_anthropic_thinking_blocks.py
@@ -73,6 +73,11 @@ def test_payload_preserves_existing_thinking_text():
     assert blocks[0]["thinking"] == "let me reason"
 
 
+def test_compat_class_rebuilds_deferred_parent_annotations():
+    assert ChatAnthropicThinkingCompat.model_rebuild(force=True) is True
+    assert ChatAnthropicThinkingCompat.__pydantic_complete__
+
+
 def test_ensure_thinking_field_handles_missing_and_none():
     payload = {
         "messages": [

--- a/src/lfx/src/lfx/base/models/anthropic_chat_model.py
+++ b/src/lfx/src/lfx/base/models/anthropic_chat_model.py
@@ -11,6 +11,7 @@ Agent turn with an empty final message.
 from typing import Any
 
 from langchain_anthropic import ChatAnthropic
+from pydantic import SecretStr
 
 
 def _ensure_thinking_field(payload: dict) -> None:
@@ -31,3 +32,8 @@ class ChatAnthropicThinkingCompat(ChatAnthropic):
         payload = super()._get_request_payload(*args, **kwargs)
         _ensure_thinking_field(payload)
         return payload
+
+
+# Pydantic resolves inherited forward annotations in the subclass module. Make
+# ChatAnthropic's SecretStr annotation available before the first construction.
+ChatAnthropicThinkingCompat.model_rebuild(_types_namespace={"SecretStr": SecretStr})

--- a/src/lfx/tests/unit/base/models/test_anthropic_chat_model.py
+++ b/src/lfx/tests/unit/base/models/test_anthropic_chat_model.py
@@ -3,6 +3,7 @@
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from lfx.base.models.anthropic_chat_model import ChatAnthropicThinkingCompat, _ensure_thinking_field
 from lfx.base.models.unified_models.class_registry import get_model_class
+from lfx.base.models.unified_models.instantiation import get_llm
 
 
 def _malformed_history() -> list:
@@ -71,6 +72,31 @@ def test_payload_preserves_existing_thinking_text():
 
 def test_agent_registry_resolves_compat_class():
     assert get_model_class("ChatAnthropic") is ChatAnthropicThinkingCompat
+
+
+def test_unified_language_model_builds_anthropic_compat_class():
+    model = get_llm(
+        [
+            {
+                "name": "claude-sonnet-5",
+                "provider": "Anthropic",
+                "metadata": {
+                    "model_class": "ChatAnthropic",
+                    "model_name_param": "model",
+                    "api_key_param": "api_key",  # pragma: allowlist secret
+                },
+            }
+        ],
+        user_id=None,
+        api_key="test-key",  # pragma: allowlist secret
+    )
+
+    assert type(model) is ChatAnthropicThinkingCompat
+
+
+def test_compat_class_rebuilds_deferred_parent_annotations():
+    assert ChatAnthropicThinkingCompat.model_rebuild(force=True) is True
+    assert ChatAnthropicThinkingCompat.__pydantic_complete__
 
 
 def test_ensure_thinking_field_handles_missing_and_none():

--- a/uv.lock
+++ b/uv.lock
@@ -9620,7 +9620,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-anthropic"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "src/bundles/anthropic" }
 dependencies = [
     { name = "langchain-anthropic" },


### PR DESCRIPTION
## What changed

- make both Anthropic compatibility wrappers rebuild their Pydantic model with an explicit `SecretStr` type namespace
- add regression coverage for forced schema rebuilds and the real unified `get_llm` construction path
- bump `lfx-anthropic` to 0.1.2 so the standalone bundle can publish the same fix

## Root cause

PR #14092 introduced `ChatAnthropicThinkingCompat` as a subclass in Langflow-owned modules. Under the Pydantic behavior in the reported 1.11.0rc3 environment, the inherited `anthropic_api_key: SecretStr` forward annotation is resolved in the subclass namespace. Because `SecretStr` was not defined there and the subclass was not rebuilt, Anthropic model construction failed with `class-not-fully-defined` before any API request.

## User impact

Anthropic models selected through the unified **Language Model** component can build again. The request-payload compatibility behavior added for thinking blocks remains unchanged.

## Validation

- `src/lfx`: 6 focused tests passed on Python 3.12, including real unified Anthropic construction
- `src/bundles/anthropic`: 4 focused tests passed on Python 3.12
- Ruff check and format check passed for all changed Python files
- pre-commit structural and detect-secrets checks passed
- built `lfx_anthropic-0.1.2-py3-none-any.whl` and verified wheel metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic chat compatibility by preserving thinking blocks in follow-up requests.
  * Prevented request failures when thinking content is missing by supplying an empty value.
  * Ensured Anthropic models initialize and rebuild reliably.

* **Tests**
  * Added coverage for Anthropic model creation and compatibility behavior.

* **Chores**
  * Updated the Anthropic bundle version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->