### PR TITLE
fix(mcp): respect server timeout during session validation

### DIFF
--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -54,6 +54,7 @@ is_dangerous_mcp_env_var = mcp_security.is_dangerous_mcp_env_var
 
 # MCP Session Manager constants - lazy loaded
 _mcp_settings_cache: dict[str, Any] = {}
+_SESSION_VALIDATION_TIMEOUT_FLOOR = 10.0
 
 
 def _validate_mcp_stdio_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -90,6 +91,14 @@ def _resolve_mcp_tool_execution_timeout(tool_execution_timeout: float | None) ->
 
     configured_timeouts = [float(value) for value in (configured, mcp_server_timeout) if value is not None]
     return max(configured_timeouts) if configured_timeouts else 180.0
+
+
+def get_session_validation_timeout() -> float:
+    """Derive a fast session health-check timeout from the configured connection budget."""
+    connect_timeout = _get_mcp_setting("mcp_server_timeout", None)
+    if connect_timeout is None:
+        return _SESSION_VALIDATION_TIMEOUT_FLOOR
+    return max(_SESSION_VALIDATION_TIMEOUT_FLOOR, float(connect_timeout) / 3.0)
 
 
 def get_max_sessions_per_server() -> int:
@@ -1150,8 +1159,8 @@ class MCPSessionManager:
         """Validate that the session is actually usable by testing a simple operation."""
         try:
             # Try to list tools as a connectivity test (this is a lightweight operation)
-            # Use a shorter timeout for the connectivity test to fail fast
-            response = await asyncio.wait_for(session.list_tools(), timeout=3.0)
+            # Keep the health check shorter than connection setup while honoring its configured budget.
+            response = await asyncio.wait_for(session.list_tools(), timeout=get_session_validation_timeout())
         except Exception as e:  # noqa: BLE001
             # Any failure means the session is not safe to reuse (SDK errors, terminated session, etc.)
             await logger.adebug(f"Session connectivity test failed: {type(e).__name__}: {e}")

--- a/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
+++ b/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
@@ -1,9 +1,13 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from lfx.base.mcp.util import (
+    MCPSessionManager,
     MCPStdioClient,
     MCPStreamableHttpClient,
     _resolve_mcp_tool_execution_timeout,
+    get_session_validation_timeout,
 )
 
 
@@ -53,6 +57,43 @@ def test_resolve_mcp_tool_execution_timeout_uses_server_timeout_when_tool_timeou
 def test_resolve_mcp_tool_execution_timeout_falls_back_to_180_when_no_settings_exist():
     with patch("lfx.base.mcp.util._get_mcp_setting", return_value=None):
         assert _resolve_mcp_tool_execution_timeout(None) == 180.0
+
+
+@pytest.mark.parametrize(
+    ("server_timeout", "expected"),
+    [
+        (None, 10.0),
+        (20, 10.0),
+        (60, 20.0),
+    ],
+)
+def test_get_session_validation_timeout_uses_connection_budget(server_timeout, expected):
+    with patch("lfx.base.mcp.util._get_mcp_setting", return_value=server_timeout):
+        assert get_session_validation_timeout() == expected
+
+
+@pytest.mark.asyncio
+async def test_session_connectivity_validation_uses_resolved_timeout():
+    manager = MCPSessionManager()
+    session = AsyncMock()
+    session.list_tools.return_value = SimpleNamespace(tools=[])
+    observed_timeout = None
+
+    async def wait_for(awaitable, *, timeout):
+        nonlocal observed_timeout
+        observed_timeout = timeout
+        return await awaitable
+
+    try:
+        with (
+            patch("lfx.base.mcp.util.get_session_validation_timeout", return_value=20.0),
+            patch("lfx.base.mcp.util.asyncio.wait_for", side_effect=wait_for),
+        ):
+            assert await manager._validate_session_connectivity(session) is True
+    finally:
+        await manager.cleanup_all()
+
+    assert observed_timeout == 20.0
 
 
 def test_mcp_stdio_client_uses_resolved_timeout():


### PR DESCRIPTION
## Summary

- derive the pooled-session connectivity timeout from `mcp_server_timeout`
- keep validation reasonably fast by using one third of the connection budget, with a 10-second floor
- add regression coverage for missing, default, and raised server timeout budgets and for the session-manager call site

## Root cause

`MCPSessionManager._validate_session_connectivity()` used a hardcoded 3-second timeout for `list_tools()`. Slow stdio transports such as `npx mcp-remote` could therefore lose the health-check race and have a valid pooled session discarded even when `LANGFLOW_MCP_SERVER_TIMEOUT` was configured with a larger connection budget.

## Validation

- `cd src/lfx && uv run --no-sync pytest tests/unit/mcp/test_tool_execution_timeout.py -q` — 12 passed
- `uv run --no-sync ruff check src/lfx/src/lfx/base/mcp/util.py src/lfx/tests/unit/mcp/test_tool_execution_timeout.py` — passed
- `uv run --no-sync ruff format --check src/lfx/src/lfx/base/mcp/util.py src/lfx/tests/unit/mcp/test_tool_execution_timeout.py` — passed
- `uv run --no-sync pytest src/backend/tests/unit/base/mcp/test_mcp_util.py::TestStreamableHttpTransportPolicy::test_validate_connectivity_mcp_session_terminated_returns_false -q` — 1 passed

Closes #14193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP session reuse reliability by making connectivity checks respect the configured server timeout.
  * Added a minimum validation timeout to prevent checks from ending too quickly.

* **Tests**
  * Added coverage for timeout calculation and session connectivity validation across different server timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->