### PR TITLE
fix: render flows whose nodes have no position instead of crashing the canvas

### DIFF
--- a/src/frontend/src/utils/__tests__/layoutUtils.test.ts
+++ b/src/frontend/src/utils/__tests__/layoutUtils.test.ts
@@ -74,6 +74,19 @@ describe("needsLayout", () => {
     expect(needsLayout([node])).toBe(true);
   });
 
+  it("flags non-finite coordinates", () => {
+    const positive = {
+      ...makeNode("A"),
+      position: { x: Number.POSITIVE_INFINITY, y: 0 },
+    };
+    const negative = {
+      ...makeNode("B"),
+      position: { x: 0, y: Number.NEGATIVE_INFINITY },
+    };
+    expect(needsLayout([positive])).toBe(true);
+    expect(needsLayout([negative])).toBe(true);
+  });
+
   it("accepts well-formed positions", () => {
     const node = { ...makeNode("A"), position: { x: 0, y: 0 } };
     expect(needsLayout([node])).toBe(false);
@@ -100,6 +113,41 @@ describe("getLayoutedNodes with handle-less edges", () => {
     const nodes = ["A", "B"].map(makeNode);
     const layouted = await getLayoutedNodes(nodes, []);
     expect(layouted.every(hasNumericPosition)).toBe(true);
+  });
+});
+
+describe("getLayoutedNodes when ELK rejects", () => {
+  afterEach(() => {
+    jest.dontMock("elkjs/lib/elk.bundled.js");
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it("falls back to the deterministic grid instead of propagating", async () => {
+    jest.resetModules();
+    jest.doMock("elkjs/lib/elk.bundled.js", () => ({
+      __esModule: true,
+      default: class {
+        layout = jest.fn().mockRejectedValue(new Error("ELK exploded"));
+      },
+    }));
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    // Re-require so the module picks up the failing ELK singleton.
+    const {
+      getFallbackGridPositions: freshFallback,
+      getLayoutedNodes: withFailingElk,
+    } = require("../layoutUtils");
+
+    const nodes = ["ChatInput-a", "Prompt-b", "ChatOutput-c"].map(makeNode);
+    const edges = [makeHandlelessEdge("ChatInput-a", "Prompt-b")];
+
+    const layouted = await withFailingElk(nodes, edges);
+
+    // Resolves rather than rejecting, and every node is usable.
+    expect(layouted).toHaveLength(3);
+    expect(layouted.every(hasNumericPosition)).toBe(true);
+    expect(layouted).toEqual(freshFallback(nodes));
   });
 });
 

--- a/src/frontend/src/utils/__tests__/layoutUtils.test.ts
+++ b/src/frontend/src/utils/__tests__/layoutUtils.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Jest tests for the auto-layout fallback used by flows whose nodes carry no
+ * `position` — e.g. payloads produced by `GET /api/v1/starter-projects/`, which
+ * emits nodes without `position` and edges without `id`/`sourceHandle`/
+ * `targetHandle`.
+ *
+ * Regression coverage for two defects:
+ *  1. getLayoutedNodes passed `id: undefined` to ELK for edges and for ports
+ *     derived from absent handles, so ELK threw
+ *     `JsonImportException: Id must be a string or an integer: 'null'` for
+ *     exactly the flows that needed the layout.
+ *  2. processFlows never awaits processDataFromFlow, so the layout landed after
+ *     the nodes had already been handed to React Flow, whose
+ *     getNodePositionWithOrigin dereferences `node.position.x` unguarded.
+ */
+
+import type { AllNodeType, EdgeType } from "@/types/flow";
+import { getFallbackGridPositions, getLayoutedNodes } from "../layoutUtils";
+import { needsLayout, processFlows } from "../reactflowUtils";
+
+const makeNode = (id: string): AllNodeType =>
+  ({
+    id,
+    data: { id, type: id.split("-")[0], node: { template: {}, outputs: [] } },
+  }) as unknown as AllNodeType;
+
+// Shaped like a /starter-projects/ edge: no id, no sourceHandle, no targetHandle.
+const makeHandlelessEdge = (source: string, target: string): EdgeType =>
+  ({ source, target, data: {} }) as unknown as EdgeType;
+
+const hasNumericPosition = (node: AllNodeType) =>
+  !!node.position &&
+  typeof node.position.x === "number" &&
+  typeof node.position.y === "number" &&
+  !Number.isNaN(node.position.x) &&
+  !Number.isNaN(node.position.y);
+
+describe("getFallbackGridPositions", () => {
+  it("gives every node a numeric position", () => {
+    const nodes = ["A", "B", "C", "D", "E"].map(makeNode);
+    expect(getFallbackGridPositions(nodes).every(hasNumericPosition)).toBe(
+      true,
+    );
+  });
+
+  it("does not place two nodes at the same coordinates", () => {
+    const positioned = getFallbackGridPositions(
+      ["A", "B", "C", "D"].map(makeNode),
+    );
+    const coords = positioned.map((n) => `${n.position.x},${n.position.y}`);
+    expect(new Set(coords).size).toBe(coords.length);
+  });
+
+  it("handles an empty node list", () => {
+    expect(getFallbackGridPositions([])).toEqual([]);
+  });
+});
+
+describe("needsLayout", () => {
+  it("flags nodes with no position at all", () => {
+    expect(needsLayout([makeNode("A")])).toBe(true);
+  });
+
+  it("flags nodes whose coordinates are not numbers", () => {
+    const node = {
+      ...makeNode("A"),
+      position: { x: "12" as unknown as number, y: 0 },
+    };
+    expect(needsLayout([node])).toBe(true);
+  });
+
+  it("flags NaN coordinates", () => {
+    const node = { ...makeNode("A"), position: { x: Number.NaN, y: 0 } };
+    expect(needsLayout([node])).toBe(true);
+  });
+
+  it("accepts well-formed positions", () => {
+    const node = { ...makeNode("A"), position: { x: 0, y: 0 } };
+    expect(needsLayout([node])).toBe(false);
+  });
+});
+
+describe("getLayoutedNodes with handle-less edges", () => {
+  it("lays out a graph whose edges have no id or handles", async () => {
+    const nodes = ["ChatInput-a", "Prompt-b", "ChatOutput-c"].map(makeNode);
+    const edges = [
+      makeHandlelessEdge("ChatInput-a", "Prompt-b"),
+      makeHandlelessEdge("Prompt-b", "ChatOutput-c"),
+    ];
+
+    const layouted = await getLayoutedNodes(nodes, edges);
+
+    expect(layouted).toHaveLength(3);
+    expect(layouted.every(hasNumericPosition)).toBe(true);
+    // A real layered layout must separate the nodes, not stack them at 0,0.
+    expect(new Set(layouted.map((n) => n.position.x)).size).toBeGreaterThan(1);
+  });
+
+  it("still positions every node when there are no edges", async () => {
+    const nodes = ["A", "B"].map(makeNode);
+    const layouted = await getLayoutedNodes(nodes, []);
+    expect(layouted.every(hasNumericPosition)).toBe(true);
+  });
+});
+
+describe("processFlows on a flow with no positions", () => {
+  const makeFlow = () =>
+    ({
+      id: "flow-1",
+      name: "starter",
+      description: "",
+      is_component: false,
+      data: {
+        nodes: ["ChatInput-a", "ChatOutput-b"].map(makeNode),
+        edges: [makeHandlelessEdge("ChatInput-a", "ChatOutput-b")],
+      },
+    }) as never;
+
+  it("positions every node synchronously, before React Flow can adopt them", () => {
+    const flow = makeFlow() as unknown as {
+      data: { nodes: AllNodeType[] };
+    };
+
+    processFlows([flow as never]);
+
+    // processFlows returns without awaiting the async layout, so the guarantee
+    // has to hold at this point — this is the reference the store captures.
+    expect(flow.data.nodes.every(hasNumericPosition)).toBe(true);
+  });
+});

--- a/src/frontend/src/utils/layoutUtils.ts
+++ b/src/frontend/src/utils/layoutUtils.ts
@@ -17,6 +17,22 @@ const layoutOptions = {
 };
 const elk = new ELK();
 
+// Deterministic grid used when ELK cannot lay the graph out. Guarantees every
+// node still receives a numeric position so React Flow never adopts a node
+// whose `position` is undefined.
+export const getFallbackGridPositions = (
+  nodes: AllNodeType[],
+): AllNodeType[] => {
+  const columns = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+  return nodes.map((node, index) => ({
+    ...node,
+    position: {
+      x: (index % columns) * (NODE_WIDTH + 80),
+      y: Math.floor(index / columns) * (NODE_HEIGHT / 2 + 80),
+    },
+  }));
+};
+
 // uses elkjs to give each node a layouted position
 export const getLayoutedNodes = async (
   nodes: AllNodeType[],
@@ -26,8 +42,12 @@ export const getLayoutedNodes = async (
     id: "root",
     layoutOptions,
     children: cloneDeep(nodes).map((n) => {
+      // ELK rejects any id that is not a string or integer, so ports derived
+      // from an absent sourceHandle/targetHandle must be dropped rather than
+      // emitted with `id: undefined`. Edges referencing those handles fall back
+      // to the always-present node-id port below.
       const targetPorts = edges
-        .filter((e) => e.source === n.id)
+        .filter((e) => e.source === n.id && e.sourceHandle)
         .map((e) => ({
           id: e.sourceHandle,
           properties: {
@@ -36,7 +56,7 @@ export const getLayoutedNodes = async (
         }));
 
       const sourcePorts = edges
-        .filter((e) => e.target === n.id)
+        .filter((e) => e.target === n.id && e.targetHandle)
         .map((e) => ({
           id: e.targetHandle,
           properties: {
@@ -55,13 +75,25 @@ export const getLayoutedNodes = async (
         ports: [{ id: n.id }, ...targetPorts, ...sourcePorts],
       };
     }) as ElkNode[],
-    edges: edges.map((e) => ({
-      id: e.id,
+    edges: edges.map((e, index) => ({
+      // Flows built programmatically (e.g. the /starter-projects/ payload) have
+      // no edge id; ELK requires one.
+      id: e.id ?? `elk-edge-${index}`,
       sources: [e.sourceHandle || e.source],
       targets: [e.targetHandle || e.target],
     })),
   };
-  const layoutedGraph = await elk.layout(graph);
+
+  let layoutedGraph: ElkNode;
+  try {
+    layoutedGraph = await elk.layout(graph);
+  } catch (error) {
+    console.error(
+      "getLayoutedNodes: ELK layout failed, using grid fallback",
+      error,
+    );
+    return getFallbackGridPositions(nodes);
+  }
 
   const layoutedNodes = nodes.map((node) => {
     const layoutedNode = layoutedGraph.children?.find(

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -66,7 +66,7 @@ import {
   cleanMcpConfig,
   type MCPServerValue,
 } from "./helpers/clean-mcp-config";
-import { getLayoutedNodes } from "./layoutUtils";
+import { getFallbackGridPositions, getLayoutedNodes } from "./layoutUtils";
 import { createRandomKey, toTitleCase } from "./utils";
 
 const uid = new ShortUniqueId();
@@ -609,7 +609,14 @@ export const processFlows = (DbData: FlowType[], skipUpdate = true) => {
 };
 
 export const needsLayout = (nodes: AllNodeType[]) => {
-  return nodes.some((node) => !node.position);
+  return nodes.some(
+    (node) =>
+      !node.position ||
+      typeof node.position.x !== "number" ||
+      typeof node.position.y !== "number" ||
+      Number.isNaN(node.position.x) ||
+      Number.isNaN(node.position.y),
+  );
 };
 
 export async function processDataFromFlow(
@@ -627,6 +634,11 @@ export async function processDataFromFlow(
     if (refreshIds) updateIds(data); // Assuming updateIds is defined elsewhere
     // add layout to nodes if not present
     if (needsLayout(data.nodes)) {
+      // Seed deterministic positions synchronously first. processFlows invokes
+      // this function without awaiting it, so anything that depends on the
+      // `await` below would still hand position-less nodes to React Flow (whose
+      // getNodePositionWithOrigin dereferences node.position.x unguarded).
+      data.nodes = getFallbackGridPositions(data.nodes);
       const layoutedNodes = await getLayoutedNodes(data.nodes, data.edges);
       data.nodes = layoutedNodes;
     }

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -609,13 +609,13 @@ export const processFlows = (DbData: FlowType[], skipUpdate = true) => {
 };
 
 export const needsLayout = (nodes: AllNodeType[]) => {
+  // Number.isFinite does not coerce, so this also rejects non-numeric
+  // coordinates as well as NaN and ±Infinity.
   return nodes.some(
     (node) =>
       !node.position ||
-      typeof node.position.x !== "number" ||
-      typeof node.position.y !== "number" ||
-      Number.isNaN(node.position.x) ||
-      Number.isNaN(node.position.y),
+      !Number.isFinite(node.position.x) ||
+      !Number.isFinite(node.position.y),
   );
 };
 


### PR DESCRIPTION
Fixes #14257.

## Problem

Any flow whose `data.nodes` lack a `position` crashes the canvas with a full-page "Sorry, we found an unexpected error!" when opened at `/flow/{id}`.

The frontend already intends to handle this — `needsLayout()` + `getLayoutedNodes()` exist precisely to lay out position-less flows — but the fallback is broken in **two independent ways**, so it never recovers.

**1. `getLayoutedNodes` passes `id: undefined` to ELK.** Edges are mapped with `id: e.id`, and ports are derived with `id: e.sourceHandle` / `id: e.targetHandle`. When a flow's edges have none of those, ELK rejects the graph with `JsonImportException: Id must be a string or an integer: 'null'` — so the layout fails for exactly the flows that need it. Bisected against a real payload, **both** id sources must be fixed; repairing either alone still throws:

```
baseline (as shipped): THREW -> JsonImportException: Id must be a string or an integer: 'null'.
edge ids fixed only:   THREW -> JsonImportException: Id must be a string or an integer: 'null'.
ports filtered only:   THREW -> JsonImportException: Id must be a string or an integer: 'null'.
both fixed:            OK -> ChatInput(12,12) PromptComponent(416,140) ...
```

**2. The layout is applied too late — the actual root cause of the crash.** `processFlows` iterates with `forEach(async (flow) => { … await processDataFromFlow(…) })`; `forEach` discards the returned promise, so `processFlows` returns *before* the layout resolves. `useApplyFlowToCanvas` then calls `setCurrentFlow()` immediately → `resetFlow()` → position-less nodes reach the store → React Flow's `adoptUserNodes` calls `getNodePositionWithOrigin`, which dereferences `node.position.x` unguarded. **This crashes even when ELK succeeds**, so fixing the ids alone is not sufficient.

## Changes

- **`layoutUtils.ts`** — drop ports whose handle is absent (their edges fall back to the always-present node-id port) and give id-less edges a stable synthetic id, so ELK accepts the graph. Wrap `elk.layout` so a failure returns a deterministic grid via the new exported `getFallbackGridPositions` instead of leaving nodes unpositioned.
- **`reactflowUtils.ts`** — `processDataFromFlow` seeds deterministic positions **synchronously** before awaiting ELK, so no node can reach React Flow without one regardless of the async timing. `needsLayout` now also rejects non-numeric and `NaN` coordinates, not just an absent `position`.

## Testing

New `src/frontend/src/utils/__tests__/layoutUtils.test.ts` (10 cases) covering the fallback grid, the tightened `needsLayout`, ELK layout with handle-less edges, and the synchronous guarantee through the real `processFlows`.

- **7 of the 10 fail on unpatched code**, all 10 pass with the fix.
- Full `src/utils` suite green: 422 tests / 30 suites.
- `tsc --noEmit` clean; `biome check` clean.

Verified end to end against all five `GET /api/v1/starter-projects/` payloads (4–9 nodes each): before the fix every node was unpositioned and ELK threw; after, each renders with a real layered layout.

## Note on scope

This stops the crash and produces a correct layout from `getLayoutedNodes`. It does **not** change `processFlows`' fire-and-forget signature, so on the `useApplyFlowToCanvas` path the canvas renders the synchronously-seeded grid rather than the ELK result — `resetFlow` captures the node array by reference before the async layout rebinds `data.nodes`:

```
store-captured array at capture time: [{"x":0,"y":0},{"x":464,"y":0}]
flow.data.nodes after ELK settles:    [{"x":12,"y":12},{"x":790,"y":12}]
what the store STILL holds:           [{"x":0,"y":0},{"x":464,"y":0}]
```

Threading `await` through `processFlows` touches 8 call sites, so I kept it out of this PR to keep the crash fix small and reviewable. Happy to follow up with it if you'd like.

## Adjacent data-quality bugs (not fixed here)

Two more issues visible in the same `/api/v1/starter-projects/` response, noted in #14257 — both look unintended and are backend-side:

- `name` is always `null` (`Graph.dump()` only sets it when `self.flow_name` is truthy).
- `endpoint_name` is the literal string `"None"` (`str(endpoint_name)` on `None` in `lfx/graph/graph/base.py`).

Let me know if you'd like those in scope and I'll add them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic layout handling for graphs with missing edge IDs or connection handles.
  * Added a reliable grid fallback when automatic layout cannot be completed.
  * Prevented crashes caused by missing, invalid, or `NaN` node positions.
  * Ensured nodes receive valid positions immediately while layout processing completes.
  * Added regression coverage for layout behavior across edge-less and handle-less graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->