### PR TITLE
fix(components): send chained input as user turn

### DIFF
--- a/src/lfx/src/lfx/base/models/chat_result.py
+++ b/src/lfx/src/lfx/base/models/chat_result.py
@@ -2,10 +2,23 @@ import warnings
 from collections.abc import Callable
 from typing import Any
 
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
 from lfx.field_typing.constants import LanguageModel
 from lfx.schema.message import Message
+
+
+def _as_user_turn(message: BaseMessage) -> BaseMessage:
+    """Send the component's input as a user turn even when it came from an upstream model.
+
+    A Language Model chained after an Agent receives that agent's response
+    (sender=Machine → AIMessage) as its input. Sending it unchanged makes the request
+    end on a model turn, which Gemini rejects with 400 "Requests ending with a model
+    turn are not supported".
+    """
+    if isinstance(message, AIMessage):
+        return HumanMessage(content=message.content)
+    return message
 
 
 def build_messages_and_runnable(
@@ -29,7 +42,7 @@ def build_messages_and_runnable(
                         system_message_added = True
                     runnable = prompt | runnable
                 else:
-                    messages.append(input_value.to_lc_message())
+                    messages.append(_as_user_turn(input_value.to_lc_message()))
         else:
             messages.append(HumanMessage(content=input_value))
 

--- a/src/lfx/src/lfx/components/models_and_agents/agent_helpers/messages_input_builder.py
+++ b/src/lfx/src/lfx/components/models_and_agents/agent_helpers/messages_input_builder.py
@@ -7,7 +7,7 @@ helper performs the conversion.
 
 from collections.abc import Iterable
 
-from langchain_core.messages import BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
 from lfx.log.logger import logger
 from lfx.schema.data import Data
@@ -26,10 +26,7 @@ def build_initial_messages(
 
     if chat_history is not None:
         for item in _normalize_history(chat_history):
-            # Mirror the current-turn guard in `_append_input`: a blank-text item is
-            # only truly empty when it ALSO has no files. An image-only message from a
-            # prior turn (text="", files=[image]) must survive — dropping it silently
-            # loses multimodal context on the next turn.
+            # Files-aware blank guard (mirrors `_append_input`): an image-only prior turn must survive.
             if _has_blank_text(item) and not getattr(item, "files", None):
                 continue
             converted = _safe_to_lc_message(item)
@@ -37,10 +34,8 @@ def build_initial_messages(
                 messages.append(converted)
 
     if not _append_input(messages, input_value):
-        # No fresh user input this turn. Always inject a deterministic continuation
-        # prompt — never let blank content reach the provider, and never let the LLM
-        # see a tail-AIMessage with no fresh user turn (causes silent re-execution
-        # of earlier tool calls).
+        # No fresh user turn: inject a deterministic prompt — blank content or a tail
+        # AIMessage makes providers fail or silently re-run earlier tool calls.
         messages.append(HumanMessage(content=CONTINUE_MESSAGE))
 
     return messages
@@ -65,11 +60,21 @@ def _append_input(messages: list[BaseMessage], input_value: Message | str | None
     A Message with blank text is still appended when files are attached — the file
     payload IS the input. `Message.to_lc_message()` builds the multimodal HumanMessage
     correctly in that case.
+
+    The input always lands as a user turn, even when it comes from an upstream Agent
+    (sender=Machine → `to_lc_message()` yields AIMessage). Chained agents such as the
+    Multi Agent Flow template would otherwise send a request ENDING in a model turn,
+    which Gemini rejects with 400 "Requests ending with a model turn are not supported".
+    The legacy AgentExecutor path rendered the input as a ("human", "{input}") turn
+    regardless of sender; this preserves that contract on the LangGraph path.
     """
     if isinstance(input_value, Message):
         if _has_blank_text(input_value) and not getattr(input_value, "files", None):
             return False
-        messages.append(input_value.to_lc_message())
+        lc_message = input_value.to_lc_message()
+        if isinstance(lc_message, AIMessage):
+            lc_message = HumanMessage(content=lc_message.content)
+        messages.append(lc_message)
         return True
     if isinstance(input_value, str):
         if not input_value.strip():

--- a/src/lfx/tests/unit/base/models/test_chat_result_messages.py
+++ b/src/lfx/tests/unit/base/models/test_chat_result_messages.py
@@ -1,0 +1,60 @@
+"""Tests for build_messages_and_runnable — the Language Model component's input contract.
+
+A Language Model chained after an Agent (or another Language Model) receives an
+AI-sender Message as its input_value. That input is THIS component's task, so it must
+be sent as a user turn: Gemini rejects any request whose last turn is a model turn with
+400 "Requests ending with a model turn are not supported".
+"""
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from lfx.base.models.chat_result import build_messages_and_runnable
+from lfx.schema.message import Message
+from lfx.utils.constants import MESSAGE_SENDER_AI, MESSAGE_SENDER_USER
+
+
+def _chat_model() -> FakeListChatModel:
+    """A real LanguageModel; build_messages_and_runnable only passes it through."""
+    return FakeListChatModel(responses=["ok"])
+
+
+def test_should_keep_user_message_as_human_turn() -> None:
+    runnable = _chat_model()
+
+    messages, returned = build_messages_and_runnable(
+        input_value=Message(text="What is 2+2?", sender=MESSAGE_SENDER_USER),
+        system_message=None,
+        original_runnable=runnable,
+    )
+
+    assert returned is runnable
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "What is 2+2?"
+
+
+def test_should_convert_ai_sender_input_to_human_turn_when_chained_from_upstream_component() -> None:
+    """An upstream Agent's output must not become the trailing model turn of the request."""
+    messages, _ = build_messages_and_runnable(
+        input_value=Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI),
+        system_message=None,
+        original_runnable=_chat_model(),
+    )
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage), "chained input must be sent as a user turn"
+    assert not isinstance(messages[0], AIMessage)
+    assert messages[0].content == "Idea: an AI-powered plant sitter."
+
+
+def test_should_end_with_human_turn_when_ai_sender_input_has_system_message() -> None:
+    """The system message is prepended, so the AI-sender input is the tail turn."""
+    messages, _ = build_messages_and_runnable(
+        input_value=Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI),
+        system_message="You are a business analyst.",
+        original_runnable=_chat_model(),
+    )
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], SystemMessage)
+    assert isinstance(messages[-1], HumanMessage), "request must never end with a model turn"

--- a/src/lfx/tests/unit/components/models_and_agents/agent_helpers/test_messages_input_builder.py
+++ b/src/lfx/tests/unit/components/models_and_agents/agent_helpers/test_messages_input_builder.py
@@ -249,6 +249,40 @@ def test_should_propagate_non_value_error_from_to_lc_message() -> None:
         build_initial_messages(input_value="ping", chat_history=history)
 
 
+def test_should_convert_ai_sender_input_to_human_message_when_chained_from_upstream_agent() -> None:
+    """Chained agents: an upstream Agent's output is THIS agent's task, i.e. a user turn.
+
+    Multi Agent Flow bug: Agent 1's response Message (sender=Machine) flows into Agent 2's
+    input_value. `to_lc_message()` maps sender=Machine to AIMessage, so the request sent to
+    the provider ENDED with a model turn. Gemini rejects that outright with
+    400 "Requests ending with a model turn are not supported". The legacy AgentExecutor
+    path rendered the input as a ("human", "{input}") turn regardless of sender; the
+    LangGraph path must preserve that contract.
+    """
+    upstream_response = Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI)
+
+    messages = build_initial_messages(input_value=upstream_response, chat_history=None)
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage), "input_value must always land as a user turn"
+    assert _content_text(messages[0]) == "Idea: an AI-powered plant sitter."
+
+
+def test_should_end_with_human_turn_when_ai_sender_input_follows_history() -> None:
+    """With history present, an AI-sender input must still leave the tail as a user turn."""
+    history = [
+        Data(text="give me a product idea", sender=MESSAGE_SENDER_USER),
+    ]
+    upstream_response = Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI)
+
+    messages = build_initial_messages(input_value=upstream_response, chat_history=history)
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[-1], HumanMessage), "request must never end with a model turn"
+    assert _content_text(messages[-1]) == "Idea: an AI-powered plant sitter."
+
+
 def test_should_skip_malformed_chat_history_items_without_crashing_the_turn() -> None:
     """Malformed `Data` entries in chat_history are skipped, not fatal.
 


### PR DESCRIPTION
The Multi Agent Flow starter template fails to run on Google Gemini with `400 INVALID_ARGUMENT — "Requests ending with a model turn are not supported"`, while the same model and key work fine in a single-agent flow.

Chained components send the upstream Agent's response as the next component's `input_value`. That `Message` carries `sender="Machine"`, so `to_lc_message()` converts it to an `AIMessage` and it lands as the final message of the request — the request ends on a model turn, which Gemini rejects outright. A single Agent never chains, so its request ends on a user turn and succeeds.

This is a regression from the migration to `create_agent` (LangGraph). The legacy `AgentExecutor` path extracted the input's text and rendered it through a `("human", "{input}")` prompt slot, so the input was always a user turn regardless of sender. `build_initial_messages` lost that normalization.

## Changes

The input of a component is that component's task, so it is always sent as a user turn:

- `messages_input_builder.py` — `_append_input` downgrades an `AIMessage` input to `HumanMessage` (Agent / LangGraph path).
- `chat_result.py` — new `_as_user_turn` helper applied when building messages (Language Model component path, which had the identical defect: a Language Model chained after an Agent failed the same way).

No component class, input, or output was renamed or removed, and no API changed — saved flows keep working. Because `agent.py` imports the builder from the live module, the fix also reaches flows that embed older serialized component code.

## Testing

Five new tests, each failing before the change with the reported symptom:

- `test_messages_input_builder.py` — AI-sender input lands as a user turn, standalone and after history.
- `test_chat_result_messages.py` — same contract for the Language Model path, including with a system message.

`434 passed` across `tests/unit/base/models/` and `tests/unit/components/models_and_agents/`, plus `16 passed` in the backend Language Model component tests. Ruff check and format clean.

End-to-end validation of the actual starter template:

- **Real provider:** ran the Multi Agent Flow with OpenAI `gpt-4o-mini` on all three Agents against the live API — the chain completes and produces a coherent final response.
- **Gemini contract:** ran the same template through a real Langflow backend with `langchain-google-genai` pointed at a local server enforcing Google's documented rule. Without the fix the run fails with the exact reported error and the second call's turns are `['user', 'model']`; with the fix all three calls end on `user` and the flow completes.

Fixes the Multi Agent Flow + Gemini failure reported for 1.11.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chained agent and model interactions by ensuring requests end with a user message rather than an AI-generated message.
  * Prevented downstream model errors when processing responses from upstream components.
  * Preserved system messages, chat history, file attachments, and continuation prompts during message preparation.

* **Tests**
  * Added coverage for user and AI-originated inputs, system messages, chat history, and chained-agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->