### PR TITLE
fix(mcp): reap cancelled session transports

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -286,6 +286,86 @@ class TestMCPSessionManager:
         # Clean up after test
         await manager.cleanup_all()
 
+    async def test_stdio_session_creation_cancellation_stops_background_task(self, session_manager):
+        """Cancelling session creation must also stop the task that owns the subprocess."""
+        initialize_started = asyncio.Event()
+
+        class BlockingClientSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def initialize(self):
+                initialize_started.set()
+                await asyncio.Event().wait()
+
+        stdio_client = MagicMock()
+        stdio_client.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+        stdio_client.return_value.__aexit__ = AsyncMock(return_value=None)
+        existing_tasks = set(session_manager._background_tasks)
+
+        with (
+            patch("lfx.base.mcp.util.ClientSession", return_value=BlockingClientSession()),
+            patch("mcp.client.stdio.stdio_client", stdio_client),
+        ):
+            creation_task = asyncio.create_task(session_manager._create_stdio_session("test_session", MagicMock()))
+            await asyncio.wait_for(initialize_started.wait(), timeout=1)
+            session_tasks = set(session_manager._background_tasks) - existing_tasks
+            assert len(session_tasks) == 1
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(creation_task, timeout=0.01)
+
+            await asyncio.wait_for(asyncio.gather(*session_tasks, return_exceptions=True), timeout=1)
+
+        assert session_tasks.isdisjoint(session_manager._background_tasks)
+
+    async def test_http_session_creation_cancellation_stops_background_task(self, session_manager):
+        """Cancelling HTTP session creation must also stop the task that owns the transport."""
+        initialize_started = asyncio.Event()
+
+        class BlockingClientSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def initialize(self):
+                initialize_started.set()
+                await asyncio.Event().wait()
+
+        streamable_client = MagicMock()
+        streamable_client.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+        streamable_client.return_value.__aexit__ = AsyncMock(return_value=None)
+        connection_params = {
+            "url": "http://test-mcp.example/mcp",
+            "headers": {},
+            "timeout_seconds": 30,
+            "verify_ssl": True,
+        }
+        existing_tasks = set(session_manager._background_tasks)
+
+        with (
+            patch("lfx.base.mcp.util.ClientSession", return_value=BlockingClientSession()),
+            patch("mcp.client.streamable_http.streamablehttp_client", streamable_client),
+        ):
+            creation_task = asyncio.create_task(
+                session_manager._create_streamable_http_session("test_session", connection_params)
+            )
+            await asyncio.wait_for(initialize_started.wait(), timeout=1)
+            session_tasks = set(session_manager._background_tasks) - existing_tasks
+            assert len(session_tasks) == 1
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(creation_task, timeout=0.01)
+
+            await asyncio.wait_for(asyncio.gather(*session_tasks, return_exceptions=True), timeout=1)
+
+        assert session_tasks.isdisjoint(session_manager._background_tasks)
+
     async def test_session_caching(self, session_manager):
         """Test that sessions are properly cached and reused."""
         context_id = "test_context"

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -952,7 +952,7 @@ class MCPSessionManager:
     def __init__(self):
         # Structure: server_key -> {"sessions": {session_id: session_info}, "last_cleanup": timestamp}
         self.sessions_by_server = {}
-        self._background_tasks = set()  # Keep references to background tasks
+        self._background_tasks: set[asyncio.Task[Any]] = set()  # Keep references to background tasks
         # Backwards-compatibility maps: which context_id uses which (server_key, session_id)
         self._context_to_session: dict[str, tuple[str, str]] = {}
         # Reference count for each active (server_key, session_id)
@@ -1270,6 +1270,24 @@ class MCPSessionManager:
 
             return session
 
+    def _abort_session_task(self, task: asyncio.Task[Any]) -> None:
+        """Cancel and reap a transport task when session creation is interrupted."""
+        if task.done():
+            self._background_tasks.discard(task)
+            return
+
+        task.cancel()
+
+        async def reap_task() -> None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+            self._background_tasks.discard(task)
+
+        # Reap outside the cancelled caller so transport shutdown can finish.
+        reaper = asyncio.create_task(reap_task())
+        self._background_tasks.add(reaper)
+        reaper.add_done_callback(self._background_tasks.discard)
+
     async def _create_stdio_session(self, session_id: str, connection_params):
         """Create a new stdio session as a background task to avoid context issues."""
         import asyncio
@@ -1309,6 +1327,9 @@ class MCPSessionManager:
         # Wait for session to be ready (use longer timeout for remote connections)
         try:
             session = await asyncio.wait_for(session_future, timeout=30.0)
+        except asyncio.CancelledError:
+            self._abort_session_task(task)
+            raise
         except asyncio.TimeoutError as timeout_err:
             # Clean up the failed task
             if not task.done():
@@ -1479,6 +1500,9 @@ class MCPSessionManager:
                 return session, task, transport_used, sse_preference_locked[0]
             msg = f"Session {session_id} established but transport not recorded"
             raise ValueError(msg)
+        except asyncio.CancelledError:
+            self._abort_session_task(task)
+            raise
         except asyncio.TimeoutError as timeout_err:
             if not task.done():
                 task.cancel()


### PR DESCRIPTION
## Summary

- cancel half-initialized MCP transport tasks when session creation is cancelled
- reap cancelled stdio and Streamable HTTP/SSE tasks outside the cancelled caller
- add regression coverage for both transport paths

## Root cause

`connect_to_server` enforces `mcp_server_timeout` (20 seconds by default), while the session creators wait up to 30 seconds for readiness. When the outer timeout fires first, `CancelledError` bypasses the existing `TimeoutError` cleanup block. The detached transport task is never registered as a session and remains alive, leaking the stdio subprocess or HTTP transport.

This change handles cancellation explicitly and tracks a detached reaper so transport teardown can finish after the caller unwinds. It intentionally preserves the existing timeout budgets, avoiding a shorter cold-start window for MCP servers.

Closes #14161

## Validation

- `uv run pytest src/backend/tests/unit/base/mcp/test_mcp_util.py -q` — 229 passed, 7 skipped
- `uv run pytest src/backend/tests/unit/base/mcp/test_mcp_util.py -q -k 'session_creation_cancellation_stops_background_task'` — 2 passed
- `uv run ruff check src/lfx/src/lfx/base/mcp/util.py src/backend/tests/unit/base/mcp/test_mcp_util.py`
- `uv run ruff format --check src/lfx/src/lfx/base/mcp/util.py src/backend/tests/unit/base/mcp/test_mcp_util.py`
- pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling when creating MCP sessions over stdio or HTTP.
  * Ensured interrupted session creation stops associated background tasks and cleans up resources properly.

* **Tests**
  * Added regression coverage for cancellation and timeout behavior across both supported transport types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->