### PR TITLE
fix(frontend): reject modifier-only keyboard shortcuts

### DIFF
--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -442,6 +442,7 @@
   "shortcuts.name.toggleSidebar": "Toggle Sidebar",
   "shortcuts.name.aiAssistant": "AI Assistant",
   "shortcuts.noKeyCombination": "No key combination recorded.",
+  "shortcuts.modifierOnly": "Add at least one non-modifier key (e.g. a letter or number).",
   "shortcuts.combinationExists": "This combination already exists!",
   "shortcuts.defaultNotFound": "Default shortcut not found.",
   "shortcuts.successChanged": "{{name}} shortcut successfully changed",

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/helpers.ts
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/helpers.ts
@@ -47,6 +47,30 @@ export function checkForKeys(keys: string, keyToCompare: string): boolean {
   );
 }
 
+/** Keys that only modify another key and cannot stand alone as a shortcut. */
+const MODIFIER_KEYS = new Set([
+  "cmd",
+  "ctrl",
+  "control",
+  "alt",
+  "option",
+  "shift",
+  "meta",
+  "mod",
+]);
+
+/**
+ * True when the recorded combination has no non-modifier key (e.g. "Cmd" or
+ * "Ctrl + Shift"). Such a combination can never fire, so it must be rejected.
+ */
+export function isModifierOnlyCombination(recorded: string): boolean {
+  const parts = recorded
+    .split("+")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  return parts.length === 0 || parts.every((part) => MODIFIER_KEYS.has(part));
+}
+
 export function normalizeRecordedCombination(recorded: string): string {
   const parts = recorded.split(" ");
   if (

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/index.tsx
@@ -12,6 +12,7 @@ import {
   findShortcutByName,
   getFixedCombination,
   isDuplicateCombination,
+  isModifierOnlyCombination,
   normalizeRecordedCombination,
 } from "./helpers";
 
@@ -87,6 +88,18 @@ export default function EditShortcutButton({
       setErrorData({
         title: t("errors.errorSavingKeyCombination"),
         list: [t("shortcuts.noKeyCombination")],
+      });
+      return;
+    }
+    if (isModifierOnlyCombination(key)) {
+      setErrorData({
+        title: t("errors.errorSavingKeyCombination"),
+        list: [
+          t("shortcuts.modifierOnly", {
+            defaultValue:
+              "Add at least one non-modifier key (e.g. a letter or number).",
+          }),
+        ],
       });
       return;
     }

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.helpers.test.ts
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.helpers.test.ts
@@ -3,6 +3,7 @@ import {
   findShortcutByName,
   getFixedCombination,
   isDuplicateCombination,
+  isModifierOnlyCombination,
   normalizeRecordedCombination,
 } from "../EditShortcutButton/helpers";
 
@@ -45,5 +46,18 @@ describe("EditShortcutButton helpers", () => {
   it("checks for existing keys", () => {
     expect(checkForKeys("Ctrl + K", "Ctrl")).toBe(true);
     expect(checkForKeys("Ctrl + K", "Shift")).toBe(false);
+  });
+
+  it("rejects modifier-only combinations", () => {
+    expect(isModifierOnlyCombination("Cmd")).toBe(true);
+    expect(isModifierOnlyCombination("Ctrl + Shift")).toBe(true);
+    expect(isModifierOnlyCombination("Cmd + Alt + Shift")).toBe(true);
+    expect(isModifierOnlyCombination("")).toBe(true);
+  });
+
+  it("accepts combinations that include a non-modifier key", () => {
+    expect(isModifierOnlyCombination("Cmd + C")).toBe(false);
+    expect(isModifierOnlyCombination("Shift + K")).toBe(false);
+    expect(isModifierOnlyCombination("Space")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The keyboard-shortcut editor allowed saving a modifier-only combination (e.g. `Cmd`, or `Ctrl + Shift`). Such a shortcut can never fire because there is no non-modifier key to press alongside the modifier, producing a dead binding.

## Root cause

`editCombination` in `EditShortcutButton/index.tsx` only guarded the empty case (`!key`). Any recorded value that contained at least one key — including a lone modifier — passed validation and was persisted.

## Fix

- `helpers.ts`: add `isModifierOnlyCombination()`, which returns `true` when the recorded combination is empty or every part is a modifier (`cmd`, `ctrl`, `control`, `alt`, `option`, `shift`, `meta`, `mod`).
- `EditShortcutButton/index.tsx`: block saving when `isModifierOnlyCombination(key)` is true, surfacing an error toast (mirrors the existing empty / duplicate guards).
- `en.json`: `shortcuts.modifierOnly` message.
- Helper unit tests: reject modifier-only combinations; accept combinations that include a non-modifier key.

## Validation

- `EditShortcutButton.helpers.test.ts` — 8/8 pass (2 new cases); Biome clean.
- Cases: `Cmd` → reject, `Ctrl + Shift` → reject, `Cmd + C` → accept, `Space` → accept.

### How to test

Settings → Shortcuts → edit any shortcut (e.g. Copy):
1. Press only `Cmd` and click Apply → error toast, nothing saved (previously it saved).
2. Press `Cmd + C` → saves normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented keyboard shortcuts containing only modifier keys—such as Ctrl, Shift, or Alt—from being saved.
  * Added a clear message explaining that shortcuts must include at least one non-modifier key.
* **Tests**
  * Added coverage for valid and invalid shortcut combinations, including empty input and standalone keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->