### PR TITLE
fix(frontend): align shortcut label with Parameters button

### DIFF
--- a/src/frontend/src/customization/constants.ts
+++ b/src/frontend/src/customization/constants.ts
@@ -3,7 +3,7 @@ export const baseURL = "";
 
 export const customDefaultShortcuts = [
   {
-    display_name: "Controls",
+    display_name: "Parameters",
     name: "Advanced Settings",
     shortcut: "mod+shift+a",
   },

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "Diese Kombination gibt es bereits!",
   "shortcuts.defaultNotFound": "Standard-Tastenkombination nicht gefunden.",
   "shortcuts.description": "Verwalten Sie Verknüpfungen für den schnellen Zugriff auf häufig verwendete Aktionen.",
-  "shortcuts.name.advancedSettings": "Kontrollmechanismen",
+  "shortcuts.name.advancedSettings": "Parameter",
   "shortcuts.name.aiAssistant": "KI-Assistent",
   "shortcuts.name.api": "-API",
   "shortcuts.name.changesSave": "Änderungen speichern",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -414,7 +414,7 @@
   "shortcuts.restoreButton": "Restore",
   "shortcuts.columnFunctionality": "Functionality",
   "shortcuts.columnKeyboardShortcut": "Keyboard Shortcut",
-  "shortcuts.name.advancedSettings": "Controls",
+  "shortcuts.name.advancedSettings": "Parameters",
   "shortcuts.name.searchComponentsSidebar": "Search Components on Sidebar",
   "shortcuts.name.minimize": "Minimize",
   "shortcuts.name.code": "Code",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "¡Esa combinación ya existe!",
   "shortcuts.defaultNotFound": "No se ha encontrado el atajo predeterminado.",
   "shortcuts.description": "Gestiona los accesos directos para acceder rápidamente a las acciones que utilizas con más frecuencia.",
-  "shortcuts.name.advancedSettings": "Controles",
+  "shortcuts.name.advancedSettings": "Parámetros",
   "shortcuts.name.aiAssistant": "Asistente de IA",
   "shortcuts.name.api": "API",
   "shortcuts.name.changesSave": "Guardar cambios",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "Cette combinaison existe déjà!",
   "shortcuts.defaultNotFound": "Raccourci par défaut introuvable.",
   "shortcuts.description": "Gérez les raccourcis pour accéder rapidement aux actions que vous utilisez souvent.",
-  "shortcuts.name.advancedSettings": "Contrôles",
+  "shortcuts.name.advancedSettings": "Paramètres",
   "shortcuts.name.aiAssistant": "Assistant IA",
   "shortcuts.name.api": "interface de programme d\"application",
   "shortcuts.name.changesSave": "Enregistrer les modifications",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "この組み合わせはすでに存在します！",
   "shortcuts.defaultNotFound": "既定のショートカットが見つかりません。",
   "shortcuts.description": "よく使う操作にすばやくアクセスできるよう、ショートカットを管理します。",
-  "shortcuts.name.advancedSettings": "コントロール",
+  "shortcuts.name.advancedSettings": "パラメーター",
   "shortcuts.name.aiAssistant": "AIアシスタント",
   "shortcuts.name.api": "API",
   "shortcuts.name.changesSave": "変更を保存",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "Essa combinação já existe!",
   "shortcuts.defaultNotFound": "Não foi encontrado o atalho padrão.",
   "shortcuts.description": "Gerencie atalhos para acessar rapidamente as ações mais utilizadas.",
-  "shortcuts.name.advancedSettings": "Controles",
+  "shortcuts.name.advancedSettings": "Parâmetros",
   "shortcuts.name.aiAssistant": "Assistente de IA",
   "shortcuts.name.api": "API do",
   "shortcuts.name.changesSave": "Salvar alterações",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1834,7 +1834,7 @@
   "shortcuts.combinationExists": "这种组合已经存在了！",
   "shortcuts.defaultNotFound": "未找到默认快捷键。",
   "shortcuts.description": "管理快捷方式，以便快速访问常用操作。",
-  "shortcuts.name.advancedSettings": "控件",
+  "shortcuts.name.advancedSettings": "参数",
   "shortcuts.name.aiAssistant": "AI 助手",
   "shortcuts.name.api": "个 API",
   "shortcuts.name.changesSave": "保存更改",


### PR DESCRIPTION
## Problem

The node toolbar button was relabeled to **Parameters**, but its keyboard shortcut kept the old **Controls** name. As a result the button's hover tooltip (and the Settings → Shortcuts table) still read "Controls" while the button said "Parameters".

## Fix

Renamed the shortcut display strings from "Controls" to "Parameters" in the two render paths:

- `src/frontend/src/customization/constants.ts` — `display_name` (Settings shortcuts table)
- `src/frontend/src/locales/en.json` — `shortcuts.name.advancedSettings` (toolbar tooltip)

The shortcut identifier (`name: "Advanced Settings"`) and keybinding (`mod+shift+a`) are unchanged.

## Screenshot context

Button reads "Parameters" but tooltip showed "Controls ⌘⇧A" — now both say "Parameters".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed the “Controls” shortcut label to “Parameters” for clearer navigation.
  * Updated the corresponding English localization text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->