### PR TITLE
fix: preserve raw secret output values

### DIFF
--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1300,8 +1300,9 @@ class Component(CustomComponent):
         for output in self._get_outputs_to_process():
             self._current_output = output.name
             result = await self._get_output_result(output)
-            results[output.name] = result
-            artifacts[output.name] = self._build_artifact(result)
+            masked_result = self._sanitize_secret_values(result)
+            results[output.name] = masked_result
+            artifacts[output.name] = self._build_artifact(masked_result)
             self._log_output(output)
 
         self._finalize_results(results, artifacts)
@@ -1387,7 +1388,6 @@ class Component(CustomComponent):
         ):
             result.set_flow_id(self._vertex.graph.flow_id)
         result = output.apply_options(result)
-        result = self._sanitize_secret_values(result)
         output.value = result
 
         return result
@@ -1440,11 +1440,13 @@ class Component(CustomComponent):
         if isinstance(value, str):
             return self._sanitize_secret_string(value)
         if isinstance(value, Message):
+            value = value.model_copy()
             if isinstance(value.text, str):
                 value.text = self._sanitize_secret_string(value.text)
             value.data = self._sanitize_secret_values(value.data)
             return value
         if isinstance(value, Data):
+            value = value.model_copy()
             value.data = self._sanitize_secret_values(value.data)
             if isinstance(value.default_value, str):
                 value.default_value = self._sanitize_secret_string(value.default_value)

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1433,6 +1433,9 @@ class Component(CustomComponent):
             value = value.replace(secret, "**********")
         return value
 
+    def add_secret_values(self, secret_values: set[str]) -> None:
+        self._secret_values.update(secret for secret in secret_values if secret)
+
     def _sanitize_secret_values(self, value):
         if not self._secret_values:
             return _mask_secret_value(value)
@@ -1440,17 +1443,17 @@ class Component(CustomComponent):
         if isinstance(value, str):
             return self._sanitize_secret_string(value)
         if isinstance(value, Message):
-            value = value.model_copy()
-            if isinstance(value.text, str):
-                value.text = self._sanitize_secret_string(value.text)
-            value.data = self._sanitize_secret_values(value.data)
-            return value
+            text = self._sanitize_secret_string(value.text) if isinstance(value.text, str) else value.text
+            data = self._sanitize_secret_values(deepcopy(value.data))
+            return value.model_copy(update={"text": text, "data": data})
         if isinstance(value, Data):
-            value = value.model_copy()
-            value.data = self._sanitize_secret_values(value.data)
-            if isinstance(value.default_value, str):
-                value.default_value = self._sanitize_secret_string(value.default_value)
-            return value
+            data = self._sanitize_secret_values(deepcopy(value.data))
+            default_value = (
+                self._sanitize_secret_string(value.default_value)
+                if isinstance(value.default_value, str)
+                else value.default_value
+            )
+            return value.model_copy(update={"data": data, "default_value": default_value})
         if isinstance(value, dict):
             return {key: self._sanitize_secret_values(item) for key, item in value.items()}
         if isinstance(value, list):

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -647,6 +647,7 @@ class Vertex:
     async def _build_vertex_and_update_params(self, key, vertex: Vertex) -> None:
         """Builds a given vertex and updates the params dictionary accordingly."""
         result = await vertex.get_result(self, target_handle_name=key)
+        self._inherit_secret_values_from_vertex(vertex)
         self._handle_func(key, result)
         if isinstance(result, list):
             self._extend_params_list_with_result(key, result)
@@ -668,6 +669,7 @@ class Vertex:
             if not vertex.built and vertex.id in self.graph.conditionally_excluded_vertices:
                 continue
             result = await vertex.get_result(self, target_handle_name=key)
+            self._inherit_secret_values_from_vertex(vertex)
             # Weird check to see if the params[key] is a list
             # because sometimes it is a Data and breaks the code
             if not isinstance(self.params[key], list):
@@ -688,6 +690,16 @@ class Vertex:
                         f"Error building Component {self.display_name}: \n\n{e}"
                     )
                     raise ValueError(msg) from e
+
+    def _inherit_secret_values_from_vertex(self, vertex: Vertex) -> None:
+        source_component = getattr(vertex, "custom_component", None)
+        target_component = self.custom_component
+        if source_component is None or target_component is None:
+            return
+
+        secret_values = getattr(source_component, "_secret_values", None)
+        if secret_values and hasattr(target_component, "add_secret_values"):
+            target_component.add_secret_values(secret_values)
 
     def _handle_func(self, key, result) -> None:
         """Handles 'func' key by checking if the result is a function and setting it as coroutine."""

--- a/src/lfx/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_component_events.py
@@ -34,6 +34,14 @@ class ComponentForTesting(Component):
         return {"name": "test_tool", "description": "A test tool"}
 
 
+class SecretOutputComponent(ComponentForTesting):
+    def get_connection_string(self) -> Message:
+        return Message(
+            text="postgresql://demo_user:hunter2@localhost:5432/demo_db",
+            data={"url": "postgresql://demo_user:hunter2@localhost:5432/demo_db"},
+        )
+
+
 @pytest.mark.asyncio
 async def test_component_message_sending():
     """Test component's message sending functionality."""
@@ -171,6 +179,27 @@ async def test_component_build_results():
     assert "text_output" in artifacts
     assert "tool_output" in artifacts
     assert artifacts["text_output"]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_component_build_results_masks_display_values_without_mutating_output_value():
+    component = SecretOutputComponent()
+    component._secret_values = {"hunter2"}
+    component._outputs_map = {
+        "conn_string": Output(name="conn_string", method="get_connection_string"),
+    }
+    component.outputs = [
+        Output(name="conn_string", method="get_connection_string"),
+    ]
+
+    results, artifacts = await component._build_results()
+    output_value = component._outputs_map["conn_string"].value
+
+    assert output_value.text == "postgresql://demo_user:hunter2@localhost:5432/demo_db"
+    assert output_value.data["url"] == "postgresql://demo_user:hunter2@localhost:5432/demo_db"
+    assert results["conn_string"].text == "postgresql://demo_user:**********@localhost:5432/demo_db"
+    assert results["conn_string"].data["url"] == "postgresql://demo_user:**********@localhost:5432/demo_db"
+    assert artifacts["conn_string"]["raw"] == "postgresql://demo_user:**********@localhost:5432/demo_db"
 
 
 @pytest.mark.asyncio

--- a/src/lfx/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_component_events.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from lfx.custom.custom_component.component import Component
 from lfx.events.event_manager import EventManager
+from lfx.graph.vertex.base import Vertex
 from lfx.schema.content_block import ContentBlock
 from lfx.schema.content_types import TextContent, ToolContent
 from lfx.schema.message import Message
@@ -39,6 +40,14 @@ class SecretOutputComponent(ComponentForTesting):
         return Message(
             text="postgresql://demo_user:hunter2@localhost:5432/demo_db",
             data={"url": "postgresql://demo_user:hunter2@localhost:5432/demo_db"},
+        )
+
+
+class SecretEchoComponent(ComponentForTesting):
+    def get_connection_string(self) -> Message:
+        return Message(
+            text=self.connection_string,
+            data={"url": self.connection_string},
         )
 
 
@@ -185,6 +194,41 @@ async def test_component_build_results():
 async def test_component_build_results_masks_display_values_without_mutating_output_value():
     component = SecretOutputComponent()
     component._secret_values = {"hunter2"}
+    component._outputs_map = {
+        "conn_string": Output(name="conn_string", method="get_connection_string"),
+    }
+    component.outputs = [
+        Output(name="conn_string", method="get_connection_string"),
+    ]
+
+    results, artifacts = await component._build_results()
+    output_value = component._outputs_map["conn_string"].value
+
+    assert output_value.text == "postgresql://demo_user:hunter2@localhost:5432/demo_db"
+    assert output_value.data["url"] == "postgresql://demo_user:hunter2@localhost:5432/demo_db"
+    assert results["conn_string"].text == "postgresql://demo_user:**********@localhost:5432/demo_db"
+    assert results["conn_string"].data["url"] == "postgresql://demo_user:**********@localhost:5432/demo_db"
+    assert artifacts["conn_string"]["raw"] == "postgresql://demo_user:**********@localhost:5432/demo_db"
+
+
+def test_vertex_inherits_secret_values_from_upstream_component():
+    source_component = ComponentForTesting()
+    source_component.add_secret_values({"hunter2"})
+    target_component = ComponentForTesting()
+    source_vertex = MagicMock(custom_component=source_component)
+    target_vertex = object.__new__(Vertex)
+    target_vertex.custom_component = target_component
+
+    target_vertex._inherit_secret_values_from_vertex(source_vertex)
+
+    assert target_component._sanitize_secret_values("hunter2") == "**********"
+
+
+@pytest.mark.asyncio
+async def test_component_build_results_masks_inherited_secret_values_without_mutating_output_value():
+    component = SecretEchoComponent()
+    component.connection_string = "postgresql://demo_user:hunter2@localhost:5432/demo_db"
+    component.add_secret_values({"hunter2"})
     component._outputs_map = {
         "conn_string": Output(name="conn_string", method="get_connection_string"),
     }


### PR DESCRIPTION
## Summary
- keep `output.value` as the raw component output so connected downstream components receive real secret-containing values
- mask a separate result copy for human-facing result/artifact serialization
- make `Message` and `Data` secret sanitization non-mutating with shallow `model_copy()` before edits
- add regression coverage for a connection-string style secret output

Closes #14152

## Tests
- `PYTHONPATH=src/lfx/src python -m pytest src/lfx/tests/unit/custom/custom_component/test_component_events.py -q`
- `python -m ruff check src/lfx/tests/unit/custom/custom_component/test_component_events.py --select I,F,E,W,UP,B,SIM,PL`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret masking in component results and artifacts.
  * Preserved original output values while displaying sanitized values.
  * Prevented sanitization from unintentionally modifying message and data objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->