### PR TITLE
fix(api): retry project delete on sqlite lock

### DIFF
--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -43,6 +43,11 @@ from langflow.services.authorization import (
 )
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
 from langflow.services.authorization.utils import _resolve_authz_domain
+from langflow.services.database.lock_retry import (
+    is_database_lock_error,
+    run_with_lock_retry,
+    sanitize_database_error,
+)
 from langflow.services.database.models.deployment.exceptions import (
     araise_if_deployment_guard_error_or_skip,
     remap_flow_guard_for_project_delete,
@@ -63,6 +68,10 @@ from langflow.services.deps import get_service, get_settings_service
 from langflow.services.schema import ServiceType
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
+
+PROJECT_READ_FAILED = "Could not read the project."
+PROJECT_DELETE_FAILED = "Could not delete the project."
+PROJECT_DELETE_BUSY = "The database is busy. Please retry the request."
 
 # Backwards-compatible local alias; the implementation now lives in lfx.utils.util_strings so the
 # same LIKE-escaping is shared across the API endpoints + the tracing repository.
@@ -659,8 +668,8 @@ async def delete_project(
     project_id: UUID,
     current_user: CurrentActiveUser,
 ):
-    try:
-        project = await authorized_or_owner_scoped(
+    async def _load_project() -> Folder | None:
+        return await authorized_or_owner_scoped(
             session,
             Folder,
             id_column=Folder.id,
@@ -668,8 +677,11 @@ async def delete_project(
             owner_column=Folder.user_id,
             owner_id=current_user.id,
         )
+
+    try:
+        project = await _load_project()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail=sanitize_database_error(e, PROJECT_READ_FAILED)) from e
 
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -694,33 +706,49 @@ async def delete_project(
             detail=msg,
         )
 
-    await cleanup_mcp_on_delete(project, project_id, current_user, session)
-
     # Cascade and deployment guards operate over the project owner's flows —
     # a non-owner with a delete share must remove the owner's resources, not
     # only their own (which is the empty set for a non-owner).
     project_owner_id = project.user_id
 
-    async def _delete_project_operation() -> None:
-        flows = (
-            await session.exec(select(Flow).where(Flow.folder_id == project_id, Flow.user_id == project_owner_id))
-        ).all()
-        if len(flows) > 0:
-            for flow in flows:
-                await cascade_delete_flow(session, flow.id)
+    def _make_delete_operation(target: Folder):
+        async def _delete_project_operation() -> None:
+            flows = (
+                await session.exec(select(Flow).where(Flow.folder_id == project_id, Flow.user_id == project_owner_id))
+            ).all()
+            if len(flows) > 0:
+                for flow in flows:
+                    await cascade_delete_flow(session, flow.id)
 
-        await check_project_has_deployments(session, project_id=project_id)
-        await session.delete(project)
-        # Flush eagerly so guard/constraint errors surface in-request rather than at teardown commit.
-        await session.flush()
+            await check_project_has_deployments(session, project_id=project_id)
+            await session.delete(target)
+            # Flush eagerly so guard/constraint errors surface in-request rather than at teardown commit.
+            await session.flush()
 
-    try:
+        return _delete_project_operation
+
+    # LE-2020: a retry runs in a brand new transaction, and the rollback that
+    # precedes it expires every instance loaded so far. The user and the row are
+    # therefore re-read with awaits — a plain attribute read on expired state
+    # would lazy-load outside the greenlet context and raise MissingGreenlet.
+    async def _delete_attempt(attempt: int) -> None:
+        if attempt == 0:
+            target = project
+        else:
+            await session.refresh(current_user)
+            target = await _load_project()
+        if target is None:
+            return
+        await cleanup_mcp_on_delete(target, project_id, current_user, session)
         await retry_project_operation_on_deployment_guard(
             db=session,
             user_id=project_owner_id,
             project_id=project_id,
-            operation=_delete_project_operation,
+            operation=_make_delete_operation(target),
         )
+
+    try:
+        await run_with_lock_retry(_delete_attempt, session=session, description=f"delete_project {project_id}")
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         await araise_if_deployment_guard_error_or_skip(
@@ -728,7 +756,17 @@ async def delete_project(
             log_message=f"op=delete_project project_id={project_id}",
             remap=remap_flow_guard_for_project_delete,
         )
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        if is_database_lock_error(e):
+            # Contention that outlived the retry budget is transient, not a
+            # server fault: 503 + Retry-After lets a client retry correctly.
+            await logger.awarning("op=delete_project project_id=%s exhausted lock retries", project_id)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=PROJECT_DELETE_BUSY,
+                headers={"Retry-After": "1"},
+            ) from e
+        await logger.aexception("op=delete_project project_id=%s failed with %s", project_id, type(e).__name__)
+        raise HTTPException(status_code=500, detail=sanitize_database_error(e, PROJECT_DELETE_FAILED)) from e
 
 
 @router.get("/download/{project_id}", status_code=200)

--- a/src/backend/base/langflow/services/database/lock_retry.py
+++ b/src/backend/base/langflow/services/database/lock_retry.py
@@ -1,0 +1,111 @@
+"""Recovery helpers for transient database write-lock contention.
+
+SQLite serializes writers, and under WAL a transaction that has already read
+cannot be upgraded to a writer once another connection has committed: SQLite
+answers ``SQLITE_BUSY_SNAPSHOT`` (message: "database is locked") *immediately*
+and deliberately does not invoke the busy handler, because waiting could never
+resolve a stale snapshot. ``busy_timeout`` therefore has no effect on this
+class of failure — the only valid recovery is to end the transaction and run it
+again against a fresh snapshot, which is what :func:`run_with_lock_retry` does.
+
+PostgreSQL deployments never take this path: the predicate below only matches
+SQLite lock errors, so the retry is inert elsewhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import TYPE_CHECKING, TypeVar
+
+from lfx.log.logger import logger
+from sqlalchemy.exc import DBAPIError, SQLAlchemyError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+T = TypeVar("T")
+
+DEFAULT_LOCK_RETRY_ATTEMPTS = 8
+DEFAULT_LOCK_RETRY_BASE_DELAY = 0.02
+MAX_LOCK_RETRY_DELAY = 0.75
+
+# sqlite3 exposes the extended result code by name from Python 3.11 on; the
+# message check keeps older interpreters and non-extended codes covered.
+_SQLITE_LOCK_ERROR_NAMES = frozenset(
+    {
+        "SQLITE_BUSY",
+        "SQLITE_BUSY_SNAPSHOT",
+        "SQLITE_BUSY_RECOVERY",
+        "SQLITE_BUSY_TIMEOUT",
+        "SQLITE_LOCKED",
+        "SQLITE_LOCKED_SHAREDCACHE",
+    }
+)
+_SQLITE_LOCK_MESSAGES = ("database is locked", "database table is locked")
+
+
+def is_database_lock_error(exc: BaseException | None) -> bool:
+    """Return True when *exc* (or anything it wraps) is a transient SQLite lock error."""
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        error_name = getattr(exc, "sqlite_errorname", None)
+        if error_name in _SQLITE_LOCK_ERROR_NAMES:
+            return True
+        if isinstance(exc, DBAPIError | SQLAlchemyError) or error_name is not None:
+            message = str(exc).lower()
+            if any(marker in message for marker in _SQLITE_LOCK_MESSAGES):
+                return True
+        exc = getattr(exc, "orig", None) or exc.__cause__
+    return False
+
+
+def sanitize_database_error(exc: BaseException, fallback: str) -> str:
+    """Return a client-safe message for *exc*.
+
+    SQLAlchemy's ``str()`` embeds the failing statement, the table name and the
+    bound parameters, so it must never reach an API consumer.
+    """
+    if isinstance(exc, SQLAlchemyError):
+        return fallback
+    return str(exc)
+
+
+async def run_with_lock_retry(
+    operation: Callable[[int], Awaitable[T]],
+    *,
+    session: AsyncSession,
+    description: str,
+    attempts: int = DEFAULT_LOCK_RETRY_ATTEMPTS,
+    base_delay: float = DEFAULT_LOCK_RETRY_BASE_DELAY,
+) -> T:
+    """Run *operation* until it succeeds, retrying only transient lock failures.
+
+    *operation* receives the zero-based attempt number and must be safe to run
+    again from scratch: every retry starts a brand new transaction, so state
+    read or written by a failed attempt is gone and has to be re-established.
+
+    The last attempt's error propagates unchanged so callers can map an
+    exhausted retry budget to their own response.
+    """
+    last_attempt = attempts - 1
+    for attempt in range(attempts):
+        try:
+            return await operation(attempt)
+        except Exception as exc:
+            if attempt == last_attempt or not is_database_lock_error(exc):
+                raise
+            # The snapshot is stale: roll the transaction back so the retry
+            # reads current data instead of failing on the same conflict.
+            await session.rollback()
+            delay = min(base_delay * (2**attempt), MAX_LOCK_RETRY_DELAY)
+            # Jitter keeps concurrent losers from colliding again in lockstep.
+            await asyncio.sleep(delay * (0.5 + random.random()))  # noqa: S311
+            await logger.adebug(
+                "Database lock contention on %s, retrying (attempt %s/%s)", description, attempt + 2, attempts
+            )
+    msg = "unreachable: the retry loop either returns or raises"
+    raise AssertionError(msg)

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -182,6 +182,76 @@ async def test_delete_project_then_404(client: AsyncClient, logged_in_headers, b
     assert get_resp.status_code == status.HTTP_404_NOT_FOUND
 
 
+async def test_delete_project_recovers_from_concurrent_write_lock(
+    client: AsyncClient, logged_in_headers, basic_case, monkeypatch
+):
+    """LE-2020: a competing commit must not turn DELETE into a 500 that leaves the project behind.
+
+    ``delete_project`` runs inside ``begin_nested()`` — the SAVEPOINT opens a DEFERRED
+    SQLite transaction, and the reads it performs (flow enumeration, deployment check)
+    pin a read snapshot. When another connection commits before the row delete runs,
+    SQLite answers SQLITE_BUSY_SNAPSHOT *immediately*: the busy handler is never
+    invoked, so ``busy_timeout`` cannot help and only restarting the transaction can.
+
+    The contention is injected with a real second connection committing a real row —
+    the DB is never mocked, only the timing is made deterministic instead of load-dependent.
+    """
+    from langflow.api.v1 import projects as projects_module
+
+    create_resp = await client.post("api/v1/projects/", json=basic_case, headers=logged_in_headers)
+    assert create_resp.status_code == status.HTTP_201_CREATED
+    project_id = create_resp.json()["id"]
+
+    original_check = projects_module.check_project_has_deployments
+    attempts = {"count": 0}
+
+    async def check_with_competing_commit(session, *, project_id):
+        # Only the first attempt races: a retry must find a quiet database and win.
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            async with session_scope() as competing_session:
+                competing_session.add(Folder(name=f"competing-write-{uuid4()}", user_id=None))
+        return await original_check(session, project_id=project_id)
+
+    monkeypatch.setattr(projects_module, "check_project_has_deployments", check_with_competing_commit)
+
+    delete_resp = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+
+    assert attempts["count"] >= 1, "the contention hook never ran — the test no longer exercises the race"
+    assert delete_resp.status_code == status.HTTP_204_NO_CONTENT, delete_resp.text
+
+    get_resp = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert get_resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_delete_project_does_not_leak_sql_on_database_error(
+    client: AsyncClient, logged_in_headers, basic_case, monkeypatch
+):
+    """LE-2020: the error payload must never echo the statement, table or bound parameters."""
+    import sqlite3
+
+    from langflow.api.v1 import projects as projects_module
+    from sqlalchemy.exc import OperationalError
+
+    create_resp = await client.post("api/v1/projects/", json=basic_case, headers=logged_in_headers)
+    project_id = create_resp.json()["id"]
+
+    leaked_statement = "DELETE FROM folder WHERE folder.id = ?"
+
+    async def always_locked(session, *, project_id):  # noqa: ARG001
+        raise OperationalError(leaked_statement, {"id": project_id}, sqlite3.OperationalError("database is locked"))
+
+    monkeypatch.setattr(projects_module, "check_project_has_deployments", always_locked)
+
+    delete_resp = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+
+    assert delete_resp.status_code != status.HTTP_204_NO_CONTENT
+    detail = delete_resp.json()["detail"]
+    assert "DELETE FROM folder" not in detail
+    assert "sqlalche.me" not in detail
+    assert str(project_id) not in detail
+
+
 async def test_read_project_invalid_id_format(client: AsyncClient, logged_in_headers):
     bad_id = "not-a-uuid"
     response = await client.get(f"api/v1/projects/{bad_id}", headers=logged_in_headers)

--- a/src/backend/tests/unit/services/database/test_lock_retry.py
+++ b/src/backend/tests/unit/services/database/test_lock_retry.py
@@ -1,0 +1,102 @@
+"""Unit coverage for the LE-2020 database lock retry helper."""
+
+import sqlite3
+
+import pytest
+from langflow.services.database.lock_retry import (
+    is_database_lock_error,
+    run_with_lock_retry,
+    sanitize_database_error,
+)
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+
+class RecordingSession:
+    """Minimal stand-in that records rollbacks; the helper only ever calls rollback()."""
+
+    def __init__(self):
+        self.rollbacks = 0
+
+    async def rollback(self):
+        self.rollbacks += 1
+
+
+def make_lock_error(errorname: str = "SQLITE_BUSY_SNAPSHOT") -> OperationalError:
+    original = sqlite3.OperationalError("database is locked")
+    original.sqlite_errorname = errorname
+    return OperationalError("DELETE FROM folder WHERE folder.id = ?", {"id": "abc"}, original)
+
+
+def test_should_detect_lock_error_from_extended_result_code():
+    assert is_database_lock_error(make_lock_error()) is True
+    assert is_database_lock_error(make_lock_error("SQLITE_BUSY")) is True
+    assert is_database_lock_error(make_lock_error("SQLITE_LOCKED")) is True
+
+
+def test_should_detect_lock_error_from_message_without_error_name():
+    assert is_database_lock_error(OperationalError("stmt", {}, Exception("database is locked"))) is True
+
+
+def test_should_not_treat_other_database_errors_as_lock_errors():
+    assert is_database_lock_error(IntegrityError("stmt", {}, Exception("UNIQUE constraint failed"))) is False
+    assert is_database_lock_error(ValueError("database is locked")) is False
+    assert is_database_lock_error(None) is False
+
+
+def test_should_detect_lock_error_wrapped_in_another_exception():
+    lock_error = make_lock_error()
+    wrapper = RuntimeError("delete failed")
+    wrapper.__cause__ = lock_error
+    assert is_database_lock_error(wrapper) is True
+
+
+def test_should_hide_sql_from_database_errors_only():
+    leaky = make_lock_error()
+    assert sanitize_database_error(leaky, "Could not delete the project.") == "Could not delete the project."
+    assert sanitize_database_error(ValueError("plain failure"), "fallback") == "plain failure"
+
+
+async def test_should_retry_until_the_operation_succeeds():
+    session = RecordingSession()
+    seen: list[int] = []
+
+    async def operation(attempt: int) -> str:
+        seen.append(attempt)
+        if attempt < 2:
+            raise make_lock_error()
+        return "deleted"
+
+    result = await run_with_lock_retry(operation, session=session, description="test", base_delay=0.001)
+
+    assert result == "deleted"
+    assert seen == [0, 1, 2]
+    assert session.rollbacks == 2, "each retry must start from a rolled-back transaction"
+
+
+async def test_should_reraise_the_last_error_when_attempts_are_exhausted():
+    session = RecordingSession()
+
+    async def always_locked(_attempt: int) -> None:
+        raise make_lock_error()
+
+    with pytest.raises(OperationalError):
+        await run_with_lock_retry(always_locked, session=session, description="test", attempts=3, base_delay=0.001)
+
+    assert session.rollbacks == 2
+
+
+async def test_should_not_retry_errors_that_are_not_lock_contention():
+    session = RecordingSession()
+    calls = {"count": 0}
+
+    constraint_error = IntegrityError("stmt", {}, sqlite3.IntegrityError("UNIQUE constraint failed"))
+
+    async def failing(_attempt: int) -> None:
+        calls["count"] += 1
+        raise constraint_error
+
+    with pytest.raises(IntegrityError):
+        await run_with_lock_retry(failing, session=session, description="test", base_delay=0.001)
+
+    assert calls["count"] == 1
+    assert session.rollbacks == 0


### PR DESCRIPTION
`DELETE /api/v1/projects/{project_id}` is declared `204`, but whenever another write commits while the request is in flight it answers **`500` with the raw SQL echoed to the client and the project is not deleted**. This retries the transaction instead, so the endpoint keeps its contract under concurrency.

Fixes LE-2020.

## Root cause

`delete_project` runs its work inside `retry_project_operation_on_deployment_guard`, which wraps the operation in `db.begin_nested()`. The `SAVEPOINT` opens a **DEFERRED** SQLite transaction, and the reads that follow (flow enumeration, deployment guard) pin a read snapshot. When another connection commits before the row delete runs, SQLite answers `SQLITE_BUSY_SNAPSHOT` **immediately and deliberately does not invoke the busy handler** — waiting could never resolve a stale snapshot. That is why the configured `busy_timeout=30000` has no effect and the failures come back in milliseconds.

Isolated with a probe against a WAL database with `busy_timeout=30000`:

| shape | result |
| --- | --- |
| read → write | OK, 0.0005s |
| **SAVEPOINT → read → write** | **fails in 0.0002s, `SQLITE_BUSY_SNAPSHOT`** |
| SAVEPOINT → read → write, then rollback + retry | recovers on the 2nd attempt |

Sibling endpoints survive the same contention because they do not pair a savepoint with reads before the write.

## Changes

- **`services/database/lock_retry.py`** (new): `is_database_lock_error` (extended result code plus message, walking `orig`/`__cause__`), `run_with_lock_retry` (rollback → exponential backoff with jitter → re-run in a fresh transaction), and `sanitize_database_error`. The predicate only matches SQLite lock errors, so PostgreSQL deployments never take this path.
- **`delete_project`**: the retryable unit now includes re-loading the row and re-applying the MCP cleanup. The rollback that precedes a retry expires every loaded instance, so the user and the project row are re-read with awaits — a plain attribute read on expired state would lazy-load outside the greenlet context and raise `MissingGreenlet`.
- Contention that outlives the retry budget maps to **`503` + `Retry-After`** instead of `500`, and SQLAlchemy errors no longer echo the statement, table or bound parameters to the client; the full error is logged server-side instead.

## Verification

Reproduced first against a live server on SQLite with concurrent create+delete clients, matching the report byte for byte:

```
DELETE status distribution: {500: 15, 204: 15}
failure latency: 0.009s / 0.010s / 0.013s
{"detail":"(sqlite3.OperationalError) database is locked
[SQL: DELETE FROM folder WHERE folder.id = ?] ..."}
projects still present after a failed DELETE: 15/15
```

Same script and server after the fix:

| concurrent clients | before | after |
| --- | --- | --- |
| 2 | 15/30 → `500` | **30/30 → `204`** |
| 4 | ~50% → `500` | **60/60 → `204`** |
| 8 | 67/80 → `500` | **120/120 → `204`** |
| 8 × 40 rounds (stress) | — | 316/320 → `204`, 4 → clean `503` after ~2.3s |

No `500` and no SQL leak at any concurrency level. The residual `503`s only appear with eight clients hammering with zero think time, where SQLite is genuinely saturated and a transient, retryable status is the correct answer.

Tests:

- `test_delete_project_recovers_from_concurrent_write_lock` — written first and confirmed failing with the exact payload from the report. The contention is injected by a real second connection committing a real row, so the database is never mocked; only the timing is made deterministic instead of load-dependent.
- `test_delete_project_does_not_leak_sql_on_database_error` — the error payload must not echo the statement, table or parameters.
- 8 unit tests for the retry helper (detection, retry, exhaustion, and no retry for non-lock errors).
- `test_projects.py` + `test_folders.py`: 54 passed, 1 skipped. `test_deployment_guard_retry.py`: passing. `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project deletion reliability during temporary database lock contention.
  * Project deletion now retries safely and returns a clear busy response with retry guidance when contention persists.
  * Improved error handling for project read and deletion failures.
  * Sanitized database errors to prevent SQL statements, parameters, and internal details from appearing in API responses.
* **Tests**
  * Added coverage for lock retries, deletion under contention, retry exhaustion, and error sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->