### PR TITLE
test(authz): align share-level double with enterprise enforcement semantics

### DIFF
--- a/src/backend/tests/unit/services/authorization/_policy_double.py
+++ b/src/backend/tests/unit/services/authorization/_policy_double.py
@@ -38,14 +38,19 @@ if TYPE_CHECKING:
     from lfx.services.settings.service import SettingsService
     from sqlmodel.ext.asyncio.session import AsyncSession
 
-# Actions granted by each AuthzShare.permission_level. ``write`` and ``execute``
-# are independent (each grants ``read`` plus itself); ``admin`` grants the lot.
-# Mirrors SharePermissionLevel without baking a questionable write<execute order.
+# Actions granted by each AuthzShare.permission_level, ordered weakest to
+# strongest. This is the canonical share contract enforced by the enterprise
+# Casbin plugin (share_sync.PERMISSION_ACTIONS) and described by the share UI
+# (Viewer/Runner/Editor/Admin): ``execute`` grants ``read`` so a runner can
+# fetch the flow it invokes; ``write`` grants ``read`` + ``execute`` (an editor
+# can also view and run); ``admin`` additionally grants ``delete``. The
+# enterprise repo's check-authz-share-contract.py compares this dict against
+# the plugin's mapping — keep the two in lockstep.
 _SHARE_LEVEL_ACTIONS: dict[str, frozenset[str]] = {
     "read": frozenset({"read"}),
-    "write": frozenset({"read", "write"}),
     "execute": frozenset({"read", "execute"}),
-    "admin": frozenset({"read", "write", "execute", "create", "delete", "deploy", "update", "share"}),
+    "write": frozenset({"read", "write", "execute"}),
+    "admin": frozenset({"read", "write", "execute", "delete"}),
 }
 
 # Built-in role permission sets — mirrors migration 7c8d9e0f1a2b_authz_foundations


### PR DESCRIPTION
## Summary

The RBAC policy test double (`_SHARE_LEVEL_ACTIONS` in `src/backend/tests/unit/services/authorization/_policy_double.py`) granted its own per-level action sets that diverged from what the enterprise Casbin plugin actually compiles for `AuthzShare.permission_level`:

- `write` did not include `execute`, but the production contract (and the share UI: Editor = "View, run, and edit") is that an editor can also run the flow.
- `admin` bundled speculative actions (`create`, `deploy`, `update`, `share`) that no production enforcer compiles for a share.

That meant integration tests written against the double could assert sharing semantics that production enforcement would deny (or vice versa). This aligns the double to the canonical mapping, ordered weakest → strongest:

| Level | Actions |
|-------|---------|
| `read` | read |
| `execute` | read, execute |
| `write` | read, write, execute |
| `admin` | read, write, execute, delete |

The enterprise repo's drift guard now compares this dict against the plugin's mapping, so the two can't silently diverge again.

No test currently depends on the old semantics — the share-level integration tests only exercise `read` and `admin` levels, which are compatible with both mappings.

## Test plan

- [x] `pytest src/backend/tests/unit/services/authorization/` — 221 passed
- [x] `pytest src/backend/tests/unit/api/v1/test_authz_share_routes.py src/backend/tests/unit/api/v1/test_authz_share_schemas.py src/backend/tests/unit/test_authz_models.py` — 54 passed
- [x] Enterprise drift guard (`check-authz-share-contract.py`) passes against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated share permission behavior to align with the enterprise contract.
  * Corrected allowed actions for execute, write, and admin permission levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->