### PR TITLE
fix(lfx): derive secret_key ACL from process token SID

### DIFF
--- a/scripts/migrate_secret_key.py
+++ b/scripts/migrate_secret_key.py
@@ -62,7 +62,11 @@ def set_secure_permissions(file_path: Path) -> None:
             import win32con
             import win32security
 
-            user, _, _ = win32security.LookupAccountName("", win32api.GetUserName())
+            # The user SID must come from the process token: resolving by name
+            # (LookupAccountName + GetUserName) returns the machine-domain SID
+            # when the computer name equals the username, locking the user out.
+            token = win32security.OpenProcessToken(win32api.GetCurrentProcess(), win32con.TOKEN_QUERY)
+            user, _attributes = win32security.GetTokenInformation(token, win32security.TokenUser)
             sd = win32security.GetFileSecurity(str(file_path), win32security.DACL_SECURITY_INFORMATION)
             dacl = win32security.ACL()
             dacl.AddAccessAllowedAce(

--- a/src/lfx/src/lfx/services/settings/utils.py
+++ b/src/lfx/src/lfx/services/settings/utils.py
@@ -69,15 +69,32 @@ def generate_rsa_key_pair() -> tuple[str, str]:
     return private_key_pem, public_key_pem
 
 
+def _get_windows_process_user_sid():
+    """Return the SID of the user that owns the current process token.
+
+    Resolving the user by name (``LookupAccountName("", GetUserName())``) is
+    ambiguous: when the machine name equals the username, the bare name
+    resolves to the machine-domain object (SidTypeDomain, no user RID), and a
+    DACL granting only that SID locks the real user out of the file. The
+    process token needs no name resolution and always yields the user SID.
+    """
+    import win32api
+    import win32con
+    import win32security
+
+    token = win32security.OpenProcessToken(win32api.GetCurrentProcess(), win32con.TOKEN_QUERY)
+    sid, _attributes = win32security.GetTokenInformation(token, win32security.TokenUser)
+    return sid
+
+
 def set_secure_permissions(file_path: Path) -> None:
     if platform.system() in {"Linux", "Darwin"}:  # Unix/Linux/Mac
         file_path.chmod(0o600)
     elif platform.system() == "Windows":
-        import win32api
         import win32con
         import win32security
 
-        user, _, _ = win32security.LookupAccountName("", win32api.GetUserName())
+        user = _get_windows_process_user_sid()
         sd = win32security.GetFileSecurity(str(file_path), win32security.DACL_SECURITY_INFORMATION)
         dacl = win32security.ACL()
 
@@ -102,7 +119,17 @@ def write_secret_to_file(path: Path, value: str) -> None:
 
 
 def read_secret_from_file(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    try:
+        return path.read_text(encoding="utf-8")
+    except PermissionError:
+        if platform.system() != "Windows":
+            raise
+        # Self-heal files whose DACL was written by a version affected by the
+        # machine-name/username collision: the file owner keeps implicit
+        # WRITE_DAC, so the ACL can be rewritten even with no read access.
+        logger.warning(f"Permission denied reading secret file at {path}; rewriting its ACL and retrying")
+        set_secure_permissions(path)
+        return path.read_text(encoding="utf-8")
 
 
 def write_public_key_to_file(path: Path, value: str) -> None:

--- a/src/lfx/tests/unit/services/settings/test_secure_permissions_windows.py
+++ b/src/lfx/tests/unit/services/settings/test_secure_permissions_windows.py
@@ -1,0 +1,124 @@
+"""Windows DACL hardening for the secret_key file.
+
+Regression tests for the machine-name/username collision bug: when the
+computer name equals the username (e.g. computer DANIEL, user daniel),
+``LookupAccountName("", GetUserName())`` resolves the bare name to the
+machine-domain object (SidTypeDomain, no user RID). Writing a DACL that
+grants access only to that SID locks out the real user, and the next
+startup dies with PermissionError when reading the secret_key back.
+
+The fix takes the user SID from the process token instead of resolving
+by name, and read_secret_from_file self-heals files whose DACL was
+already broken by an affected version.
+"""
+
+import platform
+from pathlib import Path
+
+import pytest
+from lfx.services.settings.utils import (
+    read_secret_from_file,
+    set_secure_permissions,
+    write_secret_to_file,
+)
+
+pytestmark = pytest.mark.skipif(platform.system() != "Windows", reason="Windows DACL behavior")
+
+SECRET = "test-secret-value"  # noqa: S105
+
+
+def _current_process_user_sid():
+    import win32api
+    import win32con
+    import win32security
+
+    token = win32security.OpenProcessToken(win32api.GetCurrentProcess(), win32con.TOKEN_QUERY)
+    sid, _attributes = win32security.GetTokenInformation(token, win32security.TokenUser)
+    return sid
+
+
+def _dacl_sids(path: Path) -> list:
+    import win32security
+
+    sd = win32security.GetFileSecurity(str(path), win32security.DACL_SECURITY_INFORMATION)
+    dacl = sd.GetSecurityDescriptorDacl()
+    assert dacl is not None, "expected a protected DACL, got NULL (allow-everyone)"
+    return [dacl.GetAce(i)[2] for i in range(dacl.GetAceCount())]
+
+
+def _apply_broken_domain_sid_dacl(path: Path) -> None:
+    """Reproduce the DACL an affected version wrote: single ACE for the machine-domain SID."""
+    import win32api
+    import win32con
+    import win32security
+
+    domain_sid, _, sid_type = win32security.LookupAccountName("", win32api.GetComputerName())
+    assert sid_type == win32security.SidTypeDomain
+    sd = win32security.GetFileSecurity(str(path), win32security.DACL_SECURITY_INFORMATION)
+    dacl = win32security.ACL()
+    dacl.AddAccessAllowedAce(
+        win32security.ACL_REVISION,
+        win32con.GENERIC_READ | win32con.GENERIC_WRITE,
+        domain_sid,
+    )
+    sd.SetSecurityDescriptorDacl(1, dacl, 0)
+    win32security.SetFileSecurity(str(path), win32security.DACL_SECURITY_INFORMATION, sd)
+
+
+@pytest.fixture
+def secret_path(tmp_path: Path):
+    path = tmp_path / "secret_key"
+    yield path
+    # Reset the ACL so pytest can clean tmp_path even after a broken-DACL test.
+    if path.exists():
+        import win32security
+
+        sd = win32security.GetFileSecurity(str(path), win32security.DACL_SECURITY_INFORMATION)
+        sd.SetSecurityDescriptorDacl(1, None, 0)
+        win32security.SetFileSecurity(str(path), win32security.DACL_SECURITY_INFORMATION, sd)
+
+
+def test_write_then_read_roundtrip(secret_path: Path):
+    write_secret_to_file(secret_path, SECRET)
+    assert read_secret_from_file(secret_path) == SECRET
+
+
+def test_dacl_grants_the_process_token_user(secret_path: Path):
+    """The ACE must target the token user SID, never a name-resolved principal."""
+    write_secret_to_file(secret_path, SECRET)
+    sids = _dacl_sids(secret_path)
+    assert sids == [_current_process_user_sid()]
+
+
+def test_survives_machine_name_username_collision(secret_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Simulate computer name == username: GetUserName() returns the machine name.
+
+    On an affected host the bare name resolves to the machine-domain SID; a fix
+    based on the process token must be immune to whatever GetUserName returns.
+    """
+    import win32api
+
+    monkeypatch.setattr(win32api, "GetUserName", win32api.GetComputerName)
+    write_secret_to_file(secret_path, SECRET)
+    assert read_secret_from_file(secret_path) == SECRET
+    sids = _dacl_sids(secret_path)
+    assert sids == [_current_process_user_sid()]
+
+
+def test_read_self_heals_broken_dacl(secret_path: Path):
+    """Installs already hit by the bug must recover without manual icacls /reset."""
+    secret_path.write_text(SECRET, encoding="utf-8")
+    _apply_broken_domain_sid_dacl(secret_path)
+    with pytest.raises(PermissionError):
+        secret_path.read_text(encoding="utf-8")
+
+    assert read_secret_from_file(secret_path) == SECRET
+    # The repaired file must stay readable and carry the correct ACE.
+    assert secret_path.read_text(encoding="utf-8") == SECRET
+    assert _dacl_sids(secret_path) == [_current_process_user_sid()]
+
+
+def test_set_secure_permissions_direct(secret_path: Path):
+    secret_path.write_text(SECRET, encoding="utf-8")
+    set_secure_permissions(secret_path)
+    assert secret_path.read_text(encoding="utf-8") == SECRET


### PR DESCRIPTION
## Problem

On Windows, `set_secure_permissions` hardens the `secret_key` file by resolving the current user with `win32security.LookupAccountName("", win32api.GetUserName())` and writing a protected DACL that grants access only to the returned SID.

When the **machine name equals the username** (case-insensitive) — e.g. computer `DANIEL`, user `daniel` — `LookupAccountName` resolves the bare name to the machine/domain object and returns a **`SidTypeDomain`** SID *without* the user RID (`S-1-5-21-…-712507774` instead of the real `…-712507774-1001`). The code never validates the SID type, so it writes a DACL that grants no access to the actual user.

The creating process still works, but **the next startup fails** when it reads the file back — not even the file owner has read-data rights under the protected DACL:

```
File ".../lfx/services/settings/auth.py", line 331, in get_secret_key
    value = read_secret_from_file(secret_key_path)
PermissionError: [Errno 13] Permission denied: '...\secret_key'
```

The server never binds; `GET /health` never returns 200. `LANGFLOW_SECRET_KEY` does not work around it (the file is still read). Recovery required a manual `icacls <dir>\secret_key /reset`.

## Fix

Derive the user SID from the **process token** instead of resolving it by name:

```diff
-user, _, _ = win32security.LookupAccountName("", win32api.GetUserName())
+token = win32security.OpenProcessToken(win32api.GetCurrentProcess(), win32con.TOKEN_QUERY)
+user, _attributes = win32security.GetTokenInformation(token, win32security.TokenUser)
```

The token user is always the real `SidTypeUser` SID — no name resolution, so the machine-name/username collision can't occur. Applied in both `lfx/services/settings/utils.py` (`set_secure_permissions`, via a new `_get_windows_process_user_sid` helper) and `scripts/migrate_secret_key.py`.

**Self-heal for already-broken files:** `read_secret_from_file` now catches `PermissionError` on Windows and rewrites the DACL before retrying. The file owner keeps implicit `WRITE_DAC` even with no read access, so the ACL can be repaired in place — users already hit by an affected nightly recover automatically, without a manual `icacls /reset`.

## Testing

New `test_secure_permissions_windows.py`:

- `test_write_then_read_roundtrip` — baseline write/read.
- `test_dacl_grants_the_process_token_user` — DACL is keyed to the token user SID.
- `test_survives_machine_name_username_collision` — reproduces the reported trigger; fails before the fix.
- `test_read_self_heals_broken_dacl` — a file with a broken DACL is repaired and read on the next open.
- `test_set_secure_permissions_direct` — direct call coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows secret-file permissions to grant access to the correct signed-in user.
  * Fixed issues caused by computer-name and username collisions during permission setup.
  * Secret files with incorrect permissions are now automatically repaired and read successfully on Windows.
  * Improved reliability when writing and reading protected secret files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->