### PR TITLE
fix(assistant): block duplicate flow input on add

### DIFF
--- a/docs/features/langflow-assistant.md
+++ b/docs/features/langflow-assistant.md
@@ -1570,6 +1570,26 @@ With WatsonX configured (9 live models visible in the model-providers modal), th
 
 ---
 
+### ADR-033: Flow-Proposal "Add to Canvas" Withheld on Entry-Point Conflict
+
+**Status**: Accepted
+
+#### Context
+A flow may hold exactly one entry point — a single `ChatInput` **or** a single `Webhook`, never both. The sidebar and the canvas `paste` path already enforce this through the shared rule engine in `utils/componentConstraints.ts`, but the assistant's flow-proposal card offered **Add to canvas** unconditionally, and its handler merged the proposal via `mergeFlowIntoCanvas` → `store.setNodes` — writing the store directly and bypassing `paste`. Accepting a proposal that carried its own `ChatInput` onto a canvas that already had one therefore produced exactly the duplicate the constraint forbids, and the same proposal could be added repeatedly.
+
+#### Decision
+1. `AssistantFlowPreview` reads the current canvas nodes and evaluates every proposal node with `evaluatePlacement` against the types already present. On any violation the **Add to canvas** button is not rendered; **Replace canvas** takes the primary styling and an explanatory notice (`assistant.flowProposalReplaceOnly`, translated in all seven locales) states why.
+2. `handleApplyFlowProposal`'s `add` branch re-applies `filterPlaceableSelection` before merging, so the policy holds even if the button is reached through another path. Dropped nodes take their dangling edges with them.
+
+Non-conflicting proposals (no `ChatInput`/`Webhook`, or a canvas without one) are unaffected — both actions remain available.
+
+#### Key Files
+- `src/frontend/.../assistantPanel/components/assistant-flow-preview.tsx` — conflict evaluation + conditional actions
+- `src/frontend/.../assistantPanel/hooks/use-assistant-chat.ts` — `filterPlaceableSelection` guard on the merge path
+- `src/frontend/src/utils/componentConstraints.ts` — unchanged; the canonical policy both paths consume
+
+---
+
 ## 6. Technical Specification
 
 ### 6.1 Dependencies

--- a/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-flow-preview-io-constraint.test.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-flow-preview-io-constraint.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from "@testing-library/react";
+import { AssistantFlowPreview } from "../assistant-flow-preview";
+
+jest.mock("@xyflow/react", () => ({
+  __esModule: true,
+  ReactFlow: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="react-flow-mock">{children}</div>
+  ),
+  ReactFlowProvider: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Background: () => null,
+}));
+
+let canvasNodes: { id: string; data?: { type?: string } }[] = [];
+jest.mock("@/stores/flowStore", () => {
+  const fn = (selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = { paste: jest.fn(), nodes: canvasNodes };
+    return selector ? selector(state) : state;
+  };
+  fn.getState = () => ({ paste: jest.fn(), nodes: canvasNodes });
+  return { __esModule: true, default: fn };
+});
+
+function previewWith(types: string[]) {
+  return {
+    flow: {
+      name: "Proposal",
+      data: {
+        nodes: types.map((type, i) => ({
+          id: `${type}-${i}`,
+          position: { x: i * 200, y: 0 },
+          data: { type },
+        })),
+        edges: [],
+      },
+    },
+    name: "Proposal",
+    nodeCount: types.length,
+    edgeCount: 0,
+    graph: "",
+  };
+}
+
+function node(id: string, type: string) {
+  return { id, data: { type } };
+}
+
+describe("AssistantFlowPreview flow-IO constraints", () => {
+  beforeEach(() => {
+    canvasNodes = [];
+  });
+
+  it("should_offer_add_to_canvas_when_canvas_has_no_flow_input", () => {
+    canvasNodes = [node("a", "ChatOutput")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["ChatInput", "ChatOutput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("assistant-flow-add-button")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("assistant-flow-replace-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("should_hide_add_to_canvas_when_proposal_chat_input_duplicates_canvas_chat_input", () => {
+    canvasNodes = [node("a", "ChatInput")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["ChatInput", "ChatOutput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("assistant-flow-add-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("assistant-flow-replace-button"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("assistant-flow-dismiss-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("should_hide_add_to_canvas_when_proposal_webhook_conflicts_with_canvas_chat_input", () => {
+    canvasNodes = [node("a", "ChatInput")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["Webhook", "ChatOutput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("assistant-flow-add-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_hide_add_to_canvas_when_proposal_chat_input_conflicts_with_canvas_webhook", () => {
+    canvasNodes = [node("a", "Webhook")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["ChatInput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("assistant-flow-add-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_explain_why_add_to_canvas_is_unavailable", () => {
+    canvasNodes = [node("a", "ChatInput")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["ChatInput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("assistant-flow-replace-only-notice"),
+    ).toBeInTheDocument();
+  });
+
+  it("should_offer_add_to_canvas_when_proposal_has_no_constrained_component", () => {
+    canvasNodes = [node("a", "ChatInput")];
+    render(
+      <AssistantFlowPreview
+        flowPreview={previewWith(["Agent", "ChatOutput"])}
+        status="pending"
+        onApply={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("assistant-flow-add-button")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("assistant-flow-replace-only-notice"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-flow-preview.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-flow-preview.tsx
@@ -7,8 +7,13 @@ import {
 } from "@xyflow/react";
 import { ArrowRight, Check, GitBranch, X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import useAssistantManagerStore from "@/stores/assistantManagerStore";
 import useFlowStore from "@/stores/flowStore";
+import {
+  evaluatePlacement,
+  getPresentComponentTypes,
+} from "@/utils/componentConstraints";
 import type { FlowProposalStatus } from "../assistant-panel.types";
 import {
   GHOST_PRIMARY_BUTTON,
@@ -115,18 +120,46 @@ function extractReactFlowData(flow: Record<string, unknown>): {
   return { nodes, edges };
 }
 
+function proposalConflictsWithCanvas(
+  flow: Record<string, unknown>,
+  canvasNodes: unknown,
+): boolean {
+  const proposalNodes =
+    (flow.data as { nodes?: { data?: { type?: string } }[] } | undefined)
+      ?.nodes ?? [];
+  if (proposalNodes.length === 0) return false;
+
+  const presentTypes = getPresentComponentTypes(
+    Array.isArray(canvasNodes)
+      ? (canvasNodes as { data?: { type?: string } }[])
+      : [],
+  );
+  return proposalNodes.some(
+    (node) => evaluatePlacement(node.data?.type, presentTypes) !== null,
+  );
+}
+
 export function AssistantFlowPreview({
   flowPreview,
   status,
   onApply,
   onDismiss,
 }: AssistantFlowPreviewProps) {
+  const { t } = useTranslation();
   const [showApproved, setShowApproved] = useState(false);
   const paste = useFlowStore((state) => state.paste);
+  const canvasNodes = useFlowStore((state) => state.nodes);
 
   const { nodes, edges } = useMemo(
     () => extractReactFlowData(flowPreview.flow),
     [flowPreview.flow],
+  );
+
+  // Merging a proposal that carries its own entry point into a canvas that
+  // already has one produces the duplicate COMPONENT_CONSTRAINTS forbids.
+  const addWouldConflict = useMemo(
+    () => proposalConflictsWithCanvas(flowPreview.flow, canvasNodes),
+    [flowPreview.flow, canvasNodes],
   );
 
   // The reported node count is authoritative; fall back to the parsed nodes.
@@ -202,6 +235,15 @@ export function AssistantFlowPreview({
         </div>
       )}
 
+      {status === "pending" && addWouldConflict && (
+        <div
+          data-testid="assistant-flow-replace-only-notice"
+          className="mb-2 rounded-md border border-dashed border-border bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground"
+        >
+          {t("assistant.flowProposalReplaceOnly")}
+        </div>
+      )}
+
       {/* Actions */}
       <div className="flex items-center gap-1">{renderActions()}</div>
     </div>
@@ -214,26 +256,31 @@ export function AssistantFlowPreview({
           {/* Primary action: ADD to canvas. Non-destructive, keeps existing
               nodes/edges intact. Keeps the legacy `assistant-flow-continue-button`
               alias so older E2E specs still find it. */}
-          <button
-            type="button"
-            data-testid="assistant-flow-add-button"
-            data-add-button-alias="assistant-flow-continue-button"
-            className={GHOST_PRIMARY_BUTTON}
-            onClick={() => onApply?.("add")}
-          >
-            <span>Add to canvas</span>
-            <ArrowRight className="h-3.5 w-3.5" />
-          </button>
-          {/* Secondary action: REPLACE canvas. Destructive — same muted ghost
-              styling as Dismiss; tooltip carries the destructive intent. */}
+          {!addWouldConflict && (
+            <button
+              type="button"
+              data-testid="assistant-flow-add-button"
+              data-add-button-alias="assistant-flow-continue-button"
+              className={GHOST_PRIMARY_BUTTON}
+              onClick={() => onApply?.("add")}
+            >
+              <span>Add to canvas</span>
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
+          )}
+          {/* Destructive — promoted to primary styling when it is the only
+              way to apply the proposal. */}
           <button
             type="button"
             data-testid="assistant-flow-replace-button"
-            className={GHOST_SECONDARY_BUTTON}
+            className={
+              addWouldConflict ? GHOST_PRIMARY_BUTTON : GHOST_SECONDARY_BUTTON
+            }
             onClick={() => onApply?.("replace")}
             title="Discard the current canvas and replace it with this flow"
           >
             <span>Replace canvas</span>
+            {addWouldConflict && <ArrowRight className="h-3.5 w-3.5" />}
           </button>
           <button
             type="button"

--- a/src/frontend/src/components/core/assistantPanel/hooks/__tests__/use-assistant-chat.test.ts
+++ b/src/frontend/src/components/core/assistantPanel/hooks/__tests__/use-assistant-chat.test.ts
@@ -1045,6 +1045,71 @@ describe("useAssistantChat", () => {
       expect(arg).toHaveLength(1 + FRESH_FLOW.data.nodes.length);
       expect(arg[0].id).toBe("Existing-1");
     });
+
+    it("should_drop_conflicting_flow_input_when_mode_is_add", async () => {
+      _mockNodes = [
+        {
+          id: "ChatInput-old",
+          position: { x: 0, y: 0 },
+          data: { type: "ChatInput" },
+        },
+      ];
+      _mockEdges = [];
+
+      const CONFLICTING_FLOW = {
+        name: "Conflicting",
+        data: {
+          nodes: [
+            {
+              id: "ChatInput-new",
+              position: { x: 0, y: 0 },
+              data: { type: "ChatInput" },
+            },
+            {
+              id: "Agent-new",
+              position: { x: 200, y: 0 },
+              data: { type: "Agent" },
+            },
+          ],
+          edges: [{ id: "e1", source: "ChatInput-new", target: "Agent-new" }],
+        },
+      };
+
+      mockPostAssistStream.mockImplementation(
+        async (_req: unknown, callbacks: Record<string, Function>) => {
+          callbacks.onFlowUpdate({
+            event: "flow_update",
+            action: "set_flow",
+            flow: CONFLICTING_FLOW,
+          });
+        },
+      );
+
+      const { result } = renderHook(() => useAssistantChat());
+      await act(async () => {
+        await result.current.handleSend("build a flow", TEST_MODEL);
+      });
+      const msg = result.current.messages[1];
+
+      mockSetNodes.mockClear();
+      mockSetEdges.mockClear();
+
+      act(() => {
+        result.current.handleApplyFlowProposal(msg.id, "add");
+      });
+
+      const nodesArg = mockSetNodes.mock.calls[0][0] as Array<{
+        id: string;
+        data?: { type?: string };
+      }>;
+      expect(nodesArg.filter((n) => n.data?.type === "ChatInput")).toHaveLength(
+        1,
+      );
+      expect(nodesArg.map((n) => n.id)).toContain("ChatInput-old");
+
+      const edgesArg = mockSetEdges.mock.calls[0][0] as Array<{ id: string }>;
+      expect(edgesArg).toHaveLength(0);
+    });
   });
 
   describe("flow proposal gating (set_flow only)", () => {

--- a/src/frontend/src/components/core/assistantPanel/hooks/use-assistant-chat.ts
+++ b/src/frontend/src/components/core/assistantPanel/hooks/use-assistant-chat.ts
@@ -15,6 +15,7 @@ import useAssistantManagerStore from "@/stores/assistantManagerStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import type { APIClassType } from "@/types/api";
+import { filterPlaceableSelection } from "@/utils/componentConstraints";
 import type {
   AssistantMessage,
   AssistantModel,
@@ -781,6 +782,12 @@ export function useAssistantChat(): UseAssistantChatReturn {
             source: string;
             target: string;
           }>) ?? [];
+        // Re-applied here because this merge writes the store directly
+        // instead of going through `paste`, which enforces the same policy.
+        const placeable = filterPlaceableSelection(
+          { nodes: proposalNodes as never[], edges: proposalEdges as never[] },
+          store.nodes as Array<{ data?: { type?: string } }>,
+        );
         const merged = mergeFlowIntoCanvas(
           store.nodes as Array<{
             id: string;
@@ -791,7 +798,7 @@ export function useAssistantChat(): UseAssistantChatReturn {
             source: string;
             target: string;
           }>,
-          { nodes: proposalNodes, edges: proposalEdges },
+          { nodes: placeable.nodes, edges: placeable.edges },
         );
         store.setNodes(merged.nodes as never[]);
         store.setEdges(merged.edges as never[]);

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "Max. Sitzungen",
   "assistant.maxSessionsTooltip": "Die maximale Anzahl von {{max}} -Sitzungen wurde erreicht. Löschen Sie eine Sitzung, um eine neue zu erstellen.",
   "assistant.mentionNoMatches": "Keine passenden Komponenten auf der Arbeitsfläche",
+  "assistant.flowProposalReplaceOnly": "Dieser Flow enthält einen Chat Input oder Webhook und Ihre Arbeitsfläche hat bereits einen. Ein Flow kann nur einen haben. Ersetzen Sie die Arbeitsfläche, um diesen Flow zu verwenden.",
   "assistant.messageCounts": "{{count}} Nachrichten",
   "assistant.newConversation": "Neue Konversation",
   "assistant.newPill": "Neu",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1297,6 +1297,7 @@
   "assistant.messageCounts": "{{count}} msgs",
   "assistant.workingOnIt": "Working on it...",
   "assistant.mentionNoMatches": "No matching components on the canvas",
+  "assistant.flowProposalReplaceOnly": "This flow includes a Chat Input or Webhook and your canvas already has one. A flow can only have one. Replace the canvas to use this flow.",
   "assistant.title": "Langflow Assistant",
   "assistant.user": "User",
   "sidebar.mcpNewBadge": "New",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "Máx. sesiones",
   "assistant.maxSessionsTooltip": "Se ha alcanzado el límite de sesiones de {{max}}. Elimina una sesión para crear una nueva.",
   "assistant.mentionNoMatches": "No hay componentes coincidentes en el lienzo",
+  "assistant.flowProposalReplaceOnly": "Este flujo incluye un Chat Input o Webhook y tu lienzo ya tiene uno. Un flujo solo puede tener uno. Reemplaza el lienzo para usar este flujo.",
   "assistant.messageCounts": "{{count}} mensajes",
   "assistant.newConversation": "Nueva conversación",
   "assistant.newPill": "Nuevo",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "Nbre max. de sessions",
   "assistant.maxSessionsTooltip": "Le nombre maximal de sessions d' {{max}} s a été atteint. Supprimez une session pour en créer une nouvelle.",
   "assistant.mentionNoMatches": "Aucun composant correspondant sur le canevas",
+  "assistant.flowProposalReplaceOnly": "Ce flux comprend un Chat Input ou un Webhook et votre canevas en possède déjà un. Un flux ne peut en avoir qu'un seul. Remplacez le canevas pour utiliser ce flux.",
   "assistant.messageCounts": "{{count}} messages",
   "assistant.newConversation": "Nouvelle conversation",
   "assistant.newPill": "Nouveau",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "セッションの最大数",
   "assistant.maxSessionsTooltip": "{{max}} セッションの上限に達しました。 セッションを削除して、新しいセッションを作成します。",
   "assistant.mentionNoMatches": "キャンバス上に一致するコンポーネントがありません",
+  "assistant.flowProposalReplaceOnly": "このフローには Chat Input または Webhook が含まれていますが、キャンバスには既に存在します。フローに設定できるのは 1 つだけです。このフローを使用するにはキャンバスを置き換えてください。",
   "assistant.messageCounts": "{{count}} メッセージ",
   "assistant.newConversation": "新規会話",
   "assistant.newPill": "新規",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "Máximo de sessões",
   "assistant.maxSessionsTooltip": "Atingido o limite máximo de {{max}} sessões. Exclua uma sessão para criar uma nova.",
   "assistant.mentionNoMatches": "Não há componentes correspondentes na tela",
+  "assistant.flowProposalReplaceOnly": "Este fluxo inclui um Chat Input ou Webhook e sua tela já possui um. Um fluxo só pode ter um. Substitua a tela para usar este fluxo.",
   "assistant.messageCounts": "{{count}} mensagens",
   "assistant.newConversation": "Nova conversa",
   "assistant.newPill": "Novo",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -73,6 +73,7 @@
   "assistant.maxSessionsLabel": "最大会话数",
   "assistant.maxSessionsTooltip": "已达到 {{max}} 会话的上限。 删除当前会话以创建新会话。",
   "assistant.mentionNoMatches": "画布上没有匹配的组件",
+  "assistant.flowProposalReplaceOnly": "此流程包含 Chat Input 或 Webhook，而您的画布中已有一个。一个流程只能有一个。请替换画布以使用此流程。",
   "assistant.messageCounts": "{{count}} msgs",
   "assistant.newConversation": "新建对话",
   "assistant.newPill": "新",


### PR DESCRIPTION
A flow may hold exactly one entry point — a single `ChatInput` **or** a single `Webhook`, never both. The sidebar and the canvas `paste` path already enforce this via the shared rule engine in `utils/componentConstraints.ts`, but the Assistant's flow-proposal card did not.

**Add to canvas** was rendered unconditionally, and its handler merged the proposal with `mergeFlowIntoCanvas` → `store.setNodes`, writing the store **directly** and bypassing `paste()` — where the constraint lives. `mergeFlowIntoCanvas` only remaps colliding IDs and offsets positions; it knows nothing about component constraints. So accepting a proposal that carried its own `ChatInput` onto a canvas that already had one produced exactly the duplicate the rule forbids, and the same proposal could be added over and over.

## Changes

- **`assistant-flow-preview.tsx`** — reads the current canvas nodes and evaluates every proposal node with `evaluatePlacement` against the types already present. On conflict, **Add to canvas** is not rendered; **Replace canvas** takes the primary styling and a notice explains why.
- **`use-assistant-chat.ts`** — the `add` branch re-applies `filterPlaceableSelection` before merging, so the policy holds even if the button is reached through another path. Dropped nodes take their dangling edges with them.
- **`componentConstraints.ts`** — unchanged. It stays the single source of truth; this PR just makes the Assistant consume it.

Non-conflicting proposals are unaffected — both actions remain available.

## i18n

New key `assistant.flowProposalReplaceOnly`, added to all seven locale files (de, en, es, fr, ja, pt, zh-Hans).

## Tests

- `assistant-flow-preview-io-constraint.test.tsx` — 6 new tests covering conflict/no-conflict for ChatInput↔ChatInput, Webhook↔ChatInput, ChatInput↔Webhook, and unconstrained proposals. Confirmed RED before the fix (4 failing).
- `use-assistant-chat.test.ts` — `should_drop_conflicting_flow_input_when_mode_is_add` covers the store-level guard.

Full frontend suite green: 468 suites / 5439 tests.

## Notes

`use-assistant-chat.ts` still trips the repo's file-size (747 vs 700 lines) and comment-density hooks. Both were already failing at baseline (743 lines) — splitting that file is a refactor that doesn't belong in this fix.

Docs: ADR-033 added to `docs/features/langflow-assistant.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant flow proposals now detect conflicting Chat Input or Webhook components already on the canvas.
  * The “Add to canvas” option is hidden when conflicts exist, with “Replace canvas” presented as the available action.
  * Conflicting nodes and their disconnected edges are excluded when adding compatible proposals.
  * Added localized conflict guidance across supported languages.

* **Bug Fixes**
  * Prevented duplicate entry-point components from being added to a canvas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->