### PR TITLE
fix(settings): default agentic env-mirror off

### DIFF
--- a/src/lfx/src/lfx/services/settings/groups/variables.py
+++ b/src/lfx/src/lfx/services/settings/groups/variables.py
@@ -38,9 +38,7 @@ class VariablesSettings(BaseModel):
 
         result = list(set(VARIABLES_TO_GET_FROM_ENVIRONMENT + value))
 
-        # Add agentic variables if agentic_experience is enabled
-        # Check env var directly since we can't access instance attributes in validator
-        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
+        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "false").lower() == "true":
             result.extend(AGENTIC_VARIABLES)
 
         return list(set(result))

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -431,8 +431,9 @@ def test_env_var_round_trip(monkeypatch, env_var, env_value, field, expected):
 
 
 def test_agentic_variables_excluded_when_experience_off(monkeypatch):
-    """Agentic env vars (incl. the ASTRA_TOKEN credential) must NOT be mirrored
-    from the environment while the agentic experience is off (the default).
+    """Agentic env vars must NOT be mirrored from the environment while the experience is off.
+
+    The ASTRA_TOKEN credential is among them, and the agentic experience is off by default.
 
     Regression: the env-mirror list used to be extended with AGENTIC_VARIABLES
     whenever LANGFLOW_AGENTIC_EXPERIENCE was unset, provisioning ASTRA_TOKEN into

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -23,6 +23,7 @@ from lfx.services.settings.base import (
     load_settings_from_yaml,
     save_settings_to_yaml,
 )
+from lfx.services.settings.constants import AGENTIC_VARIABLES
 
 
 def test_voice_mode_requires_openai_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -427,3 +428,27 @@ def test_env_var_round_trip(monkeypatch, env_var, env_value, field, expected):
     monkeypatch.setenv(env_var, env_value)
     settings = Settings()
     assert getattr(settings, field) == expected
+
+
+def test_agentic_variables_excluded_when_experience_off(monkeypatch):
+    """Agentic env vars (incl. the ASTRA_TOKEN credential) must NOT be mirrored
+    from the environment while the agentic experience is off (the default).
+
+    Regression: the env-mirror list used to be extended with AGENTIC_VARIABLES
+    whenever LANGFLOW_AGENTIC_EXPERIENCE was unset, provisioning ASTRA_TOKEN into
+    the DB for a feature whose endpoints stay 404.
+    """
+    monkeypatch.delenv("LANGFLOW_AGENTIC_EXPERIENCE", raising=False)
+    settings = Settings()
+    assert settings.agentic_experience is False
+    for var in AGENTIC_VARIABLES:
+        assert var not in settings.variables_to_get_from_environment
+
+
+def test_agentic_variables_included_when_experience_on(monkeypatch):
+    """Enabling the agentic experience mirrors its variables from the environment."""
+    monkeypatch.setenv("LANGFLOW_AGENTIC_EXPERIENCE", "true")
+    settings = Settings()
+    assert settings.agentic_experience is True
+    for var in AGENTIC_VARIABLES:
+        assert var in settings.variables_to_get_from_environment


### PR DESCRIPTION
## Problem

`LANGFLOW_AGENTIC_EXPERIENCE` had two defaults that disagreed inside `lfx/services/settings/groups/variables.py`:

- The feature toggle defaults **off**: `agentic_experience: bool = False`. Its endpoints stay gated (404 via `require_agentic_experience`).
- The env-mirror validator defaulted **on** when the env var was unset: `os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true")`, so it still extended `variables_to_get_from_environment` with `AGENTIC_VARIABLES`.

On a default install (env var unset) the feature is off, yet the agentic variables — including `ASTRA_TOKEN`, a credential — were mirrored from the environment into the DB as Global Variables. A disabled feature ended up provisioning a credential it never uses.

## Fix

Align the validator's fallback with the field default so the two agree:

```diff
-if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
+if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "false").lower() == "true":
```

- Default install → feature off → `AGENTIC_VARIABLES` (incl. `ASTRA_TOKEN`) are **not** mirrored to the DB.
- `LANGFLOW_AGENTIC_EXPERIENCE=true` → the enabled path is unchanged: the agentic variables are provisioned as before, which is when the feature actually uses them.

The validator still reads the env var directly (rather than `self.agentic_experience`) because it is a field validator with no access to sibling fields — only its default was wrong.

## Testing

Added two regression tests in `test_settings_composition.py`:

- `test_agentic_variables_excluded_when_experience_off` — with the env var unset, no `AGENTIC_VARIABLES` leak into `variables_to_get_from_environment` (fails before the fix).
- `test_agentic_variables_included_when_experience_on` — with the toggle on, the enabled path still mirrors them.

Full `test_settings_composition.py` suite passes (31/31).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agentic environment variables are no longer enabled by default.
  * These variables are included only when `LANGFLOW_AGENTIC_EXPERIENCE` is explicitly enabled.
  * Added validation to ensure environment-variable behavior is correct in both enabled and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->