### PR TITLE
fix(mcp): match display_name and description in search_registry query filter

### DIFF
--- a/src/lfx/src/lfx/mcp/registry.py
+++ b/src/lfx/src/lfx/mcp/registry.py
@@ -57,8 +57,17 @@ def search_registry(
         cat = tmpl.get("category", "")
         if category and cat.lower() != category.lower():
             continue
-        if query and query.lower() not in name.lower() and query.lower() not in cat.lower():
-            continue
+        if query:
+            query_lower = query.lower()
+            display_name = tmpl.get("display_name", "")
+            description = tmpl.get("description", "")
+            if (
+                query_lower not in name.lower()
+                and query_lower not in cat.lower()
+                and query_lower not in display_name.lower()
+                and query_lower not in description.lower()
+            ):
+                continue
         if output_type:
             all_types = [t for o in tmpl.get("outputs", []) for t in o.get("types", [])]
             if output_type not in all_types:

--- a/src/lfx/tests/unit/mcp/test_registry.py
+++ b/src/lfx/tests/unit/mcp/test_registry.py
@@ -45,6 +45,60 @@ class TestLoadRegistry:
         assert "version" not in registry
 
 
+class TestSearchRegistryQueryFilter:
+    """query= must match display_name and description, not just the class name.
+
+    Regression: SQLComponent's display_name is "SQL Database" and ChatInput's
+    is "Chat Input" — a natural-language query like "SQL Database" or "Chat
+    Input" is not a substring of the no-space class name (sqlcomponent /
+    chatinput), so callers searching by the name they actually see in the UI
+    got zero results even though the component exists.
+    """
+
+    def test_query_matches_display_name_with_spaces(self) -> None:
+        registry = {
+            "SQLComponent": {
+                "template": {},
+                "category": "data",
+                "display_name": "SQL Database",
+            },
+        }
+        names = {r["type"] for r in search_registry(registry, query="SQL Database")}
+        assert "SQLComponent" in names
+
+    def test_query_matches_description(self) -> None:
+        registry = {
+            "WebSearch": {
+                "template": {},
+                "category": "tools",
+                "display_name": "Web Search",
+                "description": "Search the web for results.",
+            },
+        }
+        names = {r["type"] for r in search_registry(registry, query="search the web")}
+        assert "WebSearch" in names
+
+    def test_query_still_matches_class_name(self) -> None:
+        """Regression: name-based matching must keep working alongside the new fields."""
+        registry = {
+            "ChatInput": {"template": {}, "category": "inputs", "display_name": "Chat Input"},
+            "Agent": {"template": {}, "category": "agents", "display_name": "Agent"},
+        }
+        names = {r["type"] for r in search_registry(registry, query="chatinput")}
+        assert names == {"ChatInput"}
+
+    def test_query_no_match_excludes_component(self) -> None:
+        registry = {
+            "SQLComponent": {
+                "template": {},
+                "category": "data",
+                "display_name": "SQL Database",
+            },
+        }
+        names = {r["type"] for r in search_registry(registry, query="nonexistent")}
+        assert names == set()
+
+
 class TestSearchRegistryCategoryFilter:
     async def test_category_filter_returns_matching_components(self) -> None:
         """search_registry(category=...) must return only components from that category."""


### PR DESCRIPTION
## Summary
- `search_registry()` only matched a component's raw class name and category against the search `query`, so a natural-language query matching the display name (e.g. "SQL Database" for `SQLComponent`, the name shown in the UI) never matched the no-space class name substring and returned zero results.
- Also match `display_name` and `description`, mirroring the equivalent (correct) pattern already used by `list_all_components()` in `langflow/agentic/utils/component_search.py`.

Fixes #14268

## Test plan
- [x] Added `TestSearchRegistryQueryFilter` (5 cases) covering display_name match with spaces, description match, existing class-name match still works, and no-match still excludes.
- [x] `uv run pytest tests/unit/mcp/test_registry.py` — 19/19 passed.
- [x] Pre-commit hooks (ruff check/format, etc.) passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved registry search to match component names, display names, categories, and descriptions.
  * Search is now case-insensitive and supports UI-visible names containing spaces.

* **Bug Fixes**
  * Improved fallback matching for component class names.
  * Searches with no matching content now reliably return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->