### PR TITLE
fix(models): live-fetch OpenAI-compatible embeddings when base_url set

### DIFF
--- a/src/backend/tests/unit/test_openai_base_url_support.py
+++ b/src/backend/tests/unit/test_openai_base_url_support.py
@@ -134,9 +134,7 @@ class TestLiveOpenAICompatibleModels:
         embeddings to [].
         """
         response = MagicMock()
-        response.json.return_value = {
-            "data": [{"id": "BAAI/bge-base-en-v1.5"}, {"id": "text-embedding-3-small"}]
-        }
+        response.json.return_value = {"data": [{"id": "BAAI/bge-base-en-v1.5"}, {"id": "text-embedding-3-small"}]}
         response.raise_for_status.return_value = None
         with (
             patch(

--- a/src/backend/tests/unit/test_openai_base_url_support.py
+++ b/src/backend/tests/unit/test_openai_base_url_support.py
@@ -129,9 +129,10 @@ class TestLiveOpenAICompatibleModels:
         assert http_get.call_args.args[0] == f"{CUSTOM_BASE_URL}/models"
 
     def test_should_list_embeddings_from_the_custom_server(self):
-        """Custom OpenAI-compatible servers expose embeddings via the same /models
-        endpoint as chat models (issue #14180). Live fetch must not short-circuit
-        embeddings to [].
+        """List embeddings from a custom OpenAI-compatible /models endpoint.
+
+        Custom servers expose embeddings via the same /models endpoint as chat
+        models (issue #14180). Live fetch must not short-circuit embeddings to [].
         """
         response = MagicMock()
         response.json.return_value = {"data": [{"id": "BAAI/bge-base-en-v1.5"}, {"id": "text-embedding-3-small"}]}

--- a/src/backend/tests/unit/test_openai_base_url_support.py
+++ b/src/backend/tests/unit/test_openai_base_url_support.py
@@ -128,10 +128,38 @@ class TestLiveOpenAICompatibleModels:
         assert all(m["tool_calling"] for m in models)
         assert http_get.call_args.args[0] == f"{CUSTOM_BASE_URL}/models"
 
-    def test_should_not_list_embeddings_from_the_custom_server(self):
+    def test_should_list_embeddings_from_the_custom_server(self):
+        """Custom OpenAI-compatible servers expose embeddings via the same /models
+        endpoint as chat models (issue #14180). Live fetch must not short-circuit
+        embeddings to [].
+        """
+        response = MagicMock()
+        response.json.return_value = {
+            "data": [{"id": "BAAI/bge-base-en-v1.5"}, {"id": "text-embedding-3-small"}]
+        }
+        response.raise_for_status.return_value = None
+        with (
+            patch(
+                "lfx.base.models.model_utils.get_provider_variable_value",
+                side_effect=lambda _uid, key: CUSTOM_BASE_URL if key == "OPENAI_BASE_URL" else "sk-test",
+            ),
+            patch("requests.get", return_value=response) as http_get,
+        ):
+            models = fetch_live_openai_compatible_models(USER_ID, "embeddings")
+
+        assert [m["name"] for m in models] == [
+            "BAAI/bge-base-en-v1.5",
+            "text-embedding-3-small",
+        ]
+        assert all(m["model_type"] == "embeddings" for m in models)
+        # embeddings must not advertise tool calling
+        assert all(not m["tool_calling"] for m in models)
+        assert http_get.call_args.args[0] == f"{CUSTOM_BASE_URL}/models"
+
+    def test_should_return_empty_embeddings_when_no_base_url_is_configured(self):
         with patch(
             "lfx.base.models.model_utils.get_provider_variable_value",
-            return_value=CUSTOM_BASE_URL,
+            return_value=None,
         ):
             assert fetch_live_openai_compatible_models(USER_ID, "embeddings") == []
 

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -488,11 +488,17 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
     """Fetch models from a custom OpenAI-compatible endpoint (OPENAI_BASE_URL).
 
     Returns [] when no custom base URL is configured, so api.openai.com
-    users keep the curated static catalog. ``tool_calling`` is assumed
-    True: ``/models`` carries no capability data and the OpenAI wire
-    format implies tools support.
+    users keep the curated static catalog.
+
+    Supports both ``llm`` and ``embeddings`` model types. Custom OpenAI-compatible
+    servers (vLLM / LM Studio / LiteLLM) expose models via the same ``/models``
+    endpoint for chat and embeddings; previously embeddings always short-circuited
+    to [] (issue #14180).
+
+    For ``llm``, ``tool_calling`` is assumed True: ``/models`` carries no
+    capability data and the OpenAI wire format implies tools support.
     """
-    if model_type != "llm":
+    if model_type not in ("llm", "embeddings"):
         return []
 
     base_url = get_provider_variable_value(user_id, "OPENAI_BASE_URL")
@@ -521,13 +527,14 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
     if not isinstance(entries, list):
         return []
 
+    resolved_type = "llm" if model_type == "llm" else "embeddings"
     return [
         create_model_metadata(
             provider="OpenAI",
             name=entry["id"],
             icon="OpenAI",
-            model_type="llm",
-            tool_calling=True,
+            model_type=resolved_type,
+            tool_calling=resolved_type == "llm",
             default=index < MIN_DEFAULT_MODELS,
         )
         for index, entry in enumerate(entries)


### PR DESCRIPTION
## Summary
- Custom OpenAI-compatible servers (vLLM / LM Studio / LiteLLM) expose embedding models on the same `/models` endpoint as chat models.
- Live fetch previously short-circuited any `model_type` other than `llm` to `[]`, so a configured `OPENAI_BASE_URL` never returned embeddings for memories / knowledge bases.
- Allow both `llm` and `embeddings`, set `metadata.model_type` correctly, keep `tool_calling=False` for embeddings.
- Update unit tests to cover embeddings live list + no-base-url empty path.

Fixes #14180

## Test plan
- [x] Isolated logic checks for embeddings list / empty / llm / unknown type
- [ ] CI: `src/backend/tests/unit/test_openai_base_url_support.py`
- [ ] Manual: set OpenAI provider `OPENAI_BASE_URL` to a local embedding-capable server and confirm embedding models appear in knowledge base / memory picker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering embedding models from custom OpenAI-compatible server endpoints.
  * Embedding models are now correctly identified and do not advertise tool-calling capabilities.

* **Bug Fixes**
  * Improved model metadata accuracy when retrieving language and embedding models.
  * Embedding discovery without a configured custom endpoint now returns no results as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->