### PR TITLE
refactor(frontend): Add customization hook for API timestamp parsing

### DIFF
--- a/src/frontend/src/customization/utils/custom-normalizeApiTimeStamp.ts
+++ b/src/frontend/src/customization/utils/custom-normalizeApiTimeStamp.ts
@@ -1,0 +1,3 @@
+export const normalizeApiTimestamp = (raw: string): string => {
+  return raw;
+};

--- a/src/frontend/src/utils/dateTime.ts
+++ b/src/frontend/src/utils/dateTime.ts
@@ -1,3 +1,5 @@
+import { normalizeApiTimestamp } from "@/customization/utils/custom-normalizeApiTimeStamp";
+
 const pad2 = (num: number): string => String(num).padStart(2, "0");
 
 const hasExplicitTimezone = (value: string): boolean =>
@@ -9,7 +11,7 @@ export const parseApiTimestamp = (value: unknown): Date | null => {
     return Number.isNaN(value.getTime()) ? null : value;
   }
 
-  const raw = String(value).trim();
+  const raw = normalizeApiTimestamp(String(value).trim());
   if (!raw) return null;
 
   const normalized = hasExplicitTimezone(raw)


### PR DESCRIPTION
## Objective
Allow embedders (e.g. Langflow Desktop) to normalize backend timestamp formats before parsing, without changing OSS behavior.

## Changes
- Add `customization/utils/custom-normalizeApiTimeStamp.ts` with an identity (no-op) `normalizeApiTimestamp`
- Route `parseApiTimestamp` input through the new hook in `utils/dateTime.ts`

## Notes
No behavior change in OSS — the default implementation returns the input unchanged. Desktop overrides the customization file with a real normalizer because WebKit (WKWebView/Safari) rejects the backend "%Y-%m-%d %H:%M:%S.%f %Z" timestamp format, which reversed message ordering in the desktop playground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp processing to provide more consistent date and time normalization.
  * Preserved existing smart timestamp display behavior, including timezone handling and contextual date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->