### PR TITLE
fix(api): serve favicon from a dedicated route

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -973,6 +973,22 @@ def setup_static_files(app: FastAPI, static_files_dir: Path) -> None:
     async def api_not_found(_path: str):
         raise HTTPException(status_code=404, detail="Not Found")
 
+    # Serve the favicon from an explicit high-priority route instead of relying on
+    # the low-priority app.frontend() static route. Browsers request /favicon.ico
+    # with an image Accept header, which app.frontend() does not treat as a
+    # navigation request; if the file is ever missed there the request falls
+    # through to the 404 handler, which returns index.html (HTML) and the browser
+    # renders no icon. A dedicated route always answers with the file and the
+    # correct media type, or a clean 404 when it is absent, independent of the
+    # frontend fallback heuristics.
+    favicon_path = static_files_dir / "favicon.ico"
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    async def favicon():
+        if await anyio.Path(favicon_path).exists():
+            return FileResponse(favicon_path, media_type="image/x-icon")
+        raise HTTPException(status_code=404, detail="Not Found")
+
     # FastAPI >=0.138 serves the frontend build as low-priority routes: path
     # operations are matched first, static files only if nothing else matched.
     # fallback="index.html" returns the SPA entrypoint for extensionless


### PR DESCRIPTION
## Summary

Reported: on SQLite the browser favicon was missing, while a PostgreSQL instance rendered it. This adds a dedicated backend route so the favicon serves deterministically regardless of database backend or deployment mode.

## Investigation

The database backend does not gate favicon serving — no middleware, dependency, or worker path is DB-correlated. Verified on a full packaged instance under SQLite that `/favicon.ico` already returns `200 image/x-icon`, and that both the old `StaticFiles(html=True)` mount and the current `app.frontend()` route serve the icon when the file is present. The DB correlation in the report is most plausibly browser favicon caching (the PostgreSQL tab had the icon cached; the fresh SQLite tab did not).

The one real code path that yields a missing favicon: browsers request `/favicon.ico` with an image `Accept` header, which `app.frontend()` does not treat as a navigation request. If the file is ever missed on that low-priority static route, the request falls through to the `404` handler, which returns `index.html` (HTML, `200`) — the browser then cannot parse the response as an icon and renders none.

## Fix

Add an explicit high-priority `/favicon.ico` route in `setup_static_files`:

```python
@app.get("/favicon.ico", include_in_schema=False)
async def favicon():
    if await anyio.Path(favicon_path).exists():
        return FileResponse(favicon_path, media_type="image/x-icon")
    raise HTTPException(status_code=404, detail="Not Found")
```

It answers with the file and the correct media type, independent of the frontend fallback heuristics, `Accept`-header parsing, and worker forking. No new imports (`anyio` / `FileResponse` / `HTTPException` are already used by the surrounding handlers). Purely additive — it only introduces a deterministic path for one asset, so it cannot regress existing routing.

## Validation

- Full packaged app under SQLite, image `Accept` header: `GET /favicon.ico` → `200 image/x-icon`.
- Isolated: present → `200 image/x-icon`; absent → `404` (no HTML shell served for the asset request).
- App boots clean with the route registered.

### How to test

Bypass browser favicon cache with curl (a normal reload will not refetch a favicon):

```bash
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
  -H 'Accept: image/avif,image/webp,*/*' localhost:7861/favicon.ico
# expect: 200 image/x-icon
```

In-browser, hard-reload or use a private window to force a favicon refetch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favicon handling so browsers receive the correct icon when available.
  * Missing favicon files now return a proper 404 response instead of the application’s main page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->