### PR TITLE
fix: stop secret masking from corrupting values passed to connected components

### DIFF
--- a/src/backend/tests/unit/test_credential_variable_leakage.py
+++ b/src/backend/tests/unit/test_credential_variable_leakage.py
@@ -242,3 +242,77 @@ async def test_credential_variable_accepted_when_use_global_variable_toggled_on(
     assert "Credential-typed global variable" in str(excinfo.value)
     assert "input_value" in str(excinfo.value)
     assert _LEAKY_SECRET not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_secret_value_reaches_connected_component_unmasked_but_masked_for_display():
+    """Regression for https://github.com/langflow-ai/langflow/issues/14152.
+
+    Masking must apply only to human-facing surfaces (results / artifacts / status /
+    logs), never to ``output.value`` -- the object a connected downstream component
+    reads when resolving a graph edge (``ComponentVertex._get_result`` prefers
+    ``output.value`` over the ``results`` dict). A component that legitimately embeds a
+    real secret in its output (e.g. a connection string) must hand the *real* value to
+    its connected consumer while still masking every displayed copy.
+    """
+
+    class _BuildConnectionString(Component):
+        display_name = "BuildConnectionString"
+        name = "BuildConnectionString"
+        inputs = [SecretStrInput(name="password", display_name="Password")]
+        outputs = [Output(display_name="Connection String", name="conn_string", method="build_conn_string")]
+
+        def build_conn_string(self) -> Message:
+            return Message(text=f"postgresql://demo_user:{self.password}@localhost:5432/demo_db")
+
+    component = _BuildConnectionString(_user_id=str(uuid.uuid4()))
+    component.set_attributes({"password": "hunter2"})  # pragma: allowlist secret
+
+    results, artifacts = await component._build_results()
+
+    real = "postgresql://demo_user:hunter2@localhost:5432/demo_db"  # pragma: allowlist secret
+    masked = "postgresql://demo_user:**********@localhost:5432/demo_db"
+
+    # (a) The value delivered on a graph edge (``output.value``) is the REAL secret.
+    edge_value = component._outputs_map["conn_string"].value
+    assert edge_value.text == real
+    assert "hunter2" in edge_value.text  # pragma: allowlist secret
+
+    # (b) Every human-facing copy is masked (preserves the guarantee from #12908).
+    assert results["conn_string"].text == masked
+    assert artifacts["conn_string"]["raw"] == masked
+    assert "**********" in artifacts["conn_string"]["repr"]
+    assert "hunter2" not in artifacts["conn_string"]["repr"]  # pragma: allowlist secret
+
+    # The masked, serialized copy must be an independent object -- not the edge value.
+    assert results["conn_string"] is not edge_value
+
+
+@pytest.mark.asyncio
+async def test_sanitize_secret_values_returns_masked_copy_without_mutating_source():
+    """`_sanitize_secret_values` must be non-mutating.
+
+    It returns a masked copy and leaves the source ``Message`` (and therefore
+    ``output.value``) untouched. Regression for #14152: the previous in-place mutation
+    of ``Message.text`` / ``Data.data`` is what corrupted the edge value.
+    """
+
+    class _Noop(Component):
+        display_name = "Noop"
+        name = "Noop"
+        inputs = [SecretStrInput(name="password", display_name="Password")]
+        outputs = [Output(display_name="Output", name="output", method="build_output")]
+
+        def build_output(self) -> Message:
+            return Message(text="unused")
+
+    component = _Noop(_user_id=str(uuid.uuid4()))
+    component.set_attributes({"password": "hunter2"})  # pragma: allowlist secret
+
+    original = Message(text="token=hunter2")  # pragma: allowlist secret
+    masked = component._sanitize_secret_values(original)
+
+    assert masked is not original
+    assert masked.text == "token=**********"
+    # Source is unchanged -- this is what a connected downstream component would receive.
+    assert original.text == "token=hunter2"  # pragma: allowlist secret

--- a/src/backend/tests/unit/test_credential_variable_leakage.py
+++ b/src/backend/tests/unit/test_credential_variable_leakage.py
@@ -27,6 +27,7 @@ from lfx.custom import Component
 from lfx.inputs.inputs import IntInput, SecretStrInput, StrInput
 from lfx.interface.initialize.loading import update_params_with_load_from_db_fields
 from lfx.io import Output
+from lfx.schema.data import Data
 from lfx.schema.message import Message
 from pydantic import SecretStr, ValidationError
 
@@ -244,7 +245,6 @@ async def test_credential_variable_accepted_when_use_global_variable_toggled_on(
     assert _LEAKY_SECRET not in str(excinfo.value)
 
 
-@pytest.mark.asyncio
 async def test_secret_value_reaches_connected_component_unmasked_but_masked_for_display():
     """Regression for https://github.com/langflow-ai/langflow/issues/14152.
 
@@ -288,7 +288,6 @@ async def test_secret_value_reaches_connected_component_unmasked_but_masked_for_
     assert results["conn_string"] is not edge_value
 
 
-@pytest.mark.asyncio
 async def test_sanitize_secret_values_returns_masked_copy_without_mutating_source():
     """`_sanitize_secret_values` must be non-mutating.
 
@@ -316,3 +315,38 @@ async def test_sanitize_secret_values_returns_masked_copy_without_mutating_sourc
     assert masked.text == "token=**********"
     # Source is unchanged -- this is what a connected downstream component would receive.
     assert original.text == "token=hunter2"  # pragma: allowlist secret
+
+
+def test_sanitize_secret_values_masks_data_object_without_mutating_source():
+    """`_sanitize_secret_values` masks `Data` on a copy, leaving the source intact.
+
+    Regression for #14152: the `Data` branch must sanitize `data` and `default_value`
+    on an independent copy (via `model_copy`), so the real `Data` an edge delivers to a
+    connected component is never mutated. Complements the `Message` coverage above.
+    """
+
+    class _NoopData(Component):
+        display_name = "NoopData"
+        name = "NoopData"
+        inputs = [SecretStrInput(name="password", display_name="Password")]
+        outputs = [Output(display_name="Output", name="output", method="build_output")]
+
+        def build_output(self) -> Message:
+            return Message(text="unused")
+
+    component = _NoopData(_user_id=str(uuid.uuid4()))
+    component.set_attributes({"password": "hunter2"})  # pragma: allowlist secret
+
+    original = Data(
+        data={"conn": "postgres://user:hunter2@localhost/db"},  # pragma: allowlist secret
+        default_value="token=hunter2",  # pragma: allowlist secret
+    )
+    masked = component._sanitize_secret_values(original)
+
+    # Returned copy is masked in both data and default_value...
+    assert masked is not original
+    assert masked.data["conn"] == "postgres://user:**********@localhost/db"
+    assert masked.default_value == "token=**********"
+    # ...and the source Data (what a connected downstream component receives) is unchanged.
+    assert original.data["conn"] == "postgres://user:hunter2@localhost/db"  # pragma: allowlist secret
+    assert original.default_value == "token=hunter2"  # pragma: allowlist secret

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1320,7 +1320,12 @@ class Component(CustomComponent):
         for output in self._get_outputs_to_process():
             self._current_output = output.name
             result = await self._get_output_result(output)
-            results[output.name] = result
+            # ``result`` (and ``output.value``) is the real value graph edges consume.
+            # Serialize an independent masked copy to the API / event stream / UI so
+            # secrets never surface to a human, without corrupting the value a connected
+            # downstream component receives. ``_build_artifact`` sanitizes internally.
+            # See issue #14152.
+            results[output.name] = self._sanitize_secret_values(result)
             artifacts[output.name] = self._build_artifact(result)
             self._log_output(output)
 
@@ -1407,7 +1412,12 @@ class Component(CustomComponent):
         ):
             result.set_flow_id(self._vertex.graph.flow_id)
         result = output.apply_options(result)
-        result = self._sanitize_secret_values(result)
+        # ``output.value`` is what a connected downstream vertex reads when resolving a
+        # graph edge (see ``ComponentVertex._get_result``). Keep it the real, unmasked
+        # value so a component can legitimately hand a secret (e.g. a connection string
+        # containing a password) to a single connected consumer. Masking for human-facing
+        # surfaces happens separately on the serialized copies in ``_build_results`` /
+        # ``_build_artifact`` / ``_finalize_results``. See issue #14152.
         output.value = result
 
         return result
@@ -1460,15 +1470,22 @@ class Component(CustomComponent):
         if isinstance(value, str):
             return self._sanitize_secret_string(value)
         if isinstance(value, Message):
-            if isinstance(value.text, str):
-                value.text = self._sanitize_secret_string(value.text)
-            value.data = self._sanitize_secret_values(value.data)
-            return value
+            # Copy with an independent ``data`` dict before masking. ``Message.text``'s
+            # setter writes into ``self.data`` and a shallow ``model_copy`` shares that
+            # dict, so masking the copy would otherwise still mutate the original (and
+            # thus ``output.value``). ``model_copy(deep=True)`` is not usable here:
+            # Message/Data inherit a ``__deepcopy__`` that raises TypeError. See #14152.
+            copied = value.model_copy(update={"data": dict(value.data)})
+            if isinstance(copied.text, str):
+                copied.text = self._sanitize_secret_string(copied.text)
+            copied.data = self._sanitize_secret_values(copied.data)
+            return copied
         if isinstance(value, Data):
-            value.data = self._sanitize_secret_values(value.data)
-            if isinstance(value.default_value, str):
-                value.default_value = self._sanitize_secret_string(value.default_value)
-            return value
+            copied = value.model_copy(update={"data": dict(value.data)})
+            copied.data = self._sanitize_secret_values(copied.data)
+            if isinstance(copied.default_value, str):
+                copied.default_value = self._sanitize_secret_string(copied.default_value)
+            return copied
         if isinstance(value, dict):
             return {key: self._sanitize_secret_values(item) for key, item in value.items()}
         if isinstance(value, list):


### PR DESCRIPTION
## What broke

PR #12908 added masking of any output value containing a password-typed input's raw
text (replacing it with `**********`). This is correct for human-facing surfaces, but
the same masked object was also handed to connected downstream components over graph
edges. A component whose job is to pass a real secret to exactly one connected
consumer — e.g. a connection-string builder feeding a **SQL Database** component —
delivered the literal `postgresql://user:**********@host/db` placeholder instead of
the real password, breaking real functionality (not just display).

## Root cause

`Component._get_output_result()` masked the result in place and assigned it to
`output.value`:

```python
result = self._sanitize_secret_values(result)  # mutates Message.text / Data.data in place
output.value = result
```

`output.value` is exactly what a connected downstream vertex reads when resolving a
graph edge (`ComponentVertex._get_result` prefers `output.value` over `self.results`).
Because `_sanitize_secret_values` mutated `Message.text` / `Data.data` **in place**,
there was no way to mask for display without also masking for every edge consumer.
`_mask_secret_value` also collapses any `SecretStr`-shaped value, so even explicitly
`SecretStr`-typed outputs degraded to the placeholder.

## Fix

Separate "the value a connected component receives" from "the value shown to a human":

1. `_get_output_result` no longer masks — `output.value` stays the real, unmasked value
   graph edges consume.
2. `_build_results` serializes an **independent masked copy** into the `results` dict
   (API / event stream / UI / traces). `artifacts` and `status` are already masked
   independently by `_build_artifact` / `_finalize_results`.
3. `_sanitize_secret_values` is now **non-mutating**, returning a masked copy via
   `model_copy(update={"data": dict(value.data)})`.
   - A shallow `model_copy()` alone is insufficient: `Message.text`'s setter writes into
     `self.data`, and a shallow copy shares that dict — so masking the copy would still
     mutate the original. Supplying an independent `data` dict fixes this.
   - `model_copy(deep=True)` is not usable: `Message`/`Data` inherit a `__deepcopy__`
     that raises `TypeError: JSON.__deepcopy__() missing 1 required positional argument:
     'memo'` (verified).

Every display-side masking guarantee from #12908 is preserved.

## How this was tested

Environment: `uv sync --group dev` for `lfx` and `langflow-base` (Python 3.13).

Added two regression tests in `test_credential_variable_leakage.py`:
- `test_secret_value_reaches_connected_component_unmasked_but_masked_for_display` —
  asserts (a) the edge value (`output.value`) is the real unmasked secret AND
  (b) `results`/`artifacts` are masked.
- `test_sanitize_secret_values_returns_masked_copy_without_mutating_source` —
  asserts the source `Message` is not mutated.

Commands and actual results:

```
# Regression file (2 new #14152 tests + 5 existing #12908 tests)
$ python -m pytest src/backend/tests/unit/test_credential_variable_leakage.py -v
7 passed, 1 warning in 1.03s

# Broader regression
$ python -m pytest test_credential_variable_leakage.py test_credential_resolution.py \
    test_custom_component.py base/tools/test_component_toolkit_multiple_outputs.py
72 passed, 7 warnings in 3.55s

# Formatting (make format_backend => ruff), scoped to changed files
$ ruff check <changed files> --fix   -> All checks passed!
$ ruff format <changed files>        -> 1 file reformatted, 1 file left unchanged
$ ruff check <changed files>         -> All checks passed!
```

Note: `make lint` is currently a no-op in this repo ("No type checker configured. See
PR #12448 for context."), so there is no mypy gate.

Files changed: `src/lfx/src/lfx/custom/custom_component/component.py`,
`src/backend/tests/unit/test_credential_variable_leakage.py`.

Fixes #14152.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential and secret masking across component outputs.
  * Preserved original secret values for downstream processing while displaying masked values in results, artifacts, and representations.
  * Prevented sanitization from modifying source messages or data, avoiding unintended changes for downstream consumers.
  * Added regression coverage to verify secret values are not exposed through user-facing outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->