### PR TITLE
feat(catalog): enforce component policy at runtime

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -16,6 +16,7 @@ from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
     CustomComponentValidationError,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -850,6 +851,13 @@ async def build_public_tmp(
         async with session_scope() as session:
             flow = await session.get(Flow, flow_id)
             if flow and flow.data:
+                # The default anonymous build path sanitizes component code directly
+                # and therefore does not call validate_flow_for_current_settings.
+                # Enforce the exact catalog snapshot after the public-access check
+                # and before any graph is queued or built. The explicit public-custom
+                # opt-in already runs the unified validator inside prepare_public_flow_build.
+                if not settings.allow_public_custom_components:
+                    validate_catalog_policy_for_flow(flow.data)
                 # Block unauthenticated builds of flows that run arbitrary code
                 # (Python interpreter/REPL, legacy Python Code Structured tool,
                 # Smart Transform lambda) or invoke another saved flow (Run Flow,

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -89,6 +89,32 @@ async def test_build_flow_validates_request_data_instead_of_stale_db_flow(
     assert "job_id" in response.json()
 
 
+async def test_build_flow_maps_catalog_policy_validation_to_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    validation_message = "Flow build blocked: catalog policy blocks components: Agent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"api/v1/build/{flow_id}/flow",
+        json={},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"].endswith("Agent")
+
+
 async def test_build_flow_with_frozen_path(client, json_memory_chatbot_no_llm, logged_in_headers):
     """Test building a flow with a frozen path."""
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
@@ -695,7 +721,7 @@ async def test_build_public_tmp_checks_public_access_before_validation(
         raise ValueError(public_access_validation_message)
 
     monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_flow_for_current_settings",
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
         fail_if_validation_runs,
     )
 
@@ -707,6 +733,40 @@ async def test_build_public_tmp_checks_public_access_before_validation(
 
     assert response.status_code == codes.FORBIDDEN
     assert response.json()["detail"] == "Flow is not public"
+
+
+async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_request(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+    validation_message = "Flow build blocked: catalog policy blocks components: SecretComponent"
+
+    def reject_catalog_component(_target):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
+        reject_catalog_component,
+    )
+    client.cookies.set("client_id", "test-catalog-policy-client")
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.BAD_REQUEST
+    assert response.json()["detail"] == "This flow cannot be executed."
+    assert "SecretComponent" not in response.text
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -702,6 +702,30 @@ async def test_successful_run_no_payload(client, simple_api_test, created_api_ke
     assert all(result is not None for result in inner_results), (outputs_dict, output_results_has_results)
 
 
+async def test_run_by_id_maps_catalog_policy_validation_to_bad_request(
+    client, simple_api_test, created_api_key, monkeypatch
+):
+    from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+    validation_message = "Flow build blocked: catalog policy blocks components: ChatInput"
+
+    def reject_catalog_component(_target, **_kwargs):
+        raise CatalogPolicyValidationError(validation_message)
+
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.validate_flow_for_current_settings",
+        reject_catalog_component,
+    )
+
+    response = await client.post(
+        f"/api/v1/run/{simple_api_test['id']}",
+        headers={"x-api-key": created_api_key.api_key},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith("ChatInput")
+
+
 async def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1378,10 +1378,17 @@ class Graph:
             Graph: The created graph.
         """
         from lfx.extension.migration import migrate_flow_payload
-        from lfx.utils.flow_validation import validate_flow_for_current_settings
+        from lfx.services.deps import get_catalog_policy_service
+        from lfx.utils.flow_validation import validate_catalog_policy_for_flow, validate_flow_for_current_settings
 
         if "data" in payload:
             payload = payload["data"]
+        # Catalog identity is the exact, case-sensitive stored node.data.type.
+        # Validate it before extension migration rewrites legacy identifiers.
+        # Reuse this same immutable snapshot below so migrated executable types
+        # are checked against the identical policy view without a TOCTOU gap.
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
+        validate_catalog_policy_for_flow(payload, snapshot=catalog_policy_snapshot)
         # Rewrite legacy component references in place against the append-only
         # extension migration table.  Best-effort: a corrupt table or unmapped
         # reference produces typed errors on the report but never raises, so
@@ -1448,8 +1455,19 @@ class Graph:
         # boundary (middleware or endpoint dependency) so from_payload stays
         # pure deserialization, but a missed endpoint means arbitrary code
         # execution, so we keep this as a safety net.
-        validate_flow_for_current_settings(payload)
+        validate_flow_for_current_settings(payload, catalog_policy_snapshot=catalog_policy_snapshot)
         try:
+            # The extension migrator intentionally rewrites only the nodes at
+            # the payload level it receives, while process_flow later flattens
+            # inlined nested flows for execution. Build that executable view
+            # on a deep copy, migrate it, and enforce the same snapshot so a
+            # nested legacy alias cannot bypass a block on its canonical key.
+            # Migration errors on this policy-only copy remain best-effort and
+            # are not exposed. Skip the work for the default allow-all policy.
+            if catalog_policy_snapshot.blocked_component_keys:
+                effective_catalog_payload = process_flow(payload)
+                migrate_flow_payload(effective_catalog_payload)
+                validate_catalog_policy_for_flow(effective_catalog_payload, snapshot=catalog_policy_snapshot)
             vertices = payload["nodes"]
             edges = payload["edges"]
             graph = cls(flow_id=flow_id, flow_name=flow_name, user_id=user_id, context=context)

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
 from lfx.utils.component_aliases import get_component_type_aliases
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
 
 INITIALIZING_COMPONENT_TEMPLATES_MESSAGE = (
     "Flow build blocked: component templates are still initializing. Please try again in a few seconds."
@@ -57,6 +60,10 @@ class CustomComponentValidationError(ValueError):
     still catch it, but callers can catch this specifically to
     distinguish policy errors from other ValueErrors.
     """
+
+
+class CatalogPolicyValidationError(CustomComponentValidationError):
+    """Raised when a flow contains a component blocked by catalog policy."""
 
 
 class PublicFlowValidationError(CustomComponentValidationError):
@@ -166,6 +173,77 @@ def _extract_flow_data(target: Mapping[str, Any] | Any | None) -> dict[str, Any]
         return _normalize_flow_data(target)
 
     return _normalize_flow_data(_extract_graph_payload(target))
+
+
+def _collect_catalog_component_keys(nodes: Any) -> set[str]:
+    """Collect exact component keys from a graph and its inlined nested flows."""
+    component_keys: set[str] = set()
+    if not isinstance(nodes, list):
+        return component_keys
+
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        node_data = node.get("data")
+        if not isinstance(node_data, Mapping):
+            continue
+
+        component_type = node_data.get("type")
+        if isinstance(component_type, str):
+            component_keys.add(component_type)
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, Mapping):
+            continue
+        nested_flow = node_info.get("flow")
+        if not isinstance(nested_flow, Mapping):
+            continue
+        nested_data = nested_flow.get("data")
+        if not isinstance(nested_data, Mapping):
+            continue
+        component_keys.update(_collect_catalog_component_keys(nested_data.get("nodes")))
+
+    return component_keys
+
+
+def validate_catalog_policy_for_flow(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject a flow containing component keys blocked by the current catalog snapshot.
+
+    Component identity is the exact, case-sensitive ``node.data.type`` value.
+    The immutable snapshot is captured once when the caller does not provide
+    one, so every node in a request is evaluated against the same policy view.
+    """
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.blocked_component_keys:
+        return
+
+    normalized_flow_data = _extract_flow_data(target)
+    if target is not None and normalized_flow_data is None:
+        msg = (
+            "Flow validation failed: could not extract graph data from the provided target. "
+            "Ensure the flow payload or Graph object contains valid graph data."
+        )
+        raise CatalogPolicyValidationError(msg)
+    if not normalized_flow_data:
+        return
+
+    component_keys = _collect_catalog_component_keys(normalized_flow_data.get("nodes"))
+    blocked = snapshot.blocked_components(component_keys)
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Flow build blocked by catalog policy: {blocked_names}")
+    message = f"Flow build blocked: catalog policy blocks components: {blocked_names}"
+    raise CatalogPolicyValidationError(message)
 
 
 def collect_component_hash_lookups(
@@ -479,14 +557,20 @@ def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     return component_cache.type_to_current_hash
 
 
-def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -> None:
-    """Enforce custom-component policy for a payload or graph-like object."""
-    from lfx.services.deps import get_settings_service
+def validate_flow_for_current_settings(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    catalog_policy_snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Enforce catalog and custom-component policy for a payload or graph-like object."""
+    from lfx.services.deps import get_catalog_policy_service, get_settings_service
 
     settings_service = get_settings_service()
     if settings_service is None:
         raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
 
+    if catalog_policy_snapshot is None:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
     settings = settings_service.settings
     allow_custom_components = getattr(settings, "allow_custom_components", True)
     block_code_interpreter_components = getattr(settings, "block_code_interpreter_components", False)
@@ -495,14 +579,18 @@ def validate_flow_for_current_settings(target: Mapping[str, Any] | Any | None) -
     # If a blocking policy is active and we received a target but couldn't extract any flow
     # data from it, fail fast rather than silently skipping validation — the caller passed
     # something we can't verify.
-    if (not allow_custom_components or block_code_interpreter_components) and (
-        target is not None and normalized_flow_data is None
-    ):
+    if (
+        not allow_custom_components
+        or block_code_interpreter_components
+        or bool(catalog_policy_snapshot.blocked_component_keys)
+    ) and (target is not None and normalized_flow_data is None):
         msg = (
             "Flow validation failed: could not extract graph data from the provided target. "
             "Ensure the flow payload or Graph object contains valid graph data."
         )
         raise CustomComponentValidationError(msg)
+
+    validate_catalog_policy_for_flow(normalized_flow_data, snapshot=catalog_policy_snapshot)
 
     if block_code_interpreter_components:
         check_code_execution_components_and_raise(normalized_flow_data)

--- a/src/lfx/tests/unit/graph/test_graph.py
+++ b/src/lfx/tests/unit/graph/test_graph.py
@@ -15,7 +15,8 @@ from lfx.graph.graph.utils import (
 )
 from lfx.graph.vertex.base import Vertex
 from lfx.interface.components import component_cache
-from lfx.utils.flow_validation import CustomComponentValidationError
+from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError, CustomComponentValidationError
 
 # Test cases for the graph module
 
@@ -125,6 +126,110 @@ def test_from_payload_blocks_custom_components_when_disabled(monkeypatch):
 
     with pytest.raises(CustomComponentValidationError, match="custom components are not allowed"):
         Graph.from_payload(_blocked_custom_flow())
+
+
+@pytest.mark.parametrize(
+    "blocked_key",
+    [
+        "DuckDuckGoSearchComponent",
+        "ext:duckduckgo:DuckDuckGoSearchComponent@official",
+    ],
+)
+def test_from_payload_checks_catalog_policy_before_and_after_extension_migration(monkeypatch, blocked_key):
+    class CountingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            return CatalogPolicySnapshot(blocked_component_keys=frozenset({blocked_key}))
+
+    service = CountingCatalogPolicyService()
+    payload = {
+        "nodes": [
+            {
+                "id": "duck-search",
+                "type": "genericNode",
+                "data": {
+                    "id": "duck-search",
+                    "type": "DuckDuckGoSearchComponent",
+                    "node": {"template": {}},
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=blocked_key):
+        Graph.from_payload(payload)
+
+    assert service.snapshot_calls == 1
+
+
+def test_from_payload_checks_canonical_policy_for_nested_legacy_component(monkeypatch):
+    canonical_key = "ext:duckduckgo:DuckDuckGoSearchComponent@official"
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({canonical_key})),
+    )
+    nested_node = {
+        "id": "duck-search",
+        "type": "genericNode",
+        "data": {
+            "id": "duck-search",
+            "type": "DuckDuckGoSearchComponent",
+            "node": {"template": {}},
+        },
+    }
+    payload = {
+        "nodes": [
+            {
+                "id": "group-1",
+                "type": "genericNode",
+                "data": {
+                    "id": "group-1",
+                    "type": "Group",
+                    "node": {
+                        "template": {},
+                        "flow": {
+                            "data": {
+                                "nodes": [nested_node],
+                                "edges": [],
+                            }
+                        },
+                    },
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match=canonical_key):
+        Graph.from_payload(payload)
+
+
+def test_from_payload_catalog_policy_preserves_invalid_payload_error_mapping(monkeypatch):
+    service = SimpleNamespace(
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: _settings_service(allow_custom_components=True),
+    )
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(ValueError, match="Error while creating graph from payload"):
+        Graph.from_payload({"edges": []})
 
 
 def test_find_last_node(grouped_chat_json_flow):

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -6,14 +6,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from lfx.services.catalog_policy import CatalogPolicySnapshot
 from lfx.utils.flow_validation import (
     CODE_EXECUTION_COMPONENT_TYPES,
     FLOW_REFERENCE_COMPONENT_TYPES,
+    CatalogPolicyValidationError,
     CustomComponentValidationError,
     PublicFlowValidationError,
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
+    validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
 )
@@ -77,6 +80,75 @@ def test_validate_flow_for_current_settings_requires_settings_service(monkeypatc
 
     with pytest.raises(RuntimeError, match="Settings service must be initialized"):
         validate_flow_for_current_settings(graph)
+
+
+def _catalog_flow(*component_types: str) -> dict:
+    return {
+        "nodes": [
+            {
+                "id": f"{component_type}-1",
+                "data": {
+                    "id": f"{component_type}-1",
+                    "type": component_type,
+                    "node": {"template": {}},
+                },
+            }
+            for component_type in component_types
+        ],
+        "edges": [],
+    }
+
+
+def test_catalog_policy_validation_blocks_top_level_components_deterministically():
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"Zed", "Agent"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match=r"Agent, Zed$"):
+        validate_catalog_policy_for_flow(_catalog_flow("Zed", "Agent", "Zed"), snapshot=snapshot)
+
+
+def test_catalog_policy_validation_blocks_nested_components():
+    flow = _catalog_flow("Group")
+    flow["nodes"][0]["data"]["node"]["flow"] = {"data": _catalog_flow("NestedBlocked")}
+    snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"NestedBlocked"}))
+
+    with pytest.raises(CatalogPolicyValidationError, match="NestedBlocked"):
+        validate_catalog_policy_for_flow(flow, snapshot=snapshot)
+
+
+def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_allows():
+    validate_catalog_policy_for_flow(
+        _catalog_flow("agent"),
+        snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
+    )
+    validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):
+    class ChangingCatalogPolicyService:
+        def __init__(self):
+            self.snapshot_calls = 0
+
+        @property
+        def snapshot(self):
+            self.snapshot_calls += 1
+            if self.snapshot_calls == 1:
+                return CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"}))
+            return CatalogPolicySnapshot()
+
+    service = ChangingCatalogPolicyService()
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=False,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: service)
+
+    with pytest.raises(CatalogPolicyValidationError, match="Agent"):
+        validate_flow_for_current_settings(_catalog_flow("Agent"))
+
+    assert service.snapshot_calls == 1
 
 
 # --- public-flow component sanitization (H1-3754930 follow-up) --------------------


### PR DESCRIPTION
## Summary

- add exact, recursive catalog-policy validation for flow component types
- reuse one immutable snapshot across stored, migrated, and nested executable identities
- enforce policy in graph construction, authenticated build/run paths, and public builds
- preserve generic public errors and default-allow performance

## Jira

- [LE-1939](https://datastax.jira.com/browse/LE-1939)
- Epic: [LE-1864](https://datastax.jira.com/browse/LE-1864)

## Stack

- Base: `feat/agent-catalog-templates` (#14321)
- This PR should merge after its base PR

## Validation

- LFX flow-validation and graph suites: 95 passed, 1 skipped
- authenticated build, run-by-id, private-access ordering, and public 400 mappings verified
- Ruff and pre-commit hooks passed
- Independent code and security reviews found and closed legacy migration bypasses, then reported no remaining findings

[LE-1939]: https://datastax.jira.com/browse/LE-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LE-1864]: https://datastax.jira.com/browse/LE-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ