### PR TITLE
fix(ssrf): honor connector loopback policy for requests

### DIFF
--- a/src/bundles/openai-compatible/pyproject.toml
+++ b/src/bundles/openai-compatible/pyproject.toml
@@ -15,14 +15,14 @@ keywords = ["langflow", "lfx", "extension", "bundle", "model-provider", "openai-
 # provider targets any OpenAI-compatible server, so its model/embedding classes
 # (``ChatOpenAI`` / ``OpenAIEmbeddings``) are the langchain-openai classes lfx
 # already ships and resolves lazily -- the bundle does not import them directly,
-# so they are not re-declared here. ``requests`` backs the live ``/v1/models``
-# discovery and the credential-validation probe in ``discovery.py``.
+# so they are not re-declared here. ``httpx`` backs the SSRF-safe, DNS-pinned
+# live ``/v1/models`` discovery and credential-validation probe.
 # The lfx floor is the current major.minor line (the seam ships in 1.11) and is
 # re-synced on ``make patch`` via scripts/ci/sync_bundle_lfx_pin.py; fine-grained
 # BUNDLE_API compatibility is enforced via extension.json's lfx.compat list.
 dependencies = [
     "lfx>=1.11.0.dev0,<2.0.0",
-    "requests>=2.31.0,<3.0.0",
+    "httpx>=0.24.0,<1.0.0",
 ]
 
 [project.urls]

--- a/src/bundles/openai-compatible/src/lfx_openai_compatible/discovery.py
+++ b/src/bundles/openai-compatible/src/lfx_openai_compatible/discovery.py
@@ -17,7 +17,7 @@ import requests
 from lfx.base.models.model_metadata import create_model_metadata
 from lfx.base.models.model_utils import MIN_DEFAULT_MODELS, get_provider_variable_value
 from lfx.log.logger import logger
-from lfx.utils.ssrf_protection import validate_url_for_ssrf
+from lfx.utils.ssrf_protection import validate_connector_url_for_ssrf
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -65,7 +65,7 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        validate_url_for_ssrf(models_url)
+        validate_connector_url_for_ssrf(models_url)
         response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
         response.raise_for_status()
         model_names = _parse_model_names(response.json())
@@ -110,7 +110,7 @@ def validate_openai_compatible_credentials(
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        validate_url_for_ssrf(models_url)
+        validate_connector_url_for_ssrf(models_url)
         response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
         if response.status_code in (401, 403):
             msg = "Authentication failed for the OpenAI-compatible endpoint. Check OPENAI_COMPATIBLE_API_KEY."

--- a/src/bundles/openai-compatible/src/lfx_openai_compatible/discovery.py
+++ b/src/bundles/openai-compatible/src/lfx_openai_compatible/discovery.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import requests
+import httpx
 from lfx.base.models.model_metadata import create_model_metadata
 from lfx.base.models.model_utils import MIN_DEFAULT_MODELS, get_provider_variable_value
 from lfx.log.logger import logger
-from lfx.utils.ssrf_protection import validate_connector_url_for_ssrf
+from lfx.utils.ssrf_httpx import ssrf_safe_httpx_get
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -65,8 +65,7 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        validate_connector_url_for_ssrf(models_url)
-        response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
+        response = ssrf_safe_httpx_get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS, follow_redirects=False)
         response.raise_for_status()
         model_names = _parse_model_names(response.json())
         return [
@@ -110,25 +109,24 @@ def validate_openai_compatible_credentials(
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        validate_connector_url_for_ssrf(models_url)
-        response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
+        response = ssrf_safe_httpx_get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS, follow_redirects=False)
         if response.status_code in (401, 403):
             msg = "Authentication failed for the OpenAI-compatible endpoint. Check OPENAI_COMPATIBLE_API_KEY."
             logger.error(msg)
             raise ValueError(msg)
         response.raise_for_status()
-    except requests.ConnectionError as e:
+    except httpx.ConnectError as e:
         msg = (
             f"Could not connect to the OpenAI-compatible endpoint at {base_url.rstrip('/')}. "
             "Please check that the server is running and the URL is correct."
         )
         logger.error(msg)
         raise ValueError(msg) from e
-    except requests.Timeout as e:
+    except httpx.TimeoutException as e:
         msg = f"Connection to the OpenAI-compatible endpoint at {base_url.rstrip('/')} timed out."
         logger.error(msg)
         raise ValueError(msg) from e
-    except requests.HTTPError as e:
+    except httpx.HTTPStatusError as e:
         status = e.response.status_code if e.response is not None else "unknown"
         msg = (
             f"The OpenAI-compatible endpoint at {base_url.rstrip('/')} returned HTTP {status} for {models_url}. "
@@ -136,7 +134,7 @@ def validate_openai_compatible_credentials(
         )
         logger.error(msg)
         raise ValueError(msg) from e
-    except requests.RequestException as e:
+    except httpx.RequestError as e:
         msg = f"Could not validate the OpenAI-compatible endpoint at {base_url.rstrip('/')}: {e}"
         logger.error(msg)
         raise ValueError(msg) from e

--- a/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
+++ b/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-import requests
 from lfx_openai_compatible import discovery
 
 # ---------------------------------------------------------------------------
@@ -58,6 +58,13 @@ def _ok_response(payload: dict | list) -> MagicMock:
     return resp
 
 
+def _set_loopback_policy(monkeypatch, *, allowed: bool) -> None:
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", str(allowed).lower())
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # fetch_live_openai_compatible_models
 # ---------------------------------------------------------------------------
@@ -68,12 +75,55 @@ def test_fetch_returns_empty_when_no_base_url():
         assert discovery.fetch_live_openai_compatible_models("user-id", "llm") == []
 
 
+def test_fetch_allows_literal_loopback_by_default(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=True)
+    response = _ok_response({"data": [{"id": "local-model"}]})
+
+    with (
+        patch.object(discovery, "get_provider_variable_value", side_effect=["http://127.0.0.1:1234/v1", None]),
+        patch("httpx.Client.get", return_value=response) as mock_get,
+    ):
+        result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
+
+    assert [model["name"] for model in result] == ["local-model"]
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
+
+
+def test_fetch_blocks_literal_loopback_when_connector_policy_opts_out(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=False)
+
+    with (
+        patch.object(discovery, "get_provider_variable_value", side_effect=["http://127.0.0.1:1234/v1", None]),
+        patch("httpx.Client.get") as mock_get,
+    ):
+        result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
+
+    assert result == []
+    mock_get.assert_not_called()
+
+
+def test_fetch_does_not_follow_redirects(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=True)
+    request = httpx.Request("GET", "http://127.0.0.1:1234/v1/models")
+    redirect = httpx.Response(302, headers={"location": "http://169.254.169.254/latest/meta-data/"}, request=request)
+
+    with (
+        patch.object(discovery, "get_provider_variable_value", side_effect=["http://127.0.0.1:1234/v1", None]),
+        patch("httpx.Client.get", return_value=redirect) as mock_get,
+    ):
+        result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
+
+    assert result == []
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
+
+
 def test_fetch_openai_dict_format():
     response = _ok_response({"data": [{"id": "meta-llama/llama-3.1-8b"}, {"id": "mistral-7b"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["https://openrouter.ai/api/v1", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert {m["name"] for m in result} == {"meta-llama/llama-3.1-8b", "mistral-7b"}
@@ -85,8 +135,7 @@ def test_fetch_plain_list_format():
     response = _ok_response(["qwen2-7b", "deepseek-r1"])
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert {m["name"] for m in result} == {"qwen2-7b", "deepseek-r1"}
@@ -96,8 +145,7 @@ def test_fetch_sorts_alphabetically():
     response = _ok_response({"data": [{"id": "zzz"}, {"id": "aaa"}, {"id": "mmm"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert [m["name"] for m in result] == ["aaa", "mmm", "zzz"]
@@ -122,8 +170,7 @@ def test_fetch_models_url_normalization(base_url, expected):
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=[base_url, None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert captured[0] == expected
@@ -143,8 +190,7 @@ def test_fetch_forwards_api_key_as_bearer():
             "get_provider_variable_value",
             side_effect=["http://localhost:8000", "secret-key"],  # pragma: allowlist secret
         ),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert captured[0].get("Authorization") == "Bearer secret-key"  # pragma: allowlist secret
@@ -160,8 +206,7 @@ def test_fetch_no_auth_header_when_no_key():
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert "Authorization" not in captured[0]
@@ -170,8 +215,7 @@ def test_fetch_no_auth_header_when_no_key():
 def test_fetch_swallows_connection_error():
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ConnectError("refused")),
     ):
         assert discovery.fetch_live_openai_compatible_models("user-id", "llm") == []
 
@@ -180,8 +224,7 @@ def test_fetch_swallows_bad_payload():
     response = _ok_response({"unexpected": "shape"})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         assert discovery.fetch_live_openai_compatible_models("user-id", "llm") == []
 
@@ -198,8 +241,7 @@ def test_fetch_swallows_api_key_lookup_error():
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=fake_get_var),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
     assert {m["name"] for m in result} == {"llama-3"}
@@ -209,8 +251,7 @@ def test_fetch_embeddings_tagged_embeddings():
     response = _ok_response({"data": [{"id": "bge-m3"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "embeddings")
     assert result[0]["model_type"] == "embeddings"
@@ -236,8 +277,7 @@ def test_validate_happy_path_uses_v1_models():
         return response
 
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.validate_openai_compatible_credentials(
             "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://localhost:8000/v1"}
@@ -246,32 +286,24 @@ def test_validate_happy_path_uses_v1_models():
 
 
 def test_validate_allows_literal_loopback_by_default(monkeypatch):
-    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
-    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
-    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
-    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+    _set_loopback_policy(monkeypatch, allowed=True)
     response = _ok_response({"data": []})
 
-    with patch.object(discovery.requests, "get", return_value=response) as mock_get:
+    with patch("httpx.Client.get", return_value=response) as mock_get:
         discovery.validate_openai_compatible_credentials(
             "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:1234/v1"}
         )
 
-    mock_get.assert_called_once_with(
-        "http://127.0.0.1:1234/v1/models",
-        headers={},
-        timeout=discovery._TIMEOUT_SECONDS,
-    )
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["url"] == "http://127.0.0.1:1234/v1/models"
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
 
 
 def test_validate_blocks_literal_loopback_when_connector_policy_opts_out(monkeypatch):
-    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
-    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
-    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "false")
-    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+    _set_loopback_policy(monkeypatch, allowed=False)
 
     with (
-        patch.object(discovery.requests, "get") as mock_get,
+        patch("httpx.Client.get") as mock_get,
         pytest.raises(ValueError, match=r"127\.0\.0\.1.*blocked"),
     ):
         discovery.validate_openai_compatible_credentials(
@@ -279,6 +311,23 @@ def test_validate_blocks_literal_loopback_when_connector_policy_opts_out(monkeyp
         )
 
     mock_get.assert_not_called()
+
+
+def test_validate_does_not_follow_redirects(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=True)
+    request = httpx.Request("GET", "http://127.0.0.1:1234/v1/models")
+    redirect = httpx.Response(302, headers={"location": "http://169.254.169.254/latest/meta-data/"}, request=request)
+
+    with (
+        patch("httpx.Client.get", return_value=redirect) as mock_get,
+        pytest.raises(ValueError, match="returned HTTP 302"),
+    ):
+        discovery.validate_openai_compatible_credentials(
+            "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:1234/v1"}
+        )
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
 
 
 def test_validate_forwards_api_key():
@@ -290,8 +339,7 @@ def test_validate_forwards_api_key():
         return response
 
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.validate_openai_compatible_credentials(
             "OpenAI Compatible",
@@ -308,8 +356,7 @@ def test_validate_raises_on_auth_failure(status):
     response = MagicMock()
     response.status_code = status
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
         pytest.raises(ValueError, match="Authentication failed"),
     ):
         discovery.validate_openai_compatible_credentials(
@@ -321,11 +368,12 @@ def test_validate_raises_value_error_on_server_error():
     """Non-auth HTTP failures (e.g. 500) surface as the same user-facing ValueError shape."""
     response = MagicMock()
     response.status_code = 500
-    http_error = requests.HTTPError("server error", response=response)
+    request = httpx.Request("GET", "http://localhost:8000/v1/models")
+    error_response = httpx.Response(500, request=request)
+    http_error = httpx.HTTPStatusError("server error", request=request, response=error_response)
     response.raise_for_status.side_effect = http_error
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
         pytest.raises(ValueError, match="returned HTTP 500"),
     ):
         discovery.validate_openai_compatible_credentials(
@@ -335,8 +383,7 @@ def test_validate_raises_value_error_on_server_error():
 
 def test_validate_raises_on_connection_error():
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ConnectError("refused")),
         pytest.raises(ValueError, match="Could not connect to the OpenAI-compatible endpoint"),
     ):
         discovery.validate_openai_compatible_credentials(
@@ -346,8 +393,7 @@ def test_validate_raises_on_connection_error():
 
 def test_validate_raises_on_timeout():
     with (
-        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.Timeout("slow")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ReadTimeout("slow")),
         pytest.raises(ValueError, match="timed out"),
     ):
         discovery.validate_openai_compatible_credentials(

--- a/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
+++ b/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
@@ -72,7 +72,7 @@ def test_fetch_openai_dict_format():
     response = _ok_response({"data": [{"id": "meta-llama/llama-3.1-8b"}, {"id": "mistral-7b"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["https://openrouter.ai/api/v1", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -85,7 +85,7 @@ def test_fetch_plain_list_format():
     response = _ok_response(["qwen2-7b", "deepseek-r1"])
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -96,7 +96,7 @@ def test_fetch_sorts_alphabetically():
     response = _ok_response({"data": [{"id": "zzz"}, {"id": "aaa"}, {"id": "mmm"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -122,7 +122,7 @@ def test_fetch_models_url_normalization(base_url, expected):
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=[base_url, None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -143,7 +143,7 @@ def test_fetch_forwards_api_key_as_bearer():
             "get_provider_variable_value",
             side_effect=["http://localhost:8000", "secret-key"],  # pragma: allowlist secret
         ),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -160,7 +160,7 @@ def test_fetch_no_auth_header_when_no_key():
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=fake_get),
     ):
         discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -170,7 +170,7 @@ def test_fetch_no_auth_header_when_no_key():
 def test_fetch_swallows_connection_error():
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
     ):
         assert discovery.fetch_live_openai_compatible_models("user-id", "llm") == []
@@ -180,7 +180,7 @@ def test_fetch_swallows_bad_payload():
     response = _ok_response({"unexpected": "shape"})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         assert discovery.fetch_live_openai_compatible_models("user-id", "llm") == []
@@ -198,7 +198,7 @@ def test_fetch_swallows_api_key_lookup_error():
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=fake_get_var),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "llm")
@@ -209,7 +209,7 @@ def test_fetch_embeddings_tagged_embeddings():
     response = _ok_response({"data": [{"id": "bge-m3"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
     ):
         result = discovery.fetch_live_openai_compatible_models("user-id", "embeddings")
@@ -236,13 +236,49 @@ def test_validate_happy_path_uses_v1_models():
         return response
 
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=fake_get),
     ):
         discovery.validate_openai_compatible_credentials(
             "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://localhost:8000/v1"}
         )
     assert captured[0] == "http://localhost:8000/v1/models"
+
+
+def test_validate_allows_literal_loopback_by_default(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+    response = _ok_response({"data": []})
+
+    with patch.object(discovery.requests, "get", return_value=response) as mock_get:
+        discovery.validate_openai_compatible_credentials(
+            "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:1234/v1"}
+        )
+
+    mock_get.assert_called_once_with(
+        "http://127.0.0.1:1234/v1/models",
+        headers={},
+        timeout=discovery._TIMEOUT_SECONDS,
+    )
+
+
+def test_validate_blocks_literal_loopback_when_connector_policy_opts_out(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "false")
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+
+    with (
+        patch.object(discovery.requests, "get") as mock_get,
+        pytest.raises(ValueError, match=r"127\.0\.0\.1.*blocked"),
+    ):
+        discovery.validate_openai_compatible_credentials(
+            "OpenAI Compatible", {"OPENAI_COMPATIBLE_BASE_URL": "http://127.0.0.1:1234/v1"}
+        )
+
+    mock_get.assert_not_called()
 
 
 def test_validate_forwards_api_key():
@@ -254,7 +290,7 @@ def test_validate_forwards_api_key():
         return response
 
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=fake_get),
     ):
         discovery.validate_openai_compatible_credentials(
@@ -272,7 +308,7 @@ def test_validate_raises_on_auth_failure(status):
     response = MagicMock()
     response.status_code = status
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
         pytest.raises(ValueError, match="Authentication failed"),
     ):
@@ -288,7 +324,7 @@ def test_validate_raises_value_error_on_server_error():
     http_error = requests.HTTPError("server error", response=response)
     response.raise_for_status.side_effect = http_error
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", return_value=response),
         pytest.raises(ValueError, match="returned HTTP 500"),
     ):
@@ -299,7 +335,7 @@ def test_validate_raises_value_error_on_server_error():
 
 def test_validate_raises_on_connection_error():
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
         pytest.raises(ValueError, match="Could not connect to the OpenAI-compatible endpoint"),
     ):
@@ -310,7 +346,7 @@ def test_validate_raises_on_connection_error():
 
 def test_validate_raises_on_timeout():
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
+        patch.object(discovery, "validate_connector_url_for_ssrf", return_value=None),
         patch.object(discovery.requests, "get", side_effect=requests.Timeout("slow")),
         pytest.raises(ValueError, match="timed out"),
     ):

--- a/src/bundles/vllm/pyproject.toml
+++ b/src/bundles/vllm/pyproject.toml
@@ -15,14 +15,14 @@ keywords = ["langflow", "lfx", "extension", "bundle", "vllm", "model-provider", 
 # is OpenAI-compatible, so its model/embedding classes (``ChatOpenAI`` /
 # ``OpenAIEmbeddings``) are the langchain-openai classes lfx already ships and
 # resolves lazily -- the bundle does not import them directly, so it is not
-# re-declared here. ``requests`` backs the live ``/v1/models`` discovery and the
-# credential-validation probe in ``discovery.py``.
+# re-declared here. ``httpx`` backs the SSRF-safe, DNS-pinned live ``/v1/models``
+# discovery and credential-validation probe.
 # The lfx floor is the current major.minor line (the seam ships in 1.11) and is
 # re-synced on ``make patch`` via scripts/ci/sync_bundle_lfx_pin.py; fine-grained
 # BUNDLE_API compatibility is enforced via extension.json's lfx.compat list.
 dependencies = [
     "lfx>=1.11.0.dev0,<2.0.0",
-    "requests>=2.31.0,<3.0.0",
+    "httpx>=0.24.0,<1.0.0",
 ]
 
 [project.urls]

--- a/src/bundles/vllm/src/lfx_vllm/discovery.py
+++ b/src/bundles/vllm/src/lfx_vllm/discovery.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import requests
+import httpx
 from lfx.base.models.model_metadata import create_model_metadata
 from lfx.base.models.model_utils import MIN_DEFAULT_MODELS, get_provider_variable_value
 from lfx.log.logger import logger
-from lfx.utils.ssrf_protection import validate_url_for_ssrf
+from lfx.utils.ssrf_httpx import ssrf_safe_httpx_get
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -62,8 +62,7 @@ def fetch_live_vllm_models(user_id: UUID | str | None, model_type: str = "llm") 
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        validate_url_for_ssrf(models_url)
-        response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
+        response = ssrf_safe_httpx_get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS, follow_redirects=False)
         response.raise_for_status()
         model_names = _parse_model_names(response.json())
         return [
@@ -102,21 +101,32 @@ def validate_vllm_credentials(provider: str, variables: dict[str, str], model_na
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        validate_url_for_ssrf(models_url)
-        response = requests.get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS)
+        response = ssrf_safe_httpx_get(models_url, headers=headers, timeout=_TIMEOUT_SECONDS, follow_redirects=False)
         if response.status_code in (401, 403):
             msg = "Authentication failed for vLLM server. Check VLLM_API_KEY."
             logger.error(msg)
             raise ValueError(msg)
         response.raise_for_status()
-    except requests.ConnectionError as e:
+    except httpx.ConnectError as e:
         msg = (
             f"Could not connect to vLLM server at {base_url.rstrip('/')}. "
             "Please check that the server is running and the URL is correct."
         )
         logger.error(msg)
         raise ValueError(msg) from e
-    except requests.Timeout as e:
+    except httpx.TimeoutException as e:
         msg = f"Connection to vLLM server at {base_url.rstrip('/')} timed out."
+        logger.error(msg)
+        raise ValueError(msg) from e
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else "unknown"
+        msg = (
+            f"The vLLM server at {base_url.rstrip('/')} returned HTTP {status} for {models_url}. "
+            "Check that the base URL points to a vLLM OpenAI-compatible API."
+        )
+        logger.error(msg)
+        raise ValueError(msg) from e
+    except httpx.RequestError as e:
+        msg = f"Could not validate the vLLM server at {base_url.rstrip('/')}: {e}"
         logger.error(msg)
         raise ValueError(msg) from e

--- a/src/bundles/vllm/tests/test_vllm_provider.py
+++ b/src/bundles/vllm/tests/test_vllm_provider.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-import requests
 from lfx_vllm import discovery
 
 # ---------------------------------------------------------------------------
@@ -54,6 +54,13 @@ def _ok_response(payload: dict | list) -> MagicMock:
     return resp
 
 
+def _set_loopback_policy(monkeypatch, *, allowed: bool) -> None:
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", str(allowed).lower())
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # fetch_live_vllm_models
 # ---------------------------------------------------------------------------
@@ -64,12 +71,39 @@ def test_fetch_returns_empty_when_no_base_url():
         assert discovery.fetch_live_vllm_models("user-id", "llm") == []
 
 
+def test_fetch_allows_literal_loopback_by_default(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=True)
+    response = _ok_response({"data": [{"id": "local-model"}]})
+
+    with (
+        patch.object(discovery, "get_provider_variable_value", side_effect=["http://127.0.0.1:8000/v1", None]),
+        patch("httpx.Client.get", return_value=response) as mock_get,
+    ):
+        result = discovery.fetch_live_vllm_models("user-id", "llm")
+
+    assert [model["name"] for model in result] == ["local-model"]
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
+
+
+def test_fetch_blocks_literal_loopback_when_connector_policy_opts_out(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=False)
+
+    with (
+        patch.object(discovery, "get_provider_variable_value", side_effect=["http://127.0.0.1:8000/v1", None]),
+        patch("httpx.Client.get") as mock_get,
+    ):
+        result = discovery.fetch_live_vllm_models("user-id", "llm")
+
+    assert result == []
+    mock_get.assert_not_called()
+
+
 def test_fetch_openai_dict_format():
     response = _ok_response({"data": [{"id": "meta-llama/llama-3.1-8b"}, {"id": "mistral-7b"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_vllm_models("user-id", "llm")
     assert {m["name"] for m in result} == {"meta-llama/llama-3.1-8b", "mistral-7b"}
@@ -81,8 +115,7 @@ def test_fetch_plain_list_format():
     response = _ok_response(["qwen2-7b", "deepseek-r1"])
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_vllm_models("user-id", "llm")
     assert {m["name"] for m in result} == {"qwen2-7b", "deepseek-r1"}
@@ -92,8 +125,7 @@ def test_fetch_sorts_alphabetically():
     response = _ok_response({"data": [{"id": "zzz"}, {"id": "aaa"}, {"id": "mmm"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_vllm_models("user-id", "llm")
     assert [m["name"] for m in result] == ["aaa", "mmm", "zzz"]
@@ -117,8 +149,7 @@ def test_fetch_models_url_normalization(base_url, expected):
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=[base_url, None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_vllm_models("user-id", "llm")
     assert captured[0] == expected
@@ -138,8 +169,7 @@ def test_fetch_forwards_api_key_as_bearer():
             "get_provider_variable_value",
             side_effect=["http://localhost:8000", "secret-key"],  # pragma: allowlist secret
         ),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_vllm_models("user-id", "llm")
     assert captured[0].get("Authorization") == "Bearer secret-key"  # pragma: allowlist secret
@@ -155,8 +185,7 @@ def test_fetch_no_auth_header_when_no_key():
 
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.fetch_live_vllm_models("user-id", "llm")
     assert "Authorization" not in captured[0]
@@ -165,8 +194,7 @@ def test_fetch_no_auth_header_when_no_key():
 def test_fetch_swallows_connection_error():
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ConnectError("refused")),
     ):
         assert discovery.fetch_live_vllm_models("user-id", "llm") == []
 
@@ -175,8 +203,7 @@ def test_fetch_swallows_bad_payload():
     response = _ok_response({"unexpected": "shape"})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         assert discovery.fetch_live_vllm_models("user-id", "llm") == []
 
@@ -185,8 +212,7 @@ def test_fetch_embeddings_tagged_embeddings():
     response = _ok_response({"data": [{"id": "bge-m3"}]})
     with (
         patch.object(discovery, "get_provider_variable_value", side_effect=["http://localhost:8000", None]),
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
     ):
         result = discovery.fetch_live_vllm_models("user-id", "embeddings")
     assert result[0]["model_type"] == "embeddings"
@@ -212,11 +238,34 @@ def test_validate_happy_path_uses_v1_models():
         return response
 
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://localhost:8000/v1"})
     assert captured[0] == "http://localhost:8000/v1/models"
+
+
+def test_validate_allows_literal_loopback_by_default(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=True)
+    response = _ok_response({"data": []})
+
+    with patch("httpx.Client.get", return_value=response) as mock_get:
+        discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://127.0.0.1:8000/v1"})
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["url"] == "http://127.0.0.1:8000/v1/models"
+    assert mock_get.call_args.kwargs["follow_redirects"] is False
+
+
+def test_validate_blocks_literal_loopback_when_connector_policy_opts_out(monkeypatch):
+    _set_loopback_policy(monkeypatch, allowed=False)
+
+    with (
+        patch("httpx.Client.get") as mock_get,
+        pytest.raises(ValueError, match=r"127\.0\.0\.1.*blocked"),
+    ):
+        discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://127.0.0.1:8000/v1"})
+
+    mock_get.assert_not_called()
 
 
 def test_validate_forwards_api_key():
@@ -228,8 +277,7 @@ def test_validate_forwards_api_key():
         return response
 
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=fake_get),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=fake_get),
     ):
         discovery.validate_vllm_credentials(
             "vLLM",
@@ -243,8 +291,7 @@ def test_validate_raises_on_auth_failure(status):
     response = MagicMock()
     response.status_code = status
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", return_value=response),
+        patch.object(discovery, "ssrf_safe_httpx_get", return_value=response),
         pytest.raises(ValueError, match="Authentication failed"),
     ):
         discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
@@ -252,8 +299,7 @@ def test_validate_raises_on_auth_failure(status):
 
 def test_validate_raises_on_connection_error():
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.ConnectionError("refused")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ConnectError("refused")),
         pytest.raises(ValueError, match="Could not connect to vLLM server"),
     ):
         discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
@@ -261,8 +307,19 @@ def test_validate_raises_on_connection_error():
 
 def test_validate_raises_on_timeout():
     with (
-        patch.object(discovery, "validate_url_for_ssrf", return_value=None),
-        patch.object(discovery.requests, "get", side_effect=requests.Timeout("slow")),
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=httpx.ReadTimeout("slow")),
         pytest.raises(ValueError, match="timed out"),
+    ):
+        discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})
+
+
+def test_validate_raises_value_error_on_server_error():
+    request = httpx.Request("GET", "http://localhost:8000/v1/models")
+    response = httpx.Response(500, request=request)
+    error = httpx.HTTPStatusError("server error", request=request, response=response)
+
+    with (
+        patch.object(discovery, "ssrf_safe_httpx_get", side_effect=error),
+        pytest.raises(ValueError, match="returned HTTP 500"),
     ):
         discovery.validate_vllm_credentials("vLLM", {"VLLM_API_BASE": "http://localhost:8000"})

--- a/src/lfx/src/lfx/utils/ssrf_httpx.py
+++ b/src/lfx/src/lfx/utils/ssrf_httpx.py
@@ -10,8 +10,8 @@ import httpx
 from lfx.utils.ssrf_protection import (
     SSRFProtectionError,
     is_ssrf_protection_enabled,
-    validate_and_resolve_url,
-    validate_url_for_ssrf,
+    validate_and_resolve_connector_url,
+    validate_connector_url_for_ssrf,
 )
 from lfx.utils.ssrf_transport import (
     SSRFProtectedSyncTransport,
@@ -22,9 +22,9 @@ from lfx.utils.ssrf_transport import (
 
 
 def validate_url_for_ssrf_or_raise(url: str) -> None:
-    """Validate a user URL and raise a UI-facing error when it is blocked."""
+    """Validate a connector URL and raise a UI-facing error when it is blocked."""
     try:
-        validate_url_for_ssrf(url, warn_only=False)
+        validate_connector_url_for_ssrf(url)
     except SSRFProtectionError as e:
         msg = f"SSRF Protection: {e}"
         raise ValueError(msg) from e
@@ -53,9 +53,9 @@ def _sync_client_for_url(url: str, validated_ips: list[str]) -> httpx.Client:
 
 
 def ssrf_protected_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Return sync/async httpx kwargs that enforce SSRF protection for SDK clients."""
+    """Return sync/async httpx kwargs that enforce connector SSRF protection for SDK clients."""
     try:
-        validated_url, validated_ips = validate_and_resolve_url(url)
+        validated_url, validated_ips = validate_and_resolve_connector_url(url)
     except SSRFProtectionError as e:
         msg = f"SSRF Protection: {e}"
         raise ValueError(msg) from e
@@ -87,32 +87,32 @@ def ssrf_protected_openai_clients_for_url(url: str) -> dict[str, httpx.Client | 
 
 
 async def ssrf_safe_async_get(url: str, **request_kwargs: Any) -> httpx.Response:
-    """Perform an async GET with SSRF validation and DNS pinning."""
+    """Perform an async GET with connector SSRF validation and DNS pinning."""
     _raise_if_following_redirects(request_kwargs)
-    validated_url, validated_ips = validate_and_resolve_url(url)
+    validated_url, validated_ips = validate_and_resolve_connector_url(url)
     async with _async_client_for_url(validated_url, validated_ips) as client:
         return await client.get(url=validated_url, **request_kwargs)
 
 
 async def ssrf_safe_async_post(url: str, **request_kwargs: Any) -> httpx.Response:
-    """Perform an async POST with SSRF validation and DNS pinning."""
+    """Perform an async POST with connector SSRF validation and DNS pinning."""
     _raise_if_following_redirects(request_kwargs)
-    validated_url, validated_ips = validate_and_resolve_url(url)
+    validated_url, validated_ips = validate_and_resolve_connector_url(url)
     async with _async_client_for_url(validated_url, validated_ips) as client:
         return await client.post(url=validated_url, **request_kwargs)
 
 
 def ssrf_safe_httpx_get(url: str, **request_kwargs: Any) -> httpx.Response:
-    """Perform a synchronous GET with SSRF validation and DNS pinning."""
+    """Perform a synchronous GET with connector SSRF validation and DNS pinning."""
     _raise_if_following_redirects(request_kwargs)
-    validated_url, validated_ips = validate_and_resolve_url(url)
+    validated_url, validated_ips = validate_and_resolve_connector_url(url)
     with _sync_client_for_url(validated_url, validated_ips) as client:
         return client.get(url=validated_url, **request_kwargs)
 
 
 def ssrf_safe_httpx_post(url: str, **request_kwargs: Any) -> httpx.Response:
-    """Perform a synchronous POST with SSRF validation and DNS pinning."""
+    """Perform a synchronous POST with connector SSRF validation and DNS pinning."""
     _raise_if_following_redirects(request_kwargs)
-    validated_url, validated_ips = validate_and_resolve_url(url)
+    validated_url, validated_ips = validate_and_resolve_connector_url(url)
     with _sync_client_for_url(validated_url, validated_ips) as client:
         return client.post(url=validated_url, **request_kwargs)

--- a/src/lfx/src/lfx/utils/ssrf_protection.py
+++ b/src/lfx/src/lfx/utils/ssrf_protection.py
@@ -453,6 +453,23 @@ def _is_loopback_host(hostname: str) -> bool:
         return False
 
 
+def _connector_url_has_loopback_exemption(url: str) -> bool:
+    """Validate connector URL shape and return whether its literal host is exempt."""
+    if not is_ssrf_protection_enabled():
+        return False
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        msg = (
+            f"Connector URL must be an http(s) URL with a host for SSRF validation; got {url!r}. "
+            "Use an explicit scheme (e.g. 'http://host:port'); to reach an internal host, also add "
+            "it to LANGFLOW_SSRF_ALLOWED_HOSTS (allowlisting alone does not permit a scheme-less host)."
+        )
+        raise SSRFProtectionError(msg)
+
+    return is_connector_loopback_allowed() and _is_loopback_host(parsed.hostname)
+
+
 def validate_connector_url_for_ssrf(url: str) -> None:
     """SSRF-validate a tenant-controlled connector URL unless connector validation is disabled.
 
@@ -476,28 +493,38 @@ def validate_connector_url_for_ssrf(url: str) -> None:
     """
     if not is_connector_ssrf_validation_enabled():
         return
-    # The shared validator only understands http/https URLs that carry a host. Connector fields
-    # are sometimes a bare "host:port" (e.g. Milvus) or a non-HTTP scheme, which urlparse maps to
-    # a missing/garbage scheme -- without this, that would surface as a confusing
-    # "Invalid URL scheme ''". Only raise when host validation would actually run (global SSRF
-    # protection on); otherwise stay a no-op exactly as before.
-    if is_ssrf_protection_enabled():
-        parsed = urlparse(url)
-        if parsed.scheme not in ("http", "https") or not parsed.hostname:
-            msg = (
-                f"Connector URL must be an http(s) URL with a host for SSRF validation; got {url!r}. "
-                "Use an explicit scheme (e.g. 'http://host:port'); to reach an internal host, also add "
-                "it to LANGFLOW_SSRF_ALLOWED_HOSTS (allowlisting alone does not permit a scheme-less host)."
-            )
-            raise SSRFProtectionError(msg)
-        # Connectors commonly target a local service (Ollama / LM Studio default to localhost,
-        # local vector stores bind to loopback). Allow a literal loopback host by default; a
-        # multi-tenant deployer sets connector_ssrf_allow_loopback=false to block it too. Only a
-        # literal loopback reference is exempted — a hostname that resolves to loopback still goes
-        # through the full check below, so DNS-rebinding cannot abuse this.
-        if is_connector_loopback_allowed() and _is_loopback_host(parsed.hostname):
-            return
+    # Connectors commonly target a local service (Ollama / LM Studio default to localhost,
+    # local vector stores bind to loopback). Allow a literal loopback host by default; a
+    # multi-tenant deployer sets connector_ssrf_allow_loopback=false to block it too. Only a
+    # literal loopback reference is exempted — a hostname that resolves to loopback still goes
+    # through the full check below, so DNS-rebinding cannot abuse this.
+    if _connector_url_has_loopback_exemption(url):
+        return
     validate_url_for_ssrf(url)
+
+
+def validate_and_resolve_connector_url(url: str) -> tuple[str, list[str]]:
+    """Validate a connector URL and return IPs for DNS-pinned HTTP clients.
+
+    This applies the same connector policy as :func:`validate_connector_url_for_ssrf`, including
+    the literal-loopback exemption, while retaining DNS pinning for non-exempt hosts used by HTTP
+    connector clients.
+
+    Args:
+        url: Connector URL to validate.
+
+    Returns:
+        The original URL and validated IP addresses. The IP list is empty when connector
+        validation is disabled, global SSRF protection is disabled, the host is allowlisted, or
+        the literal-loopback exemption applies.
+
+    Raises:
+        SSRFProtectionError: If connector validation is enabled and the URL is blocked or malformed.
+        ValueError: If the URL format is invalid.
+    """
+    if not is_connector_ssrf_validation_enabled() or _connector_url_has_loopback_exemption(url):
+        return url, []
+    return validate_and_resolve_url(url)
 
 
 # SQLAlchemy dialects that read/write the local filesystem instead of connecting over the

--- a/src/lfx/tests/unit/utils/test_ssrf_httpx.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_httpx.py
@@ -1,10 +1,10 @@
 import os
 import socket
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpcore
 import pytest
-from lfx.utils.ssrf_httpx import ssrf_safe_httpx_get
+from lfx.utils.ssrf_httpx import ssrf_safe_async_get, ssrf_safe_async_post, ssrf_safe_httpx_get
 from lfx.utils.ssrf_protection import SSRFProtectionError
 
 
@@ -43,6 +43,49 @@ class TestSSRFSafeHTTPX:
             ssrf_safe_httpx_get("http://127.0.0.1:1234/v1/models", timeout=5)
 
         mock_get.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("request_fn", "client_method"),
+        [(ssrf_safe_async_get, "get"), (ssrf_safe_async_post, "post")],
+    )
+    async def test_async_literal_loopback_is_allowed_by_connector_policy(self, request_fn, client_method):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "true",
+                },
+                clear=True,
+            ),
+            patch(f"httpx.AsyncClient.{client_method}", new_callable=AsyncMock) as mock_request,
+        ):
+            await request_fn("http://127.0.0.1:1234/v1/models", timeout=5)
+
+        mock_request.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        ("request_fn", "client_method"),
+        [(ssrf_safe_async_get, "get"), (ssrf_safe_async_post, "post")],
+    )
+    async def test_async_literal_loopback_is_blocked_when_connector_policy_opts_out(self, request_fn, client_method):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+                },
+                clear=True,
+            ),
+            patch(f"httpx.AsyncClient.{client_method}", new_callable=AsyncMock) as mock_request,
+            pytest.raises(SSRFProtectionError, match=r"127\.0\.0\.1.*blocked"),
+        ):
+            await request_fn("http://127.0.0.1:1234/v1/models", timeout=5)
+
+        mock_request.assert_not_awaited()
 
     def test_direct_internal_ip_is_blocked(self):
         with (

--- a/src/lfx/tests/unit/utils/test_ssrf_httpx.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_httpx.py
@@ -9,6 +9,41 @@ from lfx.utils.ssrf_protection import SSRFProtectionError
 
 
 class TestSSRFSafeHTTPX:
+    def test_literal_loopback_is_allowed_by_connector_policy(self):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "true",
+                },
+                clear=True,
+            ),
+            patch("httpx.Client.get") as mock_get,
+        ):
+            ssrf_safe_httpx_get("http://127.0.0.1:1234/v1/models", timeout=5)
+
+        mock_get.assert_called_once()
+
+    def test_literal_loopback_is_blocked_when_connector_policy_opts_out(self):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+                },
+                clear=True,
+            ),
+            patch("httpx.Client.get") as mock_get,
+            pytest.raises(SSRFProtectionError, match=r"127\.0\.0\.1.*blocked"),
+        ):
+            ssrf_safe_httpx_get("http://127.0.0.1:1234/v1/models", timeout=5)
+
+        mock_get.assert_not_called()
+
     def test_direct_internal_ip_is_blocked(self):
         with (
             patch.dict(os.environ, {"LANGFLOW_SSRF_PROTECTION_ENABLED": "true"}),

--- a/uv.lock
+++ b/uv.lock
@@ -10538,14 +10538,14 @@ name = "lfx-openai-compatible"
 version = "0.1.0"
 source = { editable = "src/bundles/openai-compatible" }
 dependencies = [
+    { name = "httpx" },
     { name = "lfx" },
-    { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.24.0,<1.0.0" },
     { name = "lfx", editable = "src/lfx" },
-    { name = "requests", specifier = ">=2.31.0,<3.0.0" },
 ]
 
 [[package]]
@@ -10587,14 +10587,14 @@ name = "lfx-vllm"
 version = "0.1.0"
 source = { editable = "src/bundles/vllm" }
 dependencies = [
+    { name = "httpx" },
     { name = "lfx" },
-    { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.24.0,<1.0.0" },
     { name = "lfx", editable = "src/lfx" },
-    { name = "requests", specifier = ">=2.31.0,<3.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- apply the connector/model-provider SSRF policy to shared DNS-pinned HTTP request helpers
- route OpenAI-Compatible and vLLM discovery/credential probes through the DNS-pinned helper with redirects disabled
- preserve strict blocking when `connector_ssrf_allow_loopback=false` and keep DNS pinning for non-exempt hosts

## Root cause

`validate_connector_url_for_ssrf` exempted literal loopback hosts by default, but request-time helpers called the generic SSRF validator again. The stricter second check rejected `localhost`, `127.0.0.0/8`, and `::1`, so validation and the outbound request path disagreed.

The provider discovery paths also validated a hostname and then sent the request through a separate client resolution. They now use the shared DNS-pinned helper, which prevents DNS rebinding between validation and connection and rejects automatic redirect following.

## User impact

Local/self-hosted model endpoints such as LM Studio, Ollama, and vLLM work with the default settings, without requiring `LANGFLOW_SSRF_ALLOWED_HOSTS`. Multi-tenant operators can still disable the exemption with `LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK=false`.

The shared connector helper change also aligns its current Home Assistant, Glean, Hugging Face, and Docling consumers with the documented connector loopback policy.

## Validation

- `137 passed`: lfx SSRF protection, HTTP helper, and connector-loopback tests
- `29 passed`: OpenAI-Compatible provider tests
- `25 passed`: vLLM provider tests
- Ruff check and format check on all changed files
- `uv lock --check`
- repository pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened SSRF protection for connector URLs, including DNS pinning and configurable loopback handling.
  * Literal loopback addresses are now allowed or blocked according to connector security settings.
  * OpenAI-compatible model discovery and credential validation now use connector-specific URL protections.
* **Bug Fixes**
  * Improved validation and clearer errors for malformed connector URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
