### PR TITLE
fix: restore user_id on HITL checkpoint resume

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -479,6 +479,8 @@ async def generate_flow_events(
             # or expired checkpoint is unrecoverable, so surface a clean 404 instead.
             raise HTTPException(status_code=404, detail="Checkpoint expired or not found; cannot resume this run.")
         graph = LfxGraph.resume_from_checkpoint(checkpoint, checkpoint_store=store)
+        if not graph.user_id:
+            graph.user_id = str(current_user.id)
         # Resume skips the initial run's trace setup (trace_context_var stays unset → post-pause
         # vertices like Chat Output never trace); re-init so the resumed vertices trace.
         graph.flow_name = graph.flow_name or flow_name

--- a/src/lfx/src/lfx/components/models_and_agents/a2a_agent.py
+++ b/src/lfx/src/lfx/components/models_and_agents/a2a_agent.py
@@ -503,6 +503,53 @@ class A2AAgentComponent(Component):
             return await self._run_internal_agent()
         return await self._call_external_agent()
 
+    async def _run_target_isolated(self, graph, flow_id: str):
+        """Run the target flow with the caller's LangChain run-config context reset.
+
+        When the caller Agent is under tool-approval (HITL), it runs inside a LangGraph
+        whose RunnableConfig — carrying ``configurable.thread_id`` + the durable checkpointer —
+        is propagated to child runnables through ``var_child_runnable_config``. ``graph.arun``
+        does ``copy_context()``, so the target flow's own Agent would inherit that thread id and
+        checkpoint against the CALLER's HITL thread, corrupting its tool loop ("tool_use without
+        tool_result"). Resetting the contextvar to a clean config before the nested run makes the
+        target execute as a fresh, independent graph.
+        """
+        from lfx.helpers import run_flow
+
+        try:
+            from langchain_core.runnables.config import var_child_runnable_config
+        except ImportError:
+            var_child_runnable_config = None
+
+        async def _do_run():
+            return await run_flow(
+                inputs={"input_value": self.input_value, "type": "chat"},
+                graph=graph,
+                user_id=str(self.user_id),
+                session_id=self._isolated_sub_session(flow_id),
+                output_type="chat",
+            )
+
+        if var_child_runnable_config is None:
+            return await _do_run()
+        token = var_child_runnable_config.set(None)
+        try:
+            return await _do_run()
+        finally:
+            var_child_runnable_config.reset(token)
+
+    def _isolated_sub_session(self, flow_id: str) -> str:
+        """Session for the internal sub-run, isolated from the caller's LangGraph thread.
+
+        Running the target on the caller's raw session_id makes the target's Agent inherit the
+        caller's in-flight thread — which mid-tool-execution holds this ``send_to_agent`` call as
+        an orphan ``tool_use`` with no ``tool_result`` yet — so the target's LLM call is rejected
+        ("tool_use without tool_result"). Namespacing by (caller session, target flow) gives the
+        sub-agent its own thread while staying stable across calls within one caller session.
+        """
+        base = getattr(getattr(self, "graph", None), "session_id", None)
+        return f"{base}:a2a:{flow_id}" if base else uuid.uuid4().hex
+
     async def _run_internal_agent(self) -> Message:
         # An in-project A2A agent is just a flow with chat I/O, so run it in-process (no HTTP, no
         # SSRF, no api key) and read its chat reply. Same three primitives Run Flow uses.
@@ -538,14 +585,7 @@ class A2AAgentComponent(Component):
             flow_id=str(flow.data.get("id", "")),
             flow_name=flow.data.get("name"),
         )
-        session_id = getattr(getattr(self, "graph", None), "session_id", None)
-        run_outputs = await run_flow(
-            inputs={"input_value": self.input_value, "type": "chat"},
-            graph=graph,
-            user_id=str(self.user_id),
-            session_id=session_id,
-            output_type="chat",
-        )
+        run_outputs = await self._run_target_isolated(graph, flow_id)
         answer = self._reply_from_run(run_outputs)
         message = Message(text=answer or "No response received from the agent.")
         self.status = message

--- a/src/lfx/src/lfx/components/models_and_agents/a2a_agent.py
+++ b/src/lfx/src/lfx/components/models_and_agents/a2a_agent.py
@@ -554,7 +554,7 @@ class A2AAgentComponent(Component):
         # An in-project A2A agent is just a flow with chat I/O, so run it in-process (no HTTP, no
         # SSRF, no api key) and read its chat reply. Same three primitives Run Flow uses.
         from lfx.graph.graph.base import Graph
-        from lfx.helpers import get_flow_by_id_or_name, run_flow
+        from lfx.helpers import get_flow_by_id_or_name
 
         agent_name = self.agent_name_selected or None
         if not agent_name:

--- a/src/lfx/src/lfx/graph/checkpoint/builder.py
+++ b/src/lfx/src/lfx/graph/checkpoint/builder.py
@@ -51,6 +51,7 @@ def build_checkpoint(graph: Graph) -> GraphCheckpoint:
         run_id=str(graph.run_id),
         flow_id=str(graph.flow_id) if graph.flow_id else None,
         session_id=graph.session_id or None,
+        user_id=str(graph.user_id) if graph.user_id else None,
         job_id=graph.job_id,
         flow_payload=flow_payload,
         run_map={k: list(v) for k, v in run_state["run_map"].items()},

--- a/src/lfx/src/lfx/graph/checkpoint/resume.py
+++ b/src/lfx/src/lfx/graph/checkpoint/resume.py
@@ -142,6 +142,10 @@ def restore_graph_from_checkpoint(checkpoint: GraphCheckpoint, *, store: Checkpo
     graph.set_run_id(checkpoint.run_id)
     if checkpoint.session_id:
         graph.session_id = checkpoint.session_id
+    # Continue under the starting identity; else self.user_id (via graph.user_id) is None
+    # and str(None) fails UUID parsing for A2A/flow tools ("badly formed hexadecimal UUID string").
+    if checkpoint.user_id:
+        graph.user_id = checkpoint.user_id
     graph.job_id = checkpoint.job_id
     graph.checkpointing_enabled = True
     graph.checkpoint_store = store

--- a/src/lfx/src/lfx/graph/checkpoint/schema.py
+++ b/src/lfx/src/lfx/graph/checkpoint/schema.py
@@ -33,6 +33,9 @@ class GraphCheckpoint(BaseModel):
     run_id: str
     flow_id: str | None = None
     session_id: str | None = None
+    # The identity the run started under; restored so a resumed run continues as the same
+    # user (e.g. self.user_id-reading components keep working after a HITL pause).
+    user_id: str | None = None
     job_id: str | None = None
     flow_payload: dict[str, Any] = Field(default_factory=dict)
     run_map: dict[str, list[str]] = Field(default_factory=dict)

--- a/src/lfx/tests/unit/components/models_and_agents/test_a2a_agent.py
+++ b/src/lfx/tests/unit/components/models_and_agents/test_a2a_agent.py
@@ -525,3 +525,79 @@ def test_card_payload_clips_untrusted_strings():
 
     assert len(payload["title"]) <= 500
     assert len(payload["sections"][0]["text"]) <= 500
+
+
+class TestInternalSubSessionIsolation:
+    """The internal sub-run must not share the caller's LangGraph thread.
+
+    Running the target on the caller's raw session_id makes the target's Agent inherit the
+    caller's in-flight thread — which, mid tool-approval, holds the send_to_agent call as an
+    orphan tool_use with no tool_result — so the target's LLM call is rejected with
+    'tool_use ids were found without tool_result blocks'. The sub-run must get an isolated
+    session namespaced off the caller's.
+    """
+
+    def test_sub_session_is_namespaced_off_caller_session(self):
+        from types import SimpleNamespace
+
+        component = A2AAgentComponent(mode="Internal", input_value="hi")
+        component._vertex = SimpleNamespace(graph=SimpleNamespace(session_id="caller-session-abc"))
+
+        sub = component._isolated_sub_session("flow-123")
+
+        assert sub == "caller-session-abc:a2a:flow-123"
+        assert sub != "caller-session-abc"  # never the caller's own thread
+
+    def test_sub_session_is_unique_when_caller_has_no_session(self):
+        from types import SimpleNamespace
+
+        component = A2AAgentComponent(mode="Internal", input_value="hi")
+        component._vertex = SimpleNamespace(graph=SimpleNamespace(session_id=None))
+
+        sub = component._isolated_sub_session("flow-123")
+
+        assert sub  # non-empty
+        assert sub != "flow-123"
+        assert ":a2a:" not in sub  # falls back to a fresh uuid, not a namespaced base
+
+
+class TestNestedRunConfigIsolation:
+    """The nested target run must not inherit the caller's LangChain RunnableConfig.
+
+    Under tool-approval (HITL), the caller Agent runs inside a LangGraph whose config carries
+    ``configurable.thread_id`` + the durable checkpointer. LangChain propagates that config to
+    child runnables via ``var_child_runnable_config``, and ``graph.arun`` copies the context, so
+    the target flow's Agent would checkpoint against the CALLER's HITL thread and corrupt its own
+    tool loop ("tool_use ids were found without tool_result blocks"). ``_run_target_isolated``
+    must reset the contextvar for the duration of the nested run and restore it after.
+    """
+
+    async def test_nested_run_sees_reset_config_and_restores_after(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from langchain_core.runnables.config import var_child_runnable_config
+
+        from lfx import helpers
+
+        seen: dict = {}
+
+        async def fake_run_flow(**kwargs):
+            seen["config_during_run"] = var_child_runnable_config.get()
+            seen["session_id"] = kwargs.get("session_id")
+            return []
+
+        monkeypatch.setattr(helpers, "run_flow", fake_run_flow)
+
+        component = A2AAgentComponent(mode="Internal", input_value="hi")
+        component._vertex = SimpleNamespace(graph=SimpleNamespace(session_id="caller-1"))
+        component._user_id = "user-1"
+
+        sentinel = {"configurable": {"thread_id": "caller-hitl-thread"}}
+        token = var_child_runnable_config.set(sentinel)
+        try:
+            await component._run_target_isolated(graph=object(), flow_id="target-flow")
+            assert seen["config_during_run"] is None  # caller's HITL thread never leaks in
+            assert seen["session_id"] == "caller-1:a2a:target-flow"
+            assert var_child_runnable_config.get() == sentinel  # restored for the caller loop
+        finally:
+            var_child_runnable_config.reset(token)

--- a/src/lfx/tests/unit/graph/checkpoint/test_resume_round_trip.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_resume_round_trip.py
@@ -89,6 +89,32 @@ async def test_resume_without_decision_suspends_again():
         await resumed.process(fallback_to_env_vars=False)
 
 
+async def test_resume_restores_user_id_from_checkpoint():
+    """A durable run must resume under the identity that started it.
+
+    The checkpoint is written mid-run (user_id already stamped by the initial build), so
+    resume must restore graph.user_id too. Without it, a component that reads self.user_id
+    on resume — e.g. an A2A Agent tool listing in-project agents under HITL tool-approval —
+    resolves it to None via the graph.user_id fallback, and str(None) == "None" is then
+    parsed as a UUID: "badly formed hexadecimal UUID string".
+    """
+    store = InMemoryCheckpointStore()
+    first = _graph(store)
+    first.user_id = "f7bee55e-6daa-4d9d-916a-2f8783e02ed8"
+    with pytest.raises(GraphPausedException):
+        await first.process(fallback_to_env_vars=False)
+
+    checkpoint = await store.load_by_run_id("job-1")
+    resumed = Graph.resume_from_checkpoint(checkpoint, checkpoint_store=store)
+
+    # Root cause: the resumed graph must carry the original identity.
+    assert resumed.user_id == "f7bee55e-6daa-4d9d-916a-2f8783e02ed8"
+    # Exact A2A failure mechanism: the component's user_id property falls back to
+    # graph.user_id, so a restored component (its own _user_id lost) must still resolve it.
+    pauser_component = resumed.get_vertex("pauser").custom_component
+    assert pauser_component.user_id == "f7bee55e-6daa-4d9d-916a-2f8783e02ed8"
+
+
 async def test_resume_reapplies_user_id_to_restored_component():
     """A checkpoint-restored component loses _user_id; the build re-applies it on resume.
 


### PR DESCRIPTION
## Summary

A durable HITL run lost the identity it started with on resume, so any component that reads `self.user_id` after a pause failed. The concrete symptom: an **Internal-mode A2A Agent used as an Agent tool with tool-approval** errors on resume-after-approve with:

```
Error listing A2A agents: badly formed hexadecimal UUID string
```

The same tool call succeeds with approval **off** (it runs inline during the initial build); only the resume path broke.

## Root cause

`GraphCheckpoint` persisted `flow_id` / `session_id` / `job_id` but **not `user_id`**, and `restore_graph_from_checkpoint` never re-applied it. So the resumed `graph.user_id` was `None`.

The A2A component's `user_id` property falls back to `self.graph.user_id`, so on resume it resolved to `None` → `str(None)` == `"None"`, which passes the `if not user_id` guard (a truthy string) and reaches `UUID("None")` in `helpers/flow.py` → `ValueError: badly formed hexadecimal UUID string`.

`lfx serve` durable already re-applied identity via `apply_run_defaults`; the **langflow backend resume path did not**.

## Fix

Persist identity in the checkpoint so a durable run resumes as the user that started it:

- `schema.py` — add `user_id: str | None` to `GraphCheckpoint`.
- `builder.py` — write `user_id` in `build_checkpoint`.
- `resume.py` — restore `graph.user_id` in `restore_graph_from_checkpoint`.
- `api/build.py` — back-compat fallback to the resuming caller for checkpoints written before this change.

## Testing

- **Unit (TDD, RED→GREEN):** new `test_resume_restores_user_id_from_checkpoint` — before the fix the resumed graph and restored component both resolved `user_id` to `None`; after, both carry the original identity. Full checkpoint suite green (52), incl. `test_resume_after_restart` which round-trips the new field through the real SQLite durable store across a restart. Backend durable/resume tests green (31 + 20).
- **Live end-to-end via API** (`/api/v2/workflows`, background HITL): reproduced the exact scenario — Agent + Internal A2A tool + tool approval → paused at `send_to_agent` → approved → job **`completed`** with the specialist's reply flowing back through the resumed tool, **no** "badly formed hexadecimal UUID string".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user identity when pausing and resuming human-in-the-loop workflows.
  * Improved resumed workflow reliability for tools and components that require user identification.
  * Ensured resumed runs fall back to the authenticated user when identity information is unavailable.

* **Tests**
  * Added coverage verifying user identity is retained across checkpoint and resume cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->