### PR TITLE
chore: bump release versions to 1.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.11.1"
+version = "1.11.2"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base[complete]>=0.11.1",
+    "langflow-base[complete]>=0.11.2",
     # langflow-extensions:bundle-deps-start
     # Release coordination: langflow declares BOUNDED ranges (>=A,<B) for every
     # curated lfx-* package, never exact pins -- exact pins in reusable library

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.11.1"
+version = "0.11.2"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "lfx~=1.11.1",
+    "lfx~=1.11.2",
     "fastapi>=0.139.0,<1.0.0",
     "slowapi>=0.1.9,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
@@ -192,7 +192,7 @@ local = [
 
 # Individual database providers
 couchbase = ["couchbase>=4.2.1"]
-cassandra = ["lfx[cassandra]~=1.11.1"]  # cassio relocated to lfx (lfx-core Cassandra components)
+cassandra = ["lfx[cassandra]~=1.11.2"]  # cassio relocated to lfx (lfx-core Cassandra components)
 clickhouse = ["clickhouse-connect==0.7.19"]
 
 
@@ -263,7 +263,7 @@ opendsstar = [
 ]
 
 # Individual tools
-beautifulsoup = ["lfx~=1.11.1"]  # beautifulsoup4 is now a hard lfx dependency
+beautifulsoup = ["lfx~=1.11.2"]  # beautifulsoup4 is now a hard lfx dependency
 serpapi = ["google-search-results>=2.4.1,<3.0.0"]
 google-api = ["google-api-python-client~=2.161"]
 wikipedia = ["wikipedia==1.4.0"]
@@ -341,7 +341,7 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 # Toolguard Integration
-toolguard = ["lfx[toolguard]~=1.11.1"]  # toolguard relocated to lfx
+toolguard = ["lfx[toolguard]~=1.11.2"]  # toolguard relocated to lfx
 
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
         "@chakra-ui/number-input": "^2.1.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "1.11.1"
+version = "1.11.2"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [
@@ -57,7 +57,7 @@ dependencies = [
     "cryptography>=48.0.1",
     "pyjwt>=2.10.0,<3.0.0",
     "ag-ui-protocol>=0.1.10",
-    "langflow-sdk>=0.3.1",
+    "langflow-sdk>=0.3.2",
     "markitdown>=0.1.4,<2.0.0",
     "setuptools>=83.0.0,<84.0.0",
     "wheel>=0.46.2,<1.0.0",

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -32569,6 +32569,6 @@
     "num_components": 131,
     "num_modules": 17
   },
-  "sha256": "c826bf26b0573b55e24336c985c6dc2de21892ec03452a2064a56278637ed8e6",
-  "version": "1.11.1"
+  "sha256": "b315ca02ffbf12f54cca052186236a63d20988be3dd21ae434975837a85ca233",
+  "version": "1.11.2"
 }

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-sdk"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python SDK for the Langflow REST API"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -7796,7 +7796,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.11.1"
+version = "1.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "langflow-base", extra = ["complete"] },
@@ -7980,7 +7980,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -8770,7 +8770,7 @@ dev = [
 
 [[package]]
 name = "langflow-sdk"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "src/sdk" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -9044,7 +9044,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "1.11.1"
+version = "1.11.2"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "a2wsgi", marker = "sys_platform != 'win32'" },


### PR DESCRIPTION
## Summary

- bump Langflow, LFX, and the frontend package metadata to `1.11.2`
- bump `langflow-base` to `0.11.2`
- bump `langflow-sdk` to `0.3.2` and raise LFX's published SDK floor accordingly
- refresh the frontend lockfile, workspace lockfile, and component-index version/checksum

## Validation

- `uv lock --check`
- `23 passed` in the versioning-focused pytest set
- built and inspected wheels for `langflow==1.11.2`, `langflow-base==0.11.2`, `lfx==1.11.2`, and `langflow-sdk==0.3.2`
- verified wheel dependency metadata for `langflow-base[complete]>=0.11.2`, `lfx~=1.11.2`, and `langflow-sdk>=0.3.2`
- pre-commit hooks passed

## Release follow-up

The existing lightweight `v1.11.2` tag still points to `1a0b571ca4`, where `pyproject.toml` reports `1.11.1`. Recreate that tag at the merged version-bump commit before running the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the platform and related packages to version 1.11.2.
  * Updated the Python SDK to version 0.3.2.
  * Refreshed component metadata for the new release.
  * Updated package compatibility requirements to align with the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->