### PR TITLE
fix(playground): separate public identity namespaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1467,7 +1467,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_monitor_shared.py",
         "hashed_secret": "f409ce90a1cd144912d1df8620215b2dc9fda731",
         "is_verified": false,
-        "line_number": 306,
+        "line_number": 316,
         "is_secret": false
       }
     ],
@@ -7242,5 +7242,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T22:44:10Z"
+  "generated_at": "2026-07-30T18:50:09Z"
 }

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from fastapi import HTTPException
 from lfx.graph.graph.base import Graph
@@ -171,17 +171,25 @@ def validate_public_files(files: list[str] | None, source_flow_id: uuid.UUID) ->
             raise HTTPException(status_code=400, detail="Invalid filename")
 
 
-def compute_virtual_flow_id(identifier: str | uuid.UUID, flow_id: uuid.UUID) -> uuid.UUID:
+def compute_virtual_flow_id(
+    identifier: str | uuid.UUID,
+    flow_id: uuid.UUID,
+    *,
+    principal_type: Literal["user", "client"] | None = None,
+) -> uuid.UUID:
     """Compute a deterministic virtual flow ID for session/message isolation.
 
     Args:
         identifier: A unique identifier (user_id for authenticated users, client_id for anonymous).
         flow_id: The original flow ID.
+        principal_type: Optional identity domain for public-flow callers. Authenticated
+            user IDs and anonymous client IDs must never share a UUID namespace.
 
     Returns:
         A deterministic UUID v5 derived from the identifier and flow_id.
     """
-    return uuid.uuid5(uuid.NAMESPACE_DNS, f"{identifier}_{flow_id}")
+    namespaced_identifier = f"{principal_type}:{identifier}" if principal_type else str(identifier)
+    return uuid.uuid5(uuid.NAMESPACE_DNS, f"{namespaced_identifier}_{flow_id}")
 
 
 def scope_session_to_namespace(session: str | None, namespace: str) -> str | None:
@@ -250,8 +258,10 @@ async def verify_public_flow_and_get_user(
             raise HTTPException(status_code=403, detail="Flow is not public")
 
     # Use authenticated user_id for deterministic UUID when available, otherwise client_id
-    identifier = str(authenticated_user_id) if authenticated_user_id else client_id
-    new_flow_id = compute_virtual_flow_id(identifier, flow_id)
+    is_authenticated = authenticated_user_id is not None
+    identifier = str(authenticated_user_id) if is_authenticated else client_id
+    principal_type: Literal["user", "client"] = "user" if is_authenticated else "client"
+    new_flow_id = compute_virtual_flow_id(identifier, flow_id, principal_type=principal_type)
 
     # Get the user associated with the flow
     try:

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -257,10 +257,16 @@ async def verify_public_flow_and_get_user(
         if not flow or flow.access_type is not AccessTypeEnum.PUBLIC:
             raise HTTPException(status_code=403, detail="Flow is not public")
 
-    # Use authenticated user_id for deterministic UUID when available, otherwise client_id
-    is_authenticated = authenticated_user_id is not None
-    identifier = str(authenticated_user_id) if is_authenticated else client_id
-    principal_type: Literal["user", "client"] = "user" if is_authenticated else "client"
+    # Use authenticated user_id for deterministic UUID when available, otherwise client_id.
+    # Keep the branches explicit so identifier is non-optional at the UUID boundary.
+    if authenticated_user_id is not None:
+        identifier = str(authenticated_user_id)
+        principal_type: Literal["user", "client"] = "user"
+    else:
+        if client_id is None:
+            raise HTTPException(status_code=400, detail="No client_id cookie found")
+        identifier = client_id
+        principal_type = "client"
     new_flow_id = compute_virtual_flow_id(identifier, flow_id, principal_type=principal_type)
 
     # Get the user associated with the flow

--- a/src/backend/tests/unit/api/v1/test_monitor_shared.py
+++ b/src/backend/tests/unit/api/v1/test_monitor_shared.py
@@ -41,6 +41,16 @@ def test_compute_virtual_flow_id_differs_per_user():
     assert result_a != result_b
 
 
+def test_compute_virtual_flow_id_separates_user_and_client_identity_domains():
+    shared_identifier = uuid.uuid4()
+    flow_id = uuid.uuid4()
+
+    user_namespace = compute_virtual_flow_id(shared_identifier, flow_id, principal_type="user")
+    client_namespace = compute_virtual_flow_id(shared_identifier, flow_id, principal_type="client")
+
+    assert user_namespace != client_namespace
+
+
 def test_compute_virtual_flow_id_differs_per_flow():
     """Same user produces different virtual flow_ids for different flows."""
     user_id = uuid.uuid4()

--- a/src/backend/tests/unit/api/v2/test_workflow_public.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_public.py
@@ -239,7 +239,7 @@ async def test_public_endpoint_namespaces_caller_session(client: AsyncClient, pu
         assert response.status_code == codes.OK
         await _read_stream(response)
 
-    expected_namespace = str(compute_virtual_flow_id(client_id, public_flow_id))
+    expected_namespace = str(compute_virtual_flow_id(client_id, public_flow_id, principal_type="client"))
     sent_inputs = captured["inputs"]
     assert sent_inputs is not None
     assert sent_inputs.session == f"{expected_namespace}:{victim_session}"
@@ -272,7 +272,7 @@ async def test_public_endpoint_uses_virtual_flow_id_for_storage(client: AsyncCli
         assert response.status_code == codes.OK
         await _read_stream(response)
 
-    expected_virtual = compute_virtual_flow_id(client_id, public_flow_id)
+    expected_virtual = compute_virtual_flow_id(client_id, public_flow_id, principal_type="client")
     assert captured["flow_id"] == expected_virtual
     assert captured["source_flow_id"] == public_flow_id
 

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -1172,7 +1172,7 @@ async def test_build_public_tmp_namespaces_caller_session(
     )
     assert response.status_code == codes.OK
 
-    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id, principal_type="client"))
     sent_inputs = captured["inputs"]
     assert sent_inputs is not None
     assert sent_inputs.session == f"{expected_namespace}:{victim_session}"
@@ -1200,7 +1200,7 @@ async def test_build_public_tmp_session_already_namespaced_unchanged(
 
     client_id = "ns-passthrough-client"
     _send_unauthenticated(client, client_id)
-    namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    namespace = str(compute_virtual_flow_id(client_id, flow_id, principal_type="client"))
     already_scoped = f"{namespace}:thread-1"
 
     response = await client.post(
@@ -1316,7 +1316,7 @@ async def test_build_public_tmp_empty_session_is_namespaced(
     )
     assert response.status_code == codes.OK
 
-    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id, principal_type="client"))
     sent_session = captured["inputs"].session
     assert sent_session != ""
     assert sent_session == f"{expected_namespace}:"
@@ -1349,7 +1349,7 @@ async def test_build_public_tmp_authenticated_namespace_uses_user_id(
     )
     assert response.status_code == codes.OK
 
-    expected_namespace = str(compute_virtual_flow_id(active_user.id, flow_id))
+    expected_namespace = str(compute_virtual_flow_id(active_user.id, flow_id, principal_type="user"))
     assert captured["inputs"].session == f"{expected_namespace}:thread-A"
 
 

--- a/src/frontend/src/components/core/playgroundComponent/hooks/use-get-flow-id.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/hooks/use-get-flow-id.test.tsx
@@ -61,7 +61,7 @@ describe("useGetFlowId", () => {
     );
 
     expect(useGetFlowId()).toBe(
-      uuidv5(`${USER_ID}_${REAL_FLOW_ID}`, uuidv5.DNS),
+      uuidv5(`user:${USER_ID}_${REAL_FLOW_ID}`, uuidv5.DNS),
     );
   });
 
@@ -75,7 +75,7 @@ describe("useGetFlowId", () => {
     );
 
     expect(useGetFlowId()).toBe(
-      uuidv5(`${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS),
+      uuidv5(`client:${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS),
     );
   });
 

--- a/src/frontend/src/components/core/playgroundComponent/hooks/use-get-flow-id.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/hooks/use-get-flow-id.tsx
@@ -15,8 +15,8 @@ export const useGetFlowId = () => {
   if (!playgroundPage) return realFlowId;
 
   if (isAuthenticated && autoLogin === false && userData?.id) {
-    return uuidv5(`${userData.id}_${realFlowId}`, uuidv5.DNS);
+    return uuidv5(`user:${userData.id}_${realFlowId}`, uuidv5.DNS);
   }
 
-  return uuidv5(`${clientId}_${realFlowId}`, uuidv5.DNS);
+  return uuidv5(`client:${clientId}_${realFlowId}`, uuidv5.DNS);
 };

--- a/src/frontend/src/modals/IOModal/hooks/__tests__/useGetFlowId.test.ts
+++ b/src/frontend/src/modals/IOModal/hooks/__tests__/useGetFlowId.test.ts
@@ -35,6 +35,16 @@ const REAL_FLOW_ID = "real-flow-id-123";
 const CLIENT_ID = "client-id-456";
 const USER_ID = "user-id-789";
 
+type AuthState = {
+  isAuthenticated: boolean;
+  autoLogin: boolean;
+  userData: { id: string } | null;
+};
+type FlowState = { playgroundPage: boolean };
+type FlowsManagerState = { currentFlowId: string };
+type UtilityState = { clientId: string };
+type StoreSelector<TState> = (state: TState) => unknown;
+
 describe("useGetFlowId", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,9 +56,7 @@ describe("useGetFlowId", () => {
     mockUtilityStore.mockReturnValue(CLIENT_ID); // clientId
     mockAuthStore.mockReturnValue(false); // isAuthenticated (first call)
 
-    // Re-mock to handle multiple selector calls
-    let authCallCount = 0;
-    mockAuthStore.mockImplementation((selector: any) => {
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) => {
       const state = {
         isAuthenticated: false,
         autoLogin: false,
@@ -57,33 +65,39 @@ describe("useGetFlowId", () => {
       return selector(state);
     });
 
-    mockFlowStore.mockImplementation((selector: any) => {
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) => {
       return selector({ playgroundPage: false });
     });
 
-    mockFlowsManagerStore.mockImplementation((selector: any) => {
-      return selector({ currentFlowId: REAL_FLOW_ID });
-    });
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) => {
+        return selector({ currentFlowId: REAL_FLOW_ID });
+      },
+    );
 
-    mockUtilityStore.mockImplementation((selector: any) => {
-      return selector({ clientId: CLIENT_ID });
-    });
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) => {
+        return selector({ clientId: CLIENT_ID });
+      },
+    );
 
     const result = useGetFlowId();
     expect(result).toBe(REAL_FLOW_ID);
   });
 
   it("should_use_client_id_for_uuid_when_anonymous_on_playground", () => {
-    mockFlowStore.mockImplementation((selector: any) =>
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) =>
       selector({ playgroundPage: true }),
     );
-    mockFlowsManagerStore.mockImplementation((selector: any) =>
-      selector({ currentFlowId: REAL_FLOW_ID }),
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) =>
+        selector({ currentFlowId: REAL_FLOW_ID }),
     );
-    mockUtilityStore.mockImplementation((selector: any) =>
-      selector({ clientId: CLIENT_ID }),
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) =>
+        selector({ clientId: CLIENT_ID }),
     );
-    mockAuthStore.mockImplementation((selector: any) =>
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) =>
       selector({
         isAuthenticated: false,
         autoLogin: true,
@@ -92,21 +106,23 @@ describe("useGetFlowId", () => {
     );
 
     const result = useGetFlowId();
-    const expected = uuidv5(`${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
+    const expected = uuidv5(`client:${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
     expect(result).toBe(expected);
   });
 
   it("should_use_user_id_for_uuid_when_authenticated_on_playground", () => {
-    mockFlowStore.mockImplementation((selector: any) =>
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) =>
       selector({ playgroundPage: true }),
     );
-    mockFlowsManagerStore.mockImplementation((selector: any) =>
-      selector({ currentFlowId: REAL_FLOW_ID }),
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) =>
+        selector({ currentFlowId: REAL_FLOW_ID }),
     );
-    mockUtilityStore.mockImplementation((selector: any) =>
-      selector({ clientId: CLIENT_ID }),
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) =>
+        selector({ clientId: CLIENT_ID }),
     );
-    mockAuthStore.mockImplementation((selector: any) =>
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) =>
       selector({
         isAuthenticated: true,
         autoLogin: false,
@@ -115,21 +131,23 @@ describe("useGetFlowId", () => {
     );
 
     const result = useGetFlowId();
-    const expected = uuidv5(`${USER_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
+    const expected = uuidv5(`user:${USER_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
     expect(result).toBe(expected);
   });
 
   it("should_use_client_id_when_autologin_even_if_authenticated", () => {
-    mockFlowStore.mockImplementation((selector: any) =>
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) =>
       selector({ playgroundPage: true }),
     );
-    mockFlowsManagerStore.mockImplementation((selector: any) =>
-      selector({ currentFlowId: REAL_FLOW_ID }),
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) =>
+        selector({ currentFlowId: REAL_FLOW_ID }),
     );
-    mockUtilityStore.mockImplementation((selector: any) =>
-      selector({ clientId: CLIENT_ID }),
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) =>
+        selector({ clientId: CLIENT_ID }),
     );
-    mockAuthStore.mockImplementation((selector: any) =>
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) =>
       selector({
         isAuthenticated: true,
         autoLogin: true,
@@ -138,21 +156,23 @@ describe("useGetFlowId", () => {
     );
 
     const result = useGetFlowId();
-    const expected = uuidv5(`${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
+    const expected = uuidv5(`client:${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
     expect(result).toBe(expected);
   });
 
   it("should_use_client_id_when_user_data_has_no_id", () => {
-    mockFlowStore.mockImplementation((selector: any) =>
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) =>
       selector({ playgroundPage: true }),
     );
-    mockFlowsManagerStore.mockImplementation((selector: any) =>
-      selector({ currentFlowId: REAL_FLOW_ID }),
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) =>
+        selector({ currentFlowId: REAL_FLOW_ID }),
     );
-    mockUtilityStore.mockImplementation((selector: any) =>
-      selector({ clientId: CLIENT_ID }),
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) =>
+        selector({ clientId: CLIENT_ID }),
     );
-    mockAuthStore.mockImplementation((selector: any) =>
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) =>
       selector({
         isAuthenticated: true,
         autoLogin: false,
@@ -161,7 +181,7 @@ describe("useGetFlowId", () => {
     );
 
     const result = useGetFlowId();
-    const expected = uuidv5(`${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
+    const expected = uuidv5(`client:${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
     expect(result).toBe(expected);
   });
 });

--- a/src/frontend/src/modals/IOModal/hooks/__tests__/useGetFlowId.test.ts
+++ b/src/frontend/src/modals/IOModal/hooks/__tests__/useGetFlowId.test.ts
@@ -37,7 +37,7 @@ const USER_ID = "user-id-789";
 
 type AuthState = {
   isAuthenticated: boolean;
-  autoLogin: boolean;
+  autoLogin: boolean | null;
   userData: { id: string } | null;
 };
 type FlowState = { playgroundPage: boolean };
@@ -151,6 +151,31 @@ describe("useGetFlowId", () => {
       selector({
         isAuthenticated: true,
         autoLogin: true,
+        userData: { id: USER_ID },
+      }),
+    );
+
+    const result = useGetFlowId();
+    const expected = uuidv5(`client:${CLIENT_ID}_${REAL_FLOW_ID}`, uuidv5.DNS);
+    expect(result).toBe(expected);
+  });
+
+  it("should_use_client_id_while_autologin_is_unresolved", () => {
+    mockFlowStore.mockImplementation((selector: StoreSelector<FlowState>) =>
+      selector({ playgroundPage: true }),
+    );
+    mockFlowsManagerStore.mockImplementation(
+      (selector: StoreSelector<FlowsManagerState>) =>
+        selector({ currentFlowId: REAL_FLOW_ID }),
+    );
+    mockUtilityStore.mockImplementation(
+      (selector: StoreSelector<UtilityState>) =>
+        selector({ clientId: CLIENT_ID }),
+    );
+    mockAuthStore.mockImplementation((selector: StoreSelector<AuthState>) =>
+      selector({
+        isAuthenticated: true,
+        autoLogin: null,
         userData: { id: USER_ID },
       }),
     );

--- a/src/frontend/src/modals/IOModal/hooks/useGetFlowId.ts
+++ b/src/frontend/src/modals/IOModal/hooks/useGetFlowId.ts
@@ -19,9 +19,9 @@ export const useGetFlowId = () => {
   // Use `autoLogin === false` (not `!autoLogin`) to avoid race condition
   // when autoLogin is still null (unresolved) — treat null same as true.
   if (isAuthenticated && autoLogin === false && userData?.id) {
-    return uuidv5(`${userData.id}_${realFlowId}`, uuidv5.DNS);
+    return uuidv5(`user:${userData.id}_${realFlowId}`, uuidv5.DNS);
   }
 
   // Anonymous/auto-login users: use client_id (original behavior)
-  return uuidv5(`${clientId}_${realFlowId}`, uuidv5.DNS);
+  return uuidv5(`client:${clientId}_${realFlowId}`, uuidv5.DNS);
 };

--- a/src/frontend/src/pages/Playground/PlaygroundPage.stories.tsx
+++ b/src/frontend/src/pages/Playground/PlaygroundPage.stories.tsx
@@ -74,7 +74,7 @@ const withQueryClient = (
 
     useEffect(() => {
       const clientId = "test-client-id";
-      const computedFlowId = uuidv5(`${clientId}_${flowId}`, uuidv5.DNS);
+      const computedFlowId = uuidv5(`client:${clientId}_${flowId}`, uuidv5.DNS);
 
       queryClient.setQueryData(
         [
@@ -223,7 +223,7 @@ const withPlaygroundPageSetup = (
           useUtilityStore.getState().clientId || "test-client-id";
         const playgroundPage = useFlowStore.getState().playgroundPage;
         const computedFlowId = playgroundPage
-          ? uuidv5(`${clientId}_${realFlowId}`, uuidv5.DNS)
+          ? uuidv5(`client:${clientId}_${realFlowId}`, uuidv5.DNS)
           : realFlowId;
         const sessionId = session || computedFlowId;
 

--- a/src/frontend/src/stores/__tests__/flowStore.test.ts
+++ b/src/frontend/src/stores/__tests__/flowStore.test.ts
@@ -1276,6 +1276,34 @@ describe("useFlowStore", () => {
         }),
       );
     });
+
+    it("uses the authenticated user virtual flow id for the active building session", async () => {
+      const expectedFlowId = uuidv5("user:user-123_flow-abc", uuidv5.DNS);
+
+      useAuthStore.setState({
+        isAuthenticated: true,
+        autoLogin: false,
+        userData: { id: "user-123" },
+      });
+      useFlowStore.setState({ playgroundPage: true });
+      mockedRunFlow.mockImplementation(async () => {
+        const state = useFlowStore.getState();
+        expect(state.buildingFlowId).toBe(expectedFlowId);
+        expect(state.buildingSessionId).toBe("session-123");
+        useFlowStore.setState({ buildInfo: null });
+      });
+
+      await useFlowStore.getState().buildFlow({
+        session: "session-123",
+      });
+
+      expect(mockedRunFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flowId: "flow-abc",
+          threadId: "session-123",
+        }),
+      );
+    });
   });
 
   describe("setNode broken-edge warning", () => {

--- a/src/frontend/src/stores/__tests__/flowStore.test.ts
+++ b/src/frontend/src/stores/__tests__/flowStore.test.ts
@@ -1249,7 +1249,7 @@ describe("useFlowStore", () => {
     });
 
     it("uses the public playground virtual flow id for the active building session", async () => {
-      const expectedFlowId = uuidv5("client-123_flow-abc", uuidv5.DNS);
+      const expectedFlowId = uuidv5("client:client-123_flow-abc", uuidv5.DNS);
 
       useUtilityStore.setState({ clientId: "client-123" });
       useAuthStore.setState({

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -923,13 +923,17 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     let buildingFlowId = currentFlow!.id;
     if (get().playgroundPage) {
       const authState = useAuthStore.getState();
+      const authenticatedVisitorId =
+        authState.isAuthenticated && authState.autoLogin === false
+          ? authState.userData?.id
+          : undefined;
       const visitorId =
-        authState.isAuthenticated &&
-        authState.autoLogin === false &&
-        authState.userData?.id
-          ? authState.userData.id
-          : useUtilityStore.getState().clientId;
-      buildingFlowId = uuidv5(`${visitorId}_${currentFlow!.id}`, uuidv5.DNS);
+        authenticatedVisitorId ?? useUtilityStore.getState().clientId;
+      const principalType = authenticatedVisitorId ? "user" : "client";
+      buildingFlowId = uuidv5(
+        `${principalType}:${visitorId}_${currentFlow!.id}`,
+        uuidv5.DNS,
+      );
     }
     get().setBuildingSession(buildingFlowId, session ?? null);
 


### PR DESCRIPTION
## Summary

- domain-separate authenticated user IDs from anonymous client IDs in public-flow UUID derivation
- update both playground hooks, active build-session state, and Storybook setup to match the backend
- intentionally rotate existing public virtual namespaces so anonymous identifiers cannot collide with user identities

## Validation

- 7 backend namespace and public endpoint regressions
- 61 frontend hook and flow-store tests
- Ruff, Biome, secret baseline, and repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session and flow ID isolation by separating authenticated user and anonymous client identity namespaces.
  * Prevented identical identifiers from producing shared flow sessions across different identity types.
* **Tests**
  * Updated coverage for user/client flow ID separation and public playground session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->