### PR TITLE
feat(catalog): expose governance config flag

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -16,6 +16,7 @@ from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
     CustomComponentValidationError,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -850,6 +851,13 @@ async def build_public_tmp(
         async with session_scope() as session:
             flow = await session.get(Flow, flow_id)
             if flow and flow.data:
+                # The default anonymous build path sanitizes component code directly
+                # and therefore does not call validate_flow_for_current_settings.
+                # Enforce the exact catalog snapshot after the public-access check
+                # and before any graph is queued or built. The explicit public-custom
+                # opt-in already runs the unified validator inside prepare_public_flow_build.
+                if not settings.allow_public_custom_components:
+                    validate_catalog_policy_for_flow(flow.data)
                 # Block unauthenticated builds of flows that run arbitrary code
                 # (Python interpreter/REPL, legacy Python Code Structured tool,
                 # Smart Transform lambda) or invoke another saved flow (Run Flow,

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Collection
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID, uuid4
@@ -181,22 +181,34 @@ async def parse_input_request_from_body(http_request: Request) -> SimplifiedAPIR
 
 
 @router.get("/all")
-async def get_all(request: Request, current_user: CurrentActiveUser):
+async def get_all(request: Request, current_user: CurrentActiveUser, *, include_blocked: bool = False):
     """Retrieve all component types with compression for better performance.
 
     Returns a compressed response containing all available component types,
     with display_names translated to the locale indicated by Accept-Language.
     """
+    if include_blocked and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only superusers can include blocked catalog components.",
+        )
+
     from langflow.interface.components import get_and_cache_all_types_dict
     from langflow.utils.i18n import build_component_display_names, translate_component_dict
 
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         all_types_en = await get_and_cache_all_types_dict(settings_service=get_settings_service())
         visible_types_en = _filter_component_palette_by_provider_policy(
             all_types_en,
             user_id=current_user.id,
             attributes={"is_superuser": bool(current_user.is_superuser)},
         )
+        if not include_blocked:
+            visible_types_en = _filter_component_palette_by_catalog_policy(
+                visible_types_en,
+                blocked_component_keys=catalog_policy_snapshot.blocked_component_keys,
+            )
 
         locale = getattr(request.state, "locale", "en")
         all_types = translate_component_dict(visible_types_en, locale) if locale != "en" else visible_types_en
@@ -244,6 +256,28 @@ def _filter_component_palette_by_provider_policy(
             or not isinstance(component.get("metadata"), dict)
             or not (provider_id := component["metadata"].get("model_provider_id"))
             or policy.allows(provider_id)
+        }
+        for category, components in all_types.items()
+    }
+
+
+def _filter_component_palette_by_catalog_policy(
+    all_types: dict[str, dict[str, dict]],
+    *,
+    blocked_component_keys: Collection[str],
+) -> dict[str, dict[str, dict]]:
+    """Return shallow category copies with exact blocked component keys removed.
+
+    Catalog policy keys match the inner component-registry keys exactly and
+    case-sensitively across every category. Category order, component order,
+    and empty categories are preserved. Component payloads remain shared with
+    the process-wide cache and are never mutated or deep-copied.
+    """
+    return {
+        category: {
+            component_key: component
+            for component_key, component in components.items()
+            if component_key not in blocked_component_keys
         }
         for category, components in all_types.items()
     }

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -80,6 +80,7 @@ from langflow.services.database.models.jobs.model import JobType
 from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import (
     get_auth_service,
+    get_catalog_policy_service,
     get_job_service,
     get_memory_base_service,
     get_session_service,
@@ -1670,14 +1671,27 @@ async def get_config(
     """
     try:
         settings_service: SettingsService = get_settings_service()
+        try:
+            catalog_governance_enabled = get_catalog_policy_service().enabled
+        except Exception as exc:  # noqa: BLE001
+            # Catalog governance is explicitly fail-open. A broken custom
+            # policy implementation must not break the public config endpoint
+            # or expose its internal exception text.
+            await logger.aexception("Catalog policy status unavailable; reporting governance disabled", exception=exc)
+            catalog_governance_enabled = False
 
         if user is None:
             return PublicConfigResponse.from_settings(
                 settings_service.settings,
                 settings_service.auth_settings,
+                catalog_governance_enabled=catalog_governance_enabled,
             )
 
-        return ConfigResponse.from_settings(settings_service.settings, settings_service.auth_settings)
+        return ConfigResponse.from_settings(
+            settings_service.settings,
+            settings_service.auth_settings,
+            catalog_governance_enabled=catalog_governance_enabled,
+        )
 
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import threading
 import zipfile
+from collections.abc import Collection
 from typing import Annotated
 from uuid import UUID
 
@@ -49,7 +50,7 @@ from langflow.api.v1.flows_helpers import (
 from langflow.api.v1.mappers.deployments.sync import retry_flow_operation_on_deployment_guard
 from langflow.api.v1.schemas import FlowListCreate
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
-from langflow.services.auth.utils import get_current_active_user
+from langflow.services.auth.utils import get_current_active_user, get_optional_user
 from langflow.services.authorization import (
     FlowAction,
     ensure_flow_permission,
@@ -78,7 +79,8 @@ from langflow.services.database.models.flow.model import (
 # and FlowVersionError from the flow_version modules.
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import Folder
-from langflow.services.deps import get_settings_service, get_storage_service
+from langflow.services.database.models.user.model import User
+from langflow.services.deps import get_catalog_policy_service, get_settings_service, get_storage_service
 from langflow.services.storage.service import StorageService
 from langflow.utils.compression import compress_response
 from langflow.utils.i18n import translate_flow_notes, translate_starter_flows
@@ -906,26 +908,60 @@ _starter_flows_translated_cache: ThreadingInMemoryCache[threading.RLock] = Threa
 _starter_flows_lock = asyncio.Lock()
 
 
+def _filter_basic_examples_by_catalog_policy(
+    flows: list[FlowRead],
+    *,
+    blocked_template_keys: Collection[str],
+) -> list[FlowRead]:
+    """Return a request-local view without exact blocked template keys."""
+    return [flow for flow in flows if flow.name_key not in blocked_template_keys]
+
+
 @router.get("/basic_examples/", response_model=list[FlowRead], status_code=200)
 async def read_basic_examples(
     *,
     session: DbSession,
     request: Request,
+    user: Annotated[User | None, Depends(get_optional_user)],
+    include_blocked: bool = False,
 ):
     """Retrieve a list of basic example flows."""
+    if include_blocked and (user is None or not user.is_superuser):
+        raise HTTPException(
+            status_code=403,
+            detail="Only superusers can include blocked catalog templates.",
+        )
+
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
     locale = getattr(request.state, "locale", "en")
     translated_cache_key = f"starter_flows_{locale}"
 
     # Fast path: translated result already cached for this locale
     cached_translated = _starter_flows_translated_cache.get(translated_cache_key)
     if cached_translated is not CACHE_MISS:
-        return compress_response(cached_translated)
+        visible_flows = (
+            cached_translated
+            if include_blocked
+            else _filter_basic_examples_by_catalog_policy(
+                cached_translated,
+                blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+            )
+        )
+        return compress_response(visible_flows)
 
     async with _starter_flows_lock:
         # Double-check inside lock to prevent thundering herd
         cached_translated = _starter_flows_translated_cache.get(translated_cache_key)
         if cached_translated is not CACHE_MISS:
-            return compress_response(cached_translated)
+            visible_flows = (
+                cached_translated
+                if include_blocked
+                else _filter_basic_examples_by_catalog_policy(
+                    cached_translated,
+                    blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+                )
+            )
+            return compress_response(visible_flows)
 
         # Ensure raw DB data is cached
         cached_flow_reads = _starter_flows_cache.get("starter_flows")
@@ -967,7 +1003,15 @@ async def read_basic_examples(
 
         _starter_flows_translated_cache.set(translated_cache_key, result)
 
-    return compress_response(result)
+    visible_flows = (
+        result
+        if include_blocked
+        else _filter_basic_examples_by_catalog_policy(
+            result,
+            blocked_template_keys=catalog_policy_snapshot.blocked_template_keys,
+        )
+    )
+    return compress_response(visible_flows)
 
 
 @router.post("/expand/", status_code=200, dependencies=[Depends(get_current_active_user)], include_in_schema=False)

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -394,6 +394,9 @@ class BaseConfigResponse(BaseModel):
     # Mirrors ``LANGFLOW_AUTHZ_ENABLED``. EE/custom frontends gate the Access
     # Control settings entry on this flag; OSS UI ignores it until wired.
     authz_enabled: bool = False
+    # Signals that at least one component or template is governed without
+    # exposing the policy contents through the public config response.
+    catalog_governance_enabled: bool = False
 
 
 class PublicConfigResponse(BaseConfigResponse):
@@ -407,12 +410,19 @@ class PublicConfigResponse(BaseConfigResponse):
     allow_custom_components: bool
 
     @classmethod
-    def from_settings(cls, settings: Settings, auth_settings) -> "PublicConfigResponse":
+    def from_settings(
+        cls,
+        settings: Settings,
+        auth_settings,
+        *,
+        catalog_governance_enabled: bool = False,
+    ) -> "PublicConfigResponse":
         """Create a PublicConfigResponse instance using values from a Settings object.
 
         Parameters:
             settings (Settings): The Settings object containing configuration values.
             auth_settings: Auth settings (for ``authz_enabled``).
+            catalog_governance_enabled: Whether any catalog policy currently restricts resources.
 
         Returns:
             PublicConfigResponse: An instance populated with public-safe configuration values.
@@ -427,6 +437,7 @@ class PublicConfigResponse(BaseConfigResponse):
             enable_extension_reload=settings.enable_extension_reload,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            catalog_governance_enabled=catalog_governance_enabled,
         )
 
 
@@ -465,12 +476,19 @@ class ConfigResponse(BaseConfigResponse):
     agentic_experience: bool = True
 
     @classmethod
-    def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
+    def from_settings(
+        cls,
+        settings: Settings,
+        auth_settings,
+        *,
+        catalog_governance_enabled: bool = False,
+    ) -> "ConfigResponse":
         """Create a ConfigResponse instance using values from a Settings object and AuthSettings.
 
         Parameters:
             settings (Settings): The Settings object containing configuration values.
             auth_settings: The AuthSettings object containing authentication configuration values.
+            catalog_governance_enabled: Whether any catalog policy currently restricts resources.
 
         Returns:
             ConfigResponse: An instance populated with configuration and feature flag values.
@@ -498,6 +516,7 @@ class ConfigResponse(BaseConfigResponse):
             hide_getting_started_progress=settings.hide_getting_started_progress,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            catalog_governance_enabled=catalog_governance_enabled,
             embedded_mode=settings.embedded_mode,
             hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
             hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,

--- a/src/backend/base/langflow/api/v1/starter_projects.py
+++ b/src/backend/base/langflow/api/v1/starter_projects.py
@@ -1,9 +1,10 @@
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from langflow.services.auth.utils import get_current_active_user
+from langflow.api.utils import CurrentActiveUser
+from langflow.services.deps import get_catalog_policy_service
 
 router = APIRouter(prefix="/starter-projects", tags=["Flows"])
 
@@ -37,16 +38,26 @@ class GraphDumpResponse(BaseModel):
     data: GraphData
     is_component: bool | None = None
     name: str | None = None
+    name_key: str
     description: str | None = None
     endpoint_name: str | None = None
 
 
-@router.get("/", dependencies=[Depends(get_current_active_user)], status_code=200)
-async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
+@router.get("/", status_code=200)
+async def get_starter_projects(
+    request: Request,
+    current_user: CurrentActiveUser,
+    *,
+    include_blocked: bool = False,
+) -> list[GraphDumpResponse]:
     """Get a list of starter projects."""
     from langflow.initial_setup.load import get_starter_projects_dump
     from langflow.utils.i18n import translate_flow_notes
 
+    if include_blocked and not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="Only superusers can include blocked catalog templates.")
+
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
     locale = getattr(request.state, "locale", "en")
 
     try:
@@ -56,6 +67,12 @@ async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
         # Convert TypedDict GraphDump to Pydantic GraphDumpResponse
         results = []
         for item in raw_data:
+            name_key = item.get("name_key")
+            if not isinstance(name_key, str):
+                continue
+            if not include_blocked and catalog_policy_snapshot.is_template_blocked(name_key):
+                continue
+
             nodes = item.get("data", {}).get("nodes", [])
             translated_nodes = translate_flow_notes(nodes, locale)
 
@@ -71,6 +88,7 @@ async def get_starter_projects(request: Request) -> list[GraphDumpResponse]:
                 data=graph_data,
                 is_component=item.get("is_component"),
                 name=item.get("name"),
+                name_key=name_key,
                 description=item.get("description"),
                 endpoint_name=item.get("endpoint_name"),
             )

--- a/src/backend/base/langflow/initial_setup/load.py
+++ b/src/backend/base/langflow/initial_setup/load.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from typing import Any
 
+from langflow.utils.i18n_keys import safe_flow_key
+
 from .starter_projects import (
     basic_prompting_graph,
     blog_writer_graph,
@@ -56,5 +58,9 @@ def get_starter_projects_graphs():
 
 def get_starter_projects_dump():
     return [
-        build_graph().dump(name=name, description=description) for build_graph, name, description in STARTER_PROJECTS
+        {
+            **build_graph().dump(name=name, description=description),
+            "name_key": safe_flow_key(name),
+        }
+        for build_graph, name, description in STARTER_PROJECTS
     ]

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from types import SimpleNamespace
 from typing import Any
 
 from anyio import Path
@@ -416,6 +417,49 @@ async def test_get_config_without_authentication_returns_public_config(client: A
     """Test that /config returns public config when accessed without authentication."""
     response = await client.get("api/v1/config")
     assert response.status_code == status.HTTP_200_OK
+
+
+async def test_get_config_reports_catalog_governance_without_exposing_policy_contents(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """Both config variants expose only the derived governance indicator."""
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(enabled=True),
+    )
+
+    public_response = await client.get("api/v1/config")
+    authenticated_response = await client.get("api/v1/config", headers=logged_in_headers)
+
+    assert public_response.status_code == status.HTTP_200_OK
+    assert authenticated_response.status_code == status.HTTP_200_OK
+    for result in (public_response.json(), authenticated_response.json()):
+        assert result["catalog_governance_enabled"] is True
+        assert "blocked_component_keys" not in result
+        assert "blocked_template_keys" not in result
+
+
+async def test_get_config_fails_open_without_exposing_catalog_policy_errors(client: AsyncClient, monkeypatch):
+    """A broken custom policy accessor does not leak through public config."""
+
+    class BrokenCatalogPolicy:
+        @property
+        def enabled(self) -> bool:
+            msg = "sensitive catalog backend detail"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        BrokenCatalogPolicy,
+    )
+
+    response = await client.get("api/v1/config")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["catalog_governance_enabled"] is False
+    assert "sensitive catalog backend detail" not in response.text
 
 
 async def test_get_config_unauthenticated_returns_expected_fields(client: AsyncClient):

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -568,6 +568,71 @@ async def test_read_basic_examples(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_200_OK
     assert isinstance(result, list), "The result must be a list"
     assert len(result) > 0, "The result must have at least one flow"
+    assert all(item["name_key"] for item in result)
+
+
+async def test_read_basic_examples_catalog_policy_preserves_public_cache_and_unblocks(
+    client: AsyncClient,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    flows._starter_flows_cache.clear()
+    flows._starter_flows_translated_cache.clear()
+
+    blocked_response = await client.get("api/v1/flows/basic_examples/")
+    assert blocked_response.status_code == status.HTTP_200_OK, blocked_response.text
+    blocked_keys = {flow["name_key"] for flow in blocked_response.json()}
+    assert "basic_prompting" not in blocked_keys
+
+    service.snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/flows/basic_examples/")
+    assert unblocked_response.status_code == status.HTTP_200_OK, unblocked_response.text
+    unblocked_keys = {flow["name_key"] for flow in unblocked_response.json()}
+    assert "basic_prompting" in unblocked_keys
+
+
+async def test_read_basic_examples_include_blocked_requires_superuser(
+    client: AsyncClient,
+    logged_in_headers,
+):
+    anonymous_response = await client.get("api/v1/flows/basic_examples/?include_blocked=true")
+    assert anonymous_response.status_code == status.HTTP_403_FORBIDDEN
+
+    denied_response = await client.get(
+        "api/v1/flows/basic_examples/?include_blocked=true",
+        headers=logged_in_headers,
+    )
+    assert denied_response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_read_basic_examples_superuser_can_include_blocked(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    service = type(
+        "CatalogPolicyService",
+        (),
+        {"snapshot": CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})},
+    )()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+
+    override_response = await client.get(
+        "api/v1/flows/basic_examples/?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+    assert override_response.status_code == status.HTTP_200_OK, override_response.text
+    assert "basic_prompting" in {flow["name_key"] for flow in override_response.json()}
 
 
 async def test_read_flows_user_isolation(client: AsyncClient, logged_in_headers, active_user):

--- a/src/backend/tests/unit/api/v1/test_starter_projects.py
+++ b/src/backend/tests/unit/api/v1/test_starter_projects.py
@@ -2,6 +2,7 @@ import importlib
 
 from fastapi import status
 from httpx import AsyncClient
+from lfx.services.catalog_policy import CatalogPolicySnapshot
 
 
 async def test_get_starter_projects(client: AsyncClient, logged_in_headers):
@@ -29,6 +30,14 @@ EXPECTED_STARTER_PROJECTS = {
     "Vector Store RAG": "Load your data for chat context with Retrieval Augmented Generation.",
 }
 
+EXPECTED_STARTER_PROJECT_KEYS = {
+    "basic_prompting",
+    "blog_writer",
+    "document_q_a",
+    "memory_chatbot",
+    "vector_store_rag",
+}
+
 
 async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClient, logged_in_headers):
     """Each starter project must expose its canonical name and description.
@@ -46,6 +55,7 @@ async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClien
 
     names = [project["name"] for project in result]
     assert len(set(names)) == len(names), f"Starter project names must be unique, got: {names}"
+    assert {project["name_key"] for project in result} == EXPECTED_STARTER_PROJECT_KEYS
 
     actual = {project["name"]: project["description"] for project in result}
     assert actual == EXPECTED_STARTER_PROJECTS
@@ -56,6 +66,64 @@ async def test_get_starter_projects_expose_canonical_metadata(client: AsyncClien
     assert endpoint_names == [None] * len(result), (
         f"endpoint_name must be null, not the string 'None': {endpoint_names}"
     )
+
+
+async def test_starter_projects_catalog_policy_is_request_local_and_unblocks_without_restart(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import starter_projects
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(starter_projects, "get_catalog_policy_service", lambda: service)
+
+    blocked_response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
+    assert blocked_response.status_code == status.HTTP_200_OK, blocked_response.text
+    assert {project["name_key"] for project in blocked_response.json()} == (
+        EXPECTED_STARTER_PROJECT_KEYS - {"basic_prompting"}
+    )
+
+    service.snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/starter-projects/", headers=logged_in_headers)
+    assert unblocked_response.status_code == status.HTTP_200_OK, unblocked_response.text
+    assert {project["name_key"] for project in unblocked_response.json()} == EXPECTED_STARTER_PROJECT_KEYS
+
+
+async def test_starter_projects_include_blocked_requires_superuser(
+    client: AsyncClient,
+    logged_in_headers,
+):
+    denied_response = await client.get(
+        "api/v1/starter-projects/?include_blocked=true",
+        headers=logged_in_headers,
+    )
+    assert denied_response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_starter_projects_superuser_can_include_blocked(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import starter_projects
+
+    service = type(
+        "CatalogPolicyService",
+        (),
+        {"snapshot": CatalogPolicySnapshot(blocked_template_keys={"basic_prompting"})},
+    )()
+    monkeypatch.setattr(starter_projects, "get_catalog_policy_service", lambda: service)
+
+    override_response = await client.get(
+        "api/v1/starter-projects/?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+    assert override_response.status_code == status.HTTP_200_OK, override_response.text
+    assert {project["name_key"] for project in override_response.json()} == EXPECTED_STARTER_PROJECT_KEYS
 
 
 def test_starter_projects_keep_optional_crewai_exports_lazy():

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -89,6 +89,32 @@ async def test_build_flow_validates_request_data_instead_of_stale_db_flow(
     assert "job_id" in response.json()
 
 
+async def test_build_flow_maps_catalog_policy_validation_to_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    validation_message = "Flow build blocked: catalog policy blocks components: Agent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"api/v1/build/{flow_id}/flow",
+        json={},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"].endswith("Agent")
+
+
 async def test_build_flow_with_frozen_path(client, json_memory_chatbot_no_llm, logged_in_headers):
     """Test building a flow with a frozen path."""
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
@@ -695,7 +721,7 @@ async def test_build_public_tmp_checks_public_access_before_validation(
         raise ValueError(public_access_validation_message)
 
     monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
         fail_if_validation_runs,
     )
 
@@ -707,6 +733,40 @@ async def test_build_public_tmp_checks_public_access_before_validation(
 
     assert response.status_code == codes.FORBIDDEN
     assert response.json()["detail"] == "Flow is not public"
+
+
+async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+    validation_message = "Flow build blocked: catalog policy blocks components: SecretComponent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
+        reject_catalog_component,
+    )
+    client.cookies.set("client_id", "test-catalog-policy-client")
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"] == "This flow cannot be executed."
+    assert "SecretComponent" not in response.text
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -201,6 +201,213 @@ def test_component_palette_policy_filters_models_without_mutating_shared_cache(m
     assert filtered["mixed"] is not cached["mixed"]
 
 
+def test_catalog_policy_filter_is_case_sensitive_and_does_not_mutate_shared_cache():
+    from langflow.api.v1 import endpoints
+
+    blocked_component = {"display_name": "Blocked", "metadata": {"nested": True}}
+    allowed_component = {"display_name": "Allowed", "metadata": {"nested": True}}
+    cached = {
+        "models": {
+            "BlockedAgent": blocked_component,
+            "blockedagent": allowed_component,
+        },
+        "empty": {},
+    }
+
+    filtered = endpoints._filter_component_palette_by_catalog_policy(
+        cached,
+        blocked_component_keys=frozenset({"BlockedAgent"}),
+    )
+
+    assert list(filtered) == ["models", "empty"]
+    assert list(filtered["models"]) == ["blockedagent"]
+    assert filtered["empty"] == {}
+    assert filtered is not cached
+    assert filtered["models"] is not cached["models"]
+    assert filtered["empty"] is not cached["empty"]
+    assert filtered["models"]["blockedagent"] is allowed_component
+    assert list(cached["models"]) == ["BlockedAgent", "blockedagent"]
+    assert cached["models"]["BlockedAgent"] is blocked_component
+
+
+async def test_get_all_filters_catalog_policy_and_uses_current_snapshot(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+    from langflow.interface import components as components_module
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    cached = {
+        "models": {
+            "AllowedAgent": {
+                "display_name": "Allowed Agent",
+                "description": "Visible",
+                "template": {},
+                "metadata": {},
+            },
+            "BlockedAgent": {
+                "display_name": "Blocked Agent",
+                "description": "Hidden",
+                "template": {},
+                "metadata": {},
+            },
+        },
+        "empty": {},
+    }
+
+    class MutableCatalogPolicyService:
+        def __init__(self):
+            self.current_snapshot = CatalogPolicySnapshot(blocked_component_keys={"BlockedAgent"})
+            self.snapshot_reads = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_reads += 1
+            return self.current_snapshot
+
+    service = MutableCatalogPolicyService()
+
+    async def get_cached_types(*, settings_service):
+        _ = settings_service
+        return cached
+
+    monkeypatch.setattr(components_module, "get_and_cache_all_types_dict", get_cached_types)
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(
+        endpoints,
+        "_filter_component_palette_by_provider_policy",
+        lambda all_types, **_kwargs: {category: dict(components) for category, components in all_types.items()},
+    )
+
+    blocked_response = await client.get("api/v1/all", headers=logged_in_headers)
+
+    assert blocked_response.status_code == status.HTTP_200_OK
+    blocked_payload = blocked_response.json()
+    assert list(blocked_payload["models"]) == ["AllowedAgent"]
+    assert "blockedagent" not in blocked_payload["component_display_names"]
+    assert blocked_payload["empty"] == {}
+    assert service.snapshot_reads == 1
+    assert "BlockedAgent" in cached["models"]
+
+    service.current_snapshot = CatalogPolicySnapshot()
+    unblocked_response = await client.get("api/v1/all", headers=logged_in_headers)
+
+    assert unblocked_response.status_code == status.HTTP_200_OK
+    unblocked_payload = unblocked_response.json()
+    assert list(unblocked_payload["models"]) == ["AllowedAgent", "BlockedAgent"]
+    assert "blockedagent" in unblocked_payload["component_display_names"]
+    assert service.snapshot_reads == 2
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent"]
+
+
+async def test_get_all_rejects_include_blocked_for_non_superuser_before_broad_exception_handler(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+
+    def unexpected_catalog_service_lookup():
+        msg = "catalog policy must not be read for an unauthorized override"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", unexpected_catalog_service_lookup)
+
+    response = await client.get("api/v1/all?include_blocked=true", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_get_all_superuser_override_skips_only_catalog_filter_without_cache_poisoning(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    monkeypatch,
+):
+    from langflow.api.v1 import endpoints
+    from langflow.interface import components as components_module
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    cached = {
+        "models": {
+            "AllowedAgent": {
+                "display_name": "Allowed Agent",
+                "description": "Visible",
+                "template": {},
+                "metadata": {},
+            },
+            "BlockedAgent": {
+                "display_name": "Blocked Agent",
+                "description": "Catalog blocked",
+                "template": {},
+                "metadata": {},
+            },
+            "ProviderBlockedAgent": {
+                "display_name": "Provider Blocked Agent",
+                "description": "Provider blocked",
+                "template": {},
+                "metadata": {"model_provider_id": "denied-provider"},
+            },
+        }
+    }
+
+    class CountingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_reads = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_reads += 1
+            return CatalogPolicySnapshot(blocked_component_keys={"BlockedAgent"})
+
+    service = CountingCatalogPolicyService()
+    provider_filter_calls = 0
+
+    async def get_cached_types(*, settings_service):
+        _ = settings_service
+        return cached
+
+    def filter_provider_policy(all_types, *, user_id, attributes=None):
+        nonlocal provider_filter_calls
+        _ = user_id
+        provider_filter_calls += 1
+        assert attributes == {"is_superuser": True}
+        return {
+            category: {
+                key: component
+                for key, component in components.items()
+                if component.get("metadata", {}).get("model_provider_id") != "denied-provider"
+            }
+            for category, components in all_types.items()
+        }
+
+    monkeypatch.setattr(components_module, "get_and_cache_all_types_dict", get_cached_types)
+    monkeypatch.setattr(endpoints, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(endpoints, "_filter_component_palette_by_provider_policy", filter_provider_policy)
+
+    override_response = await client.get(
+        "api/v1/all?include_blocked=true",
+        headers=logged_in_headers_super_user,
+    )
+
+    assert override_response.status_code == status.HTTP_200_OK
+    override_payload = override_response.json()
+    assert list(override_payload["models"]) == ["AllowedAgent", "BlockedAgent"]
+    assert "ProviderBlockedAgent" not in override_payload["models"]
+    assert service.snapshot_reads == 1
+    assert provider_filter_calls == 1
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent", "ProviderBlockedAgent"]
+
+    default_response = await client.get("api/v1/all", headers=logged_in_headers_super_user)
+
+    assert default_response.status_code == status.HTTP_200_OK
+    assert list(default_response.json()["models"]) == ["AllowedAgent"]
+    assert service.snapshot_reads == 2
+    assert provider_filter_calls == 2
+    assert list(cached["models"]) == ["AllowedAgent", "BlockedAgent", "ProviderBlockedAgent"]
+
+
 @pytest.mark.usefixtures("active_user")
 async def test_post_validate_code(client: AsyncClient, logged_in_headers):
     # Test case with a valid import and function
@@ -493,6 +700,30 @@ async def test_successful_run_no_payload(client, simple_api_test, created_api_ke
     inner_results = [output.get("results") for output in outputs_dict.get("outputs")]
 
     assert all(result is not None for result in inner_results), (outputs_dict, output_results_has_results)
+
+
+async def test_run_by_id_maps_catalog_policy_validation_to_bad_request(
+    client, simple_api_test, created_api_key, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    validation_message = "Flow build blocked: catalog policy blocks components: ChatInput"
+
+    def reject_catalog_component(_target, **_kwargs):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"/api/v1/run/{simple_api_test['id']}",
+        headers={"x-api-key": created_api_key.api_key},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith("ChatInput")
 
 
 async def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1378,10 +1378,17 @@ class Graph:
             Graph: The created graph.
         """
         from lfx.extension.migration import migrate_flow_payload
-        from lfx.utils.flow_validation import validate_flow_for_current_settings
+        from lfx.services.deps import get_catalog_policy_service
+        from lfx.utils.flow_validation import validate_catalog_policy_for_flow, validate_flow_for_current_settings
 
         if "data" in payload:
             payload = payload["data"]
+        # Catalog identity is the exact, case-sensitive stored node.data.type.
+        # Validate it before extension migration rewrites legacy identifiers.
+        # Reuse this same immutable snapshot below so migrated executable types
+        # are checked against the identical policy view without a TOCTOU gap.
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
+        validate_catalog_policy_for_flow(payload, snapshot=catalog_policy_snapshot)
         # Rewrite legacy component references in place against the append-only
         # extension migration table.  Best-effort: a corrupt table or unmapped
         # reference produces typed errors on the report but never raises, so
@@ -1448,8 +1455,19 @@ class Graph:
         # boundary (middleware or endpoint dependency) so from_payload stays
         # pure deserialization, but a missed endpoint means arbitrary code
         # execution, so we keep this as a safety net.
-        validate_flow_for_current_settings(payload)
+        validate_flow_for_current_settings(payload, catalog_policy_snapshot=catalog_policy_snapshot)
         try:
+            # The extension migrator intentionally rewrites only the nodes at
+            # the payload level it receives, while process_flow later flattens
+            # inlined nested flows for execution. Build that executable view
+            # on a deep copy, migrate it, and enforce the same snapshot so a
+            # nested legacy alias cannot bypass a block on its canonical key.
+            # Migration errors on this policy-only copy remain best-effort and
+            # are not exposed. Skip the work for the default allow-all policy.
+            if catalog_policy_snapshot.blocked_component_keys:
+                effective_catalog_payload = process_flow(payload)
+                migrate_flow_payload(effective_catalog_payload)
+                validate_catalog_policy_for_flow(effective_catalog_payload, snapshot=catalog_policy_snapshot)
             vertices = payload["nodes"]
             edges = payload["edges"]
             graph = cls(flow_id=flow_id, flow_name=flow_name, user_id=user_id, context=context)

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
 from lfx.utils.component_aliases import get_component_type_aliases
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
 
 INITIALIZING_COMPONENT_TEMPLATES_MESSAGE = (
     "Flow build blocked: component templates are still initializing. Please try again in a few seconds."
@@ -57,6 +60,10 @@ class CustomComponentValidationError(ValueError):
     still catch it, but callers can catch this specifically to
     distinguish policy errors from other ValueErrors.
     """
+
+
+class CatalogPolicyValidationError(CustomComponentValidationError):
+    """Raised when a flow contains a component blocked by catalog policy."""
 
 
 class PublicFlowValidationError(CustomComponentValidationError):
@@ -166,6 +173,77 @@ def _extract_flow_data(target: Mapping[str, Any] | Any | None) -> dict[str, Any]
         return _normalize_flow_data(target)
 
     return _normalize_flow_data(_extract_graph_payload(target))
+
+
+def _collect_catalog_component_keys(nodes: Any) -> set[str]:
+    """Collect exact component keys from a graph and its inlined nested flows."""
+    component_keys: set[str] = set()
+    if not isinstance(nodes, list):
+        return component_keys
+
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        node_data = node.get("data")
+        if not isinstance(node_data, Mapping):
+            continue
+
+        component_type = node_data.get("type")
+        if isinstance(component_type, str):
+            component_keys.add(component_type)
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, Mapping):
+            continue
+        nested_flow = node_info.get("flow")
+        if not isinstance(nested_flow, Mapping):
+            continue
+        nested_data = nested_flow.get("data")
+        if not isinstance(nested_data, Mapping):
+            continue
+        component_keys.update(_collect_catalog_component_keys(nested_data.get("nodes")))
+
+    return component_keys
+
+
+def validate_catalog_policy_for_flow(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject a flow containing component keys blocked by the current catalog snapshot.
+
+    Component identity is the exact, case-sensitive ``node.data.type`` value.
+    The immutable snapshot is captured once when the caller does not provide
+    one, so every node in a request is evaluated against the same policy view.
+    """
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.blocked_component_keys:
+        return
+
+    normalized_flow_data = _extract_flow_data(target)
+    if target is not None and normalized_flow_data is None:
+        msg = (
+            "Flow validation failed: could not extract graph data from the provided target. "
+            "Ensure the flow payload or Graph object contains valid graph data."
+        )
+        raise CatalogPolicyValidationError(msg)
+    if not normalized_flow_data:
+        return
+
+    component_keys = _collect_catalog_component_keys(normalized_flow_data.get("nodes"))
+    blocked = snapshot.blocked_components(component_keys)
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Flow build blocked by catalog policy: {blocked_names}")
+    message = f"Flow build blocked: catalog policy blocks components: {blocked_names}"
+    raise CatalogPolicyValidationError(message)
 
 
 def collect_component_hash_lookups(
@@ -479,14 +557,20 @@ def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     return component_cache.type_to_current_hash
 
 
-def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -> None:
-    """Enforce custom-component policy for a payload or graph-like object."""
-    from lfx.services.deps import get_settings_service
+def validate_flow_for_current_settings(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    catalog_policy_snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Enforce catalog and custom-component policy for a payload or graph-like object."""
+    from lfx.services.deps import get_catalog_policy_service, get_settings_service
 
     settings_service = get_settings_service()
     if settings_service is None:
         raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
 
+    if catalog_policy_snapshot is None:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
     settings = settings_service.settings
     allow_custom_components = getattr(settings, "allow_custom_components", True)
     block_code_interpreter_components = getattr(settings, "block_code_interpreter_components", False)
@@ -495,14 +579,18 @@ def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -
     # If a blocking policy is active and we received a target but couldn't extract any flow
     # data from it, fail fast rather than silently skipping validation — the caller passed
     # something we can't verify.
-    if (not allow_custom_components or block_code_interpreter_components) and (
-        target is not None and normalized_flow_data is None
-    ):
+    if (
+        not allow_custom_components
+        or block_code_interpreter_components
+        or bool(catalog_policy_snapshot.blocked_component_keys)
+    ) and (target is not None and normalized_flow_data is None):
         msg = (
             "Flow validation failed: could not extract graph data from the provided target. "
             "Ensure the flow payload or Graph object contains valid graph data."
         )
         raise CustomComponentValidationError(msg)
+
+    validate_catalog_policy_for_flow(normalized_flow_data, snapshot=catalog_policy_snapshot)
 
     if block_code_interpreter_components:
         check_code_execution_components_and_raise(normalized_flow_data)

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -15,7 +15,8 @@ from lfx.graph.graph.utils import (
 )
 from lfx.graph.vertex.base import Vertex
 from lfx.interface.components import component_cache
-from lfx.utils.flow_validation import CustomComponentValidationError
+from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError, CustomComponentValidationError
 
 # Test cases for the graph module
 
@@ -125,6 +126,110 @@ def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
 
     with pytest.raises(CustomComponentValidationError, match="custom components are not allowed"):
         Graph.from_payload(_blocked_custom_flow())
+
+
+@pytest.mark.parametrize(
+    "blocked_key",
+    [
+        "DuckDuckGoSearchComponent",
+        "ext:duckduckgo:DuckDuckGoSearchComponent@official",
+    ],
+)
+def test_from_payload_checks_catalog_policy_before_and_after_extension_migration(monkeypatch, blocked_key):
+    class CountingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            return CatalogPolicySnapshot(blocked_component_keys=frozenset({blocked_key}))
+
+    service = CountingCatalogPolicyService()
+    payload = {
+        "nodes": [
+            {
+                "id": "duck-search",
+                "type": "genericNode",
+                "data": {
+                    "id": "duck-search",
+                    "type": "DuckDuckGoSearchComponent",
+                    "node": {"template": {}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=blocked_key):
+        Graph.from_payload(payload)
+
+    assert service.snapshot_calls == 1
+
+
+def test_from_payload_checks_canonical_policy_for_nested_legacy_component(monkeypatch):
+    canonical_key = "ext:duckduckgo:DuckDuckGoSearchComponent@official"
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({canonical_key})),
+    )
+    nested_node = {
+        "id": "duck-search",
+        "type": "genericNode",
+        "data": {
+            "id": "duck-search",
+            "type": "DuckDuckGoSearchComponent",
+            "node": {"template": {}},
+        },
+    }
+    payload = {
+        "nodes": [
+            {
+                "id": "group-1",
+                "type": "genericNode",
+                "data": {
+                    "id": "group-1",
+                    "type": "Group",
+                    "node": {
+                        "template": {},
+                        "flow": {
+                            "data": {
+                                "nodes": [nested_node],
+                                "edges": [],
+                            }
+                        },
+                    },
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=canonical_key):
+        Graph.from_payload(payload)
+
+
+def test_from_payload_catalog_policy_preserves_invalid_payload_error_mapping(monkeypatch):
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(ValueError, match="Error while creating graph from payload"):
+        Graph.from_payload({"edges": []})
 
 
 def test_find_last_node(grouped_chat_json_flow):

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -6,14 +6,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from lfx.services.catalog_policy import CatalogPolicySnapshot
 from lfx.utils.flow_validation import (
     CODE_EXECUTION_COMPONENT_TYPES,
     FLOW_REFERENCE_COMPONENT_TYPES,
+    CatalogPolicyValidationError,
     CustomComponentValidationError,
     PublicFlowValidationError,
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -77,6 +80,75 @@ def test_validate_flow_for_current_settings_requires_settings_service(monkeypatc
 
     with pytest.raises(RuntimeError, match="Settings service must be initialized"):
         validate_flow_for_current_settings(graph)
+
+
+def _catalog_flow(*component_types: str) -> dict:
+    return {
+        "nodes": [
+            {
+                "id": f"{component_type}-1",
+                "data": {
+                    "id": f"{component_type}-1",
+                    "type": component_type,
+                    "node": {"template": {}},
+                },
+            }
+            for component_type in component_types
+        ],
+        "edges": [],
+    }
+
+
+def test_catalog_policy_validation_blocks_top_level_components_deterministically():
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"Zed", "Agent"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match=r"Agent, Zed$"):
+        validate_catalog_policy_for_flow(_catalog_flow("Zed", "Agent", "Zed"), snapshot=snapshot)
+
+
+def test_catalog_policy_validation_blocks_nested_components():
+    flow = _catalog_flow("Group")
+    flow["nodes"][0]["data"]["node"]["flow"] = {"data": _catalog_flow("NestedBlocked")}
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"NestedBlocked"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match="NestedBlocked"):
+        validate_catalog_policy_for_flow(flow, snapshot=snapshot)
+
+
+def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_allows():
+    validate_catalog_policy_for_flow(
+        _catalog_flow("agent"),
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):
+    class ChangingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            if self.snapshot_calls == 1:
+                return CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"}))
+            return CatalogPolicySnapshot()
+
+    service = ChangingCatalogPolicyService()
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=False,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match="Agent"):
+        validate_flow_for_current_settings(_catalog_flow("Agent"))
+
+    assert service.snapshot_calls == 1
 
 
 # --- public-flow component sanitization (H1-3754930 follow-up) --------------------


### PR DESCRIPTION
## Summary

Surfaces a lightweight catalog-governance indicator through `GET /api/v1/config` for builder restricted-state gating.

- add `catalog_governance_enabled` to the shared public/full config schema
- derive the value from the immutable catalog policy snapshot
- return only the boolean indicator; never serialize component/template blocklist contents
- fail open to `false` if a custom policy accessor fails, logging the exception server-side without leaking it through the public response

## Jira

- Epic: [LE-1864](https://datastax.jira.com/browse/LE-1864)
- Implements: [LE-1934](https://datastax.jira.com/browse/LE-1934)

## Validation

- `test_endpoints.py -k get_config` — 15 passed
- Ruff, format, diff-check, and pre-commit hooks — passed
- code review — no findings
- public-config security review — no findings after exception-disclosure hardening

[LE-1864]: https://datastax.jira.com/browse/LE-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LE-1934]: https://datastax.jira.com/browse/LE-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ