### PR TITLE
fix(memory): stop cross-flow chat-history leak in legacy flows (LE-1929)

### DIFF
--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -138,6 +138,11 @@ async def aget_messages(
     Returns:
         List[Data]: A list of Data objects representing the retrieved messages.
     """
+    if flow_id is None:
+        # Default to the executing graph's flow_id so old saved flows (frozen code calls this without one) cannot surface another flow's history on a colliding session_id (issue #13059).  # noqa: E501
+        from lfx.memory.flow_context import coerce_flow_id, get_current_flow_id
+
+        flow_id = coerce_flow_id(get_current_flow_id())
     async with session_scope() as session:
         stmt = _get_variable_query(
             sender, sender_name, session_id, context_id, order_by, order, flow_id, limit, user_id=user_id

--- a/src/backend/tests/unit/test_message_flow_context_scoping.py
+++ b/src/backend/tests/unit/test_message_flow_context_scoping.py
@@ -131,6 +131,37 @@ class _OldStyleMemory(MemoryComponent):
         return cast("Data", list(reversed(stored)))
 
 
+async def test_graph_without_flow_id_shadows_outer_scope(client):  # noqa: ARG001
+    """A graph with no ``flow_id`` must run unscoped, not inherit an outer flow's ambient scope.
+
+    If an outer flow is executing (ambient scope bound) and a nested graph without ``flow_id``
+    runs a legacy memory component, the documented fallback is legacy *unscoped* retrieval —
+    inheriting the outer flow's scope would silently attribute the messages to the wrong flow.
+    """
+    flow_a = uuid4()
+    session_id = "shared-session-13059-shadow"
+    await _store(session_id, flow_a, "SECRET_FROM_A")
+    await _store(session_id, uuid4(), "hello from B")
+
+    probe = _OldStyleMemory(_id="old_memory_shadow")
+    probe.set(session_id=session_id, n_messages=100, order="Ascending")
+    chat_output = ChatOutput(_id="chat_output_shadow")
+    chat_output.set(input_value=probe.retrieve_messages_as_text)
+
+    graph = Graph(probe, chat_output)  # no flow_id
+    outer_token = set_current_flow_id(flow_a)  # simulate an outer flow still bound
+    try:
+        async for _ in graph.async_start():
+            pass
+    finally:
+        reset_current_flow_id(outer_token)
+
+    rendered = chat_output.get_output_by_method(chat_output.message_response).value
+    text = rendered.text if hasattr(rendered, "text") else str(rendered)
+    assert "SECRET_FROM_A" in text, "unscoped legacy retrieval must include Flow A's message"
+    assert "hello from B" in text, "outer flow scope leaked into the flow_id-less graph run"
+
+
 async def test_graph_execution_binds_flow_scope_end_to_end(client):  # noqa: ARG001
     """End-to-end: running Flow B's graph must not surface Flow A's message via unscoped frozen code.
 

--- a/src/backend/tests/unit/test_message_flow_context_scoping.py
+++ b/src/backend/tests/unit/test_message_flow_context_scoping.py
@@ -1,0 +1,157 @@
+"""Regression tests: ambient flow-scope defaults ``aget_messages`` by ``flow_id`` (issue #13059).
+
+Langflow executes the *frozen* component ``code`` embedded in each saved flow, not the installed
+library version (``lfx.interface.initialize.loading.instantiate_class`` -> ``eval_custom_component_code``).
+A flow saved before PR #13087 therefore carries the old ``retrieve_messages`` that calls
+``aget_messages`` WITHOUT ``flow_id`` and leaks chat history across flows on a colliding
+``session_id`` — even when running on a patched server.
+
+Defense-in-depth: the engine binds the executing graph's ``flow_id`` to a ContextVar so
+``aget_messages`` can default the scope. This closes the leak for old frozen flows without:
+- touching frozen code (impossible),
+- changing callers that pass ``flow_id`` explicitly (the default only applies when it is ``None``),
+- changing callers outside a graph run (the ContextVar is unset -> identical to today).
+"""
+
+from typing import cast
+from uuid import uuid4
+
+from langflow.memory import aadd_messages, aget_messages
+from langflow.schema.message import Message
+from lfx.components.input_output import ChatOutput
+from lfx.components.models_and_agents.memory import MemoryComponent
+from lfx.graph.graph.base import Graph
+from lfx.memory.flow_context import reset_current_flow_id, set_current_flow_id
+from lfx.schema.data import Data
+
+
+async def _store(session_id: str, flow_id, text: str) -> None:
+    msg = Message(text=text, sender="User", sender_name="User", session_id=session_id)
+    await aadd_messages([msg], flow_id=flow_id)
+
+
+async def test_aget_messages_defaults_flow_id_from_context(client):  # noqa: ARG001
+    """The reproduction: two flows share a session_id; the ambient scope isolates them.
+
+    Simulates old frozen code calling ``aget_messages(session_id=...)`` with no flow_id while
+    Flow B's graph is executing. The ambient flow scope must prevent Flow A's row from leaking.
+    """
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059"
+    await _store(session_id, flow_a, "secret from A")
+    await _store(session_id, flow_b, "hello from B")
+
+    token = set_current_flow_id(flow_b)
+    try:
+        scoped = await aget_messages(session_id=session_id)
+    finally:
+        reset_current_flow_id(token)
+
+    assert [m.text for m in scoped] == ["hello from B"]
+
+
+async def test_explicit_flow_id_overrides_context(client):  # noqa: ARG001
+    """An explicitly-passed flow_id must win over the ambient context (no silent override)."""
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059-explicit"
+    await _store(session_id, flow_a, "secret from A")
+    await _store(session_id, flow_b, "hello from B")
+
+    token = set_current_flow_id(flow_b)
+    try:
+        a_msgs = await aget_messages(session_id=session_id, flow_id=flow_a)
+    finally:
+        reset_current_flow_id(token)
+
+    assert [m.text for m in a_msgs] == ["secret from A"]
+
+
+async def test_no_context_preserves_legacy_unscoped(client):  # noqa: ARG001
+    """With no ambient scope and no explicit flow_id, behavior is unchanged (both rows)."""
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059-legacy"
+    await _store(session_id, flow_a, "secret from A")
+    await _store(session_id, flow_b, "hello from B")
+
+    unscoped = await aget_messages(session_id=session_id)
+
+    assert len(unscoped) == 2
+
+
+async def test_context_accepts_string_flow_id(client):  # noqa: ARG001
+    """``graph.flow_id`` is commonly a ``str``; the default path must coerce it, not crash.
+
+    ``MessageTable.flow_id`` is UUID-typed; on SQLite comparing it to a raw string makes the
+    ``Uuid`` bind processor call ``value.hex`` and raise. The default must coerce str -> UUID.
+    """
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059-str"
+    await _store(session_id, flow_a, "secret from A")
+    await _store(session_id, flow_b, "hello from B")
+
+    token = set_current_flow_id(str(flow_b))
+    try:
+        scoped = await aget_messages(session_id=session_id)
+    finally:
+        reset_current_flow_id(token)
+
+    assert [m.text for m in scoped] == ["hello from B"]
+
+
+async def test_invalid_context_flow_id_degrades_to_unscoped(client):  # noqa: ARG001
+    """A non-UUID ambient flow_id (synthetic/test graphs) must degrade, never crash retrieval."""
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059-badctx"
+    await _store(session_id, flow_a, "secret from A")
+    await _store(session_id, flow_b, "hello from B")
+
+    token = set_current_flow_id("not-a-uuid")
+    try:
+        result = await aget_messages(session_id=session_id)
+    finally:
+        reset_current_flow_id(token)
+
+    assert len(result) == 2
+
+
+class _OldStyleMemory(MemoryComponent):
+    """Simulates a flow saved before PR #13087: its frozen ``retrieve_messages`` omits ``flow_id``.
+
+    We cannot recreate frozen bytes in a unit test, so we reproduce the one behavior that matters:
+    the internal-memory retrieve calls ``aget_messages`` with no ``flow_id``. The engine's ambient
+    flow scope must still isolate it.
+    """
+
+    name = "OldStyleMemory"
+
+    async def retrieve_messages(self) -> Data:
+        from langflow.memory import aget_messages as backend_aget_messages
+
+        stored = await backend_aget_messages(session_id=self.session_id, order="DESC")
+        return cast("Data", list(reversed(stored)))
+
+
+async def test_graph_execution_binds_flow_scope_end_to_end(client):  # noqa: ARG001
+    """End-to-end: running Flow B's graph must not surface Flow A's message via unscoped frozen code.
+
+    This is the real reproduction path — ``get_instance_results`` binds ``graph.flow_id`` so the
+    old-style component's unscoped ``aget_messages`` call is defaulted to Flow B's scope.
+    """
+    flow_a, flow_b = uuid4(), uuid4()
+    session_id = "shared-session-13059-e2e"
+    await _store(session_id, flow_a, "SECRET_FROM_A")
+    await _store(session_id, flow_b, "hello from B")
+
+    probe = _OldStyleMemory(_id="old_memory")
+    probe.set(session_id=session_id, n_messages=100, order="Ascending")
+    chat_output = ChatOutput(_id="chat_output")
+    chat_output.set(input_value=probe.retrieve_messages_as_text)
+
+    graph = Graph(probe, chat_output, flow_id=str(flow_b))
+    async for _ in graph.async_start():
+        pass
+
+    rendered = chat_output.get_output_by_method(chat_output.message_response).value
+    text = rendered.text if hasattr(rendered, "text") else str(rendered)
+    assert "SECRET_FROM_A" not in text, "Flow A's message leaked into Flow B's graph run"
+    assert "hello from B" in text

--- a/src/frontend/src/utils/__tests__/reconcileNodeDimensions.test.ts
+++ b/src/frontend/src/utils/__tests__/reconcileNodeDimensions.test.ts
@@ -1,0 +1,50 @@
+/**
+ * LE-1929: flows saved when the node card was `w-96` (384px) kept `width: 384`. React Flow then
+ * uses that stale width to place the right-side output handle ~64px past the actual `w-80` (320px)
+ * card, so edges render detached from the handle. Reconciling drops the persisted dimensions so
+ * React Flow re-measures the real DOM size. noteNodes are user-resizable and must be preserved.
+ */
+
+import { reconcileStaleGenericNodeDimensions } from "../reactflowUtils";
+
+describe("reconcileStaleGenericNodeDimensions", () => {
+  it("drops stale width/height/measured from genericNodes so React Flow re-measures", () => {
+    const nodes: any[] = [
+      {
+        id: "Memory-1",
+        type: "genericNode",
+        width: 384,
+        height: 366,
+        measured: { width: 384, height: 366 },
+        position: { x: 0, y: 0 },
+        data: {},
+      },
+    ];
+
+    reconcileStaleGenericNodeDimensions(nodes as any);
+
+    expect(nodes[0].width).toBeUndefined();
+    expect(nodes[0].height).toBeUndefined();
+    expect(nodes[0].measured).toBeUndefined();
+  });
+
+  it("preserves dimensions on noteNodes (they are user-resizable)", () => {
+    const nodes: any[] = [
+      {
+        id: "note-1",
+        type: "noteNode",
+        width: 500,
+        height: 300,
+        measured: { width: 500, height: 300 },
+        position: { x: 0, y: 0 },
+        data: {},
+      },
+    ];
+
+    reconcileStaleGenericNodeDimensions(nodes as any);
+
+    expect(nodes[0].width).toBe(500);
+    expect(nodes[0].height).toBe(300);
+    expect(nodes[0].measured).toEqual({ width: 500, height: 300 });
+  });
+});

--- a/src/frontend/src/utils/__tests__/reconcileNodeDimensions.test.ts
+++ b/src/frontend/src/utils/__tests__/reconcileNodeDimensions.test.ts
@@ -5,11 +5,12 @@
  * React Flow re-measures the real DOM size. noteNodes are user-resizable and must be preserved.
  */
 
+import type { AllNodeType } from "../../types/flow";
 import { reconcileStaleGenericNodeDimensions } from "../reactflowUtils";
 
 describe("reconcileStaleGenericNodeDimensions", () => {
   it("drops stale width/height/measured from genericNodes so React Flow re-measures", () => {
-    const nodes: any[] = [
+    const nodes = [
       {
         id: "Memory-1",
         type: "genericNode",
@@ -19,9 +20,9 @@ describe("reconcileStaleGenericNodeDimensions", () => {
         position: { x: 0, y: 0 },
         data: {},
       },
-    ];
+    ] as unknown as AllNodeType[];
 
-    reconcileStaleGenericNodeDimensions(nodes as any);
+    reconcileStaleGenericNodeDimensions(nodes);
 
     expect(nodes[0].width).toBeUndefined();
     expect(nodes[0].height).toBeUndefined();
@@ -29,7 +30,7 @@ describe("reconcileStaleGenericNodeDimensions", () => {
   });
 
   it("preserves dimensions on noteNodes (they are user-resizable)", () => {
-    const nodes: any[] = [
+    const nodes = [
       {
         id: "note-1",
         type: "noteNode",
@@ -39,9 +40,9 @@ describe("reconcileStaleGenericNodeDimensions", () => {
         position: { x: 0, y: 0 },
         data: {},
       },
-    ];
+    ] as unknown as AllNodeType[];
 
-    reconcileStaleGenericNodeDimensions(nodes as any);
+    reconcileStaleGenericNodeDimensions(nodes);
 
     expect(nodes[0].width).toBe(500);
     expect(nodes[0].height).toBe(300);

--- a/src/frontend/src/utils/__tests__/updatePathEdgeMigration.test.ts
+++ b/src/frontend/src/utils/__tests__/updatePathEdgeMigration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Reproduction for LE-1929: updating an outdated saved flow must not drop edges whose
+ * output type was renamed (DataFrame -> Table, #11554).
+ *
+ * Flow B (Memory Chatbot, legacy) has a Memory."dataframe" output that was typed ["DataFrame"]
+ * when saved but is ["Table"] in the current library. When the user clicks "Update All", the
+ * node definition is swapped to the current one (Table) while the edge still stores the old
+ * DataFrame handle. cleanEdges must migrate + keep the edge, not drop it.
+ */
+
+import { cleanEdges, scapedJSONStringfy } from "../reactflowUtils";
+
+const stringify = (obj: object): string => scapedJSONStringfy(obj);
+
+describe("LE-1929 update-path edge migration (DataFrame -> Table)", () => {
+  it("keeps the Memory->TypeConverter edge after the Memory output migrates to Table", () => {
+    // Memory node AFTER "Update All": dataframe output is now typed Table.
+    const memoryNode: any = {
+      id: "Memory-8X8Cq",
+      type: "genericNode",
+      data: {
+        id: "Memory-8X8Cq",
+        type: "Memory",
+        selected_output: "dataframe",
+        node: {
+          display_name: "Message History",
+          template: {},
+          outputs: [
+            {
+              name: "dataframe",
+              display_name: "Table",
+              types: ["Table"],
+              selected: "Table",
+            },
+          ],
+        },
+      },
+    };
+
+    // TypeConverter node AFTER update: input_data accepts the migrated types.
+    const typeConverterNode: any = {
+      id: "TypeConverterComponent-koSIz",
+      type: "genericNode",
+      data: {
+        id: "TypeConverterComponent-koSIz",
+        type: "TypeConverterComponent",
+        node: {
+          display_name: "Type Convert",
+          template: {
+            input_data: {
+              type: "other",
+              input_types: ["Message", "Data", "JSON", "DataFrame", "Table"],
+              display_name: "Input",
+            },
+          },
+          outputs: [],
+        },
+      },
+    };
+
+    // Edge as SAVED in the legacy flow: source handle still says DataFrame.
+    const sourceHandle = stringify({
+      dataType: "Memory",
+      id: "Memory-8X8Cq",
+      name: "dataframe",
+      output_types: ["DataFrame"],
+    });
+    const targetHandle = stringify({
+      fieldName: "input_data",
+      id: "TypeConverterComponent-koSIz",
+      inputTypes: ["Message", "Data", "DataFrame"],
+      type: "other",
+    });
+
+    const edge: any = {
+      id:
+        "xy-edge__Memory-8X8Cq" +
+        sourceHandle +
+        "-TypeConverter" +
+        targetHandle,
+      source: "Memory-8X8Cq",
+      target: "TypeConverterComponent-koSIz",
+      sourceHandle,
+      targetHandle,
+      data: {
+        sourceHandle: {
+          dataType: "Memory",
+          id: "Memory-8X8Cq",
+          name: "dataframe",
+          output_types: ["DataFrame"],
+        },
+        targetHandle: {
+          fieldName: "input_data",
+          id: "TypeConverterComponent-koSIz",
+          inputTypes: ["Message", "Data", "DataFrame"],
+          type: "other",
+        },
+      },
+    };
+
+    const result = cleanEdges([memoryNode, typeConverterNode], [edge]);
+
+    expect(result.brokenEdges.length).toBe(0);
+    expect(result.edges.length).toBe(1);
+    // The kept edge must have its source handle rewritten to the migrated Table type.
+    expect(result.edges[0].sourceHandle).toContain("Table");
+  });
+});

--- a/src/frontend/src/utils/__tests__/updatePathEdgeMigration.test.ts
+++ b/src/frontend/src/utils/__tests__/updatePathEdgeMigration.test.ts
@@ -6,103 +6,145 @@
  * when saved but is ["Table"] in the current library. When the user clicks "Update All", the
  * node definition is swapped to the current one (Table) while the edge still stores the old
  * DataFrame handle. cleanEdges must migrate + keep the edge, not drop it.
+ *
+ * Also covers the inverse guarantee: once the target migration rewrites the retained edge's id,
+ * later removal paths (invalid source handle, hidden target field) must still find the edge —
+ * filtering by the original id would silently keep a broken edge in the graph.
  */
 
+import type { AllNodeType, EdgeType } from "../../types/flow";
 import { cleanEdges, scapedJSONStringfy } from "../reactflowUtils";
 
 const stringify = (obj: object): string => scapedJSONStringfy(obj);
 
+function buildMemoryNode(): AllNodeType {
+  // Memory node AFTER "Update All": dataframe output is now typed Table.
+  return {
+    id: "Memory-8X8Cq",
+    type: "genericNode",
+    data: {
+      id: "Memory-8X8Cq",
+      type: "Memory",
+      selected_output: "dataframe",
+      node: {
+        display_name: "Message History",
+        template: {},
+        outputs: [
+          {
+            name: "dataframe",
+            display_name: "Table",
+            types: ["Table"],
+            selected: "Table",
+          },
+        ],
+      },
+    },
+  } as unknown as AllNodeType;
+}
+
+function buildTypeConverterNode({
+  show = true,
+}: {
+  show?: boolean;
+} = {}): AllNodeType {
+  // TypeConverter node AFTER update: input_data accepts the migrated types.
+  return {
+    id: "TypeConverterComponent-koSIz",
+    type: "genericNode",
+    data: {
+      id: "TypeConverterComponent-koSIz",
+      type: "TypeConverterComponent",
+      node: {
+        display_name: "Type Convert",
+        template: {
+          input_data: {
+            type: "other",
+            input_types: ["Message", "Data", "JSON", "DataFrame", "Table"],
+            display_name: "Input",
+            show,
+          },
+        },
+        outputs: [],
+      },
+    },
+  } as unknown as AllNodeType;
+}
+
+function buildLegacyEdge({
+  sourceOutputTypes = ["DataFrame"],
+}: {
+  sourceOutputTypes?: string[];
+} = {}): EdgeType {
+  // Edge as SAVED in the legacy flow: handles still reference pre-migration types.
+  const sourceHandle = stringify({
+    dataType: "Memory",
+    id: "Memory-8X8Cq",
+    name: "dataframe",
+    output_types: sourceOutputTypes,
+  });
+  const targetHandle = stringify({
+    fieldName: "input_data",
+    id: "TypeConverterComponent-koSIz",
+    inputTypes: ["Message", "Data", "DataFrame"],
+    type: "other",
+  });
+
+  return {
+    id:
+      "xy-edge__Memory-8X8Cq" + sourceHandle + "-TypeConverter" + targetHandle,
+    source: "Memory-8X8Cq",
+    target: "TypeConverterComponent-koSIz",
+    sourceHandle,
+    targetHandle,
+    data: {
+      sourceHandle: {
+        dataType: "Memory",
+        id: "Memory-8X8Cq",
+        name: "dataframe",
+        output_types: sourceOutputTypes,
+      },
+      targetHandle: {
+        fieldName: "input_data",
+        id: "TypeConverterComponent-koSIz",
+        inputTypes: ["Message", "Data", "DataFrame"],
+        type: "other",
+      },
+    },
+  } as unknown as EdgeType;
+}
+
 describe("LE-1929 update-path edge migration (DataFrame -> Table)", () => {
   it("keeps the Memory->TypeConverter edge after the Memory output migrates to Table", () => {
-    // Memory node AFTER "Update All": dataframe output is now typed Table.
-    const memoryNode: any = {
-      id: "Memory-8X8Cq",
-      type: "genericNode",
-      data: {
-        id: "Memory-8X8Cq",
-        type: "Memory",
-        selected_output: "dataframe",
-        node: {
-          display_name: "Message History",
-          template: {},
-          outputs: [
-            {
-              name: "dataframe",
-              display_name: "Table",
-              types: ["Table"],
-              selected: "Table",
-            },
-          ],
-        },
-      },
-    };
-
-    // TypeConverter node AFTER update: input_data accepts the migrated types.
-    const typeConverterNode: any = {
-      id: "TypeConverterComponent-koSIz",
-      type: "genericNode",
-      data: {
-        id: "TypeConverterComponent-koSIz",
-        type: "TypeConverterComponent",
-        node: {
-          display_name: "Type Convert",
-          template: {
-            input_data: {
-              type: "other",
-              input_types: ["Message", "Data", "JSON", "DataFrame", "Table"],
-              display_name: "Input",
-            },
-          },
-          outputs: [],
-        },
-      },
-    };
-
-    // Edge as SAVED in the legacy flow: source handle still says DataFrame.
-    const sourceHandle = stringify({
-      dataType: "Memory",
-      id: "Memory-8X8Cq",
-      name: "dataframe",
-      output_types: ["DataFrame"],
-    });
-    const targetHandle = stringify({
-      fieldName: "input_data",
-      id: "TypeConverterComponent-koSIz",
-      inputTypes: ["Message", "Data", "DataFrame"],
-      type: "other",
-    });
-
-    const edge: any = {
-      id:
-        "xy-edge__Memory-8X8Cq" +
-        sourceHandle +
-        "-TypeConverter" +
-        targetHandle,
-      source: "Memory-8X8Cq",
-      target: "TypeConverterComponent-koSIz",
-      sourceHandle,
-      targetHandle,
-      data: {
-        sourceHandle: {
-          dataType: "Memory",
-          id: "Memory-8X8Cq",
-          name: "dataframe",
-          output_types: ["DataFrame"],
-        },
-        targetHandle: {
-          fieldName: "input_data",
-          id: "TypeConverterComponent-koSIz",
-          inputTypes: ["Message", "Data", "DataFrame"],
-          type: "other",
-        },
-      },
-    };
-
-    const result = cleanEdges([memoryNode, typeConverterNode], [edge]);
+    const result = cleanEdges(
+      [buildMemoryNode(), buildTypeConverterNode()],
+      [buildLegacyEdge()],
+    );
 
     expect(result.brokenEdges.length).toBe(0);
     expect(result.edges.length).toBe(1);
     // The kept edge must have its source handle rewritten to the migrated Table type.
     expect(result.edges[0].sourceHandle).toContain("Table");
+  });
+
+  it("removes an edge whose source is invalid even after the target migration rewrote its id", () => {
+    // Source handle stores a type that no longer matches the output and has no
+    // migration path — the edge is broken and must NOT survive cleanup just
+    // because the target block rewrote the retained edge's id first.
+    const result = cleanEdges(
+      [buildMemoryNode(), buildTypeConverterNode()],
+      [buildLegacyEdge({ sourceOutputTypes: ["Vector"] })],
+    );
+
+    expect(result.brokenEdges.length).toBe(1);
+    expect(result.edges.length).toBe(0);
+  });
+
+  it("removes an edge into a hidden field even after the target migration rewrote its id", () => {
+    const result = cleanEdges(
+      [buildMemoryNode(), buildTypeConverterNode({ show: false })],
+      [buildLegacyEdge()],
+    );
+
+    expect(result.edges.length).toBe(0);
   });
 });

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -125,6 +125,9 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
     // check if the source and target handle still exists
     const sourceHandle = edge.sourceHandle; //right
     const targetHandle = edge.targetHandle; //left
+    // Hold by reference: the target block rewrites edge.id on migration, so a second find-by-id in
+    // the source block would miss it and skip the source-handle migration (DataFrame stays). LE-1929.
+    const edgeInNewEdges = newEdges.find((e) => e.id === edge.id);
     if (targetHandle) {
       const targetHandleObject: targetHandleType = scapeJSONParse(targetHandle);
       const field = targetHandleObject.fieldName;
@@ -199,7 +202,7 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
           isAdvanced) &&
         !isLoopInput
       ) {
-        newEdges = newEdges.filter((e) => e.id !== edge.id);
+        newEdges = newEdges.filter((e) => e !== edgeInNewEdges);
         brokenEdges.push(generateAlertObject(sourceNode, targetNode, edge));
       } else if (
         targetHandlesMatchResult &&
@@ -207,7 +210,6 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
       ) {
         // Handles match via migration but IDs differ — update edge to use current types
         // so React Flow can find the DOM handle
-        const edgeInNewEdges = newEdges.find((e) => e.id === edge.id);
         if (edgeInNewEdges) {
           edgeInNewEdges.targetHandle = expectedTargetHandle;
           if (edgeInNewEdges.data) {
@@ -284,7 +286,6 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
             expectedSourceHandle !== sourceHandle
           ) {
             // Handles match via migration but IDs differ — update edge to use current types
-            const edgeInNewEdges = newEdges.find((e) => e.id === edge.id);
             if (edgeInNewEdges) {
               edgeInNewEdges.sourceHandle = expectedSourceHandle;
               if (edgeInNewEdges.data) {
@@ -1901,6 +1902,24 @@ export function processFlowNodes(flow: FlowType) {
     const { nodes, edges } = updateNewOutput(flow.data);
     flow.data.nodes = nodes;
     flow.data.edges = edges;
+  }
+  reconcileStaleGenericNodeDimensions(flow.data.nodes);
+}
+
+/**
+ * Drop persisted width/height on genericNodes so React Flow re-measures the real DOM size.
+ *
+ * The component card is a fixed Tailwind width (`w-80`/`w-48`). Flows saved when that width was
+ * larger (`w-96` = 384px) kept `width: 384`, which React Flow then uses to place the right-side
+ * output handle — landing it ~64px past the visual dot so edges render detached (LE-1929). Only
+ * genericNodes are content-sized; noteNodes are user-resizable and keep their dimensions.
+ */
+export function reconcileStaleGenericNodeDimensions(nodes: AllNodeType[]) {
+  for (const node of nodes) {
+    if (node.type !== "genericNode") continue;
+    delete node.width;
+    delete node.height;
+    delete node.measured;
   }
 }
 

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -279,7 +279,7 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
             sourceHandle,
           );
           if (!sourceMatchResult && !hasAllowsLoop) {
-            newEdges = newEdges.filter((e) => e.id !== edge.id);
+            newEdges = newEdges.filter((e) => e !== edgeInNewEdges);
             brokenEdges.push(generateAlertObject(sourceNode, targetNode, edge));
           } else if (
             sourceMatchResult &&
@@ -303,13 +303,18 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
             }
           }
         } else {
-          newEdges = newEdges.filter((e) => e.id !== edge.id);
+          newEdges = newEdges.filter((e) => e !== edgeInNewEdges);
           brokenEdges.push(generateAlertObject(sourceNode, targetNode, edge));
         }
       }
     }
 
-    newEdges = filterHiddenFieldsEdges(edge, newEdges, targetNode);
+    // Pass the retained reference: its id/handles reflect any migration above.
+    newEdges = filterHiddenFieldsEdges(
+      edgeInNewEdges ?? edge,
+      newEdges,
+      targetNode,
+    );
   });
 
   return { edges: newEdges, brokenEdges };

--- a/src/lfx/src/lfx/interface/initialize/loading.py
+++ b/src/lfx/src/lfx/interface/initialize/loading.py
@@ -79,7 +79,9 @@ async def get_instance_results(
     from lfx.memory.flow_context import reset_current_flow_id, set_current_flow_id
 
     flow_id = getattr(getattr(vertex, "graph", None), "flow_id", None)
-    flow_scope_token = set_current_flow_id(flow_id) if flow_id is not None else None
+    # Always bind — including None — so a graph without flow_id shadows any outer
+    # flow scope instead of inheriting it (nested runs must stay legacy-unscoped).
+    flow_scope_token = set_current_flow_id(flow_id)
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=PydanticDeprecatedSince20)
@@ -90,8 +92,7 @@ async def get_instance_results(
             msg = f"Base type {base_type} not found."
             raise ValueError(msg)
     finally:
-        if flow_scope_token is not None:
-            reset_current_flow_id(flow_scope_token)
+        reset_current_flow_id(flow_scope_token)
 
 
 def get_params(vertex_params):

--- a/src/lfx/src/lfx/interface/initialize/loading.py
+++ b/src/lfx/src/lfx/interface/initialize/loading.py
@@ -76,14 +76,22 @@ async def get_instance_results(
         vertex.load_from_db_fields,
         fallback_to_env_vars=fallback_to_env_vars,
     )
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=PydanticDeprecatedSince20)
-        if base_type == "custom_components":
-            return await build_custom_component(params=custom_params, custom_component=custom_component)
-        if base_type == "component":
-            return await build_component(params=custom_params, custom_component=custom_component)
-        msg = f"Base type {base_type} not found."
-        raise ValueError(msg)
+    from lfx.memory.flow_context import reset_current_flow_id, set_current_flow_id
+
+    flow_id = getattr(getattr(vertex, "graph", None), "flow_id", None)
+    flow_scope_token = set_current_flow_id(flow_id) if flow_id is not None else None
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=PydanticDeprecatedSince20)
+            if base_type == "custom_components":
+                return await build_custom_component(params=custom_params, custom_component=custom_component)
+            if base_type == "component":
+                return await build_component(params=custom_params, custom_component=custom_component)
+            msg = f"Base type {base_type} not found."
+            raise ValueError(msg)
+    finally:
+        if flow_scope_token is not None:
+            reset_current_flow_id(flow_scope_token)
 
 
 def get_params(vertex_params):

--- a/src/lfx/src/lfx/memory/flow_context.py
+++ b/src/lfx/src/lfx/memory/flow_context.py
@@ -1,0 +1,60 @@
+"""Ambient flow-scope for chat-memory retrieval (defense-in-depth for old saved flows).
+
+Langflow executes the *frozen* component ``code`` embedded in each saved flow, not the installed
+library version (see ``lfx.interface.initialize.loading.instantiate_class`` ->
+``eval_custom_component_code``). A flow saved before PR #13087 therefore carries the old
+``MemoryComponent.retrieve_messages`` that calls ``aget_messages`` WITHOUT ``flow_id`` and leaks
+chat history across flows on a colliding ``session_id`` (issue #13059) — even on a patched server,
+because the fix only updated the library default, not code already frozen into saved flows.
+
+This ContextVar carries the executing graph's ``flow_id`` so ``aget_messages`` can default the
+scope when a caller omits it. It is bound only for the duration of a component's execution
+(``get_instance_results``) and reset afterward, so:
+
+* callers that pass ``flow_id`` explicitly are unaffected (the default applies only when ``None``),
+* callers outside a graph run see an unset ContextVar and thus identical, legacy behavior.
+
+This is not new semantics — it is the PR #13087 flow-scoping contract, applied at the platform
+function the frozen code calls instead of inside the (unchangeable) frozen code.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from uuid import UUID
+
+_current_flow_id: contextvars.ContextVar[str | UUID | None] = contextvars.ContextVar(
+    "lfx_current_flow_id",
+    default=None,
+)
+
+
+def get_current_flow_id() -> str | UUID | None:
+    """Return the ``flow_id`` of the graph currently executing, or ``None`` outside a graph run."""
+    return _current_flow_id.get()
+
+
+def set_current_flow_id(flow_id: str | UUID | None) -> contextvars.Token[str | UUID | None]:
+    """Bind *flow_id* as the ambient flow scope for the current async task / thread."""
+    return _current_flow_id.set(flow_id)
+
+
+def reset_current_flow_id(token: contextvars.Token[str | UUID | None]) -> None:
+    """Restore the previous ambient flow scope."""
+    _current_flow_id.reset(token)
+
+
+def coerce_flow_id(flow_id: str | UUID | None) -> UUID | None:
+    """Coerce an ambient ``flow_id`` (usually ``graph.flow_id``, a ``str``) to ``UUID``.
+
+    Returns ``None`` when the value is missing or not a valid UUID (synthetic/test graph ids),
+    so retrieval degrades to the previous unscoped behavior rather than crashing.
+    """
+    if flow_id is None or flow_id == "":
+        return None
+    if isinstance(flow_id, UUID):
+        return flow_id
+    try:
+        return UUID(str(flow_id))
+    except (ValueError, TypeError, AttributeError):
+        return None


### PR DESCRIPTION
## Summary

Fixes a cross-flow chat-history leak (issue #13059) that still affected **legacy saved flows**, plus two flow-editor rendering bugs surfaced while validating the same legacy flow.

## 1. Memory — cross-flow chat-history leak in legacy flows (primary)

`MemoryComponent.retrieve_messages` was scoped by `flow_id` in #13087, but Langflow executes the **frozen component `code` embedded in each saved flow** (`lfx.interface.initialize.loading.instantiate_class` → `eval_custom_component_code`), not the installed library. A flow saved before #13087 keeps the old *unscoped* `retrieve_messages` and leaks another flow's history on a colliding `session_id` — on any server version.

**Fix (defense-in-depth; frozen code untouched):** an ambient `flow_id` ContextVar (`lfx/memory/flow_context.py`) is bound around component execution in `get_instance_results`; `aget_messages` defaults its scope from it **only when `flow_id is None`**. Explicit callers and non-graph callers are unchanged — this extends the #13087 contract to the platform function the frozen code calls, instead of the (unchangeable) frozen code.

Verified live on the reporter's actual legacy flow across `POST /api/v1/run/{flow}` and `POST /api/v1/build/{flow}/flow` (Playground): leaked before, no leak after.

## 2. Frontend — `cleanEdges` skips the source-handle migration when both handles migrate

When an edge needs **both** handles migrated (e.g. `DataFrame`→`Table`, #11554), the target block rewrote `edge.id`, then the source block's `find`-by-original-id failed and silently skipped the source rewrite — leaving a kept-but-detached edge. Fixed by capturing the edge reference once and reusing it in both blocks.

## 3. Frontend — legacy nodes render with detached edges (stale width)

Flows saved when the node card was `w-96` (384px) kept `width: 384`; the card now renders `w-80` (320px), so React Flow placed the right-side output handle ~64px past the visual dot (edges rendered detached, unfixable by dragging). `processFlowNodes` now drops persisted `width`/`height`/`measured` on `genericNode`s so React Flow re-measures the real size; `noteNode`s (user-resizable) are preserved.

## Testing

- **Backend:** 6 new tests in `test_message_flow_context_scoping.py` (incl. a graph-level e2e reproducing an old-style unscoped component); 115 existing memory tests green; `ruff format`/`check` clean.
- **Frontend:** `updatePathEdgeMigration.test.ts`, `reconcileNodeDimensions.test.ts`; 40 existing edge/type-compatibility tests green; biome clean.

## Backward compatibility

No component class or `name`/input/output renames. Changes are additive and default to legacy behavior when the new context is absent, so existing flows and API consumers are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat memory retrieval is now correctly scoped to the active flow, preventing messages from other flows with the same session from appearing.
  * Explicit flow selections continue to override automatic scoping, while invalid or missing context preserves legacy behavior.
  * Fixed migration of saved connections when output types change from `DataFrame` to `Table`.
  * Generic nodes now refresh stale dimensions correctly while preserving user-resized note dimensions.

* **Tests**
  * Added regression coverage for flow-scoped memory retrieval, graph execution, edge migration, and node dimension reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->