### PR TITLE
fix: populate name and description on starter-projects API response

### DIFF
--- a/src/backend/base/langflow/initial_setup/load.py
+++ b/src/backend/base/langflow/initial_setup/load.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 from .starter_projects import (
     basic_prompting_graph,
     blog_writer_graph,
@@ -6,11 +9,17 @@ from .starter_projects import (
     vector_store_rag_graph,
 )
 
-# Name and description for each starter project, kept in sync with the
-# corresponding files in ``initial_setup/starter_projects/*.json``.
-STARTER_PROJECT_METADATA: list[tuple[str, str]] = [
-    ("Basic Prompting", "Perform basic prompting with an OpenAI model."),
+# Each starter project is declared alongside its canonical name and description so
+# that reordering cannot associate a graph with the wrong metadata. The names and
+# descriptions are kept in sync with ``initial_setup/starter_projects/*.json``.
+STARTER_PROJECTS: list[tuple[Callable[[], Any], str, str]] = [
     (
+        basic_prompting_graph,
+        "Basic Prompting",
+        "Perform basic prompting with an OpenAI model.",
+    ),
+    (
+        blog_writer_graph,
         "Blog Writer",
         (
             "Write blog posts from web references using an Agent. URL fetches references, you provide the "
@@ -18,6 +27,7 @@ STARTER_PROJECT_METADATA: list[tuple[str, str]] = [
         ),
     ),
     (
+        document_qa_graph,
         "Document Q&A",
         (
             "Ask questions about your own document using a built-in Knowledge Base (RAG). File ingests into "
@@ -25,29 +35,26 @@ STARTER_PROJECT_METADATA: list[tuple[str, str]] = [
         ),
     ),
     (
+        memory_chatbot_graph,
         "Memory Chatbot",
         (
             "Create a chatbot that saves and references previous messages, enabling the model to maintain "
             "context throughout the conversation."
         ),
     ),
-    ("Vector Store RAG", "Load your data for chat context with Retrieval Augmented Generation."),
+    (
+        vector_store_rag_graph,
+        "Vector Store RAG",
+        "Load your data for chat context with Retrieval Augmented Generation.",
+    ),
 ]
 
 
 def get_starter_projects_graphs():
-    return [
-        basic_prompting_graph(),
-        blog_writer_graph(),
-        document_qa_graph(),
-        memory_chatbot_graph(),
-        vector_store_rag_graph(),
-    ]
+    return [build_graph() for build_graph, _name, _description in STARTER_PROJECTS]
 
 
 def get_starter_projects_dump():
-    graphs = get_starter_projects_graphs()
     return [
-        graph.dump(name=name, description=description)
-        for graph, (name, description) in zip(graphs, STARTER_PROJECT_METADATA, strict=True)
+        build_graph().dump(name=name, description=description) for build_graph, name, description in STARTER_PROJECTS
     ]

--- a/src/backend/base/langflow/initial_setup/load.py
+++ b/src/backend/base/langflow/initial_setup/load.py
@@ -6,6 +6,34 @@ from .starter_projects import (
     vector_store_rag_graph,
 )
 
+# Name and description for each starter project, kept in sync with the
+# corresponding files in ``initial_setup/starter_projects/*.json``.
+STARTER_PROJECT_METADATA: list[tuple[str, str]] = [
+    ("Basic Prompting", "Perform basic prompting with an OpenAI model."),
+    (
+        "Blog Writer",
+        (
+            "Write blog posts from web references using an Agent. URL fetches references, you provide the "
+            "topic via Chat Input, and the Agent writes a grounded post. Core components only."
+        ),
+    ),
+    (
+        "Document Q&A",
+        (
+            "Ask questions about your own document using a built-in Knowledge Base (RAG). File ingests into "
+            "the KB; an Agent answers from retrieved context. No external vector database required."
+        ),
+    ),
+    (
+        "Memory Chatbot",
+        (
+            "Create a chatbot that saves and references previous messages, enabling the model to maintain "
+            "context throughout the conversation."
+        ),
+    ),
+    ("Vector Store RAG", "Load your data for chat context with Retrieval Augmented Generation."),
+]
+
 
 def get_starter_projects_graphs():
     return [
@@ -18,4 +46,8 @@ def get_starter_projects_graphs():
 
 
 def get_starter_projects_dump():
-    return [g.dump() for g in get_starter_projects_graphs()]
+    graphs = get_starter_projects_graphs()
+    return [
+        graph.dump(name=name, description=description)
+        for graph, (name, description) in zip(graphs, STARTER_PROJECT_METADATA, strict=True)
+    ]

--- a/src/backend/tests/unit/api/v1/test_starter_projects.py
+++ b/src/backend/tests/unit/api/v1/test_starter_projects.py
@@ -12,27 +12,50 @@ async def test_get_starter_projects(client: AsyncClient, logged_in_headers):
     assert isinstance(result, list), "The result must be a list"
 
 
-async def test_get_starter_projects_are_named(client: AsyncClient, logged_in_headers):
-    """Every starter project must expose a non-empty, unique top-level name.
+EXPECTED_STARTER_PROJECTS = {
+    "Basic Prompting": "Perform basic prompting with an OpenAI model.",
+    "Blog Writer": (
+        "Write blog posts from web references using an Agent. URL fetches references, you provide the "
+        "topic via Chat Input, and the Agent writes a grounded post. Core components only."
+    ),
+    "Document Q&A": (
+        "Ask questions about your own document using a built-in Knowledge Base (RAG). File ingests into "
+        "the KB; an Agent answers from retrieved context. No external vector database required."
+    ),
+    "Memory Chatbot": (
+        "Create a chatbot that saves and references previous messages, enabling the model to maintain "
+        "context throughout the conversation."
+    ),
+    "Vector Store RAG": "Load your data for chat context with Retrieval Augmented Generation.",
+}
 
-    Without this, API clients cannot select a template by name.
+
+async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClient, logged_in_headers):
+    """Each starter project must expose its canonical name and description.
+
+    Without a populated top-level name, API clients cannot select a template by name.
+    Comparing the full mapping also catches a graph paired with the wrong metadata.
     """
     response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
     assert response.status_code == status.HTTP_200_OK, response.text
     result = response.json()
 
-    assert result, "Expected at least one starter project"
+    assert len(result) == len(EXPECTED_STARTER_PROJECTS), (
+        f"Expected {len(EXPECTED_STARTER_PROJECTS)} starter projects, got {len(result)}"
+    )
 
     names = [project["name"] for project in result]
-    assert all(names), f"Every starter project needs a name, got: {names}"
     assert len(set(names)) == len(names), f"Starter project names must be unique, got: {names}"
 
-    descriptions = [project["description"] for project in result]
-    assert all(descriptions), f"Every starter project needs a description, got: {descriptions}"
+    actual = {project["name"]: project["description"] for project in result}
+    assert actual == EXPECTED_STARTER_PROJECTS
 
     # ``endpoint_name`` used to be stringified unconditionally, yielding the literal "None".
+    # The response model always emits the field, so it must be present and null here.
     endpoint_names = [project["endpoint_name"] for project in result]
-    assert "None" not in endpoint_names, f"endpoint_name must be null, not the string 'None': {endpoint_names}"
+    assert endpoint_names == [None] * len(result), (
+        f"endpoint_name must be null, not the string 'None': {endpoint_names}"
+    )
 
 
 def test_starter_projects_keep_optional_crewai_exports_lazy():

--- a/src/backend/tests/unit/api/v1/test_starter_projects.py
+++ b/src/backend/tests/unit/api/v1/test_starter_projects.py
@@ -12,6 +12,29 @@ async def test_get_starter_projects(client: AsyncClient, logged_in_headers):
     assert isinstance(result, list), "The result must be a list"
 
 
+async def test_get_starter_projects_are_named(client: AsyncClient, logged_in_headers):
+    """Every starter project must expose a non-empty, unique top-level name.
+
+    Without this, API clients cannot select a template by name.
+    """
+    response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    result = response.json()
+
+    assert result, "Expected at least one starter project"
+
+    names = [project["name"] for project in result]
+    assert all(names), f"Every starter project needs a name, got: {names}"
+    assert len(set(names)) == len(names), f"Starter project names must be unique, got: {names}"
+
+    descriptions = [project["description"] for project in result]
+    assert all(descriptions), f"Every starter project needs a description, got: {descriptions}"
+
+    # ``endpoint_name`` used to be stringified unconditionally, yielding the literal "None".
+    endpoint_names = [project["endpoint_name"] for project in result]
+    assert "None" not in endpoint_names, f"endpoint_name must be null, not the string 'None': {endpoint_names}"
+
+
 def test_starter_projects_keep_optional_crewai_exports_lazy():
     from langflow.initial_setup import starter_projects
 

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -278,7 +278,8 @@ class Graph:
             graph_dict["description"] = description
         elif description is None and self.description:
             graph_dict["description"] = self.description
-        graph_dict["endpoint_name"] = str(endpoint_name)
+        if endpoint_name is not None:
+            graph_dict["endpoint_name"] = str(endpoint_name)
         return graph_dict
 
     def add_nodes_and_edges(self, nodes: list[NodeData], edges: list[EdgeData]) -> None:


### PR DESCRIPTION
Fixes #14255

## Problem

`GET /api/v1/starter-projects/` returns a `null` top-level `name` for every one of the five templates, so an API client cannot select a template by name. `description` is `null` too, and `endpoint_name` is the literal **string** `"None"` rather than JSON `null`.

The name is not recoverable from anywhere else in the response — I searched the full nested `data` payload of all five entries for the known template names and found no match — so the endpoint is unusable for programmatic template selection.

The UI is unaffected: the templates modal reads `GET /api/v1/flows/basic_examples/`, and the frontend constant `URLs.STARTER_PROJECTS` is defined but never referenced. That lack of an in-tree consumer is likely why this went unnoticed.

## Root cause

`get_starter_projects_dump()` calls `Graph.dump()` with no arguments, and each starter project builder returns `Graph(start=..., end=...)` without `flow_name`. `Graph.dump()` only writes `name` when either the argument or `self.flow_name` is truthy:

```python
if name:
    graph_dict["name"] = name
elif name is None and self.flow_name:      # self.flow_name is None
    graph_dict["name"] = self.flow_name
```

Neither holds, so the key is never written and the endpoint's `item.get("name")` yields `None`. `description` fails identically. Separately, the following line stringified unconditionally — `str(None) == "None"`.

## Changes

- **`initial_setup/load.py`** — pass the canonical name and description into `dump()`, copied verbatim from the matching `starter_projects/*.json` files.
- **`lfx/graph/graph/base.py`** — only set `endpoint_name` when it is not `None`. `GraphDump` is `total=False`, so omitting the key is type-valid, and no in-tree caller reads `endpoint_name` off a `Graph.dump()` result (`setup.py` and `cli/push.py` read it from flow JSON/dicts, not from a dump).
- **`tests/unit/api/v1/test_starter_projects.py`** — assert names are present and unique, descriptions are present, and `endpoint_name` is never the string `"None"`.

## Testing

The two existing tests asserted only the status code and `isinstance(result, list)`, so no field was ever inspected — hence the gap.

The new test is **red on the unpatched branch** and green with this change. Before:

```json
[{"name": null, "description": null, "endpoint_name": "None", "is_component": false}, ...]
```

After:

```json
[
  {"name": "Basic Prompting",  "endpoint_name": null, "description": "Perform basic prompting with an OpenAI model."},
  {"name": "Blog Writer",      "endpoint_name": null, "description": "Write blog posts from web references using an Agent. ..."},
  {"name": "Document Q&A",     "endpoint_name": null, "description": "Ask questions about your own document using a built-in Knowledge Base (RAG). ..."},
  {"name": "Memory Chatbot",   "endpoint_name": null, "description": "Create a chatbot that saves and references previous messages, ..."},
  {"name": "Vector Store RAG", "endpoint_name": null, "description": "Load your data for chat context with Retrieval Augmented Generation."}
]
```

Originally found against `52b1ea1d`, reproduced over HTTP on a running server, and re-verified against this PR's base (`720cabcf`). `ruff check` and `ruff format` introduce no new findings on the touched files.

## Alternative worth considering

Setting `flow_name`/`description` on the `Graph` in each of the five builders would fix the dump the same way and additionally give correct tracing run names (`Graph` builds `run_name` from `self.flow_name`), at the cost of touching five files instead of one. Happy to switch to that shape if you prefer it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starter projects now include clear, human-readable names and descriptions.
  * Starter project listings provide unique names and omit empty endpoint names.

* **Bug Fixes**
  * Prevented unspecified endpoint names from appearing as the literal value “None.”

* **Tests**
  * Added validation to ensure starter projects include complete, unique metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->