### PR TITLE
fix(components): send chained input as user turn

### DIFF
--- a/src/frontend/src/customization/utils/custom-a2a-address.ts
+++ b/src/frontend/src/customization/utils/custom-a2a-address.ts
@@ -1,0 +1,3 @@
+export function customA2aPublishOrigin(): string {
+  return window.location.origin;
+}

--- a/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
+++ b/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
@@ -20,6 +20,7 @@ import {
   overridesToForm,
 } from "@/controllers/API/queries/a2a/utils";
 import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
+import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -30,7 +31,6 @@ import {
   cardInputContract,
   cardRequiresApiKey,
 } from "../types";
-import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 
 const errorDetail = (e: unknown, fallback: string): string => {
   const err = e as {
@@ -74,7 +74,7 @@ export default function AgentCardPanel({
 
   const flowId = currentFlow?.id ?? "";
   const isPublished = !!currentFlow?.a2a_enabled;
-  
+
   const publishOrigin = customA2aPublishOrigin();
   const cardUrl = `${publishOrigin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
   const rpcUrl = `${publishOrigin}/api/v1/a2a/${flowId}/jsonrpc`;

--- a/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
+++ b/src/frontend/src/pages/FlowPage/components/AgentMainContent/components/AgentCardPanel.tsx
@@ -30,6 +30,7 @@ import {
   cardInputContract,
   cardRequiresApiKey,
 } from "../types";
+import { customA2aPublishOrigin } from "@/customization/utils/custom-a2a-address";
 
 const errorDetail = (e: unknown, fallback: string): string => {
   const err = e as {
@@ -73,8 +74,10 @@ export default function AgentCardPanel({
 
   const flowId = currentFlow?.id ?? "";
   const isPublished = !!currentFlow?.a2a_enabled;
-  const cardUrl = `${window.location.origin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
-  const rpcUrl = `${window.location.origin}/api/v1/a2a/${flowId}/jsonrpc`;
+  
+  const publishOrigin = customA2aPublishOrigin();
+  const cardUrl = `${publishOrigin}/api/v1/a2a/${flowId}/.well-known/agent-card.json`;
+  const rpcUrl = `${publishOrigin}/api/v1/a2a/${flowId}/jsonrpc`;
 
   const [enabled, setEnabled] = useState(isPublished);
   const [form, setForm] = useState<A2ACardForm>(
@@ -107,10 +110,8 @@ export default function AgentCardPanel({
     try {
       const updatedFlow = await mutateAsync({
         id: flowId,
-        // flow_type is derived from the graph (has chat I/O = agent). Write it
-        // here so the langflow A2A serve guard passes; an ineligible flow can
-        // never be served, so force it off. (Backend derive-on-save is a
-        // follow-up; today the tab is the only place that recomputes it.)
+        // flow_type derived from graph chat I/O so the langflow A2A serve guard
+        // passes; an ineligible flow can never be served, so force it off.
         flow_type: eligible ? "agent" : "workflow",
         a2a_enabled: eligible ? enabled : false,
         a2a_card_overrides: formToOverrides(form),
@@ -174,9 +175,8 @@ export default function AgentCardPanel({
             variant: "secondaryStatic" as const,
           };
 
-  // What to tell the user when the flow can't serve: the server switch wins,
-  // then eligibility (a published flow that lost its chat I/O needs turning
-  // off; a draft one just needs the missing half added).
+  // Banner precedence: server switch wins, then eligibility (published flows
+  // that lost chat I/O need turning off; drafts just need the missing half).
   const banner = !serverEnabled
     ? t("agentTab.serverDisabled")
     : !eligible

--- a/src/lfx/src/lfx/base/models/chat_result.py
+++ b/src/lfx/src/lfx/base/models/chat_result.py
@@ -2,10 +2,23 @@ import warnings
 from collections.abc import Callable
 from typing import Any
 
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
 from lfx.field_typing.constants import LanguageModel
 from lfx.schema.message import Message
+
+
+def _as_user_turn(message: BaseMessage) -> BaseMessage:
+    """Send the component's input as a user turn even when it came from an upstream model.
+
+    A Language Model chained after an Agent receives that agent's response
+    (sender=Machine → AIMessage) as its input. Sending it unchanged makes the request
+    end on a model turn, which Gemini rejects with 400 "Requests ending with a model
+    turn are not supported".
+    """
+    if isinstance(message, AIMessage):
+        return HumanMessage(content=message.content)
+    return message
 
 
 def build_messages_and_runnable(
@@ -29,7 +42,7 @@ def build_messages_and_runnable(
                         system_message_added = True
                     runnable = prompt | runnable
                 else:
-                    messages.append(input_value.to_lc_message())
+                    messages.append(_as_user_turn(input_value.to_lc_message()))
         else:
             messages.append(HumanMessage(content=input_value))
 

--- a/src/lfx/src/lfx/components/models_and_agents/agent_helpers/messages_input_builder.py
+++ b/src/lfx/src/lfx/components/models_and_agents/agent_helpers/messages_input_builder.py
@@ -7,7 +7,7 @@ helper performs the conversion.
 
 from collections.abc import Iterable
 
-from langchain_core.messages import BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
 from lfx.log.logger import logger
 from lfx.schema.data import Data
@@ -26,10 +26,7 @@ def build_initial_messages(
 
     if chat_history is not None:
         for item in _normalize_history(chat_history):
-            # Mirror the current-turn guard in `_append_input`: a blank-text item is
-            # only truly empty when it ALSO has no files. An image-only message from a
-            # prior turn (text="", files=[image]) must survive — dropping it silently
-            # loses multimodal context on the next turn.
+            # Files-aware blank guard (mirrors `_append_input`): an image-only prior turn must survive.
             if _has_blank_text(item) and not getattr(item, "files", None):
                 continue
             converted = _safe_to_lc_message(item)
@@ -37,10 +34,8 @@ def build_initial_messages(
                 messages.append(converted)
 
     if not _append_input(messages, input_value):
-        # No fresh user input this turn. Always inject a deterministic continuation
-        # prompt — never let blank content reach the provider, and never let the LLM
-        # see a tail-AIMessage with no fresh user turn (causes silent re-execution
-        # of earlier tool calls).
+        # No fresh user turn: inject a deterministic prompt — blank content or a tail
+        # AIMessage makes providers fail or silently re-run earlier tool calls.
         messages.append(HumanMessage(content=CONTINUE_MESSAGE))
 
     return messages
@@ -65,11 +60,21 @@ def _append_input(messages: list[BaseMessage], input_value: Message | str | None
     A Message with blank text is still appended when files are attached — the file
     payload IS the input. `Message.to_lc_message()` builds the multimodal HumanMessage
     correctly in that case.
+
+    The input always lands as a user turn, even when it comes from an upstream Agent
+    (sender=Machine → `to_lc_message()` yields AIMessage). Chained agents such as the
+    Multi Agent Flow template would otherwise send a request ENDING in a model turn,
+    which Gemini rejects with 400 "Requests ending with a model turn are not supported".
+    The legacy AgentExecutor path rendered the input as a ("human", "{input}") turn
+    regardless of sender; this preserves that contract on the LangGraph path.
     """
     if isinstance(input_value, Message):
         if _has_blank_text(input_value) and not getattr(input_value, "files", None):
             return False
-        messages.append(input_value.to_lc_message())
+        lc_message = input_value.to_lc_message()
+        if isinstance(lc_message, AIMessage):
+            lc_message = HumanMessage(content=lc_message.content)
+        messages.append(lc_message)
         return True
     if isinstance(input_value, str):
         if not input_value.strip():

--- a/src/lfx/tests/unit/base/models/test_chat_result_messages.py
+++ b/src/lfx/tests/unit/base/models/test_chat_result_messages.py
@@ -1,0 +1,60 @@
+"""Tests for build_messages_and_runnable — the Language Model component's input contract.
+
+A Language Model chained after an Agent (or another Language Model) receives an
+AI-sender Message as its input_value. That input is THIS component's task, so it must
+be sent as a user turn: Gemini rejects any request whose last turn is a model turn with
+400 "Requests ending with a model turn are not supported".
+"""
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from lfx.base.models.chat_result import build_messages_and_runnable
+from lfx.schema.message import Message
+from lfx.utils.constants import MESSAGE_SENDER_AI, MESSAGE_SENDER_USER
+
+
+def _chat_model() -> FakeListChatModel:
+    """A real LanguageModel; build_messages_and_runnable only passes it through."""
+    return FakeListChatModel(responses=["ok"])
+
+
+def test_should_keep_user_message_as_human_turn() -> None:
+    runnable = _chat_model()
+
+    messages, returned = build_messages_and_runnable(
+        input_value=Message(text="What is 2+2?", sender=MESSAGE_SENDER_USER),
+        system_message=None,
+        original_runnable=runnable,
+    )
+
+    assert returned is runnable
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "What is 2+2?"
+
+
+def test_should_convert_ai_sender_input_to_human_turn_when_chained_from_upstream_component() -> None:
+    """An upstream Agent's output must not become the trailing model turn of the request."""
+    messages, _ = build_messages_and_runnable(
+        input_value=Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI),
+        system_message=None,
+        original_runnable=_chat_model(),
+    )
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage), "chained input must be sent as a user turn"
+    assert not isinstance(messages[0], AIMessage)
+    assert messages[0].content == "Idea: an AI-powered plant sitter."
+
+
+def test_should_end_with_human_turn_when_ai_sender_input_has_system_message() -> None:
+    """The system message is prepended, so the AI-sender input is the tail turn."""
+    messages, _ = build_messages_and_runnable(
+        input_value=Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI),
+        system_message="You are a business analyst.",
+        original_runnable=_chat_model(),
+    )
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], SystemMessage)
+    assert isinstance(messages[-1], HumanMessage), "request must never end with a model turn"

--- a/src/lfx/tests/unit/components/models_and_agents/agent_helpers/test_messages_input_builder.py
+++ b/src/lfx/tests/unit/components/models_and_agents/agent_helpers/test_messages_input_builder.py
@@ -249,6 +249,40 @@ def test_should_propagate_non_value_error_from_to_lc_message() -> None:
         build_initial_messages(input_value="ping", chat_history=history)
 
 
+def test_should_convert_ai_sender_input_to_human_message_when_chained_from_upstream_agent() -> None:
+    """Chained agents: an upstream Agent's output is THIS agent's task, i.e. a user turn.
+
+    Multi Agent Flow bug: Agent 1's response Message (sender=Machine) flows into Agent 2's
+    input_value. `to_lc_message()` maps sender=Machine to AIMessage, so the request sent to
+    the provider ENDED with a model turn. Gemini rejects that outright with
+    400 "Requests ending with a model turn are not supported". The legacy AgentExecutor
+    path rendered the input as a ("human", "{input}") turn regardless of sender; the
+    LangGraph path must preserve that contract.
+    """
+    upstream_response = Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI)
+
+    messages = build_initial_messages(input_value=upstream_response, chat_history=None)
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage), "input_value must always land as a user turn"
+    assert _content_text(messages[0]) == "Idea: an AI-powered plant sitter."
+
+
+def test_should_end_with_human_turn_when_ai_sender_input_follows_history() -> None:
+    """With history present, an AI-sender input must still leave the tail as a user turn."""
+    history = [
+        Data(text="give me a product idea", sender=MESSAGE_SENDER_USER),
+    ]
+    upstream_response = Message(text="Idea: an AI-powered plant sitter.", sender=MESSAGE_SENDER_AI)
+
+    messages = build_initial_messages(input_value=upstream_response, chat_history=history)
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[-1], HumanMessage), "request must never end with a model turn"
+    assert _content_text(messages[-1]) == "Idea: an AI-powered plant sitter."
+
+
 def test_should_skip_malformed_chat_history_items_without_crashing_the_turn() -> None:
     """Malformed `Data` entries in chat_history are skipped, not fatal.
 


### PR DESCRIPTION
This pull request addresses a critical bug where chained agents could produce requests ending with a model turn, which Gemini rejects. The changes ensure that any input from an upstream agent (AI sender) is always converted to a user turn (human message) before being sent to the language model. Additionally, the PR introduces a utility for customizable publish origins and clarifies some comments for better maintainability. Comprehensive tests are added to verify the corrected behavior.

**Chained agent input handling and Gemini compatibility:**

* Added logic in `build_messages_and_runnable` and `_append_input` to convert any AI-sender input (i.e., `AIMessage`) into a user turn (`HumanMessage`), preventing requests from ending with a model turn, which Gemini rejects. [[1]](diffhunk://#diff-b5fc96d6ab908b0c0d02ad5886b69866aecf3390797eb288c2cee8c245098889L5-R23) [[2]](diffhunk://#diff-b5fc96d6ab908b0c0d02ad5886b69866aecf3390797eb288c2cee8c245098889L32-R45) [[3]](diffhunk://#diff-09c8cc3f9ab0f3caafde6a0baf699b97bab695a23f6ad22b579a4ad16828ca78L10-R10) [[4]](diffhunk://#diff-09c8cc3f9ab0f3caafde6a0baf699b97bab695a23f6ad22b579a4ad16828ca78R63-R77)
* Updated comments to clarify the rationale and contract for user turn enforcement in agent chaining scenarios. [[1]](diffhunk://#diff-09c8cc3f9ab0f3caafde6a0baf699b97bab695a23f6ad22b579a4ad16828ca78L29-R38) [[2]](diffhunk://#diff-09c8cc3f9ab0f3caafde6a0baf699b97bab695a23f6ad22b579a4ad16828ca78R63-R77)

**Testing improvements:**

* Added unit tests in `test_chat_result_messages.py` and `test_messages_input_builder.py` to confirm that AI-sender inputs are always converted to user turns, both with and without chat history, and that the request never ends with a model turn. [[1]](diffhunk://#diff-836a870aa588ac7d471a22c38eee219bd67647c631038f86a84516271f259c3aR1-R60) [[2]](diffhunk://#diff-1902bdba1ed662ef4122654f25e6265b29d3e4bac9e3a91bd971baedc5a39b95R252-R285)

**Frontend customization:**

* Introduced a `customA2aPublishOrigin` utility to centralize and customize the publish origin for agent card URLs, replacing direct usage of `window.location.origin`. [[1]](diffhunk://#diff-d43c736b01b5fae91f80eadabf5f6ef64d1372dec437b15dc169c266268f01d6R1-R3) [[2]](diffhunk://#diff-246707e527ed48adb9c559515c3a0ce81943afd4ede1ecaa5b1285c9d0309315R23) [[3]](diffhunk://#diff-246707e527ed48adb9c559515c3a0ce81943afd4ede1ecaa5b1285c9d0309315L76-R80)

**Minor improvements and clarifications:**

* Reworded and clarified comments in the frontend and backend for better readability and maintainability. [[1]](diffhunk://#diff-246707e527ed48adb9c559515c3a0ce81943afd4ede1ecaa5b1285c9d0309315L110-R114) [[2]](diffhunk://#diff-246707e527ed48adb9c559515c3a0ce81943afd4ede1ecaa5b1285c9d0309315L177-R179)

These changes ensure robust agent chaining, prevent Gemini request errors, and improve code clarity and customization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published agent-card and JSON-RPC links now use the configured publishing origin.

* **Bug Fixes**
  * Improved chained-agent and multimodal message handling by ensuring requests end with a valid user message.
  * Preserved image-only conversation history and added a continuation prompt when needed.
  * Prevented blank or invalid model turns from being sent to providers.

* **Tests**
  * Added coverage for message ordering, chained-agent inputs, system messages, and conversation history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->