### PR TITLE
fix(release): prevent frontend restore source collision

### DIFF
--- a/scripts/ci/install_release_wheels.py
+++ b/scripts/ci/install_release_wheels.py
@@ -91,8 +91,14 @@ def _restore_frontend(python: Path, frontend_source: Path) -> None:
         "assert spec is not None and spec.origin is not None; "
         "print(Path(spec.origin).parent)"
     )
-    package_dir = Path(subprocess.check_output([python, "-c", command], text=True).strip())  # noqa: S603
-    frontend_target = package_dir / "frontend"
+    # Isolated mode keeps the Dockerfile's source-tree working directory off
+    # sys.path so find_spec resolves the wheel installed in site-packages.
+    package_dir = Path(subprocess.check_output([python, "-I", "-c", command], text=True).strip())  # noqa: S603
+    frontend_source = frontend_source.resolve()
+    frontend_target = (package_dir / "frontend").resolve()
+    if frontend_source == frontend_target:
+        msg = f"Frontend source and target must be different: {frontend_source}"
+        raise ValueError(msg)
     shutil.rmtree(frontend_target, ignore_errors=True)
     shutil.copytree(frontend_source, frontend_target)
     print(f"Restored Docker-built frontend assets to {frontend_target}")

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -118,11 +118,36 @@ def test_restore_frontend_replaces_wheel_assets(tmp_path: Path, monkeypatch: pyt
     installed_frontend = package_dir / "frontend"
     installed_frontend.mkdir(parents=True)
     (installed_frontend / "index.html").write_text("wheel build", encoding="utf-8")
+
+    commands: list[list[object]] = []
+
+    def find_installed_package(command: list[object], **_kwargs: object) -> str:
+        commands.append(command)
+        return str(package_dir)
+
+    monkeypatch.setattr(
+        "scripts.ci.install_release_wheels.subprocess.check_output",
+        find_installed_package,
+    )
+
+    python = tmp_path / "python"
+    _restore_frontend(python, frontend_source)
+
+    assert commands[0][:3] == [python, "-I", "-c"]
+    assert (installed_frontend / "index.html").read_text(encoding="utf-8") == "docker build"
+
+
+def test_restore_frontend_rejects_source_target_collision(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package_dir = tmp_path / "langflow"
+    frontend_source = package_dir / "frontend"
+    frontend_source.mkdir(parents=True)
+    (frontend_source / "index.html").write_text("docker build", encoding="utf-8")
     monkeypatch.setattr(
         "scripts.ci.install_release_wheels.subprocess.check_output",
         lambda *_args, **_kwargs: str(package_dir),
     )
 
-    _restore_frontend(tmp_path / "python", frontend_source)
+    with pytest.raises(ValueError, match="must be different"):
+        _restore_frontend(tmp_path / "python", frontend_source)
 
-    assert (installed_frontend / "index.html").read_text(encoding="utf-8") == "docker build"
+    assert (frontend_source / "index.html").read_text(encoding="utf-8") == "docker build"


### PR DESCRIPTION
## Summary

- resolve the installed `langflow` package in Python isolated mode so the Docker source checkout cannot shadow the release wheel
- fail closed before deleting files if the frontend source and target resolve to the same directory
- add regression coverage for isolated package lookup and source/target collisions

## Context

Release run https://github.com/langflow-ai/langflow/actions/runs/29956614166/job/89068551136 failed while restoring Docker-built frontend assets after installing the release wheels. Because the Docker working directory was `/app/src/backend/base`, `find_spec("langflow")` resolved the source checkout. The restore helper then treated the same frontend directory as both source and target, deleted it, and failed with `ENOENT`.

The dry-run setting only disabled registry pushes; the Docker build itself follows the same path in a real release.

## Validation

- `pytest scripts/ci/test_install_release_wheels.py scripts/ci/test_release_workflow.py`: 10 passed
- Ruff check and format validation passed for both changed files
- repository pre-commit hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and safety of restoring frontend assets in release packages.
  * Prevented accidental deletion or modification when frontend source and destination paths overlap.
  * Ensured package discovery runs in an isolated Python environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->