### PR TITLE
fix(lfx): keep serve message persistence DB-less

### DIFF
--- a/src/backend/tests/unit/test_lfx_serve_message_persistence.py
+++ b/src/backend/tests/unit/test_lfx_serve_message_persistence.py
@@ -1,0 +1,62 @@
+"""Regression coverage for message persistence through the lfx serve v2 API."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from lfx.cli.commands import build_registry_from_paths
+from lfx.cli.flow_store import NullFlowStore
+from lfx.cli.serve_app import create_multi_serve_app
+from lfx.services.database.service import NoopDatabaseService
+from lfx.services.deps import get_db_service
+from lfx.services.manager import ServiceManager
+
+
+def test_v2_sync_and_stream_chat_flow_keep_noop_database(monkeypatch):
+    """DB-less serve runs must not create Langflow persistence between chat vertices."""
+    from lfx.services import manager as manager_module
+
+    service_manager = ServiceManager()
+    monkeypatch.setattr(manager_module, "_service_manager", service_manager)
+    monkeypatch.setenv("LANGFLOW_API_KEY", "test-key")
+
+    repo_root = Path(__file__).parents[4]
+    flow_path = repo_root / "src/lfx/tests/data/simple_chat_no_llm.json"
+    registry = asyncio.run(
+        build_registry_from_paths(
+            [flow_path],
+            lambda _message: None,
+            check_variables=True,
+            store=NullFlowStore(),
+        )
+    )
+    flow_id = registry.list_metas()[0].id
+
+    with TestClient(create_multi_serve_app(registry=registry)) as client:
+        sync_response = client.post(
+            "/api/v2/workflows?mode=sync",
+            json={"flow_id": flow_id, "input_value": "hello"},
+            headers={"x-api-key": "test-key"},
+        )
+        stream_response = client.post(
+            "/api/v2/workflows",
+            json={
+                "flow_id": flow_id,
+                "input_value": "hello",
+                "mode": "stream",
+                "stream_protocol": "agui",
+            },
+            headers={"x-api-key": "test-key"},
+        )
+
+    assert sync_response.status_code == 200, sync_response.text
+    body = sync_response.json()
+    assert body["status"] == "completed", body["errors"]
+    assert body["output"]["text"] == "hello"
+
+    assert stream_response.status_code == 200, stream_response.text
+    assert "RUN_FINISHED" in stream_response.text
+    assert "hello" in stream_response.text
+    assert isinstance(get_db_service(), NoopDatabaseService)

--- a/src/lfx/src/lfx/graph/utils.py
+++ b/src/lfx/src/lfx/graph/utils.py
@@ -11,7 +11,8 @@ from lfx.schema.data import Data
 from lfx.schema.message import Message
 
 # Database imports removed - lfx should be lightweight
-from lfx.services.deps import get_settings_service
+from lfx.services.database.service import NoopDatabaseService
+from lfx.services.deps import get_db_service, get_settings_service
 
 if TYPE_CHECKING:
     from lfx.graph.vertex.base import Vertex
@@ -356,13 +357,19 @@ async def log_vertex_build(
     try:
         # Try to use langflow's services if available (when running within langflow)
         try:
-            from langflow.services.deps import get_db_service as langflow_get_db_service
-            from langflow.services.deps import get_settings_service as langflow_get_settings_service
-
-            settings_service = langflow_get_settings_service()
+            settings_service = get_settings_service()
             if not settings_service:
                 return
             if not getattr(settings_service.settings, "vertex_builds_storage_enabled", False):
+                return
+
+            # Resolve only the database service already registered with the shared
+            # LFX service manager. Calling langflow.services.deps.get_db_service()
+            # here would install Langflow's default DatabaseService as a lookup
+            # side effect, turning a DB-less `lfx serve` process into a partially
+            # initialized DB runtime between two vertices in the same graph run.
+            db_service = get_db_service()
+            if isinstance(db_service, NoopDatabaseService):
                 return
 
             if isinstance(flow_id, str):
@@ -405,10 +412,6 @@ async def log_vertex_build(
             if getattr(
                 settings_service.settings, "telemetry_writer_enabled", False
             ) and _try_enqueue_via_telemetry_writer(vertex_build):
-                return
-
-            db_service = langflow_get_db_service()
-            if db_service is None:
                 return
 
             async with db_service._with_session() as session:  # noqa: SLF001


### PR DESCRIPTION
## Summary

- prevent vertex-build logging from instantiating Langflow's database service inside DB-less `lfx serve`
- keep chat-message operations on the no-DB implementation for the full v2 workflow run
- add an end-to-end regression for an exported ChatInput to ChatOutput flow in sync and stream modes

## Root cause

The v2 sync path runs through `Graph.arun`. After ChatInput stores its message through the LFX no-DB implementation, vertex-build logging called `langflow.services.deps.get_db_service()`. That lookup installs Langflow's default `DatabaseService` when no service was registered, so ChatOutput sees a different persistence backend later in the same request. The accidental backend has neither a migrated schema nor the stub's nanoid-compatible message state, producing the chained UUID and schema errors.

Vertex-build logging now resolves only the database service already registered with the shared LFX service manager and exits when it is `NoopDatabaseService`. Full Langflow processes still persist vertex builds because startup explicitly registers the real database service.

## Tests

- `pytest src/backend/tests/unit/test_lfx_serve_message_persistence.py -q`
- `pytest src/backend/tests/unit/test_database.py::test_delete_flows_with_transaction_and_build -q`
- `cd src/lfx && uv run pytest tests/unit/cli/test_serve_workflow.py tests/unit/memory/test_memory_dispatch.py -q`
- pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat-flow requests in database-less configurations so synchronous and streaming responses complete successfully.
  * Prevented unnecessary persistence attempts when database storage is disabled.
  * Improved reliability for lightweight serve-mode deployments without database services.

* **Tests**
  * Added regression coverage for sync and streaming chat-flow requests in no-persistence configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->