### PR TITLE
fix(security): enforce SSRF policy for unified models

### DIFF
--- a/src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py
+++ b/src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -42,15 +42,20 @@ def test_foundry_embedding_kwargs_use_endpoint_when_api_base_blank(unified_model
 
 def test_foundry_embedding_kwargs_prefer_explicit_api_base(unified_models_module):
     override = "https://override.example/openai/v1"
-    composed = _compose_embedding_kwargs(
-        "Azure AI Foundry",
-        "text-embedding-3-small",
-        uuid4(),
-        unified_models_module,
-        selected_provider="Azure AI Foundry",
-        api_base=override,
-    )
+    with patch(
+        "lfx.base.models.unified_models.instantiation.ssrf_protected_openai_clients_for_url",
+        return_value={},
+    ) as protect_clients:
+        composed = _compose_embedding_kwargs(
+            "Azure AI Foundry",
+            "text-embedding-3-small",
+            uuid4(),
+            unified_models_module,
+            selected_provider="Azure AI Foundry",
+            api_base=override,
+        )
 
     assert composed is not None
     _, kwargs = composed
     assert kwargs["base_url"] == override
+    protect_clients.assert_called_once_with(override)

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -609,13 +609,16 @@ def test_get_embeddings_populates_available_models_from_all_configured_providers
 )
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
+@patch("lfx.base.models.unified_models.instantiation.ssrf_protected_openai_clients_for_url")
 def test_get_embeddings_openai_api_base_env_fallback(
+    mock_ssrf_protection,
     mock_get_class,
     mock_get_api_key,
     monkeypatch,
     env_values,
     expected_base_url,
 ):
+    mock_ssrf_protection.return_value = {}
     mock_get_api_key.return_value = "sk-test"
     mock_embedding_class = MagicMock()
     mock_get_class.return_value = mock_embedding_class
@@ -628,6 +631,7 @@ def test_get_embeddings_openai_api_base_env_fallback(
 
     kwargs = mock_embedding_class.call_args.kwargs
     assert kwargs["base_url"] == expected_base_url
+    mock_ssrf_protection.assert_called_once_with(expected_base_url)
 
 
 @pytest.mark.parametrize("variable_name", ["OPENAI_EMBEDDINGS_API_BASE", "OPENAI_API_BASE"])
@@ -652,7 +656,11 @@ def test_get_embeddings_openai_api_base_env_fallback_can_be_disabled(
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
-def test_get_embeddings_openai_explicit_api_base_overrides_env(mock_get_class, mock_get_api_key, monkeypatch):
+@patch("lfx.base.models.unified_models.instantiation.ssrf_protected_openai_clients_for_url")
+def test_get_embeddings_openai_explicit_api_base_overrides_env(
+    mock_ssrf_protection, mock_get_class, mock_get_api_key, monkeypatch
+):
+    mock_ssrf_protection.return_value = {}
     mock_get_api_key.return_value = "sk-test"
     mock_embedding_class = MagicMock()
     mock_get_class.return_value = mock_embedding_class
@@ -667,6 +675,7 @@ def test_get_embeddings_openai_explicit_api_base_overrides_env(mock_get_class, m
 
     kwargs = mock_embedding_class.call_args.kwargs
     assert kwargs["base_url"] == "http://component.example/v1"
+    mock_ssrf_protection.assert_called_once_with("http://component.example/v1")
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
@@ -752,7 +761,9 @@ def test_get_embeddings_ollama_defaults_to_localhost(mock_get_vars, mock_get_cla
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 @patch("lfx.base.models.unified_models.get_all_variables_for_provider")
-def test_get_embeddings_ollama_custom_base_url(mock_get_vars, mock_get_class, mock_get_api_key):
+@patch("lfx.base.models.unified_models.instantiation.ssrf_protected_httpx_client_kwargs_for_url")
+def test_get_embeddings_ollama_custom_base_url(mock_ssrf_protection, mock_get_vars, mock_get_class, mock_get_api_key):
+    mock_ssrf_protection.return_value = ({}, {})
     mock_get_api_key.return_value = None
     mock_get_vars.return_value = {}
     mock_embedding_class = MagicMock()
@@ -771,12 +782,16 @@ def test_get_embeddings_ollama_custom_base_url(mock_get_vars, mock_get_class, mo
 
     kwargs = mock_embedding_class.call_args.kwargs
     assert kwargs.get("base_url") == "http://custom-host:11434"
+    mock_ssrf_protection.assert_called_once_with("http://custom-host:11434")
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 @patch("lfx.base.models.unified_models.get_all_variables_for_provider")
-def test_get_embeddings_watsonx_url_and_project_id(mock_get_vars, mock_get_class, mock_get_api_key):
+@patch("lfx.base.models.unified_models.instantiation.validate_url_for_ssrf_or_raise")
+def test_get_embeddings_watsonx_url_and_project_id(
+    mock_ssrf_validation, mock_get_vars, mock_get_class, mock_get_api_key
+):
     mock_get_api_key.return_value = "ibm-key"
     mock_get_vars.return_value = {}
     mock_embedding_class = MagicMock()
@@ -806,12 +821,16 @@ def test_get_embeddings_watsonx_url_and_project_id(mock_get_vars, mock_get_class
     kwargs = mock_embedding_class.call_args.kwargs
     assert kwargs.get("url") == "https://us-south.ml.cloud.ibm.com"
     assert kwargs.get("project_id") == "proj-123"
+    mock_ssrf_validation.assert_called_once_with("https://us-south.ml.cloud.ibm.com")
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 @patch("lfx.base.models.unified_models.get_all_variables_for_provider")
-def test_get_embeddings_watsonx_truncate_and_input_text(mock_get_vars, mock_get_class, mock_get_api_key):
+@patch("lfx.base.models.unified_models.instantiation.validate_url_for_ssrf_or_raise")
+def test_get_embeddings_watsonx_truncate_and_input_text(
+    mock_ssrf_validation, mock_get_vars, mock_get_class, mock_get_api_key
+):
     """truncate_input_tokens and input_text should be passed as WatsonX params dict."""
     mock_get_api_key.return_value = "ibm-key"
     mock_get_vars.return_value = {}
@@ -851,12 +870,16 @@ def test_get_embeddings_watsonx_truncate_and_input_text(mock_get_vars, mock_get_
     return_opts = [v for v in params.values() if isinstance(v, dict) and "input_text" in v]
     assert return_opts, "Expected return_options with input_text in params"
     assert return_opts[0]["input_text"] is True
+    mock_ssrf_validation.assert_called_once_with("https://us-south.ml.cloud.ibm.com")
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 @patch("lfx.base.models.unified_models.get_all_variables_for_provider")
-def test_get_embeddings_watsonx_no_params_when_not_provided(mock_get_vars, mock_get_class, mock_get_api_key):
+@patch("lfx.base.models.unified_models.instantiation.validate_url_for_ssrf_or_raise")
+def test_get_embeddings_watsonx_no_params_when_not_provided(
+    mock_ssrf_validation, mock_get_vars, mock_get_class, mock_get_api_key
+):
     """When truncate_input_tokens and input_text are not provided, params should not be set."""
     mock_get_api_key.return_value = "ibm-key"
     mock_get_vars.return_value = {}
@@ -886,6 +909,7 @@ def test_get_embeddings_watsonx_no_params_when_not_provided(mock_get_vars, mock_
 
     kwargs = mock_embedding_class.call_args.kwargs
     assert "params" not in kwargs
+    mock_ssrf_validation.assert_called_once_with("https://us-south.ml.cloud.ibm.com")
 
 
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -11,6 +11,11 @@ from lfx.base.models.model_utils import _to_str, inject_custom_enabled_models, r
 from lfx.log.logger import logger
 from lfx.services.variable.request_scope import is_env_fallback_disabled
 from lfx.utils.async_helpers import run_until_complete
+from lfx.utils.ssrf_httpx import (
+    ssrf_protected_httpx_client_kwargs_for_url,
+    ssrf_protected_openai_clients_for_url,
+    validate_url_for_ssrf_or_raise,
+)
 
 from .class_registry import EMBEDDING_PARAM_MAPPINGS, EMBEDDING_PROVIDER_CLASS_MAPPING
 from .credentials import _fetch_enabled_providers_for_user, _get_model_status, model_status_contains
@@ -72,6 +77,38 @@ def _apply_registered_provider_connection(provider: str, user_id: UUID | str | N
         kwargs[langchain_param] = transform_localhost_url(value) if langchain_param == "base_url" else value
     if default_headers:
         kwargs.setdefault("default_headers", {}).update(default_headers)
+
+
+def _protect_model_connection(
+    kwargs: dict[str, Any],
+    *,
+    model_class_name: str,
+    url_param: str | None,
+) -> None:
+    """Enforce connector SSRF policy on the final provider endpoint.
+
+    OpenAI-compatible and Ollama clients expose HTTP-client hooks, so use the
+    repository's DNS-pinned transports for those classes. Other provider SDKs
+    do not expose a compatible transport seam; validate their effective URL
+    before constructing the SDK client.
+    """
+    effective_url = _to_str(kwargs.get(url_param)) if url_param else None
+    if not effective_url:
+        return
+
+    if model_class_name in {"ChatOpenAI", "OpenAIEmbeddings"}:
+        kwargs.update(ssrf_protected_openai_clients_for_url(effective_url))
+        return
+
+    if model_class_name in {"ChatOllama", "OllamaEmbeddings"}:
+        sync_client_kwargs, async_client_kwargs = ssrf_protected_httpx_client_kwargs_for_url(effective_url)
+        if sync_client_kwargs:
+            kwargs["sync_client_kwargs"] = sync_client_kwargs
+        if async_client_kwargs:
+            kwargs["async_client_kwargs"] = async_client_kwargs
+        return
+
+    validate_url_for_ssrf_or_raise(effective_url)
 
 
 def get_llm(
@@ -263,6 +300,7 @@ def get_llm(
         kwargs["stream_usage"] = True
 
     # Add provider-specific parameters
+    connection_url_param: str | None = None
     if provider in {"IBM WatsonX", "IBM watsonx.ai"}:
         # For watsonx, url and project_id are required parameters
         # Try database first, then component values, then environment variables
@@ -291,6 +329,7 @@ def get_llm(
             # Both provided - add them to kwargs
             kwargs[url_param] = watsonx_url_value
             kwargs[project_id_param] = watsonx_project_id_value
+            connection_url_param = url_param
         elif has_url or has_project_id:
             # Only one provided - this is a misconfiguration
             missing = "project ID (WATSONX_PROJECT_ID)" if has_url else "URL (WATSONX_URL)"
@@ -317,6 +356,7 @@ def get_llm(
         )
         if ollama_base_url_value:
             kwargs[base_url_param] = ollama_base_url_value
+            connection_url_param = base_url_param
     elif provider == "OpenAI":
         from lfx.utils.util import transform_localhost_url
 
@@ -324,6 +364,7 @@ def get_llm(
         openai_base_url_value = provider_vars.get("OPENAI_BASE_URL") or _env_if_allowed("OPENAI_BASE_URL")
         if openai_base_url_value:
             kwargs["base_url"] = transform_localhost_url(openai_base_url_value)
+            connection_url_param = "base_url"
     elif provider == "OpenRouter":
         # OpenRouter speaks the OpenAI wire format. Point ChatOpenAI at the
         # OpenRouter base URL (declared in MODEL_PROVIDER_METADATA) and forward
@@ -360,20 +401,34 @@ def get_llm(
             )
             raise ValueError(msg)
         kwargs["endpoint"] = endpoint_value
+        connection_url_param = "endpoint"
         # Bound hung/blackholed endpoints the same way live discovery does.
         kwargs["request_timeout"] = AZURE_AI_FOUNDRY_REQUEST_TIMEOUT
     elif is_registered(provider):
         # Bundle-contributed provider: apply its declared connection variables
         # (base_url, attribution headers, etc.) generically from its metadata.
         _apply_registered_provider_connection(provider, user_id, kwargs)
+        if kwargs.get("base_url"):
+            connection_url_param = "base_url"
 
     # Apply overrides discovered from a prior failed call to this model (cache)
     # plus any the caller passed for this attempt (error-driven remediation).
     from lfx.base.models.model_remediation import cached_overrides
 
-    kwargs.update(cached_overrides(provider, model_name))
+    remediation_overrides = cached_overrides(provider, model_name)
+    kwargs.update(remediation_overrides)
     if overrides:
         kwargs.update(overrides)
+    if model_class_name in {"ChatOpenAI", "ChatOllama"} and (
+        "base_url" in remediation_overrides or (overrides and "base_url" in overrides)
+    ):
+        connection_url_param = "base_url"
+
+    _protect_model_connection(
+        kwargs,
+        model_class_name=model_class_name,
+        url_param=connection_url_param,
+    )
 
     try:
         return model_class(**kwargs)
@@ -563,6 +618,7 @@ def _compose_embedding_kwargs(
             )
 
     kwargs: dict[str, Any] = {}
+    connection_url_param: str | None = None
     if "model" in param_mapping:
         kwargs[param_mapping["model"]] = model_name
     elif "model_id" in param_mapping:
@@ -605,7 +661,8 @@ def _compose_embedding_kwargs(
 
         if has_url and has_project_id:
             if "url" in param_mapping:
-                kwargs[param_mapping["url"]] = url_value
+                connection_url_param = param_mapping["url"]
+                kwargs[connection_url_param] = url_value
             if "project_id" in param_mapping:
                 kwargs[param_mapping["project_id"]] = pid_value
         elif has_url or has_project_id:
@@ -647,13 +704,16 @@ def _compose_embedding_kwargs(
             or _env_if_allowed("OLLAMA_BASE_URL")
             or "http://localhost:11434"
         )
-        kwargs[param_mapping["base_url"]] = base_url_value
+        connection_url_param = param_mapping["base_url"]
+        kwargs[connection_url_param] = base_url_value
 
     # Bundle-contributed provider: apply its declared connection variables
     # (e.g. an OpenAI-compatible base_url) generically from its metadata. Runs
     # before the optional-params loop so an explicit api_base still wins.
     if is_registered(provider):
         _apply_registered_provider_connection(provider, user_id, kwargs)
+        if kwargs.get("base_url"):
+            connection_url_param = "base_url"
 
     for param_name, param_value in optional_params.items():
         if param_value is None:
@@ -669,6 +729,8 @@ def _compose_embedding_kwargs(
             kwargs[param_mapping[param_name]] = {"timeout": param_value}
         elif param_name in param_mapping:
             kwargs[param_mapping[param_name]] = param_value
+            if param_name == "api_base":
+                connection_url_param = param_mapping[param_name]
 
     # Apply Foundry endpoint last so a blank component api_base cannot wipe it.
     if provider == "Azure AI Foundry" and "api_base" in param_mapping:
@@ -686,7 +748,14 @@ def _compose_embedding_kwargs(
                 )
                 raise ValueError(msg)
             return None
-        kwargs[param_mapping["api_base"]] = endpoint_value
+        connection_url_param = param_mapping["api_base"]
+        kwargs[connection_url_param] = endpoint_value
+
+    _protect_model_connection(
+        kwargs,
+        model_class_name=embedding_class_name,
+        url_param=connection_url_param,
+    )
 
     return embedding_class, kwargs
 

--- a/src/lfx/src/lfx/utils/ssrf_httpx.py
+++ b/src/lfx/src/lfx/utils/ssrf_httpx.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
 
 import httpx
 
@@ -36,9 +35,14 @@ def _raise_if_following_redirects(request_kwargs: dict[str, Any]) -> None:
         raise SSRFProtectionError(msg)
 
 
+def _transport_host(url: str) -> str:
+    """Return the IDNA-normalized host httpx/httpcore uses for connections."""
+    return httpx.URL(url).raw_host.decode("ascii")
+
+
 def _async_client_for_url(url: str, validated_ips: list[str]) -> httpx.AsyncClient:
     if is_ssrf_protection_enabled() and validated_ips:
-        hostname = urlparse(url).hostname
+        hostname = _transport_host(url)
         if hostname:
             return create_ssrf_protected_client(hostname=hostname, validated_ips=validated_ips)
     return httpx.AsyncClient()
@@ -46,7 +50,7 @@ def _async_client_for_url(url: str, validated_ips: list[str]) -> httpx.AsyncClie
 
 def _sync_client_for_url(url: str, validated_ips: list[str]) -> httpx.Client:
     if is_ssrf_protection_enabled() and validated_ips:
-        hostname = urlparse(url).hostname
+        hostname = _transport_host(url)
         if hostname:
             return create_ssrf_protected_sync_client(hostname=hostname, validated_ips=validated_ips)
     return httpx.Client()
@@ -66,7 +70,7 @@ def ssrf_protected_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any]
     sync_kwargs: dict[str, Any] = {"follow_redirects": False}
     async_kwargs: dict[str, Any] = {"follow_redirects": False}
 
-    hostname = urlparse(validated_url).hostname
+    hostname = _transport_host(validated_url)
     if hostname and validated_ips:
         ip_list = list(validated_ips)
         sync_kwargs["transport"] = SSRFProtectedSyncTransport(pinned_ips={hostname: ip_list})

--- a/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
+++ b/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
@@ -242,6 +242,7 @@ def _build_azure_ai_foundry_model_selection() -> list[dict]:
 
 def test_get_llm_wires_azure_ai_foundry_endpoint_and_credential():
     from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models import instantiation
     from lfx.base.models.unified_models.instantiation import get_llm
 
     captured_kwargs: dict = {}
@@ -262,6 +263,7 @@ def test_get_llm_wires_azure_ai_foundry_endpoint_and_credential():
             "get_all_variables_for_provider",
             return_value={"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1"},
         ),
+        patch.object(instantiation, "validate_url_for_ssrf_or_raise"),
     ):
         get_llm(_build_azure_ai_foundry_model_selection(), user_id="user-1", stream=False)
 

--- a/src/lfx/tests/unit/base/models/test_get_llm_ollama_base_url.py
+++ b/src/lfx/tests/unit/base/models/test_get_llm_ollama_base_url.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import lfx.base.models.unified_models as unified_models_module
 import pytest
+from lfx.base.models.unified_models import instantiation
 from lfx.base.models.unified_models.instantiation import get_llm
 
 
@@ -69,6 +70,7 @@ def test_get_llm_resolves_ollama_base_url_by_precedence(
         patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
         patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
         patch.object(unified_models_module, "get_all_variables_for_provider", return_value=provider_vars),
+        patch.object(instantiation, "ssrf_protected_httpx_client_kwargs_for_url", return_value=({}, {})),
     ):
         get_llm(
             _ollama_model_selection(),

--- a/src/lfx/tests/unit/base/models/test_get_llm_watsonx_params.py
+++ b/src/lfx/tests/unit/base/models/test_get_llm_watsonx_params.py
@@ -58,6 +58,7 @@ def _raw_watsonx_selection() -> list[dict]:
 
 def _build_llm_from_raw_selection() -> dict:
     from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models import instantiation
     from lfx.base.models.unified_models.instantiation import get_llm
 
     fake_cls, captured = _capture_factory()
@@ -77,6 +78,7 @@ def _build_llm_from_raw_selection() -> dict:
                 "WATSONX_PROJECT_ID": "proj-123",
             },
         ),
+        patch.object(instantiation, "validate_url_for_ssrf_or_raise"),
     ):
         get_llm(_raw_watsonx_selection(), user_id=None, stream=True)
 

--- a/src/lfx/tests/unit/base/models/test_provider_registry.py
+++ b/src/lfx/tests/unit/base/models/test_provider_registry.py
@@ -25,6 +25,7 @@ from lfx.base.models.unified_models import (
     get_model_provider_metadata,
     get_model_provider_variable_mapping,
     get_model_providers,
+    instantiation,
     validate_model_provider_key,
 )
 from lfx.base.models.unified_models.class_registry import (
@@ -271,6 +272,7 @@ def test_get_llm_applies_registered_provider_base_url(monkeypatch):
     monkeypatch.setattr(
         um, "get_all_variables_for_provider", lambda *_a, **_k: {"FAKECO_API_BASE": "http://vllm.example:8000"}
     )
+    monkeypatch.setattr(instantiation, "ssrf_protected_openai_clients_for_url", lambda _url: {})
 
     model_selection = [
         {
@@ -322,6 +324,7 @@ def test_get_llm_real_resolver_uses_placeholder_not_base_url(monkeypatch):
     # Base URL comes from the env via the connection handler; do NOT patch the
     # api-key resolver -- that is the path under test.
     monkeypatch.setattr(um, "get_all_variables_for_provider", lambda *_a, **_k: {})
+    monkeypatch.setattr(instantiation, "ssrf_protected_openai_clients_for_url", lambda _url: {})
 
     model_selection = [{"name": "m1", "provider": "FakeCo", "metadata": {"model_class": "ChatOpenAI"}}]
     get_llm(model_selection, user_id=None)
@@ -354,6 +357,7 @@ def test_get_embeddings_applies_registered_provider_base_url_and_key(monkeypatch
     monkeypatch.setattr(
         um, "get_all_variables_for_provider", lambda *_a, **_k: {"FAKECO_API_BASE": "http://vllm.example:8000"}
     )
+    monkeypatch.setattr(instantiation, "ssrf_protected_openai_clients_for_url", lambda _url: {})
 
     model_selection = [
         {

--- a/src/lfx/tests/unit/base/models/test_unified_model_ssrf.py
+++ b/src/lfx/tests/unit/base/models/test_unified_model_ssrf.py
@@ -1,0 +1,234 @@
+"""SSRF regression coverage for unified model and embedding instantiation."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from lfx.base.models import unified_models as unified_models_module
+from lfx.base.models.unified_models import instantiation
+
+
+def _capture_factory():
+    captured: dict = {}
+
+    class FakeModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    return FakeModel, captured
+
+
+def _model_selection(provider: str, model_class: str, **metadata) -> list[dict]:
+    return [
+        {
+            "name": "test-model",
+            "provider": provider,
+            "metadata": {
+                "model_class": model_class,
+                "model_name_param": "model",
+                "api_key_param": "api_key",  # pragma: allowlist secret
+                **metadata,
+            },
+        }
+    ]
+
+
+def _embedding_selection(provider: str, embedding_class: str, param_mapping: dict[str, str]) -> list[dict]:
+    return [
+        {
+            "name": "test-embedding",
+            "provider": provider,
+            "metadata": {
+                "embedding_class": embedding_class,
+                "param_mapping": param_mapping,
+            },
+        }
+    ]
+
+
+def _blocked_connector_policy() -> dict[str, str]:
+    return {
+        "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+    }
+
+
+def test_get_llm_blocks_disallowed_ollama_loopback_before_model_construction():
+    fake_cls, captured = _capture_factory()
+
+    with (
+        patch.dict(os.environ, _blocked_connector_policy()),
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
+        patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        pytest.raises(ValueError, match=r"SSRF Protection:.*127\.0\.0\.1.*blocked"),
+    ):
+        instantiation.get_llm(
+            _model_selection("Ollama", "ChatOllama", base_url_param="base_url"),
+            user_id="user-1",
+            ollama_base_url="http://127.0.0.1:17864",
+        )
+
+    assert captured == {}
+
+
+def test_get_embeddings_blocks_disallowed_ollama_loopback_before_model_construction():
+    fake_cls, captured = _capture_factory()
+
+    with (
+        patch.dict(os.environ, _blocked_connector_policy()),
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
+        patch.object(unified_models_module, "get_embedding_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        patch.object(instantiation, "_build_available_embedding_models", return_value={}),
+        pytest.raises(ValueError, match=r"SSRF Protection:.*127\.0\.0\.1.*blocked"),
+    ):
+        instantiation.get_embeddings(
+            _embedding_selection(
+                "Ollama",
+                "OllamaEmbeddings",
+                {"model": "model", "base_url": "base_url"},
+            ),
+            user_id="user-1",
+            ollama_base_url="http://127.0.0.1:17864",
+        )
+
+    assert captured == {}
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {
+            "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+            "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+            "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "true",
+        },
+        {
+            "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+            "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "false",
+            "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+        },
+    ],
+)
+def test_get_llm_preserves_explicit_ollama_ssrf_opt_outs(policy):
+    fake_cls, captured = _capture_factory()
+
+    with (
+        patch.dict(os.environ, policy),
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value=None),
+        patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+    ):
+        instantiation.get_llm(
+            _model_selection("Ollama", "ChatOllama", base_url_param="base_url"),
+            user_id="user-1",
+            ollama_base_url="http://127.0.0.1:11434",
+        )
+
+    assert captured["base_url"] == "http://127.0.0.1:11434"
+    assert captured["sync_client_kwargs"] == {"follow_redirects": False}
+    assert captured["async_client_kwargs"] == {"follow_redirects": False}
+
+
+def test_get_llm_protects_final_openai_base_url_after_overrides():
+    fake_cls, captured = _capture_factory()
+
+    with (
+        patch.dict(os.environ, _blocked_connector_policy()),
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value="test-key"),
+        patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        pytest.raises(ValueError, match=r"SSRF Protection:.*169\.254\.169\.254.*blocked"),
+    ):
+        instantiation.get_llm(
+            _model_selection("OpenAI", "ChatOpenAI"),
+            user_id="user-1",
+            overrides={"base_url": "http://169.254.169.254/latest/meta-data/"},
+        )
+
+    assert captured == {}
+
+
+def test_get_llm_injects_protected_openai_clients_for_custom_base_url():
+    fake_cls, captured = _capture_factory()
+    protected_clients = {"http_client": object(), "http_async_client": object()}
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value="test-key"),
+        patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
+        patch.object(
+            unified_models_module,
+            "get_all_variables_for_provider",
+            return_value={"OPENAI_BASE_URL": "https://models.example/v1"},
+        ),
+        patch.object(
+            instantiation,
+            "ssrf_protected_openai_clients_for_url",
+            return_value=protected_clients,
+            create=True,
+        ) as protect_clients,
+    ):
+        instantiation.get_llm(_model_selection("OpenAI", "ChatOpenAI"), user_id="user-1")
+
+    protect_clients.assert_called_once_with("https://models.example/v1")
+    assert captured["http_client"] is protected_clients["http_client"]
+    assert captured["http_async_client"] is protected_clients["http_async_client"]
+
+
+def test_get_embeddings_injects_protected_openai_clients_for_custom_base_url():
+    fake_cls, captured = _capture_factory()
+    protected_clients = {"http_client": object(), "http_async_client": object()}
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value="test-key"),
+        patch.object(unified_models_module, "get_embedding_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        patch.object(instantiation, "_build_available_embedding_models", return_value={}),
+        patch.object(
+            instantiation,
+            "ssrf_protected_openai_clients_for_url",
+            return_value=protected_clients,
+            create=True,
+        ) as protect_clients,
+    ):
+        instantiation.get_embeddings(
+            _embedding_selection(
+                "OpenAI",
+                "OpenAIEmbeddings",
+                {"model": "model", "api_key": "api_key", "api_base": "base_url"},  # pragma: allowlist secret
+            ),
+            user_id="user-1",
+            api_base="https://embeddings.example/v1",
+        )
+
+    protect_clients.assert_called_once_with("https://embeddings.example/v1")
+    assert captured["http_client"] is protected_clients["http_client"]
+    assert captured["http_async_client"] is protected_clients["http_async_client"]
+
+
+def test_get_llm_validates_watsonx_url_before_model_construction():
+    fake_cls, captured = _capture_factory()
+
+    with (
+        patch.object(unified_models_module, "get_api_key_for_provider", return_value="test-key"),
+        patch.object(unified_models_module, "get_model_class", return_value=fake_cls),
+        patch.object(unified_models_module, "get_all_variables_for_provider", return_value={}),
+        patch.object(
+            instantiation,
+            "validate_url_for_ssrf_or_raise",
+            create=True,
+        ) as validate_url,
+    ):
+        instantiation.get_llm(
+            _model_selection("IBM WatsonX", "ChatWatsonx"),
+            user_id="user-1",
+            watsonx_url="https://us-south.ml.cloud.ibm.com",
+            watsonx_project_id="project-1",
+        )
+
+    validate_url.assert_called_once_with("https://us-south.ml.cloud.ibm.com")
+    assert captured["url"] == "https://us-south.ml.cloud.ibm.com"

--- a/src/lfx/tests/unit/base/models/test_unified_model_status_identity.py
+++ b/src/lfx/tests/unit/base/models/test_unified_model_status_identity.py
@@ -253,6 +253,7 @@ def test_legacy_name_normalization_preserves_first_provider():
 
 def test_reasoning_model_instantiation_omits_temperature_and_preserves_max_tokens():
     from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models import instantiation
     from lfx.base.models.unified_models.instantiation import get_llm
 
     captured: dict = {}
@@ -276,6 +277,7 @@ def test_reasoning_model_instantiation_omits_temperature_and_preserves_max_token
             "get_all_variables_for_provider",
             return_value={"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1"},
         ),
+        patch.object(instantiation, "validate_url_for_ssrf_or_raise"),
     ):
         get_llm(selection, user_id="user-1", temperature=0.7, max_tokens=25)
 

--- a/src/lfx/tests/unit/utils/test_ssrf_httpx.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_httpx.py
@@ -4,11 +4,34 @@ from unittest.mock import AsyncMock, patch
 
 import httpcore
 import pytest
-from lfx.utils.ssrf_httpx import ssrf_safe_async_get, ssrf_safe_async_post, ssrf_safe_httpx_get
+from lfx.utils.ssrf_httpx import (
+    ssrf_protected_httpx_client_kwargs_for_url,
+    ssrf_safe_async_get,
+    ssrf_safe_async_post,
+    ssrf_safe_httpx_get,
+)
 from lfx.utils.ssrf_protection import SSRFProtectionError
+from lfx.utils.ssrf_transport import SSRFProtectedSyncTransport, SSRFProtectedTransport
 
 
 class TestSSRFSafeHTTPX:
+    def test_client_kwargs_pin_idn_under_httpx_connect_host(self):
+        with (
+            patch(
+                "lfx.utils.ssrf_httpx.validate_and_resolve_connector_url",
+                return_value=("https://exämple.com/v1", ["93.184.216.34"]),
+            ),
+            patch("lfx.utils.ssrf_httpx.is_ssrf_protection_enabled", return_value=True),
+        ):
+            sync_kwargs, async_kwargs = ssrf_protected_httpx_client_kwargs_for_url("https://exämple.com/v1")
+
+        sync_transport = sync_kwargs["transport"]
+        async_transport = async_kwargs["transport"]
+        assert isinstance(sync_transport, SSRFProtectedSyncTransport)
+        assert isinstance(async_transport, SSRFProtectedTransport)
+        assert sync_transport.pinned_ips == {"xn--exmple-cua.com": ["93.184.216.34"]}
+        assert async_transport.pinned_ips == {"xn--exmple-cua.com": ["93.184.216.34"]}
+
     def test_literal_loopback_is_allowed_by_connector_policy(self):
         with (
             patch.dict(


### PR DESCRIPTION
## Summary
- enforce connector SSRF policy on the final effective unified LLM and embedding endpoint
- inject DNS-pinned HTTP clients for OpenAI-compatible and Ollama SDKs
- validate provider SDK endpoints and normalize IDN transport pin keys
- preserve explicit connector validation and loopback opt-outs

Addresses LE-2082.

## Testing
- 388 impacted LFX model and SSRF tests passed
- ruff check and ruff format --check passed
- repository pre-commit suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added SSRF protection when connecting to LLM and embedding providers.
  * Blocked unsafe network targets before model creation.
  * Added DNS-pinned HTTP clients for supported providers.
  * Improved handling of internationalized domain names during connection protection.

* **Bug Fixes**
  * Prevented unsafe URL overrides from bypassing connection validation.

* **Tests**
  * Added regression coverage for protected connections, blocked targets, provider URLs, and DNS pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->