### PR TITLE
docs: add blog links for 1.11

### DIFF
--- a/docs/docs/Components/bundles-nextplaid.mdx
+++ b/docs/docs/Components/bundles-nextplaid.mdx
@@ -99,6 +99,10 @@ For more information on the vLLM server, see the [vLLM documentation](https://do
 | **Request Timeout** (`request_timeout`) | Float | Input parameter. Timeout in seconds for each request to the vLLM API. Default: `60.0`. Advanced. |
 | **Max Retries** (`max_retries`) | Integer | Input parameter. Number of times to retry a failed request before raising an error. Default: `3`. Advanced. |
 
+## Use NextPlaid in a flow
+
+For more information, see the [NextPlaid blog](https://www.langflow.org/blog/blog-nextplaid).
+
 ## See also
 
 * [**Embedding model** components](/components-embedding-models)

--- a/docs/docs/Components/human-input.mdx
+++ b/docs/docs/Components/human-input.mdx
@@ -48,6 +48,10 @@ To handle unanswered requests, do the following:
 
 <PartialParams />
 
+## Use HITL in a flow
+
+For a video example, see the [Langflow 1.11 release blog](https://www.langflow.org/blog/langflow-1-11).
+
 ## See also
 
 - [Human-in-the-Loop](./human-in-the-loop)

--- a/docs/docs/Deployment/deployment-docker.mdx
+++ b/docs/docs/Deployment/deployment-docker.mdx
@@ -25,7 +25,7 @@ With Docker installed and running on your system, run the following command:
     ```bash
     docker run -p 7860:7860 \
       -e LANGFLOW_AUTO_LOGIN=false \
-      -e LANGFLOW_SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
+      -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
       langflowai/langflow:latest
     ```
 
@@ -394,7 +394,7 @@ Because auto-login is disabled, you must set `LANGFLOW_SUPERUSER_PASSWORD` (and 
 ```bash
 docker run -p 7860:7860 \
   -e LANGFLOW_AUTO_LOGIN=true \
-  -e LANGFLOW_SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
+  -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
   langflowai/langflow:latest
 ```
 

--- a/docs/docs/Flows/human-in-the-loop.mdx
+++ b/docs/docs/Flows/human-in-the-loop.mdx
@@ -21,6 +21,10 @@ The **Agent** tool approval enables **Requires approval** on the Git commit tool
 The run pauses when the agent tries to call that tool, but doesn't add a branch.
 For more information, see [Require approval for agent tools](./agents-tools#require-approval-for-agent-tools).
 
+## Use HITL in a flow
+
+For a video example, see the [Langflow 1.11 release blog](https://www.langflow.org/blog/langflow-1-11).
+
 ## See also
 
 - [Human Input component](./human-input)

--- a/docs/docs/Lfx/extensions-bundle-list.mdx
+++ b/docs/docs/Lfx/extensions-bundle-list.mdx
@@ -32,6 +32,7 @@ These providers ship as their own pip packages, each on its own release cadence.
 | [`openai-compatible`](./bundles-openai-compatible) (OpenAI Compatible) | `uv pip install lfx-openai-compatible` |
 | [`oracle`](./bundles-oracle) (Oracle) | `uv pip install lfx-oracle` |
 | [`paddle`](./bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
+| [`valkey`](./bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
 | [`vllm`](/bundles-vllm) (vLLM) | `uv pip install lfx-vllm` |
 
 ## Long-tail bundles (`lfx-bundles`)

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -69,8 +69,10 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
     The legacy value `langflow` is not allowed, even if `LANGFLOW_AUTO_LOGIN=True`.
 
     ```bash
-    export LANGFLOW_SUPERUSER_PASSWORD='your-strong-password'
+    export LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD
     ```
+
+    Replace `SUPERUSER_PASSWORD` with a strong password for the Langflow superuser.
 
     If `LANGFLOW_AUTO_LOGIN=true`, setting `LANGFLOW_SUPERUSER_PASSWORD` is optional. If you omit it, Langflow generates a random bootstrap password for the auto-login account.
 
@@ -84,10 +86,12 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
       -e LANGFLOW_HOST=0.0.0.0 \
       -e LANGFLOW_PORT=7860 \
       -e LANGFLOW_AUTO_LOGIN=false \
-      -e LANGFLOW_SUPERUSER_PASSWORD \
+      -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
       -v langflow-data:/app/langflow \
       ${IMAGE}
     ```
+
+    Replace `SUPERUSER_PASSWORD` with a strong password for the Langflow superuser.
 
 - Docker images disable auto-login by default
 

--- a/docs/versioned_docs/version-1.11.0/Components/bundles-nextplaid.mdx
+++ b/docs/versioned_docs/version-1.11.0/Components/bundles-nextplaid.mdx
@@ -99,6 +99,10 @@ For more information on the vLLM server, see the [vLLM documentation](https://do
 | **Request Timeout** (`request_timeout`) | Float | Input parameter. Timeout in seconds for each request to the vLLM API. Default: `60.0`. Advanced. |
 | **Max Retries** (`max_retries`) | Integer | Input parameter. Number of times to retry a failed request before raising an error. Default: `3`. Advanced. |
 
+## Use NextPlaid in a flow
+
+For more information, see the [NextPlaid blog](https://www.langflow.org/blog/blog-nextplaid).
+
 ## See also
 
 * [**Embedding model** components](/components-embedding-models)

--- a/docs/versioned_docs/version-1.11.0/Components/human-input.mdx
+++ b/docs/versioned_docs/version-1.11.0/Components/human-input.mdx
@@ -48,6 +48,10 @@ To handle unanswered requests, do the following:
 
 <PartialParams />
 
+## Use HITL in a flow
+
+For a video example, see the [Langflow 1.11 release blog](https://www.langflow.org/blog/langflow-1-11).
+
 ## See also
 
 - [Human-in-the-Loop](./human-in-the-loop)

--- a/docs/versioned_docs/version-1.11.0/Deployment/deployment-docker.mdx
+++ b/docs/versioned_docs/version-1.11.0/Deployment/deployment-docker.mdx
@@ -25,7 +25,7 @@ With Docker installed and running on your system, run the following command:
     ```bash
     docker run -p 7860:7860 \
       -e LANGFLOW_AUTO_LOGIN=false \
-      -e LANGFLOW_SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
+      -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
       langflowai/langflow:latest
     ```
 
@@ -394,7 +394,7 @@ Because auto-login is disabled, you must set `LANGFLOW_SUPERUSER_PASSWORD` (and 
 ```bash
 docker run -p 7860:7860 \
   -e LANGFLOW_AUTO_LOGIN=true \
-  -e LANGFLOW_SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
+  -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
   langflowai/langflow:latest
 ```
 

--- a/docs/versioned_docs/version-1.11.0/Flows/human-in-the-loop.mdx
+++ b/docs/versioned_docs/version-1.11.0/Flows/human-in-the-loop.mdx
@@ -21,6 +21,10 @@ The **Agent** tool approval enables **Requires approval** on the Git commit tool
 The run pauses when the agent tries to call that tool, but doesn't add a branch.
 For more information, see [Require approval for agent tools](./agents-tools#require-approval-for-agent-tools).
 
+## Use HITL in a flow
+
+For a video example, see the [Langflow 1.11 release blog](https://www.langflow.org/blog/langflow-1-11).
+
 ## See also
 
 - [Human Input component](./human-input)

--- a/docs/versioned_docs/version-1.11.0/Lfx/extensions-bundle-list.mdx
+++ b/docs/versioned_docs/version-1.11.0/Lfx/extensions-bundle-list.mdx
@@ -32,6 +32,7 @@ These providers ship as their own pip packages, each on its own release cadence.
 | [`openai-compatible`](./bundles-openai-compatible) (OpenAI Compatible) | `uv pip install lfx-openai-compatible` |
 | [`oracle`](./bundles-oracle) (Oracle) | `uv pip install lfx-oracle` |
 | [`paddle`](./bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
+| [`valkey`](./bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
 | [`vllm`](/bundles-vllm) (vLLM) | `uv pip install lfx-vllm` |
 
 ## Long-tail bundles (`lfx-bundles`)

--- a/docs/versioned_docs/version-1.11.0/Support/release-notes.mdx
+++ b/docs/versioned_docs/version-1.11.0/Support/release-notes.mdx
@@ -60,8 +60,10 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
     The legacy value `langflow` is not allowed, even if `LANGFLOW_AUTO_LOGIN=True`.
 
     ```bash
-    export LANGFLOW_SUPERUSER_PASSWORD='your-strong-password'
+    export LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD
     ```
+
+    Replace `SUPERUSER_PASSWORD` with a strong password for the Langflow superuser.
 
     If `LANGFLOW_AUTO_LOGIN=true`, setting `LANGFLOW_SUPERUSER_PASSWORD` is optional. If you omit it, Langflow generates a random bootstrap password for the auto-login account.
 
@@ -75,10 +77,12 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
       -e LANGFLOW_HOST=0.0.0.0 \
       -e LANGFLOW_PORT=7860 \
       -e LANGFLOW_AUTO_LOGIN=false \
-      -e LANGFLOW_SUPERUSER_PASSWORD \
+      -e LANGFLOW_SUPERUSER_PASSWORD=SUPERUSER_PASSWORD \
       -v langflow-data:/app/langflow \
       ${IMAGE}
     ```
+
+    Replace `SUPERUSER_PASSWORD` with a strong password for the Langflow superuser.
 
 - Docker images disable auto-login by default
 


### PR DESCRIPTION
A few fixes before publication:
1. Incomplete docker superuser snippet in release note.
2. Link to HITL blog.
3. Link to Nextplaid blog.
4. Add valkey as a standalone provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added usage guidance and video examples for NextPlaid and Human Input flows.
  * Added the Valkey extension bundle and installation command to the bundle listings.
  * Clarified Docker and upgrade instructions for setting a strong superuser password.
  * Standardized password placeholders in Docker command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->