### PR TITLE
fix: increment previous_content with content streamed

### DIFF
--- a/src/backend/base/langflow/api/v1/openai_responses.py
+++ b/src/backend/base/langflow/api/v1/openai_responses.py
@@ -164,6 +164,8 @@ async def run_flow_for_openai_responses(
                                 # Handle add_message events
                                 if event_type == "token":
                                     token_data = data.get("chunk", "")
+                                    if isinstance(token_data, str):
+                                        previous_content += token_data
                                     await logger.adebug(
                                         "[OpenAIResponses][stream] token: token_data=%s",
                                         token_data,


### PR DESCRIPTION
This pull request makes a small change to the `openai_stream_generator` function to ensure that only string tokens are appended to `previous_content`. This adds a type check for robustness and prevents potential errors when handling non-string data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling to ensure content updates are tracked correctly when receiving text data.
  * Prevented non-text streaming data from causing incorrect content differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->