### PR TITLE
fix(frontend): dismiss welcome overlay synchronously when picking a template

### DIFF
--- a/src/frontend/src/components/core/flowBuilderWelcome/__tests__/flow-builder-welcome-mount.test.tsx
+++ b/src/frontend/src/components/core/flowBuilderWelcome/__tests__/flow-builder-welcome-mount.test.tsx
@@ -108,6 +108,25 @@ describe("FlowBuilderWelcomeMount placeholder cleanup", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("should_still_reap_the_placeholder_after_the_overlay_was_dismissed_for_navigation", () => {
+    // The templates path calls dismissForNavigation() in the same tick as the
+    // navigate, so this effect always runs with isOpen already false. Cleanup
+    // must key off openedForFlowId alone, never isOpen.
+    welcomeState = { isOpen: false, openedForFlowId: "flow-placeholder" };
+    flowsManagerState = {
+      currentFlowId: "flow-template",
+      flows: [
+        { id: "flow-placeholder", data: { nodes: [] } },
+        { id: "flow-template", data: { nodes: [{ id: "n1" }] } },
+      ],
+    };
+
+    render(<FlowBuilderWelcomeMount />);
+
+    expect(deleteFlow).toHaveBeenCalledWith({ id: "flow-placeholder" });
+    expect(close).toHaveBeenCalled();
+  });
+
   it("should_not_delete_anything_when_still_on_the_placeholder_flow", () => {
     // Quick-template path mutates the placeholder in place — same flow id, so
     // there is nothing to clean up.

--- a/src/frontend/src/components/core/flowBuilderWelcome/flow-builder-welcome-mount.tsx
+++ b/src/frontend/src/components/core/flowBuilderWelcome/flow-builder-welcome-mount.tsx
@@ -45,13 +45,12 @@ export function FlowBuilderWelcomeMount() {
   // placeholder. Delete that placeholder here so the user is left with a SINGLE
   // flow (the template they chose) instead of two. Guarded to only remove a
   // still-blank placeholder so we never discard a flow the user built on.
+  // Intentionally NOT guarded on ``isOpen``: the templates path dismisses the
+  // overlay synchronously at navigation (see ``dismissForNavigation``), so by
+  // the time this runs ``isOpen`` is already false and only ``openedForFlowId``
+  // is left to tell us there is a placeholder to reap.
   useEffect(() => {
-    if (
-      isOpen &&
-      openedForFlowId &&
-      currentFlowId &&
-      currentFlowId !== openedForFlowId
-    ) {
+    if (openedForFlowId && currentFlowId && currentFlowId !== openedForFlowId) {
       const placeholder = flows?.find((flow) => flow.id === openedForFlowId);
       const isBlankPlaceholder =
         !!placeholder && (placeholder.data?.nodes?.length ?? 0) === 0;
@@ -61,7 +60,7 @@ export function FlowBuilderWelcomeMount() {
       }
       close();
     }
-  }, [isOpen, openedForFlowId, currentFlowId, close, flows, deleteFlow]);
+  }, [openedForFlowId, currentFlowId, close, flows, deleteFlow]);
   const setAssistantSidebarOpen = useAssistantManagerStore(
     (state) => state.setAssistantSidebarOpen,
   );

--- a/src/frontend/src/modals/templatesModal/components/TemplateContentComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/TemplateContentComponent/index.tsx
@@ -6,6 +6,7 @@ import { ENABLE_KNOWLEDGE_BASES } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAddFlow from "@/hooks/flows/use-add-flow";
+import useFlowBuilderWelcomeStore from "@/stores/flowBuilderWelcomeStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { ForwardedIconComponent } from "../../../../components/common/genericIconComponent";
 import { Input } from "../../../../components/ui/input";
@@ -47,6 +48,9 @@ export default function TemplateContentComponent({
   const [filteredExamples, setFilteredExamples] = useState(examples);
   const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
+  const dismissWelcomeForNavigation = useFlowBuilderWelcomeStore(
+    (state) => state.dismissForNavigation,
+  );
   const { folderId } = useParams();
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -82,6 +86,8 @@ export default function TemplateContentComponent({
     updateIds(example.data);
     addFlow({ flow: example })
       .then((id) => {
+        // Same tick as the navigate — see ``dismissForNavigation``.
+        dismissWelcomeForNavigation();
         navigate(`/flow/${id}/folder/${folderIdUrl}`);
       })
       .finally(() => {

--- a/src/frontend/src/modals/templatesModal/components/TemplateGetStartedCardComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/TemplateGetStartedCardComponent/index.tsx
@@ -4,6 +4,7 @@ import { convertTestName } from "@/components/common/storeCardComponent/utils/co
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAddFlow from "@/hooks/flows/use-add-flow";
+import useFlowBuilderWelcomeStore from "@/stores/flowBuilderWelcomeStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { updateIds } from "@/utils/reactflowUtils";
 import { cn } from "@/utils/utils";
@@ -25,6 +26,9 @@ export default function TemplateGetStartedCardComponent({
 }: TemplateGetStartedCardComponentProps) {
   const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
+  const dismissWelcomeForNavigation = useFlowBuilderWelcomeStore(
+    (state) => state.dismissForNavigation,
+  );
   const { folderId } = useParams();
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
 
@@ -38,6 +42,8 @@ export default function TemplateGetStartedCardComponent({
       updateIds(flow.data!);
       addFlow({ flow })
         .then((id) => {
+          // Same tick as the navigate — see ``dismissForNavigation``.
+          dismissWelcomeForNavigation();
           navigate(`/flow/${id}/folder/${folderIdUrl}`);
         })
         .finally(() => {

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAddFlow from "@/hooks/flows/use-add-flow";
+import useFlowBuilderWelcomeStore from "@/stores/flowBuilderWelcomeStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import type { Category } from "@/types/templates/types";
 import { cn } from "@/utils/utils";
@@ -25,6 +26,9 @@ export default function TemplatesModal({
   const [loading, setLoading] = useState(false);
   const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
+  const dismissWelcomeForNavigation = useFlowBuilderWelcomeStore(
+    (state) => state.dismissForNavigation,
+  );
   const { folderId } = useParams();
   const hideStarterProjects = useUtilityStore(
     (state) => state.hideStarterProjects,
@@ -48,6 +52,8 @@ export default function TemplatesModal({
 
     addFlow()
       .then((id) => {
+        // Same tick as the navigate — see ``dismissForNavigation``.
+        dismissWelcomeForNavigation();
         navigate(`/flow/${id}${folderId ? `/folder/${folderId}` : ""}`);
       })
       .finally(() => {

--- a/src/frontend/src/stores/__tests__/flowBuilderWelcomeStore.test.ts
+++ b/src/frontend/src/stores/__tests__/flowBuilderWelcomeStore.test.ts
@@ -70,4 +70,46 @@ describe("useFlowBuilderWelcomeStore", () => {
       expect(state.isOpen).toBe(true);
     });
   });
+
+  describe("dismissForNavigation", () => {
+    it("should_hide_the_overlay_immediately", () => {
+      useFlowBuilderWelcomeStore.setState({
+        isOpen: true,
+        openedForFlowId: "flow-placeholder",
+      });
+
+      useFlowBuilderWelcomeStore.getState().dismissForNavigation();
+
+      // The sidebar keys off isOpen, so this MUST be false before the new flow
+      // paints — otherwise it stays at display:none and ReactFlow fits against
+      // a canvas width it is about to lose.
+      expect(useFlowBuilderWelcomeStore.getState().isOpen).toBe(false);
+    });
+
+    it("should_retain_openedForFlowId_so_the_placeholder_can_still_be_reaped", () => {
+      useFlowBuilderWelcomeStore.setState({
+        isOpen: true,
+        openedForFlowId: "flow-placeholder",
+      });
+
+      useFlowBuilderWelcomeStore.getState().dismissForNavigation();
+
+      // Unlike close(), this keeps the id — the mount's cleanup effect is the
+      // only thing that knows how to delete the orphaned blank placeholder.
+      expect(useFlowBuilderWelcomeStore.getState().openedForFlowId).toBe(
+        "flow-placeholder",
+      );
+    });
+
+    it("should_drop_a_stale_pendingMessage", () => {
+      useFlowBuilderWelcomeStore.setState({
+        isOpen: true,
+        pendingMessage: "stale",
+      });
+
+      useFlowBuilderWelcomeStore.getState().dismissForNavigation();
+
+      expect(useFlowBuilderWelcomeStore.getState().pendingMessage).toBeNull();
+    });
+  });
 });

--- a/src/frontend/src/stores/flowBuilderWelcomeStore.ts
+++ b/src/frontend/src/stores/flowBuilderWelcomeStore.ts
@@ -25,6 +25,9 @@ interface FlowBuilderWelcomeState {
   openedForFlowId: string | null;
   open: (flowId?: string | null) => void;
   close: () => void;
+  /** Hide the overlay *synchronously*, at the moment we navigate to another
+   *  flow, while keeping ``openedForFlowId`` for the mount's cleanup effect. */
+  dismissForNavigation: () => void;
   setPendingMessage: (message: string) => void;
   clearPendingMessage: () => void;
 }
@@ -38,6 +41,15 @@ const useFlowBuilderWelcomeStore = create<FlowBuilderWelcomeState>((set) => ({
   // otherwise replay into the assistant the next time the overlay opens.
   close: () =>
     set({ isOpen: false, pendingMessage: null, openedForFlowId: null }),
+  // Navigating to a different flow must hide the overlay in the SAME tick as
+  // the ``navigate`` call. Routing reuses the FlowPage instance (no
+  // ``key={id}``), so the mount's id-comparison effect only fires a beat
+  // later — and until it does, the new flow paints while ``isOpen`` is still
+  // true, which keeps the sidebar at ``display: none`` and lets ReactFlow
+  // fitView against a full-width canvas it is about to lose. Hence a
+  // synchronous dismiss here. ``openedForFlowId`` is deliberately retained so
+  // the mount can still find and delete the orphaned blank placeholder.
+  dismissForNavigation: () => set({ isOpen: false, pendingMessage: null }),
   setPendingMessage: (message) => set({ pendingMessage: message }),
   clearPendingMessage: () => set({ pendingMessage: null }),
 }));


### PR DESCRIPTION
## Problem

Picking a template from **Browse Templates** left the flow page mis-rendered: the left sidebar disappeared and a block of dead space showed up on the right.

Both symptoms come from **one** cause — a state-lifetime race, not a styling bug.

Picking a template creates a new flow and navigates to it, but routing reuses the `FlowPage` instance (there is no `key={id}`). The welcome overlay's global `isOpen` flag was only cleared a beat later, by an effect that compares the current flow id to `openedForFlowId`. Until that effect ran, the new flow painted while the app still believed the welcome was open:

- `FlowPage` keeps the sidebar wrapper at `display: none` while the welcome is open → **sidebar vanishes**
- ReactFlow therefore measured, and ran `fitView` against, a full-width canvas it was about to lose. The sidebar then appeared and shrank the container, leaving the already-fitted content offset → **apparent "padding" on the right**

That second symptom is not padding at all, which is why it was hard to locate.

The window is only a frame or two, so it reproduced on slower machines and cold caches but not on fast ones — and only via `blank screen → Browse more → gallery → click a card`. The quick-start buttons mutate the current flow in place without navigating, and opening a flow from the list remounts cleanly, so neither path hits it.

## Fix

Dismiss the overlay in the **same tick as the navigate**, instead of waiting on the effect.

- `flowBuilderWelcomeStore.ts` — new `dismissForNavigation()`: clears `isOpen`, but deliberately **retains `openedForFlowId```
- `flow-builder-welcome-mount.tsx` — the placeholder-cleanup effect no longer guards on `isOpen` (already false by the time it runs), so the orphaned blank placeholder flow is still reaped
- the three template navigation call sites (card grid, get-started card, blank flow) call it before `navigate()`

### Why not `key={id}`

`key={id}` on the route was the other candidate. It forces a full remount of the entire `FlowPage` subtree on *every* flow→flow navigation — a broad cost to fix a narrow state-lifetime bug — and it hides the stale flag rather than correcting it.

## Tests

- 3 store tests covering the `dismissForNavigation` contract (hides overlay, retains `openedForFlowId`, drops stale `pendingMessage`)
- 1 mount test proving the placeholder is still reaped after the overlay was dismissed for navigation

All 4 were confirmed to **fail against the unfixed code** (guard reverted, watched them fail, restored) — they are real regression guards, not mirrors.

81 suites / 1374 tests green across `stores`, `flowBuilderWelcome`, `templatesModal`, `FlowPage`.

## Verification note

The race is 1–2 frames on a fast machine. A live run with a MutationObserver caught exactly one `display` toggle — on the old page, under the modal — and none after the new flow mounted; final canvas measured `x=280, w=1448`. That is corroboration rather than proof; confirmation from someone who could reproduce the original would be worth having.

## Out of scope

The model dropdown reverting its value on load (two queries with different cache windows → saved value treated as missing → phantom "unsaved changes") is a separate defect and is not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved welcome overlay dismissal during template navigation.
  * Ensured unused placeholder flows are cleaned up after navigating away.
  * Prevented stale pending messages from persisting during navigation.

* **Tests**
  * Added coverage for overlay dismissal and placeholder cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->