### PR TITLE
docs: fastapi pagination error troubleshooting

### DIFF
--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -51,6 +51,10 @@ To avoid the impact of potential breaking changes and test new versions, the Lan
 Highlights of this release include the following changes.
 For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/releases).
 
+:::tip
+If Langflow fails to start with a `get_body_field` error after installing version 1.11.0, see [`get_body_field` error after installing Langflow](/troubleshoot#get_body_field-error-after-installing-langflow).
+:::
+
 ### Breaking changes
 
 - Short `LANGFLOW_SECRET_KEY` upgrade compatibility

--- a/docs/docs/Support/troubleshooting.mdx
+++ b/docs/docs/Support/troubleshooting.mdx
@@ -81,6 +81,40 @@ sudo apt-get install gcc
 
 If you experience an error from the `webrtcvad` package, run `uv pip install webrtcvad-wheels` in your virtual environment, and then retry the Langflow installation.
 
+### `get_body_field` error after installing Langflow
+
+After installing Langflow OSS with `pip install langflow` or `uv pip install langflow`, Langflow fails to start with an error that mentions `get_body_field`, such as:
+
+```text
+ImportError: cannot import name 'get_body_field' from 'fastapi.dependencies.utils'
+```
+
+or:
+
+```text
+NameError: name 'get_body_field' is not defined
+```
+
+This happens when the resolver installs FastAPI `0.140.5` or later, which removed `get_body_field`.
+
+Langflow 1.11.0 allows FastAPI `>=0.139.0,<1.0.0`, so a fresh install can pull an incompatible FastAPI 0.140.x release.
+
+To work around this, pin FastAPI below 0.140.
+
+To pin FastAPI when installing Langflow:
+
+```bash
+uv pip install langflow "fastapi<0.140"
+```
+
+To pin FastAPI in an environment where Langflow is already installed:
+
+```bash
+uv pip install "fastapi<0.140"
+```
+
+Langflow version 1.11.1 constrains FastAPI to `<0.140.0`, so a new install of Langflow version `>=1.11.1` does not require this pin.
+
 ## Langflow Desktop installation issues
 
 The following issues can occur when Langflow Desktop installs or updates its bundled Langflow OSS instance.

--- a/docs/versioned_docs/version-1.11.0/Support/release-notes.mdx
+++ b/docs/versioned_docs/version-1.11.0/Support/release-notes.mdx
@@ -51,6 +51,10 @@ To avoid the impact of potential breaking changes and test new versions, the Lan
 Highlights of this release include the following changes.
 For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/releases).
 
+:::tip
+If Langflow fails to start with a `get_body_field` error after installing version 1.11.0, see [`get_body_field` error after installing Langflow](/troubleshoot#get_body_field-error-after-installing-langflow).
+:::
+
 ### Breaking changes
 
 - Default superuser password removed

--- a/docs/versioned_docs/version-1.11.0/Support/troubleshooting.mdx
+++ b/docs/versioned_docs/version-1.11.0/Support/troubleshooting.mdx
@@ -81,6 +81,40 @@ sudo apt-get install gcc
 
 If you experience an error from the `webrtcvad` package, run `uv pip install webrtcvad-wheels` in your virtual environment, and then retry the Langflow installation.
 
+### `get_body_field` error after installing Langflow
+
+After installing Langflow OSS with `pip install langflow` or `uv pip install langflow`, Langflow fails to start with an error that mentions `get_body_field`, such as:
+
+```text
+ImportError: cannot import name 'get_body_field' from 'fastapi.dependencies.utils'
+```
+
+or:
+
+```text
+NameError: name 'get_body_field' is not defined
+```
+
+This happens when the resolver installs FastAPI `0.140.5` or later, which removed `get_body_field`.
+
+Langflow 1.11.0 allows FastAPI `>=0.139.0,<1.0.0`, so a fresh install can pull an incompatible FastAPI 0.140.x release.
+
+To work around this, pin FastAPI below 0.140.
+
+To pin FastAPI when installing Langflow:
+
+```bash
+uv pip install langflow "fastapi<0.140"
+```
+
+To pin FastAPI in an environment where Langflow is already installed:
+
+```bash
+uv pip install "fastapi<0.140"
+```
+
+Langflow version 1.11.1 constrains FastAPI to `<0.140.0`, so a new install of Langflow version `>=1.11.1` does not require this pin.
+
 ## Langflow Desktop installation issues
 
 The following issues can occur when Langflow Desktop installs or updates its bundled Langflow OSS instance.


### PR DESCRIPTION
This needs to go to `main` too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for startup failures involving the `get_body_field` error after installing Langflow 1.11.0.
  - Documented workarounds for affected FastAPI versions during new and existing installations.
  - Clarified that Langflow 1.11.1 and later no longer require this workaround.
  - Added links from the 1.11.x release notes to the troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->