### PR TITLE
fix: materialize Blog Writer URL prompt input

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -66,6 +66,7 @@ from langflow.services.deps import (
 # importable via the bundle shims) -- it is what the migration table and the
 # template tests resolve.
 _RUNTIME_EXT_MODULE_PREFIX = "_lfx_ext."
+_PROMPT_COMPONENT_TYPES = frozenset({"Prompt", "Prompt Template"})
 
 
 def _merge_node_metadata(current_metadata, latest_metadata):
@@ -96,6 +97,7 @@ def update_projects_components_with_latest_component_versions(project_data, all_
     for node in project_data_copy.get("nodes", []):
         node_data = node.get("data").get("node")
         node_type = node.get("data").get("type")
+        is_prompt_component = node_type in _PROMPT_COMPONENT_TYPES
 
         if node_type in all_types_dict_flat:
             latest_node = all_types_dict_flat.get(node_type)
@@ -142,7 +144,7 @@ def update_projects_components_with_latest_component_versions(project_data, all_
 
             if node_data["template"]["_type"] != latest_template["_type"]:
                 node_data["template"]["_type"] = latest_template["_type"]
-                if node_type != "Prompt":
+                if not is_prompt_component:
                     node_data["template"] = deepcopy(latest_template)
                 else:
                     for key, value in latest_template.items():
@@ -227,7 +229,7 @@ def update_projects_components_with_latest_component_versions(project_data, all_
                             )
                             node_data["template"][field_name][attr] = deepcopy(field_dict[attr])
             # Remove fields that are not in the latest template
-            if node_type != "Prompt":
+            if not is_prompt_component:
                 for field_name in list(node_data["template"].keys()):
                     is_tool_mode_and_field_is_tools_metadata = (
                         node_data.get("tool_mode", False) and field_name == "tools_metadata"

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -1812,29 +1812,6 @@
             "priority": null,
             "replacement": null,
             "template": {
-              "URL": {
-                "advanced": false,
-                "display_name": "URL",
-                "dynamic": false,
-                "field_type": "str",
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "input_types": [
-                  "Message",
-                  "Text"
-                ],
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "URL",
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "type": "str",
-                "value": ""
-              },
               "_type": "Component",
               "code": {
                 "advanced": true,

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -1812,6 +1812,29 @@
             "priority": null,
             "replacement": null,
             "template": {
+              "URL": {
+                "advanced": false,
+                "display_name": "URL",
+                "dynamic": false,
+                "field_type": "str",
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "input_types": [
+                  "Message",
+                  "Text"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "URL",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "type": "str",
+                "value": ""
+              },
               "_type": "Component",
               "code": {
                 "advanced": true,

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -105,7 +105,8 @@
             "fieldName": "URL",
             "id": "Prompt Template-3URhM",
             "inputTypes": [
-              "Message"
+              "Message",
+              "Text"
             ],
             "type": "str"
           }
@@ -115,7 +116,7 @@
         "source": "ChatInput-w522Z",
         "sourceHandle": "{œdataTypeœ: œChatInputœ, œidœ: œChatInput-w522Zœ, œnameœ: œmessageœ, œoutput_typesœ: [œMessageœ]}",
         "target": "Prompt Template-3URhM",
-        "targetHandle": "{œfieldNameœ: œURLœ, œidœ: œPrompt Template-3URhMœ, œinputTypesœ: [œMessageœ], œtypeœ: œstrœ}"
+        "targetHandle": "{œfieldNameœ: œURLœ, œidœ: œPrompt Template-3URhMœ, œinputTypesœ: [œMessageœ, œTextœ], œtypeœ: œstrœ}"
       }
     ],
     "nodes": [
@@ -1812,6 +1813,29 @@
             "priority": null,
             "replacement": null,
             "template": {
+              "URL": {
+                "advanced": false,
+                "display_name": "URL",
+                "dynamic": false,
+                "field_type": "str",
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "input_types": [
+                  "Message",
+                  "Text"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "URL",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "type": "str",
+                "value": ""
+              },
               "_type": "Component",
               "code": {
                 "advanced": true,

--- a/src/backend/tests/test_starter_projects.py
+++ b/src/backend/tests/test_starter_projects.py
@@ -122,6 +122,29 @@ class TestStarterProjects:
         data = load_json_file(json_file)
         assert isinstance(data, dict), f"{json_file.name} should be a valid JSON object"
 
+    def test_prompt_custom_fields_are_materialized(self, json_file: Path):
+        """Prompt variables declared in custom_fields must exist in the serialized template."""
+        data = load_json_file(json_file)
+        missing_fields: list[str] = []
+
+        for node in data.get("data", {}).get("nodes", []):
+            node_data = node.get("data", {}) or {}
+            node_config = node_data.get("node", {}) or {}
+            template = node_config.get("template", {}) or {}
+            custom_fields = node_config.get("custom_fields", {}) or {}
+
+            for field_names in custom_fields.values():
+                if not isinstance(field_names, list):
+                    continue
+                for field_name in field_names:
+                    if field_name not in template:
+                        node_id = node_data.get("id", node.get("id", "<unknown>"))
+                        missing_fields.append(f"{node_id}.{field_name}")
+
+        assert not missing_fields, (
+            f"{json_file.name}: custom prompt fields are missing from the serialized node template: {missing_fields}"
+        )
+
     def test_width_height_at_node_level(self, json_file: Path):
         """Test that width/height are removed from node root level for all node types EXCEPT noteNode.
 

--- a/src/backend/tests/unit/test_initial_setup.py
+++ b/src/backend/tests/unit/test_initial_setup.py
@@ -674,6 +674,52 @@ def test_update_projects_resolves_prompt_via_component_type_alias():
     )
 
 
+def test_update_projects_preserves_current_prompt_custom_fields():
+    """Current Prompt Template nodes must retain serialized dynamic inputs."""
+    url_field = {
+        "name": "URL",
+        "type": "str",
+        "value": "",
+        "input_types": ["Message", "Text"],
+    }
+    all_types_dict = {
+        "models_and_agents": {
+            "Prompt Template": {
+                "template": {
+                    "_type": "Component",
+                    "code": {"value": "new_prompt_code"},
+                    "template": {"type": "prompt", "value": ""},
+                },
+                "display_name": "Prompt Template",
+            }
+        }
+    }
+    project_data = {
+        "nodes": [
+            {
+                "data": {
+                    "type": "Prompt Template",
+                    "node": {
+                        "custom_fields": {"template": ["URL"]},
+                        "template": {
+                            "_type": "Component",
+                            "code": {"value": "old_prompt_code"},
+                            "template": {"type": "prompt", "value": "Source: {URL}"},
+                            "URL": url_field,
+                        },
+                        "outputs": [],
+                    },
+                }
+            }
+        ]
+    }
+
+    updated_project = update_projects_components_with_latest_component_versions(project_data, all_types_dict)
+
+    updated_template = updated_project["nodes"][0]["data"]["node"]["template"]
+    assert updated_template["URL"] == url_field
+
+
 def test_update_projects_direct_key_takes_precedence_over_alias():
     """Test that a direct key match is preferred over the derived alias."""
     all_types_dict = {


### PR DESCRIPTION
## Summary

- materialize the `URL` dynamic input in the shipped Blog Writer Prompt Template node
- preserve custom prompt inputs when starter-project CI updates either legacy `Prompt` nodes or current `Prompt Template` nodes
- add regressions for serialized prompt-field integrity and updater preservation

## Root cause

`Blog Writer.json` declared `custom_fields.template = ["URL"]` and wired Chat Input to the `URL` handle, but omitted `node.template.URL`.

The starter-project updater only exempted nodes whose saved type was exactly `Prompt` from unknown-field removal. Blog Writer uses the current `Prompt Template` type, so restoring `URL` in JSON alone caused autofix CI to delete it again.

## User impact

The Blog Writer starter can build its Prompt Template with the connected URL value instead of failing immediately with `KeyError: 'URL'`. Future starter-project regeneration preserves that dynamic field.

## Validation

- reproduced the updater failure before the source fix with `KeyError: 'URL'`
- ran `scripts/ci/update_starter_projects.py` twice under Python 3.13; the second run produced identical output
- `271 passed`: `src/backend/tests/unit/test_initial_setup.py` plus `src/backend/tests/test_starter_projects.py::TestStarterProjects`
- Ruff passed for all changed Python files
- JSON parsing, `git diff --check`, and all pre-commit hooks passed, including starter-template validation and secret scanning