### PR TITLE
fix(hitl): don't reschedule restored vertices on resume

### DIFF
--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -113,6 +113,7 @@ The pause probe is a no-op unless a component requests it, so normal flows are b
 - **Given** a paused run with already-built vertices
 - **When** the run resumes
 - **Then** built vertices are restored, not re-executed (no LLM re-billing, no re-fired tools)
+- **And** a restored-built vertex is never handed back to the build loop by the runnable-predecessor walk (a re-run Chat Input would persist a duplicate `User` message for the turn)
 - **And** branches killed before the pause stay dead
 
 ### Scenario: HITL inside a nested flow is rejected
@@ -197,9 +198,12 @@ Re-executing completed vertices on resume would re-bill LLMs, re-fire tools, and
 #### Decision
 Restore built vertices from the checkpoint; re-run only the paused vertex's **non-input predecessors whose dropped output an unbuilt consumer will actually read** (`_rerun_non_input_predecessors` / `_unbuild_needed_dropped_producers`). A producer behind a still-built, round-tripped consumer is left alone — re-running it is wasted work and, for a side-effecting node (an Agent re-bills its LLM and re-emits its message), surfaces as duplicate outputs on every later resume. Inputs (e.g. Chat Input) are never re-executed.
 
+Selecting the resume layer is not enough to hold that invariant. A resume restores `vertices_to_run` verbatim from the checkpoint, so vertices that came back **built** stay in the runnable pool; because `RunnableVerticesManager.is_vertex_runnable` never consulted `built`, the backward walk that looks for runnable predecessors when a successor is blocked (`find_runnable_predecessors_for_successor`) could hand one back to the build loop mid-resume. `Graph.is_vertex_runnable` therefore rejects a vertex that is still `built` **and** was restored from the checkpoint (`checkpoint_restored_built_ids`), excluding loop vertices, which legitimately re-run. Reading the live `built` flag rather than the checkpoint's is what keeps the gated node and the opaque-dropped producers — built at checkpoint time, deliberately un-built by the resume — eligible.
+
 #### Consequences
 - **Benefits**: no double billing, no duplicate side effects, deterministic continuation.
 - **Trade-offs**: the resume re-runs a minimal predecessor set; the terminal output is produced fresh on resume (see ADR-004).
+- **Symptom this prevents**: a re-executed Chat Input persists a second `User` message for the same turn, so the paused chat renders the user's question twice after the decision.
 
 ### ADR-004: The whole run is one durable backend trace (gate + Chat Output as spans)
 
@@ -309,6 +313,7 @@ Bare `lfx serve` gains the same background + HITL contract without a database, b
 |---------|-------|-------------|
 | Pause signal + checkpoint | `lfx/graph/graph/base.py`, `lfx/graph/checkpoint/` | `GraphPausedException`, `resume_from_checkpoint`, `set_run_id` |
 | Build seam + resume rebuild | `api/build.py` | `build_resumed_graph_and_get_order`, `_rerun_non_input_predecessors` |
+| Resume scheduling guard | `lfx/graph/graph/base.py` | `is_vertex_runnable`, `checkpoint_restored_built_ids` |
 | Run-id pinning | `api/utils/flow_utils.py` | `build_graph_from_data` |
 | Durable job + single-flight | `services/background_execution/{runner,service}.py` | `JobStatus.SUSPENDED`, `claim_suspended_for_resume` |
 | lfx serve durable substrate | `lfx/services/durable/`, `lfx/cli/serve_durable.py` | `SqliteDurableJobStore`, `SqliteCheckpointStore`, `DurableServeWorkflowHost` |

--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -294,6 +294,7 @@ Drain the queue **inline** after cancelling the worker (`service.py::_stop`), an
 - `useGetTraceQuery` → `GET /api/v1/monitor/traces/{id}` returns the span tree.
 - `TraceDetailView.tsx`: renders the backend gate span; `backendHasGate` dedup prevents a duplicate synthetic node; `executedOutputSpans` bridges Chat Output from live `flowPool` only during the resume window (deduped by name).
 - `hitlStore.ts`: in-memory only (`pending` slot); `localStorage`/`persist` removed.
+- Answered-card propagation: the chat's session cache is a subscription-only query (`staleTime: Infinity`, fed by `setQueryData`), so `invalidateQueries` cannot refresh it and it re-hydrates from the backend only while empty. A decision taken on another surface — canvas badge, trace bar, another tab — is therefore adopted on load by `withAnsweredHumanInputCards` (`human-input-card.ts`), which stamps `submitted_action` from the backend copy onto cards the cache still shows as open. Without it an answered pause keeps rendering its buttons until a full page reload.
 
 ### 6.7 lfx serve durable mode (LE-1695)
 

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/__tests__/use-chat-history.test.ts
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/__tests__/use-chat-history.test.ts
@@ -22,6 +22,8 @@ jest.mock("@/stores/playgroundStore", () => ({
     selector({ isOpen: true }),
 }));
 
+import { findHumanInputContent } from "@/controllers/API/agui/human-input-card";
+import type { Message } from "@/types/messages";
 import { useChatHistory } from "../use-chat-history";
 
 const createWrapper = (queryClient: QueryClient) => {
@@ -102,5 +104,83 @@ describe("useChatHistory message ordering", () => {
 
     expect(prepended).toBe(0);
     expect(mockGetMessages).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useChatHistory answered HITL cards", () => {
+  const sessionCacheKey = [
+    "useGetMessagesQuery",
+    { id: "flow-1", session_id: "session-1" },
+  ];
+
+  const card = (submittedAction?: string) => ({
+    id: "card-1",
+    flow_id: "flow-1",
+    session_id: "session-1",
+    sender: "Machine",
+    text: "",
+    content_blocks: [
+      {
+        type: "group",
+        contents: [
+          {
+            type: "human_input",
+            request_id: "HumanInput-x:run-1",
+            options: [{ action_id: "tibia", label: "Tibia" }],
+            ...(submittedAction ? { submitted_action: submittedAction } : {}),
+          },
+        ],
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMessages.mockResolvedValue({ data: [] });
+  });
+
+  it("adopts the answered state when the decision was made on another surface", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // The playground was open before the pause, so its cache already holds the
+    // unanswered card; the decision was then taken from the canvas badge and only
+    // the backend knows about it.
+    queryClient.setQueryData(sessionCacheKey, [card()]);
+    mockUseGetMessagesQuery.mockReturnValue({
+      data: { rows: { data: [card("world_of_warcraft")] } },
+    });
+
+    renderHook(() => useChatHistory("session-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {});
+
+    const cached = queryClient.getQueryData<Message[]>(sessionCacheKey) ?? [];
+    expect(
+      findHumanInputContent(cached[0]?.content_blocks)?.submitted_action,
+    ).toBe("world_of_warcraft");
+  });
+
+  it("does not clobber a card the cache already answered", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(sessionCacheKey, [card("tibia")]);
+    mockUseGetMessagesQuery.mockReturnValue({
+      data: { rows: { data: [card()] } },
+    });
+
+    renderHook(() => useChatHistory("session-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {});
+
+    const cached = queryClient.getQueryData<Message[]>(sessionCacheKey) ?? [];
+    expect(
+      findHumanInputContent(cached[0]?.content_blocks)?.submitted_action,
+    ).toBe("tibia");
   });
 });

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-chat-history.ts
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-chat-history.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGetFlowId } from "@/components/core/playgroundComponent/hooks/use-get-flow-id";
+import { withAnsweredHumanInputCards } from "@/controllers/API/agui/human-input-card";
 import {
   getMessages,
   useGetMessagesQuery,
@@ -70,7 +71,6 @@ export const useChatHistory = (visibleSession: string | null) => {
     refetchOnWindowFocus: false,
   });
 
-  // Initialize cache with backend messages on first load (only if cache is empty)
   useEffect(() => {
     if (queryData && typeof queryData === "object" && "rows" in queryData) {
       const rowsData = queryData.rows as { data?: Message[] } | undefined;
@@ -86,6 +86,12 @@ export const useChatHistory = (visibleSession: string | null) => {
         if (existingCache.length === 0 && backendMessages.length > 0) {
           queryClient.setQueryData(sessionCacheKey, backendMessages);
           offsetRef.current = backendMessages.length;
+        } else if (existingCache.length > 0) {
+          const reconciled = withAnsweredHumanInputCards(
+            existingCache,
+            backendMessages,
+          );
+          if (reconciled) queryClient.setQueryData(sessionCacheKey, reconciled);
         }
       }
     }

--- a/src/frontend/src/controllers/API/agui/human-input-card.ts
+++ b/src/frontend/src/controllers/API/agui/human-input-card.ts
@@ -154,25 +154,30 @@ export function isHumanInputCardAnswered(
  * selection is derived from a stable source — local React state is lost when the
  * resume reattach replays the stream and re-renders the message list.
  */
+function stampSubmittedAction(
+  blocks: ContentBlockItem[] | undefined,
+  actionId: string,
+): ContentBlockItem[] {
+  return (blocks ?? []).map((block) => {
+    if (block.type === "human_input")
+      return { ...block, submitted_action: actionId };
+    const contents = (block as ContentBlock).contents;
+    if (!Array.isArray(contents)) return block;
+    return {
+      ...block,
+      contents: contents.map((c) =>
+        c?.type === "human_input" ? { ...c, submitted_action: actionId } : c,
+      ),
+    };
+  });
+}
+
 export function markHumanInputSubmitted(
   requestId: string,
   actionId: string,
 ): void {
-  const stampBlocks = (
-    blocks: ContentBlockItem[] | undefined,
-  ): ContentBlockItem[] =>
-    (blocks ?? []).map((block) => {
-      if (block.type === "human_input")
-        return { ...block, submitted_action: actionId };
-      const contents = (block as ContentBlock).contents;
-      if (!Array.isArray(contents)) return block;
-      return {
-        ...block,
-        contents: contents.map((c) =>
-          c?.type === "human_input" ? { ...c, submitted_action: actionId } : c,
-        ),
-      };
-    });
+  const stampBlocks = (blocks: ContentBlockItem[] | undefined) =>
+    stampSubmittedAction(blocks, actionId);
   forEachMessageCache((key, messages) => {
     if (!messages.some((m) => isCardMessageFor(m, requestId))) return;
     queryClient.setQueryData(key, (old: Message[] = []) =>
@@ -193,6 +198,41 @@ export function markHumanInputSubmitted(
       content_blocks: stampBlocks(target.content_blocks),
     });
   }
+}
+
+/**
+ * Adopt decisions the backend already recorded but this cache never saw.
+ *
+ * The chat's session cache is a subscription-only query (staleTime Infinity, fed by
+ * setQueryData) and it re-hydrates from the backend only while empty, so a pause
+ * answered on another surface — the canvas badge, the trace bar, another tab — leaves
+ * an answered card still rendering its buttons until a full page reload.
+ */
+export function withAnsweredHumanInputCards(
+  cachedMessages: Message[],
+  backendMessages: Message[],
+): Message[] | null {
+  const answeredByRequest = new Map<string, string>();
+  for (const message of backendMessages) {
+    const content = findHumanInputContent(message.content_blocks);
+    if (content?.submitted_action)
+      answeredByRequest.set(content.request_id, content.submitted_action);
+  }
+  if (answeredByRequest.size === 0) return null;
+
+  let changed = false;
+  const reconciled = cachedMessages.map((message) => {
+    const content = findHumanInputContent(message.content_blocks);
+    if (!content || content.submitted_action) return message;
+    const action = answeredByRequest.get(content.request_id);
+    if (!action) return message;
+    changed = true;
+    return {
+      ...message,
+      content_blocks: stampSubmittedAction(message.content_blocks, action),
+    };
+  });
+  return changed ? reconciled : null;
 }
 
 /** Render the pause as an interactive card in the chat and flag awaiting-input. */

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -2584,8 +2584,14 @@ class Graph:
         # Check if vertex is conditionally excluded (for conditional routing)
         if vertex_id in self.conditionally_excluded_vertices:
             return False
-        is_active = self.get_vertex(vertex_id).is_active()
-        is_loop = self.get_vertex(vertex_id).is_loop
+        vertex = self.get_vertex(vertex_id)
+        is_active = vertex.is_active()
+        is_loop = vertex.is_loop
+        # A resume keeps the checkpoint's vertices_to_run, so a restored-built vertex stays eligible
+        # and the backward predecessor walk can re-execute it (Chat Input then persists a duplicate
+        # User message). Vertices the resume un-builds have built=False and stay eligible.
+        if not is_loop and vertex.built and vertex_id in self.checkpoint_restored_built_ids:
+            return False
         return self.run_manager.is_vertex_runnable(vertex_id, is_active=is_active, is_loop=is_loop)
 
     def build_run_map(self) -> None:

--- a/src/lfx/tests/unit/graph/checkpoint/test_resume_does_not_reschedule_built.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_resume_does_not_reschedule_built.py
@@ -1,0 +1,98 @@
+"""A resume must never reschedule a vertex the checkpoint restored as built.
+
+``_restore_run_manager`` used to copy ``vertices_to_run`` verbatim from the checkpoint,
+so already-built vertices stayed eligible. ``is_vertex_runnable`` does not consult
+``built``, so the backward walk that looks for runnable predecessors when a successor
+is blocked (``find_runnable_predecessors_for_successor``) could hand an already-built
+vertex back to the build loop. For Chat Input that re-executes the component and
+persists a second User message for the same turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lfx.components.flow_controls.human_input import HumanInput
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.graph.checkpoint.store import InMemoryCheckpointStore
+from lfx.graph.exceptions import GraphPausedException
+from lfx.graph.graph.base import Graph
+from lfx.schema.schema import INPUT_FIELD_NAME
+
+CHAT_INPUT = "chat_input"
+HITL = "hitl1"
+
+
+def _node(component) -> dict:
+    frontend = component.to_frontend_node()
+    return {"id": frontend["id"], "data": frontend["data"]}
+
+
+def _edge(source: str, target: str, handle: str, field: str = "input_value") -> dict:
+    return {
+        "source": source,
+        "target": target,
+        "id": f"{source}-{handle}-{target}",
+        "data": {
+            "sourceHandle": {"dataType": "x", "id": source, "name": handle, "output_types": ["Message"]},
+            "targetHandle": {"fieldName": field, "id": target, "inputTypes": ["Message"], "type": "str"},
+        },
+    }
+
+
+def _pausing_graph() -> Graph:
+    payload = {
+        "nodes": [
+            _node(ChatInput(_id=CHAT_INPUT)),
+            _node(HumanInput(_id=HITL)),
+            _node(ChatOutput(_id="co_approve")),
+            _node(ChatOutput(_id="co_reject")),
+        ],
+        "edges": [
+            _edge(CHAT_INPUT, HITL, "message", field="prompt"),
+            _edge(HITL, "co_approve", "branch_approve"),
+            _edge(HITL, "co_reject", "branch_reject"),
+        ],
+    }
+    graph = Graph.from_payload(payload, flow_id="resume-reschedule")
+    graph.prepare()
+    return graph
+
+
+@pytest.fixture
+async def resumed_graph():
+    """The graph a resume hands to the build loop, with the gated vertex un-built."""
+    store = InMemoryCheckpointStore()
+    graph = _pausing_graph()
+    graph.checkpointing_enabled = True
+    graph.checkpoint_store = store
+    graph._set_inputs([], {INPUT_FIELD_NAME: "hello"}, "chat")
+
+    with pytest.raises(GraphPausedException):
+        await graph.process(fallback_to_env_vars=False)
+
+    checkpoint = await store.load_by_run_id(str(graph.run_id))
+    assert checkpoint is not None
+    resumed = Graph.resume_from_checkpoint(checkpoint, checkpoint_store=store)
+    resumed.get_vertex(HITL).built = False
+    return resumed
+
+
+async def test_built_vertices_are_not_eligible_to_run_again(resumed_graph):
+    assert resumed_graph.get_vertex(CHAT_INPUT).built is True
+    assert resumed_graph.is_vertex_runnable(CHAT_INPUT) is False
+
+
+async def test_no_restored_built_vertex_is_runnable(resumed_graph):
+    """Generalized: the backward walk can reach any built vertex, not just Chat Input."""
+    still_runnable = [v.id for v in resumed_graph.vertices if v.built and resumed_graph.is_vertex_runnable(v.id)]
+    assert still_runnable == []
+
+
+async def test_the_gated_vertex_stays_runnable(resumed_graph):
+    """Guards the tempting wrong fix: pruning built vertices from ``vertices_to_run`` at restore.
+
+    The gated node (and opaque-dropped producers) are built at checkpoint time yet MUST re-run,
+    so eligibility has to read the live ``built`` flag after the resume un-builds them.
+    """
+    assert HITL in resumed_graph.run_manager.vertices_to_run
+    assert resumed_graph.is_vertex_runnable(HITL) is True


### PR DESCRIPTION
## Objective
Stop a HITL resume from re-executing vertices the checkpoint restored as built, which duplicated the user's chat message on every decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkpoint resume behavior so components already completed before pausing are not run again.
  - Prevented duplicate messages and other repeated inputs when workflows resume.
  - Ensured only the intended pending components are scheduled after resuming.

- **Documentation**
  - Clarified resume behavior and scheduling safeguards in the durable execution documentation.
  - Added guidance on how restored completed components are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->