### PR TITLE
fix(ssrf): re-check IPv4 embedded in 6to4 / NAT64 addresses

### DIFF
--- a/src/lfx/src/lfx/utils/ssrf_protection.py
+++ b/src/lfx/src/lfx/utils/ssrf_protection.py
@@ -171,6 +171,28 @@ def is_host_allowed(hostname: str, ip: str | None = None) -> bool:
     return False
 
 
+# Transition prefixes that embed an IPv4 target. Their embedded IPv4 is re-checked against the
+# blocklist (below) rather than blocking the whole prefix, which would cut off legitimate public
+# egress on IPv6-only / DNS64 networks (where public IPv4 services are reached via 64:ff9b::/96).
+_SIXTO4_PREFIX = ipaddress.ip_network("2002::/16")
+_NAT64_WELL_KNOWN_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _embedded_ipv4(ip_obj: ipaddress.IPv6Address) -> ipaddress.IPv4Address | None:
+    """Return the IPv4 embedded in a 6to4 or well-known NAT64 address, else None.
+
+    6to4 (RFC 3056) carries the IPv4 in bytes 2-5 (``2002:AABB:CCDD::/48`` -> ``AA.BB.CC.DD``); the
+    NAT64 well-known ``64:ff9b::/96`` (RFC 6052) carries it in the low 32 bits. Local-use NAT64
+    (``64:ff9b:1::/48``, RFC 8215) uses a deployment-chosen prefix length, so its embedded IPv4
+    can't be located reliably and isn't decoded here.
+    """
+    if ip_obj in _SIXTO4_PREFIX:
+        return ipaddress.IPv4Address(ip_obj.packed[2:6])
+    if ip_obj in _NAT64_WELL_KNOWN_PREFIX:
+        return ipaddress.IPv4Address(ip_obj.packed[12:16])
+    return None
+
+
 def is_ip_blocked(ip: str | ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Check if an IP address is in a blocked range.
 
@@ -182,12 +204,23 @@ def is_ip_blocked(ip: str | ipaddress.IPv4Address | ipaddress.IPv6Address) -> bo
     """
     try:
         ip_obj = ipaddress.ip_address(ip) if isinstance(ip, str) else ip
-
-        # Check against all blocked ranges
-        return any(ip_obj in blocked_range for blocked_range in get_blocked_ip_ranges())
     except (ValueError, ipaddress.AddressValueError):
         # If we can't parse the IP, treat it as blocked for safety
         return True
+
+    # Check against all blocked ranges
+    if any(ip_obj in blocked_range for blocked_range in get_blocked_ip_ranges()):
+        return True
+
+    # A 6to4 / NAT64 address is only as safe as the IPv4 it encodes: re-check the embedded IPv4
+    # so a transition prefix can't reach a blocked target, while a public IPv4 target (the
+    # legitimate NAT64/6to4 case) still passes.
+    if isinstance(ip_obj, ipaddress.IPv6Address):
+        embedded = _embedded_ipv4(ip_obj)
+        if embedded is not None:
+            return is_ip_blocked(embedded)
+
+    return False
 
 
 def resolve_hostname(hostname: str) -> list[str]:

--- a/src/lfx/tests/unit/utils/test_ssrf_protection.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_protection.py
@@ -137,6 +137,11 @@ class TestIPBlocking:
             "fc00::1",  # ULA
             "fe80::1",  # Link-local
             "ff00::1",  # Multicast
+            # IPv6 transition prefixes whose embedded IPv4 is blocked (decoded + re-checked, SSRF)
+            "2002:a9fe:a9fe::1",  # 6to4 of 169.254.169.254 (metadata)
+            "2002:0a00:0005::1",  # 6to4 of 10.0.0.5 (RFC 1918)
+            "64:ff9b::a9fe:a9fe",  # NAT64 of 169.254.169.254 (metadata)
+            "64:ff9b::169.254.169.254",  # NAT64 dotted form of metadata
         ],
     )
     def test_blocked_ips(self, ip):
@@ -155,6 +160,10 @@ class TestIPBlocking:
             # Public IPv6 addresses
             "2001:4860:4860::8888",  # Google DNS
             "2606:4700:4700::1111",  # Cloudflare DNS
+            # Transition prefixes encoding a *public* IPv4 must stay reachable (IPv6-only / DNS64)
+            "64:ff9b::8.8.8.8",  # NAT64 of 8.8.8.8 (public)
+            "64:ff9b::0808:0808",  # NAT64 of 8.8.8.8, hextet form
+            "2002:0808:0808::1",  # 6to4 of 8.8.8.8 (public)
         ],
     )
     def test_allowed_ips(self, ip):


### PR DESCRIPTION
## Summary

`is_ip_blocked` blocks literal and IPv4-mapped internal addresses, but not the IPv6 transition-prefix encodings of the same targets. A 6to4 (`2002::/16`) or NAT64 well-known (`64:ff9b::/96`) address can encode a blocked IPv4 (loopback, RFC 1918, or cloud metadata `169.254.169.254`), and those fell through as not-blocked. `is_ip_blocked` backs the shared SSRF floor (A2A client off-origin hop, connectors, Docling, MCP, etc.), so a caller-controlled URL could reach an internal/metadata target through a disguised address.

## Fix

Decode the IPv4 embedded in a 6to4 or well-known NAT64 address and re-check it against the existing IPv4 blocklist, rather than blocking the whole prefix. This blocks a transition address whose embedded IPv4 is internal, while leaving transition addresses that encode a *public* IPv4 reachable, so IPv6-only / DNS64 deployments that reach public IPv4-only services via `64:ff9b::/96` are unaffected.

- 6to4 (RFC 3056): IPv4 is bytes 2-5.
- NAT64 well-known `64:ff9b::/96` (RFC 6052): IPv4 is the low 32 bits.
- Local-use NAT64 (`64:ff9b:1::/48`, RFC 8215) uses a deployment-chosen prefix length, so its embedded IPv4 can't be located reliably; it isn't decoded.

## Tests

Blocked: 6to4/NAT64 of metadata and RFC 1918. Allowed: 6to4/NAT64 of a public IPv4 (8.8.8.8), alongside the existing public IPv4/IPv6 cases.

## Notes

Reaching the target still needs the host network to route 6to4 (a relay) or NAT64 (a gateway), so in most environments this is defense-in-depth. Surfaced during QA of the 1.11.0 release candidate.
