### PR TITLE
fix(frontend): fire logout request when auto-login is disabled

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -1,7 +1,4 @@
-import {
-  IS_AUTO_LOGIN,
-  LANGFLOW_AUTO_LOGIN_OPTION,
-} from "@/constants/constants";
+import { LANGFLOW_AUTO_LOGIN_OPTION } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -19,13 +16,15 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   const { mutate, queryClient } = UseRequestProcessor();
   const cookies = getCookiesInstance();
   const logout = useAuthStore((state) => state.logout);
-  const isAutoLoginEnv = IS_AUTO_LOGIN;
 
   async function logoutUser(): Promise<any> {
+    // Auto-login state is per-backend runtime config, not a build-time constant.
+    // Only skip the server logout when this backend actually runs in auto-login
+    // mode; otherwise the HttpOnly refresh cookie survives and POST /refresh
+    // silently re-authenticates the user after logout.
     const autoLogin =
-      useAuthStore.getState().autoLogin ||
-      getAuthCookie(cookies, LANGFLOW_AUTO_LOGIN_OPTION) === "auto" ||
-      isAutoLoginEnv;
+      useAuthStore.getState().autoLogin === true ||
+      getAuthCookie(cookies, LANGFLOW_AUTO_LOGIN_OPTION) === "auto";
 
     if (autoLogin) {
       return {};

--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -17,7 +17,7 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   const cookies = getCookiesInstance();
   const logout = useAuthStore((state) => state.logout);
 
-  async function logoutUser(): Promise<any> {
+  async function logoutUser(): Promise<unknown> {
     // Auto-login state is per-backend runtime config, not a build-time constant.
     // Only skip the server logout when this backend actually runs in auto-login
     // mode; otherwise the HttpOnly refresh cookie survives and POST /refresh


### PR DESCRIPTION
## Summary

With `LANGFLOW_AUTO_LOGIN=false`, clicking **Logout** did not end the session:

- No `POST /api/v1/logout` was fired by the click.
- The HttpOnly refresh cookie survived (JS can't clear it), so the follow-up `POST /api/v1/refresh` silently re-authenticated the user.
- Result: no redirect to `/login`, and the session survived a page reload.

Under `AUTO_LOGIN=true` the bug was masked (auto-login re-auths anyway). The `logout-flow.spec.ts` E2E specs — which mock auto-login off — hard-failed on this.

## Root cause

`useLogout` (`use-post-logout.ts`) gated the server call on:

```ts
const autoLogin =
  useAuthStore.getState().autoLogin ||
  getAuthCookie(cookies, LANGFLOW_AUTO_LOGIN_OPTION) === "auto" ||
  IS_AUTO_LOGIN;               // build-time constant
```

`IS_AUTO_LOGIN` is baked at build time from the frontend `LANGFLOW_AUTO_LOGIN` env var, which nightly/dev builds don't set — so it is `true` regardless of the backend's runtime configuration. That forced the guard truthy on every logout, short-circuiting before `POST /logout`.

## Fix

Trust the per-backend **runtime** auth state; drop the build-time constant:

```ts
const autoLogin =
  useAuthStore.getState().autoLogin === true ||
  getAuthCookie(cookies, LANGFLOW_AUTO_LOGIN_OPTION) === "auto";
```

Under `AUTO_LOGIN=false`, runtime `autoLogin` is `false` (and the Logout button only renders when it's falsy), so `POST /logout` now fires → backend clears the refresh cookie → `POST /refresh` 401s → the auth guard redirects to `/login`, and reload stays logged out. Genuine auto-login mode (runtime `true` or the `auto` cookie) still skips the server call as before.

## Validation

- Manual: `AUTO_LOGIN=false` instance — Logout now sends `POST /api/v1/logout → 200`, redirects to `/login`; reload stays on the login page.
- Unit: `use-post-logout.test.ts` — 6/6 pass (POST fires when runtime auto-login is off; skipped when the `auto` cookie is present).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling when auto-login is enabled by accurately detecting the current authentication mode at runtime.
  * Preserved existing state resets, cache clearing, and error handling during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->