### PR TITLE
fix(mcp): make agentic MCP server removal actually delete the row

### DIFF
--- a/src/backend/base/langflow/api/utils/mcp/agentic_mcp.py
+++ b/src/backend/base/langflow/api/utils/mcp/agentic_mcp.py
@@ -151,14 +151,18 @@ async def remove_agentic_mcp_server(session: AsyncSession) -> None:
 
         for user in users:
             try:
-                # Remove the server by passing empty config
+                # An empty config without delete=True would *replace* the config (or even
+                # create an empty-config row for users who never had the server), leaving a
+                # broken entry in the server list. delete=True removes the row; a user
+                # without the server raises HTTPException, caught below.
                 await update_server(
                     server_name=server_name,
-                    server_config={},  # Empty config removes the server
+                    server_config={},
                     current_user=user,
                     session=session,
                     storage_service=storage_service,
                     settings_service=settings_service,
+                    delete=True,
                 )
 
                 servers_removed += 1

--- a/src/backend/tests/unit/api/utils/test_agentic_mcp.py
+++ b/src/backend/tests/unit/api/utils/test_agentic_mcp.py
@@ -1,0 +1,104 @@
+"""Tests for the agentic MCP server removal helper.
+
+``remove_agentic_mcp_server`` previously called ``update_server`` without
+``delete=True`` under a comment claiming "Empty config removes the server". That
+was never true: the call *replaced* the config with ``{}`` for users who had the
+server, and — worse — *created* an empty-config ``langflow-agentic`` row for
+users who never had it (the flag-less call takes the create path when no row
+exists). These tests pin the corrected behavior against a real SQLite DB.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import langflow.services.database.models  # noqa: F401  (register SQLModel tables)
+import pytest
+from langflow.api.utils.mcp.agentic_mcp import remove_agentic_mcp_server
+from langflow.api.v2.mcp import get_server_list, update_server
+from langflow.services.database.models import MCPServer
+from langflow.services.database.models.user.model import User
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel.pool import StaticPool
+
+# _clear_server_cache() calls the shared component cache service, which isn't booted
+# in a bare unit test; no-op it (orthogonal to the behavior under test).
+CACHE_PATCH = {
+    "get_shared_component_cache_service": MagicMock(return_value=SimpleNamespace()),
+    "safe_cache_get": MagicMock(return_value={}),
+    "safe_cache_set": MagicMock(),
+}
+
+# remove_agentic_mcp_server resolves storage/settings services at call time; neither
+# is used by the DB-backed update_server, so plain mocks suffice.
+SERVICE_PATCH = {
+    "get_service": MagicMock(return_value=MagicMock()),
+    "get_settings_service": MagicMock(return_value=MagicMock()),
+}
+
+
+async def _engine():
+    engine = create_async_engine("sqlite+aiosqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    return engine
+
+
+async def _add_user(session: AsyncSession, username: str) -> User:
+    user = User(id=uuid.uuid4(), username=username, password="pw", is_active=True)  # noqa: S106
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_remove_agentic_mcp_server_removes_row():
+    """Removal deletes the langflow-agentic row and leaves other servers untouched."""
+    engine = await _engine()
+
+    with patch.multiple("langflow.api.v2.mcp", **CACHE_PATCH):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            user = await _add_user(session, "agentic_user")
+            await update_server(
+                "langflow-agentic",
+                {"command": "python", "args": ["-m", "langflow.agentic.mcp"]},
+                user,
+                session,
+                None,
+                None,
+            )
+            await update_server("other", {"url": "https://example.com/mcp"}, user, session, None, None)
+
+            with patch.multiple("langflow.api.utils.mcp.agentic_mcp", **SERVICE_PATCH):
+                await remove_agentic_mcp_server(session)
+
+            servers = (await get_server_list(user, session, None, None))["mcpServers"]
+
+    await engine.dispose()
+    assert "langflow-agentic" not in servers, f"agentic server must be removed, got {sorted(servers)}"
+    assert "other" in servers, "removal must not touch unrelated servers"
+    assert servers["other"] == {"url": "https://example.com/mcp"}
+
+
+@pytest.mark.asyncio
+async def test_remove_agentic_mcp_server_absent_is_noop():
+    """A user without the server must not gain an empty-config row, and removal must not raise.
+
+    The pre-fix flag-less call created a `langflow-agentic` row with `{}` config for such
+    users (create path of update_server), surfacing a broken entry in the servers list.
+    """
+    engine = await _engine()
+
+    with patch.multiple("langflow.api.v2.mcp", **CACHE_PATCH):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            user = await _add_user(session, "no_server_user")
+
+            with patch.multiple("langflow.api.utils.mcp.agentic_mcp", **SERVICE_PATCH):
+                await remove_agentic_mcp_server(session)
+
+            rows = (await session.exec(select(MCPServer).where(MCPServer.user_id == user.id))).all()
+
+    await engine.dispose()
+    assert rows == [], f"no row may be created for a user who never had the server, got {rows}"


### PR DESCRIPTION
## Problem

`remove_agentic_mcp_server` "removes" the `langflow-agentic` MCP server by calling `update_server` with an empty config, under a comment claiming "Empty config removes the server". That has never been true — for either the DB-backed store or the old file-based one:

- users who **had** the server are left with a `{}`-config row (the flag-less call is a full replace), and
- users who **never had it** *gain* a brand-new empty-config row (the call takes the create path when no row exists).

Either way, a broken `langflow-agentic` entry surfaces in the user's MCP servers list.

Mitigating factor: the helper currently has no callers on `main` or `release-1.12.0` (the agentic-experience disable path was never wired up), so nothing ships the broken behavior today. This fixes the latent utility and pins its semantics before anything wires it up. Found while tracing `update_server` callers during review of #14005.

## Fix

Pass `delete=True` so the row is actually removed. A user without the server raises `HTTPException` from the delete path, which the existing per-user `except`/`continue` block already handles — and `servers_removed` now counts only actual removals.

## Tests

`src/backend/tests/unit/api/utils/test_agentic_mcp.py` — real functions against a real SQLite DB, in the style of `test_mcp_db_store.py`:

- removal deletes the `langflow-agentic` row and leaves the user's other servers untouched
- a user without the server gains no empty-config row, and no error propagates

- [x] Both tests fail against the unfixed code (verified red) and pass with the fix (verified green)
- [x] Existing `test_mcp_db_store.py` suite passes alongside
- [x] ruff lint/format clean; pre-commit hooks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected removal of the agentic MCP server so deleted entries are fully removed.
  * Prevented empty or broken server entries from being created when no matching server exists.

* **Tests**
  * Added coverage verifying successful removal while preserving other MCP servers.
  * Added coverage confirming removal is safely ignored when no matching entry exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->