### PR TITLE
docs(authz): correct role-assignment domain types in model docstring

### DIFF
--- a/src/backend/base/langflow/services/database/models/auth/authz.py
+++ b/src/backend/base/langflow/services/database/models/auth/authz.py
@@ -130,7 +130,7 @@ class AuthzRoleAssignment(SQLModel, table=True):  # type: ignore[call-arg]
     role_id: UUIDstr = Field(
         sa_column=Column(sa.Uuid(), ForeignKey("authz_role.id", ondelete="CASCADE"), nullable=False, index=True),
     )
-    domain_type: str = Field(default="global", description="global, org, workspace")
+    domain_type: str = Field(default="global", description="global, workspace, project")
     # Explicit ``sa_column`` so SQLModel emits ``sa.Uuid()`` matching the
     # migration's column type. Without this, SQLModel can fall back to
     # ``AutoString``/``CHAR(32)`` on SQLite, which drifts from the migration


### PR DESCRIPTION
## Summary

`AuthzRoleAssignment.domain_type` accepts `global`, `workspace`, and `project` — the values the enterprise enforcer resolves and the partial unique indexes assume — but the field description still said `"global, org, workspace"` from an earlier draft of the scoping model. Docstring-only change; no behavior, schema, or migration impact.

Companion to the enterprise-side RBAC vocabulary cleanup (WatsonOrchestrate/Langflow-Enterprise#136).

## Test plan

- [x] Doc-only: `git grep '"global, org, workspace"'` returns nothing; no code reads the Field description at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented domain types for role assignments to accurately list global, workspace, and project options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->