### PR TITLE
fix(tracing): detach orphan spans before database flush

### DIFF
--- a/src/backend/base/langflow/services/tracing/span_sorting.py
+++ b/src/backend/base/langflow/services/tracing/span_sorting.py
@@ -63,22 +63,37 @@ def topological_sort_spans(
     sort over the batch so that every parent is inserted first.
 
     Spans whose ``parent_span_id`` points outside the current batch are
-    treated as roots (the parent already exists in the DB from a prior
-    flush).
+    detached from that missing parent. Native tracing persists a trace's
+    spans in a single batch, so retaining the reference would violate the
+    immediate foreign-key constraint.
     """
     batch_ids = {span_uuid for _, span_uuid, _ in resolved}
 
+    normalized: list[tuple[dict[str, Any], UUID, UUID | None]] = []
+    missing_parent_count = 0
+    for span_data, span_uuid, parent_uuid in resolved:
+        normalized_parent_uuid = parent_uuid
+        if normalized_parent_uuid is not None and normalized_parent_uuid not in batch_ids:
+            normalized_parent_uuid = None
+            missing_parent_count += 1
+        normalized.append((span_data, span_uuid, normalized_parent_uuid))
+
+    if missing_parent_count:
+        logger.warning(
+            "Detached %d tracing spans from missing parents to preserve database integrity.",
+            missing_parent_count,
+        )
+
     sorted_spans: list[tuple[dict[str, Any], UUID, UUID | None]] = []
     inserted: set[UUID] = set()
-    remaining = list(resolved)
+    remaining = normalized
 
     while remaining:
         next_round: list[tuple[dict[str, Any], UUID, UUID | None]] = []
         progress = False
         for item in remaining:
             _, span_uuid, parent_uuid = item
-            # Insert if: no parent, parent outside batch, or parent already inserted
-            if parent_uuid is None or parent_uuid not in batch_ids or parent_uuid in inserted:
+            if parent_uuid is None or parent_uuid in inserted:
                 sorted_spans.append(item)
                 inserted.add(span_uuid)
                 progress = True

--- a/src/backend/tests/unit/services/tracing/test_native_tracer.py
+++ b/src/backend/tests/unit/services/tracing/test_native_tracer.py
@@ -691,13 +691,14 @@ class TestTopologicalSortSpans:
         assert uuids.index(root) < uuids.index(mid) < uuids.index(leaf)
 
     def test_parent_outside_batch(self):
-        """Spans referencing a parent not in the batch are treated as roots."""
+        """Spans referencing a missing parent are detached before insertion."""
         external_parent = uuid4()
         child_id = uuid4()
         items = [self._make_span(child_id, external_parent)]
         result = topological_sort_spans(items)
         assert len(result) == 1
         assert result[0][1] == child_id
+        assert result[0][2] is None
 
     def test_mixed_roots_and_children(self):
         root_a = uuid4()
@@ -891,3 +892,43 @@ class TestFlushParentChildOrder:
         assert span_objects[0].id == parent_uuid
         assert span_objects[1].id == child_uuid
         assert span_objects[1].parent_span_id == parent_uuid
+
+    async def test_flush_detaches_span_from_missing_parent(self):
+        """A missing parent must not leave an invalid self-referential FK."""
+        tracer = _make_tracer(flow_id=str(uuid4()))
+        tracer.completed_spans = [
+            {
+                "id": str(uuid4()),
+                "name": "Orphan Span",
+                "span_type": SpanType.CHAIN,
+                "inputs": {},
+                "outputs": None,
+                "start_time": datetime.now(tz=timezone.utc),
+                "end_time": datetime.now(tz=timezone.utc),
+                "latency_ms": 5,
+                "status": SpanStatus.OK,
+                "error": None,
+                "attributes": {},
+                "span_source": "langchain",
+                "parent_span_id": uuid4(),
+            }
+        ]
+
+        merged_objects = []
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def capture_merge(obj):
+            merged_objects.append(obj)
+
+        mock_session.merge = capture_merge
+
+        with patch("lfx.services.deps.session_scope", return_value=mock_session):
+            await tracer._flush_to_database()
+
+        from langflow.services.database.models.traces.model import SpanTable
+
+        span_objects = [obj for obj in merged_objects if isinstance(obj, SpanTable)]
+        assert len(span_objects) == 1
+        assert span_objects[0].parent_span_id is None


### PR DESCRIPTION
## Summary

Prevent native trace persistence from aborting workflow execution when a completed span references a parent that is not present in the trace's single flush batch.

The existing topological sort already keeps valid parents before children. This change additionally detaches spans from parents that cannot be inserted, preserving the span as a root instead of sending an invalid `span.parent_span_id` foreign key to the database.

## Root cause

`topological_sort_spans()` treated a parent outside the current batch as though it had already been persisted. Native tracing writes a trace and all of its spans in one batch, so that assumption is invalid for a new trace: an out-of-batch parent row is missing, and PostgreSQL rejects the child row.

Disabling session autoflush does not resolve that case because the referenced row does not exist. It would also change flush semantics for every Langflow database session, well beyond tracing.

## Validation

- `uv run pytest -q src/backend/tests/unit/services/tracing/test_native_tracer.py` — 81 passed
- `uv run ruff check src/backend/base/langflow/services/tracing/span_sorting.py src/backend/tests/unit/services/tracing/test_native_tracer.py`
- Repository pre-commit checks, including Ruff and detect-secrets

The regression tests cover both layers:

- sorting converts a missing-parent reference to a root span;
- the native database flush receives `parent_span_id=None` for that span;
- valid parent-before-child ordering remains unchanged.

## Credit

Thanks to @ashutoshdharibm for reporting the production impact and investigating the trace flush path in #14229. That PR prompted this focused re-audit of the foreign-key failure.

Relates to DSLF-524.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing span ordering when a span references a parent that is not included in the current batch.
  * Orphaned spans are now safely detached and persisted without invalid parent references.
  * Added warnings when spans are detached due to missing parents.

* **Tests**
  * Expanded coverage for span ordering and database flush behavior involving missing parent spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->