### PR TITLE
fix: preserve secret values across graph edges

### DIFF
--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1320,7 +1320,8 @@ class Component(CustomComponent):
         for output in self._get_outputs_to_process():
             self._current_output = output.name
             result = await self._get_output_result(output)
-            results[output.name] = result
+            # Output.value is the private graph-edge cache; results are display-facing copies.
+            results[output.name] = self._sanitize_secret_values(result)
             artifacts[output.name] = self._build_artifact(result)
             self._log_output(output)
 
@@ -1407,7 +1408,7 @@ class Component(CustomComponent):
         ):
             result.set_flow_id(self._vertex.graph.flow_id)
         result = output.apply_options(result)
-        result = self._sanitize_secret_values(result)
+        # Keep the edge value usable. Human-facing copies are sanitized in _build_results.
         output.value = result
 
         return result
@@ -1454,21 +1455,29 @@ class Component(CustomComponent):
         return value
 
     def _sanitize_secret_values(self, value):
+        """Return a sanitized value without mutating caller-owned Message or Data objects."""
         if not self._secret_values:
             return _mask_secret_value(value)
         value = _mask_secret_value(value)
         if isinstance(value, str):
             return self._sanitize_secret_string(value)
         if isinstance(value, Message):
+            sanitized = value.model_copy(
+                update={
+                    "data": self._sanitize_secret_values(value.data),
+                    "content_blocks": list(value.content_blocks),
+                }
+            )
             if isinstance(value.text, str):
-                value.text = self._sanitize_secret_string(value.text)
-            value.data = self._sanitize_secret_values(value.data)
-            return value
+                sanitized.text = self._sanitize_secret_string(value.text)
+            return sanitized
         if isinstance(value, Data):
-            value.data = self._sanitize_secret_values(value.data)
-            if isinstance(value.default_value, str):
-                value.default_value = self._sanitize_secret_string(value.default_value)
-            return value
+            default_value = value.default_value
+            if isinstance(default_value, str):
+                default_value = self._sanitize_secret_string(default_value)
+            return value.model_copy(
+                update={"data": self._sanitize_secret_values(value.data), "default_value": default_value}
+            )
         if isinstance(value, dict):
             return {key: self._sanitize_secret_values(item) for key, item in value.items()}
         if isinstance(value, list):

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -72,6 +72,8 @@ class Vertex:
         self._is_loop = None
         self.has_session_id = None
         self.custom_component = None
+        # Runtime-only metadata used to mask downstream display results without changing edge values.
+        self._upstream_secret_values: set[str] = set()
         self.has_external_input = False
         self.has_external_output = False
         self.graph = graph
@@ -228,6 +230,7 @@ class Vertex:
         state = self.__dict__.copy()
         state["_lock"] = None  # Locks are not serializable
         state["custom_component"] = None  # Component instances are rebuilt and may hold non-serializable runtime state
+        state["_upstream_secret_values"] = set()  # Never persist raw secrets carried between components
         state["built_object"] = None if isinstance(self.built_object, UnbuiltObject) else self.built_object
         state["built_result"] = None if isinstance(self.built_result, UnbuiltResult) else self.built_result
         return state
@@ -235,6 +238,7 @@ class Vertex:
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._lock = asyncio.Lock()  # Reinitialize the lock
+        self._upstream_secret_values = state.get("_upstream_secret_values", set())
         self.built_object = state.get("built_object") or UnbuiltObject()
         self.built_result = state.get("built_result") or UnbuiltResult()
 
@@ -413,6 +417,9 @@ class Vertex:
                 self.custom_component.set_event_manager(event_manager)
             custom_params = initialize.loading.get_params(self.params)
             custom_params.pop("code", None)
+
+        if hasattr(custom_component, "_secret_values"):
+            custom_component._secret_values.update(self._upstream_secret_values)  # noqa: SLF001
 
         await self._build_results(
             custom_component=custom_component,
@@ -604,7 +611,15 @@ class Vertex:
             The result of the vertex.
         """
         async with self.lock:
-            return await self._get_result(requester, target_handle_name)
+            result = await self._get_result(requester, target_handle_name)
+            requester._inherit_secret_values(self)
+            return result
+
+    def _inherit_secret_values(self, source_vertex: Vertex) -> None:
+        """Track secrets carried by an upstream component so displayed results stay masked."""
+        source_component = source_vertex.custom_component
+        if source_component is not None:
+            self._upstream_secret_values.update(getattr(source_component, "_secret_values", set()))
 
     async def _log_transaction_async(
         self,

--- a/src/lfx/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_component_events.py
@@ -9,6 +9,7 @@ from lfx.custom.custom_component.component import Component
 from lfx.events.event_manager import EventManager
 from lfx.schema.content_block import ContentBlock
 from lfx.schema.content_types import TextContent, ToolContent
+from lfx.schema.data import Data
 from lfx.schema.message import Message
 from lfx.schema.properties import Properties, Source
 from lfx.template.field.base import Output
@@ -171,6 +172,44 @@ async def test_component_build_results():
     assert "text_output" in artifacts
     assert "tool_output" in artifacts
     assert artifacts["text_output"]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_component_build_results_masks_display_values_without_mutating_output_value():
+    """Display results are masked copies while graph-edge output values remain usable."""
+
+    class SecretOutputComponent(Component):
+        def get_connection_string(self) -> Message:
+            return Message(text="postgresql://demo:hunter2@localhost/db")  # pragma: allowlist secret
+
+        def get_connection_data(self) -> Data:
+            return Data(
+                data={"url": "postgresql://demo:hunter2@localhost/db"},  # pragma: allowlist secret
+                default_value="token=hunter2",  # pragma: allowlist secret
+            )
+
+    component = SecretOutputComponent()
+    component._secret_values.add("hunter2")  # pragma: allowlist secret
+    message_output = Output(name="connection_string", method="get_connection_string")
+    data_output = Output(name="connection_data", method="get_connection_data")
+    component._outputs_map = {message_output.name: message_output, data_output.name: data_output}
+    component.outputs = [message_output, data_output]
+
+    results, artifacts = await component._build_results()
+
+    displayed_message = results[message_output.name]
+    assert displayed_message.text == "postgresql://demo:**********@localhost/db"
+    assert artifacts[message_output.name]["raw"] == "postgresql://demo:**********@localhost/db"
+    assert message_output.value.text == "postgresql://demo:hunter2@localhost/db"  # pragma: allowlist secret
+    assert displayed_message is not message_output.value
+
+    displayed_data = results[data_output.name]
+    assert displayed_data.data["url"] == "postgresql://demo:**********@localhost/db"
+    assert displayed_data.default_value == "token=**********"
+    assert artifacts[data_output.name]["raw"]["url"] == "postgresql://demo:**********@localhost/db"
+    assert data_output.value.data["url"] == "postgresql://demo:hunter2@localhost/db"  # pragma: allowlist secret
+    assert data_output.value.default_value == "token=hunter2"  # pragma: allowlist secret
+    assert displayed_data is not data_output.value
 
 
 @pytest.mark.asyncio

--- a/src/lfx/tests/unit/graph/graph/test_base.py
+++ b/src/lfx/tests/unit/graph/graph/test_base.py
@@ -6,9 +6,31 @@ from ag_ui.core import RunFinishedEvent, RunStartedEvent
 from lfx.components.input_output import ChatInput, ChatOutput, TextInputComponent, TextOutputComponent
 from lfx.components.langchain_utilities.tool_calling import ToolCallingAgentComponent
 from lfx.components.processing.combine_text import CombineTextComponent
+from lfx.custom.custom_component.component import Component
 from lfx.graph import Graph
 from lfx.graph.graph.constants import Finish
+from lfx.io import MessageTextInput, Output, SecretStrInput
+from lfx.schema.message import Message
 from lfx.schema.schema import INPUT_FIELD_NAME
+
+
+class SecretConnectionString(Component):
+    display_name = "Secret Connection String"
+    inputs = [SecretStrInput(name="password", display_name="Password")]
+    outputs = [Output(name="connection_string", method="build_connection_string")]
+
+    def build_connection_string(self) -> Message:
+        return Message(text=f"postgresql://demo:{self.password}@localhost/db")
+
+
+class SecretEcho(Component):
+    display_name = "Secret Echo"
+    inputs = [MessageTextInput(name="value", display_name="Value")]
+    outputs = [Output(name="message", method="echo")]
+
+    def echo(self) -> Message:
+        self.received_value = self.value
+        return Message(text=self.value)
 
 
 @pytest.mark.asyncio
@@ -41,6 +63,20 @@ async def test_graph_with_edge():
     assert graph.vertices[1].id == output_id
     assert graph.edges[0].source_id == input_id
     assert graph.edges[0].target_id == output_id
+
+
+@pytest.mark.asyncio
+async def test_graph_preserves_secret_on_edge_and_masks_terminal_result():
+    """A downstream component receives the secret while public graph results remain masked."""
+    test_secret = "hunter2"  # noqa: S105  # pragma: allowlist secret
+    producer = SecretConnectionString(_id="producer").set(password=test_secret)
+    consumer = SecretEcho(_id="consumer").set(value=producer.build_connection_string)
+    graph = Graph(producer, consumer)
+
+    outputs = await graph.arun(inputs=[{}], outputs=[consumer.get_id()])
+
+    assert consumer.received_value == "postgresql://demo:hunter2@localhost/db"  # pragma: allowlist secret
+    assert outputs[0].outputs[0].outputs["message"]["message"] == "postgresql://demo:**********@localhost/db"
 
 
 @pytest.mark.asyncio

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -33,12 +33,14 @@ def test_vertex_getstate_drops_custom_component_runtime_state():
     vertex = object.__new__(Vertex)
     vertex._lock = Mock()
     vertex.custom_component = UnpickleableComponent()
+    vertex._upstream_secret_values = {"do-not-persist"}
     vertex.built_object = object()
     vertex.built_result = object()
 
     state = vertex.__getstate__()
 
     assert state["custom_component"] is None
+    assert state["_upstream_secret_values"] == set()
     pickle.dumps(state)
 
 


### PR DESCRIPTION
## Summary

- keep real component output values in the private `Output.value` cache used by connected graph edges
- sanitize independent `Message` and `Data` copies for results, artifacts, tracing, status, and other display-facing surfaces
- propagate secret metadata across component edges so downstream results remain masked even though execution receives the real value
- drop propagated raw secret metadata when vertices are serialized
- add unit and end-to-end graph regressions for both edge delivery and public output masking

Fixes #14152

## Root cause

`Component._get_output_result()` sanitized its return value in place before storing it in `Output.value`. `ComponentVertex._get_result()` prefers that cache for connected edges, so downstream components received the literal mask instead of the real value.

Moving masking to `_build_results()` alone is insufficient: downstream components then receive the real value but do not know it originated from a secret input, which can expose it again in terminal flow results. This change carries runtime-only secret metadata with the edge so each downstream component can sanitize its own display-facing copies without altering execution values.

## Validation

- `src/lfx/tests/unit/graph`: 282 passed, 6 skipped, 1 xfailed
- `src/lfx/tests/unit/custom/custom_component`: 31 passed, 1 xfailed
- focused post-rebase regressions: 3 passed
- existing backend env-secret leakage regressions: 2 passed
- Ruff check and format: passed
- pre-commit hooks, including detect-secrets: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret values are now masked in displayed component and graph results.
  * Secret data remains available internally for connected components without being exposed in terminal outputs.
  * Sanitization no longer alters underlying message or data values.

* **Tests**
  * Added coverage for secret masking, graph propagation, and runtime state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->