### PR TITLE
fix(frontend): stop flow route request storm

### DIFF
--- a/src/frontend/src/customization/hooks/use-custom-navigate.ts
+++ b/src/frontend/src/customization/hooks/use-custom-navigate.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import {
   type NavigateFunction,
   type NavigateOptions,
@@ -12,16 +13,17 @@ export function useCustomNavigate(): NavigateFunction {
 
   const { customParam } = useParams();
 
-  function navigate(to: To | number, options?: NavigateOptions) {
-    if (typeof to === "number") {
-      domNavigate(to);
-    } else {
-      domNavigate(
-        ENABLE_CUSTOM_PARAM && to[0] === "/" ? `/${customParam}${to}` : to,
-        options,
-      );
-    }
-  }
-
-  return navigate;
+  return useCallback(
+    (to: To | number, options?: NavigateOptions) => {
+      if (typeof to === "number") {
+        domNavigate(to);
+      } else {
+        domNavigate(
+          ENABLE_CUSTOM_PARAM && to[0] === "/" ? `/${customParam}${to}` : to,
+          options,
+        );
+      }
+    },
+    [customParam, domNavigate],
+  );
 }

--- a/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
@@ -1,4 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import type { FlowType } from "@/types/flow";
 import useLoadFlowForRoute from "../use-load-flow-for-route";
 
@@ -24,6 +27,18 @@ const deferred = <T>(): Deferred<T> => {
   });
   return { promise, resolve, reject };
 };
+
+const RouterWrapper = ({ children }: PropsWithChildren) =>
+  createElement(
+    MemoryRouter,
+    {
+      future: {
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      },
+    },
+    children,
+  );
 
 const renderRouteLoader = (
   options: {
@@ -70,6 +85,37 @@ describe("useLoadFlowForRoute", () => {
       expect(applyFlowToCanvas).toHaveBeenCalledWith(FLOW);
     });
     expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not restart a pending load when the parent rerenders", async () => {
+    const pending = deferred<FlowType>();
+    const getFlow = jest.fn().mockReturnValue(pending.promise);
+    const applyFlowToCanvas = jest.fn();
+    const flows: FlowType[] = [];
+    const types = { flow: "Flow" };
+
+    const { rerender } = renderHook(
+      () => {
+        const navigate = useCustomNavigate();
+        useLoadFlowForRoute({
+          id: FLOW.id,
+          flows,
+          currentFlowId: "",
+          types,
+          getFlow,
+          applyFlowToCanvas,
+          navigate,
+        });
+      },
+      { wrapper: RouterWrapper },
+    );
+
+    await waitFor(() => expect(getFlow).toHaveBeenCalledTimes(1));
+    Array.from({ length: 5 }).forEach(() => rerender());
+
+    expect(getFlow).toHaveBeenCalledTimes(1);
+    await act(async () => pending.resolve(FLOW));
+    expect(applyFlowToCanvas).toHaveBeenCalledWith(FLOW);
   });
 
   it("logs and redirects when the server cannot confirm the flow", async () => {


### PR DESCRIPTION
## Summary

- memoize useCustomNavigate so effect dependencies stay stable across ordinary parent rerenders
- add regression coverage for a pending route load across six renders
- preserve the server-confirmation and 404 redirect behavior added in #14288

## Root cause

#14288 added navigate to the flow-loading effect dependencies and cancellation during cleanup. useCustomNavigate returned a new function on every render, so each flows-list update cancelled the pending load and started another GET /flows/<id>. The flow never reached applyFlowToCanvas, while mutation settlement kept refetching the flows list and driving the next render.

## Validation

- regression test before fix: six renders produced six getFlow calls
- focused Jest suite: 6 passed
- Biome check: passed
- production Vite build: passed

Regression follow-up to #14288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation stability by preventing unnecessary callback recreation during page updates.
  * Prevented flow data requests from restarting when a page rerenders while loading is still in progress.
  * Ensured loaded flow data is applied correctly after pending requests complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->