### PR TITLE
fix(auth): keep refresh sessions alive on HTTP

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2567,7 +2567,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
         "is_verified": false,
-        "line_number": 764,
+        "line_number": 767,
         "is_secret": false
       },
       {
@@ -2575,7 +2575,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "3806954324550e26ef5de85d007f1746825a073c",
         "is_verified": false,
-        "line_number": 765,
+        "line_number": 768,
         "is_secret": false
       },
       {
@@ -2583,7 +2583,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 955,
+        "line_number": 962,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T21:27:29Z"
+  "generated_at": "2026-07-24T22:23:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2567,7 +2567,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
         "is_verified": false,
-        "line_number": 767,
+        "line_number": 764,
         "is_secret": false
       },
       {
@@ -2575,7 +2575,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "3806954324550e26ef5de85d007f1746825a073c",
         "is_verified": false,
-        "line_number": 768,
+        "line_number": 765,
         "is_secret": false
       },
       {
@@ -2583,7 +2583,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 952,
+        "line_number": 955,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T14:19:19Z"
+  "generated_at": "2026-07-24T21:27:29Z"
 }

--- a/docs/docs/Develop/api-keys-and-authentication.mdx
+++ b/docs/docs/Develop/api-keys-and-authentication.mdx
@@ -451,17 +451,20 @@ LANGFLOW_CORS_ALLOW_METHODS=["GET","POST","PUT"]
 ```
 :::
 
-###  LANGFLOW_ACCESS_* {#session-cookie-hardening}
+### LANGFLOW_ACCESS_* and LANGFLOW_REFRESH_* {#session-cookie-hardening}
 
-For a shared or public deployment served over HTTPS, harden the access-token cookie. These default to permissive values for local HTTP development and for the current frontend, which reads the access token in JavaScript.
+For a shared or public deployment served over HTTPS, harden the session cookies. These default to values that support local HTTP development and same-site deployments. The current frontend reads the access token in JavaScript, while the refresh token remains `HttpOnly`.
 
-The refresh-token cookie is `HttpOnly` + `Secure` + `SameSite` by default.
+Set both `LANGFLOW_ACCESS_SECURE` and `LANGFLOW_REFRESH_SECURE` to `True` for HTTPS deployments. Cross-site HTTPS deployments must also set `LANGFLOW_REFRESH_SAME_SITE=none`.
 
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
 | `LANGFLOW_ACCESS_SECURE` | Boolean | `False` | When `true`, the `access_token_lf` cookie is sent only over HTTPS. Recommended `true` for any HTTPS deployment. |
 | `LANGFLOW_ACCESS_HTTPONLY` | Boolean | `False` | When `true`, the `access_token_lf` cookie is not readable by JavaScript. The default is `false` because the bundled frontend currently reads this cookie in JavaScript. |
 | `LANGFLOW_ACCESS_SAME_SITE` | String | `lax` | The `SameSite` attribute of the access-token cookie (`lax`, `strict`, or `none`). |
+| `LANGFLOW_REFRESH_SECURE` | Boolean | `False` | When `true`, the `refresh_token_lf` cookie is sent only over HTTPS. Set this to `true` for any HTTPS deployment. |
+| `LANGFLOW_REFRESH_HTTPONLY` | Boolean | `True` | When `true`, the `refresh_token_lf` cookie is not readable by JavaScript. |
+| `LANGFLOW_REFRESH_SAME_SITE` | String | `lax` | The `SameSite` attribute of the refresh-token cookie (`lax`, `strict`, or `none`). |
 
 ### LANGFLOW_RATE_LIMIT_* {#login-rate-limiting}
 

--- a/src/backend/tests/unit/test_security_cors.py
+++ b/src/backend/tests/unit/test_security_cors.py
@@ -438,35 +438,30 @@ class TestRefreshTokenSecurity:
                         # user_id is converted to string in JWT payload, then back to UUID in service
                         mock_create_tokens.assert_called_once_with(str(user_id), mock_db)
 
-    def test_refresh_token_samesite_setting_current_behavior(self):
-        """Test current refresh token SameSite settings (warns about security)."""
+    def test_refresh_cookie_defaults_support_same_site_http(self):
+        """Refresh cookies use the same safe, HTTP-compatible defaults as access cookies."""
         from lfx.services.settings.auth import AuthSettings
 
         with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {"LANGFLOW_CONFIG_DIR": temp_dir}):
             auth_settings = AuthSettings(CONFIG_DIR=temp_dir)
-            # Current behavior: refresh token uses 'none' (allows cross-site)
-            assert auth_settings.REFRESH_SAME_SITE == "none"  # Current: allows cross-site (less secure)
-            assert auth_settings.ACCESS_SAME_SITE == "lax"  # Access token is already lax (good)
+            assert auth_settings.REFRESH_SAME_SITE == "lax"
+            assert auth_settings.REFRESH_SECURE is False
+            assert auth_settings.ACCESS_SAME_SITE == "lax"
+            assert auth_settings.ACCESS_SECURE is False
             assert auth_settings.ACCESS_HTTPONLY is True
 
-            # Warn about security implications
-            warnings.warn(
-                "SECURITY WARNING: Refresh tokens currently use SameSite=none which allows "
-                "cross-site requests. This should be changed to 'lax' or 'strict' in production. "
-                "In v1.7, this will default to 'lax' for better security.",
-                UserWarning,
-                stacklevel=2,
-            )
+    def test_refresh_cookie_cross_site_https_can_be_enabled(self):
+        """Operators can retain cross-site HTTPS refresh cookies explicitly."""
+        from lfx.services.settings.auth import AuthSettings
 
-    @pytest.mark.skip(reason="Uncomment in v1.7 - represents future secure SameSite behavior")
-    def test_refresh_token_samesite_setting_future_secure(self):
-        """Test future secure refresh token SameSite settings (skip until v1.7)."""
-        # Future secure behavior (uncomment in v1.7):
-        # from langflow.services.settings.auth import AuthSettings
-        # with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {"LANGFLOW_CONFIG_DIR": temp_dir}):
-        #     auth_settings = AuthSettings(CONFIG_DIR=temp_dir)
-        #     assert auth_settings.REFRESH_SAME_SITE == "lax"  # Secure default
-        #     assert auth_settings.ACCESS_SAME_SITE == "lax"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            auth_settings = AuthSettings(
+                CONFIG_DIR=temp_dir,
+                REFRESH_SAME_SITE="none",
+                REFRESH_SECURE=True,
+            )
+            assert auth_settings.REFRESH_SAME_SITE == "none"
+            assert auth_settings.REFRESH_SECURE is True
 
 
 class TestCORSIntegration:

--- a/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
+++ b/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
@@ -1,0 +1,34 @@
+describe("authentication token refresh timing", () => {
+  const originalAccessTokenExpiry = process.env.ACCESS_TOKEN_EXPIRE_SECONDS;
+
+  afterEach(() => {
+    if (originalAccessTokenExpiry === undefined) {
+      delete process.env.ACCESS_TOKEN_EXPIRE_SECONDS;
+    } else {
+      process.env.ACCESS_TOKEN_EXPIRE_SECONDS = originalAccessTokenExpiry;
+    }
+    jest.resetModules();
+  });
+
+  it("defaults to refreshing 10% before the one-hour backend expiry", async () => {
+    delete process.env.ACCESS_TOKEN_EXPIRE_SECONDS;
+    jest.resetModules();
+
+    const { LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV } = await import(
+      "../constants"
+    );
+
+    expect(LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV).toBe(3240);
+  });
+
+  it("refreshes 10% before a configured expiry", async () => {
+    process.env.ACCESS_TOKEN_EXPIRE_SECONDS = "7200";
+    jest.resetModules();
+
+    const { LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV } = await import(
+      "../constants"
+    );
+
+    expect(LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV).toBe(6480);
+  });
+});

--- a/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
+++ b/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
@@ -16,6 +16,9 @@ describe("authentication token refresh timing", () => {
   });
 
   it("defaults to refreshing 10% before the one-hour backend expiry", async () => {
+    expect(ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY).toBe(
+      "__LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS__",
+    );
     const definitions = createAccessTokenExpireSecondsDefinition();
     expect(definitions[ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]).toBe("3600");
     process.env.ACCESS_TOKEN_EXPIRE_SECONDS = String(

--- a/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
+++ b/src/frontend/src/constants/__tests__/auth-token-expiration.test.ts
@@ -1,3 +1,8 @@
+import {
+  ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY,
+  createAccessTokenExpireSecondsDefinition,
+} from "../../../vite-env-definitions";
+
 describe("authentication token refresh timing", () => {
   const originalAccessTokenExpiry = process.env.ACCESS_TOKEN_EXPIRE_SECONDS;
 
@@ -11,7 +16,11 @@ describe("authentication token refresh timing", () => {
   });
 
   it("defaults to refreshing 10% before the one-hour backend expiry", async () => {
-    delete process.env.ACCESS_TOKEN_EXPIRE_SECONDS;
+    const definitions = createAccessTokenExpireSecondsDefinition();
+    expect(definitions[ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]).toBe("3600");
+    process.env.ACCESS_TOKEN_EXPIRE_SECONDS = String(
+      JSON.parse(definitions[ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]),
+    );
     jest.resetModules();
 
     const { LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV } = await import(
@@ -22,7 +31,11 @@ describe("authentication token refresh timing", () => {
   });
 
   it("refreshes 10% before a configured expiry", async () => {
-    process.env.ACCESS_TOKEN_EXPIRE_SECONDS = "7200";
+    const definitions = createAccessTokenExpireSecondsDefinition("7200");
+    expect(definitions[ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]).toBe('"7200"');
+    process.env.ACCESS_TOKEN_EXPIRE_SECONDS = String(
+      JSON.parse(definitions[ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]),
+    );
     jest.resetModules();
 
     const { LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV } = await import(

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -13,17 +13,14 @@ export const SLIDING_TRANSITION_MS = 300;
 
 const getEnvVar = <T = string | undefined>(
   key: string,
+  viteValue: T | undefined,
   defaultValue?: T,
 ): T | undefined => {
-  if (typeof process !== "undefined" && process.env) {
-    return (process.env[key] as T) ?? defaultValue;
-  }
-  try {
-    const value = new Function(`return import.meta.env?.${key}`)() as T;
-    return value ?? defaultValue;
-  } catch {
-    return defaultValue;
-  }
+  const processValue =
+    typeof process !== "undefined" && process.env
+      ? (process.env[key] as T | undefined)
+      : undefined;
+  return processValue ?? viteValue ?? defaultValue;
 };
 
 /**
@@ -881,9 +878,15 @@ export const LANGFLOW_AUTO_LOGIN_OPTION = "auto_login_lf";
 export const LANGFLOW_REFRESH_TOKEN = "refresh_token_lf";
 
 export const LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 - 60 * 60 * 0.1;
+const configuredAccessTokenExpireSeconds = Number(
+  getEnvVar<string | number>(
+    "ACCESS_TOKEN_EXPIRE_SECONDS",
+    import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS,
+    60 * 60,
+  ),
+);
 export const LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV =
-  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60 * 60)) -
-  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60 * 60)) * 0.1;
+  configuredAccessTokenExpireSeconds - configuredAccessTokenExpireSeconds * 0.1;
 export const TEXT_FIELD_TYPES: string[] = ["str", "SecretStr"];
 export const NODE_WIDTH = 384;
 export const NODE_HEIGHT = NODE_WIDTH * 3;
@@ -958,9 +961,12 @@ export const POLLING_MESSAGES = {
 
 export const BUILD_POLLING_INTERVAL = 25;
 
+const autoLoginEnv = getEnvVar<string | boolean>(
+  "LANGFLOW_AUTO_LOGIN",
+  import.meta.env.LANGFLOW_AUTO_LOGIN,
+);
 export const IS_AUTO_LOGIN =
-  !getEnvVar("LANGFLOW_AUTO_LOGIN") ||
-  String(getEnvVar("LANGFLOW_AUTO_LOGIN"))?.toLowerCase() !== "false";
+  !autoLoginEnv || String(autoLoginEnv).toLowerCase() !== "false";
 
 export const AUTO_LOGIN_RETRY_DELAY = 2000;
 export const AUTO_LOGIN_MAX_RETRY_DELAY = 60000;

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -7,6 +7,9 @@ import {
 import { customDefaultShortcuts } from "../customization/constants";
 import type { languageMap } from "../types/components";
 
+declare const __LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS__: string | number;
+declare const __LANGFLOW_AUTO_LOGIN__: string | boolean;
+
 export const DEFAULT_SESSION_NAME = "Default Session";
 export const NEW_SESSION_NAME = "New Session";
 export const SLIDING_TRANSITION_MS = 300;
@@ -878,10 +881,14 @@ export const LANGFLOW_AUTO_LOGIN_OPTION = "auto_login_lf";
 export const LANGFLOW_REFRESH_TOKEN = "refresh_token_lf";
 
 export const LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 - 60 * 60 * 0.1;
+const viteAccessTokenExpireSeconds =
+  typeof __LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS__ === "undefined"
+    ? undefined
+    : __LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS__;
 const configuredAccessTokenExpireSeconds = Number(
   getEnvVar<string | number>(
     "ACCESS_TOKEN_EXPIRE_SECONDS",
-    import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS,
+    viteAccessTokenExpireSeconds,
     60 * 60,
   ),
 );
@@ -961,9 +968,13 @@ export const POLLING_MESSAGES = {
 
 export const BUILD_POLLING_INTERVAL = 25;
 
+const viteAutoLogin =
+  typeof __LANGFLOW_AUTO_LOGIN__ === "undefined"
+    ? undefined
+    : __LANGFLOW_AUTO_LOGIN__;
 const autoLoginEnv = getEnvVar<string | boolean>(
   "LANGFLOW_AUTO_LOGIN",
-  import.meta.env.LANGFLOW_AUTO_LOGIN,
+  viteAutoLogin,
 );
 export const IS_AUTO_LOGIN =
   !autoLoginEnv || String(autoLoginEnv).toLowerCase() !== "false";

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -882,8 +882,8 @@ export const LANGFLOW_REFRESH_TOKEN = "refresh_token_lf";
 
 export const LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 - 60 * 60 * 0.1;
 export const LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV =
-  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60)) -
-  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60)) * 0.1;
+  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60 * 60)) -
+  Number(getEnvVar("ACCESS_TOKEN_EXPIRE_SECONDS", 60 * 60)) * 0.1;
 export const TEXT_FIELD_TYPES: string[] = ["str", "SecretStr"];
 export const NODE_WIDTH = 384;
 export const NODE_HEIGHT = NODE_WIDTH * 3;

--- a/src/frontend/vite-env-definitions.ts
+++ b/src/frontend/vite-env-definitions.ts
@@ -1,5 +1,5 @@
 export const ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY =
-  "import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS";
+  "__LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS__";
 export const DEFAULT_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60;
 
 export const createAccessTokenExpireSecondsDefinition = (

--- a/src/frontend/vite-env-definitions.ts
+++ b/src/frontend/vite-env-definitions.ts
@@ -1,0 +1,11 @@
+export const ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY =
+  "import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS";
+export const DEFAULT_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60;
+
+export const createAccessTokenExpireSecondsDefinition = (
+  configuredValue?: string,
+) => ({
+  [ACCESS_TOKEN_EXPIRE_SECONDS_ENV_KEY]: JSON.stringify(
+    configuredValue ?? DEFAULT_ACCESS_TOKEN_EXPIRE_SECONDS,
+  ),
+});

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -48,7 +48,7 @@ export default defineConfig(({ mode }) => {
         envLangflow.BACKEND_URL ?? "http://localhost:7860",
       ),
       "import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS": JSON.stringify(
-        envLangflow.ACCESS_TOKEN_EXPIRE_SECONDS ?? 60,
+        envLangflow.ACCESS_TOKEN_EXPIRE_SECONDS ?? 60 * 60,
       ),
       "import.meta.env.CI": JSON.stringify(envLangflow.CI ?? false),
       "import.meta.env.LANGFLOW_AUTO_LOGIN": JSON.stringify(

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -11,6 +11,7 @@ import {
   PORT,
   PROXY_TARGET,
 } from "./src/customization/config-constants";
+import { createAccessTokenExpireSecondsDefinition } from "./vite-env-definitions";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -44,11 +45,11 @@ export default defineConfig(({ mode }) => {
       outDir: "build",
     },
     define: {
+      ...createAccessTokenExpireSecondsDefinition(
+        envLangflow.ACCESS_TOKEN_EXPIRE_SECONDS,
+      ),
       "import.meta.env.BACKEND_URL": JSON.stringify(
         envLangflow.BACKEND_URL ?? "http://localhost:7860",
-      ),
-      "import.meta.env.ACCESS_TOKEN_EXPIRE_SECONDS": JSON.stringify(
-        envLangflow.ACCESS_TOKEN_EXPIRE_SECONDS ?? 60 * 60,
       ),
       "import.meta.env.CI": JSON.stringify(envLangflow.CI ?? false),
       "import.meta.env.LANGFLOW_AUTO_LOGIN": JSON.stringify(

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -52,7 +52,7 @@ export default defineConfig(({ mode }) => {
         envLangflow.BACKEND_URL ?? "http://localhost:7860",
       ),
       "import.meta.env.CI": JSON.stringify(envLangflow.CI ?? false),
-      "import.meta.env.LANGFLOW_AUTO_LOGIN": JSON.stringify(
+      __LANGFLOW_AUTO_LOGIN__: JSON.stringify(
         envLangflow.LANGFLOW_AUTO_LOGIN ?? true,
       ),
       "import.meta.env.LANGFLOW_MCP_COMPOSER_ENABLED": JSON.stringify(

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -123,9 +123,9 @@ class AuthSettings(BaseSettings):
     # Store password as SecretStr to prevent accidental plaintext exposure
     SUPERUSER_PASSWORD: SecretStr = Field(default=DEFAULT_SUPERUSER_PASSWORD)
 
-    REFRESH_SAME_SITE: Literal["lax", "strict", "none"] = "none"
+    REFRESH_SAME_SITE: Literal["lax", "strict", "none"] = "lax"
     """The SameSite attribute of the refresh token cookie."""
-    REFRESH_SECURE: bool = True
+    REFRESH_SECURE: bool = False
     """The Secure attribute of the refresh token cookie."""
     REFRESH_HTTPONLY: bool = True
     """The HttpOnly attribute of the refresh token cookie."""


### PR DESCRIPTION
## Summary
- align the frontend refresh fallback with the backend one-hour access-token lifetime, scheduling refresh at 54 minutes instead of 54 seconds
- make refresh-cookie defaults work on same-site HTTP deployments while retaining explicit secure cross-site overrides
- add regression coverage for default and configured refresh timing and cookie settings

## Testing
- `npm test -- --runInBand src/constants/__tests__/auth-token-expiration.test.ts src/components/authorization/authGuard/__tests__/proactive-refresh.test.tsx`
- `uv run pytest src/backend/tests/unit/test_auth_settings.py src/backend/tests/unit/test_security_cors.py -q`
- `npx @biomejs/biome check src/constants/constants.ts src/constants/__tests__/auth-token-expiration.test.ts vite.config.mts`
- `uv run ruff check src/lfx/src/lfx/services/settings/auth.py src/backend/tests/unit/test_security_cors.py`
- `uv run ruff format --check src/lfx/src/lfx/services/settings/auth.py src/backend/tests/unit/test_security_cors.py`
- `npm run build`

Addresses [LE-2013](https://datastax.jira.com/browse/LE-2013).

[LE-2013]: https://datastax.jira.com/browse/LE-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Refresh-token cookies now use safer same-site defaults and do not require HTTPS by default.
  - Cross-site refresh cookies remain available when explicitly configured for secure HTTPS use.

- **Authentication**
  - Frontend access-token expiration now defaults to a one-hour backend lifetime.
  - Tokens refresh automatically 10% before expiration to help maintain active sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->