### PR TITLE
fix(schema): preserve subclass type when deep-copying Data

### DIFF
--- a/src/lfx/src/lfx/schema/data.py
+++ b/src/lfx/src/lfx/schema/data.py
@@ -6,7 +6,6 @@ Data is maintained as an alias for backwards compatibility.
 
 from __future__ import annotations
 
-import copy
 import json
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -260,10 +259,14 @@ class JSON(CrossModuleModel):
         else:
             del self.data[key]
 
-    def __deepcopy__(self, memo):
-        """Custom deepcopy implementation to handle copying of the JSON object."""
-        # Create a new JSON object with a deep copy of the data dictionary
-        return JSON(data=copy.deepcopy(self.data, memo), text_key=self.text_key, default_value=self.default_value)
+    def __deepcopy__(self, memo=None):
+        """Deep-copy the object while preserving its concrete class.
+
+        Rebuilding a bare ``JSON`` here would downgrade subclasses such as ``Message`` and drop
+        their fields, so the copy is delegated to pydantic. ``memo`` defaults to ``None`` because
+        ``model_copy(deep=True)`` calls ``__deepcopy__()`` without arguments.
+        """
+        return super().__deepcopy__(memo)
 
     # check which attributes the JSON has by checking the keys in the data dictionary
     def __dir__(self):

--- a/src/lfx/tests/unit/schema/test_schema_data.py
+++ b/src/lfx/tests/unit/schema/test_schema_data.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -93,6 +94,28 @@ class TestDataSchema:
         data = Data(data={"incomplete": "data"})
         with pytest.raises(ValueError, match="Missing required keys"):
             data.to_lc_message()
+
+    def test_deepcopy_keeps_fields_and_isolates_data(self):
+        """Test that deep copying a Data keeps its fields and does not share nested values."""
+        data = Data(data={"text": "hello", "nested": ["a"]}, text_key="text", default_value="fallback")
+        copied = copy.deepcopy(data)
+
+        assert isinstance(copied, Data)
+        assert copied.text_key == "text"
+        assert copied.default_value == "fallback"
+        assert copied.data == data.data
+
+        copied.data["nested"].append("b")
+        assert data.data["nested"] == ["a"]
+
+    def test_model_copy_deep_returns_data(self):
+        """Test that model_copy(deep=True) works - pydantic calls __deepcopy__ without a memo."""
+        data = Data(data={"text": "hello"}, text_key="text")
+        copied = data.model_copy(deep=True)
+
+        assert isinstance(copied, Data)
+        assert copied.data == {"text": "hello"}
+        assert copied.data is not data.data
 
     def test_data_to_message_invalid_image_path(self, tmp_path):
         """Test handling of invalid image path."""

--- a/src/lfx/tests/unit/schema/test_schema_message.py
+++ b/src/lfx/tests/unit/schema/test_schema_message.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -6,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
+from lfx.components.input_output import ChatInput
 from lfx.log.logger import logger
 from lfx.schema.message import Message
 from lfx.utils.constants import MESSAGE_SENDER_AI, MESSAGE_SENDER_USER
@@ -185,6 +187,44 @@ def test_message_serialization():
     parsed = datetime.strptime(serialized["timestamp"], "%Y-%m-%d %H:%M:%S.%f %Z").replace(tzinfo=timezone.utc)
     assert parsed.tzinfo == timezone.utc
     assert parsed == timestamp_dt
+
+
+def test_deepcopy_preserves_message_type():
+    """Test that deep copying a Message returns a Message and not a bare Data."""
+    message = Message(text="Test message", sender=MESSAGE_SENDER_USER, sender_name="User", session_id="session-1")
+
+    copied = copy.deepcopy(message)
+
+    assert isinstance(copied, Message)
+    assert copied.text == "Test message"
+    assert copied.sender == MESSAGE_SENDER_USER
+    assert copied.sender_name == "User"
+    assert copied.session_id == "session-1"
+    assert copied.properties is not message.properties
+
+
+def test_model_copy_deep_preserves_message_type():
+    """Test that model_copy(deep=True) works on a Message and preserves its type."""
+    message = Message(text="Test message", sender=MESSAGE_SENDER_USER)
+
+    copied = message.model_copy(deep=True)
+
+    assert isinstance(copied, Message)
+    assert copied.text == "Test message"
+    assert copied.sender == MESSAGE_SENDER_USER
+
+
+def test_deepcopy_of_component_output_preserves_message_type():
+    """Test that copying a component keeps Message results typed as Message."""
+    component = ChatInput()
+    output = next(iter(component._outputs_map.values()))
+    output.value = Message(text="Test message", sender=MESSAGE_SENDER_USER)
+
+    copied_component = copy.deepcopy(component)
+
+    copied_value = next(iter(copied_component._outputs_map.values())).value
+    assert isinstance(copied_value, Message)
+    assert copied_value.text == "Test message"
 
 
 def test_message_to_lc_without_sender():


### PR DESCRIPTION
## Problem

`JSON.__deepcopy__` (in `src/lfx/src/lfx/schema/data.py`) rebuilds every copy as a bare `JSON`:

```python
def __deepcopy__(self, memo):
    return JSON(data=copy.deepcopy(self.data, memo), text_key=self.text_key, default_value=self.default_value)
```

This causes two bugs:

**1. Deep-copying a `Message` returns a `Data`.** `Message` subclasses `Data`/`JSON`, so any `copy.deepcopy(message)` silently downgrades the object and every downstream `isinstance(value, Message)` check fails.

This happens on a real code path: `Component.__deepcopy__` deep-copies `_outputs_map` (`src/lfx/src/lfx/custom/custom_component/component.py:444`), so a component's `Message` result becomes a `Data` whenever the component is copied.

```python
component = ChatInput()
next(iter(component._outputs_map.values())).value = Message(text="hello", sender="User")

copied = copy.deepcopy(component)
value = next(iter(copied._outputs_map.values())).value
type(value)                      # JSON  (expected: Message)
isinstance(value, Message)       # False (expected: True)
```

**2. `model_copy(deep=True)` raises `TypeError` on any `Data`/`Message`.** Pydantic calls `self.__deepcopy__()` with no arguments, but `memo` had no default:

```python
Message(text="hi").model_copy(deep=True)
# TypeError: JSON.__deepcopy__() missing 1 required positional argument: 'memo'
```

`model_copy(deep=True)` is used on arbitrary `BaseModel` values in `_copy_component_template` (`component.py:106`) and in `knowledge.py:90`.

## Fix

Delegate to pydantic's `BaseModel.__deepcopy__`, which preserves the concrete class, deep-copies all fields (including `data`, private attrs and extras) and accepts an optional `memo`.

## Tests

Added regression tests to `src/lfx/tests/unit/schema/test_schema_data.py` and `test_schema_message.py` covering deep-copy type preservation, data isolation, `model_copy(deep=True)`, and the component-output path. 4 of the 5 new tests fail on `main` and pass with this change.

Full `src/lfx/tests/unit` suite: identical results before and after (6194 passed; the same 43 pre-existing Windows-only failures — symlink privileges, `fcntl`, path separators — in both runs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-copy behavior for schema data and messages.
  * Deep copies now preserve the original object type, fields, and nested values while preventing shared nested data.
  * Deep-copying chat input results maintains correctly typed message outputs.

* **Tests**
  * Added coverage for deep-copy and model-copy behavior across data and message schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->