### PR TITLE
fix(components): stop legacy aliases from importing every bundle at startup

### DIFF
--- a/src/lfx/src/lfx/components/__init__.py
+++ b/src/lfx/src/lfx/components/__init__.py
@@ -212,7 +212,14 @@ _discovered_modules = set()
 
 
 def _discover_components_from_module(module_name):
-    """Discover individual components from a specific module on-demand."""
+    """Discover individual components from a specific module on-demand.
+
+    Importing a component module executes third-party integration code, which is allowed to fail in
+    ways that have nothing to do with this package (a missing optional dependency, an import-time
+    write to a read-only ``$HOME``, a network probe). Discovery is best-effort by design, so any
+    failure here only removes that module's components from the lookup table -- it must never abort
+    the import that triggered the scan.
+    """
     if module_name in _discovered_modules or module_name == "Notion":
         return
 
@@ -230,9 +237,13 @@ def _discover_components_from_module(module_name):
 
         _discovered_modules.add(module_name)
 
-    except (ImportError, AttributeError):
+    except Exception as exc:  # noqa: BLE001 - see docstring: discovery must not break the caller
         # If import fails, mark as discovered to avoid retrying
         _discovered_modules.add(module_name)
+        # Imported lazily so the failure path is the only thing that pulls in the logger.
+        from lfx.log.logger import logger
+
+        logger.debug(f"Skipping component discovery for '{module_name}': {exc!r}")
 
 
 # Static base __all__ with module names

--- a/src/lfx/src/lfx/components/helpers/__init__.py
+++ b/src/lfx/src/lfx/components/helpers/__init__.py
@@ -103,9 +103,14 @@ def __getattr__(attr_name: str) -> Any:
         raise AttributeError(msg)
 
     # CurrentDateComponent, CalculatorComponent, and IDGeneratorComponent were moved to utilities
-    # Forward them to utilities for backwards compatibility
+    # Forward them to utilities for backwards compatibility.
+    # Import the submodule directly instead of `from lfx.components import utilities`: the latter
+    # routes through lfx.components.__getattr__, which brute-force imports every registered bundle
+    # module looking for a name that is not in its _dynamic_imports table. See _discover_all note.
     if attr_name in ("CurrentDateComponent", "CalculatorComponent", "IDGeneratorComponent"):
-        from lfx.components import utilities
+        from importlib import import_module
+
+        utilities = import_module("lfx.components.utilities")
 
         result = getattr(utilities, attr_name)
         globals()[attr_name] = result

--- a/src/lfx/src/lfx/components/logic/__init__.py
+++ b/src/lfx/src/lfx/components/logic/__init__.py
@@ -148,7 +148,11 @@ def __getattr__(attr_name: str) -> Any:
         raise AttributeError(msg)
 
     # Most logic components were moved to flow_controls
-    # Forward them to flow_controls for backwards compatibility
+    # Forward them to flow_controls for backwards compatibility.
+    # Import the submodule directly rather than `from lfx.components import flow_controls`: neither
+    # flow_controls nor llm_operations is registered in lfx.components._dynamic_imports, so the
+    # `from ... import` form falls into lfx.components.__getattr__ and brute-force imports every
+    # bundle module before giving up.
     if attr_name in (
         "ConditionalRouterComponent",
         "DataConditionalRouterComponent",
@@ -159,7 +163,9 @@ def __getattr__(attr_name: str) -> Any:
         "RunFlowComponent",
         "SubFlowComponent",
     ):
-        from lfx.components import flow_controls
+        from importlib import import_module
+
+        flow_controls = import_module("lfx.components.flow_controls")
 
         result = getattr(flow_controls, attr_name)
         globals()[attr_name] = result
@@ -167,7 +173,9 @@ def __getattr__(attr_name: str) -> Any:
 
     # SmartRouterComponent was moved to llm_operations
     if attr_name == "SmartRouterComponent":
-        from lfx.components import llm_operations
+        from importlib import import_module
+
+        llm_operations = import_module("lfx.components.llm_operations")
 
         result = getattr(llm_operations, attr_name)
         globals()[attr_name] = result

--- a/src/lfx/tests/unit/components/test_legacy_alias_imports.py
+++ b/src/lfx/tests/unit/components/test_legacy_alias_imports.py
@@ -1,0 +1,130 @@
+"""Regression tests for the legacy component alias modules.
+
+``lfx.components.helpers`` and ``lfx.components.logic`` are backwards-compatibility
+shims: the components they advertise now live in ``utilities``, ``flow_controls`` and
+``llm_operations``.  Forwarding used to be written as ``from lfx.components import
+utilities``, which looks harmless but is not -- none of those three target modules is
+registered in ``lfx.components._dynamic_imports``, so the ``from ... import`` form falls
+through to ``lfx.components.__getattr__``, which brute-force imports *every* registered
+bundle module hunting for a name it can never find.
+
+That turned a two-module forward into an eager import of the entire integration tail
+during app startup (``langflow.api.v1.knowledge_bases`` reaches here via
+``memory_base.preprocessing`` -> ``models_and_agents.agent``).  Any third-party package
+with an import-time side effect then owns process startup -- see #14227, where mem0's
+``os.makedirs($HOME/.mem0)`` aborted boot on a read-only Kubernetes filesystem.
+
+Locked here:
+  1. The aliases still resolve to the same classes (no behavioural change).
+  2. Resolving them does not trigger the package-wide discovery scan.
+  3. Discovery itself swallows *any* import failure, not just ``ImportError``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+# Bundle modules that a legacy alias lookup has no business importing. These sit early in
+# the discovery table, so a reintroduced brute-force scan pulls them in first.
+CANARY_BUNDLES = (
+    "lfx.components.mem0",
+    "lfx.components.openai",
+    "lfx.components.anthropic",
+    "lfx.components.chroma",
+)
+
+
+def _run_probe(script: str) -> dict:
+    """Execute ``script`` in a clean interpreter and return its JSON stdout.
+
+    A subprocess is required: discovery state (``_discovered_modules``,
+    ``_dynamic_imports``, ``sys.modules``) is process-global, so any earlier test that
+    touched ``lfx.components`` would mask a regression here.
+    """
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestLegacyAliasesResolve:
+    """The forwards must keep pointing at the modules the components actually live in."""
+
+    def test_helpers_forwards_to_utilities(self):
+        from lfx.components.helpers import CalculatorComponent, CurrentDateComponent, IDGeneratorComponent
+
+        assert CalculatorComponent.__module__ == "lfx.components.utilities.calculator_core"
+        assert CurrentDateComponent.__module__ == "lfx.components.utilities.current_date"
+        assert IDGeneratorComponent.__module__ == "lfx.components.utilities.id_generator"
+
+    def test_logic_forwards_to_flow_controls(self):
+        from lfx.components.logic import ConditionalRouterComponent, LoopComponent
+
+        assert ConditionalRouterComponent.__module__ == "lfx.components.flow_controls.conditional_router"
+        assert LoopComponent.__module__ == "lfx.components.flow_controls.loop"
+
+    def test_logic_forwards_smart_router_to_llm_operations(self):
+        from lfx.components.logic import SmartRouterComponent
+
+        assert SmartRouterComponent.__module__.startswith("lfx.components.llm_operations.")
+
+
+class TestLegacyAliasesDoNotScanBundles:
+    """Resolving a legacy alias must not drag in the integration tail."""
+
+    @pytest.mark.parametrize(
+        ("module", "attr"),
+        [
+            ("lfx.components.helpers", "CalculatorComponent"),
+            ("lfx.components.helpers", "CurrentDateComponent"),
+            ("lfx.components.logic", "ConditionalRouterComponent"),
+            ("lfx.components.logic", "SmartRouterComponent"),
+        ],
+    )
+    def test_alias_lookup_skips_package_wide_discovery(self, module: str, attr: str):
+        probe = _run_probe(
+            "import importlib, json, sys\n"
+            "import lfx.components as pkg\n"
+            f"getattr(importlib.import_module({module!r}), {attr!r})\n"
+            "print(json.dumps({\n"
+            '    "discovered": sorted(pkg._discovered_modules),\n'
+            '    "submodules": sorted(\n'
+            '        m for m in sys.modules if m.startswith("lfx.components.") and m.count(".") == 2\n'
+            "    ),\n"
+            "}))\n"
+        )
+
+        # An empty discovery set is the real assertion: a single entry means __getattr__
+        # started walking the table.
+        assert probe["discovered"] == [], (
+            f"resolving {module}.{attr} triggered package-wide discovery of "
+            f"{len(probe['discovered'])} module(s): {probe['discovered'][:10]}"
+        )
+        leaked = sorted(set(CANARY_BUNDLES) & set(probe["submodules"]))
+        assert not leaked, f"resolving {module}.{attr} imported unrelated bundles: {leaked}"
+
+
+class TestDiscoveryIsBestEffort:
+    """A misbehaving integration must not be able to abort the caller's import."""
+
+    @pytest.mark.parametrize("error", [OSError(30, "Read-only file system"), RuntimeError("boom"), ValueError("bad")])
+    def test_non_import_errors_are_swallowed(self, monkeypatch: pytest.MonkeyPatch, error: Exception):
+        import lfx.components as pkg
+
+        module_name = "_synthetic_failing_module"
+
+        def explode(*_args, **_kwargs):
+            raise error
+
+        monkeypatch.setattr(pkg, "import_mod", explode)
+        monkeypatch.setattr(pkg, "_discovered_modules", set(pkg._discovered_modules))
+
+        pkg._discover_components_from_module(module_name)
+
+        # Marked discovered so the failure is not retried on every subsequent lookup.
+        assert module_name in pkg._discovered_modules


### PR DESCRIPTION
## Summary

Follow-up to #14247. That PR stopped the mem0 component from importing the mem0 SDK at module scope, which fixed the crash in #14227. This PR removes the reason the mem0 module was being imported during startup at all.

`lfx.components.helpers` and `lfx.components.logic` are backwards-compatibility aliases for components that moved to `utilities`, `flow_controls` and `llm_operations`. They forwarded with `from lfx.components import utilities`. None of those three targets is registered in `lfx.components._dynamic_imports`, so the `from ... import` form falls through to `lfx.components.__getattr__`, which brute-force imports **every** registered bundle module hunting for a name it can never find.

Startup walks into this: `langflow/api/v1/knowledge_bases.py` → `api/utils/knowledge_base_service.py` → `services/memory_base/preprocessing.py` → `models_and_agents/agent.py:51` (`from lfx.components.helpers import CalculatorComponent, CurrentDateComponent`). So booting Langflow eagerly imported the whole integration tail, and any third-party package with an import-time side effect owned process startup. In #14227 that was mem0's `os.makedirs($HOME/.mem0)` raising `OSError [Errno 30]` on the Helm chart's read-only filesystem — `_discover_components_from_module` only swallowed `ImportError`/`AttributeError`, so the `OSError` propagated and killed the process.

## Changes

- **`helpers/__init__.py`, `logic/__init__.py`** — forward through a direct `import_module("lfx.components.<target>")`. This is the idiom these same files already use for their submodule forwards (`helpers/__init__.py:76-99`), so it is a local consistency fix as much as a behaviour one. Alias resolution is otherwise unchanged.
- **`components/__init__.py`** — discovery is best-effort by contract, so catch any exception rather than just `ImportError`/`AttributeError`, and log the skip at debug. A broken integration can now only remove its own components from the lookup table; it can't abort the import that triggered the scan.

## Impact

Measured on the real startup path (`import langflow.api.v1.knowledge_bases`, editable install, py3.13):

| | before | after |
|---|---|---|
| `_discover_components_from_module` calls | 95 | 0 |
| `lfx.components.*` submodules imported | 99 | 7 |
| `sys.modules` entries | 8985 | 6226 |

## Tests

New `src/lfx/tests/unit/components/test_legacy_alias_imports.py` (10 tests):

1. The aliases still resolve to the same classes — `helpers` → `utilities`, `logic` → `flow_controls` / `llm_operations`.
2. Resolving an alias does not trigger the package-wide scan. Asserted in a subprocess (discovery state is process-global, so an earlier test touching `lfx.components` would mask a regression) on `_discovered_modules == []`, plus a canary check that unrelated bundles were not imported.
3. Discovery swallows `OSError` / `RuntimeError` / `ValueError`, not just `ImportError`.

Verified the tests are a real guard: with the source changes stashed, 7 of the 10 fail (the 3 resolution tests pass either way, as they should).

```
uv run pytest tests/unit/components/ tests/unit/custom/component/test_dynamic_imports.py tests/unit/test_import_utils.py   # 806 passed, 10 skipped
uv run pytest tests/unit/interface tests/unit/test_component_index.py tests/unit/test_preload.py tests/unit/test_check_components_frozen.py   # 77 passed
uv run pytest src/backend/tests/unit/components/test_all_modules_importable.py   # 17 passed
```

End-to-end: with the pre-#14247 eager `importlib.import_module("mem0")` temporarily restored and `os.makedirs` patched to raise `EROFS` on `.mem0`, `import langflow.api.v1.knowledge_bases` now succeeds — this change alone is sufficient to keep #14227 from reoccurring, and the two fixes are independent layers.

## Notes

Not forward-ported yet — `main` and `release-1.12.0` carry the identical pattern (and the identical eager mem0 import), so both fixes still need to travel forward.

The underlying inconsistency is that `_dynamic_imports` is stale relative to what's on disk: `agentics`, `cometapi`, `data_source`, `files_and_knowledge`, `flow_controls`, `knowledge_bases`, `llm_operations`, `models`, `spider` and `utilities` are all real packages that aren't registered. Registering them would fix this more generally, but it changes which module a component name resolves to when discovery order collides, which is not a patch-release change. Worth doing on `main`.

Fixes #14227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for legacy component aliases, ensuring they resolve to the correct modern components.
  - Prevented alias lookups from triggering unnecessary package-wide component discovery.
  - Component discovery now continues gracefully when individual modules fail, avoiding import-flow interruptions.

- **Tests**
  - Added regression coverage for legacy aliases, discovery isolation, and recovery from unexpected component-loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->