### PR TITLE
refactor(frontend): add customization seam for A2A publish origin

### DIFF
--- a/src/frontend/src/customization/utils/custom-a2a-address.ts
+++ b/src/frontend/src/customization/utils/custom-a2a-address.ts
@@ -1,0 +1,3 @@
+export function customA2aPublishOrigin(): string {
+  return window.location.origin;
+}

--- a/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
+++ b/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
@@ -20,6 +20,7 @@ import {
   overridesToForm,
 } from "@/controllers/API/queries/a2a/utils";
 import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
+import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -30,7 +31,6 @@ import {
   cardInputContract,
   cardRequiresApiKey,
 } from "../types";
-import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 
 const errorDetail = (e: unknown, fallback: string): string => {
   const err = e as {
@@ -74,7 +74,7 @@ export default function AgentCardPanel({
 
   const flowId = currentFlow?.id ?? "";
   const isPublished = !!currentFlow?.a2a_enabled;
-  
+
   const publishOrigin = customA2aPublishOrigin();
   const cardUrl = `${publishOrigin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
   const rpcUrl = `${publishOrigin}/api/v1/a2a/${flowId}/jsonrpc`;

--- a/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
+++ b/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
@@ -30,6 +30,7 @@ import {
   cardInputContract,
   cardRequiresApiKey,
 } from "../types";
+import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 
 const errorDetail = (e: unknown, fallback: string): string => {
   const err = e as {
@@ -73,8 +74,10 @@ export default function AgentCardPanel({
 
   const flowId = currentFlow?.id ?? "";
   const isPublished = !!currentFlow?.a2a_enabled;
-  const cardUrl = `${window.location.origin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
-  const rpcUrl = `${window.location.origin}/api/v1/a2a/${flowId}/jsonrpc`;
+  
+  const publishOrigin = customA2aPublishOrigin();
+  const cardUrl = `${publishOrigin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
+  const rpcUrl = `${publishOrigin}/api/v1/a2a/${flowId}/jsonrpc`;
 
   const [enabled, setEnabled] = useState(isPublished);
   const [form, setForm] = useState<A2ACardForm>(
@@ -107,10 +110,8 @@ export default function AgentCardPanel({
     try {
       const updatedFlow = await mutateAsync({
         id: flowId,
-        // flow_type is derived from the graph (has chat I/O = agent). Write it
-        // here so the langflow A2A serve guard passes; an ineligible flow can
-        // never be served, so force it off. (Backend derive-on-save is a
-        // follow-up; today the tab is the only place that recomputes it.)
+        // flow_type derived from graph chat I/O so the langflow A2A serve guard
+        // passes; an ineligible flow can never be served, so force it off.
         flow_type: eligible ? "agent" : "workflow",
         a2a_enabled: eligible ? enabled : false,
         a2a_card_overrides: formToOverrides(form),
@@ -174,9 +175,8 @@ export default function AgentCardPanel({
             variant: "secondaryStatic" as const,
           };
 
-  // What to tell the user when the flow can't serve: the server switch wins,
-  // then eligibility (a published flow that lost its chat I/O needs turning
-  // off; a draft one just needs the missing half added).
+  // Banner precedence: server switch wins, then eligibility (published flows
+  // that lost chat I/O need turning off; drafts just need the missing half).
   const banner = !serverEnabled
     ? t("agentTab.serverDisabled")
     : !eligible


### PR DESCRIPTION
The A2A publish panel built its agent-card and JSON-RPC URLs straight from `window.location.origin`, so the addresses shown to the user were always the browser's own origin. Deployments that serve the A2A endpoints from a different host — behind a proxy, a dedicated gateway, or a custom domain — had no way to surface the correct address, and there was no seam to override it.

This routes both URLs through a customization util, following the same pattern as the other `src/frontend/src/customization/utils/custom-*.ts` seams (e.g. the API timestamp hook added in #14246).

## Changes

- New `customization/utils/custom-a2a-address.ts` exporting `customA2aPublishOrigin()`, which returns `window.location.origin`.
- `AgentCardPanel.tsx` derives `cardUrl` and `rpcUrl` from that helper instead of reading `window.location.origin` inline.

Behavior in OSS is unchanged — the default implementation returns exactly what the panel used before. Forks and custom builds can now swap the file to publish a different origin.

Two nearby comment blocks were also condensed while editing; no logic changed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent card and JSON-RPC endpoint addresses now use the configured publishing origin, ensuring displayed and copied URLs point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->