### PR TITLE
fix(a11y): resolve Lighthouse button-name and aria-valid-attr-value failures in output modal

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/__tests__/outputModal.a11y.test.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/__tests__/outputModal.a11y.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { axe } from "@/utils/a11y-test";
+import OutputModal from "../index";
+
+// Lighthouse flagged two real violations on this modal:
+//   1. button-name — the copy button was icon-only with no aria-label.
+//   2. aria-valid-attr-value — the active TabsTrigger's aria-controls pointed
+//      at a TabsContent id that never existed, because this modal drove its
+//      panel content from a sibling <SwitchOutputView> instead of real
+//      TabsContent elements. Fixed by pairing each TabsTrigger with a real
+//      TabsContent (Radix's expected trigger/content contract), matching the
+//      pattern in components/ui/__tests__/tabs.a11y.test.tsx.
+//
+// SwitchOutputView is mocked here — its internals (data grids, JSON views,
+// text views) are unrelated to the two ARIA fixes under test and drag in
+// heavy dependencies; it has no bearing on the modal's own tab/button ARIA.
+jest.mock("../components/switchOutputView", () => ({
+  __esModule: true,
+  default: ({ type }: { type: string }) => (
+    <div data-testid={`switch-output-view-${type}`}>{type} content</div>
+  ),
+}));
+
+// The global jest.setup.js mock for genericIconComponent only stubs the
+// default export, not the named ForwardedIconComponent OutputModal uses.
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: () => null,
+  ForwardedIconComponent: ({ name }: { name?: string }) => (
+    <span data-testid={`icon-${name}`} aria-hidden="true" />
+  ),
+}));
+
+const mockFlowPool = {
+  "node-1": [
+    {
+      data: {
+        outputs: { output_name: { message: "output content" } },
+        logs: { output_name: { message: "log content" } },
+      },
+    },
+  ],
+};
+
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { flowPool: typeof mockFlowPool }) => unknown) =>
+    selector({ flowPool: mockFlowPool }),
+}));
+
+const mockSetSuccessData = jest.fn();
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (
+    selector: (state: { setSuccessData: typeof mockSetSuccessData }) => unknown,
+  ) => selector({ setSuccessData: mockSetSuccessData }),
+}));
+
+// userEvent.setup() installs its own navigator.clipboard stub, replacing
+// any predefined one — so the writeText spy must be created after setup().
+const spyOnWriteText = () =>
+  jest.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+const renderModal = () =>
+  render(
+    <TooltipProvider>
+      <OutputModal
+        nodeId="node-1"
+        outputName="output_name"
+        disabled={false}
+        open={true}
+        setOpen={jest.fn()}
+      >
+        <button type="button">Open</button>
+      </OutputModal>
+    </TooltipProvider>,
+  );
+
+describe("OutputModal accessibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should_have_no_axe_violations", async () => {
+    const { container } = renderModal();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("names the icon-only copy button after the active tab's content", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    expect(screen.getByTestId("copy-output-button")).toHaveAccessibleName(
+      "Copy output",
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Logs" }));
+
+    expect(screen.getByTestId("copy-output-button")).toHaveAccessibleName(
+      "Copy logs",
+    );
+  });
+
+  it("gives the active tab trigger a valid aria-controls reference", () => {
+    renderModal();
+
+    const outputsTab = screen.getByRole("tab", { name: "Outputs" });
+    const controlsId = outputsTab.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).toBeInTheDocument();
+  });
+
+  // Regression guard: the pill-shaped tab switcher must stay visually
+  // isolated (absolute/overflow-hidden) to the trigger buttons only. Content
+  // was briefly nested inside that same constrained box while wiring up
+  // TabsContent, which clipped the output panel instead of letting it fill
+  // the modal.
+  it("does not trap the tab content panel inside the switcher's constrained box", () => {
+    renderModal();
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel.className).not.toMatch(/\boverflow-hidden\b/);
+    expect(panel.className).not.toMatch(/\babsolute\b/);
+  });
+
+  // Regression guard: TabsList's own base class includes w-full. That was
+  // previously inert (only the outer pill div's shrink-to-fit width
+  // mattered), but once TabsList itself became the absolutely positioned
+  // element, an unoverridden w-full stretches the switcher to the full
+  // modal width instead of staying pill-sized.
+  it("keeps the tab switcher pill-sized instead of stretching full width", () => {
+    renderModal();
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist.className).not.toMatch(/\bw-full\b/);
+  });
+
+  // Regression guard: TabsList clips overflow, so a default outset browser
+  // focus outline on TabsTrigger gets cut off and keyboard focus becomes
+  // invisible. Each trigger needs its own inset focus-visible ring, which
+  // renders within the trigger's box and can't be clipped by the ancestor.
+  it("gives each tab trigger a visible, non-clippable focus-visible ring", () => {
+    renderModal();
+
+    for (const tab of screen.getAllByRole("tab")) {
+      expect(tab.className).toMatch(/\bfocus-visible:ring-inset\b/);
+      expect(tab.className).toMatch(/\bfocus-visible:ring-2\b/);
+    }
+  });
+});
+
+describe("OutputModal behavior parity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("defaults to the Outputs tab content", () => {
+    renderModal();
+
+    expect(
+      screen.getByTestId("switch-output-view-outputs"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("switch-output-view-logs"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches panel content when the Logs tab is selected", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("tab", { name: "Logs" }));
+
+    expect(screen.getByTestId("switch-output-view-logs")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("switch-output-view-outputs"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("copies the active tab's content, defaulting to outputs", async () => {
+    const user = userEvent.setup();
+    const writeText = spyOnWriteText();
+    renderModal();
+
+    await user.click(screen.getByTestId("copy-output-button"));
+
+    expect(writeText).toHaveBeenCalledWith("output content");
+  });
+
+  it("copies the logs content after switching to the Logs tab", async () => {
+    const user = userEvent.setup();
+    const writeText = spyOnWriteText();
+    renderModal();
+
+    await user.click(screen.getByRole("tab", { name: "Logs" }));
+    await user.click(screen.getByTestId("copy-output-button"));
+
+    expect(writeText).toHaveBeenCalledWith("log content");
+  });
+});

--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/components/switchOutputView/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/components/switchOutputView/index.tsx
@@ -13,13 +13,14 @@ import {
 import { Case } from "../../../../../../shared/components/caseComponent";
 import TextOutputView from "../../../../../../shared/components/textOutputView";
 import useFlowStore from "../../../../../../stores/flowStore";
+import type { OutputModalTab } from "../../index";
 import ErrorOutput from "./components";
 
 // Define the props type
 interface SwitchOutputViewProps {
   nodeId: string;
   outputName: string;
-  type: "Outputs" | "Logs";
+  type: OutputModalTab;
 }
 
 const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
@@ -48,7 +49,7 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
       (outputConfig.types && outputConfig.types.includes("Tool")));
 
   const results: OutputLogType | LogsLogType[] =
-    (type === "Outputs"
+    (type === "outputs"
       ? flowPoolNode?.data?.outputs?.[outputName]
       : flowPoolNode?.data?.logs?.[outputName]) ?? {};
   const resultType = Array.isArray(results) ? undefined : results?.type;
@@ -132,7 +133,7 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
     );
   };
 
-  return type === "Outputs" ? (
+  return type === "outputs" ? (
     <>
       <Case condition={isToolOutput && resultMessageMemoized}>
         <ToolOutputDisplay

--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import BaseModal from "../../../../modals/baseModal";
 import SwitchOutputView from "./components/switchOutputView";
+
+export type OutputModalTab = "outputs" | "logs";
 
 export default function OutputModal({
   nodeId,
@@ -17,7 +19,7 @@ export default function OutputModal({
   setOpen,
 }): JSX.Element {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<"Outputs" | "Logs">("Outputs");
+  const [activeTab, setActiveTab] = useState<OutputModalTab>("outputs");
   const [isCopied, setIsCopied] = useState(false);
   const flowPool = useFlowStore((state) => state.flowPool);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
@@ -28,13 +30,13 @@ export default function OutputModal({
     ];
 
     const results =
-      activeTab === "Outputs"
+      activeTab === "outputs"
         ? flowPoolNode?.data?.outputs?.[outputName]
         : flowPoolNode?.data?.logs?.[outputName];
 
     if (!results) return "";
 
-    let content = results.message ?? results;
+    let content = (!Array.isArray(results) && results.message) ? results.message : results;
     content = content?.raw ?? content;
 
     return typeof content === "string"
@@ -77,6 +79,11 @@ export default function OutputModal({
           className="absolute right-12 top-2 p-2"
           onClick={handleCopy}
           data-testid="copy-output-button"
+          aria-label={
+            activeTab === "outputs"
+              ? t("output.copyOutputAria")
+              : t("output.copyLogsAria")
+          }
         >
           <ForwardedIconComponent
             name={isCopied ? "Check" : "Copy"}
@@ -87,24 +94,38 @@ export default function OutputModal({
       <BaseModal.Content>
         <Tabs
           value={activeTab}
-          onValueChange={(value) => setActiveTab(value as "Outputs" | "Logs")}
-          className={
-            "absolute top-6 flex flex-col self-center overflow-hidden rounded-md border bg-muted text-center"
-          }
+          onValueChange={(value) => setActiveTab(value as OutputModalTab)}
+          className="flex h-full w-full flex-1 flex-col"
         >
-          <TabsList>
-            <TabsTrigger value="Outputs">
+          <TabsList className="absolute top-6 flex w-fit self-center overflow-hidden rounded-md border bg-muted text-center">
+            <TabsTrigger
+              value="outputs"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            >
               {t("misc.outputsModalTitle")}
             </TabsTrigger>
-            <TabsTrigger value="Logs">{t("modal.logs")}</TabsTrigger>
+            <TabsTrigger
+              value="logs"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            >
+              {t("modal.logs")}
+            </TabsTrigger>
           </TabsList>
+          <TabsContent value="outputs" className="mt-0 flex-1 overflow-auto">
+            <SwitchOutputView
+              nodeId={nodeId}
+              outputName={outputName}
+              type="outputs"
+            />
+          </TabsContent>
+          <TabsContent value="logs" className="mt-0 flex-1 overflow-auto">
+            <SwitchOutputView
+              nodeId={nodeId}
+              outputName={outputName}
+              type="logs"
+            />
+          </TabsContent>
         </Tabs>
-
-        <SwitchOutputView
-          nodeId={nodeId}
-          outputName={outputName}
-          type={activeTab}
-        />
       </BaseModal.Content>
       <BaseModal.Footer close></BaseModal.Footer>
       <BaseModal.Trigger asChild>{children}</BaseModal.Trigger>

--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
@@ -36,7 +36,8 @@ export default function OutputModal({
 
     if (!results) return "";
 
-    let content = (!Array.isArray(results) && results.message) ? results.message : results;
+    let content =
+      !Array.isArray(results) && results.message ? results.message : results;
     content = content?.raw ?? content;
 
     return typeof content === "string"

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "Doppelklicken Sie, um mit der Eingabe zu beginnen, oder geben Sie Markdown ein...",
   "noteNode.pickColor": "Farbe auswählen",
   "output.componentOutput": "Komponentenausgang",
+  "output.copyOutputAria": "Ausgabe kopieren",
+  "output.copyLogsAria": "Protokolle kopieren",
   "output.csvError": "Fehler beim Laden von CSV",
   "output.csvNoData": "Keine Daten verfügbar",
   "output.csvTitle": "CSV Ausgabe",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1696,6 +1696,8 @@
   "output.noToolsAvailable": "No tools available",
   "output.noOutput": "NO OUTPUT",
   "output.componentOutput": "Component Output",
+  "output.copyOutputAria": "Copy output",
+  "output.copyLogsAria": "Copy logs",
   "modal.sessionLogs": "Session logs",
   "modal.flowDetails": "Flow Details",
   "modal.viewText": "View Text",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "Haz doble clic para empezar a escribir o introduce código Markdown...",
   "noteNode.pickColor": "Elige un color",
   "output.componentOutput": "Salida de componentes",
+  "output.copyOutputAria": "Copiar salida",
+  "output.copyLogsAria": "Copiar registros",
   "output.csvError": "Error al cargar CSV",
   "output.csvNoData": "No hay datos disponibles",
   "output.csvTitle": "CSV resultado",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "Double-cliquez pour commencer à taper ou entrez du code Markdown...",
   "noteNode.pickColor": "Choisissez une couleur",
   "output.componentOutput": "Sortie composante",
+  "output.copyOutputAria": "Copier la sortie",
+  "output.copyLogsAria": "Copier les journaux",
   "output.csvError": "Erreur lors du chargement de CSV",
   "output.csvNoData": "Aucune donnée disponible",
   "output.csvTitle": "CSV résultat",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "ダブルクリックして入力を開始するか、Markdownを入力してください...",
   "noteNode.pickColor": "色を選ぶ",
   "output.componentOutput": "コンポーネント出力",
+  "output.copyOutputAria": "出力をコピー",
+  "output.copyLogsAria": "ログをコピー",
   "output.csvError": "CSV の読み込みに失敗しました",
   "output.csvNoData": "使用可能なデータがありません",
   "output.csvTitle": "CSV 出力",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "Clique duas vezes para começar a digitar ou insira Markdown...",
   "noteNode.pickColor": "Escolha a cor",
   "output.componentOutput": "Saída do componente",
+  "output.copyOutputAria": "Copiar saída",
+  "output.copyLogsAria": "Copiar logs",
   "output.csvError": "Erro ao carregar CSV",
   "output.csvNoData": "Nenhum dado disponível",
   "output.csvTitle": "CSV saída",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1681,6 +1681,8 @@
   "noteNode.emptyPlaceholder": "双击开始输入或输入 Markdown 代码...",
   "noteNode.pickColor": "选择颜色",
   "output.componentOutput": "分量输出",
+  "output.copyOutputAria": "复制输出",
+  "output.copyLogsAria": "复制日志",
   "output.csvError": "加载 CSV 时出错",
   "output.csvNoData": "无可用数据",
   "output.csvTitle": "CSV 输出",


### PR DESCRIPTION
## Summary

Fixes two Lighthouse accessibility failures on the component output modal (Outputs/Logs tabs + copy-to-clipboard button):

- **`button-name`** — the icon-only copy button had no accessible name.
- **`aria-valid-attr-value`** — the tab switcher's `aria-controls` pointed at a panel element that never existed.

## What changed

- **Copy button naming**: added `aria-label` to the copy button, dynamically reflecting the active tab — "Copy output" on the Outputs tab, "Copy logs" on the Logs tab — since the button copies whatever tab is currently showing.
- **Tab/panel ARIA linkage**: paired each `TabsTrigger` with a matching `TabsContent` (Radix's expected trigger/content contract). Previously the panel content (`SwitchOutputView`) was a disconnected sibling driven by manual string branching, so Radix's auto-generated `aria-controls` referenced a nonexistent id.
- **Internal tab identifiers normalized**: `"Outputs"/"Logs"` → lowercase `"outputs"/"logs"`, decoupled from the translated visible labels. Extracted as an exported `OutputModalTab` type shared between `outputModal/index.tsx` and `switchOutputView/index.tsx` instead of duplicating the union.
- **Layout regression fix**: the real output content briefly ended up nested inside the small, `overflow-hidden`, absolutely-positioned pill meant only for the switcher buttons. Fixed by scoping that constrained styling to `TabsList` alone and giving `Tabs`/`TabsContent` a proper `flex-1` chain so the content fills the modal again.
- **Focus-visibility fix**: `TabsList`'s `overflow-hidden` was clipping the browser's default focus outline on the tab triggers. Replaced with an inset focus ring (`focus-visible:ring-2 focus-visible:ring-inset`), which renders inside the trigger's own box and can't be clipped.
- **Translations**: added `output.copyOutputAria` and `output.copyLogsAria` across all 7 locales (en, de, es, fr, ja, pt, zh-Hans).
- **Tests**: new `outputModal.a11y.test.tsx` (10 tests) — axe checks, accessible-name correctness per tab, `aria-controls` validity, tab-switch/copy behavior parity, and regression guards for the layout and focus-ring fixes.

## How QA can test

**Automated**
cd src/frontend
npx jest src/CustomNodes/GenericNode/components/outputModal --no-coverage
npx tsc --noEmit


Expect all 10 tests passing, no new type errors.

**Manual — copy button naming**
1. Run a flow so a component has output data, open its output modal.
2. Turn on a screen reader (VoiceOver on Mac: `Cmd+F5`) and Tab to the copy button.
3. Confirm it announces "Copy output" while the Outputs tab is active.
4. Switch to the Logs tab (see keyboard steps below) and Tab back to the copy button — confirm it now announces "Copy logs".
5. Click copy in each tab state and confirm the clipboard contents match what's actually shown (Outputs vs Logs).

**Manual — tab switcher keyboard behavior**
1. Tab into the modal until focus lands on the active tab trigger ("Outputs").
2. Press `Tab` again — focus should leave the tablist entirely (move to the panel content), **not** jump to "Logs". This is expected per the ARIA tabs pattern.
3. Tab back to the "Outputs" trigger, then use `Left`/`Right` arrow keys — focus and selection should move between Outputs and Logs.
4. Confirm a visible focus ring appears on whichever tab is focused at every step (this was previously invisible due to clipping).

**Manual — layout**
1. Open the output modal and confirm the output/log content still fills the full modal height, same as before this change (no clipping or empty space).
2. Confirm the Outputs/Logs switcher stays a small, centered pill at the top — not stretched to the full width of the modal.

**Manual — translations**
1. Switch the app language to each of de/es/fr/ja/pt/zh-Hans.
2. Open the output modal and confirm the copy button's accessible name (screen reader) and any visible tab labels are translated, not raw i18n keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved the output modal’s accessibility with descriptive, tab-specific copy button labels.
  - Enhanced tab navigation, focus styling, and panel associations for screen readers and keyboard users.

- **Bug Fixes**
  - Improved switching between Outputs and Logs views.
  - Copying now consistently copies content from the currently selected tab.

- **Localization**
  - Added translated accessibility labels for copying outputs and logs across supported languages.

- **Tests**
  - Added coverage for accessibility compliance, tab behavior, focus states, and clipboard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->