### PR TITLE
test(frontend): use stable float input selector

### DIFF
--- a/src/frontend/tests/core/unit/floatComponent.spec.ts
+++ b/src/frontend/tests/core/unit/floatComponent.spec.ts
@@ -44,20 +44,10 @@ test(
 
     await adjustScreenView(page);
 
-    await page.locator('//*[@id="int_int_seed"]').click();
-    await page.locator('//*[@id="int_int_seed"]').fill("");
-    await page.locator('//*[@id="int_int_seed"]').fill("3");
-
-    let value = await page.locator('//*[@id="int_int_seed"]').inputValue();
-
-    expect(value).toBe("3");
-
-    await page.locator('//*[@id="int_int_seed"]').click();
-    await page.locator('//*[@id="int_int_seed"]').fill("");
-    await page.locator('//*[@id="int_int_seed"]').fill("-3");
-
-    value = await page.locator('//*[@id="int_int_seed"]').inputValue();
-
-    expect(value).toBe("-3");
+    const seedInput = page.getByTestId("int_int_seed");
+    await seedInput.fill("3");
+    await expect(seedInput).toHaveValue("3");
+    await seedInput.fill("-3");
+    await expect(seedInput).toHaveValue("-3");
   },
 );


### PR DESCRIPTION
## Summary

- select the NVIDIA seed input through its preserved data-testid instead of its now node-scoped DOM id
- use Playwright web-first value assertions for the positive and negative input cases

## Root cause

PR #14312 made node parameter DOM ids unique by appending the node id. The FloatComponent test still waited for the obsolete exact id int_int_seed, so shard 47 timed out on every retry. The data-testid intentionally remains int_int_seed and is the stable test contract.

## Validation

- focused FloatComponent Playwright test: passed once with retries disabled
- focused FloatComponent Playwright test: passed 3/3 with repeat-each=3 and retries disabled
- Biome check: passed
- pre-commit hooks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for the FloatComponent seed input.
  * Added direct verification that positive and negative seed values are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->