### PR TITLE
fix(models): render provider logo on models.dev catalog rows

### DIFF
--- a/src/lfx/src/lfx/base/models/models_dev_catalog.py
+++ b/src/lfx/src/lfx/base/models/models_dev_catalog.py
@@ -39,7 +39,7 @@ from typing import Any
 import httpx
 from platformdirs import user_cache_dir
 
-from lfx.base.models.model_metadata import create_model_metadata
+from lfx.base.models.model_metadata import MODEL_PROVIDER_METADATA, create_model_metadata
 from lfx.log.logger import logger
 
 # models.dev exposes pinned-date snapshots (e.g. ``claude-opus-4-5-20251101``,
@@ -308,10 +308,16 @@ def _translate_model_entry(
     is_aged_out = _is_aged_out(model_dict, now)
     model_type = "embeddings" if _is_embedding_family(model_dict) else "llm"
 
+    # Resolve the provider's UI icon so models.dev-sourced rows render the same
+    # brand logo as the bundled static catalog. Without this the raw provider
+    # display name ("Google Generative AI") leaks through as the icon id, which
+    # matches no icon component and renders blank — the source of the
+    # inconsistent Gemini branding where models.dev-covered models lost the logo.
+    provider_icon = MODEL_PROVIDER_METADATA.get(provider_name, {}).get("icon", provider_name)
     metadata = create_model_metadata(
         provider=provider_name,
         name=model_id,
-        icon=provider_name,  # falls back to provider icon registry
+        icon=provider_icon,
         tool_calling=bool(model_dict.get("tool_call")),
         reasoning=bool(model_dict.get("reasoning")),
         created=_release_date_to_epoch(model_dict.get("release_date")),


### PR DESCRIPTION
## Summary

The model-provider modal showed inconsistent Gemini branding: some models rendered the Gemini logo and some did not, and the logo'd ones also carried a release-month suffix (e.g. `-09-2025`). This makes every provider's live-catalog rows render the same brand logo as the bundled static catalog.

## Root cause

The modal shows the live **models.dev** catalog merged over the bundled `*_constants.py` static lists. `_translate_model_entry` set each models.dev row's `icon=provider_name` — the provider *display name* (`"Google Generative AI"`), not the icon component id (`"GoogleGenerativeAI"`). That value matches no icon component in the frontend and renders blank.

The correct icon was only patched in on the Google *name-mismatch* fold path, so:

- models.dev rows whose name matches a curated model (`gemini-2.5-flash`, `gemini-2.5-pro`, …) kept the bad icon → **no logo**;
- curated-only preview snapshots (`gemini-2.5-flash-preview-09-2025`) passed through untouched → **logo + date suffix**.

## Fix

Resolve the icon from `MODEL_PROVIDER_METADATA` in `_translate_model_entry`:

```python
provider_icon = MODEL_PROVIDER_METADATA.get(provider_name, {}).get("icon", provider_name)
... icon=provider_icon
```

Now every models.dev row renders its provider's brand logo (Google → `GoogleGenerativeAI`, OpenAI → `OpenAI`, unknown → graceful fallback to the provider name). This makes the code's own "falls back to provider icon registry" comment accurate and fixes the branding for **all** providers, not just Google.

The `-09-2025` suffix stays on those specific rows because the name is the actual Google API model id — they are distinct preview snapshots, and renaming them would send an invalid model id. They now carry the logo like every other row, so the list reads as one consistent set.

## Validation

- `_translate_model_entry("Google Generative AI", {"id": "gemini-2.5-flash"})["icon"]` → `GoogleGenerativeAI` (was `"Google Generative AI"`).
- `OpenAI` → `OpenAI`; unknown provider → falls back to the provider name.
- Existing catalog test asserting `icon == "GoogleGenerativeAI"` still passes; `ruff` clean.

### How to test

Open the model-provider modal for **Google Generative AI**. Every Gemini row — including `gemini-2.5-flash`, `-pro`, `-flash-lite` — now shows the Gemini logo, matching the previously-logo'd preview rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider icons for models sourced from the model catalog.
  * Provider entries now display the appropriate registered icon instead of the provider name as an icon identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->