### PR TITLE
fix: validate IBM WatsonX credentials against a live model

### DIFF
--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -505,7 +505,6 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
         "OpenAI",
         "Anthropic",
         "Google Generative AI",
-        "IBM WatsonX",
     ]:
         return
 
@@ -548,14 +547,27 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
             llm.invoke("test")
 
         elif provider == "IBM WatsonX":
-            from langchain_ibm import ChatWatsonx
-
             api_key = variables.get("WATSONX_APIKEY")
             project_id = variables.get("WATSONX_PROJECT_ID")
-            url = variables.get("WATSONX_URL", "https://us-south.ml.cloud.ibm.com")
+            url = variables.get("WATSONX_URL") or "https://us-south.ml.cloud.ibm.com"
             if not api_key or not project_id:
                 return
             validate_connector_url_for_ssrf(url)
+
+            if not validation_model:
+                from lfx.base.models.model_utils import get_watsonx_llm_models
+
+                # Static WatsonX seeds may all be deprecated and filtered out.
+                # Use a current regional chat model instead of skipping validation.
+                live_models = get_watsonx_llm_models(url, default_models=[])
+                if not live_models:
+                    msg = "No IBM WatsonX chat model is available to validate credentials"
+                    logger.warning(msg)
+                    raise ValueError(msg)
+                validation_model = live_models[0]
+
+            from langchain_ibm import ChatWatsonx
+
             llm = ChatWatsonx(
                 apikey=api_key,
                 url=url,
@@ -669,6 +681,11 @@ def validate_model_provider_key(provider: str, variables: dict[str, str], model_
     except ValueError:
         raise
     except Exception as e:
+        if provider == "IBM WatsonX":
+            msg = f"Could not validate IBM WatsonX credentials: {e}"
+            logger.warning(msg)
+            raise ValueError(msg) from e
+
         error_msg = str(e).lower()
         if any(word in error_msg for word in ["401", "authentication", "api key"]):
             msg = f"Invalid API key for {provider}"

--- a/src/lfx/tests/unit/base/models/test_watsonx_provider.py
+++ b/src/lfx/tests/unit/base/models/test_watsonx_provider.py
@@ -1,0 +1,83 @@
+"""Regression tests for IBM WatsonX credential validation."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+WATSONX_VARIABLES = {
+    "WATSONX_APIKEY": "test-watsonx-key",  # pragma: allowlist secret
+    "WATSONX_PROJECT_ID": "test-project-id",
+    "WATSONX_URL": "https://us-south.ml.cloud.ibm.com",
+}
+
+
+def test_validate_watsonx_uses_live_model_when_static_catalog_has_no_active_models():
+    from lfx.base.models import model_utils
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    calls = {}
+
+    class FakeChatWatsonx:
+        def __init__(self, **kwargs):
+            calls["kwargs"] = kwargs
+
+        def invoke(self, prompt):
+            calls["prompt"] = prompt
+            return "ok"
+
+    with (
+        patch.dict("sys.modules", {"langchain_ibm": SimpleNamespace(ChatWatsonx=FakeChatWatsonx)}),
+        patch("lfx.base.models.unified_models.model_catalog.get_unified_models_detailed", return_value=[]),
+        patch("lfx.base.models.unified_models.credentials.validate_connector_url_for_ssrf"),
+        patch.object(
+            model_utils,
+            "get_watsonx_llm_models",
+            return_value=["ibm/granite-current"],
+        ) as get_live_models,
+    ):
+        validate_model_provider_key("IBM WatsonX", WATSONX_VARIABLES)
+
+    get_live_models.assert_called_once_with(
+        "https://us-south.ml.cloud.ibm.com",
+        default_models=[],
+    )
+    assert calls["kwargs"]["apikey"] == "test-watsonx-key"  # pragma: allowlist secret
+    assert calls["kwargs"]["model_id"] == "ibm/granite-current"
+    assert calls["kwargs"]["project_id"] == "test-project-id"
+    assert calls["prompt"] == "test"
+
+
+def test_validate_watsonx_rejects_ibm_iam_error():
+    from lfx.base.models import model_utils
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    class FakeChatWatsonx:
+        def __init__(self, **_kwargs):
+            pass
+
+        def invoke(self, _prompt):
+            msg = "BXNIM0410E: Provided user not found or active."
+            raise RuntimeError(msg)
+
+    with (
+        patch.dict("sys.modules", {"langchain_ibm": SimpleNamespace(ChatWatsonx=FakeChatWatsonx)}),
+        patch("lfx.base.models.unified_models.model_catalog.get_unified_models_detailed", return_value=[]),
+        patch("lfx.base.models.unified_models.credentials.validate_connector_url_for_ssrf"),
+        patch.object(model_utils, "get_watsonx_llm_models", return_value=["ibm/granite-current"]),
+        pytest.raises(ValueError, match="Could not validate IBM WatsonX credentials"),
+    ):
+        validate_model_provider_key("IBM WatsonX", WATSONX_VARIABLES)
+
+
+def test_validate_watsonx_fails_when_no_test_model_is_available():
+    from lfx.base.models import model_utils
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    with (
+        patch("lfx.base.models.unified_models.model_catalog.get_unified_models_detailed", return_value=[]),
+        patch("lfx.base.models.unified_models.credentials.validate_connector_url_for_ssrf"),
+        patch.object(model_utils, "get_watsonx_llm_models", return_value=[]),
+        pytest.raises(ValueError, match="No IBM WatsonX chat model is available"),
+    ):
+        validate_model_provider_key("IBM WatsonX", WATSONX_VARIABLES)


### PR DESCRIPTION
## Summary

- remove IBM WatsonX from the no-model credential-validation bypass
- when the static catalog has no active WatsonX model, select a current regional chat model from the live catalog before invoking `ChatWatsonx`
- fail closed on IBM SDK errors, including `BXNIM0410E`, so invalid API key/project configurations are rejected at Save time

## Root cause

Both static WatsonX LLM seeds are deprecated, and `get_unified_models_detailed()` excludes deprecated models by default. That left validation without a model and triggered an early success return. IBM IAM errors could also miss the generic `401`/`authentication`/`api key` text heuristic and be swallowed after an invoke.

The live WatsonX catalog remains unauthenticated and is used only to select a current regional chat model. The actual credential check is still the authenticated `ChatWatsonx(...).invoke("test")` call with the configured API key and project ID.

## Validation

- `uv run --no-sync ruff check` on the changed implementation and tests
- 45 focused `lfx` provider-validation tests passed (WatsonX, OpenRouter, and Azure AI Foundry)
- all pre-commit hooks passed, including ruff, formatting, and detect-secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IBM WatsonX credential validation when no predefined validation model is available.
  * Automatically discovers an available live chat model for validation.
  * Uses a default WatsonX endpoint when none is provided.
  * Provides clearer validation errors when credentials are invalid or no models are available.
  * Strengthened endpoint security checks during validation.

* **Tests**
  * Added regression coverage for live model fallback, invalid credentials, and unavailable models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->