### PR TITLE
fix(tracing): detect Azure OpenAI before OpenAI in provider attribution

### DIFF
--- a/src/backend/base/langflow/services/tracing/native_callback.py
+++ b/src/backend/base/langflow/services/tracing/native_callback.py
@@ -114,7 +114,13 @@ class NativeCallbackHandler(BaseCallbackHandler):
 
         model_lower = model_name.lower()
 
-        # Pattern-based detection works across different LangChain integrations
+        # Pattern-based detection works across different LangChain integrations.
+        # Azure is checked before OpenAI because Azure OpenAI model names contain "gpt"
+        # (e.g. "azure/gpt-4"), which would otherwise match the OpenAI branch first.
+        # ponytail: name-based detection can't catch a bare "gpt-4" Azure deployment;
+        # thread the provider from the component/model class if that case matters (LE-1993).
+        if "azure" in model_lower:
+            return "azure"
         if "gpt" in model_lower or "o1" in model_lower or model_lower.startswith("text-"):
             return "openai"
         if "claude" in model_lower:
@@ -129,8 +135,6 @@ class NativeCallbackHandler(BaseCallbackHandler):
             return "cohere"
         if "titan" in model_lower or "nova" in model_lower:
             return "amazon"
-        if "azure" in model_lower:
-            return "azure"
 
         return None
 

--- a/src/backend/tests/unit/services/tracing/test_native_callback.py
+++ b/src/backend/tests/unit/services/tracing/test_native_callback.py
@@ -689,3 +689,24 @@ class TestAgentCallbacks:
         handler.on_agent_finish(finish, run_id=run_id)
         mock_tracer.add_langchain_span.assert_not_called()
         mock_tracer.end_langchain_span.assert_not_called()
+
+
+class TestProviderDetection:
+    _detect = staticmethod(NativeCallbackHandler._detect_provider_from_model)
+
+    def test_azure_openai_not_mislabeled_openai(self):
+        # LE-1993: "azure/gpt-4" contains "gpt"; azure must win over the openai branch.
+        assert self._detect("azure/gpt-4") == "azure"
+        assert self._detect("gpt-4o") == "openai"
+
+    def test_known_providers(self):
+        assert self._detect("claude-3-5-sonnet") == "anthropic"
+        assert self._detect("gemini-1.5-pro") == "google"
+        assert self._detect("llama-3-70b") == "meta"
+        assert self._detect("mistral-large") == "mistral"
+        assert self._detect("command-r") == "cohere"
+        assert self._detect("titan-text") == "amazon"
+
+    def test_none_and_unknown(self):
+        assert self._detect(None) is None
+        assert self._detect("some-unknown-model") is None


### PR DESCRIPTION
Azure OpenAI model names contain "gpt" (e.g. `azure/gpt-4`), so in `_detect_provider_from_model` the openai branch matched before the azure branch. The azure branch was effectively unreachable, and Azure traffic got labeled `openai` on both the native tracer's flow-execution spans (`gen_ai.provider.name`) and the provider latency/error metrics. An operator couldn't tell Azure from direct OpenAI.

Fix is just reordering: check `azure` before the `gpt`/openai branch.

One thing worth calling out: this only catches the `azure/...` prefix case. A bare `gpt-4` Azure deployment name is indistinguishable from direct OpenAI by string alone. The robust fix there is to thread the provider from the component/model class (which knows it's `AzureChatOpenAI`) instead of pattern-matching the model string. I left a comment marking that. Happy to do it if we think the bare-deployment case matters.

Added a small test for the provider detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider detection for Azure models, ensuring Azure OpenAI model names are classified as Azure rather than OpenAI.
  - Preserved accurate detection for supported providers and unknown or missing model names.

- **Tests**
  - Added coverage for Azure model precedence and provider classification across supported model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->