### PR TITLE
fix(select): prevent empty asChild slot crash

### DIFF
--- a/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/select-custom.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+
+import { Select, SelectTrigger, SelectValue } from "../select-custom";
+
+describe("SelectTrigger", () => {
+  it("should render without crashing when the icon has no child", () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="Test select">
+          <SelectValue placeholder="Choose an option" />
+        </SelectTrigger>
+      </Select>,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Test select" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/ui/select-custom.tsx
+++ b/src/frontend/src/components/ui/select-custom.tsx
@@ -21,7 +21,7 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild></SelectPrimitive.Icon>
+    <SelectPrimitive.Icon />
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;


### PR DESCRIPTION
## Summary

Fixes a frontend runtime crash caused by rendering an empty Radix `SelectPrimitive.Icon` with the `asChild` property.

## Problem

When loading the collection page on the `release-1.12.0` branch, the frontend entered the application error boundary even though the backend API requests completed successfully.

The browser console reported:

    Primitive.span failed to slot onto its children.
    Expected a single React element child or `Slottable`.

The stack trace pointed to:

    select-custom.tsx
    SelectPrimitive.Icon
    SelectOptions
    SideBarFoldersButtonsComponent

The custom select trigger rendered:

    <SelectPrimitive.Icon asChild></SelectPrimitive.Icon>

Radix `asChild` requires a single valid React element child. Since the component had no child, rendering it caused a runtime exception.

## Fix

Render `SelectPrimitive.Icon` without the invalid empty `asChild` configuration:

    <SelectPrimitive.Icon />

## Validation

- Reproduced the issue on `release-1.12.0`
- Started the backend with `make backend`
- Started the frontend with `make frontend`
- Confirmed backend API requests returned successfully
- Confirmed the browser console stack trace pointed to `select-custom.tsx`
- Confirmed the frontend loaded successfully after applying the change
- Pre-commit checks passed, including Biome and secret detection

## Environment

- macOS arm64
- Node.js v22.23.2
- npm 10.9.8
- Langflow `release-1.12.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display and behavior of icons in select controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->