### PR TITLE
fix(security): preserve short-key credential upgrades

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1068,7 +1068,7 @@
         "filename": "src/backend/base/langflow/services/auth/utils.py",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -2301,7 +2301,7 @@
         "filename": "src/backend/tests/unit/test_auth_settings.py",
         "hashed_secret": "0352a8acc949c7df21fec16e566ba9a74e797a97",
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 91,
         "is_secret": false
       },
       {
@@ -2309,7 +2309,7 @@
         "filename": "src/backend/tests/unit/test_auth_settings.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 103,
         "is_secret": false
       },
       {
@@ -2317,7 +2317,7 @@
         "filename": "src/backend/tests/unit/test_auth_settings.py",
         "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
         "is_verified": false,
-        "line_number": 89,
+        "line_number": 109,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-16T21:11:07Z"
+  "generated_at": "2026-07-20T17:11:51Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2253,7 +2253,7 @@
         "filename": "src/backend/tests/unit/services/variable/test_service.py",
         "hashed_secret": "30abc0a833efea23496b4d226fffa2f90c0855c0",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 46,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T17:11:51Z"
+  "generated_at": "2026-07-20T21:20:50Z"
 }

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -53,6 +53,15 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
 
 ### Breaking changes
 
+- Short `LANGFLOW_SECRET_KEY` upgrade compatibility
+
+    Langflow 1.10.1 changed how secrets shorter than 32 characters derive the Fernet key used for encrypted credentials.
+    Langflow 1.11.x retains read compatibility with credentials encrypted by the earlier derivation while continuing to use the current SHA-256 derivation for all new writes.
+
+    If your deployment uses a `LANGFLOW_SECRET_KEY` shorter than 32 characters, keep it unchanged during the initial upgrade so Langflow can continue to decrypt existing credentials.
+    Langflow logs a startup warning for this configuration because short secrets aren't recommended for production.
+    To replace the key, first record or export the stored credentials, set a randomly generated key of at least 32 characters, and then re-enter the credentials; changing the key directly invalidates ciphertext created with the old key.
+
 - Default superuser password removed
 
     Langflow no longer creates or accepts the legacy `langflow`/`langflow` default superuser credentials.

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import jwt
-from cryptography.fernet import Fernet
 from fastapi import HTTPException, Request, WebSocketException, status
 from jwt import InvalidTokenError
 from lfx.log.logger import logger
@@ -55,6 +54,7 @@ from langflow.services.deps import session_scope
 from langflow.services.schema import ServiceType
 
 if TYPE_CHECKING:
+    from cryptography.fernet import Fernet, MultiFernet
     from lfx.services.settings.service import SettingsService
     from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -984,10 +984,14 @@ class AuthService(BaseAuthService):
         return user
 
     def _get_fernet(self) -> Fernet:
-        from langflow.services.auth.utils import ensure_fernet_key
+        from langflow.services.auth.utils import get_fernet
 
-        secret_key: str = self.settings.auth_settings.SECRET_KEY.get_secret_value()
-        return Fernet(ensure_fernet_key(secret_key))
+        return get_fernet(self.settings)
+
+    def _get_decryption_fernet(self) -> Fernet | MultiFernet:
+        from langflow.services.auth.utils import get_fernet_for_decryption
+
+        return get_fernet_for_decryption(self.settings)
 
     def encrypt_api_key(self, api_key: str) -> str:
         fernet = self._get_fernet()
@@ -1016,7 +1020,7 @@ class AuthService(BaseAuthService):
         if not encrypted_api_key.startswith("gAAAAA"):
             return encrypted_api_key
 
-        fernet = self._get_fernet()
+        fernet = self._get_decryption_fernet()
         try:
             return fernet.decrypt(encrypted_api_key.encode()).decode()
         except Exception as primary_exception:  # noqa: BLE001

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import random
 from typing import TYPE_CHECKING, Annotated, Final
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, MultiFernet
 from fastapi import Depends, HTTPException, Request, Security, WebSocket, WebSocketException, status
 from fastapi.security import APIKeyHeader, APIKeyQuery, OAuth2PasswordBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from lfx.log.logger import logger
 from lfx.services.deps import injectable_session_scope, session_scope
+from lfx.services.settings.constants import MINIMUM_SECRET_KEY_LENGTH
 
 from langflow.services.auth.exceptions import (
     AuthenticationError,
@@ -402,20 +404,12 @@ def ensure_fernet_key(secret_key: str) -> bytes:
     For short keys (< 32 chars), the 32-byte key is derived with SHA-256, a
     cryptographic hash. For longer keys, base64 padding is added.
 
-    Security note: short keys previously seeded Python's ``random`` module
-    (``random.seed(secret_key)``) to generate the key bytes. ``random`` is a
-    non-cryptographic Mersenne-Twister PRNG, so the resulting Fernet key was
-    fully predictable from the secret, and seeding it also mutated global PRNG
-    state. SHA-256 is deterministic (so the key stays stable for a given
-    secret) but is not predictable/reversible the way the PRNG output was.
-
-    Deployments that set a ``SECRET_KEY`` shorter than 32 characters will derive
-    a different key than before this fix and must re-enter encrypted secrets
-    (API keys, global variables) after upgrading. The default ``SECRET_KEY`` is
-    a 43-char ``secrets.token_urlsafe(32)`` value and is unaffected.
+    Security note: short keys previously seeded Python's ``random`` module to
+    generate key bytes. New encryption uses SHA-256 so it never depends on a
+    non-cryptographic PRNG or mutates global PRNG state. Short, guessable input
+    remains unsuitable for production; settings validation warns operators.
     """
-    MINIMUM_KEY_LENGTH = 32  # noqa: N806
-    if len(secret_key) < MINIMUM_KEY_LENGTH:
+    if len(secret_key) < MINIMUM_SECRET_KEY_LENGTH:
         digest = hashlib.sha256(secret_key.encode()).digest()  # 32 bytes
         key = base64.urlsafe_b64encode(digest)
     else:
@@ -423,17 +417,41 @@ def ensure_fernet_key(secret_key: str) -> bytes:
     return key
 
 
+def _ensure_legacy_fernet_key(secret_key: str) -> bytes:
+    """Reproduce the pre-1.10.1 short-secret key for decryption only.
+
+    This compatibility key must never be used for encryption. A local PRNG
+    instance reproduces the legacy bytes without mutating global random state.
+    """
+    legacy_random = random.Random(secret_key)  # noqa: S311
+    legacy_bytes = bytes(legacy_random.getrandbits(8) for _ in range(32))
+    return base64.urlsafe_b64encode(legacy_bytes)
+
+
 def get_fernet(settings_service: SettingsService) -> Fernet:
-    """Get a Fernet instance for encryption/decryption.
+    """Get the current Fernet instance used for encryption and decryption."""
+    secret_key: str = settings_service.auth_settings.SECRET_KEY.get_secret_value()
+    return Fernet(ensure_fernet_key(secret_key))
+
+
+def get_fernet_for_decryption(settings_service: SettingsService) -> Fernet | MultiFernet:
+    """Get a Fernet-compatible instance that can read legacy ciphertext.
 
     Args:
         settings_service: Settings service to get the secret key
 
     Returns:
-        Fernet instance for encryption/decryption
+        For short secrets, MultiFernet with the current key first and the
+        pre-1.10.1 key second. This function is used only for decryption; all
+        encryption goes through :func:`get_fernet` and the current key.
     """
     secret_key: str = settings_service.auth_settings.SECRET_KEY.get_secret_value()
-    return Fernet(ensure_fernet_key(secret_key))
+    current_fernet = get_fernet(settings_service)
+    if len(secret_key) >= MINIMUM_SECRET_KEY_LENGTH:
+        return current_fernet
+
+    legacy_fernet = Fernet(_ensure_legacy_fernet_key(secret_key))
+    return MultiFernet([current_fernet, legacy_fernet])
 
 
 def encrypt_api_key(api_key: str, settings_service: SettingsService | None = None) -> str:  # noqa: ARG001

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 import jwt
 import pytest
+from cryptography.fernet import Fernet, InvalidToken
 from fastapi import HTTPException, WebSocketException, status
 from langflow.services.auth.constants import AUTO_LOGIN_WARNING
 from langflow.services.auth.context import (
@@ -471,6 +472,40 @@ def test_encrypt_decrypt_roundtrip_with_short_key(tmp_path):
 
     encrypted = svc.encrypt_api_key("sk-test-key-12345")  # pragma: allowlist secret
     assert svc.decrypt_api_key(encrypted) == "sk-test-key-12345"  # pragma: allowlist secret
+
+
+def test_short_key_decrypts_legacy_ciphertext_without_using_legacy_key_for_new_writes(tmp_path):
+    """Short-key upgrades retain read compatibility without regressing new encryption.
+
+    Before 1.10.1, ``shortkey123`` produced the fixed Fernet key below via
+    ``random.seed(secret)`` and 32 calls to ``random.getrandbits(8)``. The
+    current SHA-256 key must decrypt that legacy ciphertext as a fallback, but
+    encryption must continue to use the SHA-256-derived primary key.
+    """
+    from langflow.services.auth.utils import ensure_fernet_key
+
+    raw_key = "shortkey123"  # pragma: allowlist secret
+    legacy_key = b"qeA9wdDv6i0_4s4YpmYkg7mByqBIVqF5L8On7wINNmo="  # pragma: allowlist secret
+    plaintext = "credential-written-before-1.10.1"  # pragma: allowlist secret
+
+    settings = AuthSettings(CONFIG_DIR=str(tmp_path))
+    settings.SECRET_KEY = SecretStr(raw_key)
+    settings_service = SimpleNamespace(
+        auth_settings=settings,
+        settings=SimpleNamespace(config_dir=str(tmp_path)),
+    )
+    svc = AuthService(settings_service)
+
+    legacy_ciphertext = Fernet(legacy_key).encrypt(plaintext.encode()).decode()
+    assert svc.decrypt_api_key(legacy_ciphertext) == plaintext
+
+    with patch("langflow.services.auth.utils._ensure_legacy_fernet_key") as mock_legacy_derivation:
+        current_ciphertext = svc.encrypt_api_key(plaintext)
+
+    mock_legacy_derivation.assert_not_called()
+    assert Fernet(ensure_fernet_key(raw_key)).decrypt(current_ciphertext.encode()).decode() == plaintext
+    with pytest.raises(InvalidToken):
+        Fernet(legacy_key).decrypt(current_ciphertext.encode())
 
 
 def test_decrypt_api_key_returns_empty_on_undecryptable_token(auth_service: AuthService):

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 from cryptography.fernet import Fernet
+from langflow.services.auth.service import AuthService
 from langflow.services.auth.utils import ensure_fernet_key
 from langflow.services.database.models.variable.model import VariableUpdate
 from langflow.services.deps import get_settings_service
@@ -20,7 +21,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 @pytest.fixture
 def service():
     settings_service = get_settings_service()
-    return DatabaseVariableService(settings_service)
+    auth_service = AuthService(settings_service)
+    with patch("langflow.services.auth.utils.get_auth_service", return_value=auth_service):
+        yield DatabaseVariableService(settings_service)
 
 
 @pytest.fixture

--- a/src/backend/tests/unit/test_auth_settings.py
+++ b/src/backend/tests/unit/test_auth_settings.py
@@ -1,8 +1,13 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from lfx.services.settings.auth import AuthSettings
-from lfx.services.settings.constants import DEFAULT_SUPERUSER, DEFAULT_SUPERUSER_PASSWORD
+from lfx.services.settings.constants import (
+    DEFAULT_SUPERUSER,
+    DEFAULT_SUPERUSER_PASSWORD,
+    SHORT_SECRET_KEY_WARNING,
+)
 from pydantic import SecretStr, ValidationError
 
 
@@ -36,6 +41,21 @@ def test_default_superuser_password_is_empty(tmp_path: Path):
     settings = AuthSettings(CONFIG_DIR=cfg_dir)
     assert settings.SUPERUSER == DEFAULT_SUPERUSER
     assert settings.SUPERUSER_PASSWORD.get_secret_value() == DEFAULT_SUPERUSER_PASSWORD.get_secret_value() == ""
+
+
+def test_short_secret_key_logs_upgrade_warning(tmp_path: Path):
+    with patch("lfx.services.settings.auth.logger") as mock_logger:
+        AuthSettings(CONFIG_DIR=tmp_path.as_posix(), SECRET_KEY=SecretStr("shortkey123"))
+
+    mock_logger.warning.assert_called_once_with(SHORT_SECRET_KEY_WARNING)
+
+
+def test_generated_secret_key_does_not_log_upgrade_warning(tmp_path: Path):
+    with patch("lfx.services.settings.auth.logger") as mock_logger:
+        settings = AuthSettings(CONFIG_DIR=tmp_path.as_posix())
+
+    assert len(settings.SECRET_KEY.get_secret_value()) >= 32
+    mock_logger.warning.assert_not_called()
 
 
 def test_auto_login_false_preserves_username_and_scrubs_password_on_reset(tmp_path: Path):

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -9,7 +9,12 @@ from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from lfx.log.logger import logger
-from lfx.services.settings.constants import DEFAULT_SUPERUSER, DEFAULT_SUPERUSER_PASSWORD
+from lfx.services.settings.constants import (
+    DEFAULT_SUPERUSER,
+    DEFAULT_SUPERUSER_PASSWORD,
+    MINIMUM_SECRET_KEY_LENGTH,
+    SHORT_SECRET_KEY_WARNING,
+)
 from lfx.services.settings.utils import (
     derive_public_key_from_private,
     generate_rsa_key_pair,
@@ -17,6 +22,12 @@ from lfx.services.settings.utils import (
     write_public_key_to_file,
     write_secret_to_file,
 )
+
+
+def _warn_if_secret_key_is_short(value: str | SecretStr) -> None:
+    secret_value = value.get_secret_value() if isinstance(value, SecretStr) else value
+    if len(secret_value) < MINIMUM_SECRET_KEY_LENGTH:
+        logger.warning(SHORT_SECRET_KEY_WARNING)
 
 
 class JWTAlgorithm(str, Enum):
@@ -306,7 +317,9 @@ class AuthSettings(BaseSettings):
 
         if not config_dir:
             logger.debug("No CONFIG_DIR provided, not saving secret key")
-            return value or secrets.token_urlsafe(32)
+            value = value or secrets.token_urlsafe(32)
+            _warn_if_secret_key_is_short(value)
+            return value
 
         secret_key_path = Path(config_dir) / "secret_key"
 
@@ -326,6 +339,7 @@ class AuthSettings(BaseSettings):
             write_secret_to_file(secret_key_path, value)
             logger.debug("Saved secret key")
 
+        _warn_if_secret_key_is_short(value)
         return value if isinstance(value, SecretStr) else SecretStr(value).get_secret_value()
 
     @field_validator("EXTERNAL_AUTH_PROVIDER", mode="before")

--- a/src/lfx/src/lfx/services/settings/constants.py
+++ b/src/lfx/src/lfx/services/settings/constants.py
@@ -5,6 +5,13 @@ DEFAULT_SUPERUSER_PASSWORD = SecretStr("")
 # Only used to detect and rotate credentials created by older releases.
 LEGACY_DEFAULT_SUPERUSER_PASSWORD = SecretStr("langflow")
 
+MINIMUM_SECRET_KEY_LENGTH = 32
+SHORT_SECRET_KEY_WARNING = (
+    "LANGFLOW_SECRET_KEY is shorter than 32 characters. Short secrets are not recommended for production. "  # noqa: S105
+    "Keep this key unchanged during an upgrade so Langflow can read credentials encrypted before 1.10.1, "
+    "then use a planned credential rotation to replace it with a randomly generated key of at least 32 characters."
+)
+
 VARIABLES_TO_GET_FROM_ENVIRONMENT = [
     "COMPOSIO_API_KEY",
     "OPENAI_API_KEY",


### PR DESCRIPTION
## Summary

- preserve decryption of credentials written before 1.10.1 with a short `LANGFLOW_SECRET_KEY`
- keep the SHA-256-derived key as the only encryption path for new values
- warn at settings startup when a configured secret is shorter than 32 characters
- document the safe upgrade and credential-rotation sequence for 1.11.x

The compatibility derivation uses an isolated local PRNG and is reachable only from the decryption path, so it neither mutates global random state nor writes new ciphertext with the legacy key.

## Validation

- reproduced the failure on current `release-1.11.0`: legacy ciphertext encrypted with `shortkey123` raises `InvalidToken` under the current SHA-256 derivation
- 105 auth, settings, API-key decryption, and MCP-encryption tests passed
- targeted Ruff check and format check passed
- all pre-commit hooks passed, including detect-secrets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved access to credentials encrypted with short secret keys during upgrades.
  * Ensured newly encrypted credentials use the current, secure key derivation.

* **User Guidance**
  * Added a startup warning for secret keys shorter than 32 characters.
  * Documented upgrade steps and credential rotation guidance for short keys in the 1.11.x breaking changes release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->