### PR TITLE
fix: preserve secret values for connected components

### DIFF
--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1312,6 +1312,12 @@ class Component(CustomComponent):
             raise
 
     async def _build_results(self) -> tuple[dict, dict]:
+        """Build sanitized display results while preserving raw values for connected components.
+
+        ``Output.value`` is the graph-edge cache and must retain the value returned by the
+        component. The results and artifacts returned here can be serialized to clients, so
+        they receive independent secret-sanitized copies.
+        """
         results, artifacts = {}, {}
 
         self._pre_run_setup_if_needed()
@@ -1320,8 +1326,9 @@ class Component(CustomComponent):
         for output in self._get_outputs_to_process():
             self._current_output = output.name
             result = await self._get_output_result(output)
-            results[output.name] = result
-            artifacts[output.name] = self._build_artifact(result)
+            sanitized_result = self._sanitize_secret_values(result)
+            results[output.name] = sanitized_result
+            artifacts[output.name] = self._build_artifact(sanitized_result)
             self._log_output(output)
 
         self._finalize_results(results, artifacts)
@@ -1381,8 +1388,9 @@ class Component(CustomComponent):
         """Computes and returns the result for a given output, applying caching and output options.
 
         If the output is cached and a value is already defined, returns the cached value. Otherwise,
-        invokes the associated output method asynchronously, applies output options, updates the cache,
-        and returns the result. Raises a ValueError if the output method is not defined, or a TypeError
+        invokes the associated output method asynchronously, applies output options, caches the raw
+        value for connected graph edges, and returns it. Display serialization is sanitized separately
+        by ``_build_results``. Raises a ValueError if the output method is not defined, or a TypeError
         if the method invocation fails.
         """
         if output.cache and output.value != UNDEFINED:
@@ -1407,7 +1415,6 @@ class Component(CustomComponent):
         ):
             result.set_flow_id(self._vertex.graph.flow_id)
         result = output.apply_options(result)
-        result = self._sanitize_secret_values(result)
         output.value = result
 
         return result
@@ -1454,21 +1461,24 @@ class Component(CustomComponent):
         return value
 
     def _sanitize_secret_values(self, value):
+        """Return a sanitized value without mutating caller-owned ``Message`` or ``Data`` objects."""
         if not self._secret_values:
             return _mask_secret_value(value)
         value = _mask_secret_value(value)
         if isinstance(value, str):
             return self._sanitize_secret_string(value)
         if isinstance(value, Message):
+            sanitized = value.model_copy(update={"data": self._sanitize_secret_values(value.data)})
             if isinstance(value.text, str):
-                value.text = self._sanitize_secret_string(value.text)
-            value.data = self._sanitize_secret_values(value.data)
-            return value
+                sanitized.text = self._sanitize_secret_string(value.text)
+            return sanitized
         if isinstance(value, Data):
-            value.data = self._sanitize_secret_values(value.data)
-            if isinstance(value.default_value, str):
-                value.default_value = self._sanitize_secret_string(value.default_value)
-            return value
+            default_value = value.default_value
+            if isinstance(default_value, str):
+                default_value = self._sanitize_secret_string(default_value)
+            return value.model_copy(
+                update={"data": self._sanitize_secret_values(value.data), "default_value": default_value}
+            )
         if isinstance(value, dict):
             return {key: self._sanitize_secret_values(item) for key, item in value.items()}
         if isinstance(value, list):

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -72,6 +72,10 @@ class Vertex:
         self._is_loop = None
         self.has_session_id = None
         self.custom_component = None
+        # Secret values inherited from upstream component outputs. Keep these in
+        # memory only so downstream display results can be masked without
+        # replacing the raw values consumed through graph edges.
+        self._upstream_secret_values: set[str] = set()
         self.has_external_input = False
         self.has_external_output = False
         self.graph = graph
@@ -414,6 +418,9 @@ class Vertex:
             custom_params = initialize.loading.get_params(self.params)
             custom_params.pop("code", None)
 
+        if hasattr(custom_component, "_secret_values"):
+            custom_component._secret_values.update(self._upstream_secret_values)  # noqa: SLF001
+
         await self._build_results(
             custom_component=custom_component,
             custom_params=custom_params,
@@ -584,7 +591,14 @@ class Vertex:
                 self.params[key][sub_key] = value
             else:
                 result = await value.get_result(self, target_handle_name=key)
+                self._inherit_secret_values(value)
                 self.params[key][sub_key] = result
+
+    def _inherit_secret_values(self, vertex: Vertex) -> None:
+        """Track secrets that arrive through an upstream component edge."""
+        component = vertex.custom_component
+        if component is not None:
+            self._upstream_secret_values.update(getattr(component, "_secret_values", set()))
 
     @staticmethod
     def _is_vertex(value):
@@ -651,6 +665,7 @@ class Vertex:
     async def _build_vertex_and_update_params(self, key, vertex: Vertex) -> None:
         """Builds a given vertex and updates the params dictionary accordingly."""
         result = await vertex.get_result(self, target_handle_name=key)
+        self._inherit_secret_values(vertex)
         self._handle_func(key, result)
         if isinstance(result, list):
             self._extend_params_list_with_result(key, result)
@@ -672,6 +687,7 @@ class Vertex:
             if not vertex.built and vertex.id in self.graph.conditionally_excluded_vertices:
                 continue
             result = await vertex.get_result(self, target_handle_name=key)
+            self._inherit_secret_values(vertex)
             # Weird check to see if the params[key] is a list
             # because sometimes it is a Data and breaks the code
             if not isinstance(self.params[key], list):

--- a/src/lfx/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_component_events.py
@@ -9,6 +9,7 @@ from lfx.custom.custom_component.component import Component
 from lfx.events.event_manager import EventManager
 from lfx.schema.content_block import ContentBlock
 from lfx.schema.content_types import TextContent, ToolContent
+from lfx.schema.data import Data
 from lfx.schema.message import Message
 from lfx.schema.properties import Properties, Source
 from lfx.template.field.base import Output
@@ -171,6 +172,38 @@ async def test_component_build_results():
     assert "text_output" in artifacts
     assert "tool_output" in artifacts
     assert artifacts["text_output"]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_component_build_results_masks_secrets_without_mutating_cached_output():
+    """Display results must be sanitized without corrupting values consumed by graph edges."""
+
+    class SecretOutputComponent(Component):
+        def get_connection_string(self) -> Message:
+            return Message(text="postgresql://demo:hunter2@localhost/db")  # pragma: allowlist secret
+
+        def get_connection_data(self) -> Data:
+            return Data(data={"url": "postgresql://demo:hunter2@localhost/db"})  # pragma: allowlist secret
+
+    component = SecretOutputComponent()
+    component._secret_values.add("hunter2")  # pragma: allowlist secret
+    message_output = Output(name="connection_string", method="get_connection_string")
+    data_output = Output(name="connection_data", method="get_connection_data")
+    component._outputs_map = {message_output.name: message_output, data_output.name: data_output}
+    component.outputs = [message_output, data_output]
+
+    results, artifacts = await component._build_results()
+
+    displayed = results[message_output.name]
+    assert displayed.text == "postgresql://demo:**********@localhost/db"
+    assert artifacts[message_output.name]["raw"] == "postgresql://demo:**********@localhost/db"
+    assert message_output.value.text == "postgresql://demo:hunter2@localhost/db"  # pragma: allowlist secret
+    assert displayed is not message_output.value
+
+    displayed_data = results[data_output.name]
+    assert displayed_data.data["url"] == "postgresql://demo:**********@localhost/db"
+    assert data_output.value.data["url"] == "postgresql://demo:hunter2@localhost/db"  # pragma: allowlist secret
+    assert displayed_data is not data_output.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve the raw component output in `Output.value` for connected graph-edge consumers
- return independent, secret-sanitized `Message` and `Data` copies in client-facing results and artifacts
- add regression coverage proving display data stays masked while downstream cached values remain usable

Fixes #14152

## Root cause

`_get_output_result()` sanitized `Message` and `Data` objects in place before assigning the same object to `Output.value`. `ComponentVertex` prefers that cache for connected edges, so downstream components received the literal mask instead of the real value.

## Validation

Environment: macOS 26.4.1 arm64, Python 3.13.13, uv 0.11.7.

- Baseline regression test: failed because `Output.value` contained `**********`
- `pytest src/lfx/tests/unit/custom/custom_component -q`: 31 passed, 1 xfailed
- `ruff 0.13.1 check` on the changed source and test files: passed
- `ruff 0.13.1 format --check` on the changed source and test files: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret values are now masked in displayed component results and artifacts.
  * Original cached output values remain unchanged for connected workflows.
  * Sanitization no longer modifies shared message or data objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->