### PR TITLE
fix(mcp): rebuild incomplete structured tools

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import sys
 from contextlib import suppress
+from typing import get_type_hints
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -3804,6 +3805,26 @@ class TestConvertMcpResult:
         assert converted[0]["type"] == "text"
         # Must be valid JSON
         json.loads(converted[0]["text"])
+
+
+def test_mcp_structured_tool_annotations_resolve_in_util_namespace():
+    """Keep LangChain's inherited forward annotations resolvable for Pydantic."""
+    from langchain_core.tools import StructuredTool
+
+    annotation_proxy = type(
+        "MCPStructuredToolAnnotations",
+        (),
+        {"__annotations__": StructuredTool.__annotations__},
+    )
+
+    resolved = get_type_hints(
+        annotation_proxy,
+        globalns=vars(util),
+        localns=vars(util),
+        include_extras=True,
+    )
+
+    assert set(StructuredTool.__annotations__) <= set(resolved)
 
 
 class TestMCPStructuredToolToolCallId:

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -9,7 +9,7 @@ import shutil
 import unicodedata
 from collections.abc import AsyncIterator, Awaitable, Callable
 from types import UnionType
-from typing import Any, TypedDict, Union, get_args, get_origin
+from typing import Annotated, Any, TypedDict, Union, get_args, get_origin
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -17,10 +17,10 @@ import httpx
 from anyio import ClosedResourceError
 from httpx import codes as httpx_codes
 from langchain_core.runnables import RunnableConfig
-from langchain_core.tools import StructuredTool
+from langchain_core.tools import ArgsSchema, StructuredTool
 from mcp import ClientSession
 from mcp.shared.exceptions import McpError
-from pydantic import BaseModel
+from pydantic import BaseModel, SkipValidation
 
 from lfx.base.agents.utils import maybe_unflatten_dict
 from lfx.base.mcp import security as mcp_security
@@ -2388,6 +2388,15 @@ async def update_tools(
                         if key not in schema_fields and key not in normalized:
                             normalized[key] = value
                     return normalized
+
+            if not MCPStructuredTool.__pydantic_complete__:
+                MCPStructuredTool.model_rebuild(
+                    _types_namespace={
+                        "Annotated": Annotated,
+                        "ArgsSchema": ArgsSchema,
+                        "SkipValidation": SkipValidation,
+                    }
+                )
 
             tool_obj = MCPStructuredTool(
                 name=tool.name,


### PR DESCRIPTION
## Summary

- make LangChain's inherited `StructuredTool` annotation namespace available to the inline `MCPStructuredTool`
- rebuild the subclass only when Pydantic still marks it incomplete
- add regression coverage for resolving the inherited forward annotations from the Langflow MCP utility module

## Root cause

#14159 repaired MCP SDK request and RootModel compatibility, but this screenshot follows a separate model-construction path. With Pydantic 2.14.0a1, the inline `MCPStructuredTool` subclass re-evaluates LangChain's inherited forward annotations in `lfx.base.mcp.util`. That namespace did not define `Annotated`, `ArgsSchema`, or `SkipValidation`, so tool discovery failed while instantiating the wrapper.

## Impact

MCP server tool discovery can again construct LangChain tool wrappers under the affected Pydantic version, allowing the MCP Tools component to populate its tool list.

## Validation

- reproduced the exact `MCPStructuredTool is not fully defined` failure with Pydantic 2.14.0a1 and LangChain Core 1.4.9
- 6 focused MCP structured-tool tests passed under Pydantic 2.14.0a1
- 227 MCP utility tests passed under the release environment (7 integration tests skipped)
- Ruff check and format passed
- repository pre-commit hooks, including detect-secrets, passed
- verified the compatibility imports against the minimum supported LangChain Core 1.2.28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading MCP tools with dynamically generated type annotations.
  * Resolved an issue that could prevent certain structured tools from being initialized correctly at runtime.

* **Tests**
  * Added coverage to verify structured tool annotations resolve successfully in the MCP utility context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->