### PR TITLE
fix(settings): enable agentic experience by default

### DIFF
--- a/src/backend/base/langflow/agentic/api/deps.py
+++ b/src/backend/base/langflow/agentic/api/deps.py
@@ -14,9 +14,11 @@ def require_agentic_experience() -> None:
 
     SECURITY: the assistant generates and EXECUTES component code in-process
     (langflow.agentic.helpers.validation.validate_component_runtime and the user-components
-    overlay). ``agentic_experience`` was only a frontend/UX + MCP-provisioning flag, so the codegen
-    endpoints were live by default. Gate them here (404 when off), matching the per-endpoint
-    precedent in api/v1/endpoints.py. The read-only ``/agentic/check-config`` probe is intentionally
+    overlay). ``agentic_experience`` is on by default (the Assistant is Langflow's entry-point
+    experience); this gate 404s the codegen endpoints when an operator opts out with
+    LANGFLOW_AGENTIC_EXPERIENCE=false, matching the per-endpoint precedent in
+    api/v1/endpoints.py. Execution entry points are additionally guarded by
+    ``allow_custom_components``. The read-only ``/agentic/check-config`` probe is intentionally
     NOT gated so non-agentic deployments can still query provider configuration.
     """
     if not get_settings_service().settings.agentic_experience:

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -368,12 +368,7 @@ class SimplifiedAPIRequest(BaseModel):
     )
 
 
-# (alias) type ReactFlowJsonObject<NodeData = any, EdgeData = any> = {
-#     nodes: Node<NodeData>[];
-#     edges: Edge<EdgeData>[];
-#     viewport: Viewport;
-# }
-# import ReactFlowJsonObject
+# Mirrors the frontend's ReactFlowJsonObject shape: { nodes, edges, viewport }.
 class FlowDataRequest(BaseModel):
     nodes: list[dict]
     edges: list[dict]
@@ -393,12 +388,8 @@ class BaseConfigResponse(BaseModel):
     voice_mode_available: bool
     frontend_timeout: int
     mcp_base_url: str
-    # Mode A only: gates the palette Bundle-header Reload action.  Surfaced
-    # at runtime so the packaged frontend (built once with the env var
-    # default) can still light up the button when an operator turns the
-    # backend reload route on -- the build-time Vite flag gates first-paint,
-    # but ``lfx extension dev`` and ``--env-file LANGFLOW_ENABLE_EXTENSION_RELOAD=true``
-    # opt in after the build is frozen, so the UI consults this field too.
+    # Runtime mirror of LANGFLOW_ENABLE_EXTENSION_RELOAD: the packaged frontend is built
+    # before an operator can opt in, so the palette Reload button consults this field too.
     enable_extension_reload: bool
     # Mirrors ``LANGFLOW_AUTHZ_ENABLED``. EE/custom frontends gate the Access
     # Control settings entry on this flag; OSS UI ignores it until wired.
@@ -469,6 +460,9 @@ class ConfigResponse(BaseConfigResponse):
     # Whether the server serves the A2A surface at all (LANGFLOW_A2A_ENABLED, default off). The
     # publish-as-agent UI reads this to explain, rather than 404, when A2A is disabled server-side.
     a2a_enabled: bool = False
+    # Mirrors LANGFLOW_AGENTIC_EXPERIENCE (default on) so the Assistant panel
+    # can explain, rather than 404, when the experience is disabled server-side.
+    agentic_experience: bool = True
 
     @classmethod
     def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
@@ -512,6 +506,7 @@ class ConfigResponse(BaseConfigResponse):
             mcp_servers_locked=settings.mcp_servers_locked,
             custom_component_admin_only=settings.custom_component_admin_only,
             a2a_enabled=settings.a2a_enabled,
+            agentic_experience=settings.agentic_experience,
         )
 
 

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -484,6 +484,8 @@ async def test_get_config_authenticated_returns_full_config(client: AsyncClient,
     assert "feature_flags" in result, "Authenticated response must contain 'feature_flags'"
     # The publish-as-agent UI reads this to explain, rather than 404, when A2A is off server-side.
     assert "a2a_enabled" in result, "Authenticated response must expose the a2a server flag"
+    # The Assistant panel reads this to explain, rather than 404, when the experience is off.
+    assert "agentic_experience" in result, "Authenticated response must expose the agentic experience flag"
 
 
 async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):

--- a/src/frontend/src/components/core/assistantPanel/assistant-panel.tsx
+++ b/src/frontend/src/components/core/assistantPanel/assistant-panel.tsx
@@ -6,11 +6,13 @@ import type { AgenticStepType } from "@/controllers/API/queries/agentic";
 import useAssistantManagerStore from "@/stores/assistantManagerStore";
 import useFlowBuilderWelcomeStore from "@/stores/flowBuilderWelcomeStore";
 import useFlowStore from "@/stores/flowStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import { cn } from "@/utils/utils";
 import type {
   AssistantModel,
   AssistantPanelProps,
 } from "./assistant-panel.types";
+import { AssistantDisabledState } from "./components/assistant-disabled-state";
 import { AssistantHeader } from "./components/assistant-header";
 import { AssistantInput } from "./components/assistant-input";
 import { AssistantMessageItem } from "./components/assistant-message";
@@ -87,14 +89,14 @@ function AssistantInputWithScroll({
 
 export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
   const { hasEnabledModels } = useEnabledModels();
+  const agenticExperienceEnabled = useUtilityStore(
+    (state) => state.agenticExperienceEnabled,
+  );
   const panelRef = useRef<HTMLDivElement>(null);
   const currentFlowId = useFlowStore((state) => state.currentFlow?.id);
   const isReadOnly = useIsFlowReadOnly(currentFlowId);
-  // Mirror the FlowPage sidebar's open state. When the sidebar is expanded
-  // the canvas is offset 280px from the viewport's left edge, so the panel
-  // shifts right by half that (140px) to align with the canvas center. When
-  // collapsed (offcanvas slid off), the canvas takes the full viewport and
-  // the panel sits at plain ``left-1/2``.
+  // The expanded sidebar offsets the canvas 280px, so the panel shifts right
+  // by half that (140px) to stay centered on the canvas.
   const isSidebarOpen = useSidebar().open;
 
   useEffect(() => {
@@ -165,13 +167,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     return () => setAssistantProcessing(false);
   }, [isProcessing, setAssistantProcessing]);
 
-  // Welcome → Assistant hand-off: when the user submits text from the
-  // FlowBuilderWelcome overlay, the typed prompt is stashed as
-  // ``pendingMessage`` and the panel is told to open. Once the panel is
-  // visible AND a model is available (read from localStorage so we don't
-  // race the ModelSelector's auto-select effect), fire a single
-  // ``handleSend`` with the pending text, then clear so a remount or
-  // re-open doesn't replay it.
+  // Welcome hand-off: fire the stashed prompt once open with a model (localStorage
+  // read avoids racing ModelSelector auto-select), then clear to prevent replay.
   const pendingMessage = useFlowBuilderWelcomeStore(
     (state) => state.pendingMessage,
   );
@@ -179,7 +176,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     (state) => state.clearPendingMessage,
   );
   useEffect(() => {
-    if (!isOpen || !pendingMessage || isReadOnly) return;
+    if (!isOpen || !pendingMessage || isReadOnly || !agenticExperienceEnabled)
+      return;
     let saved: AssistantModel | null = null;
     try {
       const raw = localStorage.getItem("langflow-assistant-selected-model");
@@ -190,20 +188,23 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
         }
       }
     } catch {
-      // localStorage may be unavailable (private browsing) — fall through;
-      // handleSend will early-return on null model and the welcome's pending
-      // message stays around for a manual retry.
+      // localStorage may be unavailable (private browsing) — the pending
+      // welcome message stays around for a manual retry.
     }
     if (!saved) return;
     void handleSend(pendingMessage, saved);
     clearPendingMessage();
-  }, [isOpen, pendingMessage, isReadOnly, handleSend, clearPendingMessage]);
+  }, [
+    isOpen,
+    pendingMessage,
+    isReadOnly,
+    agenticExperienceEnabled,
+    handleSend,
+    clearPendingMessage,
+  ]);
 
-  // When the panel opens with a pendingMessage in the store, the user just
-  // submitted from the welcome overlay. Capture that and lock a min-height
-  // so the panel doesn't open in its tiny compact form — the user has just
-  // committed an intent and needs vertical room for their auto-sent message
-  // + the assistant's reply to render without feeling cramped.
+  // A welcome-overlay submit needs vertical room for the auto-sent message +
+  // reply, so lock a min-height instead of opening in tiny compact form.
   const [openedWithPending, setOpenedWithPending] = useState(false);
   useEffect(() => {
     if (isOpen && pendingMessage) {
@@ -247,9 +248,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     }
   }, [isOpen]);
 
-  // Once the user grabs a handle in the empty state, treat the panel as
-  // expanded so its dimensions become driven by panelSize (instead of
-  // auto-fitting to the input height).
+  // A grab in the empty state flips the panel to panelSize-driven dimensions
+  // instead of auto-fitting to the input height.
   const useExpandedSize = hasMessages || hasExpandedOnce || hasUserResized;
   const [panelSize, setPanelSize] = useState(getStoredSize);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
@@ -265,16 +265,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     (e: React.MouseEvent, edges: { x?: "left" | "right"; y?: "top" }) => {
       e.preventDefault();
       e.stopPropagation();
-      // Only vertical drags transition the empty panel into expanded mode
-      // (height becomes panelSize-driven, input is pushed to the bottom).
-      // Horizontal-only drags should just widen the auto-height panel.
-      //
-      // Seed startH from the actual rendered height (not panelSize.height)
-      // when promoting from compact mode. The compact panel is auto-sized to
-      // the input (~200px) while panelSize.height carries the *expanded*
-      // default/stored value (~600px). Without this seed, the first pixel of
-      // drag flips useExpandedSize and snaps the panel from ~200px to 600px
-      // in one frame — visible as a "glitch" jump on first resize after open.
+      // Seed startH from the rendered height when promoting from compact mode —
+      // seeding from panelSize.height would snap ~200px→600px on the first drag pixel.
       const startX = e.clientX;
       const startY = e.clientY;
       const startW = panelSize.width;
@@ -285,21 +277,16 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
           const measuredH = panelRef.current.getBoundingClientRect().height;
           if (measuredH > 0) {
             startH = measuredH;
-            // Push the measured height into state before the flip so the
-            // very first frame after useExpandedSize becomes true renders at
-            // the measured height instead of the stored expanded default.
+            // Push the measured height into state before the flip so the first
+            // expanded frame renders at it instead of the stored default.
             setPanelSize((prev) => ({ ...prev, height: measuredH }));
           }
         }
         setHasUserResized(true);
       }
 
-      // When the user starts dragging the compact panel taller, the measured
-      // start height is below ``MIN_SIZE.height``. Clamping to MIN_SIZE.height
-      // on the very first mousemove would snap the panel from ~200px to 400px
-      // in one frame. The per-drag effective floor lets the panel grow
-      // smoothly from its current size while still preventing the user from
-      // shrinking BELOW where they started.
+      // Per-drag floor: clamping a compact panel to MIN_SIZE.height on the first
+      // mousemove would snap ~200px→400px in one frame.
       const effectiveMinH = Math.min(MIN_SIZE.height, startH);
 
       const handleMouseMove = (ev: MouseEvent) => {
@@ -331,14 +318,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
       const handleMouseUp = () => {
         cleanup();
         setPanelSize((prev) => {
-          // Clamp to the absolute floor in BOTH in-memory state and the
-          // persisted localStorage value. The per-drag ``effectiveMinH``
-          // intentionally lets a compact-promoted drag stay below
-          // ``MIN_SIZE.height`` while the mouse is held; once the user
-          // releases, the panel commits to at least the floor so a later
-          // transition (e.g. loaded session messages flipping
-          // ``useExpandedSize`` to true) doesn't render the panel
-          // uncomfortably small.
+          // On release, commit at least the floor (state + localStorage) so a later
+          // expanded transition doesn't render the panel uncomfortably small.
           const committed = {
             ...prev,
             height: Math.max(MIN_SIZE.height, prev.height),
@@ -368,10 +349,8 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     "opacity-100 translate-y-0 max-w-[calc(100vw-2rem)]",
   );
 
-  // When the panel was opened from a welcome submit, enforce a 18.75rem
-  // (300px) floor so the auto-sent message + assistant reply have room to
-  // breathe. Compact-mode (no messages yet) would otherwise render at the
-  // input height (~200px) — too short for the user to see what's happening.
+  // Welcome-submit opens enforce a 300px floor — compact mode's ~200px is too
+  // short for the auto-sent message + reply to be visible.
   const pendingMinHeight = openedWithPending ? "18.75rem" : undefined;
 
   const containerStyle = useExpandedSize
@@ -380,12 +359,6 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
         height: panelSize.height,
         minWidth: "28.5rem",
         minHeight: pendingMinHeight,
-        // No inline ``minHeight`` here — that would clamp the rendered height
-        // BEFORE the resize handler runs, snapping a freshly-promoted compact
-        // panel from its measured ~200px straight to MIN_SIZE.height in one
-        // frame. The mousemove clamp (``effectiveMinH``) enforces the floor
-        // for actual user drags instead. (Exception: the welcome-submit
-        // override above intentionally clamps.)
       }
     : {
         width: panelSize.width,
@@ -418,7 +391,9 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
           isExpanded={useExpandedSize}
           skipAll={skipAll}
         />
-        {!hasEnabledModels && !hasMessages ? (
+        {!agenticExperienceEnabled ? (
+          <AssistantDisabledState />
+        ) : !hasEnabledModels && !hasMessages ? (
           <AssistantNoModelsState />
         ) : hasMessages ? (
           <StickToBottom

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-disabled-state.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-disabled-state.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "react-i18next";
+import langflowAssistantIcon from "@/assets/langflow_assistant.svg";
+
+export function AssistantDisabledState() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="flex flex-1 flex-col items-center justify-center px-8 pb-6"
+      data-testid="assistant-disabled-state"
+    >
+      <div className="mb-6 flex h-16 w-16 items-center justify-center overflow-hidden rounded-2xl">
+        <img
+          src={langflowAssistantIcon}
+          alt={t("assistant.title")}
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <h3 className="mb-3 text-center text-base font-semibold leading-6 tracking-normal text-foreground">
+        {t("assistant.disabledTitle")}
+      </h3>
+      <p className="mb-3 max-w-[320px] text-center text-sm text-muted-foreground">
+        {t("assistant.disabledDescription")}
+      </p>
+      <code className="rounded-md bg-muted px-2 py-1 text-xs text-foreground">
+        LANGFLOW_AGENTIC_EXPERIENCE=true
+      </code>
+    </div>
+  );
+}

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -21,9 +21,7 @@ interface BaseConfig {
   voice_mode_available: boolean;
   allow_custom_components: boolean;
   mcp_base_url: string;
-  // Mode A only: backend's ``LANGFLOW_ENABLE_EXTENSION_RELOAD`` mirrored
-  // through to the frontend so a packaged build can light up the palette
-  // Reload button without a rebuild.  See utilityStore.enableExtensionReload.
+  // Runtime mirror of LANGFLOW_ENABLE_EXTENSION_RELOAD — see utilityStore.enableExtensionReload.
   enable_extension_reload: boolean;
 }
 
@@ -49,6 +47,7 @@ export interface ConfigResponse extends BaseConfig {
   mcp_servers_locked: boolean;
   custom_component_admin_only: boolean;
   a2a_enabled: boolean;
+  agentic_experience: boolean;
 }
 
 // Union type for the response (can be either public or full config)
@@ -119,13 +118,15 @@ export const useGetConfig: useQueryFunctionType<
     (state) => state.setCustomComponentAdminOnly,
   );
   const setA2aEnabled = useUtilityStore((state) => state.setA2aEnabled);
+  const setAgenticExperienceEnabled = useUtilityStore(
+    (state) => state.setAgenticExperienceEnabled,
+  );
 
   const { query } = UseRequestProcessor();
 
   const getConfigFn = async () => {
-    // The /config endpoint returns different responses based on authentication:
-    // - Authenticated: Full ConfigResponse with all settings
-    // - Unauthenticated: PublicConfigResponse with limited settings
+    // Authenticated requests get the full ConfigResponse; unauthenticated ones
+    // get the limited PublicConfigResponse.
     const response = await api.get<ConfigResponseType>(`${getURL("CONFIG")}`);
     const data = response["data"];
     if (data) {
@@ -169,6 +170,7 @@ export const useGetConfig: useQueryFunctionType<
         setMcpServersLocked(data.mcp_servers_locked ?? false);
         setCustomComponentAdminOnly(data.custom_component_admin_only ?? false);
         setA2aEnabled(data.a2a_enabled ?? false);
+        setAgenticExperienceEnabled(data.agentic_experience ?? true);
       }
     }
     return data;

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "Es sind keine Modelle konfiguriert",
   "assistant.noModelsConfigured": "Es ist kein Modellanbieter konfiguriert",
   "assistant.noModelsDescription": "Um den Assistenten nutzen zu können, konfigurieren Sie bitte mindestens einen Modellanbieter in Ihren Einstellungen.",
+  "assistant.disabledTitle": "Assistent Deaktiviert",
+  "assistant.disabledDescription": "Der Langflow Assistant ist auf diesem Server deaktiviert. Bitten Sie Ihren Administrator, ihn zu aktivieren, indem er die untenstehende Umgebungsvariable setzt und Langflow neu startet.",
   "assistant.noPreviousSessions": "Keine früheren Sitzungen",
   "assistant.placeholder.0": "Eine Agentenkomponente erstellen...",
   "assistant.placeholder.1": "Eine RAG-Pipeline aufbauen...",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1288,6 +1288,8 @@
   "assistant.sendMessage": "Send message",
   "assistant.sessionHistory": "Session history",
   "assistant.noModelsDescription": "To use the assistant, please configure at least one model provider in your settings.",
+  "assistant.disabledTitle": "Assistant Disabled",
+  "assistant.disabledDescription": "The Langflow Assistant is disabled on this server. Ask your administrator to enable it by setting the environment variable below and restarting Langflow.",
   "assistant.configureModels": "Configure Model Providers",
   "assistant.maxSessionsTooltip": "Maximum of {{max}} sessions reached. Delete a session to create a new one.",
   "assistant.maxSessionsLabel": "Max sessions",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "No hay modelos configurados",
   "assistant.noModelsConfigured": "No hay ningún proveedor de modelos configurado",
   "assistant.noModelsDescription": "Para utilizar el asistente, configura al menos un proveedor de modelos en tus ajustes.",
+  "assistant.disabledTitle": "Asistente Desactivado",
+  "assistant.disabledDescription": "El Langflow Assistant está desactivado en este servidor. Pida a su administrador que lo active configurando la variable de entorno siguiente y reiniciando Langflow.",
   "assistant.noPreviousSessions": "No hay sesiones anteriores",
   "assistant.placeholder.0": "Crear un componente de agente...",
   "assistant.placeholder.1": "Crear un proceso RAG...",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "Aucun modèle configuré",
   "assistant.noModelsConfigured": "Aucun fournisseur de modèles n'est configuré",
   "assistant.noModelsDescription": "Pour utiliser l'assistant, veuillez configurer au moins un fournisseur de modèles dans vos paramètres.",
+  "assistant.disabledTitle": "Assistant Désactivé",
+  "assistant.disabledDescription": "Le Langflow Assistant est désactivé sur ce serveur. Demandez à votre administrateur de l'activer en définissant la variable d'environnement ci-dessous et en redémarrant Langflow.",
   "assistant.noPreviousSessions": "Aucune session précédente",
   "assistant.placeholder.0": "Créer un composant d'agent...",
   "assistant.placeholder.1": "Mettre en place un pipeline RAG...",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "設定済みのモデルはありません",
   "assistant.noModelsConfigured": "モデルプロバイダーが設定されていません",
   "assistant.noModelsDescription": "アシスタントをご利用いただくには、設定で少なくとも1つのモデルプロバイダーを設定してください。",
+  "assistant.disabledTitle": "アシスタントは無効です",
+  "assistant.disabledDescription": "このサーバーでは Langflow Assistant が無効になっています。以下の環境変数を設定して Langflow を再起動するよう管理者に依頼してください。",
   "assistant.noPreviousSessions": "過去のセッションはありません",
   "assistant.placeholder.0": "エージェントコンポーネントを作成する...",
   "assistant.placeholder.1": "RAGパイプラインを構築する...",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "Nenhum modelo configurado",
   "assistant.noModelsConfigured": "Nenhum provedor de modelo configurado",
   "assistant.noModelsDescription": "Para usar o assistente, configure pelo menos um provedor de modelos nas suas configurações.",
+  "assistant.disabledTitle": "Assistente Desativado",
+  "assistant.disabledDescription": "O Langflow Assistant está desativado neste servidor. Peça ao administrador para ativá-lo definindo a variável de ambiente abaixo e reiniciando o Langflow.",
   "assistant.noPreviousSessions": "Não há sessões anteriores",
   "assistant.placeholder.0": "Criar um componente de agente...",
   "assistant.placeholder.1": "Crie um pipeline RAG...",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -164,6 +164,8 @@
   "assistant.noModels": "未配置任何模型",
   "assistant.noModelsConfigured": "未配置模型提供程序",
   "assistant.noModelsDescription": "要使用该助手，请在设置中配置至少一个模型提供商。",
+  "assistant.disabledTitle": "助手已禁用",
+  "assistant.disabledDescription": "此服务器上的 Langflow Assistant 已被禁用。请让管理员设置以下环境变量并重启 Langflow 以启用它。",
   "assistant.noPreviousSessions": "没有之前的会话",
   "assistant.placeholder.0": "创建一个代理组件...",
   "assistant.placeholder.1": "构建一个 RAG 管道……",

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -66,11 +66,15 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
     set({ allowCustomComponents }),
   a2aEnabled: false,
   setA2aEnabled: (a2aEnabled: boolean) => set({ a2aEnabled }),
+  // Default true (backend default) so the panel doesn't flash the disabled
+  // state before the /config reply lands.
+  agenticExperienceEnabled: true,
+  setAgenticExperienceEnabled: (agenticExperienceEnabled: boolean) =>
+    set({ agenticExperienceEnabled }),
   mcpBaseUrl: "",
   setMcpBaseUrl: (mcpBaseUrl: string) => set({ mcpBaseUrl }),
-  // Default ``false`` so a misconfigured store (no ``/config`` reply yet)
-  // matches the backend default of "reload disabled".  The /config query
-  // overwrites this on first load.
+  // Default false to match the backend's "reload disabled" default until the
+  // /config query overwrites it on first load.
   enableExtensionReload: false,
   setEnableExtensionReload: (enableExtensionReload: boolean) =>
     set({ enableExtensionReload }),

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -40,6 +40,8 @@ export type UtilityStoreType = {
   setAllowCustomComponents: (allowCustomComponents: boolean) => void;
   a2aEnabled: boolean;
   setA2aEnabled: (a2aEnabled: boolean) => void;
+  agenticExperienceEnabled: boolean;
+  setAgenticExperienceEnabled: (agenticExperienceEnabled: boolean) => void;
   mcpBaseUrl: string;
   setMcpBaseUrl: (mcpBaseUrl: string) => void;
   /**

--- a/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
@@ -7,7 +7,9 @@ import { navigateSettingsPages } from "../../utils/go-to-settings";
 
 test(
   "user must be able to see starter projects for mcp servers",
-  { tag: ["@release", "@workspace", "@components"] },
+  {
+    tag: ["@release", "@workspace", "@components"],
+  },
   async ({ page }) => {
     //starter mcp project
 
@@ -19,9 +21,9 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(
+      page.getByText("lf-starter_project", { exact: true }),
+    ).toBeVisible();
 
     await page.getByTestId("icon-ChevronLeft").first().click();
 
@@ -32,9 +34,9 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(
+      page.getByText("lf-starter_project", { exact: true }),
+    ).toBeVisible();
 
     expect(
       await page.getByText("lf-new_project", { exact: true }).count(),
@@ -71,9 +73,9 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(
+      page.getByText("lf-starter_project", { exact: true }),
+    ).toBeVisible();
 
     expect(
       await page.getByText("lf-renamed_project", { exact: true }).count(),
@@ -97,9 +99,9 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(
+      page.getByText("lf-starter_project", { exact: true }),
+    ).toBeVisible();
     expect(
       await page.getByText("lf-renamed_project", { exact: true }).count(),
     ).toBe(0);
@@ -108,7 +110,9 @@ test(
 
 test(
   "user must not be able to add duplicate mcp servers from starter projects",
-  { tag: ["@release", "@workspace", "@components"] },
+  {
+    tag: ["@release", "@workspace", "@components"],
+  },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/src/lfx/src/lfx/services/settings/groups/variables.py
+++ b/src/lfx/src/lfx/services/settings/groups/variables.py
@@ -1,6 +1,4 @@
-import os
-
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ValidationInfo, field_validator
 
 from lfx.services.settings.constants import AGENTIC_VARIABLES, VARIABLES_TO_GET_FROM_ENVIRONMENT
 
@@ -18,14 +16,14 @@ class VariablesSettings(BaseModel):
     store_environment_variables: bool = True
     """Whether to store environment variables as Global Variables in the database."""
 
-    variables_to_get_from_environment: list[str] = VARIABLES_TO_GET_FROM_ENVIRONMENT
-    """List of environment variables to get from the environment and store in the database."""
-
     # Agentic Experience
     agentic_experience: bool = True
     """Enables the Langflow Assistant and its agentic MCP server (tools for flow/component
     operations, template search, and graph visualization). On by default — the Assistant is
     Langflow's entry-point experience; set LANGFLOW_AGENTIC_EXPERIENCE=false to opt out."""
+
+    variables_to_get_from_environment: list[str] = VARIABLES_TO_GET_FROM_ENVIRONMENT
+    """List of environment variables to get from the environment and store in the database."""
 
     # Developer API
     developer_api_enabled: bool = False
@@ -33,13 +31,13 @@ class VariablesSettings(BaseModel):
 
     @field_validator("variables_to_get_from_environment", mode="before")
     @classmethod
-    def set_variables_to_get_from_environment(cls, value):
+    def set_variables_to_get_from_environment(cls, value, info: ValidationInfo):
         if isinstance(value, str):
             value = value.split(",")
 
         result = list(set(VARIABLES_TO_GET_FROM_ENVIRONMENT + value))
 
-        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
+        if info.data.get("agentic_experience", True):
             result.extend(AGENTIC_VARIABLES)
 
         return list(set(result))

--- a/src/lfx/src/lfx/services/settings/groups/variables.py
+++ b/src/lfx/src/lfx/services/settings/groups/variables.py
@@ -22,9 +22,10 @@ class VariablesSettings(BaseModel):
     """List of environment variables to get from the environment and store in the database."""
 
     # Agentic Experience
-    agentic_experience: bool = False
-    """If set to True, Langflow will start the agentic MCP server that provides tools for
-    flow/component operations, template search, and graph visualization."""
+    agentic_experience: bool = True
+    """Enables the Langflow Assistant and its agentic MCP server (tools for flow/component
+    operations, template search, and graph visualization). On by default — the Assistant is
+    Langflow's entry-point experience; set LANGFLOW_AGENTIC_EXPERIENCE=false to opt out."""
 
     # Developer API
     developer_api_enabled: bool = False
@@ -38,7 +39,7 @@ class VariablesSettings(BaseModel):
 
         result = list(set(VARIABLES_TO_GET_FROM_ENVIRONMENT + value))
 
-        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "false").lower() == "true":
+        if os.getenv("LANGFLOW_AGENTIC_EXPERIENCE", "true").lower() == "true":
             result.extend(AGENTIC_VARIABLES)
 
         return list(set(result))

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -445,6 +445,16 @@ def test_agentic_experience_on_by_default(monkeypatch):
         assert var in settings.variables_to_get_from_environment
 
 
+@pytest.mark.parametrize("env_value", ["true", "1", "yes", "on"])
+def test_agentic_variables_included_when_experience_enabled(monkeypatch, env_value):
+    """All supported true values keep the feature and its environment mirror aligned."""
+    monkeypatch.setenv("LANGFLOW_AGENTIC_EXPERIENCE", env_value)
+    settings = Settings()
+    assert settings.agentic_experience is True
+    for var in AGENTIC_VARIABLES:
+        assert var in settings.variables_to_get_from_environment
+
+
 def test_agentic_variables_excluded_when_experience_disabled(monkeypatch):
     """Opting out with LANGFLOW_AGENTIC_EXPERIENCE=false stops the env mirror.
 

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -284,7 +284,7 @@ def test_critical_defaults_unchanged():
     assert settings.load_flows_preserve_variable_bindings is True
     assert settings.do_not_track is False
     assert settings.dev is False
-    assert settings.agentic_experience is False
+    assert settings.agentic_experience is True
     assert settings.developer_api_enabled is False
 
 
@@ -430,26 +430,30 @@ def test_env_var_round_trip(monkeypatch, env_var, env_value, field, expected):
     assert getattr(settings, field) == expected
 
 
-def test_agentic_variables_excluded_when_experience_off(monkeypatch):
-    """Agentic env vars must NOT be mirrored from the environment while the experience is off.
+def test_agentic_experience_on_by_default(monkeypatch):
+    """The Assistant is Langflow's entry-point experience and must work out of the box.
 
-    The ASTRA_TOKEN credential is among them, and the agentic experience is off by default.
-
-    Regression: the env-mirror list used to be extended with AGENTIC_VARIABLES
-    whenever LANGFLOW_AGENTIC_EXPERIENCE was unset, provisioning ASTRA_TOKEN into
-    the DB for a feature whose endpoints stay 404.
+    Regression: defaulting agentic_experience off left the frontend Assistant panel
+    mounted while every /agentic endpoint returned 404 unless the operator set
+    LANGFLOW_AGENTIC_EXPERIENCE=true. With the experience on, its variables are
+    mirrored from the environment so provider credentials resolve.
     """
     monkeypatch.delenv("LANGFLOW_AGENTIC_EXPERIENCE", raising=False)
-    settings = Settings()
-    assert settings.agentic_experience is False
-    for var in AGENTIC_VARIABLES:
-        assert var not in settings.variables_to_get_from_environment
-
-
-def test_agentic_variables_included_when_experience_on(monkeypatch):
-    """Enabling the agentic experience mirrors its variables from the environment."""
-    monkeypatch.setenv("LANGFLOW_AGENTIC_EXPERIENCE", "true")
     settings = Settings()
     assert settings.agentic_experience is True
     for var in AGENTIC_VARIABLES:
         assert var in settings.variables_to_get_from_environment
+
+
+def test_agentic_variables_excluded_when_experience_disabled(monkeypatch):
+    """Opting out with LANGFLOW_AGENTIC_EXPERIENCE=false stops the env mirror.
+
+    The ASTRA_TOKEN credential is among the mirrored variables; a deployment that
+    disables the Assistant must not have it provisioned into the DB for endpoints
+    that stay 404.
+    """
+    monkeypatch.setenv("LANGFLOW_AGENTIC_EXPERIENCE", "false")
+    settings = Settings()
+    assert settings.agentic_experience is False
+    for var in AGENTIC_VARIABLES:
+        assert var not in settings.variables_to_get_from_environment


### PR DESCRIPTION
## Summary
- Default `agentic_experience` to `True` and restore the env-mirror validator default to `"true"` in `src/lfx/src/lfx/services/settings/groups/variables.py`, so the Langflow Assistant — the product's entry-point experience — works out of the box again.
- The Assistant broke by default through two combined changes: the 1.10.3 security hardening (#13530 / #14071) added `require_agentic_experience`, making every `/api/v1/agentic/*` endpoint return 404 when the flag is off, and #14189 stopped mirroring `AGENTIC_VARIABLES` for the (already `False`) default. Meanwhile the frontend mounts the Assistant panel unconditionally, so users saw the panel with every call failing.
- `LANGFLOW_AGENTIC_EXPERIENCE=false` remains a full opt-out: endpoints 404 and agentic env vars are not mirrored, preserving the actual concern behind #14189 (no `ASTRA_TOKEN` provisioning for a disabled feature).
- Updated the settings-composition regression tests to assert default-on + explicit opt-out, and refreshed the `require_agentic_experience` docstring (the gate itself is unchanged and stays as the kill switch).

## How to test
- [ ] `cd src/lfx && uv sync && uv run pytest tests/unit/services/settings/test_settings_composition.py` — 31 passed
- [ ] `uv run pytest src/backend/tests/unit/agentic/test_assistant_codeexec_gates.py` — 5 passed
- [ ] Start Langflow with no `LANGFLOW_AGENTIC_EXPERIENCE` set: the Assistant panel works and `/api/v1/agentic/*` responds (no 404)
- [ ] Start with `LANGFLOW_AGENTIC_EXPERIENCE=false`: `/api/v1/agentic/*` returns 404 and agentic variables are not mirrored from the environment

## Notes
Security consideration: default-on re-exposes the assistant codegen endpoints by default (they execute generated component code in-process). The remaining guards stay active: the `allow_custom_components` execution gate and the AST code-security scan on run. Default-on also re-enables the startup side effects (agentic global variables init + per-user agentic MCP server auto-configuration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agentic Experience is now enabled by default.
  * Agentic configuration variables are included automatically when the feature is enabled.
  * Set `LANGFLOW_AGENTIC_EXPERIENCE=false` to disable the feature and exclude its configuration variables.

* **Documentation**
  * Clarified endpoint access rules and configuration behavior for agentic features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->