### PR TITLE
fix(mcp): reap cancelled session transports

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -286,6 +286,38 @@ class TestMCPSessionManager:
         # Clean up after test
         await manager.cleanup_all()
 
+    async def test_cancelled_stdio_session_creation_closes_transport(self, session_manager):
+        """Cancelling session creation must also stop its detached transport task."""
+        initialize_started = asyncio.Event()
+        never_ready = asyncio.Event()
+
+        async def initialize():
+            initialize_started.set()
+            await never_ready.wait()
+
+        session = MagicMock()
+        session.initialize = AsyncMock(side_effect=initialize)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+
+        transport = MagicMock()
+        transport.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+        transport.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("mcp.client.stdio.stdio_client", return_value=transport),
+            patch("lfx.base.mcp.util.ClientSession", return_value=session),
+        ):
+            creation = asyncio.create_task(session_manager._create_stdio_session("test_session", MagicMock()))
+            await initialize_started.wait()
+            creation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await creation
+            await asyncio.sleep(0)
+
+        session.__aexit__.assert_awaited_once()
+        transport.__aexit__.assert_awaited_once()
+
     async def test_session_caching(self, session_manager):
         """Test that sessions are properly cached and reused."""
         context_id = "test_context"
@@ -3993,6 +4025,41 @@ class TestStreamableHttpTransportPolicy:
         inst.__aenter__ = AsyncMock(return_value=inst)
         inst.__aexit__ = AsyncMock(return_value=None)
         return inst
+
+    @pytest.mark.asyncio
+    async def test_cancelled_session_creation_closes_transport(self):
+        manager = MCPSessionManager()
+        try:
+            initialize_started = asyncio.Event()
+            never_ready = asyncio.Event()
+
+            async def initialize():
+                initialize_started.set()
+                await never_ready.wait()
+
+            session = self._fake_client_session()
+            session.initialize = AsyncMock(side_effect=initialize)
+            transport = MagicMock()
+            transport.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), None))
+            transport.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            with (
+                patch("lfx.base.mcp.util.ClientSession", return_value=session),
+                patch("mcp.client.streamable_http.streamablehttp_client", transport),
+            ):
+                creation = asyncio.create_task(
+                    manager._create_streamable_http_session("test_sess", self._connection_params(), None)
+                )
+                await initialize_started.wait()
+                creation.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await creation
+                await asyncio.sleep(0)
+
+            session.__aexit__.assert_awaited_once()
+            transport.return_value.__aexit__.assert_awaited_once()
+        finally:
+            await manager.cleanup_all()
 
     @pytest.mark.asyncio
     async def test_streamable_success_sse_not_invoked(self):

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1309,15 +1309,11 @@ class MCPSessionManager:
         # Wait for session to be ready (use longer timeout for remote connections)
         try:
             session = await asyncio.wait_for(session_future, timeout=30.0)
+        except asyncio.CancelledError:
+            await self._cancel_session_task(task)
+            raise
         except asyncio.TimeoutError as timeout_err:
-            # Clean up the failed task
-            if not task.done():
-                task.cancel()
-                import contextlib
-
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-            self._background_tasks.discard(task)
+            await self._cancel_session_task(task)
             msg = f"Timeout waiting for STDIO session {session_id} to initialize"
             await logger.aerror(msg)
             raise ValueError(msg) from timeout_err
@@ -1479,15 +1475,21 @@ class MCPSessionManager:
                 return session, task, transport_used, sse_preference_locked[0]
             msg = f"Session {session_id} established but transport not recorded"
             raise ValueError(msg)
+        except asyncio.CancelledError:
+            await self._cancel_session_task(task)
+            raise
         except asyncio.TimeoutError as timeout_err:
-            if not task.done():
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-            self._background_tasks.discard(task)
+            await self._cancel_session_task(task)
             msg = f"Timeout waiting for Streamable HTTP/SSE session {session_id} to initialize"
             await logger.aerror(msg)
             raise ValueError(msg) from timeout_err
+
+    async def _cancel_session_task(self, task: asyncio.Task) -> None:
+        """Cancel and reap a session task that failed before registration."""
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        self._background_tasks.discard(task)
 
     async def _cleanup_session_by_id(self, server_key: str, session_id: str):
         """Clean up a specific session by server key and session ID.


### PR DESCRIPTION
Fixes #14161.

`_create_stdio_session` and `_create_streamable_http_session` launch detached tasks that own their transport context managers. When the outer `mcp_server_timeout` cancels session creation, neither method handled `CancelledError`, so the detached task and its subprocess/HTTP transport remained alive but unregistered.

This change:

- cancels and awaits a half-initialized session task on caller cancellation;
- reuses the same helper for the existing inner-timeout cleanup path; and
- adds regression coverage for both stdio and streamable HTTP transports.

Validation (macOS arm64, Python 3.13.13):

- Baseline stdio regression failed because both session and transport `__aexit__` were awaited 0 times.
- Focused cancellation regressions: 2 passed.
- Related session-manager and transport-policy tests: 18 passed.
- Real stdio probe: spawned one sleeping Python child; `survivors_after_cancel=[]`.
- `uvx ruff check` and `uvx ruff format --check` passed for both changed files.
- `git diff --check` passed.

The full backend test file is not claimed: the current release worktree's documented `uv sync --group dev --package lfx` setup failed because `lfx-duckduckgo` is referenced as a workspace source but is not a workspace member. A minimal isolated environment was used for the focused and adjacent tests above.

AI assistance disclosure: Codex assisted with repository search, the regression tests, and the minimal patch; I reviewed the final diff and the reported command results before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when MCP session creation is canceled or times out.
  * Ensured associated transport resources and background tasks are properly closed and removed, preventing resource leaks.

* **Tests**
  * Added coverage for cancellation handling across standard I/O and streamable HTTP MCP sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->