### PR TITLE
fix(mcp): pin MCP SDK <2.0 for uvx-launched servers

### DIFF
--- a/src/backend/base/langflow/api/utils/mcp/config_utils.py
+++ b/src/backend/base/langflow/api/utils/mcp/config_utils.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from lfx.base.mcp.constants import MAX_MCP_SERVER_NAME_LENGTH
 from lfx.base.mcp.util import sanitize_mcp_name
+from lfx.base.mcp.uvx import mcp_sdk_constraint_args
 from lfx.log import logger
 from lfx.services.deps import get_settings_service
 from sqlmodel import select
@@ -413,6 +414,7 @@ async def auto_configure_starter_projects_mcp(session):
                 if default_auth.get("auth_type", "none") == "apikey":
                     command = "uvx"
                     args = [
+                        *mcp_sdk_constraint_args(),
                         "mcp-proxy",
                         "--transport",
                         "streamablehttp",
@@ -429,6 +431,7 @@ async def auto_configure_starter_projects_mcp(session):
                     # No authentication - direct connection
                     command = "uvx"
                     args = [
+                        *mcp_sdk_constraint_args(),
                         "mcp-proxy",
                         "--transport",
                         "streamablehttp",

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from lfx.base.mcp.constants import MAX_MCP_SERVER_NAME_LENGTH
 from lfx.base.mcp.util import sanitize_mcp_name
+from lfx.base.mcp.uvx import mcp_sdk_constraint_args
 from lfx.log import logger
 from lfx.services.deps import get_settings_service, session_scope
 from lfx.services.mcp_composer.service import (
@@ -880,6 +881,7 @@ async def install_mcp_config(
             settings = get_settings_service().settings
             command = "uvx"
             args = [
+                *mcp_sdk_constraint_args(),
                 f"mcp-composer{settings.mcp_composer_version}",
                 "--mode",
                 "http",
@@ -896,7 +898,7 @@ async def install_mcp_config(
             streamable_http_url = await get_project_streamable_http_url(project_id)
             legacy_sse_url = await get_project_sse_url(project_id)
             command = "uvx"
-            args = ["mcp-proxy"]
+            args = [*mcp_sdk_constraint_args(), "mcp-proxy"]
             # Check if we need to add Langflow API key headers
             # Necessary only when Project API Key Authentication is enabled
 

--- a/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
+++ b/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from uuid import UUID
 
 from fastapi import HTTPException
+from lfx.base.mcp.uvx import mcp_sdk_constraint_args
 from lfx.log.logger import logger
 from lfx.services.mcp_composer.service import MCPComposerService
 
@@ -117,6 +118,7 @@ async def register_mcp_servers_for_project(
             unmasked_api_key = await create_api_key(session, ApiKeyCreate(name=api_key_name), current_user.id)
             command = "uvx"
             args = [
+                *mcp_sdk_constraint_args(),
                 "mcp-proxy",
                 "--transport",
                 "streamablehttp",
@@ -132,6 +134,7 @@ async def register_mcp_servers_for_project(
         else:
             command = "uvx"
             args = [
+                *mcp_sdk_constraint_args(),
                 "mcp-proxy",
                 "--transport",
                 "streamablehttp",

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -2,6 +2,10 @@ import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { TEXTS } from "../../utils/constants/texts";
+import {
+  FETCH_SERVER_ARGS,
+  fillFetchServerCommand,
+} from "../../utils/fill-fetch-server-command";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 import { openFlowCard } from "../../utils/flow/open-flow-card";
 import { openAddMcpServerModal } from "../../utils/open-add-mcp-server-modal";
@@ -56,8 +60,7 @@ test(
     const testName = `test_server_${randomSuffix}`;
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page.getByTestId("stdio-command-input").fill("uvx");
-    await page.getByTestId("stdio-args_0").fill("mcp-server-fetch");
+    await fillFetchServerCommand(page);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -157,9 +160,11 @@ test(
     expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(
       "uvx",
     );
-    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(
-      "mcp-server-fetch",
-    );
+    for (const [index, arg] of FETCH_SERVER_ARGS.entries()) {
+      expect(await page.getByTestId(`stdio-args_${index}`).inputValue()).toBe(
+        arg,
+      );
+    }
 
     await page.waitForTimeout(500);
 
@@ -234,8 +239,7 @@ test(
 
     await page.waitForTimeout(500);
 
-    await page.getByTestId("stdio-command-input").fill("uvx");
-    await page.getByTestId("stdio-args_0").fill("mcp-server-fetch");
+    await fillFetchServerCommand(page);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -707,8 +711,7 @@ test(
     const testName = `test_server_${randomSuffix}`;
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page.getByTestId("stdio-command-input").fill("uvx");
-    await page.getByTestId("stdio-args_0").fill("mcp-server-fetch");
+    await fillFetchServerCommand(page);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -821,11 +824,16 @@ test(
     expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(
       "uvx",
     );
-    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(
-      "mcp-server-fetch",
-    );
+    for (const [index, arg] of FETCH_SERVER_ARGS.entries()) {
+      expect(await page.getByTestId(`stdio-args_${index}`).inputValue()).toBe(
+        arg,
+      );
+    }
 
-    await page.getByTestId("stdio-args_0").fill("mcp-server-time");
+    // Swap only the package operand; the leading `--with mcp~=1.28` still applies.
+    await page
+      .getByTestId(`stdio-args_${FETCH_SERVER_ARGS.length - 1}`)
+      .fill("mcp-server-time");
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -937,8 +945,7 @@ test(
 
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page.getByTestId("stdio-command-input").fill("uvx");
-    await page.getByTestId("stdio-args_0").fill("mcp-server-fetch");
+    await fillFetchServerCommand(page);
 
     await page.getByTestId("add-mcp-server-button").click();
 

--- a/src/frontend/tests/utils/fill-fetch-server-command.ts
+++ b/src/frontend/tests/utils/fill-fetch-server-command.ts
@@ -1,0 +1,19 @@
+import type { Page } from "@playwright/test";
+
+// uvx resolves each stdio server into its own environment, and mcp-server-fetch still
+// declares an unbounded `mcp>=1.1.3`. The 2.0 SDK renamed `McpError`, so an unconstrained
+// resolve installs a release the server cannot import and it exposes no tools. Pin the SDK
+// the same way Langflow pins it for the servers it launches itself.
+export const FETCH_SERVER_ARGS = ["--with", "mcp~=1.28", "mcp-server-fetch"];
+
+/** Fill the stdio command and argument rows that launch mcp-server-fetch. */
+export async function fillFetchServerCommand(page: Page) {
+  await page.getByTestId("stdio-command-input").fill("uvx");
+
+  for (const [index, arg] of FETCH_SERVER_ARGS.entries()) {
+    if (index > 0) {
+      await page.getByTestId("input-list-plus-btn_-0").click();
+    }
+    await page.getByTestId(`stdio-args_${index}`).fill(arg);
+  }
+}

--- a/src/lfx/src/lfx/base/mcp/source_policy.py
+++ b/src/lfx/src/lfx/base/mcp/source_policy.py
@@ -369,6 +369,13 @@ def _uvx_package_selection(args: list[str]) -> tuple[list[str], list[str], str |
     return from_packages, with_packages, command
 
 
+def _is_uvx_with_option(arg: str) -> bool:
+    """Match every spelling uvx accepts for ``--with``: split, inline, and clustered short."""
+    if arg in {"--with", "-w"}:
+        return True
+    return arg.startswith("--with=") or (arg.startswith("-w") and not arg.startswith("--"))
+
+
 def _package_runner_target(base_command: str, args: list[str]) -> tuple[str | None, str | None]:
     """Extract the installed package and an explicit uvx entrypoint."""
     index = 0
@@ -394,6 +401,12 @@ def _package_runner_target(base_command: str, args: list[str]) -> tuple[str | No
         if base_command == "npx" and (arg == "--package" or arg.startswith("--package=")):
             package, _ = _option_value(args, index, base_command)
             return package, None
+        if base_command == "uvx" and _is_uvx_with_option(arg):
+            # ``--with`` adds a requirement to the ephemeral environment; it never selects the
+            # executable. Skipping its value keeps the operand after it as the runner target
+            # instead of misreading the extra requirement as the package being launched.
+            index += 2 if arg in {"--with", "-w"} else 1
+            continue
         if arg.startswith("-"):
             index += 2 if arg in UVX_VALUE_OPTIONS | NPX_VALUE_OPTIONS and "=" not in arg else 1
             continue
@@ -469,12 +482,30 @@ def _validate_npx_package_selection(args: list[str], allowed_packages: frozenset
     return True
 
 
+def _sdk_constraint_exemption() -> str | None:
+    """Return the requirement Langflow itself injects as ``uvx --with``, if enabled.
+
+    Langflow prepends ``--with <mcp_sdk_constraint>`` to every MCP server it launches
+    through uvx. Exempting that exact specifier keeps operator package allowlists
+    working without every deployment adding ``mcp``; any other ``--with`` requirement
+    is still validated against the allowlist.
+    """
+    from lfx.base.mcp.uvx import DEFAULT_MCP_SDK_CONSTRAINT
+
+    value = _setting("mcp_sdk_constraint", default=DEFAULT_MCP_SDK_CONSTRAINT)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def _validate_allowed_package(base_command: str, args: list[str], allowed_packages: frozenset[str] | None) -> None:
     if allowed_packages is None or base_command not in {"npx", "uvx"}:
         return
 
     if base_command == "uvx":
         from_packages, with_packages, command = _uvx_package_selection(args)
+        exemption = _sdk_constraint_exemption()
+        with_packages = [package for package in with_packages if package != exemption]
         selected_packages = [*from_packages, *with_packages]
         if not from_packages:
             selected_packages.append(command or "<missing>")

--- a/src/lfx/src/lfx/base/mcp/uvx.py
+++ b/src/lfx/src/lfx/base/mcp/uvx.py
@@ -1,0 +1,40 @@
+"""Shared argv helpers for MCP servers that Langflow launches through ``uvx``.
+
+``uvx`` builds a fresh environment per invocation, so Langflow's own ``mcp`` pin never
+reaches the server it spawns. The packages Langflow launches (``mcp-proxy``,
+``mcp-composer``) declare an unbounded ``mcp>=1.x``, which now resolves to the 2.0 SDK --
+a release that removed ``request_ctx`` and renamed ``McpError``, so those packages fail
+at import. Injecting the constraint as ``--with`` keeps the resolve on a compatible SDK.
+"""
+
+# ``~=1.28`` is PEP 440 for ">=1.28, <2.0" and, unlike ``mcp<2.0.0``, contains no character
+# that the stdio command policy rejects as a shell metacharacter.
+DEFAULT_MCP_SDK_CONSTRAINT = "mcp~=1.28"
+
+
+def mcp_sdk_constraint_args() -> list[str]:
+    """Return the ``uvx --with`` pair that pins the MCP SDK, or an empty list when disabled.
+
+    The result is meant to be spliced in ahead of the package operand::
+
+        ["uvx", *mcp_sdk_constraint_args(), "mcp-proxy", ...]
+
+    Operators disable the injection by setting ``LANGFLOW_MCP_SDK_CONSTRAINT`` to an empty
+    string once upstream supports the 2.x SDK.
+    """
+    constraint = _configured_constraint()
+    if not constraint:
+        return []
+    return ["--with", constraint]
+
+
+def _configured_constraint() -> str:
+    from lfx.services.deps import get_settings_service
+
+    try:
+        value = getattr(get_settings_service().settings, "mcp_sdk_constraint", DEFAULT_MCP_SDK_CONSTRAINT)
+    except Exception:  # noqa: BLE001 - settings can be unavailable during early imports
+        return DEFAULT_MCP_SDK_CONSTRAINT
+    if not isinstance(value, str):
+        return DEFAULT_MCP_SDK_CONSTRAINT
+    return value.strip()

--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -16,6 +16,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
+from lfx.base.mcp.uvx import mcp_sdk_constraint_args
 from lfx.log.logger import logger
 from lfx.services.base import Service
 from lfx.services.deps import get_settings_service
@@ -1365,6 +1366,7 @@ class MCPComposerService(Service):
 
         cmd = [
             "uvx",
+            *mcp_sdk_constraint_args(),
             f"mcp-composer{settings.mcp_composer_version}",
             "--port",
             str(port),

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -73,6 +73,19 @@ class McpSettings(BaseModel):
     mcp_composer_version: str = "==0.1.0.8.10"
     """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
 
+    mcp_sdk_constraint: str = "mcp~=1.28"
+    """Requirement injected as ``uvx --with`` when Langflow launches an MCP server through uvx.
+
+    ``uvx`` resolves each server into its own ephemeral environment, so Langflow's own
+    ``mcp`` pin does not apply there. ``mcp-proxy`` and ``mcp-composer`` still declare an
+    unbounded ``mcp>=1.x``, and the 2.0 SDK removed ``request_ctx`` and renamed ``McpError``,
+    so an unconstrained resolve installs a release those packages cannot import. Keep the
+    specifier free of ``<``/``>``, which the stdio command policy rejects as shell
+    metacharacters. The exact configured specifier is exempt from
+    ``mcp_server_allowed_packages``, so allowlisted deployments keep working without
+    adding ``mcp``. Set to an empty string to disable the injection once upstream
+    supports the 2.x SDK. Env var: LANGFLOW_MCP_SDK_CONSTRAINT."""
+
     # A2A protocol
     a2a_enabled: bool = False
     """If set to True, Langflow serves spec-valid A2A agent cards at a per-flow

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -343,3 +343,53 @@ def test_docker_hardening_preserves_isolated_run():
         ["run", "--rm", "--network", "bridge", "--security-opt", "no-new-privileges", "mcp-image"],
         docker_hardening=True,
     )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--with", "mcp~=1.28", "mcp-proxy"],
+        ["--with=mcp~=1.28", "mcp-proxy"],
+        ["-w", "mcp~=1.28", "mcp-proxy"],
+        ["-wmcp~=1.28", "mcp-proxy"],
+    ],
+)
+def test_uvx_allowlist_exempts_injected_sdk_constraint(args):
+    validate_mcp_stdio_config("uvx", args, {}, allowed_packages={"mcp-proxy"})
+
+
+def test_uvx_allowlist_rejects_with_specifiers_other_than_the_configured_constraint():
+    with pytest.raises(ValueError, match=r"Package 'mcp~=1.27' is not allowed for MCP uvx"):
+        validate_mcp_stdio_config(
+            "uvx",
+            ["--with", "mcp~=1.27", "mcp-proxy"],
+            {},
+            allowed_packages={"mcp-proxy"},
+        )
+
+
+def test_uvx_sdk_constraint_cannot_mask_unapproved_runner_target():
+    with pytest.raises(ValueError, match=r"Package 'attacker-package' is not allowed for MCP uvx"):
+        validate_mcp_stdio_config(
+            "uvx",
+            ["--with", "mcp~=1.28", "attacker-package"],
+            {},
+            allowed_packages={"mcp-proxy"},
+        )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--with", "mcp~=1.28", "mcp-proxy", "--transport", "streamablehttp", "http://localhost:7860/x"],
+        ["--with=mcp~=1.28", "mcp-proxy"],
+        ["-w", "mcp~=1.28", "mcp-proxy"],
+        ["-wmcp~=1.28", "mcp-proxy"],
+    ],
+)
+def test_uvx_sdk_constraint_spellings_preserve_runner_target(args):
+    from lfx.base.mcp.source_policy import _package_runner_target
+
+    package, entrypoint = _package_runner_target("uvx", args)
+    assert package == "mcp-proxy"
+    assert entrypoint is None

--- a/src/lfx/tests/unit/mcp/test_uvx_sdk_constraint.py
+++ b/src/lfx/tests/unit/mcp/test_uvx_sdk_constraint.py
@@ -1,0 +1,40 @@
+"""Tests for the ``uvx --with`` MCP SDK constraint injection helper."""
+
+from types import SimpleNamespace
+
+import lfx.services.deps
+from lfx.base.mcp.uvx import DEFAULT_MCP_SDK_CONSTRAINT, mcp_sdk_constraint_args
+
+
+def _install_settings(monkeypatch, **settings):
+    service = SimpleNamespace(settings=SimpleNamespace(**settings))
+    monkeypatch.setattr(lfx.services.deps, "get_settings_service", lambda: service)
+
+
+def test_default_constraint_is_injected(monkeypatch):
+    _install_settings(monkeypatch, mcp_sdk_constraint=DEFAULT_MCP_SDK_CONSTRAINT)
+    assert mcp_sdk_constraint_args() == ["--with", DEFAULT_MCP_SDK_CONSTRAINT]
+
+
+def test_custom_constraint_is_injected(monkeypatch):
+    _install_settings(monkeypatch, mcp_sdk_constraint="mcp~=1.30")
+    assert mcp_sdk_constraint_args() == ["--with", "mcp~=1.30"]
+
+
+def test_empty_constraint_disables_injection(monkeypatch):
+    _install_settings(monkeypatch, mcp_sdk_constraint="")
+    assert mcp_sdk_constraint_args() == []
+
+
+def test_whitespace_constraint_disables_injection(monkeypatch):
+    _install_settings(monkeypatch, mcp_sdk_constraint="   ")
+    assert mcp_sdk_constraint_args() == []
+
+
+def test_unavailable_settings_fall_back_to_default(monkeypatch):
+    def _raise():
+        msg = "settings not ready"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(lfx.services.deps, "get_settings_service", _raise)
+    assert mcp_sdk_constraint_args() == ["--with", DEFAULT_MCP_SDK_CONSTRAINT]

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -106,6 +106,7 @@ EXPECTED_FIELDS = {
     "skip_mcp_auto_init",
     "mcp_composer_enabled",
     "mcp_composer_version",
+    "mcp_sdk_constraint",
     "a2a_enabled",
     "a2a_allow_private_webhooks",
     # TelemetrySettings
@@ -281,6 +282,7 @@ def test_critical_defaults_unchanged():
     assert settings.mcp_server_allowed_packages is None
     assert settings.mcp_server_enabled is True
     assert settings.mcp_composer_enabled is True
+    assert settings.mcp_sdk_constraint == "mcp~=1.28"
     assert settings.load_flows_preserve_variable_bindings is True
     assert settings.do_not_track is False
     assert settings.dev is False
@@ -408,6 +410,7 @@ def test_yaml_round_trip():
         ("LANGFLOW_PROMETHEUS_ENABLED", "true", "prometheus_enabled", True),
         ("LANGFLOW_PROMETHEUS_PORT", "9999", "prometheus_port", 9999),
         ("LANGFLOW_MCP_SERVER_ENABLED", "false", "mcp_server_enabled", False),
+        ("LANGFLOW_MCP_SDK_CONSTRAINT", "mcp~=1.30", "mcp_sdk_constraint", "mcp~=1.30"),
         ("LANGFLOW_SKIP_MCP_AUTO_INIT", "true", "skip_mcp_auto_init", True),
         ("LANGFLOW_DO_NOT_TRACK", "true", "do_not_track", True),
         ("LANGFLOW_DEV", "true", "dev", True),


### PR DESCRIPTION
## Problem

`mcp` 2.0.0 shipped and broke every MCP server Langflow launches through `uvx`. uvx resolves each server into its own ephemeral environment, so Langflow's own `mcp<2.0.0` pin never applies there:

- **mcp-proxy** 0.12.0 declares `mcp>=1.17.0` → imports `request_ctx`, removed in 2.0
- **mcp-server-fetch** 2026.7.10 declares `mcp>=1.1.3` → imports `McpError`, renamed `MCPError` in 2.0

The child crashes at import and the server lists no tools. This is why Playwright shards 60/61 (`mcp-server.spec.ts`) are red on every PR against this branch, and it also hits any user auto-installing a project MCP server (`uvx mcp-proxy` / `uvx mcp-composer` argv is generated by Langflow itself).

Repro:
```
uvx mcp-server-fetch --help                    → ImportError: cannot import name 'McpError'
uvx --with 'mcp~=1.28' mcp-server-fetch --help → works
```

## Fix

Inject `--with mcp~=1.28` into every uvx argv Langflow generates, behind a new `mcp_sdk_constraint` setting (mirrors `mcp_composer_version`; env `LANGFLOW_MCP_SDK_CONSTRAINT`, empty string disables once upstream supports 2.x). Argv injection (not env-based pinning) is deliberate: exported client configs (Cursor/Claude Desktop) run uvx on the user's machine, so only argv survives.

- `lfx/base/mcp/uvx.py`: shared `mcp_sdk_constraint_args()` helper; `~=1.28` is PEP 440 for `>=1.28,<2.0` and avoids `<`, which the stdio security policy blocks as a shell metacharacter
- Injected at all argv build sites: `config_utils.py`, `mcp_projects.py` (proxy + composer), `projects_mcp_helpers.py`, `mcp_composer/service.py`
- `source_policy.py`: `_package_runner_target` now skips `--with` values (all spellings: `--with X`, `--with=X`, `-w X`, `-wX`) so the constraint isn't misread as the runner target when a package allowlist is configured
- `source_policy.py`: the exact configured constraint is exempt from `mcp_server_allowed_packages`, so allowlisted deployments keep working without adding `mcp`; any other `--with` requirement is still validated, and the constraint can't mask an unapproved target
- Playwright: `fill-fetch-server-command.ts` helper pins the SDK for `mcp-server-fetch` in the three broken specs

## Testing

- `src/lfx/tests/unit/mcp`: 392 passed (includes new `test_uvx_sdk_constraint.py` and new source-policy cases for constraint spellings, allowlist exemption, and masking attempts)
- Verified `validate_mcp_stdio_config` passes the injected argv both with and without a package allowlist, and still rejects `mcp<2.0.0` and non-matching specifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP servers launched through `uvx` now use a compatible MCP SDK version by default.
  * Improved handling of MCP SDK constraints and `uvx --with` arguments.
  * Added configuration support to customize or disable automatic SDK version constraints.

* **Tests**
  * Expanded coverage for MCP server setup, SDK compatibility, argument parsing, and package validation.
  * Standardized MCP server test setup and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->