### PR TITLE
fix(lfx): honor env-file precedence in serve

### DIFF
--- a/src/lfx/src/lfx/cli/commands.py
+++ b/src/lfx/src/lfx/cli/commands.py
@@ -354,7 +354,7 @@ def serve_command(
             typer.echo(f"Error: Environment file '{env_file}' does not exist.", err=True)
             raise typer.Exit(1)
         verbose_print(f"Loading environment variables from: {env_file}")
-        load_dotenv(env_file)
+        load_dotenv(env_file, override=True)
 
     try:
         api_key = get_api_key()

--- a/src/lfx/tests/unit/cli/test_serve.py
+++ b/src/lfx/tests/unit/cli/test_serve.py
@@ -219,6 +219,36 @@ def test_serve_command_inline_json():
         assert isinstance(args[0], dict)
 
 
+def test_serve_command_env_file_overrides_shell_environment(tmp_path):
+    """An explicit --env-file must take precedence over shell environment variables."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("LANGFLOW_API_KEY=from-env-file\n")  # pragma: allowlist secret
+    flow_json = '{"nodes": [], "edges": []}'
+
+    with (
+        patch("lfx.cli.commands.load_flow_from_json") as mock_load,
+        patch("lfx.cli.commands.uvicorn.run"),
+        patch("lfx.cli.commands.is_port_in_use", return_value=False),
+        patch.dict(os.environ, {"LANGFLOW_API_KEY": "from-shell"}),  # pragma: allowlist secret
+    ):
+        import typer
+        from lfx.cli.commands import serve_command
+        from typer.testing import CliRunner
+
+        mock_graph = MagicMock()
+        mock_graph.prepare = MagicMock()
+        mock_graph.nodes = {}
+        mock_load.return_value = mock_graph
+
+        app = typer.Typer()
+        app.command()(serve_command)
+
+        result = CliRunner().invoke(app, ["--flow-json", flow_json, "--env-file", str(env_file)])
+
+        assert result.exit_code == 0, result.stdout
+        assert os.environ["LANGFLOW_API_KEY"] == "from-env-file"  # pragma: allowlist secret
+
+
 class TestBuildRegistryFromDirectory:
     def test_loads_all_json_files(self, tmp_path):
         import asyncio


### PR DESCRIPTION
## Summary

- load `lfx serve --env-file` values with override semantics
- align `lfx serve` with the documented environment-variable precedence and `langflow run`
- add regression coverage for a shell variable that is also defined in the explicit `.env` file

## Root cause

`lfx serve` called `python-dotenv` without `override=True`, so its default behavior preserved existing shell variables even though Langflow documents `.env` values as taking precedence over system environment variables.

## Impact

Users invoking `lfx serve --env-file` or `langflow lfx serve --env-file` now receive the configuration from the explicit file when the same variable was already exported in the shell.

## Validation

- `uv run --no-sync pytest tests/unit/cli/test_serve.py -q` (`50 passed`)
- `uv run --no-sync ruff check src/lfx/cli/commands.py tests/unit/cli/test_serve.py`
- repository pre-commit hooks, including Ruff, formatting, and detect-secrets
- `git diff --check`

Jira: [LE-1878](https://datastax.jira.com/browse/LE-1878)

[LE-1878]: https://datastax.jira.com/browse/LE-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment values provided through `--env-file` now take precedence over existing shell environment variables when starting the server.

* **Tests**
  * Added coverage to verify environment variable precedence during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->