### PR TITLE
refactor(frontend): add customization seams for telemetry toggle and registration data

### DIFF
--- a/src/frontend/src/customization/components/custom-registration-data.tsx
+++ b/src/frontend/src/customization/components/custom-registration-data.tsx
@@ -1,0 +1,5 @@
+export const CustomRegistrationData = () => {
+  return <></>;
+};
+
+export default CustomRegistrationData;

--- a/src/frontend/src/customization/components/custom-telemetry-toggle.tsx
+++ b/src/frontend/src/customization/components/custom-telemetry-toggle.tsx
@@ -1,0 +1,5 @@
+export const CustomTelemetryToggle = () => {
+  return <></>;
+};
+
+export default CustomTelemetryToggle;

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -8,6 +8,8 @@ import {
   useUpdateUser,
 } from "@/controllers/API/queries/auth";
 import { useGetProfilePicturesQuery } from "@/controllers/API/queries/files";
+import { CustomRegistrationData } from "@/customization/components/custom-registration-data";
+import { CustomTelemetryToggle } from "@/customization/components/custom-telemetry-toggle";
 import { CustomTermsLinks } from "@/customization/components/custom-terms-links";
 import { ENABLE_PROFILE_ICONS } from "@/customization/feature-flags";
 import useAuthStore from "@/stores/authStore";
@@ -168,6 +170,10 @@ export const GeneralPage = () => {
           />
         )}
       </div>
+
+      <CustomTelemetryToggle />
+
+      <CustomRegistrationData />
 
       <CustomTermsLinks />
     </div>


### PR DESCRIPTION
Adds two no-op customization seams to the General settings page so the Desktop distribution can inject its own telemetry toggle and registration-data section without patching OSS code.

## What changed

- New `CustomTelemetryToggle` seam (`src/frontend/src/customization/components/custom-telemetry-toggle.tsx`)
- New `CustomRegistrationData` seam (`src/frontend/src/customization/components/custom-registration-data.tsx`)
- Both rendered in `SettingsPage/pages/GeneralPage`, alongside the existing `CustomTermsLinks` seam

## Why

Desktop needs to surface a telemetry opt-out and registration details in General settings. Following the established customization-seam pattern keeps that override out of the OSS tree — same approach as `custom-terms-links`.

## Impact

None on OSS: both components render `<></>`. No behavior change, no new strings, no API surface, no backend touch. Purely additive.

## Testing

- `biome check` clean on all three touched files
- OSS General settings page renders unchanged (seams are empty fragments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry and registration sections to the General Settings page.
  * Added customizable placeholders for configuring these sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->