### PR TITLE
fix(ci): fix GP upload condition and remove broken download schedule

### DIFF
--- a/.github/workflows/gp-download.yml
+++ b/.github/workflows/gp-download.yml
@@ -1,6 +1,8 @@
 name: GP Download Translations
 
 on:
+  schedule:
+    - cron: "0 23 * * *" # 11 PM UTC daily — pulls latest translations from GP
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gp-download.yml
+++ b/.github/workflows/gp-download.yml
@@ -53,6 +53,32 @@ jobs:
           GP_BUNDLE: ${{ vars.GP_BUNDLE }}
         run: python download.py --target frontend --output ../../src/frontend/src/locales/
 
+      - name: Close stale translation PRs targeting old release branches
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const latestRelease = '${{ steps.resolve-branch.outputs.branch }}';
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:translations/update-gp`
+            });
+            for (const pull of pulls) {
+              if (pull.base.ref !== latestRelease) {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pull.number,
+                  state: 'closed'
+                });
+                console.log(`Closed PR #${pull.number} — was targeting ${pull.base.ref}, now targeting ${latestRelease}`);
+              } else {
+                console.log(`PR #${pull.number} already targets ${latestRelease}, will update in place`);
+              }
+            }
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -131,6 +157,32 @@ jobs:
           GP_INSTANCE: ${{ vars.GP_INSTANCE }}
           GP_BACKEND_BUNDLE: ${{ vars.GP_BACKEND_BUNDLE }}
         run: python download.py --target backend
+
+      - name: Close stale backend translation PRs targeting old release branches
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const latestRelease = '${{ steps.resolve-branch.outputs.branch }}';
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:translations/update-backend-gp`
+            });
+            for (const pull of pulls) {
+              if (pull.base.ref !== latestRelease) {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pull.number,
+                  state: 'closed'
+                });
+                console.log(`Closed PR #${pull.number} — was targeting ${pull.base.ref}, now targeting ${latestRelease}`);
+              } else {
+                console.log(`PR #${pull.number} already targets ${latestRelease}, will update in place`);
+              }
+            }
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/gp-download.yml
+++ b/.github/workflows/gp-download.yml
@@ -1,8 +1,6 @@
 name: GP Download Translations
 
 on:
-  schedule:
-    - cron: "0 23 * * *" # 11 PM UTC — 1h before nightly build at midnight
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gp-download.yml
+++ b/.github/workflows/gp-download.yml
@@ -53,27 +53,6 @@ jobs:
           GP_BUNDLE: ${{ vars.GP_BUNDLE }}
         run: python download.py --target frontend --output ../../src/frontend/src/locales/
 
-      - name: Close stale translation PRs
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: pulls } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open'
-            });
-            for (const pull of pulls) {
-              if (pull.title === "chore: update translations from Globalization Pipeline") {
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pull.number,
-                  state: 'closed'
-                });
-              }
-            }
-
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -89,7 +68,6 @@ jobs:
             This PR was automatically created by the `gp-download` workflow.
             If no files changed, this PR will be empty and can be closed.
           branch: translations/update-gp
-          branch-suffix: timestamp
           delete-branch: true
           maintainer-can-modify: true
           add-paths: src/frontend/src/locales/*.json
@@ -154,27 +132,6 @@ jobs:
           GP_BACKEND_BUNDLE: ${{ vars.GP_BACKEND_BUNDLE }}
         run: python download.py --target backend
 
-      - name: Close stale backend translation PRs
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: pulls } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open'
-            });
-            for (const pull of pulls) {
-              if (pull.title === "chore: update backend translations from Globalization Pipeline") {
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pull.number,
-                  state: 'closed'
-                });
-              }
-            }
-
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -190,7 +147,6 @@ jobs:
             This PR was automatically created by the `gp-download` workflow.
             If no files changed, this PR will be empty and can be closed.
           branch: translations/update-backend-gp
-          branch-suffix: timestamp
           delete-branch: true
           maintainer-can-modify: true
           add-paths: src/backend/base/langflow/locales/*.json

--- a/.github/workflows/gp-upload.yml
+++ b/.github/workflows/gp-upload.yml
@@ -14,9 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Upload frontend strings to GP
     environment: GP-test
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      contains(toJSON(github.event.commits.*.modified), 'src/frontend/src/locales/en.json')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
 
     steps:
       - name: Checkout repository
@@ -64,10 +62,8 @@ jobs:
     name: Upload backend strings to GP
     environment: GP-test
     if: >-
-      github.actor != 'github-actions[bot]' && (
-        github.event_name == 'workflow_dispatch' ||
-        contains(toJSON(github.event.commits.*.modified), 'src/backend/base/langflow/locales/en.json')
-      )
+      github.actor != 'github-actions[bot]' &&
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'push')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What was broken and what's fixed

### Upload (`gp-upload.yml`) — every run has been `skipped` since June
The job-level `if` used `contains(toJSON(github.event.commits.*.modified), ...)` to detect if `en.json` changed. GitHub **truncates per-commit file lists** in push event payloads for squash-merged PRs, so this always evaluated to `false`. The `on.push.paths` filter at the workflow level already handles path detection correctly — the job-level check was redundant and broken.

**Fix:** Replaced with `github.event_name == 'workflow_dispatch' || github.event_name == 'push'`.

### Download (`gp-download.yml`) — scheduled run always failed
The cron runs from `main` (GitHub schedules always run on the default branch). But the `GP-test` environment's branch policy blocked `main`. Every nightly run was rejected before step 1 with: *"Branch 'main' is not allowed to deploy to GP-test."*

**Fix:** No code change needed — the schedule is restored. The root cause is the environment setting (see below). Once that's fixed, the nightly download will work automatically and also supports `workflow_dispatch` for manual runs.

---

## ⚠️ One admin action required — this is why everything is blocked

### What is a GitHub Environment?

A GitHub **Environment** (`environment: GP-test` in the workflow) is a named gate that provides three things:
1. **Environment-scoped secrets** — `GP_ADMIN_USER_ID`, `GP_ADMIN_PASSWORD` only exist here, not at repo level
2. **Deployment branch policy** — restricts *which branches* can access that environment
3. *(optional)* Required reviewers before the job runs

### What's misconfigured

`GP-test` has a **custom branch policy** that currently only lists one branch: `feat/globalization-pipeline` — a branch that was merged and deleted months ago. This means **every workflow job** that uses `environment: GP-test` is rejected unless it runs from that deleted branch. Since the GP secrets only live in this environment, we can't remove the `environment:` line — the credentials would disappear.

### What the admin needs to do

**Settings → Environments → GP-test → Deployment branches**

Change from the current single entry (`feat/globalization-pipeline`) to two patterns:

| Pattern | Why |
|---|---|
| `release-*` | Allows upload jobs (triggered by push to release branches) and manual download dispatch |
| `main` | Allows the nightly schedule (GitHub always runs scheduled workflows from the default branch) |

That's it. Once those two branch patterns are added, merge this PR and both workflows will work end-to-end:
- **Upload**: Auto-fires on any push to the latest `release-*` branch that touches `en.json`
- **Download**: Runs nightly at 11 PM UTC, auto-creates a PR with translated files targeting the latest release branch. Also triggerable manually: `gh workflow run gp-download.yml --repo langflow-ai/langflow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)