### PR TITLE
fix(security): bind MCP stdio to code-exec lockdown

### DIFF
--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -69,7 +69,7 @@ async def get_mcp_file(current_user: CurrentActiveUser, *, extension: bool = Fal
     return f"{MCP_SERVERS_FILE}_{current_user.id!s}" + (".json" if extension else "")
 
 
-async def _validate_uploaded_mcp_config(file: UploadFile) -> None:
+async def _validate_uploaded_mcp_config(file: UploadFile) -> dict[str, dict]:
     """Validate an uploaded MCP servers config against MCPServerConfig.
 
     Security: the uploaded bytes become the user's MCP servers config, whose
@@ -99,6 +99,7 @@ async def _validate_uploaded_mcp_config(file: UploadFile) -> None:
             MCPServerConfig.model_validate(cfg)
         except ValidationError as exc:
             raise HTTPException(status_code=422, detail=f"Invalid MCP server '{name}': {exc}") from exc
+    return servers
 
 
 async def byte_stream_generator(file_input, chunk_size: int = 8192) -> AsyncGenerator[bytes, None]:
@@ -287,7 +288,7 @@ async def upload_user_file(
             # is on, but this branch writes the same _mcp_servers_<uid>.json that
             # get_server_list reads — so without the same guard a non-superuser could
             # replace their MCP config via the file-upload path while it's locked.
-            from langflow.api.v2.mcp import is_mcp_servers_locked
+            from langflow.api.v2.mcp import ensure_mcp_stdio_access, is_mcp_servers_locked
 
             if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
                 raise HTTPException(
@@ -299,7 +300,9 @@ async def upload_user_file(
             # path can't bypass the command allow-list enforced by the structured
             # /api/v2/mcp/servers endpoints (otherwise an attacker-supplied command
             # would later be spawned via the stdio transport -> RCE).
-            await _validate_uploaded_mcp_config(file)
+            servers = await _validate_uploaded_mcp_config(file)
+            for server_config in servers.values():
+                ensure_mcp_stdio_access(server_config, current_user, settings_service.settings)
             # Check if an existing record exists; if so, delete it to replace with the new one
             existing_mcp_file = await get_file_by_name(mcp_file, current_user, session)
             if existing_mcp_file:

--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -39,6 +39,22 @@ def is_mcp_servers_locked(settings: object) -> bool:
     return getattr(settings, "mcp_servers_locked", False) is True
 
 
+def ensure_mcp_stdio_access(server_config: dict, current_user: CurrentActiveUser, settings: object) -> None:
+    """Restrict local MCP processes when custom code execution is restricted."""
+    mode = server_config.get("mode")
+    is_stdio = bool(server_config.get("command")) or (isinstance(mode, str) and mode.lower() == "stdio")
+    code_execution_restricted = (
+        getattr(settings, "allow_custom_components", True) is False
+        or getattr(settings, "custom_component_admin_only", False) is True
+    )
+
+    if is_stdio and code_execution_restricted and getattr(current_user, "is_superuser", False) is not True:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP stdio servers are restricted to administrators when custom code execution is restricted.",
+        )
+
+
 def _enforce_immutable_server_name(server_name: str, server_config: dict) -> dict:
     """Enforce that the server name is owned by the URL path, not the request body.
 
@@ -247,6 +263,9 @@ async def get_servers(
         # Return only the server names, with mode and toolsCount as None
         return [{"name": server_name, "mode": None, "toolsCount": None} for server_name in server_list["mcpServers"]]
 
+    for server_config in server_list["mcpServers"].values():
+        ensure_mcp_stdio_access(server_config, current_user, settings_service.settings)
+
     # Check all of the tool counts for each server concurrently
     async def check_server(server_name: str) -> dict:
         server_info: dict[str, str | int | None] = {"name": server_name, "mode": None, "toolsCount": None}
@@ -402,6 +421,10 @@ async def update_server(
     in-process lock. A concurrent create of the *same* name is caught by the unique
     constraint and folded into an update.
     """
+    settings = getattr(settings_service, "settings", None)
+    if not delete:
+        ensure_mcp_stdio_access(server_config, current_user, settings)
+
     result = await session.exec(
         select(MCPServer).where(MCPServer.user_id == current_user.id, MCPServer.name == server_name)
     )
@@ -426,6 +449,7 @@ async def update_server(
     else:
         new_config = server_config
 
+    ensure_mcp_stdio_access(new_config, current_user, settings)
     encrypted_config = encrypt_mcp_config(new_config)
     transport = _derive_transport(new_config)
 
@@ -455,6 +479,7 @@ async def update_server(
             raise HTTPException(status_code=500, detail="Server already exists.") from None
         if merge_existing:
             merged = {**decrypt_mcp_config(existing.config or {}), **server_config}
+            ensure_mcp_stdio_access(merged, current_user, settings)
             existing.config = encrypt_mcp_config(merged)
             existing.transport = _derive_transport(merged)
         else:

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -982,6 +982,62 @@ async def test_v2_mcp_servers_locked_allows_superuser_add_patch_delete(
     assert response.status_code == status.HTTP_200_OK
 
 
+@pytest.mark.usefixtures("active_user")
+@pytest.mark.parametrize(
+    ("allow_custom_components", "custom_component_admin_only"),
+    [(False, False), (True, True)],
+)
+async def test_v2_mcp_stdio_registration_follows_code_execution_lockdown(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+    allow_custom_components,
+    custom_component_admin_only,
+):
+    """A non-superuser cannot register a process-spawning MCP server under code-exec lockdown."""
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "mcp_servers_locked", False)
+    monkeypatch.setattr(settings, "allow_custom_components", allow_custom_components)
+    monkeypatch.setattr(settings, "custom_component_admin_only", custom_component_admin_only)
+
+    stdio_name = f"lf-lockdown-stdio-{uuid4().hex[:8]}"
+    response = await client.post(
+        f"/api/v2/mcp/servers/{stdio_name}",
+        json={"command": "uvx", "args": ["attacker-controlled-package"]},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_v2_mcp_action_count_does_not_spawn_stdio_under_code_execution_lockdown(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    """Existing stdio configs cannot bypass a newly enabled code-exec lockdown via action_count."""
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "mcp_servers_locked", False)
+    monkeypatch.setattr(settings, "allow_custom_components", False)
+    monkeypatch.setattr(settings, "custom_component_admin_only", False)
+
+    get_server_list = AsyncMock(
+        return_value={
+            "mcpServers": {
+                "blocked-stdio": {"command": "uvx", "args": ["attacker-controlled-package"]},
+            }
+        }
+    )
+    monkeypatch.setattr("langflow.api.v2.mcp.get_server_list", get_server_list)
+    update_tools = AsyncMock()
+    monkeypatch.setattr("langflow.api.v2.mcp.update_tools", update_tools)
+
+    response = await client.get("/api/v2/mcp/servers?action_count=true", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    update_tools.assert_not_awaited()
+
+
 async def test_install_mcp_config_defaults_to_sse_transport(
     client: AsyncClient,
     user_test_project,

--- a/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_servers_file.py
@@ -333,6 +333,104 @@ async def test_mcp_servers_upload_allowed_when_locked_for_superuser(session, sto
 
 
 @pytest.mark.asyncio
+async def test_mcp_servers_upload_rejects_stdio_under_code_execution_lockdown(session, storage_service, current_user):
+    """The raw MCP config upload cannot bypass the code-execution lockdown."""
+    restricted_settings = SimpleNamespace(
+        settings=SimpleNamespace(
+            max_file_size_upload=10,
+            mcp_servers_locked=False,
+            allow_custom_components=False,
+            custom_component_admin_only=False,
+        )
+    )
+    current_user.is_superuser = False
+
+    mcp_file_ext = await get_mcp_file(current_user, extension=True)
+    content = b'{"mcpServers": {"evil": {"command": "uvx", "args": ["attacker-controlled-package"]}}}'
+    file = UploadFile(filename=mcp_file_ext, file=io.BytesIO(content))
+    file.size = len(content)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload_user_file(
+            file=file,
+            session=session,
+            current_user=current_user,
+            storage_service=storage_service,
+            settings_service=restricted_settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert storage_service._store == {}
+    assert session._db == {}
+
+
+@pytest.mark.asyncio
+async def test_mcp_servers_upload_allows_remote_server_under_code_execution_lockdown(
+    session, storage_service, current_user
+):
+    """Remote MCP configs remain usable because they do not spawn a local process."""
+    restricted_settings = SimpleNamespace(
+        settings=SimpleNamespace(
+            max_file_size_upload=10,
+            mcp_servers_locked=False,
+            allow_custom_components=True,
+            custom_component_admin_only=True,
+        )
+    )
+    current_user.is_superuser = False
+
+    mcp_file_ext = await get_mcp_file(current_user, extension=True)
+    mcp_file = await get_mcp_file(current_user)
+    content = b'{"mcpServers": {"remote": {"url": "https://mcp.example.com"}}}'
+    file = UploadFile(filename=mcp_file_ext, file=io.BytesIO(content))
+    file.size = len(content)
+
+    await upload_user_file(
+        file=file,
+        session=session,
+        current_user=current_user,
+        storage_service=storage_service,
+        settings_service=restricted_settings,
+    )
+
+    expected_path = f"{current_user.id}/{mcp_file}.json"
+    assert storage_service._store[expected_path] == content
+
+
+@pytest.mark.asyncio
+async def test_mcp_servers_upload_allows_stdio_for_superuser_under_code_execution_lockdown(
+    session, storage_service, current_user
+):
+    """Administrators retain access to local MCP processes under admin-only lockdown."""
+    restricted_settings = SimpleNamespace(
+        settings=SimpleNamespace(
+            max_file_size_upload=10,
+            mcp_servers_locked=False,
+            allow_custom_components=False,
+            custom_component_admin_only=True,
+        )
+    )
+    current_user.is_superuser = True
+
+    mcp_file_ext = await get_mcp_file(current_user, extension=True)
+    mcp_file = await get_mcp_file(current_user)
+    content = b'{"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}'
+    file = UploadFile(filename=mcp_file_ext, file=io.BytesIO(content))
+    file.size = len(content)
+
+    await upload_user_file(
+        file=file,
+        session=session,
+        current_user=current_user,
+        storage_service=storage_service,
+        settings_service=restricted_settings,
+    )
+
+    expected_path = f"{current_user.id}/{mcp_file}.json"
+    assert storage_service._store[expected_path] == content
+
+
+@pytest.mark.asyncio
 async def test_concurrent_update_server_should_not_lose_servers(tmp_path):
     """Concurrent update_server() calls must not silently drop servers.
 


### PR DESCRIPTION
## Summary

Backport of #14149 to release-1.11.0.

- deny non-superusers local MCP stdio configuration when custom code execution is disabled or admin-only
- stop action-count discovery before it can spawn an existing stdio server under lockdown
- apply the same policy to raw MCP config uploads
- adapt the guard to the release-1.11.0 database-backed MCP server store and concurrent-upsert retry path
- preserve remote HTTP/SSE servers, superuser access, and default permissive behavior

## Testing

- registration and action-count regression cases: 3 passed
- full test_mcp_servers_file.py: 17 passed
- Ruff check and format verification on all changed files
- git diff --check

Refs LE-1542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted local MCP server commands for non-administrators when custom code execution is locked down.
  * Applied the same protections to uploaded MCP configuration files and existing server configurations.
  * Remote MCP server URLs remain available under these restrictions.

* **Bug Fixes**
  * Prevented blocked MCP servers from being activated or counted as available tools.
  * Ensured rejected uploads are not stored or recorded as server metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->