### PR TITLE
fix(frontend): unclip file delete button

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/input-wrapper.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/input-wrapper.tsx
@@ -46,7 +46,9 @@ const InputWrapper = ({
   isAudioSupported,
 }: InputWrapperProps) => {
   const { t } = useTranslation();
-  const classNameFilePreview = `flex w-full items-center gap-2 py-2 overflow-auto`;
+  // Padding reserves room for the delete button, which overhangs each
+  // thumbnail and would otherwise be clipped by the scroll container.
+  const classNameFilePreview = `flex w-full items-center gap-3 overflow-auto px-2 pb-2 pt-3`;
 
   const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/utils/file-preview-display.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/utils/file-preview-display.tsx
@@ -86,38 +86,42 @@ export default function FilePreviewDisplay({
     return (
       <div
         className={cn(
-          "relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-xl border border-border/70 bg-primary-foreground shadow-sm",
+          "relative h-16 w-16 shrink-0 rounded-xl border border-border/70 bg-primary-foreground shadow-sm",
           error && "border-error",
           className,
         )}
       >
-        {loading ? (
-          <Loading className="h-4 w-4" />
-        ) : previewUrl && !imageError ? (
-          <img
-            src={previewUrl}
-            alt={fileInfo.name}
-            className="h-full w-full rounded-xl object-cover p-1"
-            crossOrigin={file instanceof File ? undefined : "use-credentials"}
-            onError={() => {
-              setImageError(true);
-              console.error("Failed to load image:", previewUrl);
-            }}
-          />
-        ) : (
-          <div className="p-3">
-            <ForwardedIconComponent name="File" className="h-6 w-6" />
-          </div>
-        )}
+        {/* Clipping lives on this inner box so the delete button, which sits
+            outside the thumbnail bounds, is not cut off by overflow-hidden. */}
+        <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl">
+          {loading ? (
+            <Loading className="h-4 w-4" />
+          ) : previewUrl && !imageError ? (
+            <img
+              src={previewUrl}
+              alt={fileInfo.name}
+              className="h-full w-full rounded-xl object-cover p-1"
+              crossOrigin={file instanceof File ? undefined : "use-credentials"}
+              onError={() => {
+                setImageError(true);
+                console.error("Failed to load image:", previewUrl);
+              }}
+            />
+          ) : (
+            <div className="p-3">
+              <ForwardedIconComponent name="File" className="h-6 w-6" />
+            </div>
+          )}
+        </div>
 
         {showDelete && onDelete && (
           <button
             onClick={onDelete}
-            className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             type="button"
             aria-label={t("playgroundComponent.deleteFile")}
           >
-            <ForwardedIconComponent name="X" className="h-3 w-3" />
+            <ForwardedIconComponent name="X" className="h-3.5 w-3.5" />
           </button>
         )}
       </div>


### PR DESCRIPTION
The file-preview thumbnail in the Playground carried `overflow-hidden` on its outer box, but the delete button is positioned **outside** that box (`-right-2 -top-2`). The result was a delete button clipped by its own container.

## Changes

**`file-preview-display.tsx`**
- Clipping moved to an inner wrapper that holds the image/icon, so the outer box no longer cuts off absolutely-positioned children. The thumbnail still clips exactly as before.
- Outer box gains `shrink-0` so the preview keeps its 16×16 footprint in flex rows instead of being squeezed.
- Delete button grows from `h-5 w-5` to `h-6 w-6` and gains `shadow-sm` — it sits over image content, so it needs the separation to stay legible.
- Adds a visible focus ring (`focus-visible:ring-2 ring-ring ring-offset-2`), which the button previously lacked.

**`input-wrapper.tsx`** — spacing adjustment so the now-unclipped button has room and does not collide with neighbouring content.

## Notes

Styling and layout only — no behavior, props, or API change. The existing `aria-label={t("playgroundComponent.deleteFile")}` is untouched, and the focus ring closes a keyboard-accessibility gap rather than introducing one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file preview layout and spacing in the chat input.
  * Prevented delete buttons from being clipped in compact file previews.
  * Enhanced delete button visibility, focus styling, and click target size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->