### PR TITLE
fix(ci): run tests when Filter Paths fails instead of skipping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,7 @@ jobs:
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
       (
         inputs.run-all-tests ||
+        needs.path-filter.result == 'failure' ||
         (needs.path-filter.result != 'skipped' &&
         needs.path-filter.outputs.docs-only != 'true' &&
         needs.path-filter.outputs.python == 'true')
@@ -282,6 +283,7 @@ jobs:
       needs.set-ci-condition.outputs.should-run-ci == 'true' &&
       (
         inputs.run-all-tests ||
+        needs.path-filter.result == 'failure' ||
         (needs.path-filter.result != 'skipped' &&
         needs.path-filter.outputs.frontend == 'true')
       )
@@ -298,6 +300,7 @@ jobs:
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
       (
         inputs.run-all-tests ||
+        needs.path-filter.result == 'failure' ||
         (needs.path-filter.result != 'skipped' &&
         needs.path-filter.outputs.docs-only != 'true')
       )
@@ -316,6 +319,7 @@ jobs:
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
       (
         inputs.run-all-tests ||
+        needs.path-filter.result == 'failure' ||
         (needs.path-filter.result != 'skipped' &&
         needs.path-filter.outputs.docs-only != 'true')
       )
@@ -336,7 +340,7 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
-      (inputs.run-all-tests || needs.path-filter.outputs.docs == 'true')
+      (inputs.run-all-tests || needs.path-filter.result == 'failure' || needs.path-filter.outputs.docs == 'true')
     name: Test Docs Build
     uses: ./.github/workflows/docs_test.yml
 
@@ -347,7 +351,7 @@ jobs:
       always() &&
       !cancelled() &&
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
-      (inputs.run-all-tests || needs.path-filter.outputs.python == 'true' || needs.path-filter.outputs.frontend == 'true')
+      (inputs.run-all-tests || needs.path-filter.result == 'failure' || needs.path-filter.outputs.python == 'true' || needs.path-filter.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -376,7 +380,11 @@ jobs:
   test-docker:
     needs: [path-filter, set-ci-condition]
     name: Test Docker Images
-    if: ${{ needs.path-filter.outputs.docker == 'true' && needs.set-ci-condition.outputs.should-run-tests == 'true' }}
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.set-ci-condition.outputs.should-run-tests == 'true' &&
+      (needs.path-filter.result == 'failure' || needs.path-filter.outputs.docker == 'true')
     uses: ./.github/workflows/docker_test.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -385,7 +393,10 @@ jobs:
   lint-design-md:
     needs: path-filter
     name: Lint DESIGN.md
-    if: ${{ inputs.run-all-tests || needs.path-filter.outputs.design-md == 'true' }}
+    if: |
+      always() &&
+      !cancelled() &&
+      (inputs.run-all-tests || needs.path-filter.result == 'failure' || needs.path-filter.outputs.design-md == 'true')
     runs-on: ubuntu-latest
     env:
       DESIGN_MD_CLI_VERSION: "0.1.1"
@@ -412,6 +423,7 @@ jobs:
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
       (
         inputs.run-all-tests ||
+        needs.path-filter.result == 'failure' ||
         (needs.path-filter.result != 'skipped' &&
         needs.path-filter.outputs.docs-only != 'true')
       )


### PR DESCRIPTION
The `path-filter` job (`Filter Paths`) publishes no outputs when it fails. Every downstream gate reads `needs.path-filter.outputs.*`, so on failure those conditions evaluate to false and the job gets **skipped**. `always()` makes the condition evaluate but cannot save it: the guard handled `result != 'skipped'` and never `result == 'failure'`. It is fail-closed where it needs to be fail-open.

This is not theoretical. On #14236 the step that failed inside `Filter Paths` was `Checkout code`, a transient infra flake:
https://github.com/langflow-ai/langflow/actions/runs/30047026683/job/89341662880

That flake skipped `Run Backend Tests`, `Test Starter Templates`, and the Backend / LFX / Frontend smoke tests, and the PR merged with those suites never having run.

## Change

Adds `needs.path-filter.result == 'failure'` to the OR branch of all nine gates that consume `path-filter`, so an unusable filter runs everything instead of nothing.

`test-docker` and `lint-design-md` also gain `always() && !cancelled()`. Without that, a failed dependency skips them regardless of the `if:`, so the fail-open clause on its own would have had no effect there.

`ci_success` is intentionally unchanged. It already goes red when `path-filter` fails, and that is the signal worth keeping.

## Verification

`actionlint` reports the same 7 pre-existing shellcheck infos before and after, and no expression errors. A script over the parsed YAML confirms all nine `path-filter` consumers now carry the fail-open clause.

Full acceptance is forcing `path-filter` to fail on a scratch PR and watching `Run Backend Tests` run instead of skip. I have not done that yet.

## Follow-ups, not in this PR

`main` has the same flaw and needs the same change.

Separately, the reason nothing blocked #14236 is that it targeted `release-1.11.1`, which has no branch rules at all. The "Merge Rule" ruleset lists target branches by hand and that one is not on the list (nor are `release-1.11.2`, `release-1.10.2`, `release-1.10.3`, `release-1.9.3` through `1.9.7`). That is a repo settings fix, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)