### PR TITLE
fix: discover embeddings from custom OpenAI endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2451,7 +2451,7 @@
         "filename": "src/backend/tests/unit/test_unified_models.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 527,
+        "line_number": 528,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T21:20:50Z"
+  "generated_at": "2026-07-22T00:14:20Z"
 }

--- a/src/backend/tests/unit/test_openai_base_url_support.py
+++ b/src/backend/tests/unit/test_openai_base_url_support.py
@@ -10,7 +10,8 @@ LM Studio, Ollama's /v1) cannot even be saved.
 Design: OPENAI_BASE_URL is OPTIONAL — the existing experience (paste an
 API key, static catalog) is byte-identical when it is not set. With it
 set, ChatOpenAI targets the custom server, validation validates against
-it, and the model list comes live from ``{base}/models``.
+it, and the model list comes live from ``{base}/models`` for both language
+model and embedding pickers.
 
 Mock boundaries: ChatOpenAI construction, variable lookups, and the HTTP
 fetch — external servers CI cannot reproduce.
@@ -27,6 +28,7 @@ from lfx.base.models.model_utils import (
     replace_with_live_models,
 )
 from lfx.base.models.unified_models import (
+    get_embeddings,
     get_model_provider_variable_mapping,
     get_provider_all_variables,
     get_provider_required_variable_keys,
@@ -83,6 +85,39 @@ class TestGetLlmBaseUrl:
         assert llm.openai_api_base is None
 
 
+class TestGetEmbeddingsBaseUrl:
+    @patch("lfx.base.models.unified_models.get_api_key_for_provider", return_value="sk-test")
+    @patch("lfx.base.models.unified_models.get_embedding_class")
+    def test_should_pass_global_base_url_to_openai_embeddings(self, get_embedding_class, get_api_key):
+        embedding_class = MagicMock()
+        get_embedding_class.return_value = embedding_class
+        model = [
+            {
+                "name": "BAAI/bge-base-en-v1.5",
+                "provider": "OpenAI",
+                "metadata": {},
+            }
+        ]
+
+        with (
+            patch(
+                "lfx.base.models.unified_models.get_all_variables_for_provider",
+                return_value={
+                    "OPENAI_API_KEY": "sk-test",  # pragma: allowlist secret
+                    "OPENAI_BASE_URL": CUSTOM_BASE_URL,
+                },
+            ),
+            patch(
+                "lfx.base.models.unified_models.instantiation._get_configured_embedding_providers",
+                return_value=[],
+            ),
+        ):
+            get_embeddings(model, user_id=USER_ID)
+
+        get_api_key.assert_any_call(USER_ID, "OpenAI", None)
+        assert embedding_class.call_args.kwargs["base_url"] == transform_localhost_url(CUSTOM_BASE_URL)
+
+
 class TestKeyValidationWithBaseUrl:
     def test_should_validate_against_the_custom_endpoint_when_base_url_is_set(self):
         chat_openai = MagicMock()
@@ -134,12 +169,30 @@ class TestLiveOpenAICompatibleModels:
         assert all(m["tool_calling"] for m in models)
         assert http_get.call_args.args[0] == f"{CUSTOM_BASE_URL}/models"
 
-    def test_should_not_list_embeddings_from_the_custom_server(self):
-        with patch(
-            "lfx.base.models.model_utils.get_provider_variable_value",
-            return_value=CUSTOM_BASE_URL,
+    def test_should_list_embeddings_from_the_custom_server(self):
+        response = MagicMock()
+        response.json.return_value = {"data": [{"id": "BAAI/bge-base-en-v1.5"}]}
+        response.raise_for_status.return_value = None
+        with (
+            patch(
+                "lfx.base.models.model_utils.get_provider_variable_value",
+                side_effect=lambda _uid, key: CUSTOM_BASE_URL
+                if key == "OPENAI_BASE_URL"
+                else "sk-test",  # pragma: allowlist secret
+            ),
+            patch("requests.get", return_value=response),
         ):
-            assert fetch_live_openai_compatible_models(USER_ID, "embeddings") == []
+            models = fetch_live_openai_compatible_models(USER_ID, "embeddings")
+
+        assert [model["name"] for model in models] == ["BAAI/bge-base-en-v1.5"]
+        assert all(model["model_type"] == "embeddings" for model in models)
+        assert all(not model["tool_calling"] for model in models)
+
+    def test_should_reject_unknown_model_type_without_fetching(self):
+        with patch("requests.get") as http_get:
+            assert fetch_live_openai_compatible_models(USER_ID, "image") == []
+
+        http_get.assert_not_called()
 
 
 class TestConditionalLiveReplacement:
@@ -174,6 +227,25 @@ class TestConditionalLiveReplacement:
             replace_with_live_models(catalog, USER_ID, ["OpenAI"], model_type="llm")
 
         assert [m["model_name"] for m in catalog[0]["models"]] == ["gpt-oss:20b"]
+
+    def test_should_replace_embedding_catalog_with_server_models_when_base_url_is_configured(self):
+        catalog = [{"provider": "OpenAI", "models": [{"model_name": "text-embedding-3-small", "metadata": {}}]}]
+        live = [
+            {
+                "name": "BAAI/bge-base-en-v1.5",
+                "provider": "OpenAI",
+                "model_type": "embeddings",
+                "tool_calling": False,
+            }
+        ]
+        with patch(
+            "lfx.base.models.model_utils.get_live_models_for_provider",
+            return_value=live,
+        ):
+            replace_with_live_models(catalog, USER_ID, ["OpenAI"], model_type="embeddings")
+
+        assert [model["model_name"] for model in catalog[0]["models"]] == ["BAAI/bge-base-en-v1.5"]
+        assert catalog[0]["models"][0]["metadata"]["model_type"] == "embeddings"
 
 
 class TestMalformedModelsPayload:

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -14,6 +14,7 @@ from lfx.base.models.unified_models import (
 )
 from lfx.base.models.unified_models.build_config import _resolve_dropdown_provider_values
 from lfx.base.models.unified_models.provider_queries import get_models_detailed
+from lfx.services.variable.request_scope import activate_no_env_fallback, reset_no_env_fallback
 
 
 @pytest.fixture(autouse=True)
@@ -627,6 +628,26 @@ def test_get_embeddings_openai_api_base_env_fallback(
 
     kwargs = mock_embedding_class.call_args.kwargs
     assert kwargs["base_url"] == expected_base_url
+
+
+@pytest.mark.parametrize("variable_name", ["OPENAI_EMBEDDINGS_API_BASE", "OPENAI_API_BASE"])
+@patch("lfx.base.models.unified_models.get_api_key_for_provider")
+@patch("lfx.base.models.unified_models.get_embedding_class")
+def test_get_embeddings_openai_api_base_env_fallback_can_be_disabled(
+    mock_get_class, mock_get_api_key, monkeypatch, variable_name
+):
+    mock_get_api_key.return_value = "sk-test"
+    mock_embedding_class = MagicMock()
+    mock_get_class.return_value = mock_embedding_class
+    monkeypatch.setenv(variable_name, "http://openai-compatible.example/v1")
+    token = activate_no_env_fallback(disabled=True)
+
+    try:
+        get_embeddings([_make_openai_embedding_model()], api_key="sk-test")
+    finally:
+        reset_no_env_fallback(token)
+
+    assert "base_url" not in mock_embedding_class.call_args.kwargs
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -528,11 +528,11 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
     """Fetch models from a custom OpenAI-compatible endpoint (OPENAI_BASE_URL).
 
     Returns [] when no custom base URL is configured, so api.openai.com
-    users keep the curated static catalog. ``tool_calling`` is assumed
-    True: ``/models`` carries no capability data and the OpenAI wire
-    format implies tools support.
+    users keep the curated static catalog. Because ``/models`` carries no
+    capability data, the endpoint's models are offered in whichever picker
+    requested them. ``tool_calling`` is assumed only for language models.
     """
-    if model_type != "llm":
+    if model_type not in {"llm", "embeddings"}:
         return []
 
     base_url = get_provider_variable_value(user_id, "OPENAI_BASE_URL")
@@ -566,8 +566,8 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
             provider="OpenAI",
             name=entry["id"],
             icon="OpenAI",
-            model_type="llm",
-            tool_calling=True,
+            model_type=model_type,
+            tool_calling=model_type == "llm",
             default=index < MIN_DEFAULT_MODELS,
         )
         for index, entry in enumerate(entries)

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -551,9 +551,16 @@ def _compose_embedding_kwargs(
     if isinstance(api_base_value, str) and not api_base_value.strip():
         api_base_value = None
     if provider == "OpenAI" and not api_base_value:
-        api_base_value = _to_str(os.environ.get("OPENAI_EMBEDDINGS_API_BASE")) or _to_str(
-            os.environ.get("OPENAI_API_BASE")
-        )
+        provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
+        openai_base_url = _to_str(provider_vars.get("OPENAI_BASE_URL")) or _to_str(_env_if_allowed("OPENAI_BASE_URL"))
+        if openai_base_url:
+            from lfx.utils.util import transform_localhost_url
+
+            api_base_value = transform_localhost_url(openai_base_url)
+        else:
+            api_base_value = _to_str(os.environ.get("OPENAI_EMBEDDINGS_API_BASE")) or _to_str(
+                os.environ.get("OPENAI_API_BASE")
+            )
 
     kwargs: dict[str, Any] = {}
     if "model" in param_mapping:

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -558,8 +558,8 @@ def _compose_embedding_kwargs(
 
             api_base_value = transform_localhost_url(openai_base_url)
         else:
-            api_base_value = _to_str(os.environ.get("OPENAI_EMBEDDINGS_API_BASE")) or _to_str(
-                os.environ.get("OPENAI_API_BASE")
+            api_base_value = _to_str(_env_if_allowed("OPENAI_EMBEDDINGS_API_BASE")) or _to_str(
+                _env_if_allowed("OPENAI_API_BASE")
             )
 
     kwargs: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

- discover models from a configured `OPENAI_BASE_URL` for the embedding picker as well as the language-model picker
- pass the saved OpenAI base URL into `OpenAIEmbeddings` at runtime
- preserve static OpenAI defaults when no custom endpoint is configured and retain existing component/env precedence

## Root cause

OpenAI live discovery returned early for every model type except `llm`, and the embedding instantiation path never read the globally saved `OPENAI_BASE_URL`.

OpenAI-compatible `/models` responses do not expose model capabilities, so discovered IDs are tagged for whichever picker requested them. This matches the existing OpenAI Compatible provider behavior.

## Validation

- `85 passed`: `test_openai_base_url_support.py` + `test_unified_models.py`
- Ruff check and format check passed for all changed files
- repository pre-commit hooks passed, including detect-secrets

Fixes #14180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI-compatible servers can now provide both language models and embedding models through a configured base URL.
  * Embedding model catalogs are populated from the server’s live model list.

* **Bug Fixes**
  * Embedding providers now consistently honor the configured OpenAI base URL, including normalized local addresses.
  * Model capabilities are correctly represented when models are loaded from custom OpenAI-compatible servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->