### PR TITLE
fix(frontend): skip template update for group nodes

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -77,6 +77,12 @@ export const mutateTemplate = async (
             callback?.();
           } catch (e) {
             const error = e as ResponseErrorDetailAPI;
+            // LE-2045: the fallback below identifies nothing, so a client-side
+            // throw is otherwise indistinguishable from a failed request.
+            console.error(
+              `Failed to update template for node ${nodeId}, field ${parameterName}`,
+              e,
+            );
             setErrorData({
               title: i18n.t("input.titleErrorUpdatingComponent"),
               list: [

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
@@ -16,7 +16,7 @@ import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 interface IPostTemplateValue {
-  value: any;
+  value: unknown;
   tool_mode?: boolean;
   // the dropdown input re-gathers all
   // dropdown items each time a single
@@ -87,14 +87,15 @@ export const usePostTemplateValue: useMutationFunctionType<
           tool_mode: payload.tool_mode,
         },
       );
-    } catch (e: any) {
+    } catch (e: unknown) {
       // Suppress 403 specifically from custom component blocking — fallback
       // for race conditions where the guards above couldn't detect the
       // outdated state in time.
       if (!allowCustomComponents && isCustomComponentBlockError(e)) {
+        const error = e as ResponseErrorDetailAPI;
         console.warn(
           `Suppressed 403 for outdated component (node ${nodeId}):`,
-          e.response.data.detail,
+          error.response.data.detail,
         );
         return undefined;
       }

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
@@ -54,6 +54,9 @@ export const usePostTemplateValue: useMutationFunctionType<
 
     if (!template) return;
 
+    // LE-2045: a grouped node proxies its fields and has no code to recompile.
+    if (!template.code) return undefined;
+
     const allowCustomComponents =
       useUtilityStore.getState().allowCustomComponents;
 

--- a/src/frontend/tests/core/unit/groupFalseError.spec.ts
+++ b/src/frontend/tests/core/unit/groupFalseError.spec.ts
@@ -31,7 +31,10 @@ test(
         if (def?.display_name === "Language Model") languageModel = def;
       }
     }
-    expect(languageModel, "Language Model not found in /api/v1/all").toBeTruthy();
+    expect(
+      languageModel,
+      "Language Model not found in /api/v1/all",
+    ).toBeTruthy();
 
     const modelField = Object.entries(languageModel.template).find(
       ([, field]: [string, any]) => field?.type === "model",
@@ -46,7 +49,11 @@ test(
       id: innerId,
       type: "genericNode",
       position: { x: 0, y: 0 },
-      data: { id: innerId, type: "LanguageModelComponent", node: languageModel },
+      data: {
+        id: innerId,
+        type: "LanguageModelComponent",
+        node: languageModel,
+      },
     };
 
     // The grouped template proxies the inner field and carries no `code` of its
@@ -75,7 +82,11 @@ test(
             name: "Group",
             description: "",
             id: groupId,
-            data: { nodes: [innerNode], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+            data: {
+              nodes: [innerNode],
+              edges: [],
+              viewport: { x: 0, y: 0, zoom: 1 },
+            },
           },
         },
       },

--- a/src/frontend/tests/core/unit/groupFalseError.spec.ts
+++ b/src/frontend/tests/core/unit/groupFalseError.spec.ts
@@ -1,3 +1,4 @@
+import type { APIClassType, APIObjectType } from "../../../src/types/api";
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
@@ -24,22 +25,25 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
-    const allTypes = await (await page.request.get("/api/v1/all")).json();
-    let languageModel: any;
-    for (const category of Object.values(allTypes) as Record<string, any>[]) {
+    const allTypes = (await (
+      await page.request.get("/api/v1/all")
+    ).json()) as APIObjectType;
+    let languageModel: APIClassType | undefined;
+    for (const category of Object.values(allTypes)) {
       for (const def of Object.values(category)) {
         if (def?.display_name === "Language Model") languageModel = def;
       }
     }
-    expect(
-      languageModel,
-      "Language Model not found in /api/v1/all",
-    ).toBeTruthy();
+    if (!languageModel) {
+      throw new Error("Language Model not found in /api/v1/all");
+    }
 
     const modelField = Object.entries(languageModel.template).find(
-      ([, field]: [string, any]) => field?.type === "model",
-    ) as [string, any];
-    expect(modelField, "Language Model has no model field").toBeTruthy();
+      ([, field]) => field.type === "model",
+    );
+    if (!modelField) {
+      throw new Error("Language Model has no model field");
+    }
 
     const innerId = "LanguageModelComponent-aaaaa";
     const groupId = "groupComponent-bbbbb";

--- a/src/frontend/tests/core/unit/groupFalseError.spec.ts
+++ b/src/frontend/tests/core/unit/groupFalseError.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+/**
+ * LE-2045: grouping succeeds but raises "Error while updating the Component".
+ *
+ * A grouped node has no `code` of its own — its fields proxy the inner
+ * components — so asking the update endpoint to recompile it throws before the
+ * request is even sent, and the generic error toast fires for an operation
+ * that never failed.
+ *
+ * The refresh only fires when the model field has no options, which is why the
+ * report needs a workspace with no provider configured: with a model selected
+ * the field never asks for a refresh and the bug stays hidden.
+ *
+ * The group node is synthesized here rather than produced by dragging and
+ * grouping in the UI so the failing shape is explicit and deterministic.
+ * The assertion targets the notifications panel because the toast
+ * auto-dismisses, while the reported message persists in the panel.
+ */
+test(
+  "a grouped node must not raise a false update error",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    const allTypes = await (await page.request.get("/api/v1/all")).json();
+    let languageModel: any;
+    for (const category of Object.values(allTypes) as Record<string, any>[]) {
+      for (const def of Object.values(category)) {
+        if (def?.display_name === "Language Model") languageModel = def;
+      }
+    }
+    expect(languageModel, "Language Model not found in /api/v1/all").toBeTruthy();
+
+    const modelField = Object.entries(languageModel.template).find(
+      ([, field]: [string, any]) => field?.type === "model",
+    ) as [string, any];
+    expect(modelField, "Language Model has no model field").toBeTruthy();
+
+    const innerId = "LanguageModelComponent-aaaaa";
+    const groupId = "groupComponent-bbbbb";
+    const proxiedName = `${modelField[0]}_${innerId}`;
+
+    const innerNode = {
+      id: innerId,
+      type: "genericNode",
+      position: { x: 0, y: 0 },
+      data: { id: innerId, type: "LanguageModelComponent", node: languageModel },
+    };
+
+    // The grouped template proxies the inner field and carries no `code` of its
+    // own; an empty option list is what makes the field ask for a refresh.
+    const groupNode = {
+      id: groupId,
+      type: "genericNode",
+      position: { x: 0, y: 0 },
+      data: {
+        id: groupId,
+        type: "GroupNode",
+        node: {
+          display_name: "Group",
+          description: "",
+          documentation: "",
+          outputs: languageModel.outputs,
+          template: {
+            [proxiedName]: {
+              ...modelField[1],
+              options: [],
+              value: "",
+              proxy: { field: modelField[0], id: innerId },
+            },
+          },
+          flow: {
+            name: "Group",
+            description: "",
+            id: groupId,
+            data: { nodes: [innerNode], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+          },
+        },
+      },
+    };
+
+    const created = await page.request.post("/api/v1/flows/", {
+      data: {
+        name: `le-2045-${Date.now()}`,
+        description: "LE-2045 false grouping error",
+        data: {
+          nodes: [groupNode],
+          edges: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+        },
+      },
+    });
+    expect(created.status()).toBe(201);
+    const flowId = (await created.json()).id;
+
+    await page.goto(`/flow/${flowId}`);
+    await expect(page.getByTestId("div-generic-node")).toHaveCount(1);
+    await page.waitForTimeout(4000);
+
+    await page.getByTestId("notification_button").click();
+    const panel = page.getByTestId("notification-dropdown-content");
+    await expect(panel).toBeVisible();
+    await expect(
+      panel.getByText("Error while updating the Component"),
+    ).toHaveCount(0);
+  },
+);


### PR DESCRIPTION
Grouping two components succeeds — the Group node is created and the flow persists — but Langflow raises **"Error while updating the Component / An unexpected error occurred while updating the Component. Please try again."** The message is false, and it persists in the Notifications panel with the bell badge lit until dismissed.

Fixes LE-2045.

## Root cause

`postTemplateValueFn` builds its payload with `code: template.code.value`. A grouped node has **no `code` of its own** — its fields are proxies onto the inner components (`code_<nodeId>`, `model_<nodeId>`, …) — so that read throws a `TypeError` **before the request is ever sent**. The throw lands in the outer `catch` of the debounced template update, which reports the generic failure message.

Captured on the reporting machine after instrumenting that `catch`:

```
Failed to update template for node groupComponent-n7UUn, field model_LanguageModelComponent-J8jPS
TypeError: Cannot read properties of undefined (reading 'value')
    at postTemplateValueFn (use-post-template-value.ts:80:31)
    fetchData @ use-fetch-data-on-mount.ts:50
```

This accounts for every symptom in the report: no request fails, none even appears in the Network tab, the console stays silent, the backend log is clean, and the message is the generic fallback (used only when a response `detail` is absent).

It also explains why the bug is invisible on most machines: the refresh that triggers it is only requested when the model field has **no options**, which happens when no model provider is configured. With a provider selected the field never asks for a refresh, so the throw never happens — reproducing this requires a workspace with no provider set up.

## Changes

- **`use-post-template-value.ts`** — return early when the template carries no `code`. There is nothing for the update endpoint to recompile on a grouped node, so the call is dropped instead of throwing.
- **`mutate-template.ts`** — log the real error before showing the generic message. Without it a client-side throw is indistinguishable from a failed request, which is what made this defect hard to trace; the ticket also asks for a message that identifies what actually failed.

## Verification

`tests/core/unit/groupFalseError.spec.ts` synthesizes the failing shape (a grouped node whose proxied model field has no options and whose template has no `code`) and asserts on the Notifications panel rather than the toast, which auto-dismisses.

| | result |
| --- | --- |
| spec with the fix reverted | **failed** — the message is present in the panel |
| spec with the fix | **passed** |
| jest `controllers/API/queries/nodes` + `CustomNodes` | 99 passed / 13 suites |
| biome + tsc on the touched files | clean |

The scenario is built through the API rather than by dragging and grouping in the UI so the failing shape is explicit and the test does not depend on selection-box timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary template update requests when grouped nodes lack template code.
  * Improved client-side error reporting for failed template updates.
  * Prevented erroneous “Error while updating the Component” notifications in grouped-node scenarios.

* **Tests**
  * Added regression coverage for grouped nodes with empty configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->