### PR TITLE
fix(mem0): defer client import during startup

### DIFF
--- a/src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
+++ b/src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py
@@ -1,6 +1,8 @@
 """Unit tests for Mem0MemoryComponent cloud validation."""
 
 import os
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +12,29 @@ from lfx.components.mem0.mem0_chat_memory import Mem0MemoryComponent
 @pytest.mark.unit
 class TestMem0CloudValidation:
     """Test Mem0 component cloud validation."""
+
+    def test_component_import_does_not_write_to_mem0_home(self):
+        """Importing the component must not initialize Mem0's user directory."""
+        script = """
+import errno
+import os
+
+real_makedirs = os.makedirs
+
+def reject_mem0_home(path, *args, **kwargs):
+    if os.fspath(path).endswith(".mem0"):
+        raise OSError(errno.EROFS, "Read-only file system", os.fspath(path))
+    return real_makedirs(path, *args, **kwargs)
+
+os.makedirs = reject_mem0_home
+from lfx.components.mem0.mem0_chat_memory import Mem0MemoryComponent
+"""
+
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", script], capture_output=True, text=True, check=False
+        )
+
+        assert result.returncode == 0, result.stderr
 
     def test_mem0_telemetry_is_disabled_by_default(self):
         """Langflow should not start mem0's PostHog telemetry on component import."""
@@ -30,8 +55,8 @@ class TestMem0CloudValidation:
             error_msg = str(exc_info.value).lower()
             assert "astra" in error_msg or "cloud" in error_msg
 
-    @patch("lfx.components.mem0.mem0_chat_memory.Memory")
-    def test_build_mem0_works_when_not_in_cloud(self, mock_memory):
+    @patch("lfx.components.mem0.mem0_chat_memory.importlib.import_module")
+    def test_build_mem0_works_when_not_in_cloud(self, mock_import_module):
         """build_mem0 works when not in cloud, passing the OpenAI key through mem0 config.
 
         The key must NOT be written to os.environ: that is process-global and persists
@@ -40,13 +65,16 @@ class TestMem0CloudValidation:
         """
         with patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "false"}):
             os.environ.pop("OPENAI_API_KEY", None)
+            mock_mem0 = Mock()
+            mock_import_module.return_value = mock_mem0
             fake_key = "not-a-real-openai-key"
             component = Mem0MemoryComponent(openai_api_key=fake_key)
             component.build_mem0()
 
             # Key flows through config, not the environment.
-            mock_memory.from_config.assert_called_once()
-            config = mock_memory.from_config.call_args.kwargs["config_dict"]
+            mock_import_module.assert_called_once_with("mem0")
+            mock_mem0.Memory.from_config.assert_called_once()
+            config = mock_mem0.Memory.from_config.call_args.kwargs["config_dict"]
             assert config["llm"]["config"]["api_key"] == fake_key
             assert config["embedder"]["config"]["api_key"] == fake_key
             # Regression guard for the credential-bleed bug: never pollute os.environ.

--- a/src/bundles/lfx-bundles/src/lfx_bundles/mem0/mem0_chat_memory.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/mem0/mem0_chat_memory.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+from typing import Any, Protocol
 
 from lfx.base.memory.model import LCChatMemoryComponent
 from lfx.inputs.inputs import DictInput, HandleInput, MessageTextInput, NestedDictInput, SecretStrInput
@@ -12,9 +13,14 @@ from lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_componen
 # disabled by default unless the deployer explicitly opts in.
 os.environ.setdefault("MEM0_TELEMETRY", "False")
 
-_mem0 = importlib.import_module("mem0")
-Memory = _mem0.Memory
-MemoryClient = _mem0.MemoryClient
+
+class Memory(Protocol):
+    def add(self, message: str, *, user_id: str, metadata: dict[str, Any]) -> Any: ...
+
+    def search(self, *, query: str, filters: dict[str, str]) -> Any: ...
+
+    def get_all(self, *, filters: dict[str, str]) -> Any: ...
+
 
 disable_component_in_astra_cloud_msg = (
     "Mem0 chat memory is not supported in Astra cloud environment. Please use local storage mode or mem0 cloud."
@@ -113,11 +119,12 @@ class Mem0MemoryComponent(LCChatMemoryComponent):
                 config[section] = sec
 
         try:
+            mem0 = importlib.import_module("mem0")
             if not self.mem0_api_key:
-                return Memory.from_config(config_dict=config) if config else Memory()
+                return mem0.Memory.from_config(config_dict=config) if config else mem0.Memory()
             if self.mem0_config:
-                return MemoryClient.from_config(api_key=self.mem0_api_key, config_dict=dict(self.mem0_config))
-            return MemoryClient(api_key=self.mem0_api_key)
+                return mem0.MemoryClient.from_config(api_key=self.mem0_api_key, config_dict=dict(self.mem0_config))
+            return mem0.MemoryClient(api_key=self.mem0_api_key)
         except ImportError as e:
             msg = "Mem0 is not properly installed. Please install it with 'pip install -U mem0ai'."
             raise ImportError(msg) from e


### PR DESCRIPTION
## Summary

- defer loading the Mem0 SDK until the Mem0 component is actually used
- preserve the existing telemetry opt-out and `Memory` output type
- add regression coverage for component discovery with a read-only Mem0 home

Fixes #14227

## Tests

- `python -m pytest -q src/backend/tests/unit/components/bundles/mem0/test_mem0_component.py` (6 passed in the Langflow 1.11.0 image)
- read-only container startup: `python -c "import langflow.main"`
- `ruff check` and `ruff format --check` on the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented importing the Mem0 integration from creating or modifying the `.mem0` home directory.
  * Preserved API key handling by passing credentials through configuration without writing them to environment variables.
  * Improved Mem0 initialization for both local and cloud-based configurations.
* **Tests**
  * Added regression coverage for filesystem side effects during import.
  * Expanded validation of Mem0 configuration and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->