### PR TITLE
fix(frontend): snapshot before duplicate so undo reverts one action

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -399,6 +399,10 @@ export default function Page({
     (e as unknown as Event).stopImmediatePropagation();
     const selectedNode = nodes.filter((obj) => obj.selected);
     if (selectedNode.length > 0) {
+      // Snapshot before pasting so the duplication is its own history entry.
+      // Without this, undo falls back to the previous snapshot (e.g. a drag's
+      // pre-move state) and reverts both the duplication and the prior action.
+      takeSnapshot();
       paste(
         { nodes: selectedNode, edges: [] },
         {


### PR DESCRIPTION
## Summary

Moving a component and then duplicating it (Cmd/Ctrl+D) collapsed both actions into one undo step: a single Cmd/Ctrl+Z removed the duplicate **and** snapped the original back to its pre-move position.

## Root cause

`handleDuplicate` in `PageComponent/index.tsx` called `paste()` directly, without first calling `takeSnapshot()`. The sibling handlers `handlePaste` and `handleDelete` both snapshot before mutating, and `paste()` does not take a snapshot internally — so duplication produced **no history entry** of its own.

Sequence:
1. Drag → `onNodeDragStart` snapshots the pre-move state; the node moves to its new position.
2. Cmd/Ctrl+D → duplicates with no snapshot; the history top is still the pre-move state.
3. Cmd/Ctrl+Z → restores the pre-move state, reverting both the duplication and the move.

## Fix

Snapshot before pasting, matching `handlePaste`/`handleDelete`:

```js
takeSnapshot();
paste(
  { nodes: selectedNode, edges: [] },
  { x: position.current.x, y: position.current.y },
);
```

Duplication is now its own history entry, so undo reverts only the duplication and leaves the original in its moved position.

## How to test

1. Select a component and drag it to a new position.
2. Press Cmd/Ctrl+D to duplicate.
3. Press Cmd/Ctrl+Z once → the duplicate is removed and the original **stays** in its moved position (previously it snapped back).
4. Undo again → the original returns to its pre-move position.

Regression check: duplicate without a prior move, then undo → only the duplicate is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo and redo behavior when duplicating items with the keyboard shortcut.
  * Duplication now appears as its own history step, preventing it from being combined with the preceding action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->