### PR TITLE
fix: normalize MCP resource flow IDs

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -221,10 +221,15 @@ async def handle_read_resource(uri: str, project_id: UUID | str | None = None) -
             raise ValueError(msg) from exc
 
         async with session_scope() as session:
-            flow_query = select(Flow).where(Flow.id == namespace_id, Flow.user_id == current_user.id)
-            if project_id is not None:
-                flow_query = flow_query.where(Flow.folder_id == project_id)
-            flow = (await session.exec(flow_query)).first()
+            try:
+                flow_id = UUID(namespace_id)
+            except ValueError:
+                flow = None
+            else:
+                flow_query = select(Flow).where(Flow.id == flow_id, Flow.user_id == current_user.id)
+                if project_id is not None:
+                    flow_query = flow_query.where(Flow.folder_id == project_id)
+                flow = (await session.exec(flow_query)).first()
 
             if flow is None:
                 # The namespace segment may refer to the user's own bucket (user-level

--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -220,6 +220,14 @@ async def handle_read_resource(uri: str, project_id: UUID | str | None = None) -
             msg = "Authenticated user context is required to read MCP resources"
             raise ValueError(msg) from exc
 
+        parsed_project_id = None
+        if project_id is not None:
+            try:
+                parsed_project_id = UUID(str(project_id))
+            except ValueError as exc:
+                msg = "Resource not found or access denied"
+                raise ValueError(msg) from exc
+
         async with session_scope() as session:
             try:
                 flow_id = UUID(namespace_id)
@@ -227,8 +235,8 @@ async def handle_read_resource(uri: str, project_id: UUID | str | None = None) -
                 flow = None
             else:
                 flow_query = select(Flow).where(Flow.id == flow_id, Flow.user_id == current_user.id)
-                if project_id is not None:
-                    flow_query = flow_query.where(Flow.folder_id == project_id)
+                if parsed_project_id is not None:
+                    flow_query = flow_query.where(Flow.folder_id == parsed_project_id)
                 flow = (await session.exec(flow_query)).first()
 
             if flow is None:

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -332,11 +332,19 @@ async def test_handle_read_resource_project_scope_binds_flow_id_as_uuid(monkeypa
     user = User(username="mcp-resource-reader", password="test-password")  # noqa: S106
     project = Folder(name="MCP Resource Project", user_id=user.id)
     flow = Flow(name="MCP Resource Flow", user_id=user.id, folder_id=project.id)
-    async_session.add_all([user, project, flow])
+    other_project = Folder(name="Other MCP Resource Project", user_id=user.id)
+    other_flow = Flow(name="Other MCP Resource Flow", user_id=user.id, folder_id=other_project.id)
+    async_session.add_all([user, project, flow, other_project, other_flow])
     await async_session.flush()
 
     file_name = "project-resource.txt"
-    storage_service = FakeStorageService({}, {f"{flow.id}/{file_name}": b"project file contents"})
+    storage_service = FakeStorageService(
+        {},
+        {
+            f"{flow.id}/{file_name}": b"project file contents",
+            f"{other_flow.id}/{file_name}": b"other project file contents",
+        },
+    )
 
     monkeypatch.setattr(mcp_utils, "session_scope", lambda: FakeSessionContext(async_session))
     monkeypatch.setattr(mcp_utils, "get_storage_service", lambda: storage_service)
@@ -345,6 +353,13 @@ async def test_handle_read_resource_project_scope_binds_flow_id_as_uuid(monkeypa
     try:
         uri = f"http://host/api/v1/files/download/{flow.id}/{file_name}"
         result = await mcp_utils.handle_read_resource(uri, project_id=project.id)
+
+        other_uri = f"http://host/api/v1/files/download/{other_flow.id}/{file_name}"
+        with pytest.raises(ValueError, match="access denied"):
+            await mcp_utils.handle_read_resource(other_uri, project_id=project.id)
+
+        with pytest.raises(ValueError, match="access denied"):
+            await mcp_utils.handle_read_resource(uri, project_id="not-a-uuid")
     finally:
         mcp_utils.current_user_ctx.reset(token)
 

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -5,6 +5,9 @@ import pytest
 from langflow.api.utils.core import extract_global_variables_from_headers
 from langflow.api.v1 import mcp_utils
 from langflow.helpers import flow as flow_helpers
+from langflow.services.database.models import Flow
+from langflow.services.database.models.folder.model import Folder
+from langflow.services.database.models.user.model import User
 from lfx.interface.components import component_cache
 
 
@@ -321,6 +324,33 @@ async def test_handle_read_resource_denies_user_bucket_under_project_scope(monke
             await mcp_utils.handle_read_resource(uri, project_id="project-xyz")
     finally:
         mcp_utils.current_user_ctx.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_handle_read_resource_project_scope_binds_flow_id_as_uuid(monkeypatch, async_session):
+    """A flow UUID parsed from an advertised resource URI must remain UUID-typed in the database query."""
+    user = User(username="mcp-resource-reader", password="test-password")  # noqa: S106
+    project = Folder(name="MCP Resource Project", user_id=user.id)
+    flow = Flow(name="MCP Resource Flow", user_id=user.id, folder_id=project.id)
+    async_session.add_all([user, project, flow])
+    await async_session.flush()
+
+    file_name = "project-resource.txt"
+    storage_service = FakeStorageService({}, {f"{flow.id}/{file_name}": b"project file contents"})
+
+    monkeypatch.setattr(mcp_utils, "session_scope", lambda: FakeSessionContext(async_session))
+    monkeypatch.setattr(mcp_utils, "get_storage_service", lambda: storage_service)
+
+    token = mcp_utils.current_user_ctx.set(user)
+    try:
+        uri = f"http://host/api/v1/files/download/{flow.id}/{file_name}"
+        result = await mcp_utils.handle_read_resource(uri, project_id=project.id)
+    finally:
+        mcp_utils.current_user_ctx.reset(token)
+
+    import base64
+
+    assert base64.b64decode(result) == b"project file contents"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- normalize flow IDs parsed from MCP resource URIs to `UUID` before querying `Flow.id`
- preserve existing own-user-bucket behavior for non-flow namespaces
- add a SQLite-backed regression test for project-scoped `resources/read`

## Root cause

`handle_read_resource` parsed the namespace from the advertised download URI as a string and bound it directly to the UUID-typed `Flow.id` column. SQLAlchemy's UUID binder expects a `UUID` instance, so project MCP `resources/read` failed with `AttributeError: 'str' object has no attribute 'hex'` even though `resources/list` advertised the file.

## Impact

Project streamable-HTTP MCP clients can read files returned by `resources/list` again.

## Test plan

- `UV_CACHE_DIR=/private/tmp/uv-cache-langflow uv run pytest src/backend/tests/unit/api/v1/test_mcp_utils.py -q` (22 passed)
- `UV_CACHE_DIR=/private/tmp/uv-cache-langflow uv run ruff check src/backend/base/langflow/api/v1/mcp_utils.py src/backend/tests/unit/api/v1/test_mcp_utils.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-langflow uv run ruff format --check src/backend/base/langflow/api/v1/mcp_utils.py src/backend/tests/unit/api/v1/test_mcp_utils.py`
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource access validation by requiring valid flow identifiers.
  * Ensured resource lookups remain scoped to the current project when applicable.
  * Fixed resource downloads to preserve correct flow identifier handling and return the expected content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->