### PR TITLE
feat: agent catalog foundations and migration

### DIFF
--- a/docs/docs/Deployment/deployment-block-custom-components.mdx
+++ b/docs/docs/Deployment/deployment-block-custom-components.mdx
@@ -31,6 +31,23 @@ LANGFLOW_CUSTOM_COMPONENT_ADMIN_ONLY=true
 
 When set to `true`, non-superusers can still view and use custom components in flows, but they cannot create new custom components or edit custom component code.
 
+## Interaction with catalog governance
+
+Catalog governance takes precedence over the custom-code settings on the custom-component create, update, and code-validation endpoints. A catalog block has no superuser bypass.
+
+| Submitted source | Catalog policy | Custom components | Admin-only mode | Result |
+|---|---|---|---|---|
+| Known server template | Blocked | Either | Either | Denied for every user |
+| Known server template | Allowed | Disabled | Either | Allowed using the trusted server source |
+| Known server template | Allowed | Enabled | Non-superuser | Allowed using the trusted server source |
+| Unknown custom source | Not blocked | Disabled | Either | Denied |
+| Unknown custom source | Not blocked | Enabled | Non-superuser | Denied |
+| Unknown custom source | Not blocked | Enabled | Superuser or admin-only disabled | Allowed |
+
+For `POST /api/v1/validate/code`, this policy runs before the source is parsed or imports are inspected. In a restricted custom-code mode, known templates are validated from the trusted server copy, while unknown source follows the same disabled or admin-only rule as the component editor. On custom-component create and update, known blocked template source is rejected before the component is built, and the resolved component type is checked again before request-supplied frontend updates are applied.
+
+An active catalog policy fails closed with a temporary `503` response while server template identities are still initializing. An empty catalog policy preserves the default behavior and does not require template identity lookups.
+
 ## Configure a custom component allow-list
 
 `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` works together with optional paths that define which component templates the server loads, and which code hashes are trusted.

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -2,7 +2,7 @@
 
 Phase: EXPAND
 Revision ID: d4a7c9e1b2f6
-Revises: b7d5f9a3c2e4
+Revises: e8f1a2b3c4d5
 Create Date: 2026-07-29 00:00:00.000000
 
 The table is empty by default, preserving the existing default-allow catalog
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine.reflection import Inspector
 
 revision: str = "d4a7c9e1b2f6"  # pragma: allowlist secret
-down_revision: str | None = "b7d5f9a3c2e4"  # pragma: allowlist secret
+down_revision: str | None = "e8f1a2b3c4d5"  # pragma: allowlist secret
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -1,0 +1,361 @@
+"""Add catalog policy rules for component and template governance.
+
+Phase: EXPAND
+Revision ID: d4a7c9e1b2f6
+Revises: b7d5f9a3c2e4
+Create Date: 2026-07-29 00:00:00.000000
+
+The table is empty by default, preserving the existing default-allow catalog
+behavior. P1 writes only global block rules; ``allow`` mode and scoped domains
+are reserved so later phases can add behavior without replacing the schema.
+
+Downgrade drops the table and all catalog-policy state. Back up policy rows
+before downgrading if they will be needed after a future roll-forward.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+from sqlmodel.sql.sqltypes import AutoString
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "d4a7c9e1b2f6"  # pragma: allowlist secret
+down_revision: str | None = "b7d5f9a3c2e4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "catalog_policy_rule"
+SCOPED_INDEX = "uq_catalog_policy_rule_scoped"
+UNSCOPED_INDEX = "uq_catalog_policy_rule_unscoped"
+_REQUIRED_INDEX_COLUMNS = (
+    "resource_kind",
+    "resource_key",
+    "scope",
+    "domain_id",
+)
+_SQLITE_UUID_LENGTH = 32
+_REQUIRED_COLUMNS = {
+    "id",
+    "resource_kind",
+    "resource_key",
+    "mode",
+    "scope",
+    "domain_id",
+    "created_by",
+    "created_at",
+    "updated_at",
+}
+_REQUIRED_CHECKS = {
+    "ck_catalog_policy_rule_resource_kind",
+    "ck_catalog_policy_rule_mode",
+    "ck_catalog_policy_rule_scope",
+    "ck_catalog_policy_rule_scope_domain_consistency",
+}
+_COLUMN_CONTRACT = {
+    "id": (False, "uuid", None),
+    "resource_kind": (False, "string", None),
+    "resource_key": (False, "string", None),
+    "mode": (False, "string", "block"),
+    "scope": (False, "string", "global"),
+    "domain_id": (True, "uuid", None),
+    "created_by": (True, "uuid", None),
+    "created_at": (False, "datetime", "timestamp"),
+    "updated_at": (False, "datetime", "timestamp"),
+}
+
+
+def _normalized_sql(value: object) -> str:
+    return "".join(character for character in str(value).lower() if character.isalnum() or character == "_")
+
+
+def _matches_column_type(column_type: sa.types.TypeEngine, expected: str) -> bool:
+    if expected == "string":
+        return isinstance(column_type, sa.String)
+    if expected == "datetime":
+        return isinstance(column_type, sa.DateTime)
+    if expected == "uuid":
+        # SQLite reflects SQLAlchemy Uuid as CHAR(32); PostgreSQL reflects UUID.
+        return isinstance(column_type, sa.Uuid) or (
+            isinstance(column_type, sa.CHAR) and getattr(column_type, "length", None) == _SQLITE_UUID_LENGTH
+        )
+    return False
+
+
+def _validate_columns(columns: list[dict[str, object]]) -> None:
+    by_name = {str(column["name"]): column for column in columns}
+    for column_name, (nullable, type_name, default_kind) in _COLUMN_CONTRACT.items():
+        column = by_name[column_name]
+        if bool(column["nullable"]) is not nullable:
+            msg = f"{TABLE_NAME}.{column_name} has incorrect nullability"
+            raise RuntimeError(msg)
+        if not _matches_column_type(column["type"], type_name):
+            msg = f"{TABLE_NAME}.{column_name} has an incompatible type"
+            raise RuntimeError(msg)
+
+        default = column.get("default")
+        normalized_default = _normalized_sql(default) if default is not None else ""
+        if default_kind is None and default is not None:
+            msg = f"{TABLE_NAME}.{column_name} has an unexpected server default"
+            raise RuntimeError(msg)
+        if default_kind in {"block", "global", "timestamp"} and not normalized_default:
+            msg = f"{TABLE_NAME}.{column_name} is missing its required server default"
+            raise RuntimeError(msg)
+
+
+def _validate_existing_table(conn: sa.Connection) -> None:
+    """Fail loudly when a partial pre-existing table cannot be repaired safely."""
+    inspector = sa.inspect(conn)
+    reflected_columns = inspector.get_columns(TABLE_NAME)
+    columns = {column["name"] for column in reflected_columns}
+    missing_columns = _REQUIRED_COLUMNS - columns
+    if missing_columns:
+        msg = f"{TABLE_NAME} exists but is missing required columns: {sorted(missing_columns)}"
+        raise RuntimeError(msg)
+    _validate_columns(reflected_columns)
+
+    reflected_checks = inspector.get_check_constraints(TABLE_NAME)
+    checks = {constraint["name"] for constraint in reflected_checks}
+    missing_checks = _REQUIRED_CHECKS - checks
+    if missing_checks:
+        msg = f"{TABLE_NAME} exists but is missing required check constraints: {sorted(missing_checks)}"
+        raise RuntimeError(msg)
+    primary_key = inspector.get_pk_constraint(TABLE_NAME)
+    if primary_key.get("constrained_columns") != ["id"]:
+        msg = f"{TABLE_NAME} exists without the required primary key on id"
+        raise RuntimeError(msg)
+
+    creator_foreign_key = next(
+        (
+            foreign_key
+            for foreign_key in inspector.get_foreign_keys(TABLE_NAME)
+            if foreign_key.get("constrained_columns") == ["created_by"]
+            and foreign_key.get("referred_table") == "user"
+            and foreign_key.get("referred_columns") == ["id"]
+        ),
+        None,
+    )
+    ondelete = (creator_foreign_key or {}).get("options", {}).get("ondelete")
+    if creator_foreign_key is None or str(ondelete).upper() != "SET NULL":
+        msg = f"{TABLE_NAME} exists without the required created_by foreign key"
+        raise RuntimeError(msg)
+
+
+def _create_missing_indexes(conn: sa.Connection) -> None:
+    """Create the NULL-safe uniqueness indexes when their columns exist."""
+    if not all(migration.column_exists(TABLE_NAME, column_name, conn) for column_name in _REQUIRED_INDEX_COLUMNS):
+        msg = f"{TABLE_NAME} is missing columns required by its unique indexes"
+        raise RuntimeError(msg)
+
+    indexes = {index["name"]: index for index in sa.inspect(conn).get_indexes(TABLE_NAME)}
+    expected_indexes = {
+        SCOPED_INDEX: ["resource_kind", "resource_key", "scope", "domain_id"],
+        UNSCOPED_INDEX: ["resource_kind", "resource_key", "scope"],
+    }
+    for index_name, expected_columns in expected_indexes.items():
+        index = indexes.get(index_name)
+        if index is None:
+            continue
+        dialect_options = index.get("dialect_options") or {}
+        predicate = dialect_options.get("sqlite_where")
+        if predicate is None:
+            predicate = dialect_options.get("postgresql_where")
+        if index.get("column_names") != expected_columns or not bool(index.get("unique")) or predicate is None:
+            msg = f"{TABLE_NAME}.{index_name} has an incompatible definition"
+            raise RuntimeError(msg)
+
+    existing_indexes = set(indexes)
+    if SCOPED_INDEX not in existing_indexes:
+        op.create_index(
+            SCOPED_INDEX,
+            TABLE_NAME,
+            ["resource_kind", "resource_key", "scope", "domain_id"],
+            unique=True,
+            postgresql_where=sa.text("domain_id IS NOT NULL"),
+            sqlite_where=sa.text("domain_id IS NOT NULL"),
+        )
+    if UNSCOPED_INDEX not in existing_indexes:
+        op.create_index(
+            UNSCOPED_INDEX,
+            TABLE_NAME,
+            ["resource_kind", "resource_key", "scope"],
+            unique=True,
+            postgresql_where=sa.text("domain_id IS NULL"),
+            sqlite_where=sa.text("domain_id IS NULL"),
+        )
+
+
+def _insert_probe(conn: sa.Connection, **overrides: object) -> None:
+    values = {
+        "id": uuid4().hex,
+        "resource_kind": "component",
+        "resource_key": f"__catalog_policy_migration_probe_{uuid4().hex}",
+        **overrides,
+    }
+    columns = list(values)
+    column_sql = ", ".join(columns)
+    value_sql = ", ".join(f":{column}" for column in columns)
+    conn.execute(
+        sa.text(f"INSERT INTO {TABLE_NAME} ({column_sql}) VALUES ({value_sql})"),  # noqa: S608
+        values,
+    )
+
+
+def _expect_probe_rejected(conn: sa.Connection, *, reason: str, **overrides: object) -> None:
+    savepoint = conn.begin_nested()
+    try:
+        _insert_probe(conn, **overrides)
+    except sa.exc.IntegrityError:
+        savepoint.rollback()
+        return
+    except Exception:
+        savepoint.rollback()
+        raise
+    savepoint.rollback()
+    msg = f"{TABLE_NAME} failed to enforce {reason}"
+    raise RuntimeError(msg)
+
+
+def _expect_probe_accepted(conn: sa.Connection, *, reason: str, **overrides: object) -> None:
+    savepoint = conn.begin_nested()
+    try:
+        _insert_probe(conn, **overrides)
+    except sa.exc.IntegrityError as exc:
+        savepoint.rollback()
+        msg = f"{TABLE_NAME} rejects {reason}"
+        raise RuntimeError(msg) from exc
+    except Exception:
+        savepoint.rollback()
+        raise
+    savepoint.commit()
+
+
+def _validate_table_behavior(conn: sa.Connection) -> None:
+    """Probe defaults and constraints inside a rolled-back savepoint."""
+    savepoint = conn.begin_nested()
+    global_key = f"__catalog_policy_global_probe_{uuid4().hex}"
+    try:
+        _insert_probe(conn, resource_key=global_key)
+        stored = conn.execute(
+            sa.text(
+                """
+                SELECT mode, scope, domain_id, created_at, updated_at
+                FROM catalog_policy_rule
+                WHERE resource_key = :resource_key
+                """
+            ),
+            {"resource_key": global_key},
+        ).one()
+        if (
+            stored.mode != "block"
+            or stored.scope != "global"
+            or stored.domain_id is not None
+            or stored.created_at is None
+            or stored.updated_at is None
+        ):
+            msg = f"{TABLE_NAME} has incompatible default values"
+            raise RuntimeError(msg)
+
+        _expect_probe_rejected(
+            conn,
+            reason="global NULL-safe uniqueness",
+            resource_key=global_key,
+        )
+        _expect_probe_rejected(conn, reason="resource-kind checks", resource_kind="flow")
+        _expect_probe_rejected(conn, reason="mode checks", mode="deny")
+        _expect_probe_rejected(conn, reason="scope checks", scope="tenant")
+        _expect_probe_rejected(
+            conn,
+            reason="global scope/domain consistency",
+            domain_id=uuid4().hex,
+        )
+        _expect_probe_rejected(
+            conn,
+            reason="scoped scope/domain consistency",
+            scope="workspace",
+        )
+
+        _expect_probe_accepted(conn, reason="valid template rules", resource_kind="template")
+        _expect_probe_accepted(conn, reason="reserved allow-mode rules", mode="allow")
+        _expect_probe_accepted(conn, reason="valid organization scopes", scope="org", domain_id=uuid4().hex)
+
+        scoped_key = f"__catalog_policy_scoped_probe_{uuid4().hex}"
+        scoped_domain = uuid4().hex
+        _expect_probe_accepted(
+            conn,
+            reason="valid workspace scopes",
+            resource_key=scoped_key,
+            scope="workspace",
+            domain_id=scoped_domain,
+        )
+        _expect_probe_accepted(
+            conn,
+            reason="the same key in distinct workspace domains",
+            resource_key=scoped_key,
+            scope="workspace",
+            domain_id=uuid4().hex,
+        )
+        _expect_probe_rejected(
+            conn,
+            reason="scoped uniqueness",
+            resource_key=scoped_key,
+            scope="workspace",
+            domain_id=scoped_domain,
+        )
+    finally:
+        savepoint.rollback()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    table_already_exists = migration.table_exists(TABLE_NAME, conn)
+    if table_already_exists:
+        _validate_existing_table(conn)
+    else:
+        op.create_table(
+            TABLE_NAME,
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("resource_kind", AutoString(), nullable=False),
+            sa.Column("resource_key", AutoString(), nullable=False),
+            sa.Column("mode", AutoString(), nullable=False, server_default=sa.text("'block'")),
+            sa.Column("scope", AutoString(), nullable=False, server_default=sa.text("'global'")),
+            sa.Column("domain_id", sa.Uuid(), nullable=True),
+            sa.Column("created_by", sa.Uuid(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.ForeignKeyConstraint(["created_by"], ["user.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.CheckConstraint(
+                "resource_kind IN ('component', 'template')",
+                name="ck_catalog_policy_rule_resource_kind",
+            ),
+            sa.CheckConstraint(
+                "mode IN ('block', 'allow')",
+                name="ck_catalog_policy_rule_mode",
+            ),
+            sa.CheckConstraint(
+                "scope IN ('global', 'org', 'workspace')",
+                name="ck_catalog_policy_rule_scope",
+            ),
+            sa.CheckConstraint(
+                "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)",
+                name="ck_catalog_policy_rule_scope_domain_consistency",
+            ),
+        )
+
+    _create_missing_indexes(conn)
+    if table_already_exists:
+        _validate_table_behavior(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if migration.table_exists(TABLE_NAME, conn):
+        op.drop_table(TABLE_NAME)

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -15,16 +15,19 @@ before downgrading if they will be needed after a future roll-forward.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import sqlalchemy as sa
 from alembic import op
 from langflow.utils import migration
+from sqlalchemy.dialects import postgresql
 from sqlmodel.sql.sqltypes import AutoString
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
+
+    from sqlalchemy.engine.reflection import Inspector
 
 revision: str = "d4a7c9e1b2f6"  # pragma: allowlist secret
 down_revision: str | None = "b7d5f9a3c2e4"  # pragma: allowlist secret
@@ -40,138 +43,735 @@ _REQUIRED_INDEX_COLUMNS = (
     "scope",
     "domain_id",
 )
+_REQUIRED_CHECKS = frozenset(
+    {
+        "ck_catalog_policy_rule_resource_kind",
+        "ck_catalog_policy_rule_mode",
+        "ck_catalog_policy_rule_scope",
+        "ck_catalog_policy_rule_scope_domain_consistency",
+    }
+)
+_SCHEMA_REMEDIATION = "Resolve the conflicting schema before rerunning this migration"
+_CHECK_COLUMNS = ("resource_kind", "mode", "scope", "domain_id")
 _SQLITE_UUID_LENGTH = 32
-_REQUIRED_COLUMNS = {
-    "id",
-    "resource_kind",
-    "resource_key",
-    "mode",
-    "scope",
-    "domain_id",
-    "created_by",
-    "created_at",
-    "updated_at",
+_BASELINE_CHECK_SQL = {
+    "ck_catalog_policy_rule_resource_kind": "resource_kind IN ('component', 'template')",
+    "ck_catalog_policy_rule_mode": "mode IN ('block', 'allow')",
+    "ck_catalog_policy_rule_scope": "scope IN ('global', 'org', 'workspace')",
+    "ck_catalog_policy_rule_scope_domain_consistency": (
+        "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)"
+    ),
 }
-_REQUIRED_CHECKS = {
-    "ck_catalog_policy_rule_resource_kind",
-    "ck_catalog_policy_rule_mode",
-    "ck_catalog_policy_rule_scope",
-    "ck_catalog_policy_rule_scope_domain_consistency",
-}
-_COLUMN_CONTRACT = {
+_BASELINE_COLUMN_CONTRACTS = {
     "id": (False, "uuid", None),
     "resource_kind": (False, "string", None),
     "resource_key": (False, "string", None),
-    "mode": (False, "string", "block"),
-    "scope": (False, "string", "global"),
+    "mode": (False, "string", "'block'"),
+    "scope": (False, "string", "'global'"),
     "domain_id": (True, "uuid", None),
     "created_by": (True, "uuid", None),
     "created_at": (False, "datetime", "timestamp"),
     "updated_at": (False, "datetime", "timestamp"),
 }
-
-
-def _normalized_sql(value: object) -> str:
-    return "".join(character for character in str(value).lower() if character.isalnum() or character == "_")
-
-
-def _matches_column_type(column_type: sa.types.TypeEngine, expected: str) -> bool:
-    if expected == "string":
-        return isinstance(column_type, sa.String)
-    if expected == "datetime":
-        return isinstance(column_type, sa.DateTime)
-    if expected == "uuid":
-        # SQLite reflects SQLAlchemy Uuid as CHAR(32); PostgreSQL reflects UUID.
-        return isinstance(column_type, sa.Uuid) or (
-            isinstance(column_type, sa.CHAR) and getattr(column_type, "length", None) == _SQLITE_UUID_LENGTH
+_REQUIRED_COLUMNS = frozenset(_BASELINE_COLUMN_CONTRACTS)
+_BASELINE_UNIQUE_INDEXES = {
+    SCOPED_INDEX: (
+        ("resource_kind", "resource_key", "scope", "domain_id"),
+        "domain_id IS NOT NULL",
+    ),
+    UNSCOPED_INDEX: (
+        ("resource_kind", "resource_key", "scope"),
+        "domain_id IS NULL",
+    ),
+}
+_BASELINE_FOREIGN_KEYS = frozenset(
+    {
+        (
+            ("created_by",),
+            None,
+            "user",
+            ("id",),
+            (("ondelete", "SET NULL"),),
         )
-    return False
+    }
+)
+_POSTGRES_CAST_PATTERN = re.compile(
+    r"::\s*(?:character\s+varying|varchar|text)(?:\s*\[\s*\])?",
+    flags=re.IGNORECASE,
+)
+_SQL_QUOTED_SEGMENT_PATTERN = re.compile(r"""('(?:''|[^'])*'|"(?:""|[^"])*")""")
+_CHECK_TOKEN_PATTERN = re.compile(
+    r"""
+    (?P<string>'(?:''|[^'])*')
+    |(?P<quoted_identifier>"(?:""|[^"])*")
+    |(?P<identifier>[a-z_][a-z0-9_]*)
+    |(?P<left_parenthesis>\()
+    |(?P<right_parenthesis>\))
+    |(?P<left_bracket>\[)
+    |(?P<right_bracket>\])
+    |(?P<comma>,)
+    |(?P<equals>=)
+    """,
+    flags=re.IGNORECASE | re.VERBOSE,
+)
 
 
-def _validate_columns(columns: list[dict[str, object]]) -> None:
-    by_name = {str(column["name"]): column for column in columns}
-    for column_name, (nullable, type_name, default_kind) in _COLUMN_CONTRACT.items():
-        column = by_name[column_name]
-        if bool(column["nullable"]) is not nullable:
-            msg = f"{TABLE_NAME}.{column_name} has incorrect nullability"
-            raise RuntimeError(msg)
-        if not _matches_column_type(column["type"], type_name):
-            msg = f"{TABLE_NAME}.{column_name} has an incompatible type"
-            raise RuntimeError(msg)
+def _strip_postgres_casts(value: object) -> str:
+    """Remove reflection-added casts outside string and identifier quotes."""
+    pieces = _SQL_QUOTED_SEGMENT_PATTERN.split(str(value))
+    return "".join(piece if index % 2 else _POSTGRES_CAST_PATTERN.sub("", piece) for index, piece in enumerate(pieces))
 
-        default = column.get("default")
-        normalized_default = _normalized_sql(default) if default is not None else ""
-        if default_kind is None and default is not None:
-            msg = f"{TABLE_NAME}.{column_name} has an unexpected server default"
-            raise RuntimeError(msg)
-        if default_kind in {"block", "global", "timestamp"} and not normalized_default:
-            msg = f"{TABLE_NAME}.{column_name} is missing its required server default"
-            raise RuntimeError(msg)
+
+def _strip_outer_parentheses(value: str) -> str:
+    """Remove parentheses only when they wrap the complete SQL expression."""
+    result = value
+    while result.startswith("(") and result.endswith(")"):
+        depth = 0
+        in_literal = False
+        wraps_expression = True
+        index = 0
+        while index < len(result):
+            character = result[index]
+            if character == "'":
+                if in_literal and index + 1 < len(result) and result[index + 1] == "'":
+                    index += 2
+                    continue
+                in_literal = not in_literal
+            elif not in_literal:
+                if character == "(":
+                    depth += 1
+                elif character == ")":
+                    depth -= 1
+                    if depth == 0 and index != len(result) - 1:
+                        wraps_expression = False
+                        break
+            index += 1
+        if not wraps_expression or depth != 0 or in_literal:
+            break
+        result = result[1:-1]
+    return result
+
+
+def _default_signature(value: object | None) -> str | None:
+    """Preserve a complete server-default expression across reflection."""
+    if value is None:
+        return None
+    sql = _strip_postgres_casts(value)
+    pieces = re.split(r"('(?:''|[^'])*')", sql)
+    normalized = "".join(
+        piece if index % 2 else "".join(character.lower() for character in piece if not character.isspace())
+        for index, piece in enumerate(pieces)
+    )
+    return _strip_outer_parentheses(normalized)
+
+
+def _column_type_signature(column_type: object, *, dialect_name: str) -> str:
+    """Normalize model and reflected column types across SQLite/PostgreSQL."""
+    if isinstance(column_type, sa.Uuid):
+        return "uuid"
+    if (
+        dialect_name == "sqlite"
+        and isinstance(column_type, sa.CHAR)
+        and getattr(column_type, "length", None) == _SQLITE_UUID_LENGTH
+    ):
+        return "uuid"
+    if isinstance(column_type, sa.DateTime):
+        if dialect_name == "postgresql" and bool(getattr(column_type, "timezone", False)):
+            return "datetime:tz"
+        return "datetime"
+    if isinstance(column_type, sa.CHAR):
+        return f"char:{getattr(column_type, 'length', None)}"
+    if dialect_name == "postgresql" and isinstance(column_type, postgresql.CITEXT):
+        return "string:case-insensitive:citext"
+    if isinstance(column_type, sa.String):
+        length = getattr(column_type, "length", None)
+        collation = getattr(column_type, "collation", None)
+        if collation is not None and str(collation).lower() not in {"binary", "default"}:
+            return f"string:collation:{str(collation).lower()}"
+        return "string" if length is None else f"string:{length}"
+    return f"{type(column_type).__module__}.{type(column_type).__qualname__}"
+
+
+def _column_default_signature(column_name: str, value: object | None) -> str | None:
+    """Normalize ordinary literals and SQLAlchemy's dialect-specific now()."""
+    signature = _default_signature(value)
+    if column_name in {"created_at", "updated_at"} and signature in {"current_timestamp", "now()"}:
+        return "timestamp"
+    return signature
+
+
+def _check_tokens(value: object) -> list[tuple[str, str]]:
+    """Tokenize the restricted CHECK grammar used by catalog policy."""
+    sql = _strip_postgres_casts(value)
+    tokens: list[tuple[str, str]] = []
+    position = 0
+    while position < len(sql):
+        if sql[position].isspace():
+            position += 1
+            continue
+        match = _CHECK_TOKEN_PATTERN.match(sql, position)
+        if match is None:
+            msg = f"Unsupported token in catalog policy CHECK expression at offset {position}"
+            raise ValueError(msg)
+        kind = str(match.lastgroup)
+        lexeme = match.group()
+        if kind == "quoted_identifier":
+            kind = "identifier"
+            lexeme = lexeme[1:-1].replace('""', '"')
+        elif kind == "identifier":
+            lexeme = lexeme.lower()
+        tokens.append((kind, lexeme))
+        position = match.end()
+
+    while True:
+        simplified: list[tuple[str, str]] = []
+        index = 0
+        changed = False
+        while index < len(tokens):
+            if (
+                index + 2 < len(tokens)
+                and tokens[index][0] == "left_parenthesis"
+                and tokens[index + 2][0] == "right_parenthesis"
+                and tokens[index + 1][0] == "identifier"
+                and tokens[index + 1][1] in _CHECK_COLUMNS
+            ):
+                simplified.append(tokens[index + 1])
+                index += 3
+                changed = True
+                continue
+            simplified.append(tokens[index])
+            index += 1
+        tokens = simplified
+        if not changed:
+            return tokens
+
+
+def _combine_boolean(operator: str, expressions: list[tuple[object, ...]]) -> tuple[object, ...]:
+    """Canonicalize commutative, associative boolean operations."""
+    flattened: list[tuple[object, ...]] = []
+    for expression in expressions:
+        if expression[0] == operator:
+            flattened.extend(expression[1:])
+        else:
+            flattened.append(expression)
+    if len(flattened) == 1:
+        return flattened[0]
+    return (operator, *sorted(flattened, key=repr))
+
+
+class _CheckParser:
+    """Parse the deliberately small, side-effect-free CHECK expression grammar."""
+
+    def __init__(self, tokens: list[tuple[str, str]]) -> None:
+        self.tokens = tokens
+        self.position = 0
+
+    def parse(self) -> tuple[object, ...]:
+        expression = self._parse_or()
+        if self.position != len(self.tokens):
+            msg = "Unexpected trailing tokens in catalog policy CHECK expression"
+            raise ValueError(msg)
+        return expression
+
+    def _parse_or(self) -> tuple[object, ...]:
+        expressions = [self._parse_and()]
+        while self._accept_keyword("or"):
+            expressions.append(self._parse_and())
+        return _combine_boolean("or", expressions)
+
+    def _parse_and(self) -> tuple[object, ...]:
+        expressions = [self._parse_factor()]
+        while self._accept_keyword("and"):
+            expressions.append(self._parse_factor())
+        return _combine_boolean("and", expressions)
+
+    def _parse_factor(self) -> tuple[object, ...]:
+        if self._accept("left_parenthesis") is not None:
+            expression = self._parse_or()
+            self._expect("right_parenthesis")
+            return expression
+        return self._parse_predicate()
+
+    def _parse_predicate(self) -> tuple[object, ...]:
+        column = self._expect("identifier")[1]
+        if column not in _CHECK_COLUMNS:
+            msg = "Unexpected column in catalog policy CHECK expression"
+            raise ValueError(msg)
+
+        if self._accept("equals") is not None:
+            if self._accept_keyword("any"):
+                return ("in", column, self._parse_postgres_array())
+            return ("equals", column, self._string_value(self._expect("string")[1]))
+        if self._accept_keyword("in"):
+            return ("in", column, self._parse_string_list())
+        if self._accept_keyword("is"):
+            is_not = self._accept_keyword("not")
+            self._expect_keyword("null")
+            return ("is_not_null" if is_not else "is_null", column)
+        msg = "Unsupported catalog policy CHECK predicate"
+        raise ValueError(msg)
+
+    def _parse_string_list(self) -> tuple[str, ...]:
+        self._expect("left_parenthesis")
+        values = self._parse_string_values()
+        self._expect("right_parenthesis")
+        return values
+
+    def _parse_postgres_array(self) -> tuple[str, ...]:
+        wrapper_count = 0
+        while self._accept("left_parenthesis") is not None:
+            wrapper_count += 1
+        if wrapper_count == 0:
+            msg = "Expected a parenthesized PostgreSQL catalog policy array"
+            raise ValueError(msg)
+        self._expect_keyword("array")
+        self._expect("left_bracket")
+        values = self._parse_string_values()
+        self._expect("right_bracket")
+        for _ in range(wrapper_count):
+            self._expect("right_parenthesis")
+        return values
+
+    def _parse_string_values(self) -> tuple[str, ...]:
+        values = [self._string_value(self._expect("string")[1])]
+        while self._accept("comma") is not None:
+            values.append(self._string_value(self._expect("string")[1]))
+        return tuple(sorted(set(values)))
+
+    def _accept(self, kind: str) -> tuple[str, str] | None:
+        if self.position < len(self.tokens) and self.tokens[self.position][0] == kind:
+            token = self.tokens[self.position]
+            self.position += 1
+            return token
+        return None
+
+    def _accept_keyword(self, keyword: str) -> bool:
+        if self.position < len(self.tokens) and self.tokens[self.position] == ("identifier", keyword):
+            self.position += 1
+            return True
+        return False
+
+    def _expect(self, kind: str) -> tuple[str, str]:
+        token = self._accept(kind)
+        if token is None:
+            msg = f"Expected {kind} in catalog policy CHECK expression"
+            raise ValueError(msg)
+        return token
+
+    def _expect_keyword(self, keyword: str) -> None:
+        if not self._accept_keyword(keyword):
+            msg = f"Expected {keyword} in catalog policy CHECK expression"
+            raise ValueError(msg)
+
+    @staticmethod
+    def _string_value(token: str) -> str:
+        return token[1:-1].replace("''", "'")
+
+
+def _check_ast(value: object) -> tuple[object, ...] | None:
+    """Return a shape-preserving AST, or None for unsupported SQL."""
+    try:
+        return _CheckParser(_check_tokens(value)).parse()
+    except ValueError:
+        return None
+
+
+def _current_model_table() -> sa.Table:
+    """Load the current model contract only for the create_all-first path."""
+    from langflow.services.database.models.catalog_policy import CatalogPolicyRule
+
+    return CatalogPolicyRule.__table__
+
+
+def _current_check_sql() -> dict[str, object]:
+    """Return named CHECK expressions from the current model."""
+    return {
+        str(constraint.name): constraint.sqltext
+        for constraint in _current_model_table().constraints
+        if isinstance(constraint, sa.CheckConstraint) and constraint.name is not None
+    }
+
+
+def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
+    """Return whether reflected checks satisfy one complete contract."""
+    if expected.keys() != reflected.keys():
+        return False
+    for name, sqltext in expected.items():
+        reflected_ast = _check_ast(reflected[name])
+        expected_ast = _check_ast(sqltext)
+        if reflected_ast is None or expected_ast is None or reflected_ast != expected_ast:
+            return False
+    return True
+
+
+def _validate_check_constraints(inspector: Inspector) -> None:
+    """Accept the frozen migration checks or the current model's checks."""
+    reflected_constraints = inspector.get_check_constraints(TABLE_NAME)
+    named_constraints = [constraint for constraint in reflected_constraints if constraint.get("name") is not None]
+    reflected = {str(constraint["name"]): constraint.get("sqltext") for constraint in named_constraints}
+    current = _current_check_sql()
+    has_unnamed_checks = any(constraint.get("name") is None for constraint in reflected_constraints)
+    has_duplicate_names = len(named_constraints) != len(reflected)
+    has_behavior_options = any(
+        any(bool(value) for value in (constraint.get("dialect_options") or {}).values())
+        for constraint in reflected_constraints
+    )
+    if (
+        not has_unnamed_checks
+        and not has_duplicate_names
+        and not has_behavior_options
+        and (_matches_check_contract(reflected, _BASELINE_CHECK_SQL) or _matches_check_contract(reflected, current))
+    ):
+        return
+
+    missing_baseline = _REQUIRED_CHECKS - reflected.keys()
+    missing_current = current.keys() - reflected.keys()
+    if missing_baseline and missing_current:
+        missing = sorted(missing_baseline if len(missing_baseline) <= len(missing_current) else missing_current)
+        detail = f"{TABLE_NAME} exists but is missing required check constraints: {missing}"
+    else:
+        detail = f"{TABLE_NAME} has incompatible check constraint definitions"
+    _raise_schema_error(detail)
+
+
+def _validate_columns(columns: list[dict[str, object]], *, dialect_name: str) -> None:
+    """Validate types, defaults, and nullability against frozen or current models."""
+    reflected = {str(column["name"]): column for column in columns}
+    current_table = _current_model_table()
+    for column_name, frozen_contract in _BASELINE_COLUMN_CONTRACTS.items():
+        baseline_contract = frozen_contract
+        if frozen_contract[1] == "datetime" and dialect_name == "postgresql":
+            baseline_contract = (frozen_contract[0], "datetime:tz", frozen_contract[2])
+        current_column = current_table.c[column_name]
+        current_default = current_column.server_default
+        current_contract = (
+            bool(current_column.nullable),
+            _column_type_signature(current_column.type, dialect_name=dialect_name),
+            _column_default_signature(column_name, current_default.arg if current_default is not None else None),
+        )
+        actual_contract = (
+            bool(reflected[column_name]["nullable"]),
+            _column_type_signature(reflected[column_name]["type"], dialect_name=dialect_name),
+            _column_default_signature(column_name, reflected[column_name].get("default")),
+        )
+        if actual_contract in {baseline_contract, current_contract}:
+            continue
+
+        if actual_contract[0] not in {baseline_contract[0], current_contract[0]}:
+            detail = f"{TABLE_NAME}.{column_name} has incompatible nullability"
+        elif actual_contract[1] not in {baseline_contract[1], current_contract[1]}:
+            detail = f"{TABLE_NAME}.{column_name} has an incompatible type"
+        else:
+            detail = f"{TABLE_NAME}.{column_name} has an incompatible default"
+        _raise_schema_error(detail)
+
+
+def _foreign_key_options(options: Mapping[str, object]) -> tuple[tuple[str, str], ...]:
+    """Normalize behavior-changing foreign-key options."""
+    normalized: list[tuple[str, str]] = []
+    for name in ("ondelete", "onupdate", "deferrable", "initially", "match"):
+        value = options.get(name)
+        if value is None or str(value).upper() == "NO ACTION":
+            continue
+        normalized.append((name, str(value).upper()))
+    return tuple(normalized)
+
+
+def _reflected_foreign_key_contracts(
+    inspector: Inspector,
+) -> frozenset[tuple[tuple[str, ...], str | None, str, tuple[str, ...], tuple[tuple[str, str], ...]]]:
+    """Return behavior-relevant reflected foreign-key fields."""
+    return frozenset(
+        (
+            tuple(str(column) for column in (foreign_key.get("constrained_columns") or ())),
+            str(foreign_key["referred_schema"]) if foreign_key.get("referred_schema") is not None else None,
+            str(foreign_key.get("referred_table")),
+            tuple(str(column) for column in (foreign_key.get("referred_columns") or ())),
+            _foreign_key_options(foreign_key.get("options") or {}),
+        )
+        for foreign_key in inspector.get_foreign_keys(TABLE_NAME)
+    )
+
+
+def _current_foreign_key_contracts() -> frozenset[
+    tuple[tuple[str, ...], str | None, str, tuple[str, ...], tuple[tuple[str, str], ...]]
+]:
+    """Return foreign-key fields emitted by the current model."""
+    return frozenset(
+        (
+            tuple(str(element.parent.name) for element in constraint.elements),
+            str(constraint.referred_table.schema) if constraint.referred_table.schema is not None else None,
+            str(constraint.referred_table.name),
+            tuple(str(element.column.name) for element in constraint.elements),
+            _foreign_key_options(
+                {
+                    "ondelete": constraint.ondelete,
+                    "onupdate": constraint.onupdate,
+                    "deferrable": constraint.deferrable,
+                    "initially": constraint.initially,
+                    "match": constraint.match,
+                }
+            ),
+        )
+        for constraint in _current_model_table().foreign_key_constraints
+    )
+
+
+def _validate_foreign_keys(inspector: Inspector) -> None:
+    """Reject foreign keys beyond the frozen or current complete contract."""
+    reflected = _reflected_foreign_key_contracts(inspector)
+    if reflected not in {_BASELINE_FOREIGN_KEYS, _current_foreign_key_contracts()}:
+        detail = f"{TABLE_NAME} has an incompatible foreign key contract"
+        _raise_schema_error(detail)
+
+
+def _raise_schema_error(detail: str) -> None:
+    """Raise an actionable error for an incompatible pre-existing table."""
+    msg = f"{detail}. {_SCHEMA_REMEDIATION}."
+    raise RuntimeError(msg)
+
+
+def _validate_sqlite_collations(conn: sa.Connection) -> None:
+    """Reject case-folding collations that change exact-key uniqueness."""
+    if conn.dialect.name != "sqlite":
+        return
+    table_sql = conn.execute(
+        sa.text(
+            """
+            SELECT sql
+            FROM sqlite_master
+            WHERE tbl_name = :table_name
+              AND type = 'table'
+            """
+        ),
+        {"table_name": TABLE_NAME},
+    ).scalar_one_or_none()
+    reflected_collations = {
+        next(value for value in match if value).lower()
+        for match in re.findall(
+            r"""\bcollate\s+(?:"([^"]+)"|`([^`]+)`|\[([^\]]+)\]|'([^']+)'|([a-z_][a-z0-9_]*))""",
+            str(table_sql or ""),
+            flags=re.IGNORECASE,
+        )
+    }
+    unique_index_names = conn.execute(
+        sa.text("""SELECT name FROM pragma_index_list(:table_name) WHERE "unique" = 1"""),
+        {"table_name": TABLE_NAME},
+    ).scalars()
+    for index_name in unique_index_names:
+        index_collations = conn.execute(
+            sa.text("SELECT coll FROM pragma_index_xinfo(:index_name) WHERE key = 1"),
+            {"index_name": index_name},
+        ).scalars()
+        reflected_collations.update(str(collation).lower() for collation in index_collations if collation is not None)
+    if reflected_collations - {"binary"}:
+        detail = f"{TABLE_NAME} has an incompatible case-insensitive collation"
+        _raise_schema_error(detail)
 
 
 def _validate_existing_table(conn: sa.Connection) -> None:
-    """Fail loudly when a partial pre-existing table cannot be repaired safely."""
+    """Validate stable structure without writing probe rows.
+
+    Langflow calls SQLModel ``create_all`` before Alembic on a fresh install, so
+    this path is normal startup behavior. Keep the checks limited to stable
+    structural invariants so future model changes do not invalidate this
+    historical migration.
+    """
     inspector = sa.inspect(conn)
     reflected_columns = inspector.get_columns(TABLE_NAME)
     columns = {column["name"] for column in reflected_columns}
     missing_columns = _REQUIRED_COLUMNS - columns
     if missing_columns:
-        msg = f"{TABLE_NAME} exists but is missing required columns: {sorted(missing_columns)}"
-        raise RuntimeError(msg)
-    _validate_columns(reflected_columns)
+        detail = f"{TABLE_NAME} exists but is missing required columns: {sorted(missing_columns)}"
+        _raise_schema_error(detail)
+    current_columns = set(_current_model_table().c.keys())
+    unsupported_required_columns = sorted(
+        str(column["name"])
+        for column in reflected_columns
+        if column["name"] not in current_columns
+        and not bool(column["nullable"])
+        and _default_signature(column.get("default")) in {None, "null"}
+        and column.get("computed") is None
+        and column.get("identity") is None
+    )
+    if unsupported_required_columns:
+        detail = f"{TABLE_NAME} has unsupported required columns: {unsupported_required_columns}"
+        _raise_schema_error(detail)
+    _validate_sqlite_collations(conn)
+    _validate_columns(reflected_columns, dialect_name=conn.dialect.name)
 
-    reflected_checks = inspector.get_check_constraints(TABLE_NAME)
-    checks = {constraint["name"] for constraint in reflected_checks}
-    missing_checks = _REQUIRED_CHECKS - checks
-    if missing_checks:
-        msg = f"{TABLE_NAME} exists but is missing required check constraints: {sorted(missing_checks)}"
-        raise RuntimeError(msg)
+    _validate_check_constraints(inspector)
     primary_key = inspector.get_pk_constraint(TABLE_NAME)
     if primary_key.get("constrained_columns") != ["id"]:
-        msg = f"{TABLE_NAME} exists without the required primary key on id"
+        detail = f"{TABLE_NAME} exists without the required primary key on id"
+        _raise_schema_error(detail)
+
+    _validate_foreign_keys(inspector)
+
+
+def _raise_for_duplicate_rows(conn: sa.Connection, *, index_name: str) -> None:
+    """Fail clearly when existing rows prevent a missing unique index repair."""
+    table = sa.Table(TABLE_NAME, sa.MetaData(), autoload_with=conn)
+    if index_name == SCOPED_INDEX:
+        key_columns = [
+            table.c.resource_kind,
+            table.c.resource_key,
+            table.c.scope,
+            table.c.domain_id,
+        ]
+        predicate = table.c.domain_id.is_not(None)
+    else:
+        key_columns = [
+            table.c.resource_kind,
+            table.c.resource_key,
+            table.c.scope,
+        ]
+        predicate = table.c.domain_id.is_(None)
+
+    duplicate = conn.execute(
+        sa.select(sa.literal(1)).where(predicate).group_by(*key_columns).having(sa.func.count() > 1).limit(1)
+    ).first()
+    if duplicate is not None:
+        msg = (
+            f"{TABLE_NAME} contains duplicate rows that prevent creating {index_name}; "
+            "remove the duplicates before rerunning this migration"
+        )
         raise RuntimeError(msg)
 
-    creator_foreign_key = next(
+
+def _index_predicate(index: Mapping[str, object]) -> object | None:
+    """Return a reflected SQLite or PostgreSQL partial-index predicate."""
+    dialect_options = index.get("dialect_options") or {}
+    predicate = dialect_options.get("sqlite_where")
+    if predicate is None:
+        predicate = dialect_options.get("postgresql_where")
+    return predicate
+
+
+def _index_contract(
+    columns: object,
+    predicate: object | None,
+) -> tuple[tuple[str, ...], tuple[object, ...] | None]:
+    """Return the stable fields that determine uniqueness behavior."""
+    column_names = tuple(str(column) for column in (columns or ()))
+    if predicate is None:
+        predicate_ast = None
+    else:
+        predicate_ast = _check_ast(predicate)
+        if predicate_ast is None:
+            predicate_ast = ("unsupported", _default_signature(predicate))
+    return column_names, predicate_ast
+
+
+def _current_unique_index_contracts() -> dict[str | None, tuple[tuple[str, ...], tuple[object, ...] | None]]:
+    """Return unique-index contracts emitted by the current model."""
+    contracts: dict[str | None, tuple[tuple[str, ...], tuple[object, ...] | None]] = {}
+    for index in _current_model_table().indexes:
+        if not index.unique:
+            continue
+        predicate = index.dialect_options["sqlite"].get("where")
+        if predicate is None:
+            predicate = index.dialect_options["postgresql"].get("where")
+        contracts[str(index.name) if index.name is not None else None] = _index_contract(
+            [column.name for column in index.columns],
+            predicate,
+        )
+    return contracts
+
+
+def _baseline_unique_index_contracts() -> dict[str, tuple[tuple[str, ...], tuple[object, ...] | None]]:
+    """Return normalized contracts owned by this migration."""
+    return {
+        name: _index_contract(columns, predicate) for name, (columns, predicate) in _BASELINE_UNIQUE_INDEXES.items()
+    }
+
+
+def _reflected_unique_index_contracts(
+    indexes: list[dict[str, object]],
+) -> dict[str | None, tuple[tuple[str, ...], tuple[object, ...] | None]]:
+    """Return explicit unique indexes, excluding constraint mirror indexes."""
+    return {
+        str(index["name"]) if index.get("name") is not None else None: _index_contract(
+            index.get("column_names"),
+            _index_predicate(index),
+        )
+        for index in indexes
+        if bool(index.get("unique")) and index.get("duplicates_constraint") is None
+    }
+
+
+def _matches_repairable_index_contract(
+    reflected: Mapping[str | None, tuple[tuple[str, ...], tuple[object, ...] | None]],
+    expected: Mapping[str | None, tuple[tuple[str, ...], tuple[object, ...] | None]],
+) -> bool:
+    """Allow missing owned indexes while rejecting unknown or malformed ones."""
+    return reflected.keys() <= expected.keys() and all(reflected[name] == expected[name] for name in reflected)
+
+
+def _current_unique_constraint_contracts() -> frozenset[tuple[str | None, tuple[str, ...]]]:
+    """Return table-level unique constraints emitted by the current model."""
+    return frozenset(
         (
-            foreign_key
-            for foreign_key in inspector.get_foreign_keys(TABLE_NAME)
-            if foreign_key.get("constrained_columns") == ["created_by"]
-            and foreign_key.get("referred_table") == "user"
-            and foreign_key.get("referred_columns") == ["id"]
-        ),
-        None,
+            str(constraint.name) if constraint.name is not None else None,
+            tuple(str(column.name) for column in constraint.columns),
+        )
+        for constraint in _current_model_table().constraints
+        if isinstance(constraint, sa.UniqueConstraint)
     )
-    ondelete = (creator_foreign_key or {}).get("options", {}).get("ondelete")
-    if creator_foreign_key is None or str(ondelete).upper() != "SET NULL":
-        msg = f"{TABLE_NAME} exists without the required created_by foreign key"
-        raise RuntimeError(msg)
+
+
+def _validate_unique_contracts(inspector: Inspector, indexes: list[dict[str, object]]) -> None:
+    """Reject uniqueness beyond the frozen or current complete model contract."""
+    reflected_indexes = _reflected_unique_index_contracts(indexes)
+    baseline_indexes = _baseline_unique_index_contracts()
+    current_indexes = _current_unique_index_contracts()
+    if not (
+        _matches_repairable_index_contract(reflected_indexes, baseline_indexes)
+        or _matches_repairable_index_contract(reflected_indexes, current_indexes)
+    ):
+        detail = f"{TABLE_NAME} has an incompatible unique index contract"
+        _raise_schema_error(detail)
+
+    reflected_constraints = frozenset(
+        (
+            str(constraint["name"]) if constraint.get("name") is not None else None,
+            tuple(str(column) for column in (constraint.get("column_names") or ())),
+        )
+        for constraint in inspector.get_unique_constraints(TABLE_NAME)
+    )
+    if reflected_constraints not in {frozenset(), _current_unique_constraint_contracts()}:
+        detail = f"{TABLE_NAME} has an incompatible unique constraint contract"
+        _raise_schema_error(detail)
 
 
 def _create_missing_indexes(conn: sa.Connection) -> None:
-    """Create the NULL-safe uniqueness indexes when their columns exist."""
+    """Create or validate the NULL-safe uniqueness indexes."""
     if not all(migration.column_exists(TABLE_NAME, column_name, conn) for column_name in _REQUIRED_INDEX_COLUMNS):
-        msg = f"{TABLE_NAME} is missing columns required by its unique indexes"
-        raise RuntimeError(msg)
+        detail = f"{TABLE_NAME} is missing columns required by its unique indexes"
+        _raise_schema_error(detail)
 
-    indexes = {index["name"]: index for index in sa.inspect(conn).get_indexes(TABLE_NAME)}
-    expected_indexes = {
-        SCOPED_INDEX: ["resource_kind", "resource_key", "scope", "domain_id"],
-        UNSCOPED_INDEX: ["resource_kind", "resource_key", "scope"],
-    }
-    for index_name, expected_columns in expected_indexes.items():
+    inspector = sa.inspect(conn)
+    reflected_indexes = inspector.get_indexes(TABLE_NAME)
+    _validate_unique_contracts(inspector, reflected_indexes)
+    indexes = {index["name"]: index for index in reflected_indexes}
+    expected_indexes = _BASELINE_UNIQUE_INDEXES
+    current_indexes = _current_unique_index_contracts()
+    for index_name, (expected_columns, expected_predicate) in expected_indexes.items():
         index = indexes.get(index_name)
         if index is None:
             continue
-        dialect_options = index.get("dialect_options") or {}
-        predicate = dialect_options.get("sqlite_where")
-        if predicate is None:
-            predicate = dialect_options.get("postgresql_where")
-        if index.get("column_names") != expected_columns or not bool(index.get("unique")) or predicate is None:
-            msg = f"{TABLE_NAME}.{index_name} has an incompatible definition"
-            raise RuntimeError(msg)
+        reflected_contract = _index_contract(index.get("column_names"), _index_predicate(index))
+        allowed_contracts = {
+            _index_contract(expected_columns, expected_predicate),
+            current_indexes.get(index_name),
+        }
+        if not bool(index.get("unique")) or reflected_contract not in allowed_contracts:
+            detail = f"{TABLE_NAME}.{index_name} has an incompatible definition"
+            _raise_schema_error(detail)
 
     existing_indexes = set(indexes)
     if SCOPED_INDEX not in existing_indexes:
+        _raise_for_duplicate_rows(conn, index_name=SCOPED_INDEX)
         op.create_index(
             SCOPED_INDEX,
             TABLE_NAME,
@@ -181,6 +781,7 @@ def _create_missing_indexes(conn: sa.Connection) -> None:
             sqlite_where=sa.text("domain_id IS NOT NULL"),
         )
     if UNSCOPED_INDEX not in existing_indexes:
+        _raise_for_duplicate_rows(conn, index_name=UNSCOPED_INDEX)
         op.create_index(
             UNSCOPED_INDEX,
             TABLE_NAME,
@@ -191,132 +792,11 @@ def _create_missing_indexes(conn: sa.Connection) -> None:
         )
 
 
-def _insert_probe(conn: sa.Connection, **overrides: object) -> None:
-    values = {
-        "id": uuid4().hex,
-        "resource_kind": "component",
-        "resource_key": f"__catalog_policy_migration_probe_{uuid4().hex}",
-        **overrides,
-    }
-    columns = list(values)
-    column_sql = ", ".join(columns)
-    value_sql = ", ".join(f":{column}" for column in columns)
-    conn.execute(
-        sa.text(f"INSERT INTO {TABLE_NAME} ({column_sql}) VALUES ({value_sql})"),  # noqa: S608
-        values,
-    )
-
-
-def _expect_probe_rejected(conn: sa.Connection, *, reason: str, **overrides: object) -> None:
-    savepoint = conn.begin_nested()
-    try:
-        _insert_probe(conn, **overrides)
-    except sa.exc.IntegrityError:
-        savepoint.rollback()
-        return
-    except Exception:
-        savepoint.rollback()
-        raise
-    savepoint.rollback()
-    msg = f"{TABLE_NAME} failed to enforce {reason}"
-    raise RuntimeError(msg)
-
-
-def _expect_probe_accepted(conn: sa.Connection, *, reason: str, **overrides: object) -> None:
-    savepoint = conn.begin_nested()
-    try:
-        _insert_probe(conn, **overrides)
-    except sa.exc.IntegrityError as exc:
-        savepoint.rollback()
-        msg = f"{TABLE_NAME} rejects {reason}"
-        raise RuntimeError(msg) from exc
-    except Exception:
-        savepoint.rollback()
-        raise
-    savepoint.commit()
-
-
-def _validate_table_behavior(conn: sa.Connection) -> None:
-    """Probe defaults and constraints inside a rolled-back savepoint."""
-    savepoint = conn.begin_nested()
-    global_key = f"__catalog_policy_global_probe_{uuid4().hex}"
-    try:
-        _insert_probe(conn, resource_key=global_key)
-        stored = conn.execute(
-            sa.text(
-                """
-                SELECT mode, scope, domain_id, created_at, updated_at
-                FROM catalog_policy_rule
-                WHERE resource_key = :resource_key
-                """
-            ),
-            {"resource_key": global_key},
-        ).one()
-        if (
-            stored.mode != "block"
-            or stored.scope != "global"
-            or stored.domain_id is not None
-            or stored.created_at is None
-            or stored.updated_at is None
-        ):
-            msg = f"{TABLE_NAME} has incompatible default values"
-            raise RuntimeError(msg)
-
-        _expect_probe_rejected(
-            conn,
-            reason="global NULL-safe uniqueness",
-            resource_key=global_key,
-        )
-        _expect_probe_rejected(conn, reason="resource-kind checks", resource_kind="flow")
-        _expect_probe_rejected(conn, reason="mode checks", mode="deny")
-        _expect_probe_rejected(conn, reason="scope checks", scope="tenant")
-        _expect_probe_rejected(
-            conn,
-            reason="global scope/domain consistency",
-            domain_id=uuid4().hex,
-        )
-        _expect_probe_rejected(
-            conn,
-            reason="scoped scope/domain consistency",
-            scope="workspace",
-        )
-
-        _expect_probe_accepted(conn, reason="valid template rules", resource_kind="template")
-        _expect_probe_accepted(conn, reason="reserved allow-mode rules", mode="allow")
-        _expect_probe_accepted(conn, reason="valid organization scopes", scope="org", domain_id=uuid4().hex)
-
-        scoped_key = f"__catalog_policy_scoped_probe_{uuid4().hex}"
-        scoped_domain = uuid4().hex
-        _expect_probe_accepted(
-            conn,
-            reason="valid workspace scopes",
-            resource_key=scoped_key,
-            scope="workspace",
-            domain_id=scoped_domain,
-        )
-        _expect_probe_accepted(
-            conn,
-            reason="the same key in distinct workspace domains",
-            resource_key=scoped_key,
-            scope="workspace",
-            domain_id=uuid4().hex,
-        )
-        _expect_probe_rejected(
-            conn,
-            reason="scoped uniqueness",
-            resource_key=scoped_key,
-            scope="workspace",
-            domain_id=scoped_domain,
-        )
-    finally:
-        savepoint.rollback()
-
-
 def upgrade() -> None:
+    """Create catalog policy storage or validate its stable existing shape."""
     conn = op.get_bind()
 
-    table_already_exists = migration.table_exists(TABLE_NAME, conn)
-    if table_already_exists:
+    if migration.table_exists(TABLE_NAME, conn):
         _validate_existing_table(conn)
     else:
         op.create_table(
@@ -333,29 +813,28 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(["created_by"], ["user.id"], ondelete="SET NULL"),
             sa.PrimaryKeyConstraint("id"),
             sa.CheckConstraint(
-                "resource_kind IN ('component', 'template')",
+                _BASELINE_CHECK_SQL["ck_catalog_policy_rule_resource_kind"],
                 name="ck_catalog_policy_rule_resource_kind",
             ),
             sa.CheckConstraint(
-                "mode IN ('block', 'allow')",
+                _BASELINE_CHECK_SQL["ck_catalog_policy_rule_mode"],
                 name="ck_catalog_policy_rule_mode",
             ),
             sa.CheckConstraint(
-                "scope IN ('global', 'org', 'workspace')",
+                _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope"],
                 name="ck_catalog_policy_rule_scope",
             ),
             sa.CheckConstraint(
-                "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)",
+                _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope_domain_consistency"],
                 name="ck_catalog_policy_rule_scope_domain_consistency",
             ),
         )
 
     _create_missing_indexes(conn)
-    if table_already_exists:
-        _validate_table_behavior(conn)
 
 
 def downgrade() -> None:
+    """Drop catalog policy storage and its rows."""
     conn = op.get_bind()
     if migration.table_exists(TABLE_NAME, conn):
         op.drop_table(TABLE_NAME)

--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -14,6 +14,7 @@ from langflow.api.v1 import (
     authz_roles_router,
     authz_shares_router,
     authz_teams_router,
+    catalog_policy_router,
     chat_router,
     endpoints_router,
     extensions_router,
@@ -101,6 +102,7 @@ router_v1.include_router(authz_roles_router)
 router_v1.include_router(authz_role_assignments_router)
 router_v1.include_router(authz_teams_router)
 router_v1.include_router(authz_me_router)
+router_v1.include_router(catalog_policy_router)
 
 
 # Extension reload is Mode A (local-dev / pip-installed) only.  The route is

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -6,6 +6,7 @@ from langflow.api.v1.authz_role_assignments import router as authz_role_assignme
 from langflow.api.v1.authz_roles import router as authz_roles_router
 from langflow.api.v1.authz_shares import router as authz_shares_router
 from langflow.api.v1.authz_teams import router as authz_teams_router
+from langflow.api.v1.catalog_policy import router as catalog_policy_router
 from langflow.api.v1.chat import router as chat_router
 from langflow.api.v1.endpoints import router as endpoints_router
 from langflow.api.v1.extensions import router as extensions_router
@@ -42,6 +43,7 @@ __all__ = [
     "authz_roles_router",
     "authz_shares_router",
     "authz_teams_router",
+    "catalog_policy_router",
     "chat_router",
     "endpoints_router",
     "extensions_router",

--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -1,0 +1,113 @@
+"""Superuser administration API for global catalog block policy."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from langflow.api.v1.schemas.catalog_policy import CatalogPolicyBlockedSet
+from langflow.services.auth.utils import get_current_active_superuser
+from langflow.services.authorization.audit import audit_decision
+from langflow.services.database.models.user.model import User
+from langflow.services.deps import get_catalog_policy_service
+
+router = APIRouter(prefix="/catalog-policy", tags=["Catalog Policy"])
+
+
+def _response(blocked: frozenset[str]) -> CatalogPolicyBlockedSet:
+    return CatalogPolicyBlockedSet(blocked=sorted(blocked))
+
+
+async def _audit_update(
+    *,
+    user_id: UUID,
+    resource_kind: Literal["component", "template"],
+    added: frozenset[str],
+    removed: frozenset[str],
+) -> None:
+    """Emit one post-commit audit event per changed catalog key."""
+    for key in sorted(added):
+        await audit_decision(
+            user_id=user_id,
+            action="catalog:block",
+            obj=f"{resource_kind}:{key}",
+            result="allow",
+            details={
+                "resource_kind": resource_kind,
+                "resource_key": key,
+            },
+        )
+    for key in sorted(removed):
+        await audit_decision(
+            user_id=user_id,
+            action="catalog:unblock",
+            obj=f"{resource_kind}:{key}",
+            result="allow",
+            details={
+                "resource_kind": resource_kind,
+                "resource_key": key,
+            },
+        )
+
+
+@router.get("/components", response_model=CatalogPolicyBlockedSet)
+async def get_component_policy(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+) -> CatalogPolicyBlockedSet:
+    """Return the complete global component block set."""
+    service = get_catalog_policy_service()
+    return _response(service.snapshot.blocked_component_keys)
+
+
+@router.put("/components", response_model=CatalogPolicyBlockedSet)
+async def replace_component_policy(
+    payload: CatalogPolicyBlockedSet,
+    admin: Annotated[User, Depends(get_current_active_superuser)],
+) -> CatalogPolicyBlockedSet:
+    """Replace the complete global component block set."""
+    service = get_catalog_policy_service()
+    update = await service.replace_blocked_component_keys(
+        payload.blocked,
+        actor_user_id=admin.id,
+    )
+    await _audit_update(
+        user_id=admin.id,
+        resource_kind="component",
+        added=update.added,
+        removed=update.removed,
+    )
+    return _response(update.snapshot.blocked_component_keys)
+
+
+@router.get("/templates", response_model=CatalogPolicyBlockedSet)
+async def get_template_policy(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+) -> CatalogPolicyBlockedSet:
+    """Return the complete global template block set."""
+    service = get_catalog_policy_service()
+    return _response(service.snapshot.blocked_template_keys)
+
+
+@router.put("/templates", response_model=CatalogPolicyBlockedSet)
+async def replace_template_policy(
+    payload: CatalogPolicyBlockedSet,
+    admin: Annotated[User, Depends(get_current_active_superuser)],
+) -> CatalogPolicyBlockedSet:
+    """Replace the complete global template block set."""
+    service = get_catalog_policy_service()
+    update = await service.replace_blocked_template_keys(
+        payload.blocked,
+        actor_user_id=admin.id,
+    )
+    await _audit_update(
+        user_id=admin.id,
+        resource_kind="template",
+        added=update.added,
+        removed=update.removed,
+    )
+    return _response(update.snapshot.blocked_template_keys)
+
+
+__all__ = ["router"]

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -16,6 +16,7 @@ from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
     CustomComponentValidationError,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -850,6 +851,13 @@ async def build_public_tmp(
         async with session_scope() as session:
             flow = await session.get(Flow, flow_id)
             if flow and flow.data:
+                # The default anonymous build path sanitizes component code directly
+                # and therefore does not call validate_flow_for_current_settings.
+                # Enforce the exact catalog snapshot after the public-access check
+                # and before any graph is queued or built. The explicit public-custom
+                # opt-in already runs the unified validator inside prepare_public_flow_build.
+                if not settings.allow_public_custom_components:
+                    validate_catalog_policy_for_flow(flow.data)
                 # Block unauthenticated builds of flows that run arbitrary code
                 # (Python interpreter/REPL, legacy Python Code Structured tool,
                 # Smart Transform lambda) or invoke another saved flow (Run Flow,

--- a/src/backend/base/langflow/api/v1/custom_component_policy.py
+++ b/src/backend/base/langflow/api/v1/custom_component_policy.py
@@ -1,0 +1,85 @@
+"""Shared catalog and custom-code policy for component source entry points."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, status
+from lfx.interface.components import component_cache
+from lfx.utils.flow_validation import (
+    CatalogPolicyValidationError,
+    code_hash_matches_any_template,
+    get_component_hash_lookups_for_validation,
+    get_trusted_code_for_validation,
+    validate_catalog_policy_for_component_code,
+    validate_catalog_policy_for_component_type,
+)
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy.base import CatalogPolicySnapshot
+
+    from langflow.services.database.models.user.model import User
+
+
+_TEMPLATES_INITIALIZING_MESSAGE = "Component templates are still initializing. Please try again in a few seconds."
+
+
+class CatalogPolicyHTTPException(HTTPException):
+    """HTTP denial raised specifically by custom-component catalog policy."""
+
+
+def resolve_component_code_for_action(
+    code: str,
+    *,
+    user: User,
+    settings: object,
+    snapshot: CatalogPolicySnapshot,
+    disabled_detail: str,
+    admin_only_detail: str,
+) -> str:
+    """Return executable/validated source after applying catalog and custom-code policy.
+
+    Catalog denial is evaluated first and has no superuser bypass. Restricted
+    custom-code modes continue to permit known server templates, but callers
+    receive the trusted server copy instead of executing client-submitted bytes.
+    """
+    try:
+        validate_catalog_policy_for_component_code(code, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    admin_only = getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
+    custom_code_disabled = not getattr(settings, "allow_custom_components", True)
+    if not custom_code_disabled and not admin_only:
+        return code
+
+    get_component_hash_lookups_for_validation()
+    all_known = component_cache.all_known_hashes
+    if all_known is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_TEMPLATES_INITIALIZING_MESSAGE,
+        )
+
+    if not code_hash_matches_any_template(code, all_known):
+        detail = disabled_detail if custom_code_disabled else admin_only_detail
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+    trusted_code = get_trusted_code_for_validation(code)
+    if trusted_code is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=disabled_detail)
+    return trusted_code
+
+
+def enforce_catalog_policy_for_component_type(
+    component_type: str,
+    *,
+    snapshot: CatalogPolicySnapshot,
+) -> None:
+    """Deny a materialized custom component whose exact runtime type is blocked."""
+    try:
+        validate_catalog_policy_for_component_type(component_type, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise CatalogPolicyHTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -22,7 +22,6 @@ from lfx.custom.utils import (
 )
 from lfx.graph.graph.base import Graph
 from lfx.graph.schema import RunOutputs
-from lfx.interface.components import component_cache
 from lfx.log.logger import logger
 from lfx.schema.legacy_render import project_payload_to_v1
 from lfx.schema.schema import InputValueRequest
@@ -33,15 +32,15 @@ from lfx.services.model_provider_policy import (
     set_current_model_provider_policy_context,
 )
 from lfx.services.settings.service import SettingsService
-from lfx.utils.flow_validation import (
-    CustomComponentValidationError,
-    code_hash_matches_any_template,
-    get_component_hash_lookups_for_validation,
-    get_trusted_code_for_validation,
-)
+from lfx.utils.flow_validation import CustomComponentValidationError
 from sqlmodel import select
 
 from langflow.api.utils import CurrentActiveUser, DbSession, extract_global_variables_from_headers, parse_value
+from langflow.api.v1.custom_component_policy import (
+    CatalogPolicyHTTPException,
+    enforce_catalog_policy_for_component_type,
+    resolve_component_code_for_action,
+)
 from langflow.api.v1.files import get_flow
 from langflow.api.v1.global_variable_defaults import apply_global_variable_defaults
 from langflow.api.v1.run_validation import raise_if_hitl_unsupported
@@ -92,14 +91,6 @@ from langflow.services.event_manager import create_webhook_event_manager, webhoo
 from langflow.services.telemetry.schema import RunPayload
 from langflow.utils.compression import compress_response
 from langflow.utils.version import get_version_info
-
-
-def _requires_component_hash_lookups(settings: object, user: CurrentActiveUser) -> bool:
-    requires_admin_only_hashes = (
-        getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
-    )
-    return requires_admin_only_hashes or not settings.allow_custom_components
-
 
 if TYPE_CHECKING:
     from langflow.events.event_manager import EventManager
@@ -1444,55 +1435,21 @@ async def custom_component(
 
     settings_service = get_settings_service()
     settings = settings_service.settings
-    all_known = None
-    if _requires_component_hash_lookups(settings, user):
-        # Lazily compute hash lookups if they haven't been built yet
-        # (e.g. during startup before the cache is fully populated).
-        get_component_hash_lookups_for_validation()
-        all_known = component_cache.all_known_hashes
-        if all_known is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Component templates are still initializing. Please try again in a few seconds.",
-            )
-
-    # In admin-only mode, non-admin users may create/refresh only known server
-    # templates. Truly custom code creation remains restricted to administrators.
-    if (
-        getattr(settings, "custom_component_admin_only", False) is True
-        and not user.is_superuser
-        and not code_hash_matches_any_template(raw_code.code, all_known)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is restricted to administrators",
-        )
-
-    if not settings.allow_custom_components and not code_hash_matches_any_template(raw_code.code, all_known):
-        # Allow updating to a known server template (core component update),
-        # but block truly custom code.
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is disabled",
-        )
-
-    # In restricted mode the request only reached here by matching a known
-    # template hash. That hash is a truncated digest, so a second-preimage
-    # collision could clear the gate with attacker-controlled bytes. Execute
-    # the server's trusted copy keyed by the same hash instead of the client
-    # bytes, and fail closed if no trusted source can be recovered.
-    effective_code = raw_code.code
-    if _requires_component_hash_lookups(settings, user):
-        effective_code = get_trusted_code_for_validation(raw_code.code)
-        if effective_code is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    effective_code = resolve_component_code_for_action(
+        raw_code.code,
+        user=user,
+        settings=settings,
+        snapshot=catalog_policy_snapshot,
+        disabled_detail="Custom component creation is disabled",
+        admin_only_detail="Custom component creation is restricted to administrators",
+    )
 
     component = Component(_code=effective_code)
 
     built_frontend_node, component_instance = build_custom_component_template(component, user_id=user.id)
+    type_ = get_instance_name(component_instance)
+    enforce_catalog_policy_for_component_type(type_, snapshot=catalog_policy_snapshot)
     if raw_code.frontend_node is not None:
         built_frontend_node = await component_instance.update_frontend_node(built_frontend_node, raw_code.frontend_node)
 
@@ -1503,7 +1460,6 @@ async def custom_component(
             field_name="tool_mode",
             field_value=tool_mode,
         )
-    type_ = get_instance_name(component_instance)
     locale = getattr(request.state, "locale", "en")
     if locale != "en":
         from langflow.utils.i18n import translate_component_node
@@ -1543,48 +1499,15 @@ async def custom_component_update(
         )
 
     settings_service = get_settings_service()
-    all_known = None
-    if _requires_component_hash_lookups(settings_service.settings, user):
-        get_component_hash_lookups_for_validation()
-        all_known = component_cache.all_known_hashes
-        if all_known is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Component templates are still initializing. Please try again in a few seconds.",
-            )
-
-    # In admin-only mode, non-admin users may refresh/update only known server
-    # templates. Truly custom code edits remain restricted to administrators.
-    if (
-        getattr(settings_service.settings, "custom_component_admin_only", False) is True
-        and not user.is_superuser
-        and not code_hash_matches_any_template(code_request.code, all_known)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component editing is restricted to administrators",
-        )
-
-    if not settings_service.settings.allow_custom_components and not code_hash_matches_any_template(
-        code_request.code, all_known
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is disabled",
-        )
-
-    # In restricted mode the request only reached here by matching a known
-    # template hash. Because that hash is a truncated digest, execute the
-    # server's trusted copy keyed by the same hash rather than the client
-    # bytes (defeats a hash collision), failing closed if it can't be found.
-    effective_code = code_request.code
-    if _requires_component_hash_lookups(settings_service.settings, user):
-        effective_code = get_trusted_code_for_validation(code_request.code)
-        if effective_code is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    effective_code = resolve_component_code_for_action(
+        code_request.code,
+        user=user,
+        settings=settings_service.settings,
+        snapshot=catalog_policy_snapshot,
+        disabled_detail="Custom component creation is disabled",
+        admin_only_detail="Custom component editing is restricted to administrators",
+    )
 
     policy_context_token = set_current_model_provider_policy_context(
         user_id=user.id,
@@ -1596,6 +1519,8 @@ async def custom_component_update(
             component,
             user_id=user.id,
         )
+        component_type = get_instance_name(cc_instance)
+        enforce_catalog_policy_for_component_type(component_type, snapshot=catalog_policy_snapshot)
 
         if isinstance(cc_instance, Component):
             # Dynamic configuration may resolve DB-backed credentials or call
@@ -1664,6 +1589,8 @@ async def custom_component_update(
                 field_value=code_request.field_value,
             )
 
+    except CatalogPolicyHTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     finally:
@@ -1674,7 +1601,7 @@ async def custom_component_update(
         from langflow.utils.i18n import translate_component_node
 
         try:
-            component_node = translate_component_node(get_instance_name(cc_instance), component_node, locale)
+            component_node = translate_component_node(component_type, component_node, locale)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to translate component node", extra={"locale": locale})
 

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Collection
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID, uuid4
@@ -80,6 +80,7 @@ from langflow.services.database.models.jobs.model import JobType
 from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import (
     get_auth_service,
+    get_catalog_policy_service,
     get_job_service,
     get_memory_base_service,
     get_session_service,
@@ -180,22 +181,34 @@ async def parse_input_request_from_body(http_request: Request) -> SimplifiedAPIR
 
 
 @router.get("/all")
-async def get_all(request: Request, current_user: CurrentActiveUser):
+async def get_all(request: Request, current_user: CurrentActiveUser, *, include_blocked: bool = False):
     """Retrieve all component types with compression for better performance.
 
     Returns a compressed response containing all available component types,
     with display_names translated to the locale indicated by Accept-Language.
     """
+    if include_blocked and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only superusers can include blocked catalog components.",
+        )
+
     from langflow.interface.components import get_and_cache_all_types_dict
     from langflow.utils.i18n import build_component_display_names, translate_component_dict
 
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         all_types_en = await get_and_cache_all_types_dict(settings_service=get_settings_service())
         visible_types_en = _filter_component_palette_by_provider_policy(
             all_types_en,
             user_id=current_user.id,
             attributes={"is_superuser": bool(current_user.is_superuser)},
         )
+        if not include_blocked:
+            visible_types_en = _filter_component_palette_by_catalog_policy(
+                visible_types_en,
+                blocked_component_keys=catalog_policy_snapshot.blocked_component_keys,
+            )
 
         locale = getattr(request.state, "locale", "en")
         all_types = translate_component_dict(visible_types_en, locale) if locale != "en" else visible_types_en
@@ -243,6 +256,28 @@ def _filter_component_palette_by_provider_policy(
             or not isinstance(component.get("metadata"), dict)
             or not (provider_id := component["metadata"].get("model_provider_id"))
             or policy.allows(provider_id)
+        }
+        for category, components in all_types.items()
+    }
+
+
+def _filter_component_palette_by_catalog_policy(
+    all_types: dict[str, dict[str, dict]],
+    *,
+    blocked_component_keys: Collection[str],
+) -> dict[str, dict[str, dict]]:
+    """Return shallow category copies with exact blocked component keys removed.
+
+    Catalog policy keys match the inner component-registry keys exactly and
+    case-sensitively across every category. Category order, component order,
+    and empty categories are preserved. Component payloads remain shared with
+    the process-wide cache and are never mutated or deep-copied.
+    """
+    return {
+        category: {
+            component_key: component
+            for component_key, component in components.items()
+            if component_key not in blocked_component_keys
         }
         for category, components in all_types.items()
     }
@@ -1670,14 +1705,27 @@ async def get_config(
     """
     try:
         settings_service: SettingsService = get_settings_service()
+        try:
+            catalog_governance_enabled = get_catalog_policy_service().enabled
+        except Exception as exc:  # noqa: BLE001
+            # Catalog governance is explicitly fail-open. A broken custom
+            # policy implementation must not break the public config endpoint
+            # or expose its internal exception text.
+            await logger.aexception("Catalog policy status unavailable; reporting governance disabled", exception=exc)
+            catalog_governance_enabled = False
 
         if user is None:
             return PublicConfigResponse.from_settings(
                 settings_service.settings,
                 settings_service.auth_settings,
+                catalog_governance_enabled=catalog_governance_enabled,
             )
 
-        return ConfigResponse.from_settings(settings_service.settings, settings_service.auth_settings)
+        return ConfigResponse.from_settings(
+            settings_service.settings,
+            settings_service.auth_settings,
+            catalog_governance_enabled=catalog_governance_enabled,
+        )
 
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import threading
 import zipfile
+from collections.abc import Collection
 from typing import Annotated
 from uuid import UUID
 
@@ -49,7 +50,7 @@ from langflow.api.v1.flows_helpers import (
 from langflow.api.v1.mappers.deployments.sync import retry_flow_operation_on_deployment_guard
 from langflow.api.v1.schemas import FlowListCreate
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
-from langflow.services.auth.utils import get_current_active_user
+from langflow.services.auth.utils import get_current_active_user, get_optional_user
 from langflow.services.authorization import (
     FlowAction,
     ensure_flow_permission,
@@ -78,7 +79,8 @@ from langflow.services.database.models.flow.model import (
 # and FlowVersionError from the flow_version modules.
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import Folder
-from langflow.services.deps import get_settings_service, get_storage_service
+from langflow.services.database.models.user.model import User
+from langflow.services.deps import get_catalog_policy_service, get_settings_service, get_storage_service
 from langflow.services.storage.service import StorageService
 from langflow.utils.compression import compress_response
 from langflow.utils.i18n import translate_flow_notes, translate_starter_flows
@@ -906,26 +908,60 @@ _starter_flows_translated_cache: ThreadingInMemoryCache[threading.RLock] = Threa
 _starter_flows_lock = asyncio.Lock()
 
 
+def _filter_basic_examples_by_catalog_policy(
+    flows: list[FlowRead],
+    *,
+    blocked_template_keys: Collection[str],
+) -> list[FlowRead]:
+    """Return a request-local view without exact blocked template keys."""
+    return [flow for flow in flows if flow.name_key not in blocked_template_keys]
+
+
 @router.get("/basic_examples/", response_model=list[FlowRead], status_code=200)
 async def read_basic_examples(
     *,
     session: DbSession,
     request: Request,
+    user: Annotated[User | None, Depends(get_optional_user)],
+    include_blocked: bool = False,
 ):
     """Retrieve a list of basic example flows."""
+    if include_blocked and (user is None or not user.is_superuser):
+        raise HTTPException(
+            status_code=403,
+            detail="Only superusers can include blocked catalog templates.",
+        )
+
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
     locale = getattr(request.state, "locale", "en")
     translated_cache_key = f"starter_flows_{locale}"
 
     # Fast path: translated result already cached for this locale
     cached_translated = _starter_flows_translated_cache.get(translated_cache_key)
     if cached_translated is not CACHE_MISS:
-        return compress_response(cached_translated)
+        visible_flows = (
+            cached_translated
+            if include_blocked
+            else _filter_basic_examples_by_catalog_policy(
+                cached_translated,
+                blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+            )
+        )
+        return compress_response(visible_flows)
 
     async with _starter_flows_lock:
         # Double-check inside lock to prevent thundering herd
         cached_translated = _starter_flows_translated_cache.get(translated_cache_key)
         if cached_translated is not CACHE_MISS:
-            return compress_response(cached_translated)
+            visible_flows = (
+                cached_translated
+                if include_blocked
+                else _filter_basic_examples_by_catalog_policy(
+                    cached_translated,
+                    blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+                )
+            )
+            return compress_response(visible_flows)
 
         # Ensure raw DB data is cached
         cached_flow_reads = _starter_flows_cache.get("starter_flows")
@@ -967,7 +1003,15 @@ async def read_basic_examples(
 
         _starter_flows_translated_cache.set(translated_cache_key, result)
 
-    return compress_response(result)
+    visible_flows = (
+        result
+        if include_blocked
+        else _filter_basic_examples_by_catalog_policy(
+            result,
+            blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+        )
+    )
+    return compress_response(visible_flows)
 
 
 @router.post("/expand/", status_code=200, dependencies=[Depends(get_current_active_user)], include_in_schema=False)

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -14,6 +14,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlmodel import apaginate
 from lfx.services.cache.utils import CACHE_MISS
+from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError, validate_catalog_policy_for_flow
 from pydantic import ValidationError
 from sqlalchemy import case
 from sqlmodel import and_, col, select
@@ -43,7 +45,6 @@ from langflow.api.v1.flows_helpers import (
     _resolve_flow_destination,
     _save_flow_to_fs,
     _update_existing_flow,
-    _upsert_flow_list,
     _validate_and_assign_folder,
     _verify_fs_path,
 )
@@ -106,6 +107,18 @@ def _handle_unique_constraint_error(exc: Exception, *, status_code: int = 400) -
     return HTTPException(status_code=status_code, detail=f"{column.capitalize().replace('_', ' ')} must be unique")
 
 
+def _validate_catalog_policy_for_write(
+    flow_data: dict | None,
+    *,
+    snapshot: CatalogPolicySnapshot,
+) -> None:
+    """Validate one effective flow graph and expose policy denials as client errors."""
+    try:
+        validate_catalog_policy_for_flow(flow_data, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 # build router
 router = APIRouter(prefix="/flows", tags=["Flows"])
 
@@ -120,6 +133,8 @@ async def create_flow(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
 ):
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
+        _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
         # FastAPI builds the dependency's body model independently from the
         # handler's body model. Carry the exact destination that was authorized
         # into the row we persist so stale caller scope fields cannot retarget
@@ -349,6 +364,7 @@ async def update_flow(
 ):
     """Update a flow."""
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         # Destination check: resolve the actual owner-folder/workspace tuple
         # before authorizing a move. ``_patch_flow`` applies payload values via
         # ``model_dump(exclude_unset=True, exclude_none=True)``, so None means
@@ -427,6 +443,8 @@ async def update_flow(
                     )
                 except HTTPException as exc:
                     raise deny_to_404(exc, detail="Flow not found") from exc
+            effective_flow_data = flow.data if flow.data is not None else db_flow_for_attempt.data
+            _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
             return await _patch_flow(
                 session=session,
                 db_flow=db_flow_for_attempt,
@@ -468,6 +486,7 @@ async def upsert_flow(
     from fastapi.responses import JSONResponse
 
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         # Check if flow exists (without user filter to distinguish ownership vs CREATE)
         existing_flow = (await session.exec(select(Flow).where(Flow.id == flow_id))).first()
 
@@ -577,6 +596,8 @@ async def upsert_flow(
                         )
                     except HTTPException as exc:
                         raise deny_to_404(exc, detail="Flow not found") from exc
+                effective_flow_data = flow.data if flow.data is not None else existing_flow_for_attempt.data
+                _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
                 return await _update_existing_flow(
                     session=session,
                     existing_flow=existing_flow_for_attempt,
@@ -600,6 +621,7 @@ async def upsert_flow(
             await ensure_flow_permission(
                 current_user, FlowAction.CREATE, workspace_id=flow.workspace_id, folder_id=flow.folder_id
             )
+            _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
             flow_read = await _new_flow(
                 session=session,
                 flow=flow,
@@ -648,6 +670,12 @@ async def create_flows(
     current_user: CurrentActiveUser,
 ):
     """Create multiple new flows."""
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    # Validate the complete request before adding or flushing any rows. This
+    # keeps a denial in a later item from partially applying an earlier item.
+    for flow in flow_list.flows:
+        _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
+
     # Resolve and authorize every flow's canonical project/workspace instead of
     # trusting caller-supplied denormalized scope fields.
     for flow in flow_list.flows:
@@ -759,17 +787,42 @@ async def upload_file(
     # When implemented, extract raw flow dicts here to read embedded "version"
     # arrays and create FlowVersion entries for each imported flow.
 
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+
+    requested_id_list = [flow.id for flow in flow_list.flows if flow.id is not None]
+    requested_ids = set(requested_id_list)
+    if len(requested_ids) != len(requested_id_list):
+        raise HTTPException(status_code=422, detail="Invalid upload: duplicate flow IDs are not allowed")
+
+    # Lock only rows this request can update. Missing IDs remain classified as
+    # creates for the whole request; if one appears concurrently, the planned
+    # insert conflicts instead of silently becoming an unvalidated update.
+    owned_existing_flows_by_id: dict[UUID, Flow] = {}
+    foreign_existing_ids: set[UUID] = set()
+    if requested_ids:
+        owned_existing_flows = (
+            await session.exec(
+                select(Flow).where(col(Flow.id).in_(requested_ids), Flow.user_id == current_user.id).with_for_update()
+            )
+        ).all()
+        owned_existing_flows_by_id = {existing_flow.id: existing_flow for existing_flow in owned_existing_flows}
+        remaining_ids = requested_ids - owned_existing_flows_by_id.keys()
+        if remaining_ids:
+            other_existing_flows = (await session.exec(select(Flow).where(col(Flow.id).in_(remaining_ids)))).all()
+            foreign_existing_ids = {
+                existing_flow.id for existing_flow in other_existing_flows if existing_flow.user_id != current_user.id
+            }
+
     # Per-flow CREATE check on the effective canonical destination. For owned
     # upserts with no destination in the payload, preserve the existing project;
     # new or stale destinations fall back to the user's default project.
     for flow in flow_list.flows:
         fallback_folder_id = None
+        existing_flow = owned_existing_flows_by_id.get(flow.id) if flow.id is not None else None
         if folder_id is not None:
             flow.folder_id = folder_id
-        elif flow.folder_id is None and flow.id is not None:
-            existing_flow = (await session.exec(select(Flow).where(Flow.id == flow.id))).first()
-            if existing_flow is not None and existing_flow.user_id == current_user.id:
-                fallback_folder_id = existing_flow.folder_id
+        elif flow.folder_id is None and existing_flow is not None and existing_flow.user_id == current_user.id:
+            fallback_folder_id = existing_flow.folder_id
         await _canonicalize_flow_destination(
             session,
             flow,
@@ -783,18 +836,52 @@ async def upload_file(
             folder_id=flow.folder_id,
         )
 
+        # Upload upserts ignore omitted/null data. Validate the stored graph in
+        # that case so a metadata-only write cannot bypass a newly blocked
+        # component. Rows owned by another user are copied as new flows and do
+        # not inherit that user's stored graph.
+        effective_flow_data = flow.data
+        if effective_flow_data is None and existing_flow is not None and existing_flow.user_id == current_user.id:
+            effective_flow_data = existing_flow.data
+        _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
+
     try:
-        return await _upsert_flow_list(
-            session=session,
-            flows=flow_list.flows,
-            current_user=current_user,
-            storage_service=storage_service,
-            folder_id=folder_id,
-        )
+        flow_reads: list[FlowRead] = []
+        for flow in flow_list.flows:
+            flow.user_id = current_user.id
+            stable_id = flow.id
+            existing_flow = owned_existing_flows_by_id.get(stable_id) if stable_id is not None else None
+            if existing_flow is not None:
+                flow_read = await _update_existing_flow(
+                    session=session,
+                    existing_flow=existing_flow,
+                    flow=flow,
+                    current_user=current_user,
+                    storage_service=storage_service,
+                )
+            elif stable_id is not None and stable_id in foreign_existing_ids:
+                flow.id = None
+                flow_read = await _new_flow(
+                    session=session,
+                    flow=flow,
+                    user_id=current_user.id,
+                    storage_service=storage_service,
+                )
+            else:
+                flow_read = await _new_flow(
+                    session=session,
+                    flow=flow,
+                    user_id=current_user.id,
+                    storage_service=storage_service,
+                    flow_id=stable_id,
+                )
+            flow_reads.append(flow_read)
     except HTTPException:
         raise
     except Exception as e:
         raise _handle_unique_constraint_error(e) from e
+    else:
+        return flow_reads
 
 
 @router.delete("/")

--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -685,60 +685,6 @@ async def _patch_flow(
     return FlowRead.model_validate(db_flow, from_attributes=True)
 
 
-async def _upsert_flow_list(
-    *,
-    session: AsyncSession,
-    flows: list[FlowCreate],
-    current_user: User,
-    storage_service: StorageService,
-    folder_id: UUID | None = None,
-) -> list[FlowRead]:
-    """Import a list of flows with upsert semantics (used by the upload endpoint).
-
-    For each flow:
-    - If it has an ID matching an existing flow owned by the user, update in place.
-    - If it has an ID claimed by another user, mint a fresh UUID.
-    - Otherwise create with the provided or generated ID.
-    """
-    flow_reads: list[FlowRead] = []
-    for flow in flows:
-        flow.user_id = current_user.id
-        if folder_id:
-            flow.folder_id = folder_id
-
-        if flow.id is not None:
-            existing = (await session.exec(select(Flow).where(Flow.id == flow.id))).first()
-
-            if existing is not None and existing.user_id == current_user.id:
-                flow_read = await _update_existing_flow(
-                    session=session,
-                    existing_flow=existing,
-                    flow=flow,
-                    current_user=current_user,
-                    storage_service=storage_service,
-                )
-            elif existing is not None:
-                flow.id = None
-                flow_read = await _new_flow(
-                    session=session, flow=flow, user_id=current_user.id, storage_service=storage_service
-                )
-            else:
-                flow_read = await _new_flow(
-                    session=session,
-                    flow=flow,
-                    user_id=current_user.id,
-                    storage_service=storage_service,
-                    flow_id=flow.id,
-                )
-        else:
-            flow_read = await _new_flow(
-                session=session, flow=flow, user_id=current_user.id, storage_service=storage_service
-            )
-
-        flow_reads.append(flow_read)
-    return flow_reads
-
-
 def _sanitize_flow_filename(raw_name: str, fallback_id: str = "flow") -> str:
     """Return a filesystem-safe filename from a flow name.
 

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -394,6 +394,9 @@ class BaseConfigResponse(BaseModel):
     # Mirrors ``LANGFLOW_AUTHZ_ENABLED``. EE/custom frontends gate the Access
     # Control settings entry on this flag; OSS UI ignores it until wired.
     authz_enabled: bool = False
+    # Signals that at least one component or template is governed without
+    # exposing the policy contents through the public config response.
+    catalog_governance_enabled: bool = False
 
 
 class PublicConfigResponse(BaseConfigResponse):
@@ -407,12 +410,19 @@ class PublicConfigResponse(BaseConfigResponse):
     allow_custom_components: bool
 
     @classmethod
-    def from_settings(cls, settings: Settings, auth_settings) -> "PublicConfigResponse":
+    def from_settings(
+        cls,
+        settings: Settings,
+        auth_settings,
+        *,
+        catalog_governance_enabled: bool = False,
+    ) -> "PublicConfigResponse":
         """Create a PublicConfigResponse instance using values from a Settings object.
 
         Parameters:
             settings (Settings): The Settings object containing configuration values.
             auth_settings: Auth settings (for ``authz_enabled``).
+            catalog_governance_enabled: Whether any catalog policy currently restricts resources.
 
         Returns:
             PublicConfigResponse: An instance populated with public-safe configuration values.
@@ -427,6 +437,7 @@ class PublicConfigResponse(BaseConfigResponse):
             enable_extension_reload=settings.enable_extension_reload,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            catalog_governance_enabled=catalog_governance_enabled,
         )
 
 
@@ -465,12 +476,19 @@ class ConfigResponse(BaseConfigResponse):
     agentic_experience: bool = True
 
     @classmethod
-    def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
+    def from_settings(
+        cls,
+        settings: Settings,
+        auth_settings,
+        *,
+        catalog_governance_enabled: bool = False,
+    ) -> "ConfigResponse":
         """Create a ConfigResponse instance using values from a Settings object and AuthSettings.
 
         Parameters:
             settings (Settings): The Settings object containing configuration values.
             auth_settings: The AuthSettings object containing authentication configuration values.
+            catalog_governance_enabled: Whether any catalog policy currently restricts resources.
 
         Returns:
             ConfigResponse: An instance populated with configuration and feature flag values.
@@ -498,6 +516,7 @@ class ConfigResponse(BaseConfigResponse):
             hide_getting_started_progress=settings.hide_getting_started_progress,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            catalog_governance_enabled=catalog_governance_enabled,
             embedded_mode=settings.embedded_mode,
             hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
             hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,

--- a/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
@@ -1,0 +1,27 @@
+"""Schemas for the catalog-policy administration API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CatalogPolicyBlockedSet(BaseModel):
+    """A normalized whole-set catalog block policy."""
+
+    blocked: list[str] = Field(
+        ...,
+        description="Complete set of blocked catalog keys for this resource kind.",
+    )
+
+    @field_validator("blocked")
+    @classmethod
+    def normalize_blocked_keys(cls, value: list[str]) -> list[str]:
+        """Trim, reject empty values, deduplicate, and sort deterministically."""
+        normalized: set[str] = set()
+        for raw_key in value:
+            key = raw_key.strip()
+            if not key:
+                msg = "Blocked catalog keys must not be empty"
+                raise ValueError(msg)
+            normalized.add(key)
+        return sorted(normalized)

--- a/src/backend/base/langflow/api/v1/starter_projects.py
+++ b/src/backend/base/langflow/api/v1/starter_projects.py
@@ -1,9 +1,10 @@
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from langflow.services.auth.utils import get_current_active_user
+from langflow.api.utils import CurrentActiveUser
+from langflow.services.deps import get_catalog_policy_service
 
 router = APIRouter(prefix="/starter-projects", tags=["Flows"])
 
@@ -37,16 +38,26 @@ class GraphDumpResponse(BaseModel):
     data: GraphData
     is_component: bool | None = None
     name: str | None = None
+    name_key: str
     description: str | None = None
     endpoint_name: str | None = None
 
 
-@router.get("/", dependencies=[Depends(get_current_active_user)], status_code=200)
-async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
+@router.get("/", status_code=200)
+async def get_starter_projects(
+    request: Request,
+    current_user: CurrentActiveUser,
+    *,
+    include_blocked: bool = False,
+) -> list[GraphDumpResponse]:
     """Get a list of starter projects."""
     from langflow.initial_setup.load import get_starter_projects_dump
     from langflow.utils.i18n import translate_flow_notes
 
+    if include_blocked and not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="Only superusers can include blocked catalog templates.")
+
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
     locale = getattr(request.state, "locale", "en")
 
     try:
@@ -56,6 +67,12 @@ async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
         # Convert TypedDict GraphDump to Pydantic GraphDumpResponse
         results = []
         for item in raw_data:
+            name_key = item.get("name_key")
+            if not isinstance(name_key, str):
+                continue
+            if not include_blocked and catalog_policy_snapshot.is_template_blocked(name_key):
+                continue
+
             nodes = item.get("data", {}).get("nodes", [])
             translated_nodes = translate_flow_notes(nodes, locale)
 
@@ -71,6 +88,7 @@ async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
                 data=graph_data,
                 is_component=item.get("is_component"),
                 name=item.get("name"),
+                name_key=name_key,
                 description=item.get("description"),
                 endpoint_name=item.get("endpoint_name"),
             )

--- a/src/backend/base/langflow/api/v1/validate.py
+++ b/src/backend/base/langflow/api/v1/validate.py
@@ -3,17 +3,28 @@ from lfx.base.prompts.api_utils import process_prompt_template
 from lfx.custom.validate import validate_code
 from lfx.log.logger import logger
 
+from langflow.api.utils import CurrentActiveUser
 from langflow.api.v1.base import Code, CodeValidationResponse, PromptValidationResponse, ValidatePromptRequest
+from langflow.api.v1.custom_component_policy import resolve_component_code_for_action
 from langflow.services.auth.utils import get_current_active_user
+from langflow.services.deps import get_catalog_policy_service, get_settings_service
 
 # build router
 router = APIRouter(prefix="/validate", tags=["Validate"])
 
 
-@router.post("/code", status_code=200, dependencies=[Depends(get_current_active_user)], include_in_schema=False)
-async def post_validate_code(code: Code) -> CodeValidationResponse:
+@router.post("/code", status_code=200, include_in_schema=False)
+async def post_validate_code(code: Code, user: CurrentActiveUser) -> CodeValidationResponse:
+    effective_code = resolve_component_code_for_action(
+        code.code,
+        user=user,
+        settings=get_settings_service().settings,
+        snapshot=get_catalog_policy_service().snapshot,
+        disabled_detail="Custom component validation is disabled",
+        admin_only_detail="Custom component validation is restricted to administrators",
+    )
     try:
-        errors = validate_code(code.code)
+        errors = validate_code(effective_code)
         return CodeValidationResponse(
             imports=errors.get("imports", {}),
             function=errors.get("function", {}),

--- a/src/backend/base/langflow/initial_setup/load.py
+++ b/src/backend/base/langflow/initial_setup/load.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from typing import Any
 
+from langflow.utils.i18n_keys import safe_flow_key
+
 from .starter_projects import (
     basic_prompting_graph,
     blog_writer_graph,
@@ -56,5 +58,9 @@ def get_starter_projects_graphs():
 
 def get_starter_projects_dump():
     return [
-        build_graph().dump(name=name, description=description) for build_graph, name, description in STARTER_PROJECTS
+        {
+            **build_graph().dump(name=name, description=description),
+            "name_key": safe_flow_key(name),
+        }
+        for build_graph, name, description in STARTER_PROJECTS
     ]

--- a/src/backend/base/langflow/services/catalog_policy/__init__.py
+++ b/src/backend/base/langflow/services/catalog_policy/__init__.py
@@ -1,0 +1,5 @@
+"""Langflow catalog-policy service."""
+
+from langflow.services.catalog_policy.service import LangflowCatalogPolicyService
+
+__all__ = ["LangflowCatalogPolicyService"]

--- a/src/backend/base/langflow/services/catalog_policy/factory.py
+++ b/src/backend/base/langflow/services/catalog_policy/factory.py
@@ -1,0 +1,31 @@
+"""Catalog-policy service factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langflow.services.factory import ServiceFactory
+from langflow.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy import BaseCatalogPolicyService
+
+    from langflow.services.catalog_policy.service import LangflowCatalogPolicyService
+    from langflow.services.database.service import DatabaseService
+
+
+class CatalogPolicyServiceFactory(ServiceFactory):
+    """Create the Langflow database-backed catalog-policy service."""
+
+    name = ServiceType.CATALOG_POLICY_SERVICE.value
+
+    service_class: type[LangflowCatalogPolicyService]
+
+    def __init__(self) -> None:
+        from langflow.services.catalog_policy.service import LangflowCatalogPolicyService
+
+        super().__init__(LangflowCatalogPolicyService)
+
+    def create(self, database_service: DatabaseService) -> BaseCatalogPolicyService:
+        """Build a catalog-policy service using the injected database service."""
+        return self.service_class(database_service)

--- a/src/backend/base/langflow/services/catalog_policy/service.py
+++ b/src/backend/base/langflow/services/catalog_policy/service.py
@@ -1,0 +1,186 @@
+"""Database-backed catalog-policy service."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicySnapshot, CatalogPolicyUpdate
+from lfx.services.deps import session_scope, session_scope_readonly
+from lfx.services.schema import ServiceType
+from sqlmodel import col, select
+
+from langflow.services.database.models.catalog_policy import (
+    CatalogPolicyMode,
+    CatalogPolicyRule,
+    CatalogPolicyScope,
+    CatalogResourceKind,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from uuid import UUID
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from langflow.services.database.service import DatabaseService
+
+
+def _normalize_keys(keys: Collection[str]) -> frozenset[str]:
+    """Trim and deduplicate keys while preserving their case."""
+    normalized: set[str] = set()
+    for raw_key in keys:
+        key = raw_key.strip()
+        if not key:
+            msg = "Catalog policy keys must not be empty"
+            raise ValueError(msg)
+        normalized.add(key)
+    return frozenset(normalized)
+
+
+class LangflowCatalogPolicyService(BaseCatalogPolicyService):
+    """Durable global catalog policy backed by an immutable local snapshot.
+
+    Each Langflow process owns its snapshot. Startup hydration and successful
+    writes update that process; coordinating snapshots across multiple workers
+    requires an external invalidation mechanism and is outside this service.
+    Before hydration, the empty snapshot deliberately allows every resource.
+    """
+
+    def __init__(self, database_service: DatabaseService) -> None:
+        super().__init__()
+        self.database_service = database_service
+        self._snapshot = CatalogPolicySnapshot()
+        self._hydrated = False
+        self._write_lock = asyncio.Lock()
+        # Direct service-class registration does not call set_ready(), unlike
+        # factory creation. The fail-open snapshot is usable immediately.
+        self.set_ready()
+
+    @property
+    def name(self) -> str:
+        """Return the canonical service-type name."""
+        return ServiceType.CATALOG_POLICY_SERVICE.value
+
+    @property
+    def snapshot(self) -> CatalogPolicySnapshot:
+        """Return the current immutable process-local snapshot."""
+        return self._snapshot
+
+    @property
+    def hydrated(self) -> bool:
+        """Return whether durable policy has been loaded successfully."""
+        return self._hydrated
+
+    async def hydrate(self) -> CatalogPolicySnapshot:
+        """Load global block rules and atomically publish a complete snapshot.
+
+        A failed load leaves the previous snapshot untouched. Callers may log
+        the failure and continue with its fail-open decision surface.
+        """
+        async with self._write_lock:
+            async with session_scope_readonly() as session:
+                snapshot, _rows = await self._read_policy(session)
+            self._snapshot = snapshot
+            self._hydrated = True
+            return snapshot
+
+    async def replace_blocked_component_keys(
+        self,
+        keys: Collection[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        """Replace the global component block set and publish it after commit."""
+        return await self._replace_blocked_keys(
+            CatalogResourceKind.COMPONENT,
+            keys,
+            actor_user_id=actor_user_id,
+        )
+
+    async def replace_blocked_template_keys(
+        self,
+        keys: Collection[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        """Replace the global template block set and publish it after commit."""
+        return await self._replace_blocked_keys(
+            CatalogResourceKind.TEMPLATE,
+            keys,
+            actor_user_id=actor_user_id,
+        )
+
+    async def _replace_blocked_keys(
+        self,
+        resource_kind: CatalogResourceKind,
+        keys: Collection[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        desired = _normalize_keys(keys)
+
+        async with self._write_lock:
+            async with session_scope() as session:
+                current_snapshot, rows = await self._read_policy(session)
+                current_rows = {row.resource_key: row for row in rows if row.resource_kind == resource_kind.value}
+                current = frozenset(current_rows)
+                added = desired - current
+                removed = current - desired
+
+                for key in removed:
+                    await session.delete(current_rows[key])
+                for key in added:
+                    session.add(
+                        CatalogPolicyRule(
+                            resource_kind=resource_kind.value,
+                            resource_key=key,
+                            mode=CatalogPolicyMode.BLOCK.value,
+                            scope=CatalogPolicyScope.GLOBAL.value,
+                            domain_id=None,
+                            created_by=actor_user_id,
+                        )
+                    )
+
+            if resource_kind == CatalogResourceKind.COMPONENT:
+                committed_snapshot = CatalogPolicySnapshot(
+                    blocked_component_keys=desired,
+                    blocked_template_keys=current_snapshot.blocked_template_keys,
+                )
+            else:
+                committed_snapshot = CatalogPolicySnapshot(
+                    blocked_component_keys=current_snapshot.blocked_component_keys,
+                    blocked_template_keys=desired,
+                )
+
+            # A single reference swap publishes both frozensets together, and
+            # occurs only after the durable transaction has committed.
+            self._snapshot = committed_snapshot
+            self._hydrated = True
+            return CatalogPolicyUpdate(
+                snapshot=committed_snapshot,
+                added=frozenset(added),
+                removed=frozenset(removed),
+            )
+
+    @staticmethod
+    async def _read_policy(
+        session: AsyncSession,
+    ) -> tuple[CatalogPolicySnapshot, list[CatalogPolicyRule]]:
+        stmt = select(CatalogPolicyRule).where(
+            CatalogPolicyRule.mode == CatalogPolicyMode.BLOCK.value,
+            CatalogPolicyRule.scope == CatalogPolicyScope.GLOBAL.value,
+            col(CatalogPolicyRule.domain_id).is_(None),
+        )
+        rows = list((await session.exec(stmt)).all())
+        return (
+            CatalogPolicySnapshot(
+                blocked_component_keys=frozenset(
+                    row.resource_key for row in rows if row.resource_kind == CatalogResourceKind.COMPONENT.value
+                ),
+                blocked_template_keys=frozenset(
+                    row.resource_key for row in rows if row.resource_kind == CatalogResourceKind.TEMPLATE.value
+                ),
+            ),
+            rows,
+        )

--- a/src/backend/base/langflow/services/database/models/__init__.py
+++ b/src/backend/base/langflow/services/database/models/__init__.py
@@ -12,6 +12,7 @@ from .auth import (
     SSOConfig,
     SSOUserProfile,
 )
+from .catalog_policy import CatalogPolicyMode, CatalogPolicyRule, CatalogPolicyScope, CatalogResourceKind
 from .deployment import Deployment
 from .deployment_provider_account import DeploymentProviderAccount
 from .file import File
@@ -43,6 +44,10 @@ __all__ = [
     "AuthzTeam",
     "AuthzTeamMember",
     "CasbinRule",
+    "CatalogPolicyMode",
+    "CatalogPolicyRule",
+    "CatalogPolicyScope",
+    "CatalogResourceKind",
     "Deployment",
     "DeploymentProviderAccount",
     "ExecutionSignal",

--- a/src/backend/base/langflow/services/database/models/catalog_policy/__init__.py
+++ b/src/backend/base/langflow/services/database/models/catalog_policy/__init__.py
@@ -1,0 +1,8 @@
+from .model import CatalogPolicyMode, CatalogPolicyRule, CatalogPolicyScope, CatalogResourceKind
+
+__all__ = [
+    "CatalogPolicyMode",
+    "CatalogPolicyRule",
+    "CatalogPolicyScope",
+    "CatalogResourceKind",
+]

--- a/src/backend/base/langflow/services/database/models/catalog_policy/model.py
+++ b/src/backend/base/langflow/services/database/models/catalog_policy/model.py
@@ -1,0 +1,123 @@
+"""Catalog-governance policy storage."""
+
+from datetime import datetime, timezone
+from enum import Enum
+from uuid import uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, Column, ForeignKey, Index, text
+from sqlmodel import Field, SQLModel
+from sqlmodel.sql.sqltypes import AutoString
+
+from langflow.schema.serialize import UUIDstr
+
+
+class CatalogResourceKind(str, Enum):
+    """Kinds of catalog resources that can be governed."""
+
+    COMPONENT = "component"
+    TEMPLATE = "template"
+
+
+class CatalogPolicyMode(str, Enum):
+    """Catalog policy modes.
+
+    ``ALLOW`` is reserved for a future allowlist phase. P1 only writes block
+    rules, but the schema can accept the future value without another enum
+    migration.
+    """
+
+    BLOCK = "block"
+    ALLOW = "allow"
+
+
+class CatalogPolicyScope(str, Enum):
+    """Policy scopes.
+
+    P1 uses only ``GLOBAL``. Organization and workspace values reserve the
+    existing authorization domain shape for a later scoped-policy phase.
+    """
+
+    GLOBAL = "global"
+    ORG = "org"
+    WORKSPACE = "workspace"
+
+
+def _tz_aware_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CatalogPolicyRule(SQLModel, table=True):  # type: ignore[call-arg]
+    """A block or allow rule for a component type or template id."""
+
+    __tablename__ = "catalog_policy_rule"
+    __table_args__ = (
+        CheckConstraint(
+            "resource_kind IN ('component', 'template')",
+            name="ck_catalog_policy_rule_resource_kind",
+        ),
+        CheckConstraint(
+            "mode IN ('block', 'allow')",
+            name="ck_catalog_policy_rule_mode",
+        ),
+        CheckConstraint(
+            "scope IN ('global', 'org', 'workspace')",
+            name="ck_catalog_policy_rule_scope",
+        ),
+        CheckConstraint(
+            "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)",
+            name="ck_catalog_policy_rule_scope_domain_consistency",
+        ),
+        Index(
+            "uq_catalog_policy_rule_scoped",
+            "resource_kind",
+            "resource_key",
+            "scope",
+            "domain_id",
+            unique=True,
+            postgresql_where=text("domain_id IS NOT NULL"),
+            sqlite_where=text("domain_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_catalog_policy_rule_unscoped",
+            "resource_kind",
+            "resource_key",
+            "scope",
+            unique=True,
+            postgresql_where=text("domain_id IS NULL"),
+            sqlite_where=text("domain_id IS NULL"),
+        ),
+    )
+
+    id: UUIDstr = Field(default_factory=uuid4, primary_key=True)
+    resource_kind: str
+    resource_key: str
+    mode: str = Field(
+        default=CatalogPolicyMode.BLOCK.value,
+        sa_column=Column(AutoString(), nullable=False, server_default=sa.text("'block'")),
+    )
+    scope: str = Field(
+        default=CatalogPolicyScope.GLOBAL.value,
+        sa_column=Column(AutoString(), nullable=False, server_default=sa.text("'global'")),
+    )
+    domain_id: UUIDstr | None = Field(
+        default=None,
+        sa_column=Column(sa.Uuid(), nullable=True),
+    )
+    created_by: UUIDstr | None = Field(
+        default=None,
+        sa_column=Column(sa.Uuid(), ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=_tz_aware_now,
+        sa_column=Column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    updated_at: datetime = Field(
+        default_factory=_tz_aware_now,
+        sa_column=Column(
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )

--- a/src/backend/base/langflow/services/database/models/catalog_policy/model.py
+++ b/src/backend/base/langflow/services/database/models/catalog_policy/model.py
@@ -22,9 +22,8 @@ class CatalogResourceKind(str, Enum):
 class CatalogPolicyMode(str, Enum):
     """Catalog policy modes.
 
-    ``ALLOW`` is reserved for a future allowlist phase. P1 only writes block
-    rules, but the schema can accept the future value without another enum
-    migration.
+    P1 reads and writes only ``BLOCK`` rules. ``ALLOW`` is a schema reservation
+    for a future allowlist phase and has no P1 resolution semantics.
     """
 
     BLOCK = "block"
@@ -34,8 +33,9 @@ class CatalogPolicyMode(str, Enum):
 class CatalogPolicyScope(str, Enum):
     """Policy scopes.
 
-    P1 uses only ``GLOBAL``. Organization and workspace values reserve the
-    existing authorization domain shape for a later scoped-policy phase.
+    P1 reads and writes only ``GLOBAL`` rules. Organization and workspace
+    values reserve the existing authorization domain shape for a later
+    scoped-policy phase and have no P1 resolution semantics.
     """
 
     GLOBAL = "global"
@@ -43,29 +43,51 @@ class CatalogPolicyScope(str, Enum):
     WORKSPACE = "workspace"
 
 
+def _enum_values_sql(enum_type: type[Enum]) -> str:
+    """Return safely quoted SQL literals for a closed internal string enum."""
+    return ", ".join(f"'{member.value}'" for member in enum_type)
+
+
+_RESOURCE_KIND_CHECK = f"resource_kind IN ({_enum_values_sql(CatalogResourceKind)})"
+_MODE_CHECK = f"mode IN ({_enum_values_sql(CatalogPolicyMode)})"
+_SCOPE_CHECK = f"scope IN ({_enum_values_sql(CatalogPolicyScope)})"
+_SCOPED_VALUES_SQL = ", ".join(f"'{scope.value}'" for scope in (CatalogPolicyScope.ORG, CatalogPolicyScope.WORKSPACE))
+_SCOPE_DOMAIN_CHECK = (
+    f"(scope = '{CatalogPolicyScope.GLOBAL.value}' AND domain_id IS NULL) "
+    f"OR (scope IN ({_SCOPED_VALUES_SQL}) AND domain_id IS NOT NULL)"
+)
+
+
 def _tz_aware_now() -> datetime:
+    """Return the current UTC timestamp for in-memory model defaults."""
     return datetime.now(timezone.utc)
 
 
 class CatalogPolicyRule(SQLModel, table=True):  # type: ignore[call-arg]
-    """A block or allow rule for a component type or template id."""
+    """A catalog rule keyed by an exact, case-sensitive resource identifier.
+
+    The P1 service considers only global block rules; reserved allow/scoped rows
+    are ignored until a future phase defines their resolution semantics. The
+    unique indexes prevent contradictory modes for the same resource and
+    domain, while intentionally allowing distinct resources in one scope.
+    """
 
     __tablename__ = "catalog_policy_rule"
     __table_args__ = (
         CheckConstraint(
-            "resource_kind IN ('component', 'template')",
+            _RESOURCE_KIND_CHECK,
             name="ck_catalog_policy_rule_resource_kind",
         ),
         CheckConstraint(
-            "mode IN ('block', 'allow')",
+            _MODE_CHECK,
             name="ck_catalog_policy_rule_mode",
         ),
         CheckConstraint(
-            "scope IN ('global', 'org', 'workspace')",
+            _SCOPE_CHECK,
             name="ck_catalog_policy_rule_scope",
         ),
         CheckConstraint(
-            "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)",
+            _SCOPE_DOMAIN_CHECK,
             name="ck_catalog_policy_rule_scope_domain_consistency",
         ),
         Index(

--- a/src/backend/base/langflow/services/deps.py
+++ b/src/backend/base/langflow/services/deps.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 # dependency functions that FastAPI evaluates at module load time.
 from lfx.services.auth.base import BaseAuthService  # noqa: TC002
 from lfx.services.authorization.base import BaseAuthorizationService  # noqa: TC002
+from lfx.services.catalog_policy.base import BaseCatalogPolicyService  # noqa: TC002
 from lfx.services.settings.service import SettingsService  # noqa: TC002
 
 from langflow.services.job_queue.service import JobQueueService  # noqa: TC001
@@ -296,6 +297,13 @@ def get_authorization_service() -> BaseAuthorizationService:
     from langflow.services.authorization.factory import AuthorizationServiceFactory
 
     return get_service(ServiceType.AUTHORIZATION_SERVICE, AuthorizationServiceFactory())
+
+
+def get_catalog_policy_service() -> BaseCatalogPolicyService:
+    """Retrieve catalog policy through LFX's validated fail-open dependency."""
+    from lfx.services.deps import get_catalog_policy_service as get_lfx_catalog_policy_service
+
+    return get_lfx_catalog_policy_service()
 
 
 def get_job_service():

--- a/src/backend/base/langflow/services/factory.py
+++ b/src/backend/base/langflow/services/factory.py
@@ -98,9 +98,11 @@ def import_all_services_into_a_dict():
     # Import settings and auth bases from lfx (used in type hints but not langflow Service subclasses)
     from lfx.services.auth.base import BaseAuthService
     from lfx.services.authorization.base import BaseAuthorizationService
+    from lfx.services.catalog_policy.base import BaseCatalogPolicyService
     from lfx.services.settings.service import SettingsService
 
     services["BaseAuthService"] = BaseAuthService
     services["BaseAuthorizationService"] = BaseAuthorizationService
+    services["BaseCatalogPolicyService"] = BaseCatalogPolicyService
     services["SettingsService"] = SettingsService
     return services

--- a/src/backend/base/langflow/services/schema.py
+++ b/src/backend/base/langflow/services/schema.py
@@ -6,6 +6,7 @@ class ServiceType(str, Enum):
 
     AUTH_SERVICE = "auth_service"
     AUTHORIZATION_SERVICE = "authorization_service"
+    CATALOG_POLICY_SERVICE = "catalog_policy_service"
     MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
     CACHE_SERVICE = "cache_service"
     SHARED_COMPONENT_CACHE_SERVICE = "shared_component_cache_service"

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -575,6 +575,8 @@ def register_all_service_factories() -> None:
     from langflow.services.authorization import factory as authorization_factory
     from langflow.services.authorization.service import LangflowAuthorizationService
     from langflow.services.cache import factory as cache_factory
+    from langflow.services.catalog_policy import factory as catalog_policy_factory
+    from langflow.services.catalog_policy.service import LangflowCatalogPolicyService
     from langflow.services.chat import factory as chat_factory
     from langflow.services.checkpoint import factory as checkpoint_factory
     from langflow.services.database import factory as database_factory
@@ -624,6 +626,12 @@ def register_all_service_factories() -> None:
     )
     service_manager.register_factory(authorization_factory.AuthorizationServiceFactory())
     service_manager.register_service_class(
+        ServiceType.CATALOG_POLICY_SERVICE,
+        LangflowCatalogPolicyService,
+        override=True,
+    )
+    service_manager.register_factory(catalog_policy_factory.CatalogPolicyServiceFactory())
+    service_manager.register_service_class(
         ServiceType.MODEL_PROVIDER_POLICY_SERVICE,
         ModelProviderPolicyService,
         override=True,
@@ -669,6 +677,19 @@ def register_builtin_deployment_mappers() -> None:
         logger.info("Skipping Watsonx Orchestrate deployment mapper registration: %s", exc)
 
 
+async def hydrate_catalog_policy() -> None:
+    """Hydrate durable catalog policy without making startup fail closed."""
+    from langflow.services.deps import get_catalog_policy_service
+
+    try:
+        await get_catalog_policy_service().hydrate()
+    except Exception as exc:  # noqa: BLE001
+        # Catalog policy is explicitly fail-open. Keep the immutable empty
+        # snapshot when durable policy cannot be hydrated, but make the
+        # governance outage visible to operators.
+        await logger.awarning("Catalog policy hydration failed; continuing with allow-all policy: %s", exc)
+
+
 async def initialize_services(*, fix_migration: bool = False, skip_superuser_setup: bool = False) -> None:
     """Initialize all the services needed."""
     from langflow.helpers.windows_postgres_helper import configure_windows_postgres_event_loop
@@ -710,6 +731,7 @@ async def initialize_services(*, fix_migration: bool = False, skip_superuser_set
     async with session_scope() as session:
         await hydrate_model_provider_policy(session)
 
+    await hydrate_catalog_policy()
     db_service = get_db_service()
     await db_service.initialize_alembic_log_file()
     settings_service = get_service(ServiceType.SETTINGS_SERVICE)

--- a/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
+++ b/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
@@ -9,8 +9,82 @@ import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+from langflow.services.database.models.catalog_policy import CatalogPolicyRule
+from langflow.services.database.models.user.model import User
+from sqlalchemy.dialects.postgresql import CITEXT as POSTGRESQL_CITEXT
+from sqlalchemy.dialects.postgresql import UUID as POSTGRESQL_UUID
+
+from .test_migration_execution import _engine_url, db_url  # noqa: F401
 
 _MIGRATION = importlib.import_module("langflow.alembic.versions.d4a7c9e1b2f6_add_catalog_policy_rule")
+_VALID_CHECKS = {
+    "ck_catalog_policy_rule_resource_kind": "resource_kind IN ('component', 'template')",
+    "ck_catalog_policy_rule_mode": "mode IN ('block', 'allow')",
+    "ck_catalog_policy_rule_scope": "scope IN ('global', 'org', 'workspace')",
+    "ck_catalog_policy_rule_scope_domain_consistency": (
+        "(scope = 'global' AND domain_id IS NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NOT NULL)"
+    ),
+}
+_POSTGRES_REFLECTED_CHECKS = {
+    "ck_catalog_policy_rule_resource_kind": (
+        "((resource_kind)::text = ANY ((ARRAY['component'::character varying, 'template'::character varying])::text[]))"
+    ),
+    "ck_catalog_policy_rule_mode": (
+        "((mode)::text = ANY ((ARRAY['block'::character varying, 'allow'::character varying])::text[]))"
+    ),
+    "ck_catalog_policy_rule_scope": (
+        "((scope)::text = ANY "
+        "((ARRAY['global'::character varying, 'org'::character varying, "
+        "'workspace'::character varying])::text[]))"
+    ),
+    "ck_catalog_policy_rule_scope_domain_consistency": (
+        "((((scope)::text = 'global'::text) AND (domain_id IS NULL)) "
+        "OR (((scope)::text = ANY "
+        "((ARRAY['org'::character varying, 'workspace'::character varying])::text[])) "
+        "AND (domain_id IS NOT NULL)))"
+    ),
+}
+
+
+def _add_existing_catalog_table(
+    metadata: sa.MetaData,
+    *,
+    mode_default: str = "'block'",
+    resource_key_type: sa.types.TypeEngine | None = None,
+    created_at_default: str | None = None,
+    updated_at_default: str | None = None,
+    checks: dict[str, str] | None = None,
+    extra_checks: tuple[tuple[str | None, str], ...] = (),
+) -> sa.Table:
+    return sa.Table(
+        _MIGRATION.TABLE_NAME,
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("resource_kind", sa.String(), nullable=False),
+        sa.Column(
+            "resource_key",
+            resource_key_type if resource_key_type is not None else sa.String(),
+            nullable=False,
+        ),
+        sa.Column("mode", sa.String(), nullable=False, server_default=sa.text(mode_default)),
+        sa.Column("scope", sa.String(), nullable=False, server_default=sa.text("'global'")),
+        sa.Column("domain_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text(created_at_default) if created_at_default is not None else sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text(updated_at_default) if updated_at_default is not None else sa.func.now(),
+        ),
+        *(sa.CheckConstraint(sqltext, name=name) for name, sqltext in (checks or {}).items()),
+        *(sa.CheckConstraint(sqltext, name=name) for name, sqltext in extra_checks),
+    )
 
 
 def test_catalog_policy_migration_upgrades_idempotently_and_downgrades(monkeypatch):
@@ -103,6 +177,11 @@ def test_catalog_policy_migration_upgrades_idempotently_and_downgrades(monkeypat
         _MIGRATION.downgrade()
         assert _MIGRATION.TABLE_NAME not in sa.inspect(connection).get_table_names()
 
+        _MIGRATION.upgrade()
+        row_count = connection.execute(sa.text("SELECT count(*) FROM catalog_policy_rule")).scalar_one()
+        assert row_count == 0
+        _MIGRATION.downgrade()
+
 
 def test_catalog_policy_migration_rejects_partial_existing_table(monkeypatch):
     engine = sa.create_engine("sqlite://")
@@ -129,23 +208,28 @@ def test_catalog_policy_migration_rejects_partial_existing_table(monkeypatch):
         assert _MIGRATION.TABLE_NAME in sa.inspect(connection).get_table_names()
 
 
-def test_catalog_policy_migration_rejects_malformed_complete_table(monkeypatch):
+def test_catalog_policy_migration_rejects_missing_named_checks(monkeypatch):
     engine = sa.create_engine("sqlite://")
     metadata = sa.MetaData()
     sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
-    sa.Table(
-        _MIGRATION.TABLE_NAME,
+    _add_existing_catalog_table(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="missing required check constraints"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_permissive_named_checks(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
         metadata,
-        sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("resource_kind", sa.String(), nullable=False),
-        sa.Column("resource_key", sa.String(), nullable=False),
-        sa.Column("mode", sa.String(), nullable=False, server_default=sa.text("'block'")),
-        sa.Column("scope", sa.String(), nullable=False, server_default=sa.text("'global'")),
-        sa.Column("domain_id", sa.Uuid(), nullable=True),
-        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        *(sa.CheckConstraint("1 = 1", name=check_name) for check_name in _MIGRATION._REQUIRED_CHECKS),
+        checks=dict.fromkeys(_VALID_CHECKS, "1 = 1"),
     )
     metadata.create_all(engine)
 
@@ -153,7 +237,284 @@ def test_catalog_policy_migration_rejects_malformed_complete_table(monkeypatch):
         operations = Operations(MigrationContext.configure(connection))
         monkeypatch.setattr(_MIGRATION, "op", operations)
 
-        with pytest.raises(RuntimeError, match="resource-kind checks"):
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_inverted_scope_domain_check(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    checks = {
+        **_VALID_CHECKS,
+        "ck_catalog_policy_rule_scope_domain_consistency": (
+            "(scope = 'global' AND domain_id IS NOT NULL) OR (scope IN ('org', 'workspace') AND domain_id IS NULL)"
+        ),
+    }
+    _add_existing_catalog_table(metadata, checks=checks)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_negated_named_checks(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        checks={name: f"({sqltext}) IS FALSE" for name, sqltext in _VALID_CHECKS.items()},
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_preserves_cast_syntax_inside_quoted_identifier(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    checks = {
+        **_VALID_CHECKS,
+        "ck_catalog_policy_rule_mode": "\"mode::text\" IN ('block', 'allow')",
+    }
+    table = _add_existing_catalog_table(metadata, checks=checks)
+    table.append_column(sa.Column("mode::text", sa.String(), nullable=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+@pytest.mark.parametrize("extra_check_name", ["ck_catalog_policy_rule_component_only", None])
+def test_catalog_policy_migration_rejects_extra_overrestrictive_check(monkeypatch, extra_check_name):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        checks=_VALID_CHECKS,
+        extra_checks=((extra_check_name, "resource_kind = 'component'"),),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_duplicate_check_names(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        checks=_VALID_CHECKS,
+        extra_checks=(("ck_catalog_policy_rule_resource_kind", "resource_kind = 'component'"),),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible check constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_normalizes_postgresql_reflection_without_losing_structure():
+    assert _MIGRATION._matches_check_contract(_POSTGRES_REFLECTED_CHECKS, _MIGRATION._BASELINE_CHECK_SQL)
+    assert _MIGRATION._default_signature("'block'::character varying") == "'block'"
+    assert (
+        _MIGRATION._check_ast(
+            "((resource_kind)::bpchar = ANY "
+            "((ARRAY['component'::character varying, 'template'::character varying])::text[]))"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("option_name", ["not_valid", "no_inherit"])
+def test_catalog_policy_migration_rejects_postgresql_check_behavior_options(option_name):
+    class ReflectedCheckInspector:
+        @staticmethod
+        def get_check_constraints(_table_name):
+            constraints = [{"name": name, "sqltext": sqltext} for name, sqltext in _POSTGRES_REFLECTED_CHECKS.items()]
+            constraints[0]["dialect_options"] = {option_name: True}
+            return constraints
+
+    with pytest.raises(RuntimeError, match="incompatible check constraint"):
+        _MIGRATION._validate_check_constraints(ReflectedCheckInspector())
+
+
+@pytest.mark.parametrize(
+    "mode_default",
+    [
+        "'allow'",
+        "(substr('block', 1, 4))",
+        "upper('block')",
+        "(char(97, 108, 108, 111, 119) || substr('block', 6))",
+    ],
+)
+def test_catalog_policy_migration_rejects_incompatible_mode_default(monkeypatch, mode_default):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        mode_default=mode_default,
+        checks=_VALID_CHECKS,
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="mode has an incompatible default"):
+            _MIGRATION.upgrade()
+
+
+@pytest.mark.parametrize(
+    "resource_key_type",
+    [sa.Integer(), sa.String(1)],
+    ids=["integer", "bounded-string"],
+)
+def test_catalog_policy_migration_rejects_incompatible_column_type(monkeypatch, resource_key_type):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        resource_key_type=resource_key_type,
+        checks=_VALID_CHECKS,
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="resource_key has an incompatible type"):
+            _MIGRATION.upgrade()
+
+
+@pytest.mark.parametrize("created_at_default", ["'not-a-timestamp'", "'now'"])
+def test_catalog_policy_migration_rejects_incompatible_timestamp_default(monkeypatch, created_at_default):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        created_at_default=created_at_default,
+        checks=_VALID_CHECKS,
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="created_at has an incompatible default"):
+            _MIGRATION.upgrade()
+
+
+@pytest.mark.parametrize("required_default", [None, "NULL"])
+def test_catalog_policy_migration_rejects_unknown_required_column(monkeypatch, required_default):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    table = _add_existing_catalog_table(metadata, checks=_VALID_CHECKS)
+    table.append_column(
+        sa.Column(
+            "required_tag",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text(required_default) if required_default is not None else None,
+        )
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="unsupported required columns"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_recognizes_postgresql_uuid_type():
+    assert _MIGRATION._column_type_signature(POSTGRESQL_UUID(), dialect_name="postgresql") == "uuid"
+    assert (
+        _MIGRATION._column_type_signature(POSTGRESQL_CITEXT(), dialect_name="postgresql")
+        == "string:case-insensitive:citext"
+    )
+    assert _MIGRATION._column_type_signature(sa.CHAR(32), dialect_name="postgresql") == "char:32"
+    assert _MIGRATION._column_type_signature(sa.CHAR(32), dialect_name="sqlite") == "uuid"
+    assert _MIGRATION._column_type_signature(sa.DateTime(timezone=True), dialect_name="postgresql") == "datetime:tz"
+    assert _MIGRATION._column_type_signature(sa.DateTime(timezone=False), dialect_name="postgresql") == "datetime"
+
+
+def test_catalog_policy_migration_rejects_case_insensitive_resource_key_collation(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    _add_existing_catalog_table(
+        metadata,
+        resource_key_type=sa.String(collation="NOCASE"),
+        checks=_VALID_CHECKS,
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible case-insensitive collation"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_case_insensitive_unique_index(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+        _MIGRATION.upgrade()
+        operations.drop_index(_MIGRATION.UNSCOPED_INDEX, table_name=_MIGRATION.TABLE_NAME)
+        connection.exec_driver_sql(
+            """
+            CREATE UNIQUE INDEX uq_catalog_policy_rule_unscoped
+            ON catalog_policy_rule (
+                resource_kind,
+                resource_key COLLATE [NOCASE],
+                scope
+            )
+            WHERE domain_id IS NULL
+            """
+        )
+
+        with pytest.raises(RuntimeError, match="incompatible case-insensitive collation"):
             _MIGRATION.upgrade()
 
 
@@ -180,7 +541,91 @@ def test_catalog_policy_migration_rejects_malformed_named_index(monkeypatch):
             _MIGRATION.upgrade()
 
 
-def test_catalog_policy_migration_rejects_adversarial_partial_predicate(monkeypatch):
+def test_catalog_policy_migration_rejects_extra_unique_index(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+        _MIGRATION.upgrade()
+        operations.create_index(
+            "uq_catalog_policy_rule_resource_kind_only",
+            _MIGRATION.TABLE_NAME,
+            ["resource_kind"],
+            unique=True,
+        )
+
+        with pytest.raises(RuntimeError, match="incompatible unique index"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_extra_unique_constraint(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    table = _add_existing_catalog_table(metadata, checks=_VALID_CHECKS)
+    sa.UniqueConstraint(table.c.resource_kind, name="uq_catalog_policy_rule_resource_kind_only")
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible unique constraint"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_extra_foreign_key(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    catalog_key = sa.Table("catalog_key", metadata, sa.Column("key", sa.String(), primary_key=True))
+    table = _add_existing_catalog_table(metadata, checks=_VALID_CHECKS)
+    sa.ForeignKeyConstraint(
+        [table.c.resource_key],
+        [catalog_key.c.key],
+        name="fk_catalog_policy_rule_resource_key",
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="incompatible foreign key contract"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_wrong_foreign_key_schema():
+    class ReflectedForeignKeyInspector:
+        @staticmethod
+        def get_foreign_keys(_table_name):
+            return [
+                {
+                    "constrained_columns": ["created_by"],
+                    "referred_schema": "shadow",
+                    "referred_table": "user",
+                    "referred_columns": ["id"],
+                    "options": {"ondelete": "SET NULL"},
+                }
+            ]
+
+    with pytest.raises(RuntimeError, match="incompatible foreign key contract"):
+        _MIGRATION._validate_foreign_keys(ReflectedForeignKeyInspector())
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        "domain_id IS NULL AND 0 = 1",
+        "domain_id IS 'NULL'",
+        "'domain_id' IS NULL",
+    ],
+)
+def test_catalog_policy_migration_rejects_adversarial_partial_predicate(monkeypatch, predicate):
     engine = sa.create_engine("sqlite://")
     metadata = sa.MetaData()
     sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
@@ -197,48 +642,54 @@ def test_catalog_policy_migration_rejects_adversarial_partial_predicate(monkeypa
             _MIGRATION.TABLE_NAME,
             ["resource_kind", "resource_key", "scope"],
             unique=True,
-            sqlite_where=sa.text("domain_id IS NULL AND 0 = 1"),
+            sqlite_where=sa.text(predicate),
         )
 
-        with pytest.raises(RuntimeError, match="global NULL-safe uniqueness"):
+        with pytest.raises(RuntimeError, match="incompatible unique index contract"):
             _MIGRATION.upgrade()
 
 
-def test_catalog_policy_migration_rejects_overrestrictive_named_checks(monkeypatch):
+def test_catalog_policy_migration_rejects_duplicates_before_repairing_index(monkeypatch):
     engine = sa.create_engine("sqlite://")
     metadata = sa.MetaData()
     sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
-    sa.Table(
-        _MIGRATION.TABLE_NAME,
-        metadata,
-        sa.Column("id", sa.Uuid(), primary_key=True),
-        sa.Column("resource_kind", sa.String(), nullable=False),
-        sa.Column("resource_key", sa.String(), nullable=False),
-        sa.Column("mode", sa.String(), nullable=False, server_default=sa.text("'block'")),
-        sa.Column("scope", sa.String(), nullable=False, server_default=sa.text("'global'")),
-        sa.Column("domain_id", sa.Uuid(), nullable=True),
-        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.CheckConstraint(
-            "resource_kind = 'component'",
-            name="ck_catalog_policy_rule_resource_kind",
-        ),
-        sa.CheckConstraint("mode = 'block'", name="ck_catalog_policy_rule_mode"),
-        sa.CheckConstraint(
-            "scope IN ('global', 'workspace')",
-            name="ck_catalog_policy_rule_scope",
-        ),
-        sa.CheckConstraint(
-            "(scope = 'global' AND domain_id IS NULL) OR (scope = 'workspace' AND domain_id IS NOT NULL)",
-            name="ck_catalog_policy_rule_scope_domain_consistency",
-        ),
-    )
     metadata.create_all(engine)
 
     with engine.begin() as connection:
         operations = Operations(MigrationContext.configure(connection))
         monkeypatch.setattr(_MIGRATION, "op", operations)
+        _MIGRATION.upgrade()
+        operations.drop_index(_MIGRATION.UNSCOPED_INDEX, table_name=_MIGRATION.TABLE_NAME)
+        for rule_id in (uuid4(), uuid4()):
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO catalog_policy_rule (id, resource_kind, resource_key)
+                    VALUES (:id, 'component', 'OpenAIModel')
+                    """
+                ),
+                {"id": rule_id.hex},
+            )
 
-        with pytest.raises(RuntimeError, match="valid template rules"):
+        with pytest.raises(RuntimeError, match="duplicate rows"):
             _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_accepts_model_created_table_without_writes(db_url, monkeypatch):  # noqa: F811
+    """Exercise the production create_all-before-Alembic ordering."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        User.__table__.create(engine, checkfirst=True)
+        CatalogPolicyRule.__table__.create(engine, checkfirst=True)
+
+        with engine.begin() as connection:
+            operations = Operations(MigrationContext.configure(connection))
+            monkeypatch.setattr(_MIGRATION, "op", operations)
+
+            _MIGRATION.upgrade()
+            _MIGRATION.upgrade()
+
+            row_count = connection.execute(sa.text("SELECT count(*) FROM catalog_policy_rule")).scalar_one()
+            assert row_count == 0
+    finally:
+        engine.dispose()

--- a/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
+++ b/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
@@ -107,7 +107,7 @@ def test_catalog_policy_migration_upgrades_idempotently_and_downgrades(monkeypat
         foreign_keys = inspector.get_foreign_keys(_MIGRATION.TABLE_NAME)
 
         assert _MIGRATION.revision == "d4a7c9e1b2f6"  # pragma: allowlist secret
-        assert _MIGRATION.down_revision == "b7d5f9a3c2e4"  # pragma: allowlist secret
+        assert _MIGRATION.down_revision == "e8f1a2b3c4d5"  # pragma: allowlist secret
         assert set(columns) == {
             "id",
             "resource_kind",

--- a/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
+++ b/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
@@ -1,0 +1,244 @@
+"""Upgrade and downgrade coverage for catalog policy storage."""
+
+from __future__ import annotations
+
+import importlib
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION = importlib.import_module("langflow.alembic.versions.d4a7c9e1b2f6_add_catalog_policy_rule")
+
+
+def test_catalog_policy_migration_upgrades_idempotently_and_downgrades(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        _MIGRATION.upgrade()
+        _MIGRATION.upgrade()
+
+        inspector = sa.inspect(connection)
+        columns = {column["name"]: column for column in inspector.get_columns(_MIGRATION.TABLE_NAME)}
+        indexes = {index["name"]: index for index in inspector.get_indexes(_MIGRATION.TABLE_NAME)}
+        checks = {constraint["name"] for constraint in inspector.get_check_constraints(_MIGRATION.TABLE_NAME)}
+        foreign_keys = inspector.get_foreign_keys(_MIGRATION.TABLE_NAME)
+
+        assert _MIGRATION.revision == "d4a7c9e1b2f6"  # pragma: allowlist secret
+        assert _MIGRATION.down_revision == "b7d5f9a3c2e4"  # pragma: allowlist secret
+        assert set(columns) == {
+            "id",
+            "resource_kind",
+            "resource_key",
+            "mode",
+            "scope",
+            "domain_id",
+            "created_by",
+            "created_at",
+            "updated_at",
+        }
+        assert columns["domain_id"]["nullable"] is True
+        assert columns["created_by"]["nullable"] is True
+        assert columns["created_at"]["nullable"] is False
+        assert columns["updated_at"]["nullable"] is False
+        assert indexes[_MIGRATION.SCOPED_INDEX]["column_names"] == [
+            "resource_kind",
+            "resource_key",
+            "scope",
+            "domain_id",
+        ]
+        assert indexes[_MIGRATION.UNSCOPED_INDEX]["column_names"] == [
+            "resource_kind",
+            "resource_key",
+            "scope",
+        ]
+        assert indexes[_MIGRATION.SCOPED_INDEX]["unique"] == 1
+        assert indexes[_MIGRATION.UNSCOPED_INDEX]["unique"] == 1
+        assert checks == {
+            "ck_catalog_policy_rule_resource_kind",
+            "ck_catalog_policy_rule_mode",
+            "ck_catalog_policy_rule_scope",
+            "ck_catalog_policy_rule_scope_domain_consistency",
+        }
+        assert len(foreign_keys) == 1
+        assert foreign_keys[0]["constrained_columns"] == ["created_by"]
+        assert foreign_keys[0]["referred_table"] == "user"
+        assert foreign_keys[0]["options"]["ondelete"] == "SET NULL"
+
+        rule_id = uuid4()
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO catalog_policy_rule (id, resource_kind, resource_key)
+                VALUES (:id, 'component', 'OpenAIModel')
+                """
+            ),
+            {"id": rule_id.hex},
+        )
+        stored = connection.execute(
+            sa.text(
+                """
+                SELECT mode, scope, domain_id, created_at, updated_at
+                FROM catalog_policy_rule
+                WHERE id = :id
+                """
+            ),
+            {"id": rule_id.hex},
+        ).one()
+        assert stored.mode == "block"
+        assert stored.scope == "global"
+        assert stored.domain_id is None
+        assert stored.created_at is not None
+        assert stored.updated_at is not None
+
+        _MIGRATION.downgrade()
+        _MIGRATION.downgrade()
+        assert _MIGRATION.TABLE_NAME not in sa.inspect(connection).get_table_names()
+
+
+def test_catalog_policy_migration_rejects_partial_existing_table(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    sa.Table(
+        _MIGRATION.TABLE_NAME,
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("resource_kind", sa.String(), nullable=False),
+        sa.Column("resource_key", sa.String(), nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("domain_id", sa.Uuid(), nullable=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="missing required columns"):
+            _MIGRATION.upgrade()
+
+        assert _MIGRATION.TABLE_NAME in sa.inspect(connection).get_table_names()
+
+
+def test_catalog_policy_migration_rejects_malformed_complete_table(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    sa.Table(
+        _MIGRATION.TABLE_NAME,
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("resource_kind", sa.String(), nullable=False),
+        sa.Column("resource_key", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False, server_default=sa.text("'block'")),
+        sa.Column("scope", sa.String(), nullable=False, server_default=sa.text("'global'")),
+        sa.Column("domain_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        *(sa.CheckConstraint("1 = 1", name=check_name) for check_name in _MIGRATION._REQUIRED_CHECKS),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="resource-kind checks"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_malformed_named_index(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+        _MIGRATION.upgrade()
+
+        operations.drop_index(_MIGRATION.SCOPED_INDEX, table_name=_MIGRATION.TABLE_NAME)
+        operations.create_index(
+            _MIGRATION.SCOPED_INDEX,
+            _MIGRATION.TABLE_NAME,
+            ["resource_kind"],
+            unique=False,
+        )
+
+        with pytest.raises(RuntimeError, match="incompatible definition"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_adversarial_partial_predicate(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+        _MIGRATION.upgrade()
+
+        operations.drop_index(_MIGRATION.UNSCOPED_INDEX, table_name=_MIGRATION.TABLE_NAME)
+        operations.create_index(
+            _MIGRATION.UNSCOPED_INDEX,
+            _MIGRATION.TABLE_NAME,
+            ["resource_kind", "resource_key", "scope"],
+            unique=True,
+            sqlite_where=sa.text("domain_id IS NULL AND 0 = 1"),
+        )
+
+        with pytest.raises(RuntimeError, match="global NULL-safe uniqueness"):
+            _MIGRATION.upgrade()
+
+
+def test_catalog_policy_migration_rejects_overrestrictive_named_checks(monkeypatch):
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    sa.Table(
+        _MIGRATION.TABLE_NAME,
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("resource_kind", sa.String(), nullable=False),
+        sa.Column("resource_key", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False, server_default=sa.text("'block'")),
+        sa.Column("scope", sa.String(), nullable=False, server_default=sa.text("'global'")),
+        sa.Column("domain_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "resource_kind = 'component'",
+            name="ck_catalog_policy_rule_resource_kind",
+        ),
+        sa.CheckConstraint("mode = 'block'", name="ck_catalog_policy_rule_mode"),
+        sa.CheckConstraint(
+            "scope IN ('global', 'workspace')",
+            name="ck_catalog_policy_rule_scope",
+        ),
+        sa.CheckConstraint(
+            "(scope = 'global' AND domain_id IS NULL) OR (scope = 'workspace' AND domain_id IS NOT NULL)",
+            name="ck_catalog_policy_rule_scope_domain_consistency",
+        ),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(_MIGRATION, "op", operations)
+
+        with pytest.raises(RuntimeError, match="valid template rules"):
+            _MIGRATION.upgrade()

--- a/src/backend/tests/unit/alembic/test_migration_execution.py
+++ b/src/backend/tests/unit/alembic/test_migration_execution.py
@@ -379,6 +379,27 @@ def test_no_phantom_migrations(db_url):
         )
 
 
+def test_create_all_then_upgrade_keeps_catalog_policy_empty(db_url):
+    """Exercise fresh-install ordering without migration-authored data writes."""
+    engine = create_engine(_engine_url(db_url))
+    try:
+        SQLModel.metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    alembic_cfg = _make_alembic_cfg(db_url)
+    command.upgrade(alembic_cfg, "head")
+
+    engine = create_engine(_engine_url(db_url))
+    try:
+        with engine.connect() as connection:
+            row_count = connection.execute(text("SELECT count(*) FROM catalog_policy_rule")).scalar_one()
+    finally:
+        engine.dispose()
+
+    assert row_count == 0
+
+
 def test_message_ingestion_message_fk_repaired(db_url):
     """Repair the Postgres-only state left by concurrent startup migrations."""
     if not db_url.startswith("postgresql"):

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -1,0 +1,183 @@
+"""Route tests for catalog-policy whole-set administration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+from langflow.api.v1 import catalog_policy
+from langflow.services.auth.utils import get_current_active_superuser
+from lfx.services.catalog_policy import CatalogPolicySnapshot, CatalogPolicyUpdate
+
+
+class _StubCatalogPolicy:
+    def __init__(self) -> None:
+        self.snapshot = CatalogPolicySnapshot(
+            blocked_component_keys=frozenset({"OldComponent"}),
+            blocked_template_keys=frozenset({"OldTemplate"}),
+        )
+        self.component_calls = []
+        self.template_calls = []
+
+    async def replace_blocked_component_keys(self, keys, *, actor_user_id):
+        desired = frozenset(keys)
+        current = self.snapshot.blocked_component_keys
+        self.component_calls.append((list(keys), actor_user_id))
+        self.snapshot = CatalogPolicySnapshot(
+            blocked_component_keys=desired,
+            blocked_template_keys=self.snapshot.blocked_template_keys,
+        )
+        return CatalogPolicyUpdate(
+            snapshot=self.snapshot,
+            added=desired - current,
+            removed=current - desired,
+        )
+
+    async def replace_blocked_template_keys(self, keys, *, actor_user_id):
+        desired = frozenset(keys)
+        current = self.snapshot.blocked_template_keys
+        self.template_calls.append((list(keys), actor_user_id))
+        self.snapshot = CatalogPolicySnapshot(
+            blocked_component_keys=self.snapshot.blocked_component_keys,
+            blocked_template_keys=desired,
+        )
+        return CatalogPolicyUpdate(
+            snapshot=self.snapshot,
+            added=desired - current,
+            removed=current - desired,
+        )
+
+
+def _client(monkeypatch, *, service=None, superuser=True):
+    stub = service or _StubCatalogPolicy()
+    app = FastAPI()
+    app.include_router(catalog_policy.router, prefix="/api/v1")
+
+    if superuser:
+        admin = SimpleNamespace(id=uuid4(), is_superuser=True)
+        app.dependency_overrides[get_current_active_superuser] = lambda: admin
+    else:
+        admin = None
+
+        def reject_non_superuser():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="The user doesn't have enough privileges",
+            )
+
+        app.dependency_overrides[get_current_active_superuser] = reject_non_superuser
+
+    monkeypatch.setattr(catalog_policy, "get_catalog_policy_service", lambda: stub)
+    audit = AsyncMock()
+    monkeypatch.setattr(catalog_policy, "audit_decision", audit)
+    return TestClient(app), stub, admin, audit
+
+
+def test_get_whole_sets_are_sorted_and_superuser_only(monkeypatch):
+    client, _service, _admin, audit = _client(monkeypatch)
+
+    components = client.get("/api/v1/catalog-policy/components")
+    templates = client.get("/api/v1/catalog-policy/templates")
+
+    assert components.status_code == 200
+    assert components.json() == {"blocked": ["OldComponent"]}
+    assert templates.status_code == 200
+    assert templates.json() == {"blocked": ["OldTemplate"]}
+    audit.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/v1/catalog-policy/components"),
+        ("put", "/api/v1/catalog-policy/components"),
+        ("get", "/api/v1/catalog-policy/templates"),
+        ("put", "/api/v1/catalog-policy/templates"),
+    ],
+)
+def test_all_routes_require_superuser(monkeypatch, method, path):
+    client, service, _admin, audit = _client(monkeypatch, superuser=False)
+
+    response = client.put(path, json={"blocked": []}) if method == "put" else client.get(path)
+
+    assert response.status_code == 403
+    assert service.component_calls == []
+    assert service.template_calls == []
+    audit.assert_not_awaited()
+
+
+def test_put_components_normalizes_whole_set_and_audits_each_delta(monkeypatch):
+    client, service, admin, audit = _client(monkeypatch)
+
+    response = client.put(
+        "/api/v1/catalog-policy/components",
+        json={"blocked": [" zeta ", "Alpha", "Alpha"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"blocked": ["Alpha", "zeta"]}
+    assert service.component_calls == [(["Alpha", "zeta"], admin.id)]
+    assert [call.kwargs for call in audit.await_args_list] == [
+        {
+            "user_id": admin.id,
+            "action": "catalog:block",
+            "obj": "component:Alpha",
+            "result": "allow",
+            "details": {"resource_kind": "component", "resource_key": "Alpha"},
+        },
+        {
+            "user_id": admin.id,
+            "action": "catalog:block",
+            "obj": "component:zeta",
+            "result": "allow",
+            "details": {"resource_kind": "component", "resource_key": "zeta"},
+        },
+        {
+            "user_id": admin.id,
+            "action": "catalog:unblock",
+            "obj": "component:OldComponent",
+            "result": "allow",
+            "details": {"resource_kind": "component", "resource_key": "OldComponent"},
+        },
+    ]
+
+
+def test_put_templates_preserves_case_and_accepts_unknown_keys(monkeypatch):
+    client, service, admin, audit = _client(monkeypatch)
+
+    response = client.put(
+        "/api/v1/catalog-policy/templates",
+        json={"blocked": ["Unknown-ID", "unknown-id"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"blocked": ["Unknown-ID", "unknown-id"]}
+    assert service.template_calls == [(["Unknown-ID", "unknown-id"], admin.id)]
+    assert audit.await_count == 3
+
+
+def test_put_rejects_empty_keys_without_writing_or_auditing(monkeypatch):
+    client, service, _admin, audit = _client(monkeypatch)
+
+    response = client.put(
+        "/api/v1/catalog-policy/components",
+        json={"blocked": ["valid", "   "]},
+    )
+
+    assert response.status_code == 422
+    assert service.component_calls == []
+    audit.assert_not_awaited()
+
+
+def test_put_requires_explicit_whole_set_without_writing_or_auditing(monkeypatch):
+    client, service, _admin, audit = _client(monkeypatch)
+
+    response = client.put("/api/v1/catalog-policy/components", json={})
+
+    assert response.status_code == 422
+    assert service.component_calls == []
+    audit.assert_not_awaited()

--- a/src/backend/tests/unit/api/v1/test_custom_component_policy.py
+++ b/src/backend/tests/unit/api/v1/test_custom_component_policy.py
@@ -1,0 +1,105 @@
+"""Tests for the custom-component/catalog policy interaction matrix."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+from langflow.api.v1 import custom_component_policy
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+
+@pytest.mark.parametrize(
+    (
+        "catalog_blocked",
+        "known_template",
+        "allow_custom_components",
+        "admin_only",
+        "is_superuser",
+        "expected_status",
+        "expected_code",
+        "expected_detail",
+    ),
+    [
+        (True, True, True, False, True, status.HTTP_403_FORBIDDEN, None, "Agent"),
+        (True, True, False, True, False, status.HTTP_403_FORBIDDEN, None, "Agent"),
+        (False, True, False, False, False, None, "trusted server code", None),
+        (False, True, True, True, False, None, "trusted server code", None),
+        (False, False, False, False, True, status.HTTP_403_FORBIDDEN, None, "disabled"),
+        (False, False, True, True, False, status.HTTP_403_FORBIDDEN, None, "admin only"),
+        (False, False, True, True, True, None, "submitted code", None),
+        (False, False, True, False, False, None, "submitted code", None),
+    ],
+)
+def test_resolve_component_code_interaction_matrix(
+    monkeypatch,
+    catalog_blocked,
+    known_template,
+    allow_custom_components,
+    admin_only,
+    is_superuser,
+    expected_status,
+    expected_code,
+    expected_detail,
+):
+    """Catalog denial wins; otherwise known templates and custom lockdown compose."""
+
+    def validate_catalog(_code, *, snapshot):
+        assert isinstance(snapshot, CatalogPolicySnapshot)
+        if catalog_blocked:
+            message = "Catalog policy blocks components: Agent"
+            raise CatalogPolicyValidationError(message)
+
+    monkeypatch.setattr(custom_component_policy, "validate_catalog_policy_for_component_code", validate_catalog)
+    monkeypatch.setattr(custom_component_policy, "get_component_hash_lookups_for_validation", dict)
+    monkeypatch.setattr(custom_component_policy.component_cache, "all_known_hashes", {"known-hash"})
+    monkeypatch.setattr(
+        custom_component_policy,
+        "code_hash_matches_any_template",
+        lambda _code, _all_known: known_template,
+    )
+    monkeypatch.setattr(
+        custom_component_policy,
+        "get_trusted_code_for_validation",
+        lambda _code: "trusted server code" if known_template else None,
+    )
+
+    call = lambda: custom_component_policy.resolve_component_code_for_action(  # noqa: E731
+        "submitted code",
+        user=SimpleNamespace(is_superuser=is_superuser),
+        settings=SimpleNamespace(
+            allow_custom_components=allow_custom_components,
+            custom_component_admin_only=admin_only,
+        ),
+        snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+        if catalog_blocked
+        else CatalogPolicySnapshot(),
+        disabled_detail="disabled",
+        admin_only_detail="admin only",
+    )
+
+    if expected_status is None:
+        assert call() == expected_code
+    else:
+        with pytest.raises(HTTPException) as exc_info:
+            call()
+        assert exc_info.value.status_code == expected_status
+        assert expected_detail in exc_info.value.detail
+
+
+def test_catalog_component_type_denial_has_no_superuser_bypass(monkeypatch):
+    def deny_agent(component_type, *, snapshot):
+        assert component_type == "Agent"
+        assert snapshot.is_component_blocked("Agent")
+        message = "Catalog policy blocks components: Agent"
+        raise CatalogPolicyValidationError(message)
+
+    monkeypatch.setattr(custom_component_policy, "validate_catalog_policy_for_component_type", deny_agent)
+
+    with pytest.raises(HTTPException) as exc_info:
+        custom_component_policy.enforce_catalog_policy_for_component_type(
+            "Agent",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from types import SimpleNamespace
 from typing import Any
 
 from anyio import Path
@@ -416,6 +417,49 @@ async def test_get_config_without_authentication_returns_public_config(client: A
     """Test that /config returns public config when accessed without authentication."""
     response = await client.get("api/v1/config")
     assert response.status_code == status.HTTP_200_OK
+
+
+async def test_get_config_reports_catalog_governance_without_exposing_policy_contents(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """Both config variants expose only the derived governance indicator."""
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(enabled=True),
+    )
+
+    public_response = await client.get("api/v1/config")
+    authenticated_response = await client.get("api/v1/config", headers=logged_in_headers)
+
+    assert public_response.status_code == status.HTTP_200_OK
+    assert authenticated_response.status_code == status.HTTP_200_OK
+    for result in (public_response.json(), authenticated_response.json()):
+        assert result["catalog_governance_enabled"] is True
+        assert "blocked_component_keys" not in result
+        assert "blocked_template_keys" not in result
+
+
+async def test_get_config_fails_open_without_exposing_catalog_policy_errors(client: AsyncClient, monkeypatch):
+    """A broken custom policy accessor does not leak through public config."""
+
+    class BrokenCatalogPolicy:
+        @property
+        def enabled(self) -> bool:
+            msg = "sensitive catalog backend detail"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        BrokenCatalogPolicy,
+    )
+
+    response = await client.get("api/v1/config")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["catalog_governance_enabled"] is False
+    assert "sensitive catalog backend detail" not in response.text
 
 
 async def test_get_config_unauthenticated_returns_expected_fields(client: AsyncClient):

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,14 +1,17 @@
 import asyncio
+import hashlib
 import inspect
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from anyio import Path
 from fastapi import status
 from httpx import AsyncClient
 from langflow.api.v1.schemas import CustomComponentRequest, UpdateCustomComponentRequest
 from lfx.components.models_and_agents.agent import AgentComponent
 from lfx.custom.utils import build_custom_component_template
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
 
 
 async def test_get_version(client: AsyncClient):
@@ -33,6 +36,97 @@ async def test_get_config_basic(client: AsyncClient, logged_in_headers: dict):
     assert "auto_saving" in result, "The dictionary must contain a key called 'auto_saving'"
     assert "health_check_max_retries" in result, "The dictionary must contain a 'health_check_max_retries' key"
     assert "max_file_size_upload" in result, "The dictionary must contain a key called 'max_file_size_upload'"
+
+
+@pytest.mark.parametrize("path", ["api/v1/custom_component", "api/v1/custom_component/update"])
+async def test_catalog_blocks_known_template_before_custom_component_build(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+    path: str,
+):
+    """A blocked built-in cannot be reintroduced through either custom-component path."""
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+
+    def fail_if_built(*_args, **_kwargs):
+        msg = "catalog policy must deny known blocked source before component build"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.endpoints.build_custom_component_template", fail_if_built)
+    if path.endswith("/update"):
+        request = UpdateCustomComponentRequest(
+            code=code,
+            frontend_node={"outputs": []},
+            field="",
+            field_value="",
+            template={},
+        )
+    else:
+        request = CustomComponentRequest(code=code)
+
+    response = await client.post(path, json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("path", ["api/v1/custom_component", "api/v1/custom_component/update"])
+async def test_catalog_blocks_resolved_custom_component_type(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+    path: str,
+):
+    """A modified custom component cannot assume an exact blocked runtime type."""
+    code = """
+from lfx.custom import Component
+from lfx.template.field.base import Output
+
+class CatalogLookalikeComponent(Component):
+    name = "Agent"
+    display_name = "Catalog Lookalike"
+    outputs = [Output(display_name="Output", name="output", method="get_result")]
+
+    def get_result(self) -> str:
+        return "blocked"
+"""
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {"different-template-hash"}},
+    )
+
+    if path.endswith("/update"):
+        request = UpdateCustomComponentRequest(
+            code=code,
+            frontend_node={"outputs": []},
+            field="",
+            field_value="",
+            template={},
+        )
+    else:
+        request = CustomComponentRequest(code=code)
+
+    response = await client.post(path, json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
 
 
 async def test_update_component_outputs(client: AsyncClient, logged_in_headers: dict):

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -568,6 +568,71 @@ async def test_read_basic_examples(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_200_OK
     assert isinstance(result, list), "The result must be a list"
     assert len(result) > 0, "The result must have at least one flow"
+    assert all(item["name_key"] for item in result)
+
+
+async def test_read_basic_examples_catalog_policy_preserves_public_cache_and_unblocks(
+    client: AsyncClient,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    flows._starter_flows_cache.clear()
+    flows._starter_flows_translated_cache.clear()
+
+    blocked_response = await client.get("api/v1/flows/basic_examples/")
+    assert blocked_response.status_code == status.HTTP_200_OK, blocked_response.text
+    blocked_keys = {flow["name_key"] for flow in blocked_response.json()}
+    assert "basic_prompting" not in blocked_keys
+
+    service.snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/flows/basic_examples/")
+    assert unblocked_response.status_code == status.HTTP_200_OK, unblocked_response.text
+    unblocked_keys = {flow["name_key"] for flow in unblocked_response.json()}
+    assert "basic_prompting" in unblocked_keys
+
+
+async def test_read_basic_examples_include_blocked_requires_superuser(
+    client: AsyncClient,
+    logged_in_headers,
+):
+    anonymous_response = await client.get("api/v1/flows/basic_examples/?include_blocked=true")
+    assert anonymous_response.status_code == status.HTTP_403_FORBIDDEN
+
+    denied_response = await client.get(
+        "api/v1/flows/basic_examples/?include_blocked=true",
+        headers=logged_in_headers,
+    )
+    assert denied_response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_read_basic_examples_superuser_can_include_blocked(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    service = type(
+        "CatalogPolicyService",
+        (),
+        {"snapshot": CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})},
+    )()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+
+    override_response = await client.get(
+        "api/v1/flows/basic_examples/?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+    assert override_response.status_code == status.HTTP_200_OK, override_response.text
+    assert "basic_prompting" in {flow["name_key"] for flow in override_response.json()}
 
 
 async def test_read_flows_user_isolation(client: AsyncClient, logged_in_headers, active_user):

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -6,6 +6,13 @@ from fastapi import status
 from httpx import AsyncClient
 
 
+def _catalog_flow_data(component_key: str) -> dict:
+    return {
+        "nodes": [{"id": f"{component_key}-node", "data": {"type": component_key}}],
+        "edges": [],
+    }
+
+
 async def _attach_deployment_to_flow(*, user_id: UUID, flow_id: UUID, project_id: UUID) -> None:
     from langflow.services.database.models.deployment.model import Deployment
     from langflow.services.database.models.deployment_provider_account.model import (
@@ -97,6 +104,106 @@ async def test_create_flow(client: AsyncClient, logged_in_headers):
     assert "updated_at" in result, "The result must have a 'updated_at' key"
     assert "user_id" in result, "The result must have a 'user_id' key"
     assert "webhook" in result, "The result must have a 'webhook' key"
+
+
+async def test_create_and_put_flow_enforce_catalog_policy_with_default_allow(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedForFlowWrites"
+    graph = _catalog_flow_data(blocked_key)
+
+    allowed_response = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-default-allow-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert allowed_response.status_code == status.HTTP_201_CREATED, allowed_response.text
+
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    blocked_create = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-blocked-create-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert blocked_create.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_create.json()["detail"].endswith(blocked_key)
+
+    put_flow_id = uuid.uuid4()
+    blocked_put = await client.put(
+        f"api/v1/flows/{put_flow_id}",
+        json={"name": f"catalog-blocked-put-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert blocked_put.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_put.json()["detail"].endswith(blocked_key)
+
+
+async def test_patch_and_put_metadata_only_updates_validate_stored_graph(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedStoredGraph"
+    graph = _catalog_flow_data(blocked_key)
+
+    patch_source = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-patch-source-{uuid.uuid4()}", "description": "original", "data": graph},
+        headers=logged_in_headers,
+    )
+    put_source = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-put-source-{uuid.uuid4()}", "description": "original", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert patch_source.status_code == status.HTTP_201_CREATED, patch_source.text
+    assert put_source.status_code == status.HTTP_201_CREATED, put_source.text
+
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    patch_response = await client.patch(
+        f"api/v1/flows/{patch_source.json()['id']}",
+        json={"description": "metadata-only patch"},
+        headers=logged_in_headers,
+    )
+    put_response = await client.put(
+        f"api/v1/flows/{put_source.json()['id']}",
+        json={"name": put_source.json()["name"], "description": "metadata-only put"},
+        headers=logged_in_headers,
+    )
+
+    assert patch_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert patch_response.json()["detail"].endswith(blocked_key)
+    assert put_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert put_response.json()["detail"].endswith(blocked_key)
+
+    unchanged_patch = await client.get(
+        f"api/v1/flows/{patch_source.json()['id']}",
+        headers=logged_in_headers,
+    )
+    unchanged_put = await client.get(
+        f"api/v1/flows/{put_source.json()['id']}",
+        headers=logged_in_headers,
+    )
+    assert unchanged_patch.json()["description"] == "original"
+    assert unchanged_put.json()["description"] == "original"
 
 
 async def test_read_flows(client: AsyncClient, logged_in_headers):
@@ -522,6 +629,52 @@ async def test_create_flows(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_201_CREATED
     assert isinstance(result, list), "The result must be a list"
     assert len(result) == amount_flows, "The result must have the same amount of flows"
+
+
+async def test_create_flows_catalog_policy_preflight_is_atomic_and_uses_one_snapshot(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    blocked_key = "BlockedLateInBatch"
+
+    class RotatingCatalogPolicyService:
+        calls = 0
+
+        @property
+        def snapshot(self):
+            self.calls += 1
+            if self.calls == 1:
+                return CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+            return CatalogPolicySnapshot()
+
+    service = RotatingCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    allowed_name = f"catalog-batch-allowed-{uuid.uuid4()}"
+    blocked_name = f"catalog-batch-blocked-{uuid.uuid4()}"
+
+    response = await client.post(
+        "api/v1/flows/batch/",
+        json={
+            "flows": [
+                {"name": allowed_name, "data": _catalog_flow_data("AllowedInBatch")},
+                {"name": blocked_name, "data": _catalog_flow_data(blocked_key)},
+            ]
+        },
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith(blocked_key)
+    assert service.calls == 1
+
+    listed = await client.get("api/v1/flows/", headers=logged_in_headers)
+    persisted_names = {flow["name"] for flow in listed.json()}
+    assert allowed_name not in persisted_names
+    assert blocked_name not in persisted_names
 
 
 async def test_create_flows_with_explicit_folder(client: AsyncClient, logged_in_headers):
@@ -1013,6 +1166,72 @@ async def test_upload_flow_accepts_valid_endpoint_name(client: AsyncClient, logg
     assert isinstance(body, list)
     assert len(body) == 1
     assert body[0]["name"] == "neuro-vision"
+
+
+async def test_upload_catalog_policy_preflights_all_effective_graphs_before_upsert(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    import json
+
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedStoredUploadGraph"
+    original_name = f"catalog-upload-source-{uuid.uuid4()}"
+    source = await client.post(
+        "api/v1/flows/",
+        json={"name": original_name, "description": "original", "data": _catalog_flow_data(blocked_key)},
+        headers=logged_in_headers,
+    )
+    assert source.status_code == status.HTTP_201_CREATED, source.text
+
+    mutation_calls = 0
+
+    async def track_unexpected_mutation(**_kwargs):
+        nonlocal mutation_calls
+        mutation_calls += 1
+        return []
+
+    monkeypatch.setattr(flows, "_new_flow", track_unexpected_mutation)
+    monkeypatch.setattr(flows, "_update_existing_flow", track_unexpected_mutation)
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    allowed_name = f"catalog-upload-allowed-{uuid.uuid4()}"
+    changed_name = f"catalog-upload-changed-{uuid.uuid4()}"
+    file_content = json.dumps(
+        {
+            "flows": [
+                {"name": allowed_name, "data": _catalog_flow_data("AllowedInUpload")},
+                {
+                    "id": source.json()["id"],
+                    "name": changed_name,
+                    "description": "metadata-only upload update",
+                },
+            ]
+        }
+    )
+
+    response = await client.post(
+        "api/v1/flows/upload/",
+        files={"file": ("flows.json", file_content, "application/json")},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith(blocked_key)
+    assert mutation_calls == 0
+
+    unchanged = await client.get(f"api/v1/flows/{source.json()['id']}", headers=logged_in_headers)
+    assert unchanged.status_code == status.HTTP_200_OK
+    assert unchanged.json()["name"] == original_name
+    listed = await client.get("api/v1/flows/", headers=logged_in_headers)
+    assert allowed_name not in {flow["name"] for flow in listed.json()}
 
 
 async def test_upload_flow_rejects_absolute_path(client: AsyncClient, logged_in_headers):

--- a/src/backend/tests/unit/api/v1/test_starter_projects.py
+++ b/src/backend/tests/unit/api/v1/test_starter_projects.py
@@ -2,6 +2,7 @@ import importlib
 
 from fastapi import status
 from httpx import AsyncClient
+from lfx.services.catalog_policy import CatalogPolicySnapshot
 
 
 async def test_get_starter_projects(client: AsyncClient, logged_in_headers):
@@ -29,6 +30,14 @@ EXPECTED_STARTER_PROJECTS = {
     "Vector Store RAG": "Load your data for chat context with Retrieval Augmented Generation.",
 }
 
+EXPECTED_STARTER_PROJECT_KEYS = {
+    "basic_prompting",
+    "blog_writer",
+    "document_q_a",
+    "memory_chatbot",
+    "vector_store_rag",
+}
+
 
 async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClient, logged_in_headers):
     """Each starter project must expose its canonical name and description.
@@ -46,6 +55,7 @@ async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClien
 
     names = [project["name"] for project in result]
     assert len(set(names)) == len(names), f"Starter project names must be unique, got: {names}"
+    assert {project["name_key"] for project in result} == EXPECTED_STARTER_PROJECT_KEYS
 
     actual = {project["name"]: project["description"] for project in result}
     assert actual == EXPECTED_STARTER_PROJECTS
@@ -56,6 +66,64 @@ async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClien
     assert endpoint_names == [None] * len(result), (
         f"endpoint_name must be null, not the string 'None': {endpoint_names}"
     )
+
+
+async def test_starter_projects_catalog_policy_is_request_local_and_unblocks_without_restart(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import starter_projects
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(starter_projects, "get_catalog_policy_service", lambda: service)
+
+    blocked_response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
+    assert blocked_response.status_code == status.HTTP_200_OK, blocked_response.text
+    assert {project["name_key"] for project in blocked_response.json()} == (
+        EXPECTED_STARTER_PROJECT_KEYS - {"basic_prompting"}
+    )
+
+    service.snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
+    assert unblocked_response.status_code == status.HTTP_200_OK, unblocked_response.text
+    assert {project["name_key"] for project in unblocked_response.json()} == EXPECTED_STARTER_PROJECT_KEYS
+
+
+async def test_starter_projects_include_blocked_requires_superuser(
+    client: AsyncClient,
+    logged_in_headers,
+):
+    denied_response = await client.get(
+        "api/v1/starter-projects/?include_blocked=true",
+        headers=logged_in_headers,
+    )
+    assert denied_response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_starter_projects_superuser_can_include_blocked(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import starter_projects
+
+    service = type(
+        "CatalogPolicyService",
+        (),
+        {"snapshot": CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})},
+    )()
+    monkeypatch.setattr(starter_projects, "get_catalog_policy_service", lambda: service)
+
+    override_response = await client.get(
+        "api/v1/starter-projects/?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+    assert override_response.status_code == status.HTTP_200_OK, override_response.text
+    assert {project["name_key"] for project in override_response.json()} == EXPECTED_STARTER_PROJECT_KEYS
 
 
 def test_starter_projects_keep_optional_crewai_exports_lazy():

--- a/src/backend/tests/unit/api/v1/test_validate.py
+++ b/src/backend/tests/unit/api/v1/test_validate.py
@@ -1,6 +1,15 @@
+import asyncio
+import hashlib
+import inspect
+from types import SimpleNamespace
+
 import pytest
+from anyio import Path
 from fastapi import status
 from httpx import AsyncClient
+from lfx.components.models_and_agents.agent import AgentComponent
+from lfx.interface.components import component_cache
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
 
 
 @pytest.mark.usefixtures("active_user")
@@ -17,6 +26,126 @@ pprint(var)
     assert isinstance(result, dict), "The result must be a dictionary"
     assert "imports" in result, "The result must have an 'imports' key"
     assert "function" in result, "The result must have a 'function' key"
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_blocks_catalog_template_before_validation(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+
+    def fail_if_validated(_code):
+        msg = "blocked source must be denied before validate_code inspects imports"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", fail_if_validated)
+
+    response = await client.post("api/v1/validate/code", json={"code": code}, headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("allow_custom_components", "admin_only", "expected_detail"),
+    [
+        (False, False, "disabled"),
+        (True, True, "restricted to administrators"),
+    ],
+)
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_applies_custom_code_lockdown_before_validation(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+    allow_custom_components,
+    admin_only,
+    expected_detail: str,
+):
+    from langflow.services.deps import get_settings_service
+
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "allow_custom_components", allow_custom_components)
+    monkeypatch.setattr(settings, "custom_component_admin_only", admin_only)
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=CatalogPolicySnapshot()),
+    )
+    monkeypatch.setattr(
+        "langflow.api.v1.custom_component_policy.get_component_hash_lookups_for_validation",
+        dict,
+    )
+    monkeypatch.setattr(component_cache, "all_known_hashes", set())
+
+    def fail_if_validated(_code):
+        msg = "restricted unknown source must be denied before validation"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", fail_if_validated)
+
+    response = await client.post(
+        "api/v1/validate/code",
+        json={"code": "import definitely_untrusted_module"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert expected_detail in response.json()["detail"]
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_uses_trusted_template_source_in_restricted_mode(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.services.deps import get_settings_service
+
+    submitted_code = "known template source"
+    trusted_code = "trusted server source"
+    code_hash = hashlib.sha256(submitted_code.encode()).hexdigest()[:12]
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "allow_custom_components", False)
+    monkeypatch.setattr(settings, "custom_component_admin_only", False)
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=CatalogPolicySnapshot()),
+    )
+    monkeypatch.setattr(
+        "langflow.api.v1.custom_component_policy.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+    monkeypatch.setattr(component_cache, "all_known_hashes", {code_hash})
+    monkeypatch.setattr(component_cache, "code_by_hash", {code_hash: trusted_code})
+    validated_codes = []
+
+    def capture_validated_code(code):
+        validated_codes.append(code)
+        return {"imports": {}, "function": {}}
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", capture_validated_code)
+
+    response = await client.post(
+        "api/v1/validate/code",
+        json={"code": submitted_code},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert validated_codes == [trusted_code]
 
 
 @pytest.mark.usefixtures("active_user")

--- a/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
@@ -176,9 +176,9 @@ def test_create_flows_guards_each_flow_with_its_destination(routes):
 def test_upload_file_guards_each_flow_with_effective_destination(routes):
     """POST /upload/ adds a per-flow check after parsing.
 
-    `_upsert_flow_list` lets the query ``folder_id`` override each flow's folder_id but
-    preserves each flow's workspace_id, so the per-flow check must use
-    ``workspace_id=flow.workspace_id`` and live inside a loop over ``flow_list.flows``.
+    The query ``folder_id`` overrides each flow's folder_id while preserving
+    each flow's workspace_id, so the per-flow check must use
+    ``workspace_id=flow.workspace_id`` inside a loop over ``flow_list.flows``.
     """
     func = routes["upload_file"]
     calls = _ensure_flow_permission_calls(func)

--- a/src/backend/tests/unit/services/authorization/test_route_ceiling_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_route_ceiling_guards.py
@@ -414,7 +414,6 @@ async def test_custom_component_editor_passes_ceiling(monkeypatch, owner):
         MagicMock(return_value=({"tool_mode": False}, instance)),
     )
     monkeypatch.setattr(endpoints, "get_instance_name", lambda _i: "MyComponent")
-    monkeypatch.setattr(endpoints, "_requires_component_hash_lookups", lambda *_a, **_k: False)
     # Settings: custom components allowed, no admin-only gate.
     settings = SimpleNamespace(allow_custom_components=True, custom_component_admin_only=False)
     monkeypatch.setattr(endpoints, "get_settings_service", lambda: SimpleNamespace(settings=settings))

--- a/src/backend/tests/unit/services/catalog_policy/__init__.py
+++ b/src/backend/tests/unit/services/catalog_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog-policy service tests."""

--- a/src/backend/tests/unit/services/catalog_policy/test_service.py
+++ b/src/backend/tests/unit/services/catalog_policy/test_service.py
@@ -1,0 +1,292 @@
+"""Database-backed catalog-policy service tests."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from langflow.services.catalog_policy import service as catalog_policy_service_module
+from langflow.services.catalog_policy.factory import CatalogPolicyServiceFactory
+from langflow.services.catalog_policy.service import LangflowCatalogPolicyService
+from langflow.services.database.models.catalog_policy import (
+    CatalogPolicyMode,
+    CatalogPolicyRule,
+    CatalogResourceKind,
+)
+from langflow.services.schema import ServiceType
+from lfx.services.catalog_policy import BaseCatalogPolicyService
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+class _Database:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+
+    @asynccontextmanager
+    async def session_scope(self):
+        async with AsyncSession(self.engine, expire_on_commit=False) as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    @asynccontextmanager
+    async def session_scope_readonly(self):
+        async with AsyncSession(self.engine, expire_on_commit=False) as session:
+            yield session
+
+
+@pytest.fixture
+async def catalog_database(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: SQLModel.metadata.create_all(
+                sync_connection,
+                tables=[CatalogPolicyRule.__table__],
+            )
+        )
+    database = _Database(engine)
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope", database.session_scope)
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope_readonly", database.session_scope_readonly)
+    yield database
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unhydrated_service_is_fail_open_then_hydrates_global_blocks(catalog_database):
+    async with catalog_database.session_scope() as session:
+        session.add_all(
+            [
+                CatalogPolicyRule(
+                    resource_kind=CatalogResourceKind.COMPONENT.value,
+                    resource_key="OpenAIModel",
+                ),
+                CatalogPolicyRule(
+                    resource_kind=CatalogResourceKind.TEMPLATE.value,
+                    resource_key="starter-template",
+                ),
+                CatalogPolicyRule(
+                    resource_kind=CatalogResourceKind.COMPONENT.value,
+                    resource_key="future-allow",
+                    mode=CatalogPolicyMode.ALLOW.value,
+                ),
+            ]
+        )
+        await session.commit()
+
+    service = LangflowCatalogPolicyService(catalog_database)
+    assert service.hydrated is False
+    assert service.enabled is False
+    assert service.is_component_allowed("OpenAIModel") is True
+
+    snapshot = await service.hydrate()
+
+    assert service.hydrated is True
+    assert snapshot.blocked_component_keys == frozenset({"OpenAIModel"})
+    assert snapshot.blocked_template_keys == frozenset({"starter-template"})
+    assert service.is_component_blocked("OpenAIModel") is True
+    assert service.is_template_blocked("starter-template") is True
+    assert service.is_component_blocked("future-allow") is False
+
+
+@pytest.mark.asyncio
+async def test_whole_set_replace_normalizes_and_preserves_other_resource_kind(catalog_database):
+    actor_id = uuid4()
+    async with catalog_database.session_scope() as session:
+        session.add(
+            CatalogPolicyRule(
+                resource_kind=CatalogResourceKind.TEMPLATE.value,
+                resource_key="keep-template",
+            )
+        )
+        await session.commit()
+
+    service = LangflowCatalogPolicyService(catalog_database)
+    await service.hydrate()
+
+    update = await service.replace_blocked_component_keys(
+        [" OpenAIModel ", "Agent", "OpenAIModel"],
+        actor_user_id=actor_id,
+    )
+
+    assert update.added == frozenset({"Agent", "OpenAIModel"})
+    assert update.removed == frozenset()
+    assert update.snapshot.blocked_component_keys == frozenset({"Agent", "OpenAIModel"})
+    assert update.snapshot.blocked_template_keys == frozenset({"keep-template"})
+    assert service.blocked_component_keys(["Agent", "Other"]) == frozenset({"Agent"})
+
+    second = await service.replace_blocked_component_keys(["Agent"], actor_user_id=actor_id)
+    assert second.added == frozenset()
+    assert second.removed == frozenset({"OpenAIModel"})
+
+    async with catalog_database.session_scope_readonly() as session:
+        rows = list((await session.exec(select(CatalogPolicyRule))).all())
+    persisted = sorted((row.resource_kind, row.resource_key, row.created_by) for row in rows)
+    assert persisted == [
+        (CatalogResourceKind.COMPONENT.value, "Agent", actor_id),
+        (CatalogResourceKind.TEMPLATE.value, "keep-template", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_replace_rejects_empty_keys_before_opening_a_transaction(catalog_database):
+    service = LangflowCatalogPolicyService(catalog_database)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        await service.replace_blocked_template_keys(["valid", "   "], actor_user_id=None)
+
+    assert service.snapshot.blocked_template_keys == frozenset()
+    assert service.hydrated is False
+
+
+class _Result:
+    def __init__(self, rows) -> None:
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _Session:
+    def __init__(self, *, commit_error: Exception | None = None) -> None:
+        self.commit_error = commit_error
+        self.added = []
+        self.rolled_back = False
+        self.before_commit = None
+
+    async def exec(self, _statement):
+        return _Result([])
+
+    def add(self, row) -> None:
+        self.added.append(row)
+
+    async def delete(self, _row) -> None:
+        return None
+
+    async def commit(self) -> None:
+        if self.before_commit is not None:
+            self.before_commit()
+        if self.commit_error is not None:
+            raise self.commit_error
+
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class _SingleSessionDatabase:
+    def __init__(self, session) -> None:
+        self.session = session
+
+    @asynccontextmanager
+    async def session_scope(self):
+        try:
+            yield self.session
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    @asynccontextmanager
+    async def session_scope_readonly(self):
+        yield self.session
+
+
+def _patch_session_scopes(monkeypatch, database) -> None:
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope", database.session_scope)
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope_readonly", database.session_scope_readonly)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_is_published_only_after_commit(monkeypatch):
+    session = _Session()
+    database = _SingleSessionDatabase(session)
+    _patch_session_scopes(monkeypatch, database)
+    service = LangflowCatalogPolicyService(database)
+    session.before_commit = lambda: (
+        pytest.fail("snapshot published before commit") if service.is_component_blocked("new") else None
+    )
+
+    await service.replace_blocked_component_keys(["new"], actor_user_id=None)
+
+    assert service.is_component_blocked("new") is True
+
+
+@pytest.mark.asyncio
+async def test_failed_commit_rolls_back_and_keeps_fail_open_snapshot(monkeypatch):
+    session = _Session(commit_error=RuntimeError("commit failed"))
+    database = _SingleSessionDatabase(session)
+    _patch_session_scopes(monkeypatch, database)
+    service = LangflowCatalogPolicyService(database)
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await service.replace_blocked_component_keys(["new"], actor_user_id=None)
+
+    assert session.rolled_back is True
+    assert service.hydrated is False
+    assert service.is_component_allowed("new") is True
+
+
+@pytest.mark.asyncio
+async def test_failed_hydration_keeps_fail_open_snapshot(monkeypatch):
+    class _UnavailableSession(_Session):
+        async def exec(self, _statement):
+            message = "database unavailable"
+            raise RuntimeError(message)
+
+    database = _SingleSessionDatabase(_UnavailableSession())
+    _patch_session_scopes(monkeypatch, database)
+    service = LangflowCatalogPolicyService(database)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await service.hydrate()
+
+    assert service.hydrated is False
+    assert service.enabled is False
+    assert service.is_component_allowed("anything") is True
+    assert service.is_template_allowed("anything") is True
+
+
+def test_factory_uses_database_dependency_and_canonical_service_type():
+    database = SimpleNamespace()
+    factory = CatalogPolicyServiceFactory()
+
+    service = factory.create(database)
+
+    assert isinstance(service, BaseCatalogPolicyService)
+    assert isinstance(service, LangflowCatalogPolicyService)
+    assert service.database_service is database
+    assert factory.name == ServiceType.CATALOG_POLICY_SERVICE.value
+
+
+def test_backend_dependency_uses_validated_lfx_catalog_policy(monkeypatch):
+    from langflow.services import deps as langflow_deps
+    from lfx.services import deps as lfx_deps
+
+    service = SimpleNamespace()
+    monkeypatch.setattr(lfx_deps, "get_catalog_policy_service", lambda: service)
+
+    assert langflow_deps.get_catalog_policy_service() is service
+
+
+@pytest.mark.asyncio
+async def test_startup_hydration_failure_logs_and_continues(monkeypatch):
+    from langflow.services import deps, utils
+
+    service = SimpleNamespace(hydrate=AsyncMock(side_effect=RuntimeError("database unavailable")))
+    warning = AsyncMock()
+    monkeypatch.setattr(deps, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(utils.logger, "awarning", warning)
+
+    await utils.hydrate_catalog_policy()
+
+    service.hydrate.assert_awaited_once_with()
+    warning.assert_awaited_once()
+    assert "continuing with allow-all policy" in warning.await_args.args[0]

--- a/src/backend/tests/unit/services/database/models/catalog_policy/__init__.py
+++ b/src/backend/tests/unit/services/database/models/catalog_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog policy model tests."""

--- a/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
+++ b/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
@@ -1,0 +1,211 @@
+"""Database contracts for catalog policy rules."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.catalog_policy import (
+    CatalogPolicyMode,
+    CatalogPolicyRule,
+    CatalogPolicyScope,
+    CatalogResourceKind,
+)
+from langflow.services.database.models.user.model import User
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+_TEST_PASSWORD = "hashed"  # noqa: S105  # pragma: allowlist secret
+
+
+@pytest.fixture(name="catalog_policy_engine")
+def catalog_policy_engine():
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection, _connection_record):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    yield engine
+    engine.sync_engine.dispose()
+
+
+@pytest.fixture(name="catalog_policy_session")
+async def catalog_policy_session(catalog_policy_engine):
+    async with catalog_policy_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(catalog_policy_engine, expire_on_commit=False) as session:
+        yield session
+    async with catalog_policy_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await catalog_policy_engine.dispose()
+
+
+def test_catalog_policy_rule_defaults_and_schema_contract():
+    rule = CatalogPolicyRule(
+        resource_kind=CatalogResourceKind.COMPONENT.value,
+        resource_key="OpenAIModel",
+    )
+
+    assert rule.mode == CatalogPolicyMode.BLOCK.value
+    assert rule.scope == CatalogPolicyScope.GLOBAL.value
+    assert rule.domain_id is None
+    assert rule.created_by is None
+    assert rule.created_at.utcoffset() == timedelta(0)
+    assert rule.updated_at.utcoffset() == timedelta(0)
+
+    table = CatalogPolicyRule.__table__
+    assert table.c.created_at.type.timezone is True
+    assert table.c.updated_at.type.timezone is True
+
+    constraint_names = {constraint.name for constraint in table.constraints}
+    assert {
+        "ck_catalog_policy_rule_resource_kind",
+        "ck_catalog_policy_rule_mode",
+        "ck_catalog_policy_rule_scope",
+        "ck_catalog_policy_rule_scope_domain_consistency",
+    } <= constraint_names
+
+    indexes = {index.name: index for index in table.indexes}
+    assert tuple(column.name for column in indexes["uq_catalog_policy_rule_scoped"].columns) == (
+        "resource_kind",
+        "resource_key",
+        "scope",
+        "domain_id",
+    )
+    assert tuple(column.name for column in indexes["uq_catalog_policy_rule_unscoped"].columns) == (
+        "resource_kind",
+        "resource_key",
+        "scope",
+    )
+    assert indexes["uq_catalog_policy_rule_scoped"].unique is True
+    assert indexes["uq_catalog_policy_rule_unscoped"].unique is True
+
+
+@pytest.mark.anyio
+async def test_catalog_policy_rule_persists_and_creator_deletion_sets_null(
+    catalog_policy_session: AsyncSession,
+):
+    creator = User(username="catalog-policy-creator", password=_TEST_PASSWORD)
+    catalog_policy_session.add(creator)
+    await catalog_policy_session.commit()
+    await catalog_policy_session.refresh(creator)
+
+    rule = CatalogPolicyRule(
+        resource_kind=CatalogResourceKind.TEMPLATE.value,
+        resource_key="starter-template-id",
+        created_by=creator.id,
+    )
+    catalog_policy_session.add(rule)
+    await catalog_policy_session.commit()
+    await catalog_policy_session.refresh(rule)
+
+    assert rule.mode == CatalogPolicyMode.BLOCK.value
+    assert rule.scope == CatalogPolicyScope.GLOBAL.value
+    assert rule.created_by == creator.id
+
+    await catalog_policy_session.delete(creator)
+    await catalog_policy_session.commit()
+    await catalog_policy_session.refresh(rule)
+    assert rule.created_by is None
+
+
+@pytest.mark.anyio
+async def test_catalog_policy_rule_enforces_null_safe_uniqueness(
+    catalog_policy_session: AsyncSession,
+):
+    global_rule = CatalogPolicyRule(
+        resource_kind=CatalogResourceKind.COMPONENT.value,
+        resource_key="OpenAIModel",
+    )
+    catalog_policy_session.add(global_rule)
+    await catalog_policy_session.commit()
+
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind=CatalogResourceKind.COMPONENT.value,
+            resource_key="OpenAIModel",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await catalog_policy_session.commit()
+    await catalog_policy_session.rollback()
+
+    workspace_id = uuid4()
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind=CatalogResourceKind.COMPONENT.value,
+            resource_key="OpenAIModel",
+            scope=CatalogPolicyScope.WORKSPACE.value,
+            domain_id=workspace_id,
+        )
+    )
+    await catalog_policy_session.commit()
+
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind=CatalogResourceKind.COMPONENT.value,
+            resource_key="OpenAIModel",
+            scope=CatalogPolicyScope.WORKSPACE.value,
+            domain_id=workspace_id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await catalog_policy_session.commit()
+    await catalog_policy_session.rollback()
+
+    other_workspace_rule = CatalogPolicyRule(
+        resource_kind=CatalogResourceKind.COMPONENT.value,
+        resource_key="OpenAIModel",
+        scope=CatalogPolicyScope.WORKSPACE.value,
+        domain_id=uuid4(),
+    )
+    catalog_policy_session.add(other_workspace_rule)
+    await catalog_policy_session.commit()
+
+    rules = (
+        await catalog_policy_session.exec(
+            select(CatalogPolicyRule).where(CatalogPolicyRule.resource_key == "OpenAIModel")
+        )
+    ).all()
+    assert len(rules) == 3
+
+
+@pytest.mark.anyio
+async def test_catalog_policy_rule_check_constraints_reject_invalid_rows(
+    catalog_policy_session: AsyncSession,
+):
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind="flow",
+            resource_key="unsupported-kind",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await catalog_policy_session.commit()
+    await catalog_policy_session.rollback()
+
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind=CatalogResourceKind.COMPONENT.value,
+            resource_key="bad-global-scope",
+            domain_id=uuid4(),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await catalog_policy_session.commit()
+    await catalog_policy_session.rollback()
+
+    catalog_policy_session.add(
+        CatalogPolicyRule(
+            resource_kind=CatalogResourceKind.TEMPLATE.value,
+            resource_key="future-allow-rule",
+            mode=CatalogPolicyMode.ALLOW.value,
+        )
+    )
+    await catalog_policy_session.commit()

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -89,6 +89,32 @@ async def test_build_flow_validates_request_data_instead_of_stale_db_flow(
     assert "job_id" in response.json()
 
 
+async def test_build_flow_maps_catalog_policy_validation_to_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    validation_message = "Flow build blocked: catalog policy blocks components: Agent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"api/v1/build/{flow_id}/flow",
+        json={},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"].endswith("Agent")
+
+
 async def test_build_flow_with_frozen_path(client, json_memory_chatbot_no_llm, logged_in_headers):
     """Test building a flow with a frozen path."""
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
@@ -695,7 +721,7 @@ async def test_build_public_tmp_checks_public_access_before_validation(
         raise ValueError(public_access_validation_message)
 
     monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
         fail_if_validation_runs,
     )
 
@@ -707,6 +733,40 @@ async def test_build_public_tmp_checks_public_access_before_validation(
 
     assert response.status_code == codes.FORBIDDEN
     assert response.json()["detail"] == "Flow is not public"
+
+
+async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+    validation_message = "Flow build blocked: catalog policy blocks components: SecretComponent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
+        reject_catalog_component,
+    )
+    client.cookies.set("client_id", "test-catalog-policy-client")
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"] == "This flow cannot be executed."
+    assert "SecretComponent" not in response.text
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -89,30 +89,32 @@ async def test_build_flow_validates_request_data_instead_of_stale_db_flow(
     assert "job_id" in response.json()
 
 
-async def test_build_flow_maps_catalog_policy_validation_to_bad_request(
-    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+async def test_build_flow_enforces_current_catalog_policy_and_recovers_when_cleared(
+    client, json_memory_chatbot_no_llm, logged_in_headers
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
-    validation_message = "Flow build blocked: catalog policy blocks components: Agent"
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
 
-    def reject_catalog_component(_target):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_flow_for_current_settings",
-        reject_catalog_component,
+    blocked_response = await client.post(
+        f"api/v1/build/{flow_id}/flow",
+        json={},
+        headers=logged_in_headers,
     )
-
-    response = await client.post(
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
         f"api/v1/build/{flow_id}/flow",
         json={},
         headers=logged_in_headers,
     )
 
-    assert response.status_code == codes.BAD_REQUEST
-    assert response.json()["detail"].endswith("Agent")
+    assert blocked_response.status_code == codes.BAD_REQUEST
+    assert blocked_response.json()["detail"].endswith("ChatInput")
+    assert allowed_response.status_code == codes.OK
+    assert "job_id" in allowed_response.json()
 
 
 async def test_build_flow_with_frozen_path(client, json_memory_chatbot_no_llm, logged_in_headers):
@@ -735,11 +737,13 @@ async def test_build_public_tmp_checks_public_access_before_validation(
     assert response.json()["detail"] == "Flow is not public"
 
 
-async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_request(
-    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+async def test_build_public_tmp_enforces_current_catalog_policy_with_generic_error(
+    client, json_memory_chatbot_no_llm, logged_in_headers
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
     response = await client.patch(
         f"api/v1/flows/{flow_id}",
@@ -747,26 +751,26 @@ async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_re
         headers=logged_in_headers,
     )
     assert response.status_code == codes.OK
-    validation_message = "Flow build blocked: catalog policy blocks components: SecretComponent"
-
-    def reject_catalog_component(_target):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
-        reject_catalog_component,
-    )
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
     client.cookies.set("client_id", "test-catalog-policy-client")
 
-    response = await client.post(
+    blocked_response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
         f"api/v1/build_public_tmp/{flow_id}/flow",
         json={},
         headers={"Content-Type": "application/json"},
     )
 
-    assert response.status_code == codes.BAD_REQUEST
-    assert response.json()["detail"] == "This flow cannot be executed."
-    assert "SecretComponent" not in response.text
+    assert blocked_response.status_code == codes.BAD_REQUEST
+    assert blocked_response.json()["detail"] == "This flow cannot be executed."
+    assert "ChatInput" not in blocked_response.text
+    assert allowed_response.status_code == codes.OK
+    assert "job_id" in allowed_response.json()
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -702,28 +702,37 @@ async def test_successful_run_no_payload(client, simple_api_test, created_api_ke
     assert all(result is not None for result in inner_results), (outputs_dict, output_results_has_results)
 
 
-async def test_run_by_id_maps_catalog_policy_validation_to_bad_request(
-    client, simple_api_test, created_api_key, monkeypatch
+async def test_run_by_id_enforces_current_catalog_policy_and_recovers_when_cleared(
+    client, json_simple_api_test, logged_in_headers, created_api_key
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
-    validation_message = "Flow build blocked: catalog policy blocks components: ChatInput"
-
-    def reject_catalog_component(_target, **_kwargs):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "lfx.utils.flow_validation.validate_flow_for_current_settings",
-        reject_catalog_component,
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    flow_payload = orjson.loads(json_simple_api_test)
+    flow = FlowCreate(
+        name="Catalog Policy Run Test",
+        data=flow_payload["data"],
+        description="Catalog policy route test",
     )
+    create_response = await client.post("api/v1/flows/", json=flow.model_dump(), headers=logged_in_headers)
+    assert create_response.status_code == status.HTTP_201_CREATED
+    flow_id = create_response.json()["id"]
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
 
-    response = await client.post(
-        f"/api/v1/run/{simple_api_test['id']}",
+    blocked_response = await client.post(
+        f"/api/v1/run/{flow_id}",
+        headers={"x-api-key": created_api_key.api_key},
+    )
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
+        f"/api/v1/run/{flow_id}",
         headers={"x-api-key": created_api_key.api_key},
     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"].endswith("ChatInput")
+    assert blocked_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_response.json()["detail"].endswith("ChatInput")
+    assert allowed_response.status_code == status.HTTP_200_OK, allowed_response.text
 
 
 async def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -201,6 +201,213 @@ def test_component_palette_policy_filters_models_without_mutating_shared_cache(m
     assert filtered["mixed"] is not cached["mixed"]
 
 
+def test_catalog_policy_filter_is_case_sensitive_and_does_not_mutate_shared_cache():
+    from langflow.api.v1 import endpoints
+
+    blocked_component = {"display_name": "Blocked", "metadata": {"nested": True}}
+    allowed_component = {"display_name": "Allowed", "metadata": {"nested": True}}
+    cached = {
+        "models": {
+            "BlockedAgent": blocked_component,
+            "blockedagent": allowed_component,
+        },
+        "empty": {},
+    }
+
+    filtered = endpoints._filter_component_palette_by_catalog_policy(
+        cached,
+        blocked_component_keys=frozenset({"BlockedAgent"}),
+    )
+
+    assert list(filtered) == ["models", "empty"]
+    assert list(filtered["models"]) == ["blockedagent"]
+    assert filtered["empty"] == {}
+    assert filtered is not cached
+    assert filtered["models"] is not cached["models"]
+    assert filtered["empty"] is not cached["empty"]
+    assert filtered["models"]["blockedagent"] is allowed_component
+    assert list(cached["models"]) == ["BlockedAgent", "blockedagent"]
+    assert cached["models"]["BlockedAgent"] is blocked_component
+
+
+async def test_get_all_filters_catalog_policy_and_uses_current_snapshot(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+    from langflow.interface import components as components_module
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    cached = {
+        "models": {
+            "AllowedAgent": {
+                "display_name": "Allowed Agent",
+                "description": "Visible",
+                "template": {},
+                "metadata": {},
+            },
+            "BlockedAgent": {
+                "display_name": "Blocked Agent",
+                "description": "Hidden",
+                "template": {},
+                "metadata": {},
+            },
+        },
+        "empty": {},
+    }
+
+    class MutableCatalogPolicyService:
+        def __init__(self):
+            self.current_snapshot = CatalogPolicySnapshot(blocked_component_keys={"BlockedAgent"})
+            self.snapshot_reads = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_reads += 1
+            return self.current_snapshot
+
+    service = MutableCatalogPolicyService()
+
+    async def get_cached_types(*, settings_service):
+        _ = settings_service
+        return cached
+
+    monkeypatch.setattr(components_module, "get_and_cache_all_types_dict", get_cached_types)
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(
+        endpoints,
+        "_filter_component_palette_by_provider_policy",
+        lambda all_types, **_kwargs: {category: dict(components) for category, components in all_types.items()},
+    )
+
+    blocked_response = await client.get("api/v1/all", headers=logged_in_headers)
+
+    assert blocked_response.status_code == status.HTTP_200_OK
+    blocked_payload = blocked_response.json()
+    assert list(blocked_payload["models"]) == ["AllowedAgent"]
+    assert "blockedagent" not in blocked_payload["component_display_names"]
+    assert blocked_payload["empty"] == {}
+    assert service.snapshot_reads == 1
+    assert "BlockedAgent" in cached["models"]
+
+    service.current_snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/all", headers=logged_in_headers)
+
+    assert unblocked_response.status_code == status.HTTP_200_OK
+    unblocked_payload = unblocked_response.json()
+    assert list(unblocked_payload["models"]) == ["AllowedAgent", "BlockedAgent"]
+    assert "blockedagent" in unblocked_payload["component_display_names"]
+    assert service.snapshot_reads == 2
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent"]
+
+
+async def test_get_all_rejects_include_blocked_for_non_superuser_before_broad_exception_handler(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+
+    def unexpected_catalog_service_lookup():
+        msg = "catalog policy must not be read for an unauthorized override"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", unexpected_catalog_service_lookup)
+
+    response = await client.get("api/v1/all?include_blocked=true", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_get_all_superuser_override_skips_only_catalog_filter_without_cache_poisoning(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+    from langflow.interface import components as components_module
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    cached = {
+        "models": {
+            "AllowedAgent": {
+                "display_name": "Allowed Agent",
+                "description": "Visible",
+                "template": {},
+                "metadata": {},
+            },
+            "BlockedAgent": {
+                "display_name": "Blocked Agent",
+                "description": "Catalog blocked",
+                "template": {},
+                "metadata": {},
+            },
+            "ProviderBlockedAgent": {
+                "display_name": "Provider Blocked Agent",
+                "description": "Provider blocked",
+                "template": {},
+                "metadata": {"model_provider_id": "denied-provider"},
+            },
+        }
+    }
+
+    class CountingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_reads = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_reads += 1
+            return CatalogPolicySnapshot(blocked_component_keys={"BlockedAgent"})
+
+    service = CountingCatalogPolicyService()
+    provider_filter_calls = 0
+
+    async def get_cached_types(*, settings_service):
+        _ = settings_service
+        return cached
+
+    def filter_provider_policy(all_types, *, user_id, attributes=None):
+        nonlocal provider_filter_calls
+        _ = user_id
+        provider_filter_calls += 1
+        assert attributes == {"is_superuser": True}
+        return {
+            category: {
+                key: component
+                for key, component in components.items()
+                if component.get("metadata", {}).get("model_provider_id") != "denied-provider"
+            }
+            for category, components in all_types.items()
+        }
+
+    monkeypatch.setattr(components_module, "get_and_cache_all_types_dict", get_cached_types)
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(endpoints, "_filter_component_palette_by_provider_policy", filter_provider_policy)
+
+    override_response = await client.get(
+        "api/v1/all?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+
+    assert override_response.status_code == status.HTTP_200_OK
+    override_payload = override_response.json()
+    assert list(override_payload["models"]) == ["AllowedAgent", "BlockedAgent"]
+    assert "ProviderBlockedAgent" not in override_payload["models"]
+    assert service.snapshot_reads == 1
+    assert provider_filter_calls == 1
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent", "ProviderBlockedAgent"]
+
+    default_response = await client.get("api/v1/all", headers=logged_in_headers_super_user)
+
+    assert default_response.status_code == status.HTTP_200_OK
+    assert list(default_response.json()["models"]) == ["AllowedAgent"]
+    assert service.snapshot_reads == 2
+    assert provider_filter_calls == 2
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent", "ProviderBlockedAgent"]
+
+
 @pytest.mark.usefixtures("active_user")
 async def test_post_validate_code(client: AsyncClient, logged_in_headers):
     # Test case with a valid import and function
@@ -493,6 +700,30 @@ async def test_successful_run_no_payload(client, simple_api_test, created_api_ke
     inner_results = [output.get("results") for output in outputs_dict.get("outputs")]
 
     assert all(result is not None for result in inner_results), (outputs_dict, output_results_has_results)
+
+
+async def test_run_by_id_maps_catalog_policy_validation_to_bad_request(
+    client, simple_api_test, created_api_key, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    validation_message = "Flow build blocked: catalog policy blocks components: ChatInput"
+
+    def reject_catalog_component(_target, **_kwargs):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"/api/v1/run/{simple_api_test['id']}",
+        headers={"x-api-key": created_api_key.api_key},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith("ChatInput")
 
 
 async def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):

--- a/src/backend/tests/unit/test_flow_validation.py
+++ b/src/backend/tests/unit/test_flow_validation.py
@@ -838,6 +838,7 @@ class TestGetTrustedCodeForValidation:
     def test_self_heals_from_all_types_dict_when_map_unbuilt(self, monkeypatch):
         trusted = "class Heal:\n    pass\n"
         monkeypatch.setattr(component_cache, "code_by_hash", None)
+        monkeypatch.setattr(component_cache, "all_types_ready", True)
         monkeypatch.setattr(
             component_cache,
             "all_types_dict",

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1441,10 +1441,17 @@ class Graph:
             Graph: The created graph.
         """
         from lfx.extension.migration import migrate_flow_payload
-        from lfx.utils.flow_validation import validate_flow_for_current_settings
+        from lfx.services.deps import get_catalog_policy_service
+        from lfx.utils.flow_validation import validate_catalog_policy_for_flow, validate_flow_for_current_settings
 
         if "data" in payload:
             payload = payload["data"]
+        # Catalog identity is the exact, case-sensitive stored node.data.type.
+        # Validate it before extension migration rewrites legacy identifiers.
+        # Reuse this same immutable snapshot below so migrated executable types
+        # are checked against the identical policy view without a TOCTOU gap.
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
+        validate_catalog_policy_for_flow(payload, snapshot=catalog_policy_snapshot)
         # Rewrite legacy component references in place against the append-only
         # extension migration table.  Best-effort: a corrupt table or unmapped
         # reference produces typed errors on the report but never raises, so
@@ -1511,8 +1518,19 @@ class Graph:
         # boundary (middleware or endpoint dependency) so from_payload stays
         # pure deserialization, but a missed endpoint means arbitrary code
         # execution, so we keep this as a safety net.
-        validate_flow_for_current_settings(payload)
+        validate_flow_for_current_settings(payload, catalog_policy_snapshot=catalog_policy_snapshot)
         try:
+            # The extension migrator intentionally rewrites only the nodes at
+            # the payload level it receives, while process_flow later flattens
+            # inlined nested flows for execution. Build that executable view
+            # on a deep copy, migrate it, and enforce the same snapshot so a
+            # nested legacy alias cannot bypass a block on its canonical key.
+            # Migration errors on this policy-only copy remain best-effort and
+            # are not exposed. Skip the work for the default allow-all policy.
+            if catalog_policy_snapshot.blocked_component_keys:
+                effective_catalog_payload = process_flow(payload)
+                migrate_flow_payload(effective_catalog_payload)
+                validate_catalog_policy_for_flow(effective_catalog_payload, snapshot=catalog_policy_snapshot)
             vertices = payload["nodes"]
             edges = payload["edges"]
             graph = cls(flow_id=flow_id, flow_name=flow_name, user_id=user_id, context=context)

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -54,6 +54,11 @@ class ComponentCache:
         Creates empty storage for all component types and tracking of fully loaded components.
         """
         self.all_types_dict: dict[str, Any] | None = None
+        # True only after the built-in, custom, and extension component maps
+        # have been merged. ``_determine_loading_strategy`` temporarily places
+        # partial values (including ``{}``) in ``all_types_dict`` while startup
+        # is still in flight, so presence alone is not a readiness signal.
+        self.all_types_ready = False
         self.fully_loaded_components: dict[str, bool] = {}
         # Precomputed code hashes for fast flow validation.
         # Populated by get_and_cache_all_types_dict() via _build_code_hash_lookups().
@@ -764,7 +769,7 @@ def _build_code_hash_lookups(cache: ComponentCache) -> None:
     - type_to_current_hash: {component_type: 12-char SHA256 prefix}
     - all_known_hashes: set of all known code hashes
     """
-    if not cache.all_types_dict:
+    if cache.all_types_dict is None or (not cache.all_types_dict and not cache.all_types_ready):
         return
 
     type_to_hash, all_hashes = collect_component_hash_lookups(cache.all_types_dict)
@@ -1256,6 +1261,7 @@ def refresh_bundle_cache_from_record(record: "BundleRecord") -> None:
         )
 
     component_cache.all_types_dict[record.bundle] = bundle_dict
+    component_cache.all_types_ready = True
 
     # Invalidate the precomputed code-hash lookups so flow validation
     # picks up the freshly-loaded class bodies instead of comparing
@@ -1284,6 +1290,7 @@ async def get_and_cache_all_types_dict(
         telemetry_service: Optional telemetry service for tracking component loading metrics
     """
     if component_cache.all_types_dict is None:
+        component_cache.all_types_ready = False
         await logger.adebug("Building components cache")
 
         langflow_components = await import_langflow_components(settings_service, telemetry_service)
@@ -1307,6 +1314,7 @@ async def get_and_cache_all_types_dict(
             **custom_flat,
             **extension_components,
         }
+        component_cache.all_types_ready = True
         component_count = sum(len(comps) for comps in component_cache.all_types_dict.values())
         await logger.adebug(f"Loaded {component_count} components")
 

--- a/src/lfx/src/lfx/services/catalog_policy/__init__.py
+++ b/src/lfx/src/lfx/services/catalog_policy/__init__.py
@@ -1,0 +1,11 @@
+"""Catalog-policy service contract and standalone default."""
+
+from lfx.services.catalog_policy.base import BaseCatalogPolicyService, CatalogPolicySnapshot, CatalogPolicyUpdate
+from lfx.services.catalog_policy.service import CatalogPolicyService
+
+__all__ = [
+    "BaseCatalogPolicyService",
+    "CatalogPolicyService",
+    "CatalogPolicySnapshot",
+    "CatalogPolicyUpdate",
+]

--- a/src/lfx/src/lfx/services/catalog_policy/base.py
+++ b/src/lfx/src/lfx/services/catalog_policy/base.py
@@ -1,0 +1,130 @@
+"""Stable catalog-policy contract shared by LFX and Langflow."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lfx.services.base import Service
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+    from uuid import UUID
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogPolicySnapshot:
+    """Immutable process-local catalog-policy decision snapshot.
+
+    An empty snapshot is intentionally fail-open: until a durable policy has
+    been hydrated, every component and template is available.
+    """
+
+    blocked_component_keys: frozenset[str] = frozenset()
+    blocked_template_keys: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blocked_component_keys", frozenset(self.blocked_component_keys))
+        object.__setattr__(self, "blocked_template_keys", frozenset(self.blocked_template_keys))
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether this snapshot blocks at least one catalog resource."""
+        return bool(self.blocked_component_keys or self.blocked_template_keys)
+
+    def is_component_blocked(self, key: str) -> bool:
+        """Return whether a component key is blocked."""
+        return key in self.blocked_component_keys
+
+    def is_template_blocked(self, key: str) -> bool:
+        """Return whether a template key is blocked."""
+        return key in self.blocked_template_keys
+
+    def blocked_components(self, keys: Iterable[str]) -> frozenset[str]:
+        """Return the blocked subset of component keys."""
+        return frozenset(key for key in keys if self.is_component_blocked(key))
+
+    def blocked_templates(self, keys: Iterable[str]) -> frozenset[str]:
+        """Return the blocked subset of template keys."""
+        return frozenset(key for key in keys if self.is_template_blocked(key))
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogPolicyUpdate:
+    """One committed whole-set replacement and its exact delta."""
+
+    snapshot: CatalogPolicySnapshot
+    added: frozenset[str]
+    removed: frozenset[str]
+
+
+class BaseCatalogPolicyService(Service, abc.ABC):
+    """Synchronous catalog-policy decision surface.
+
+    Implementations publish a complete immutable snapshot after loading
+    durable policy. The initial empty snapshot is deliberately fail-open so
+    LFX remains usable when no Langflow database-backed policy is present.
+    """
+
+    name = ServiceType.CATALOG_POLICY_SERVICE.value
+
+    @property
+    @abc.abstractmethod
+    def snapshot(self) -> CatalogPolicySnapshot:
+        """Return the current immutable process-local snapshot."""
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the current snapshot blocks any catalog resource."""
+        return self.snapshot.enabled
+
+    def is_component_blocked(self, key: str) -> bool:
+        """Return whether a component key is blocked."""
+        return self.snapshot.is_component_blocked(key)
+
+    def is_template_blocked(self, key: str) -> bool:
+        """Return whether a template key is blocked."""
+        return self.snapshot.is_template_blocked(key)
+
+    def blocked_component_keys(self, keys: Iterable[str]) -> frozenset[str]:
+        """Return the blocked subset of component keys in one lookup."""
+        return self.snapshot.blocked_components(keys)
+
+    def blocked_template_keys(self, keys: Iterable[str]) -> frozenset[str]:
+        """Return the blocked subset of template keys in one lookup."""
+        return self.snapshot.blocked_templates(keys)
+
+    def is_component_allowed(self, key: str) -> bool:
+        """Return whether a component key is allowed."""
+        return not self.is_component_blocked(key)
+
+    def is_template_allowed(self, key: str) -> bool:
+        """Return whether a template key is allowed."""
+        return not self.is_template_blocked(key)
+
+    async def hydrate(self) -> CatalogPolicySnapshot:
+        """Return the current snapshot when no durable loader is required."""
+        return self.snapshot
+
+    async def replace_blocked_component_keys(
+        self,
+        keys: Collection[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        """Replace component policy when the implementation is writable."""
+        raise NotImplementedError
+
+    async def replace_blocked_template_keys(
+        self,
+        keys: Collection[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        """Replace template policy when the implementation is writable."""
+        raise NotImplementedError
+
+    async def teardown(self) -> None:
+        """No resources are owned by the base policy service."""

--- a/src/lfx/src/lfx/services/catalog_policy/service.py
+++ b/src/lfx/src/lfx/services/catalog_policy/service.py
@@ -1,0 +1,29 @@
+"""Default fail-open catalog-policy service for standalone LFX."""
+
+from __future__ import annotations
+
+from lfx.log.logger import logger
+from lfx.services import register_service
+from lfx.services.catalog_policy.base import BaseCatalogPolicyService, CatalogPolicySnapshot
+from lfx.services.schema import ServiceType
+
+
+@register_service(ServiceType.CATALOG_POLICY_SERVICE)
+class CatalogPolicyService(BaseCatalogPolicyService):
+    """Standalone default with an immutable empty, allow-all snapshot."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._snapshot = CatalogPolicySnapshot()
+        self.set_ready()
+        logger.debug("Catalog policy service initialized (allow all)")
+
+    @property
+    def name(self) -> str:
+        """Return the canonical service-type name."""
+        return ServiceType.CATALOG_POLICY_SERVICE.value
+
+    @property
+    def snapshot(self) -> CatalogPolicySnapshot:
+        """Return the immutable allow-all snapshot."""
+        return self._snapshot

--- a/src/lfx/src/lfx/services/deps.py
+++ b/src/lfx/src/lfx/services/deps.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from lfx.services.adapters.registry import AdapterRegistry
+    from lfx.services.catalog_policy.base import BaseCatalogPolicyService
     from lfx.services.interfaces import (
         AuthServiceProtocol,
         CacheServiceProtocol,
@@ -78,6 +79,50 @@ def get_model_provider_policy_service():
         msg = "A valid, ready model_provider_policy_service is required"
         raise TypeError(msg)
     return service
+
+
+_catalog_policy_fallback: BaseCatalogPolicyService | None = None
+_catalog_policy_fallback_lock = threading.Lock()
+
+
+def get_catalog_policy_service():
+    """Return the ready catalog-policy service.
+
+    Standalone LFX resolves the built-in allow-all implementation. Langflow
+    overrides it with the database-backed process-local snapshot service. A
+    broken configured implementation is replaced with one stable built-in
+    allow-all instance so later lookups remain fail-open instead of retrying a
+    failing constructor.
+    """
+    from lfx.services.catalog_policy.base import BaseCatalogPolicyService
+    from lfx.services.catalog_policy.service import CatalogPolicyService
+    from lfx.services.manager import get_service_manager
+
+    service_manager = get_service_manager()
+    cached = service_manager.services.get(ServiceType.CATALOG_POLICY_SERVICE)
+    if isinstance(cached, BaseCatalogPolicyService) and cached.ready:
+        return cached
+
+    service = get_service(ServiceType.CATALOG_POLICY_SERVICE)
+    if isinstance(service, BaseCatalogPolicyService) and service.ready:
+        return service
+
+    global _catalog_policy_fallback  # noqa: PLW0603
+    with _catalog_policy_fallback_lock:
+        cached = service_manager.services.get(ServiceType.CATALOG_POLICY_SERVICE)
+        if isinstance(cached, BaseCatalogPolicyService) and cached.ready:
+            return cached
+        fallback = _catalog_policy_fallback
+        if fallback is None:
+            fallback = CatalogPolicyService()
+            _catalog_policy_fallback = fallback
+        service_manager.services[ServiceType.CATALOG_POLICY_SERVICE] = fallback
+
+    logger.warning(
+        "Configured catalog_policy_service is unavailable or invalid; "
+        "using the built-in allow-all policy for this process"
+    )
+    return fallback
 
 
 def get_db_service() -> DatabaseServiceProtocol:

--- a/src/lfx/src/lfx/services/manager.py
+++ b/src/lfx/src/lfx/services/manager.py
@@ -422,6 +422,12 @@ class ServiceManager:
         except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
             logger.debug(f"BaseAuthorizationService unavailable; entry-point validation skipped: {exc}")
         try:
+            from lfx.services.catalog_policy.base import BaseCatalogPolicyService
+
+            expected_bases[ServiceType.CATALOG_POLICY_SERVICE] = BaseCatalogPolicyService
+        except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
+            logger.debug(f"BaseCatalogPolicyService unavailable; entry-point validation skipped: {exc}")
+        try:
             from lfx.services.model_provider_policy.base import BaseModelProviderPolicyService
 
             expected_bases[ServiceType.MODEL_PROVIDER_POLICY_SERVICE] = BaseModelProviderPolicyService
@@ -512,6 +518,15 @@ class ServiceManager:
             if not isinstance(service_class, type) or not issubclass(service_class, BaseModelProviderPolicyService):
                 msg = "Configured model provider policy service must subclass BaseModelProviderPolicyService"
                 raise RuntimeError(msg)
+        if service_type == ServiceType.CATALOG_POLICY_SERVICE:
+            from lfx.services.catalog_policy.base import BaseCatalogPolicyService
+
+            if not isinstance(service_class, type) or not issubclass(service_class, BaseCatalogPolicyService):
+                logger.warning(
+                    "Configured catalog policy service must subclass BaseCatalogPolicyService; "
+                    "keeping the built-in fail-open service"
+                )
+                return
 
         self.register_service_class(service_type, service_class, override=True)
         logger.debug(f"Registered service from config: {service_key} -> {service_path}")

--- a/src/lfx/src/lfx/services/schema.py
+++ b/src/lfx/src/lfx/services/schema.py
@@ -8,6 +8,7 @@ from enum import Enum
 class ServiceType(str, Enum):
     AUTH_SERVICE = "auth_service"
     AUTHORIZATION_SERVICE = "authorization_service"
+    CATALOG_POLICY_SERVICE = "catalog_policy_service"
     MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
     DATABASE_SERVICE = "database_service"
     STORAGE_SERVICE = "storage_service"

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
 from lfx.utils.component_aliases import get_component_type_aliases
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
 
 INITIALIZING_COMPONENT_TEMPLATES_MESSAGE = (
     "Flow build blocked: component templates are still initializing. Please try again in a few seconds."
@@ -57,6 +60,10 @@ class CustomComponentValidationError(ValueError):
     still catch it, but callers can catch this specifically to
     distinguish policy errors from other ValueErrors.
     """
+
+
+class CatalogPolicyValidationError(CustomComponentValidationError):
+    """Raised when a flow contains a component blocked by catalog policy."""
 
 
 class PublicFlowValidationError(CustomComponentValidationError):
@@ -166,6 +173,77 @@ def _extract_flow_data(target: Mapping[str, Any] | Any | None) -> dict[str, Any]
         return _normalize_flow_data(target)
 
     return _normalize_flow_data(_extract_graph_payload(target))
+
+
+def _collect_catalog_component_keys(nodes: Any) -> set[str]:
+    """Collect exact component keys from a graph and its inlined nested flows."""
+    component_keys: set[str] = set()
+    if not isinstance(nodes, list):
+        return component_keys
+
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        node_data = node.get("data")
+        if not isinstance(node_data, Mapping):
+            continue
+
+        component_type = node_data.get("type")
+        if isinstance(component_type, str):
+            component_keys.add(component_type)
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, Mapping):
+            continue
+        nested_flow = node_info.get("flow")
+        if not isinstance(nested_flow, Mapping):
+            continue
+        nested_data = nested_flow.get("data")
+        if not isinstance(nested_data, Mapping):
+            continue
+        component_keys.update(_collect_catalog_component_keys(nested_data.get("nodes")))
+
+    return component_keys
+
+
+def validate_catalog_policy_for_flow(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject a flow containing component keys blocked by the current catalog snapshot.
+
+    Component identity is the exact, case-sensitive ``node.data.type`` value.
+    The immutable snapshot is captured once when the caller does not provide
+    one, so every node in a request is evaluated against the same policy view.
+    """
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.blocked_component_keys:
+        return
+
+    normalized_flow_data = _extract_flow_data(target)
+    if target is not None and normalized_flow_data is None:
+        msg = (
+            "Flow validation failed: could not extract graph data from the provided target. "
+            "Ensure the flow payload or Graph object contains valid graph data."
+        )
+        raise CatalogPolicyValidationError(msg)
+    if not normalized_flow_data:
+        return
+
+    component_keys = _collect_catalog_component_keys(normalized_flow_data.get("nodes"))
+    blocked = snapshot.blocked_components(component_keys)
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Flow build blocked by catalog policy: {blocked_names}")
+    message = f"Flow build blocked: catalog policy blocks components: {blocked_names}"
+    raise CatalogPolicyValidationError(message)
 
 
 def collect_component_hash_lookups(
@@ -479,14 +557,20 @@ def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     return component_cache.type_to_current_hash
 
 
-def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -> None:
-    """Enforce custom-component policy for a payload or graph-like object."""
-    from lfx.services.deps import get_settings_service
+def validate_flow_for_current_settings(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    catalog_policy_snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Enforce catalog and custom-component policy for a payload or graph-like object."""
+    from lfx.services.deps import get_catalog_policy_service, get_settings_service
 
     settings_service = get_settings_service()
     if settings_service is None:
         raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
 
+    if catalog_policy_snapshot is None:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
     settings = settings_service.settings
     allow_custom_components = getattr(settings, "allow_custom_components", True)
     block_code_interpreter_components = getattr(settings, "block_code_interpreter_components", False)
@@ -495,14 +579,18 @@ def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -
     # If a blocking policy is active and we received a target but couldn't extract any flow
     # data from it, fail fast rather than silently skipping validation — the caller passed
     # something we can't verify.
-    if (not allow_custom_components or block_code_interpreter_components) and (
-        target is not None and normalized_flow_data is None
-    ):
+    if (
+        not allow_custom_components
+        or block_code_interpreter_components
+        or bool(catalog_policy_snapshot.blocked_component_keys)
+    ) and (target is not None and normalized_flow_data is None):
         msg = (
             "Flow validation failed: could not extract graph data from the provided target. "
             "Ensure the flow payload or Graph object contains valid graph data."
         )
         raise CustomComponentValidationError(msg)
+
+    validate_catalog_policy_for_flow(normalized_flow_data, snapshot=catalog_policy_snapshot)
 
     if block_code_interpreter_components:
         check_code_execution_components_and_raise(normalized_flow_data)

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -16,6 +16,9 @@ INITIALIZING_COMPONENT_TEMPLATES_MESSAGE = (
     "Flow build blocked: component templates are still initializing. Please try again in a few seconds."
 )
 SETTINGS_SERVICE_REQUIRED_MESSAGE = "Settings service must be initialized before validating flows."
+CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE = (
+    "Catalog policy component identities are still initializing. Please try again in a few seconds."
+)
 
 # Built-in components that execute user- or model-supplied Python from input fields or during
 # runtime, rather than from the validated class ``code`` field. Their class-code hash is valid,
@@ -466,7 +469,11 @@ def get_trusted_code_for_validation(code: str) -> str | None:
 
     # Self-heal: build the lookup lazily if the cache hasn't populated it yet
     # (e.g. the eager warm-up path didn't run before the first request).
-    if component_cache.code_by_hash is None and component_cache.all_types_dict is not None:
+    if (
+        component_cache.code_by_hash is None
+        and component_cache.all_types_ready
+        and component_cache.all_types_dict is not None
+    ):
         component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
 
     code_by_hash = component_cache.code_by_hash
@@ -548,13 +555,75 @@ def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     """Return the cached component hashes, building them synchronously if possible."""
     from lfx.interface.components import component_cache
 
-    if component_cache.type_to_current_hash is None and component_cache.all_types_dict is not None:
+    if (
+        component_cache.type_to_current_hash is None
+        and component_cache.all_types_ready
+        and component_cache.all_types_dict is not None
+    ):
         type_to_hash, all_hashes = collect_component_hash_lookups(component_cache.all_types_dict)
         component_cache.type_to_current_hash = type_to_hash
         component_cache.all_known_hashes = all_hashes
         component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
 
     return component_cache.type_to_current_hash
+
+
+def validate_catalog_policy_for_component_code(
+    code: str,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject source that matches a blocked server component template.
+
+    The code hash is checked against every exact catalog key's existing alias
+    lookup before custom-component source is parsed or executed. An active
+    policy fails closed while those trusted template identities are unavailable;
+    an empty snapshot remains the documented default-allow behavior.
+    """
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.blocked_component_keys:
+        return
+
+    type_to_current_hash = get_component_hash_lookups_for_validation()
+    if type_to_current_hash is None:
+        raise RuntimeError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+
+    code_hash = _compute_code_hash(code)
+    blocked = frozenset(
+        component_type
+        for component_type in snapshot.blocked_component_keys
+        if code_hash in type_to_current_hash.get(component_type, set())
+    )
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Component action blocked by catalog policy: {blocked_names}")
+    message = f"Catalog policy blocks components: {blocked_names}"
+    raise CatalogPolicyValidationError(message)
+
+
+def validate_catalog_policy_for_component_type(
+    component_type: str,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject a materialized component whose exact runtime type is blocked."""
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.is_component_blocked(component_type):
+        return
+
+    logger.warning(f"Component action blocked by catalog policy: {component_type}")
+    message = f"Catalog policy blocks components: {component_type}"
+    raise CatalogPolicyValidationError(message)
 
 
 def validate_flow_for_current_settings(
@@ -932,7 +1001,7 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
         raise PublicFlowValidationError(message)
 
 
-async def ensure_component_hash_lookups_loaded() -> dict[str, str] | None:
+async def ensure_component_hash_lookups_loaded() -> dict[str, set[str]] | None:
     """Ensure component hash lookups are available for CLI/runtime validation."""
     from lfx.interface.components import component_cache, get_and_cache_all_types_dict
     from lfx.services.deps import get_settings_service

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -15,7 +15,8 @@ from lfx.graph.graph.utils import (
 )
 from lfx.graph.vertex.base import Vertex
 from lfx.interface.components import component_cache
-from lfx.utils.flow_validation import CustomComponentValidationError
+from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError, CustomComponentValidationError
 
 # Test cases for the graph module
 
@@ -125,6 +126,110 @@ def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
 
     with pytest.raises(CustomComponentValidationError, match="custom components are not allowed"):
         Graph.from_payload(_blocked_custom_flow())
+
+
+@pytest.mark.parametrize(
+    "blocked_key",
+    [
+        "DuckDuckGoSearchComponent",
+        "ext:duckduckgo:DuckDuckGoSearchComponent@official",
+    ],
+)
+def test_from_payload_checks_catalog_policy_before_and_after_extension_migration(monkeypatch, blocked_key):
+    class CountingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            return CatalogPolicySnapshot(blocked_component_keys=frozenset({blocked_key}))
+
+    service = CountingCatalogPolicyService()
+    payload = {
+        "nodes": [
+            {
+                "id": "duck-search",
+                "type": "genericNode",
+                "data": {
+                    "id": "duck-search",
+                    "type": "DuckDuckGoSearchComponent",
+                    "node": {"template": {}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=blocked_key):
+        Graph.from_payload(payload)
+
+    assert service.snapshot_calls == 1
+
+
+def test_from_payload_checks_canonical_policy_for_nested_legacy_component(monkeypatch):
+    canonical_key = "ext:duckduckgo:DuckDuckGoSearchComponent@official"
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({canonical_key})),
+    )
+    nested_node = {
+        "id": "duck-search",
+        "type": "genericNode",
+        "data": {
+            "id": "duck-search",
+            "type": "DuckDuckGoSearchComponent",
+            "node": {"template": {}},
+        },
+    }
+    payload = {
+        "nodes": [
+            {
+                "id": "group-1",
+                "type": "genericNode",
+                "data": {
+                    "id": "group-1",
+                    "type": "Group",
+                    "node": {
+                        "template": {},
+                        "flow": {
+                            "data": {
+                                "nodes": [nested_node],
+                                "edges": [],
+                            }
+                        },
+                    },
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=canonical_key):
+        Graph.from_payload(payload)
+
+
+def test_from_payload_catalog_policy_preserves_invalid_payload_error_mapping(monkeypatch):
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(ValueError, match="Error while creating graph from payload"):
+        Graph.from_payload({"edges": []})
 
 
 def test_find_last_node(grouped_chat_json_flow):

--- a/src/lfx/tests/unit/services/catalog_policy/__init__.py
+++ b/src/lfx/tests/unit/services/catalog_policy/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog-policy service tests."""

--- a/src/lfx/tests/unit/services/catalog_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/catalog_policy/test_policy.py
@@ -1,0 +1,74 @@
+"""Catalog-policy contract tests."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicyService, CatalogPolicySnapshot
+from lfx.services.schema import ServiceType
+
+
+def test_empty_default_is_fail_open_for_single_and_batch_decisions():
+    service = CatalogPolicyService()
+
+    assert service.ready is True
+    assert service.enabled is False
+    assert service.is_component_blocked("OpenAIModel") is False
+    assert service.is_template_blocked("starter-template") is False
+    assert service.is_component_allowed("OpenAIModel") is True
+    assert service.is_template_allowed("starter-template") is True
+    assert service.blocked_component_keys(["OpenAIModel", "Agent"]) == frozenset()
+    assert service.blocked_template_keys(["starter-template"]) == frozenset()
+
+
+def test_snapshot_is_immutable_and_supports_batch_decisions():
+    snapshot = CatalogPolicySnapshot(
+        blocked_component_keys=frozenset({"OpenAIModel", "Agent"}),
+        blocked_template_keys=frozenset({"starter-template"}),
+    )
+
+    assert snapshot.enabled is True
+    assert snapshot.is_component_blocked("Agent") is True
+    assert snapshot.is_component_blocked("agent") is False
+    assert snapshot.is_template_blocked("starter-template") is True
+    assert snapshot.blocked_components(["Agent", "Agent", "Other"]) == frozenset({"Agent"})
+    assert snapshot.blocked_templates(["other", "starter-template"]) == frozenset({"starter-template"})
+    with pytest.raises(FrozenInstanceError):
+        snapshot.blocked_component_keys = frozenset()  # type: ignore[misc]
+
+
+def test_dependency_installs_stable_fail_open_fallback_for_broken_plugin(monkeypatch):
+    from lfx.services import deps
+    from lfx.services import manager as manager_module
+    from lfx.services.manager import ServiceManager
+
+    class BrokenCatalogPolicyService(BaseCatalogPolicyService):
+        attempts = 0
+
+        def __init__(self) -> None:
+            type(self).attempts += 1
+            message = "broken catalog policy plugin"
+            raise RuntimeError(message)
+
+        @property
+        def snapshot(self) -> CatalogPolicySnapshot:
+            return CatalogPolicySnapshot()
+
+    manager = ServiceManager()
+    manager._plugins_discovered = True
+    manager.register_service_class(
+        ServiceType.CATALOG_POLICY_SERVICE,
+        BrokenCatalogPolicyService,
+        override=True,
+    )
+    monkeypatch.setattr(manager_module, "_service_manager", manager)
+    monkeypatch.setattr(deps, "_catalog_policy_fallback", None)
+
+    first = deps.get_catalog_policy_service()
+    second = deps.get_catalog_policy_service()
+
+    assert first is second
+    assert isinstance(first, CatalogPolicyService)
+    assert first.is_component_allowed("anything") is True
+    assert first.is_template_allowed("anything") is True
+    assert manager.services[ServiceType.CATALOG_POLICY_SERVICE] is first
+    assert BrokenCatalogPolicyService.attempts == 1

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -1,5 +1,6 @@
 """Unit tests for LFX flow validation helpers."""
 
+import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,8 @@ from lfx.utils.flow_validation import (
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
+    validate_catalog_policy_for_component_code,
+    validate_catalog_policy_for_component_type,
     validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
@@ -121,6 +124,76 @@ def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_al
         snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
     )
     validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+def test_catalog_policy_component_code_blocks_known_alias_before_execution(monkeypatch):
+    code = "# trusted Agent component"
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}, "AgentComponent": {code_hash}},
+    )
+
+    with pytest.raises(CatalogPolicyValidationError, match="AgentComponent"):
+        validate_catalog_policy_for_component_code(
+            code,
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"AgentComponent"}),
+        )
+
+
+def test_catalog_policy_component_code_empty_snapshot_does_not_require_template_identities(monkeypatch):
+    def fail_if_called():
+        msg = "empty policy should not load component identities"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        fail_if_called,
+    )
+
+    validate_catalog_policy_for_component_code("arbitrary code", snapshot=CatalogPolicySnapshot())
+
+
+def test_catalog_policy_component_code_fails_closed_while_identities_initialize(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="identities are still initializing"):
+        validate_catalog_policy_for_component_code(
+            "arbitrary code",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+
+def test_catalog_policy_component_code_does_not_build_from_transient_component_cache(monkeypatch):
+    from lfx.interface.components import component_cache
+
+    monkeypatch.setattr(component_cache, "all_types_dict", {})
+    monkeypatch.setattr(component_cache, "all_types_ready", False)
+    monkeypatch.setattr(component_cache, "type_to_current_hash", None)
+    monkeypatch.setattr(component_cache, "all_known_hashes", None)
+    monkeypatch.setattr(component_cache, "code_by_hash", None)
+
+    with pytest.raises(RuntimeError, match="identities are still initializing"):
+        validate_catalog_policy_for_component_code(
+            "arbitrary code",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+    assert component_cache.type_to_current_hash is None
+    assert component_cache.all_known_hashes is None
+    assert component_cache.code_by_hash is None
+
+
+def test_catalog_policy_component_type_is_exact_and_empty_snapshot_allows():
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+
+    validate_catalog_policy_for_component_type("agent", snapshot=snapshot)
+    validate_catalog_policy_for_component_type("Agent", snapshot=CatalogPolicySnapshot())
+    with pytest.raises(CatalogPolicyValidationError, match="Agent"):
+        validate_catalog_policy_for_component_type("Agent", snapshot=snapshot)
 
 
 def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -6,14 +6,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from lfx.services.catalog_policy import CatalogPolicySnapshot
 from lfx.utils.flow_validation import (
     CODE_EXECUTION_COMPONENT_TYPES,
     FLOW_REFERENCE_COMPONENT_TYPES,
+    CatalogPolicyValidationError,
     CustomComponentValidationError,
     PublicFlowValidationError,
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -77,6 +80,75 @@ def test_validate_flow_for_current_settings_requires_settings_service(monkeypatc
 
     with pytest.raises(RuntimeError, match="Settings service must be initialized"):
         validate_flow_for_current_settings(graph)
+
+
+def _catalog_flow(*component_types: str) -> dict:
+    return {
+        "nodes": [
+            {
+                "id": f"{component_type}-1",
+                "data": {
+                    "id": f"{component_type}-1",
+                    "type": component_type,
+                    "node": {"template": {}},
+                },
+            }
+            for component_type in component_types
+        ],
+        "edges": [],
+    }
+
+
+def test_catalog_policy_validation_blocks_top_level_components_deterministically():
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"Zed", "Agent"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match=r"Agent, Zed$"):
+        validate_catalog_policy_for_flow(_catalog_flow("Zed", "Agent", "Zed"), snapshot=snapshot)
+
+
+def test_catalog_policy_validation_blocks_nested_components():
+    flow = _catalog_flow("Group")
+    flow["nodes"][0]["data"]["node"]["flow"] = {"data": _catalog_flow("NestedBlocked")}
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"NestedBlocked"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match="NestedBlocked"):
+        validate_catalog_policy_for_flow(flow, snapshot=snapshot)
+
+
+def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_allows():
+    validate_catalog_policy_for_flow(
+        _catalog_flow("agent"),
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):
+    class ChangingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            if self.snapshot_calls == 1:
+                return CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"}))
+            return CatalogPolicySnapshot()
+
+    service = ChangingCatalogPolicyService()
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=False,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match="Agent"):
+        validate_flow_for_current_settings(_catalog_flow("Agent"))
+
+    assert service.snapshot_calls == 1
 
 
 # --- public-flow component sanitization (H1-3754930 follow-up) --------------------


### PR DESCRIPTION
## Summary

Establishes the persistence foundation for the approved Component / Agent Catalog epic and serves as the base of the backend PR stack.

- add the `catalog_policy_rule` model for component and template catalog rules
- encode default-allow / blocklist semantics with global and future scoped-policy fields
- enforce NULL-safe uniqueness and scope/domain consistency at the database layer
- add an additive, idempotent Alembic migration with defensive pre-existing-schema validation
- add focused model and migration coverage

## Validation

- focused catalog-policy model/migration suite — 43 passed, 4 skipped locally (PostgreSQL parametrizations run when a test database URL is configured)
- production-order `SQLModel.metadata.create_all` → Alembic head, zero-row, schema-drift, and downgrade/roll-forward coverage included
- Ruff check/format, `git diff --check`, migration validator, and pre-commit hooks — passed

## Stack

Subsequent backend-ticket PRs will be stacked on this branch, beginning with the policy service, in-process snapshot cache, and superuser CRUD API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog governance policy support for components and templates.
  * Policies can allow or block resources globally or within specific scopes.
  * Added validation for policy values, scope/domain consistency, and duplicate rules.
  * Creator references are retained safely when associated accounts are removed.

* **Tests**
  * Added coverage for policy persistence, validation, uniqueness, migrations, and rollback behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->