### PR TITLE
feat(ci): add declarative downstream bundle profiles

### DIFF
--- a/.github/workflows/release-inventory-gate.yml
+++ b/.github/workflows/release-inventory-gate.yml
@@ -44,6 +44,38 @@ env:
   DOCKER_BUILDKIT: "1"
 
 jobs:
+  downstream-bundle-profiles:
+    name: Downstream bundle profiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release profiles
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install profile validator dependency
+        run: python -m pip install --disable-pip-version-check packaging
+
+      - name: Validate profiles and checked-in locks
+        run: python scripts/ci/manage_bundle_profiles.py check
+
+      - name: Generate profile inventory artifacts
+        run: |
+          python scripts/ci/manage_bundle_profiles.py compile \
+            --output-dir bundle-profile-inventories
+
+      - name: Upload profile inventory artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: downstream-bundle-profile-inventories
+          path: bundle-profile-inventories/*.lock.json
+          if-no-files-found: error
+
   python-inventory:
     name: Python ${{ matrix.python-version }} / ${{ matrix.profile }}
     if: ${{ inputs.main-artifact-name != '' }}

--- a/docs/docs/Deployment/downstream-bundle-profiles.mdx
+++ b/docs/docs/Deployment/downstream-bundle-profiles.mdx
@@ -1,0 +1,110 @@
+---
+title: Downstream bundle profiles
+slug: /deployment/downstream-bundle-profiles
+---
+
+Downstream Langflow application images must select their provider inventory at
+image-build time. A bundle profile records that selection separately from the
+Dockerfile so the same reviewed source can be used by local builds, CI, release
+workflows, and downstream repositories. Runtime package installation or
+registry mutation is not supported.
+
+The release branch stores the profile source in
+`scripts/ci/bundle_profiles.json` and its deterministic resolved manifests in
+`scripts/ci/bundle_profile_locks/`. The `enterprise-hardened` profile is the
+reviewed profile for the supported Enterprise UBI/hardened application image
+family. The contract maps the `enterprise-ubi-hardened` image family to that
+profile with `install_phase: build`; CI rejects unknown profiles, runtime
+installation phases, and profiles that no supported image family selects. It
+includes:
+
+- a bounded Langflow application range;
+- a bounded LFX bundle API range;
+- every bundle distribution, its selected extras, its bounded compatible
+  range, and the providers it owns;
+- the approved package index; and
+- ownership and update cadence.
+
+## Select a profile during an image build
+
+Name the profile explicitly in the downstream Dockerfile and install the exact
+requirements from its checked-in lock. For example:
+
+```dockerfile
+ARG LANGFLOW_BUNDLE_PROFILE=enterprise-hardened
+
+COPY --from=oss-source /langflow-oss/scripts/ci/manage_bundle_profiles.py /tmp/bundle-profile/
+COPY --from=oss-source /langflow-oss/scripts/ci/bundle_profile_locks/ /tmp/bundle-profile/locks/
+
+RUN test "$LANGFLOW_BUNDLE_PROFILE" = "enterprise-hardened" \
+    && python /tmp/bundle-profile/manage_bundle_profiles.py requirements \
+        --lock "/tmp/bundle-profile/locks/${LANGFLOW_BUNDLE_PROFILE}.lock.json" \
+        --bundles-only \
+        > /tmp/bundle-profile/requirements.txt \
+    && uv pip install --requirement /tmp/bundle-profile/requirements.txt
+```
+
+This example uses the `oss-source` stage from the Enterprise image build so the
+profile and application source always come from the same immutable OSS commit.
+The build stage must have the Python `packaging` distribution available to run
+the profile utility. `--bundles-only` is appropriate when the application is
+already installed from that pinned source; omit it when the lock should also
+install the exact Langflow application distribution. Keep the profile argument
+fixed in the Dockerfile or the release build configuration so a moving
+environment variable cannot change an already-built image.
+
+After installation, verify the environment and write the reviewable component
+inventory into the image:
+
+```dockerfile
+RUN python /tmp/bundle-profile/manage_bundle_profiles.py verify-installed \
+      --lock "/tmp/bundle-profile/locks/${LANGFLOW_BUNDLE_PROFILE}.lock.json" \
+      --output /usr/share/langflow/bundle-profile-inventory.json
+```
+
+The verifier fails on missing or undeclared bundle distributions, version
+drift, missing or undeclared providers, duplicate providers, and incompatible
+Langflow or LFX versions. Verification only inspects the build environment; it
+does not install packages or mutate a registry.
+
+## Update a profile
+
+Profile ownership is shared by the Langflow Enterprise and Langflow release
+maintainers. Review every profile on each Langflow minor release and whenever a
+provider is added, removed, or graduated.
+
+1. Edit `scripts/ci/bundle_profiles.json`. Adding or removing a provider must
+   change the explicit distribution and provider inventory.
+2. Regenerate the resolved manifests:
+
+   ```bash
+   python scripts/ci/manage_bundle_profiles.py compile \
+     --output-dir scripts/ci/bundle_profile_locks
+   ```
+
+3. Validate the source and locks:
+
+   ```bash
+   python scripts/ci/manage_bundle_profiles.py check
+   python -m pytest scripts/ci/test_bundle_profiles.py -q
+   ```
+
+4. Review the profile and lock diffs together. CI rejects unknown bundles,
+   invalid extras, unbounded or incompatible ranges, duplicate providers,
+   application dependency drift, and stale locks.
+5. Build the downstream image, run `verify-installed`, and retain the emitted
+   inventory JSON with the image release artifacts.
+
+## Emergency pin or rollback
+
+For a bundle-only incident, narrow the affected bundle's bounded source range,
+regenerate the lock, rebuild the image, and keep both changes in the emergency
+PR. Do not patch a package into a running pod. To roll back an image, restore
+the previously reviewed profile and lock together and rebuild from the same
+source revision and indexes. Retain the old image digest and inventory artifact
+until the replacement passes the release gate.
+
+If a provider must be removed, delete its explicit profile entry, regenerate
+the lock, and verify that the inventory artifact removes the same distribution
+and provider. A lock-only edit is rejected because it would bypass profile
+review.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -241,6 +241,11 @@ module.exports = {
             },
             {
               type: "doc",
+              id: "Deployment/downstream-bundle-profiles",
+              label: "Downstream bundle profiles"
+            },
+            {
+              type: "doc",
               id: "Deployment/deployment-caddyfile",
               label: "Deploy Langflow on a remote server"
             },

--- a/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
+++ b/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
@@ -1,0 +1,226 @@
+{
+  "application": {
+    "distribution": "langflow",
+    "requested": ">=1.12.0,<1.13.0",
+    "requirement": "langflow==1.12.0",
+    "resolved_version": "1.12.0"
+  },
+  "bundle_api": {
+    "distribution": "lfx",
+    "requested": ">=1.12.0.dev0,<1.13.0",
+    "requirement": "lfx==1.12.0",
+    "resolved_version": "1.12.0"
+  },
+  "bundles": [
+    {
+      "distribution": "lfx-amazon",
+      "extras": [],
+      "providers": [
+        "lfx-amazon"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-amazon==0.1.2",
+      "resolved_version": "0.1.2"
+    },
+    {
+      "distribution": "lfx-anthropic",
+      "extras": [],
+      "providers": [
+        "lfx-anthropic"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-anthropic==0.1.3",
+      "resolved_version": "0.1.3"
+    },
+    {
+      "distribution": "lfx-arxiv",
+      "extras": [],
+      "providers": [
+        "lfx-arxiv"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-arxiv==0.1.3",
+      "resolved_version": "0.1.3"
+    },
+    {
+      "distribution": "lfx-cohere",
+      "extras": [],
+      "providers": [
+        "lfx-cohere"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-cohere==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-datastax",
+      "extras": [],
+      "providers": [
+        "lfx-datastax"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-datastax==0.1.2",
+      "resolved_version": "0.1.2"
+    },
+    {
+      "distribution": "lfx-docling",
+      "extras": [],
+      "providers": [
+        "lfx-docling"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-docling==0.1.4",
+      "resolved_version": "0.1.4"
+    },
+    {
+      "distribution": "lfx-duckduckgo",
+      "extras": [],
+      "providers": [
+        "lfx-duckduckgo"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-duckduckgo==0.1.3",
+      "resolved_version": "0.1.3"
+    },
+    {
+      "distribution": "lfx-empiriolabs",
+      "extras": [],
+      "providers": [
+        "lfx-empiriolabs"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-empiriolabs==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-exa",
+      "extras": [],
+      "providers": [
+        "lfx-exa"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-exa==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-firecrawl",
+      "extras": [],
+      "providers": [
+        "lfx-firecrawl"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-firecrawl==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-ibm",
+      "extras": [],
+      "providers": [
+        "lfx-ibm"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-ibm==0.1.3",
+      "resolved_version": "0.1.3"
+    },
+    {
+      "distribution": "lfx-nextplaid",
+      "extras": [],
+      "providers": [
+        "lfx-nextplaid"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-nextplaid==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-openai",
+      "extras": [],
+      "providers": [
+        "lfx-openai"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-openai==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-openai-compatible",
+      "extras": [],
+      "providers": [
+        "lfx-openai-compatible"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-openai-compatible==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-oracle",
+      "extras": [],
+      "providers": [
+        "lfx-oracle"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-oracle==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-paddle",
+      "extras": [],
+      "providers": [
+        "lfx-paddle"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-paddle==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-valkey",
+      "extras": [],
+      "providers": [
+        "lfx-valkey"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-valkey==0.1.1",
+      "resolved_version": "0.1.1"
+    },
+    {
+      "distribution": "lfx-vllm",
+      "extras": [],
+      "providers": [
+        "lfx-vllm"
+      ],
+      "requested": ">=0.1.0,<1.0.0",
+      "requirement": "lfx-vllm==0.1.1",
+      "resolved_version": "0.1.1"
+    }
+  ],
+  "image_families": [
+    "enterprise-ubi-hardened"
+  ],
+  "indexes": [
+    "https://pypi.org/simple"
+  ],
+  "profile": "enterprise-hardened",
+  "profile_digest": "sha256:2bf2a71f550faa0c",
+  "providers": [
+    "lfx-amazon",
+    "lfx-anthropic",
+    "lfx-arxiv",
+    "lfx-cohere",
+    "lfx-datastax",
+    "lfx-docling",
+    "lfx-duckduckgo",
+    "lfx-empiriolabs",
+    "lfx-exa",
+    "lfx-firecrawl",
+    "lfx-ibm",
+    "lfx-nextplaid",
+    "lfx-openai",
+    "lfx-openai-compatible",
+    "lfx-oracle",
+    "lfx-paddle",
+    "lfx-valkey",
+    "lfx-vllm"
+  ],
+  "python": ">=3.10,<3.15",
+  "schema_version": 1
+}

--- a/scripts/ci/bundle_profiles.json
+++ b/scripts/ci/bundle_profiles.json
@@ -1,0 +1,178 @@
+{
+  "schema_version": 1,
+  "image_families": {
+    "enterprise-ubi-hardened": {
+      "profile": "enterprise-hardened",
+      "install_phase": "build"
+    }
+  },
+  "profiles": {
+    "enterprise-hardened": {
+      "description": "Reviewed provider inventory for the supported Enterprise UBI/hardened application image family.",
+      "owners": [
+        "Langflow Enterprise maintainers",
+        "Langflow release maintainers"
+      ],
+      "update_cadence": "Review on every Langflow minor release and whenever a provider is added, removed, or graduated.",
+      "indexes": [
+        "https://pypi.org/simple"
+      ],
+      "python": ">=3.10,<3.15",
+      "application": {
+        "distribution": "langflow",
+        "version": ">=1.12.0,<1.13.0",
+        "bundle_source": "pyproject.toml"
+      },
+      "bundle_api": {
+        "distribution": "lfx",
+        "version": ">=1.12.0.dev0,<1.13.0"
+      },
+      "bundles": [
+        {
+          "distribution": "lfx-duckduckgo",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-duckduckgo"
+          ]
+        },
+        {
+          "distribution": "lfx-arxiv",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-arxiv"
+          ]
+        },
+        {
+          "distribution": "lfx-ibm",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-ibm"
+          ]
+        },
+        {
+          "distribution": "lfx-docling",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-docling"
+          ]
+        },
+        {
+          "distribution": "lfx-datastax",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-datastax"
+          ]
+        },
+        {
+          "distribution": "lfx-openai",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-openai"
+          ]
+        },
+        {
+          "distribution": "lfx-anthropic",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-anthropic"
+          ]
+        },
+        {
+          "distribution": "lfx-amazon",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-amazon"
+          ]
+        },
+        {
+          "distribution": "lfx-cohere",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-cohere"
+          ]
+        },
+        {
+          "distribution": "lfx-oracle",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-oracle"
+          ]
+        },
+        {
+          "distribution": "lfx-firecrawl",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-firecrawl"
+          ]
+        },
+        {
+          "distribution": "lfx-nextplaid",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-nextplaid"
+          ]
+        },
+        {
+          "distribution": "lfx-paddle",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-paddle"
+          ]
+        },
+        {
+          "distribution": "lfx-vllm",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-vllm"
+          ]
+        },
+        {
+          "distribution": "lfx-empiriolabs",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-empiriolabs"
+          ]
+        },
+        {
+          "distribution": "lfx-openai-compatible",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-openai-compatible"
+          ]
+        },
+        {
+          "distribution": "lfx-exa",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-exa"
+          ]
+        },
+        {
+          "distribution": "lfx-valkey",
+          "extras": [],
+          "version": ">=0.1.0,<1.0.0",
+          "providers": [
+            "lfx-valkey"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/ci/manage_bundle_profiles.py
+++ b/scripts/ci/manage_bundle_profiles.py
@@ -1,0 +1,516 @@
+"""Validate, resolve, and verify declarative downstream bundle profiles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from contextlib import suppress
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import tomllib
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PROFILES = REPO_ROOT / "scripts" / "ci" / "bundle_profiles.json"
+DEFAULT_LOCKS = REPO_ROOT / "scripts" / "ci" / "bundle_profile_locks"
+AGGREGATE_EXTRAS = {"all", "all-no-torch"}
+BUNDLE_INIT_PATH_PARTS = 3
+
+
+class ProfileError(ValueError):
+    """Raised when a bundle profile violates the release contract."""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_project(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))["project"]
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True) + "\n"
+
+
+def profile_digest(profile: dict[str, Any]) -> str:
+    encoded = json.dumps(profile, separators=(",", ":"), sort_keys=True).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def is_bounded(specifier: str) -> bool:
+    specs = list(SpecifierSet(specifier))
+    lower = any(item.operator in {">", ">=", "~=", "==", "==="} for item in specs)
+    upper = any(item.operator in {"<", "<=", "~=", "==", "==="} for item in specs)
+    return lower and upper
+
+
+def discover_bundle_catalog(repo_root: Path = REPO_ROOT) -> dict[str, dict[str, Any]]:
+    catalog: dict[str, dict[str, Any]] = {}
+    for pyproject_path in sorted((repo_root / "src" / "bundles").glob("*/pyproject.toml")):
+        project = read_project(pyproject_path)
+        distribution = canonicalize_name(project["name"])
+        entry_points = project.get("entry-points", {})
+        providers = sorted(entry_points.get("langflow.extensions", {}))
+        optional = project.get("optional-dependencies", {})
+        extras = sorted(optional)
+        if distribution == "lfx-bundles":
+            providers = sorted(name for name in optional if name not in AGGREGATE_EXTRAS)
+
+        lfx_requirements = [
+            Requirement(value)
+            for value in project.get("dependencies", [])
+            if canonicalize_name(Requirement(value).name) == "lfx"
+        ]
+        if len(lfx_requirements) != 1:
+            message = f"{distribution} must declare exactly one lfx compatibility requirement"
+            raise ProfileError(message)
+
+        catalog[distribution] = {
+            "distribution": distribution,
+            "version": project["version"],
+            "providers": providers,
+            "extras": extras,
+            "optional_dependencies": optional,
+            "lfx_specifier": str(lfx_requirements[0].specifier),
+            "path": str(pyproject_path.relative_to(repo_root)),
+        }
+    return catalog
+
+
+def selected_providers(catalog_item: dict[str, Any]) -> list[str]:
+    # lfx-bundles ships every provider's component code even when an extra is
+    # omitted; extras select SDK dependencies, not the component inventory.
+    return catalog_item["providers"]
+
+
+def application_bundle_requirements(repo_root: Path, source: str) -> dict[str, Requirement]:
+    project = read_project(repo_root / source)
+    requirements = {}
+    for value in project.get("dependencies", []):
+        requirement = Requirement(value)
+        name = canonicalize_name(requirement.name)
+        if name.startswith("lfx-"):
+            requirements[name] = requirement
+    return requirements
+
+
+def validate_profile(
+    name: str,
+    profile: dict[str, Any],
+    catalog: dict[str, dict[str, Any]],
+    repo_root: Path = REPO_ROOT,
+) -> list[str]:
+    required_fields = (
+        "description",
+        "owners",
+        "update_cadence",
+        "indexes",
+        "python",
+        "application",
+        "bundle_api",
+        "bundles",
+    )
+    errors = [f"{name}: missing required field {field!r}" for field in required_fields if field not in profile]
+    errors.extend(
+        f"{name}: field {field!r} must not be empty"
+        for field in required_fields
+        if field != "bundles" and field in profile and not profile[field]
+    )
+
+    python_specifier = profile.get("python", "")
+    try:
+        if not is_bounded(python_specifier):
+            errors.append(f"{name}: Python version {python_specifier!r} must have lower and upper bounds")
+    except ValueError as exc:
+        errors.append(f"{name}: invalid Python version {python_specifier!r}: {exc}")
+
+    application = profile.get("application", {})
+    bundle_api = profile.get("bundle_api", {})
+    for label, selection in (("application", application), ("bundle_api", bundle_api)):
+        specifier = selection.get("version", "")
+        try:
+            if not is_bounded(specifier):
+                errors.append(f"{name}: {label} version {specifier!r} must have lower and upper bounds")
+        except ValueError as exc:
+            errors.append(f"{name}: invalid {label} version {specifier!r}: {exc}")
+
+    lfx_project = read_project(repo_root / "src" / "lfx" / "pyproject.toml")
+    lfx_version = Version(lfx_project["version"])
+    if bundle_api.get("distribution") != "lfx":
+        errors.append(f"{name}: bundle_api distribution must be 'lfx'")
+    else:
+        try:
+            if lfx_version not in SpecifierSet(bundle_api.get("version", "")):
+                errors.append(f"{name}: current lfx {lfx_version} is outside the bundle_api range")
+        except ValueError:
+            pass
+
+    root_project = read_project(repo_root / "pyproject.toml")
+    if canonicalize_name(application.get("distribution", "")) != canonicalize_name(root_project["name"]):
+        errors.append(f"{name}: application distribution must match {root_project['name']!r}")
+    else:
+        try:
+            if Version(root_project["version"]) not in SpecifierSet(application.get("version", "")):
+                errors.append(f"{name}: current application {root_project['version']} is outside its profile range")
+        except ValueError:
+            pass
+
+    distributions: set[str] = set()
+    provider_owners: dict[str, list[str]] = {}
+    for item in profile.get("bundles", []):
+        distribution = canonicalize_name(item.get("distribution", ""))
+        if distribution in distributions:
+            errors.append(f"{name}: duplicate bundle distribution {distribution!r}")
+            continue
+        distributions.add(distribution)
+
+        catalog_item = catalog.get(distribution)
+        if catalog_item is None:
+            errors.append(f"{name}: unknown bundle distribution {distribution!r}")
+            continue
+
+        extras = item.get("extras")
+        if not isinstance(extras, list):
+            errors.append(f"{name}: {distribution} must declare extras as a list")
+            continue
+        if extras != sorted(set(extras)):
+            errors.append(f"{name}: {distribution} extras must be unique and sorted")
+        unknown_extras = sorted(set(extras) - set(catalog_item["extras"]))
+        if unknown_extras:
+            errors.append(f"{name}: {distribution} has unknown extras {unknown_extras}")
+
+        specifier = item.get("version", "")
+        try:
+            if not is_bounded(specifier):
+                errors.append(f"{name}: {distribution} version {specifier!r} must have lower and upper bounds")
+            elif Version(catalog_item["version"]) not in SpecifierSet(specifier):
+                errors.append(
+                    f"{name}: source version {catalog_item['version']} for {distribution} is outside {specifier}"
+                )
+        except ValueError as exc:
+            errors.append(f"{name}: invalid version range for {distribution}: {exc}")
+
+        if lfx_version not in SpecifierSet(catalog_item["lfx_specifier"]):
+            errors.append(
+                f"{name}: {distribution} requires lfx{catalog_item['lfx_specifier']}, incompatible with {lfx_version}"
+            )
+
+        expected_providers = selected_providers(catalog_item) if not unknown_extras else []
+        declared_providers = item.get("providers", [])
+        if declared_providers != sorted(set(declared_providers)):
+            errors.append(f"{name}: {distribution} providers must be unique and sorted")
+        if declared_providers != expected_providers:
+            errors.append(
+                f"{name}: {distribution} provider inventory must be {expected_providers}, got {declared_providers}"
+            )
+        for provider in declared_providers:
+            provider_owners.setdefault(provider, []).append(distribution)
+
+    duplicates = {provider: owners for provider, owners in provider_owners.items() if len(owners) > 1}
+    if duplicates:
+        errors.append(f"{name}: duplicate providers declared by multiple distributions: {duplicates}")
+
+    source = application.get("bundle_source")
+    if source:
+        try:
+            application_requirements = application_bundle_requirements(repo_root, source)
+        except (FileNotFoundError, KeyError, tomllib.TOMLDecodeError) as exc:
+            errors.append(f"{name}: cannot read application bundle source {source!r}: {exc}")
+        else:
+            actual = set(application_requirements)
+            if actual != distributions:
+                errors.append(
+                    f"{name}: application bundle source drift; undeclared={sorted(actual - distributions)}, "
+                    f"not-installed-by-application={sorted(distributions - actual)}"
+                )
+            for distribution in sorted(actual & distributions):
+                declared = next(
+                    item for item in profile["bundles"] if canonicalize_name(item["distribution"]) == distribution
+                )
+                if str(application_requirements[distribution].specifier) != str(SpecifierSet(declared["version"])):
+                    errors.append(
+                        f"{name}: {distribution} range differs from {source}: "
+                        f"{declared['version']} != {application_requirements[distribution].specifier}"
+                    )
+    return errors
+
+
+def validate_contract(
+    contract: dict[str, Any], repo_root: Path = REPO_ROOT
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    errors: list[str] = []
+    if contract.get("schema_version") != 1:
+        errors.append("bundle profile schema_version must be 1")
+    profiles = contract.get("profiles", {})
+    if not profiles:
+        errors.append("bundle profile contract must contain profiles")
+    image_families = contract.get("image_families", {})
+    if not image_families:
+        errors.append("bundle profile contract must map every supported downstream image family")
+    referenced_profiles: set[str] = set()
+    for family, selection in image_families.items():
+        profile_name = selection.get("profile")
+        if profile_name not in profiles:
+            errors.append(f"downstream image family {family!r} selects unknown profile {profile_name!r}")
+        else:
+            referenced_profiles.add(profile_name)
+        if selection.get("install_phase") != "build":
+            errors.append(f"downstream image family {family!r} must install bundles at build time")
+    if unreferenced := sorted(set(profiles) - referenced_profiles):
+        errors.append(f"bundle profiles are not selected by a supported downstream image family: {unreferenced}")
+
+    try:
+        catalog = discover_bundle_catalog(repo_root)
+    except ProfileError as exc:
+        return {}, [str(exc)]
+    for name, profile in profiles.items():
+        errors.extend(validate_profile(name, profile, catalog, repo_root))
+    return catalog, errors
+
+
+def exact_requirement(distribution: str, extras: list[str], version: str) -> str:
+    suffix = f"[{','.join(extras)}]" if extras else ""
+    return f"{distribution}{suffix}=={version}"
+
+
+def compile_profile(
+    contract: dict[str, Any],
+    profile_name: str,
+    catalog: dict[str, dict[str, Any]],
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    profile = contract["profiles"][profile_name]
+    root_project = read_project(repo_root / "pyproject.toml")
+    lfx_project = read_project(repo_root / "src" / "lfx" / "pyproject.toml")
+    bundles = []
+    for item in sorted(profile["bundles"], key=lambda value: canonicalize_name(value["distribution"])):
+        distribution = canonicalize_name(item["distribution"])
+        resolved_version = catalog[distribution]["version"]
+        bundles.append(
+            {
+                "distribution": distribution,
+                "extras": item["extras"],
+                "providers": item["providers"],
+                "requested": item["version"],
+                "resolved_version": resolved_version,
+                "requirement": exact_requirement(distribution, item["extras"], resolved_version),
+            }
+        )
+    return {
+        "schema_version": contract["schema_version"],
+        "profile": profile_name,
+        "image_families": sorted(
+            family for family, selection in contract["image_families"].items() if selection["profile"] == profile_name
+        ),
+        "profile_digest": profile_digest(profile),
+        "indexes": profile["indexes"],
+        "python": profile["python"],
+        "application": {
+            "distribution": canonicalize_name(profile["application"]["distribution"]),
+            "requested": profile["application"]["version"],
+            "resolved_version": root_project["version"],
+            "requirement": exact_requirement(root_project["name"], [], root_project["version"]),
+        },
+        "bundle_api": {
+            "distribution": "lfx",
+            "requested": profile["bundle_api"]["version"],
+            "resolved_version": lfx_project["version"],
+            "requirement": exact_requirement("lfx", [], lfx_project["version"]),
+        },
+        "bundles": bundles,
+        "providers": sorted(provider for item in bundles for provider in item["providers"]),
+    }
+
+
+def compile_all(contract_path: Path, output_dir: Path, repo_root: Path = REPO_ROOT) -> list[Path]:
+    contract = read_json(contract_path)
+    catalog, errors = validate_contract(contract, repo_root)
+    if errors:
+        raise ProfileError("\n".join(errors))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for profile_name in sorted(contract["profiles"]):
+        path = output_dir / f"{profile_name}.lock.json"
+        path.write_text(canonical_json(compile_profile(contract, profile_name, catalog, repo_root)), encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def check_locks(contract_path: Path, locks_dir: Path, repo_root: Path = REPO_ROOT) -> list[str]:
+    contract = read_json(contract_path)
+    catalog, errors = validate_contract(contract, repo_root)
+    if errors:
+        return errors
+    expected_names = {f"{name}.lock.json" for name in contract.get("profiles", {})}
+    actual_names = {path.name for path in locks_dir.glob("*.lock.json")} if locks_dir.is_dir() else set()
+    for missing in sorted(expected_names - actual_names):
+        errors.append(f"missing bundle profile lock {missing}")
+    for unexpected in sorted(actual_names - expected_names):
+        errors.append(f"unexpected bundle profile lock {unexpected}")
+    for profile_name in sorted(contract.get("profiles", {})):
+        path = locks_dir / f"{profile_name}.lock.json"
+        if path.is_file():
+            expected = canonical_json(compile_profile(contract, profile_name, catalog, repo_root))
+            if path.read_text(encoding="utf-8") != expected:
+                errors.append(f"stale bundle profile lock {path.name}; regenerate it intentionally")
+    return errors
+
+
+def installed_inventory() -> tuple[dict[str, str], dict[str, list[str]]]:
+    distributions: dict[str, str] = {}
+    provider_owners: dict[str, list[str]] = {}
+    for distribution in metadata.distributions():
+        raw_name = distribution.metadata.get("Name")
+        if not raw_name:
+            continue
+        name = canonicalize_name(raw_name)
+        entry_points = list(distribution.entry_points)
+        if not any(point.group in {"langflow.extensions", "lfx.bundles"} for point in entry_points):
+            continue
+        distributions[name] = distribution.version
+        for point in entry_points:
+            if point.group == "langflow.extensions":
+                provider_owners.setdefault(point.name, []).append(name)
+
+        if name == "lfx-bundles":
+            for file_name in distribution.files or []:
+                parts = Path(file_name).parts
+                if (
+                    len(parts) == BUNDLE_INIT_PATH_PARTS
+                    and parts[0] == "lfx_bundles"
+                    and parts[2] == "__init__.py"
+                    and not parts[1].startswith("_")
+                ):
+                    provider_owners.setdefault(parts[1], []).append(name)
+    return dict(sorted(distributions.items())), {key: sorted(value) for key, value in sorted(provider_owners.items())}
+
+
+def validate_installed(
+    lock: dict[str, Any],
+    actual_distributions: dict[str, str],
+    provider_owners: dict[str, list[str]],
+    contract_versions: dict[str, str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if contract_versions is not None:
+        for contract_key in ("application", "bundle_api"):
+            selection = lock[contract_key]
+            distribution = selection["distribution"]
+            actual = contract_versions.get(distribution)
+            if actual is None:
+                errors.append(f"missing {contract_key} distribution {distribution!r}")
+            elif actual != selection["resolved_version"]:
+                errors.append(f"{distribution} version drift: expected {selection['resolved_version']}, got {actual}")
+    expected_distributions = {item["distribution"]: item["resolved_version"] for item in lock["bundles"]}
+    missing = sorted(set(expected_distributions) - set(actual_distributions))
+    unexpected = sorted(set(actual_distributions) - set(expected_distributions))
+    if missing:
+        errors.append(f"missing declared bundle distributions: {missing}")
+    if unexpected:
+        errors.append(f"undeclared transitive bundle distributions installed: {unexpected}")
+    for distribution in sorted(set(expected_distributions) & set(actual_distributions)):
+        expected = expected_distributions[distribution]
+        actual = actual_distributions[distribution]
+        if actual != expected:
+            errors.append(f"{distribution} version drift: expected {expected}, got {actual}")
+
+    actual_providers = set(provider_owners)
+    expected_providers = set(lock["providers"])
+    if missing_providers := sorted(expected_providers - actual_providers):
+        errors.append(f"missing declared providers: {missing_providers}")
+    if unexpected_providers := sorted(actual_providers - expected_providers):
+        errors.append(f"undeclared providers installed: {unexpected_providers}")
+    duplicates = {provider: owners for provider, owners in provider_owners.items() if len(set(owners)) > 1}
+    if duplicates:
+        errors.append(f"duplicate providers installed: {duplicates}")
+    return errors
+
+
+def print_errors(errors: list[str]) -> int:
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profiles", type=Path, default=DEFAULT_PROFILES)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="validate profiles and checked-in locks")
+    check.add_argument("--locks-dir", type=Path, default=DEFAULT_LOCKS)
+
+    compile_parser = subparsers.add_parser("compile", help="resolve every profile into a deterministic lock")
+    compile_parser.add_argument("--output-dir", type=Path, required=True)
+
+    requirements = subparsers.add_parser("requirements", help="render exact build requirements from a lock")
+    requirements.add_argument("--lock", type=Path, required=True)
+    requirements.add_argument(
+        "--bundles-only",
+        action="store_true",
+        help="omit the application requirement when the downstream build installs Langflow from pinned source",
+    )
+
+    verify = subparsers.add_parser("verify-installed", help="verify an installed image against a profile lock")
+    verify.add_argument("--lock", type=Path, required=True)
+    verify.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "check":
+            errors = check_locks(args.profiles, args.locks_dir)
+            if errors:
+                return print_errors(errors)
+            print(f"Bundle profiles and locks passed: {args.profiles}")
+        elif args.command == "compile":
+            paths = compile_all(args.profiles, args.output_dir)
+            for path in paths:
+                print(path)
+        elif args.command == "requirements":
+            lock = read_json(args.lock)
+            if not args.bundles_only:
+                print(lock["application"]["requirement"])
+            for item in lock["bundles"]:
+                print(item["requirement"])
+        elif args.command == "verify-installed":
+            lock = read_json(args.lock)
+            distributions, providers = installed_inventory()
+            contract_versions = {}
+            for contract_key in ("application", "bundle_api"):
+                distribution = lock[contract_key]["distribution"]
+                with suppress(metadata.PackageNotFoundError):
+                    contract_versions[distribution] = metadata.version(distribution)
+            errors = validate_installed(lock, distributions, providers, contract_versions)
+            report = {
+                "schema_version": lock["schema_version"],
+                "profile": lock["profile"],
+                "profile_digest": lock["profile_digest"],
+                "passed": not errors,
+                "contract_versions": contract_versions,
+                "distributions": distributions,
+                "providers": providers,
+                "errors": errors,
+            }
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(canonical_json(report), encoding="utf-8")
+            if errors:
+                return print_errors(errors)
+            print(f"Installed bundle profile passed; inventory: {args.output}")
+    except (KeyError, OSError, ProfileError, ValueError) as exc:
+        return print_errors([str(exc)])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_bundle_profiles.py
+++ b/scripts/ci/test_bundle_profiles.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from manage_bundle_profiles import (
+    DEFAULT_LOCKS,
+    DEFAULT_PROFILES,
+    REPO_ROOT,
+    check_locks,
+    compile_profile,
+    discover_bundle_catalog,
+    read_json,
+    validate_contract,
+    validate_installed,
+)
+
+
+def load_contract() -> dict:
+    return read_json(DEFAULT_PROFILES)
+
+
+def test_reviewed_profiles_and_locks_are_current() -> None:
+    assert check_locks(DEFAULT_PROFILES, DEFAULT_LOCKS) == []
+
+
+def test_every_supported_downstream_image_family_selects_a_build_time_profile() -> None:
+    contract = load_contract()
+
+    assert contract["image_families"] == {
+        "enterprise-ubi-hardened": {
+            "install_phase": "build",
+            "profile": "enterprise-hardened",
+        }
+    }
+    _, errors = validate_contract(contract)
+    assert errors == []
+
+
+def test_profile_compilation_is_deterministic() -> None:
+    contract = load_contract()
+    catalog = discover_bundle_catalog()
+
+    first = compile_profile(contract, "enterprise-hardened", catalog)
+    second = compile_profile(contract, "enterprise-hardened", catalog)
+
+    assert first == second
+    assert first["image_families"] == ["enterprise-ubi-hardened"]
+    assert first["application"]["requirement"] == "langflow==1.12.0"
+    assert first["bundle_api"]["requirement"] == "lfx==1.12.0"
+    assert first["bundles"] == sorted(first["bundles"], key=lambda item: item["distribution"])
+
+
+def test_profile_matches_application_bundle_dependencies_exactly() -> None:
+    contract = load_contract()
+    profile = contract["profiles"]["enterprise-hardened"]
+    declared = {item["distribution"] for item in profile["bundles"]}
+
+    root_project = __import__("tomllib").loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    application = {
+        canonicalize_name(Requirement(value).name)
+        for value in root_project["dependencies"]
+        if canonicalize_name(Requirement(value).name).startswith("lfx-")
+    }
+
+    assert declared == application
+
+
+def test_unknown_bundle_is_rejected() -> None:
+    contract = load_contract()
+    profile = contract["profiles"]["enterprise-hardened"]
+    profile["bundles"].append(
+        {
+            "distribution": "lfx-unknown",
+            "extras": [],
+            "version": ">=1,<2",
+            "providers": ["unknown"],
+        }
+    )
+
+    _, errors = validate_contract(contract)
+
+    assert any("unknown bundle distribution 'lfx-unknown'" in error for error in errors)
+
+
+def test_runtime_profile_selection_is_rejected() -> None:
+    contract = load_contract()
+    contract["image_families"]["enterprise-ubi-hardened"]["install_phase"] = "runtime"
+
+    _, errors = validate_contract(contract)
+
+    assert any("must install bundles at build time" in error for error in errors)
+
+
+def test_unbounded_python_range_is_rejected() -> None:
+    contract = load_contract()
+    contract["profiles"]["enterprise-hardened"]["python"] = ">=3.10"
+
+    _, errors = validate_contract(contract)
+
+    assert any("Python version" in error and "must have lower and upper bounds" in error for error in errors)
+
+
+def test_unbounded_bundle_range_is_rejected() -> None:
+    contract = load_contract()
+    contract["profiles"]["enterprise-hardened"]["bundles"][0]["version"] = ">=0.1.0"
+
+    _, errors = validate_contract(contract)
+
+    assert any("must have lower and upper bounds" in error for error in errors)
+
+
+def test_unknown_extra_is_rejected() -> None:
+    contract = load_contract()
+    contract["profiles"]["enterprise-hardened"]["bundles"][0]["extras"] = ["unknown"]
+
+    _, errors = validate_contract(contract)
+
+    assert any("has unknown extras ['unknown']" in error for error in errors)
+
+
+def test_duplicate_provider_is_rejected() -> None:
+    contract = load_contract()
+    profile = contract["profiles"]["enterprise-hardened"]
+    profile["bundles"][1]["providers"] = profile["bundles"][0]["providers"]
+
+    _, errors = validate_contract(contract)
+
+    assert any("provider inventory must be" in error for error in errors)
+    assert any("duplicate providers declared" in error for error in errors)
+
+
+def test_undeclared_application_bundle_is_rejected() -> None:
+    contract = load_contract()
+    contract["profiles"]["enterprise-hardened"]["bundles"].pop()
+
+    _, errors = validate_contract(contract)
+
+    assert any("application bundle source drift" in error and "undeclared" in error for error in errors)
+
+
+def test_installed_inventory_rejects_transitive_and_provider_drift() -> None:
+    contract = load_contract()
+    catalog = discover_bundle_catalog()
+    lock = compile_profile(contract, "enterprise-hardened", catalog)
+    distributions = {item["distribution"]: item["resolved_version"] for item in lock["bundles"]}
+    providers = {provider: [item["distribution"]] for item in lock["bundles"] for provider in item["providers"]}
+    distributions["lfx-unknown"] = "1.0.0"
+    providers["unknown"] = ["lfx-unknown"]
+    first_provider = lock["providers"][0]
+    providers[first_provider].append("lfx-unknown")
+
+    errors = validate_installed(lock, distributions, providers)
+
+    assert any("undeclared transitive bundle distributions" in error for error in errors)
+    assert any("undeclared providers installed" in error for error in errors)
+    assert any("duplicate providers installed" in error for error in errors)
+
+
+def test_checked_in_lock_requires_an_intentional_profile_diff(tmp_path: Path) -> None:
+    contract = load_contract()
+    contract["profiles"]["enterprise-hardened"]["description"] += " Changed."
+    profiles_path = tmp_path / "profiles.json"
+    profiles_path.write_text(json.dumps(contract), encoding="utf-8")
+
+    errors = check_locks(profiles_path, DEFAULT_LOCKS)
+
+    assert any("stale bundle profile lock" in error for error in errors)
+
+
+def test_contract_validation_does_not_mutate_input() -> None:
+    contract = load_contract()
+    original = copy.deepcopy(contract)
+
+    validate_contract(contract)
+
+    assert contract == original

--- a/scripts/ci/test_release_inventory.py
+++ b/scripts/ci/test_release_inventory.py
@@ -120,8 +120,13 @@ def test_validation_reports_missing_forbidden_and_component_drift() -> None:
 
 
 def test_release_gate_covers_supported_python_and_image_architectures() -> None:
+    profile_job = workflow_job_block(GATE_WORKFLOW_PATH, "downstream-bundle-profiles")
     python_job = workflow_job_block(GATE_WORKFLOW_PATH, "python-inventory")
     image_job = workflow_job_block(GATE_WORKFLOW_PATH, "image-inventory")
+
+    assert "manage_bundle_profiles.py check" in profile_job
+    assert "manage_bundle_profiles.py compile" in profile_job
+    assert "downstream-bundle-profile-inventories" in profile_job
 
     assert 'python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]' in python_job
     assert "profile: [python-default, python-full]" in python_job


### PR DESCRIPTION
## What

- add a single declarative bundle-profile contract for the supported Enterprise UBI/hardened downstream image family
- list every included bundle distribution, extras selection, bounded version range, provider owner, target Langflow/LFX range, package index, profile owners, and update cadence
- generate and check in a deterministic exact-version lock plus release inventory artifact for the profile
- validate unknown distributions/extras, unbounded or incompatible ranges, duplicate providers, application dependency drift, runtime profile selection, and stale locks
- provide a build-time installed-image verifier that rejects missing, undeclared, duplicated, or version-drifted bundles/providers and emits a reviewable JSON inventory
- run profile validation and artifact generation in the existing release inventory gate
- document downstream Docker integration, provider changes, ownership, update cadence, emergency pins, and rollback

## Why

The `release-1.12.0` branch already contains the LE-1871 application-image tiers, LE-1872 release/version propagation, and LE-1873 package/image inventory gates. It did not yet contain LE-1874's downstream source of truth: Enterprise/hardened images still inherited the Langflow application's bundle dependencies without a named, exact, independently reviewable profile.

This change makes the current Enterprise/hardened bundle set explicit and fails closed when the application or installed image drifts from it. Profile selection and installation remain image-build concerns; the tooling performs no runtime package or registry mutation.

## Downstream adoption

This PR establishes the release-branch contract that downstream builds consume. After it lands, the Enterprise release branch should update its immutable OSS pin, set `LANGFLOW_BUNDLE_PROFILE=enterprise-hardened` in its Dockerfile, install the generated exact requirements during the build, and retain the `verify-installed` JSON artifact. That companion change should follow the merged OSS commit so Enterprise does not pin an unmerged release-branch revision.

## Validation

- `80 passed`: complete `scripts/ci/` test suite
- final focused bundle-profile and release-inventory regression suites passed
- Ruff check and format check
- `actionlint` for the reusable release inventory workflow
- Node syntax check for the docs sidebar
- profile/lock self-check and exact requirements rendering
- pre-commit hooks, detect-secrets, and IBM Block Secrets
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downstream bundle profiles for hardened container images.
  * Added deterministic dependency locks and installed-environment verification.
  * Added release validation that checks profiles and publishes bundle inventory artifacts.

* **Documentation**
  * Added deployment guidance for selecting, updating, verifying, and rolling back bundle profiles.

* **Tests**
  * Added comprehensive validation for profile configuration, dependency locks, provider ownership, and inventory consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->