### PR TITLE
fix(ci): target 1.12 release nightlies

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: release-1.11.0
+          ref: release-1.12.0
           persist-credentials: true
       - name: Confirm branch
         run: git branch --show-current
@@ -209,7 +209,7 @@ jobs:
       tests_folder: "tests"
       release: true
       runs-on: ubuntu-latest
-      ref: release-1.11.0
+      ref: release-1.12.0
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ secrets.STORE_API_KEY }}
@@ -230,7 +230,7 @@ jobs:
       tests_folder: "tests"
       release: true
       runs-on: windows-latest
-      ref: release-1.11.0
+      ref: release-1.12.0
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ secrets.STORE_API_KEY }}
@@ -247,7 +247,7 @@ jobs:
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       runs-on: ${{ inputs['runs_on'] || github.event.inputs['runs_on'] || 'ubuntu-latest' }}
-      ref: release-1.11.0
+      ref: release-1.12.0
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -271,7 +271,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/stress-tests.yml
     with:
-      ref: release-1.11.0
+      ref: release-1.12.0
 
   release-nightly-build:
     if: github.repository == 'langflow-ai/langflow' && always() && needs.create-nightly-tag.result == 'success' && needs.frontend-tests-linux.result != 'failure' && needs.backend-unit-tests.result != 'failure'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,7 +159,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 308,
+        "line_number": 294,
         "is_secret": false
       }
     ],
@@ -7256,5 +7256,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-23T04:33:55Z"
+  "generated_at": "2026-07-24T01:46:39Z"
 }


### PR DESCRIPTION
## Summary

- point nightly tag creation at `release-1.12.0`
- run Linux, Windows, backend, and stress-test nightlies against `release-1.12.0`
- refresh the generated secret-baseline line metadata

## Why

The scheduled workflow on `main` still checked out `release-1.11.0`. The current nightly workflow stages `src/langflow-core/pyproject.toml`, which is present on `release-1.12.0` but not on `release-1.11.0`, so tag creation failed before the downstream nightly jobs could run.

Langflow 1.11 has already been released, so the nightly line should now track 1.12.

## Validation

- `uv run pytest scripts/ci/test_release_workflow.py -q` — 4 passed
- repository pre-commit hooks — passed
- `git diff --check origin/main...HEAD` — passed
- `actionlint .github/workflows/nightly_build.yml` reports only the existing shellcheck findings also present on `origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated nightly builds and automated test workflows to use the `release-1.12.0` branch.
  - Refreshed security scanning metadata for the nightly build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->