### PR TITLE
fix: correct HITL gate span label and dedupe paused trace rows

### DIFF
--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -56,7 +56,7 @@ The pause probe is a no-op unless a component requests it, so normal flows are b
 | Decision | The human's answer: `action_id` (e.g. `approve`/`reject`) plus optional `values` | `graph.human_input_decisions` |
 | Run id | The graph's tracing identity; equals `graph_run_id` on the messages | `graph.set_run_id`, trace `id` |
 | Job id | The durable job identity used for checkpoints + resume | `JobStatus`, `/api/v2/workflows/{job_id}/resume` |
-| Gate span | The trace span recording the resolved decision: "Human In The Loop — Approved/Rejected" | `TracingService.record_event_span` |
+| Gate span | The trace span recording the resolved decision: "Human In The Loop — {action label}" (e.g. Approve/Reject/Remove) | `TracingService.record_event_span` |
 
 ---
 
@@ -211,7 +211,7 @@ Originally, resumed runs lost trace data in the backend: the **Chat Output** spa
 #### Decision
 1. On resume, call `graph.initialize_run()` on the checkpoint's `run_id` so resumed vertices trace into the **same** trace as the pre-pause run, and restore `flow_name` for the trace title.
 2. Pin the caller's `run_id` in `build_graph_from_data` **before** `initialize_run` (forwarded by `create_graph`), so the initial run traces into `graph_run_id` — not a fresh uuid.
-3. Record the resolved gate as a real span via `TracingService.record_event_span` ("Human In The Loop — Approved/Rejected").
+3. Record the resolved gate as a real span via `TracingService.record_event_span` ("Human In The Loop — {action label}", e.g. Approve/Reject/Remove).
 4. Remove the frontend `localStorage` persistence; `TraceDetailView` reads the gate + output from the backend trace and only synthesizes a gate for the live window, deduped by name.
 
 #### Consequences
@@ -263,7 +263,9 @@ Drain the queue **inline** after cancelling the worker (`service.py::_stop`), an
   decision = reroute_decision_on_timeout(pending, resume["decision"])
   graph.human_input_decisions = {resume["request_id"]: decision}
   action_id = str((decision or {}).get("action_id", ""))
-  gate_label = "Rejected" if "reject" in action_id.lower() else "Approved"
+  # HITL actions are user-defined (Approve/Reject/Remove/...), so label the span with the chosen
+  # action's button label (from the pending options), not a hardcoded approve/reject binary.
+  gate_label = _hitl_gate_label(action_id, (pending or {}).get("options"))
   graph.tracing_service.record_event_span(
       span_id=f"hitl-{resume['request_id']}",
       name=f"Human In The Loop — {gate_label}",
@@ -368,7 +370,7 @@ sequenceDiagram
   U->>API: POST /v2/workflows/{job}/resume {decision}
   API->>DB: claim SUSPENDED→IN_PROGRESS (single-flight)
   API->>G: resume_from_checkpoint + initialize_run(run_id)
-  G->>T: record "Human In The Loop — Approved" span
+  G->>T: record "Human In The Loop — {decision}" span
   G->>T: trace re-run predecessors … Chat Output
   G->>DB: flush spans (one trace) + job COMPLETED
   API-->>U: result; trace panel shows full run

--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -58,6 +58,16 @@ from langflow.services.telemetry.schema import (
 STREAMING_ACTIVITY_REFRESH_S = 10.0
 
 
+def _hitl_gate_label(action_id: str, options: list[dict] | None = None) -> str:
+    """Gate span suffix reflecting the chosen action; actions are user-defined, not a fixed approve/reject binary."""
+    for option in options or []:
+        if isinstance(option, dict) and str(option.get("action_id")) == action_id:
+            label = str(option.get("label") or "").strip()
+            if label:
+                return label
+    return action_id.replace("_", " ").strip().title() or "Resolved"
+
+
 def _project_event_to_v1(raw: str) -> str:
     """Render an ``add_message`` event's content_blocks/text to the v1 shape.
 
@@ -481,7 +491,7 @@ async def generate_flow_events(
             resume["request_id"]: decision,
         }
         action_id = str((decision or {}).get("action_id", ""))
-        gate_label = "Rejected" if "reject" in action_id.lower() else "Approved"
+        gate_label = _hitl_gate_label(action_id, (pending or {}).get("options"))
         if graph.tracing_service:
             graph.tracing_service.record_event_span(
                 span_id=f"hitl-{resume['request_id']}",

--- a/src/backend/tests/unit/api/test_hitl_gate_label.py
+++ b/src/backend/tests/unit/api/test_hitl_gate_label.py
@@ -1,0 +1,45 @@
+"""Regression tests for the resumed HITL gate span label (LE-1851).
+
+The gate span name must reflect the *actual* action the human chose, not a hardcoded
+"Approved". Actions are user-defined (Approve, Reject, Remove, Escalate, ...), so the
+label comes from the pending request's option label, falling back to a humanized
+action_id.
+"""
+
+from langflow.api.build import _hitl_gate_label
+
+_OPTIONS = [
+    {"action_id": "approve", "label": "Approve"},
+    {"action_id": "remove", "label": "Remove"},
+]
+
+
+def test_gate_label_uses_option_label_for_reject_like_action():
+    # The reported bug: a "remove" decision was mislabeled "Approved".
+    assert _hitl_gate_label("remove", _OPTIONS) == "Remove"
+
+
+def test_gate_label_uses_option_label_for_approve():
+    assert _hitl_gate_label("approve", _OPTIONS) == "Approve"
+
+
+def test_gate_label_humanizes_action_id_when_no_matching_option():
+    assert _hitl_gate_label("request_changes", _OPTIONS) == "Request Changes"
+
+
+def test_gate_label_humanizes_action_id_when_options_missing():
+    assert _hitl_gate_label("escalate", None) == "Escalate"
+
+
+def test_gate_label_prefers_option_label_over_humanized_id():
+    options = [{"action_id": "reject", "label": "Reject Request"}]
+    assert _hitl_gate_label("reject", options) == "Reject Request"
+
+
+def test_gate_label_falls_back_when_action_id_empty():
+    assert _hitl_gate_label("", _OPTIONS) == "Resolved"
+
+
+def test_gate_label_ignores_option_with_blank_label():
+    options = [{"action_id": "remove", "label": "  "}]
+    assert _hitl_gate_label("remove", options) == "Remove"

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/TraceDetailView.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/TraceDetailView.tsx
@@ -10,6 +10,25 @@ import { TraceHitlBar } from "./TraceHitlBar";
 import { Span, TraceDetailViewProps } from "./types";
 
 /**
+ * Gate span suffix reflecting the chosen HITL action. Actions are user-defined (Approve, Reject,
+ * Remove, Escalate, ...), not a fixed approve/reject binary, so prefer the option's button label
+ * and fall back to a humanized action_id. Mirrors the backend's `_hitl_gate_label` so the live
+ * label matches the persisted trace span.
+ */
+export function hitlGateLabel(
+  actionId: string,
+  options?: { action_id: string; label?: string }[],
+): string {
+  const label = options?.find((o) => o.action_id === actionId)?.label?.trim();
+  if (label) return label;
+  const humanized = actionId
+    .replace(/_/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return humanized || "Resolved";
+}
+
+/**
  * Single-trace detail view used in the right-side panel.
  * Matches the "Trace Detail" layout (header + span list + span details).
  */
@@ -160,9 +179,7 @@ export function TraceDetailView({
     if (backendHasGate || (!pendingRequest && !effectiveResolved))
       return [{ ...summarySpan, children }];
     const decisionLabel = effectiveResolved
-      ? effectiveResolved.toLowerCase().includes("reject")
-        ? "Rejected"
-        : "Approved"
+      ? hitlGateLabel(effectiveResolved, pendingRequest?.options)
       : null;
     const hitlSpan: Span = {
       id: `hitl-${pendingRequest?.request_id ?? trace.id}`,

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/__tests__/TraceDetailView.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/__tests__/TraceDetailView.test.tsx
@@ -53,14 +53,25 @@ jest.mock("@/components/ui/loading", () => ({
 }));
 
 jest.mock("../TraceHitlBar", () => ({
-  TraceHitlBar: ({ onDecision }: { onDecision?: (a: string) => void }) => (
-    <button
-      type="button"
-      data-testid="hitl-bar"
-      onClick={() => onDecision?.("approve")}
-    >
-      bar
-    </button>
+  TraceHitlBar: ({
+    pending,
+    onDecision,
+  }: {
+    pending?: { allowed_decisions?: string[] };
+    onDecision?: (a: string) => void;
+  }) => (
+    <div data-testid="hitl-bar">
+      {(pending?.allowed_decisions ?? ["approve"]).map((id: string) => (
+        <button
+          key={id}
+          type="button"
+          data-testid={`hitl-bar-${id}`}
+          onClick={() => onDecision?.(id)}
+        >
+          {id}
+        </button>
+      ))}
+    </div>
   ),
 }));
 
@@ -285,11 +296,56 @@ describe("TraceDetailView", () => {
       screen.getByTestId("span-node-hitl-Agent-oYRYa:job-1"),
     ).toBeInTheDocument();
 
-    // Approve → the gate stays as a resolved "— Approved" step, not removed.
-    fireEvent.click(screen.getByTestId("hitl-bar"));
+    // Approve → the gate stays as a resolved "— Approve" step (the action's label), not removed.
+    fireEvent.click(screen.getByTestId("hitl-bar-approve"));
+    expect(screen.getByText(/Human In The Loop — Approve/)).toBeInTheDocument();
+  });
+
+  it("labels the resolved gate with the actual action, not a hardcoded Approved (LE-1851)", () => {
+    // A "remove" decision must not be mislabeled "Approved"; the gate reflects the chosen action.
+    mockTrace = {
+      id: "trace-1",
+      name: "Gated Trace",
+      status: "ok",
+      startTime: "2024-01-01T00:00:00Z",
+      endTime: "2024-01-01T00:00:01Z",
+      totalLatencyMs: 1234,
+      totalTokens: 0,
+      totalCost: 0,
+      flowId: "flow-1",
+      sessionId: "session-1",
+      input: {},
+      output: {},
+      spans: [],
+    };
+
+    render(
+      <TraceDetailView
+        traceId="trace-1"
+        flowName="Flow"
+        hasTrace
+        pendingRequest={{
+          job_id: "job-1",
+          flow_id: "flow-1",
+          session_id: "session-1",
+          created_at: null,
+          request_id: "Node-abc:job-1",
+          kind: "node_input",
+          prompt: null,
+          options: [
+            { action_id: "approve", label: "Approve" },
+            { action_id: "remove", label: "Remove" },
+          ],
+          allowed_decisions: ["approve", "remove"],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("hitl-bar-remove"));
+    expect(screen.getByText(/Human In The Loop — Remove/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Human In The Loop — Approved/),
-    ).toBeInTheDocument();
+      screen.queryByText(/Human In The Loop — Approved/),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the resolved gate from the backend trace span after reopen", () => {

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/__tests__/traceViewHelpers.test.ts
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/__tests__/traceViewHelpers.test.ts
@@ -424,6 +424,23 @@ describe("buildActivityRows", () => {
     expect(rows[0].isPending).toBeUndefined();
   });
 
+  it("overlays the pending onto the run's trace by job_id when the job has no session_id", () => {
+    // Durable HITL flushes the paused run's trace under an id equal to job_id, but a background job
+    // can have session_id: null — so session matching fails and a duplicate synthetic row appears,
+    // hiding the real trace. Match by id so there is exactly one row that keeps its span tree.
+    const rows = buildActivityRows({
+      baseRows: [trace({ id: "job-1", status: "ok", sessionId: "f1" })],
+      pendingRequests: [pending({ session_id: null, job_id: "job-1" })],
+      statusFilter: "all",
+      fallbackName: "My Flow",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("job-1");
+    expect(rows[0].status).toBe("awaiting_human");
+    expect(rows[0].pendingRequest?.job_id).toBe("job-1");
+    expect(rows[0].isPending).toBeUndefined();
+  });
+
   it("overlays only the NEWEST trace per session — older completed siblings keep their status", () => {
     const rows = buildActivityRows({
       baseRows: [

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/traceViewHelpers.ts
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/traceViewHelpers.ts
@@ -22,21 +22,25 @@ export function buildActivityRows({
   statusFilter: string;
   fallbackName: string;
 }): TraceListItem[] {
+  const pendingByJobId = new Map<string, PendingHumanRequest>();
+  pendingRequests.forEach((req) => pendingByJobId.set(req.job_id, req));
   const pendingBySession = new Map<string, PendingHumanRequest>();
   pendingRequests.forEach((req) => {
     if (req.session_id) pendingBySession.set(req.session_id, req);
   });
 
-  // Why: overlay the pending onto only the newest trace per session (baseRows are newest-first)
-  // — that's the paused run, so older completed siblings in the session get no false awaiting bar.
-  const matchedSessions = new Set<string>();
+  // Match a pending to its run's trace by id (durable HITL flushes the trace under an id equal to
+  // job_id, and a background job may have no session_id), then fall back to newest-trace-per-session.
+  const usedJobIds = new Set<string>();
   const overlaid = baseRows.map((row) => {
-    const pending =
-      row.sessionId && !matchedSessions.has(row.sessionId)
-        ? pendingBySession.get(row.sessionId)
-        : undefined;
+    let pending = pendingByJobId.get(row.id);
+    if (pending && usedJobIds.has(pending.job_id)) pending = undefined;
+    if (!pending && row.sessionId) {
+      const bySession = pendingBySession.get(row.sessionId);
+      if (bySession && !usedJobIds.has(bySession.job_id)) pending = bySession;
+    }
     if (pending) {
-      matchedSessions.add(row.sessionId as string);
+      usedJobIds.add(pending.job_id);
       return {
         ...row,
         status: "awaiting_human" as const,
@@ -50,9 +54,7 @@ export function buildActivityRows({
     statusFilter === "all" || statusFilter === "awaiting_human";
   const syntheticRows: TraceListItem[] = includeSynthetic
     ? pendingRequests
-        .filter(
-          (req) => !req.session_id || !matchedSessions.has(req.session_id),
-        )
+        .filter((req) => !usedJobIds.has(req.job_id))
         .map((req) => ({
           id: req.job_id,
           name: fallbackName,


### PR DESCRIPTION
## Objective
Make the trace panel report HITL runs accurately — the resolved decision label and one row per run.

## Changes
- Label the resumed HITL gate span with the chosen action's real label (Approve/Reject/Remove/…) instead of a hardcoded approve/reject binary, so a `remove` decision is no longer shown as "Approved" (LE-1851).
- Mirror that label logic in the trace panel's live gate node so it matches the persisted backend span.
- Match a pending human request to its run's trace by `job_id` (not only `session_id`) in `buildActivityRows`, so a background job with no `session_id` no longer produces a duplicate synthetic row that hid the span tree and left the detail panel empty.
- Add backend (`_hitl_gate_label`) and frontend regression tests; update `docs/features/durable-execution-hitl.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Human-in-the-loop trace entries now display the selected action’s label, including custom actions such as Approve, Reject, or Remove.
  - Supports clear fallback labels when an action does not have a configured name.

- **Bug Fixes**
  - Improved pending human-review status tracking to prevent duplicate activity entries, including requests without session IDs.

- **Documentation**
  - Updated durable execution and human-in-the-loop documentation, architecture notes, and flow diagrams to reflect action-based trace labels and gate resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->