### PR TITLE
fix(ci): align nightly workflows with langflow-base

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -14,10 +14,6 @@ on:
         description: "Name of the base package artifact"
         required: true
         type: string
-      core-artifact-name:
-        description: "Name of the langflow-core package artifact"
-        required: false
-        type: string
       main-artifact-name:
         description: "Name of the main package artifact"
         required: true
@@ -262,13 +258,6 @@ jobs:
           name: ${{ inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name || 'adhoc-dist-base' }}
           path: ./base-dist
 
-      - name: Download langflow-core package artifact
-        if: steps.install-method.outputs.method == 'wheel' && inputs.core-artifact-name != ''
-        uses: actions/download-artifact@v7
-        with:
-          name: ${{ inputs.core-artifact-name }}
-          path: ./core-dist
-
       - name: Download main package artifact
         if: steps.install-method.outputs.method == 'wheel'
         uses: actions/download-artifact@v7
@@ -302,7 +291,7 @@ jobs:
 
           refresh_find_links() {
             FIND_LINKS=()
-            for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./core-dist ./bundles-dist; do
+            for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
               if [ -d "$wheel_dir" ]; then
                 FIND_LINKS+=(--find-links "$wheel_dir")
               fi
@@ -335,11 +324,6 @@ jobs:
 
           BASE_WHEELS=(./base-dist/*.whl)
           install_wheels "base" "${BASE_WHEELS[@]}"
-
-          CORE_WHEELS=(./core-dist/*.whl)
-          if [ ${#CORE_WHEELS[@]} -gt 0 ]; then
-            install_wheels "core" "${CORE_WHEELS[@]}"
-          fi
 
           if [ -d ./bundles-dist ]; then
             BUNDLE_WHEELS=(./bundles-dist/*.whl)
@@ -576,13 +560,6 @@ jobs:
           name: ${{ inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name || 'adhoc-dist-base' }}
           path: ./base-dist
 
-      - name: Download langflow-core package artifact
-        if: steps.install-method.outputs.method == 'wheel' && inputs.core-artifact-name != ''
-        uses: actions/download-artifact@v7
-        with:
-          name: ${{ inputs.core-artifact-name }}
-          path: ./core-dist
-
       - name: Download main package artifact
         if: steps.install-method.outputs.method == 'wheel'
         uses: actions/download-artifact@v7
@@ -616,7 +593,7 @@ jobs:
 
           refresh_find_links() {
             FIND_LINKS=()
-            for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./core-dist ./bundles-dist; do
+            for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
               if [ -d "$wheel_dir" ]; then
                 FIND_LINKS+=(--find-links "$wheel_dir")
               fi
@@ -646,11 +623,6 @@ jobs:
           BASE_WHEELS=(./base-dist/*.whl)
           install_wheels "base" "${BASE_WHEELS[@]}"
 
-          CORE_WHEELS=(./core-dist/*.whl)
-          if [ ${#CORE_WHEELS[@]} -gt 0 ]; then
-            install_wheels "core" "${CORE_WHEELS[@]}"
-          fi
-
           if [ -d ./bundles-dist ]; then
             BUNDLE_WHEELS=(./bundles-dist/*.whl)
             install_wheels "bundle" "${BUNDLE_WHEELS[@]}"
@@ -673,12 +645,12 @@ jobs:
         run: |
           # Expose the local wheel dirs so dependency re-resolution (the
           # pre-release path below drops --no-deps) can find the local
-          # pre-release lfx/base/core wheels. Without these, uv re-resolves
+          # pre-release SDK/LFX/base wheels. Without these, uv re-resolves
           # langflow-base's `lfx>=X.Y.Zrc0` constraint against PyPI only, where
           # the matching rc/dev wheel is not published yet, and fails with
           # "No solution found when resolving dependencies".
           FIND_LINKS=()
-          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./core-dist ./bundles-dist; do
+          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
             if [ -d "$wheel_dir" ]; then
               FIND_LINKS+=(--find-links "$wheel_dir")
             fi
@@ -734,11 +706,6 @@ jobs:
             fi
             uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/Scripts/python.exe "${INSTALL_WHEELS[@]}"
           fi
-
-          CORE_WHEEL=$(find ./core-dist -name "*.whl" -type f 2>/dev/null | head -1 || true)
-          if [ -n "$CORE_WHEEL" ]; then
-            uv pip install --force-reinstall --no-deps --python ./test-env/Scripts/python.exe "$CORE_WHEEL"
-          fi
         shell: bash
 
       - name: Force reinstall local wheels to prevent downgrades (Unix)
@@ -746,12 +713,12 @@ jobs:
         run: |
           # Expose the local wheel dirs so dependency re-resolution (the
           # pre-release path below drops --no-deps) can find the local
-          # pre-release lfx/base/core wheels. Without these, uv re-resolves
+          # pre-release SDK/LFX/base wheels. Without these, uv re-resolves
           # langflow-base's `lfx>=X.Y.Zrc0` constraint against PyPI only, where
           # the matching rc/dev wheel is not published yet, and fails with
           # "No solution found when resolving dependencies".
           FIND_LINKS=()
-          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./core-dist ./bundles-dist; do
+          for wheel_dir in ./sdk-dist ./lfx-dist ./base-dist ./bundles-dist; do
             if [ -d "$wheel_dir" ]; then
               FIND_LINKS+=(--find-links "$wheel_dir")
             fi
@@ -806,11 +773,6 @@ jobs:
               INSTALL_WHEELS=("${LOCAL_WHEELS[@]}" "$BASE_WHEEL")
             fi
             uv pip install --force-reinstall $NO_DEPS --prerelease=if-necessary-or-explicit "${FIND_LINKS[@]}" --python ./test-env/bin/python "${INSTALL_WHEELS[@]}"
-          fi
-
-          CORE_WHEEL=$(find ./core-dist -name "*.whl" -type f 2>/dev/null | head -1 || true)
-          if [ -n "$CORE_WHEEL" ]; then
-            uv pip install --force-reinstall --no-deps --python ./test-env/bin/python "$CORE_WHEEL"
           fi
         shell: bash
 
@@ -939,14 +901,17 @@ jobs:
           "
         shell: bash
 
-  test-core-runtime:
-    name: Core Runtime Wheel - Linux Python 3.14
+  test-base-runtime:
+    name: Base Distribution Wheel - Linux Python 3.14
     needs: [build-if-needed]
     if: |
       always() &&
       inputs.langflow-version == '' &&
-      (needs.build-if-needed.result == 'success' || needs.build-if-needed.result == 'skipped')
+      (needs.build-if-needed.result == 'success' || needs.build-if-needed.result == 'skipped') &&
+      (inputs.base-artifact-name != '' || needs.build-if-needed.outputs.base-artifact-name != '')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
@@ -973,7 +938,7 @@ jobs:
           name: ${{ inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name || 'adhoc-dist-base' }}
           path: ./base-dist
 
-      - name: Install only core wheels
+      - name: Install only the base dependency chain
         shell: bash
         run: |
           set -euo pipefail
@@ -982,49 +947,56 @@ jobs:
           SDK_WHEELS=(./sdk-dist/*.whl)
           LFX_WHEELS=(./lfx-dist/*.whl)
           BASE_WHEELS=(./base-dist/*.whl)
-          [ ${#LFX_WHEELS[@]} -eq 1 ] || { echo "Expected one LFX wheel, found ${#LFX_WHEELS[@]}"; exit 1; }
-          [ ${#BASE_WHEELS[@]} -eq 1 ] || { echo "Expected one base wheel, found ${#BASE_WHEELS[@]}"; exit 1; }
-          [ ${#SDK_WHEELS[@]} -le 1 ] || { echo "Expected at most one SDK wheel, found ${#SDK_WHEELS[@]}"; exit 1; }
+          [ ${#SDK_WHEELS[@]} -le 1 ] || { echo "Expected at most one SDK wheel"; exit 1; }
+          [ ${#LFX_WHEELS[@]} -le 1 ] || { echo "Expected at most one LFX wheel"; exit 1; }
+          [ ${#BASE_WHEELS[@]} -eq 1 ] || { echo "Expected one base wheel"; exit 1; }
 
-          FIND_LINKS=(--find-links ./lfx-dist --find-links ./base-dist)
-          if [ ${#SDK_WHEELS[@]} -eq 1 ]; then
-            FIND_LINKS+=(--find-links ./sdk-dist)
-          fi
-
-          uv venv core-test-env --seed --python 3.14
-          uv pip install --python core-test-env/bin/python \
+          FIND_LINKS=()
+          for directory in sdk-dist lfx-dist base-dist; do
+            if [ -d "$directory" ]; then
+              FIND_LINKS+=(--find-links "./$directory")
+            fi
+          done
+          uv venv base-test-env --seed --python 3.14
+          uv pip install --python base-test-env/bin/python \
             --prerelease=if-necessary-or-explicit \
             "${FIND_LINKS[@]}" "${SDK_WHEELS[@]}" "${LFX_WHEELS[@]}" "${BASE_WHEELS[0]}"
-          uv pip check --python core-test-env/bin/python
+          uv pip check --python base-test-env/bin/python
 
-      - name: Verify core boundary and indexed imports
+      - name: Verify base boundary and indexed imports
         shell: bash
         run: |
-          core-test-env/bin/python - <<'PY'
+          base-test-env/bin/python - <<'PY'
           import importlib
           import re
-          from importlib.metadata import distributions, entry_points
+          import sys
+          from importlib.metadata import distributions, entry_points, metadata, requires
+          from pathlib import Path
 
           from lfx.interface.components import _read_component_index
 
           normalize = lambda value: re.sub(r"[-_.]+", "-", value).lower()
           installed = {normalize(dist.metadata["Name"]) for dist in distributions() if dist.metadata["Name"]}
           assert {"langflow-base", "langflow-sdk", "lfx"} <= installed, installed
-          assert "langflow" not in installed, installed
-          extensions = sorted(name for name in installed if name.startswith("lfx-"))
-          assert not extensions, f"Extension distributions installed: {extensions}"
+          forbidden = installed & {"langflow", "langflow-core", "torch", "torchvision"}
+          forbidden |= {name for name in installed if name.startswith("lfx-")}
+          assert not forbidden, f"Forbidden base distributions: {sorted(forbidden)}"
           for group in ("lfx.bundles", "langflow.extensions", "langflow.plugins"):
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
+          scripts = Path(sys.executable).parent
+          assert (scripts / "langflow").is_file()
+          assert not (scripts / "langflow-base").exists()
+          provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
+          assert {"complete", "all"} <= provided_extras
+          compatibility_requirements = [
+              requirement for requirement in (requires("langflow-base") or [])
+              if 'extra == "complete"' in requirement or 'extra == "all"' in requirement
+          ]
+          assert not compatibility_requirements, compatibility_requirements
+
           index = _read_component_index()
           assert index is not None, "Installed LFX rejected its bundled component index"
-          expected_metadata = {
-              "num_modules": len(index["entries"]),
-              "num_components": sum(len(components) for _, components in index["entries"]),
-          }
-          assert index["metadata"] == expected_metadata, (
-            f"Unexpected component index metadata: {index['metadata']} != {expected_metadata}"
-          )
           for category, components in index["entries"]:
               for component_name, component in components.items():
                   module_path = component.get("metadata", {}).get("module")
@@ -1033,7 +1005,7 @@ jobs:
                   getattr(importlib.import_module(module_name), class_name)
           PY
 
-      - name: Boot installed core server
+      - name: Boot installed base server
         shell: bash
         timeout-minutes: 5
         run: |
@@ -1045,7 +1017,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          core-test-env/bin/langflow-base run \
+          base-test-env/bin/langflow run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {
@@ -1071,50 +1043,38 @@ jobs:
             exit 1
           fi
 
-          curl -fsS -c "$RUNTIME_DIR/cookies" http://127.0.0.1:7861/api/v1/auto_login >/dev/null
-          curl -fsS --compressed -b "$RUNTIME_DIR/cookies" \
-            http://127.0.0.1:7861/api/v1/all >"$RUNTIME_DIR/catalog.json"
-          core-test-env/bin/python - "$RUNTIME_DIR/catalog.json" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          from lfx.interface.components import _read_component_index
-
-          catalog = json.loads(Path(sys.argv[1]).read_text())
-          catalog.pop("component_display_names", None)
-          index = _read_component_index()
-          assert index is not None, "Installed LFX rejected its bundled component index"
-          actual_metadata = {
-              "num_modules": len(catalog),
-              "num_components": sum(len(components) for components in catalog.values()),
-          }
-          assert actual_metadata == index["metadata"], (
-              f"Unexpected API catalog metadata: {actual_metadata} != {index['metadata']}"
-          )
-          PY
-
   test-summary:
     name: Cross-Platform Test Summary
-    needs: [test-installation-stable, test-installation-experimental, test-core-runtime]
+    needs: [build-if-needed, test-installation-stable, test-installation-experimental, test-base-runtime]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check test results
         env:
           LANGFLOW_VERSION: ${{ inputs.langflow-version }}
+          EXPECT_BASE_RUNTIME: ${{ inputs.base-artifact-name != '' || needs.build-if-needed.outputs.base-artifact-name != '' }}
         run: |
           stable_result="${{ needs.test-installation-stable.result }}"
           experimental_result="${{ needs.test-installation-experimental.result }}"
-          core_result="${{ needs.test-core-runtime.result }}"
+          base_result="${{ needs.test-base-runtime.result }}"
 
           echo "Stable platforms result: $stable_result"
           echo "Experimental platforms result: $experimental_result"
-          echo "Core runtime result: $core_result"
+          echo "Base runtime result: $base_result"
 
-          if [ "${{ inputs.langflow-version }}" = "" ] && [ "$core_result" != "success" ]; then
-            echo "❌ Core runtime wheel test failed: $core_result"
+          if [ "$stable_result" = "skipped" ] && [ "$base_result" = "skipped" ]; then
+            echo "✅ No Langflow application distribution was selected; package build tests passed"
+            exit 0
+          fi
+
+          if [ "$EXPECT_BASE_RUNTIME" = "true" ] && [ -z "$LANGFLOW_VERSION" ] && [ "$base_result" != "success" ]; then
+            echo "❌ Base runtime wheel test failed: $base_result"
             exit 1
+          fi
+
+          if [ "$stable_result" = "skipped" ] && [ "$base_result" = "success" ]; then
+            echo "✅ Base-only wheel installation tests passed"
+            exit 0
           fi
 
           # Stable platforms must succeed, experimental can fail

--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -122,7 +122,8 @@ jobs:
           context: .
           push: ${{ inputs.push_to_registry }}
           pull: true
-          file: ./docker/build_and_push_base.Dockerfile
+          file: ./docker/build_and_push.Dockerfile
+          target: base
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false
@@ -135,7 +136,8 @@ jobs:
           context: .
           push: ${{ inputs.push_to_registry }}
           pull: true
-          file: ./docker/build_and_push_base.Dockerfile
+          file: ./docker/build_and_push.Dockerfile
+          target: base
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false
@@ -218,6 +220,7 @@ jobs:
           push: ${{ inputs.push_to_registry }}
           pull: true
           file: ./docker/build_and_push.Dockerfile
+          target: full
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false
@@ -231,6 +234,7 @@ jobs:
           push: ${{ inputs.push_to_registry }}
           pull: true
           file: ./docker/build_and_push.Dockerfile
+          target: full
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false
@@ -312,7 +316,8 @@ jobs:
           context: .
           push: ${{ inputs.push_to_registry }}
           pull: true
-          file: ./docker/build_and_push_with_extras.Dockerfile
+          file: ./docker/build_and_push.Dockerfile
+          target: full-bundles
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false
@@ -325,7 +330,8 @@ jobs:
           context: .
           push: ${{ inputs.push_to_registry }}
           pull: true
-          file: ./docker/build_and_push_with_extras.Dockerfile
+          file: ./docker/build_and_push.Dockerfile
+          target: full-bundles
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
           provenance: false

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -85,11 +85,11 @@ jobs:
         run: |
           echo "PWD: $(pwd)"
           find . -name "pypi_nightly_tag.py"
-      - name: Generate shared nightly tag (main == core == base, lockstep)
+      - name: Generate shared nightly tag (main == base, lockstep)
         id: generate_shared_tag
         run: |
-          # langflow -> langflow-core -> langflow-base uses exact nightly dev pins,
-          # so all three versions MUST be identical. Compute from one PyPI snapshot.
+          # langflow -> langflow-base uses an exact nightly dev pin, so both
+          # versions MUST be identical. Compute from one PyPI snapshot.
           # NOTE: This outputs the tag with the `v` prefix.
           TAGS_OUTPUT="$(uv run ./scripts/ci/pypi_nightly_tag.py both)"
           RELEASE_TAG="$(printf '%s\n' "$TAGS_OUTPUT" | sed -n '1p')"
@@ -142,13 +142,13 @@ jobs:
           uv run --no-sync ./scripts/ci/update_sdk_version.py $SDK_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run --no-sync ./scripts/ci/update_lfx_version.py $LFX_TAG $SDK_TAG
-          echo "Updating base/core/main project versions to the shared nightly tag"
+          echo "Updating base/main project versions to the shared nightly tag"
           uv run --no-sync ./scripts/ci/update_pyproject_combined.py main $RELEASE_TAG $BASE_TAG $LFX_TAG
 
           uv lock
           cd src/lfx && uv lock && cd ../..
 
-          git add pyproject.toml src/langflow-core/pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml \
+          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml \
             src/lfx/src/lfx/_assets/component_index.json src/sdk/pyproject.toml uv.lock
           # The nightly keeps canonical package names and the stable `lfx-*` bundles
           # are not modified (see src/bundles/NIGHTLY.md), so no bundle pyprojects ride this commit.

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -204,26 +204,36 @@ jobs:
           cache-dependency-glob: "uv.lock"
           python-version: ${{ matrix.python-version }}
           prune-cache: false
+          # This job intentionally exits before invoking uv when langflow-base
+          # has not been published yet (including its first release).
+          ignore-nothing-to-cache: true
 
       - name: Check Version
         id: check-version
-        # We need to print $3 because langflow-base is a dependency of langflow
-        # For langlow we'd use print $2
+        # The main wheel resolves its direct langflow-base dependency from PyPI.
+        # Skip until the source base version (stable or canonical nightly) exists.
         run: |
-          version=$(uv tree | grep 'langflow-base' | awk '{print $3}' | sed 's/^v//' | head -n 1)
+          version=$(python -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('src/backend/base/pyproject.toml').read_text())['project']['version'])")
           url="https://pypi.org/pypi/langflow-base/json"
-          if [ ${{ inputs.nightly }} == true ]; then
-            url="https://pypi.org/pypi/langflow-base-nightly/json"
+
+          status=$(curl -sS -o "$RUNNER_TEMP/langflow-base-pypi.json" -w "%{http_code}" "$url")
+          if [ "$status" = "404" ]; then
+            last_released_version=""
+          elif [ "$status" != "200" ]; then
+            echo "Failed to fetch langflow-base releases: HTTP $status"
+            cat "$RUNNER_TEMP/langflow-base-pypi.json"
+            exit 1
+          else
+            last_released_version=$(jq -r '.releases | keys[]' "$RUNNER_TEMP/langflow-base-pypi.json" | sort -V | tail -n 1)
           fi
 
-          last_released_version=$(curl -s $url | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
           if [ "$version" != "$last_released_version" ]; then
             echo "Version $version has not been released yet. Skipping the rest of the job."
-            echo skipped=true >> $GITHUB_OUTPUT
+            echo skipped=true >> "$GITHUB_OUTPUT"
             exit 0
           else
-            echo version=$version >> $GITHUB_OUTPUT
-            echo skipped=false >> $GITHUB_OUTPUT
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo skipped=false >> "$GITHUB_OUTPUT"
           fi
       - name: Build wheel
         if: steps.check-version.outputs.skipped == 'false'

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -244,94 +244,9 @@ jobs:
           name: dist-nightly-base
           path: src/backend/base/dist
 
-  build-nightly-core:
-    name: Build Langflow Core Nightly
-    needs: [build-nightly-lfx, build-nightly-base]
-    if: ${{ always() && needs.build-nightly-base.result == 'success' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    outputs:
-      version: ${{ steps.verify.outputs.version }}
-    steps:
-      - name: Check out the code at a specific ref
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.nightly_tag_release }}
-          persist-credentials: true
-      - name: Setup Environment
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-          python-version: ${{ env.PYTHON_VERSION }}
-          prune-cache: false
-      - name: Download SDK artifact
-        if: inputs.build_lfx
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-sdk
-          path: sdk-dist
-      - name: Download LFX artifact
-        if: inputs.build_lfx
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-lfx
-          path: lfx-dist
-      - name: Download base artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-base
-          path: base-dist
-
-      - name: Verify Nightly Name and Version
-        id: verify
-        run: |
-          name=$(grep '^name = ' src/langflow-core/pyproject.toml | head -n 1 | cut -d '"' -f 2)
-          version=$(grep '^version = ' src/langflow-core/pyproject.toml | head -n 1 | cut -d '"' -f 2)
-          if [ "$name" != "langflow-core" ]; then
-            echo "Name $name does not match langflow-core. Exiting the workflow."
-            exit 1
-          fi
-          if [ "v$version" != "${{ inputs.nightly_tag_release }}" ]; then
-            echo "Version v$version does not match nightly tag ${{ inputs.nightly_tag_release }}. Exiting the workflow."
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Build Langflow Core for distribution
-        run: |
-          rm -rf src/langflow-core/dist
-          make build_langflow_core args="--no-sources --wheel"
-      - name: Test clean core installation
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          FIND_LINKS=(--find-links ./base-dist)
-          INSTALL_WHEELS=(./base-dist/*.whl ./src/langflow-core/dist/*.whl)
-          if [ -d ./sdk-dist ]; then
-            FIND_LINKS+=(--find-links ./sdk-dist)
-            INSTALL_WHEELS=(./sdk-dist/*.whl "${INSTALL_WHEELS[@]}")
-          fi
-          if [ -d ./lfx-dist ]; then
-            FIND_LINKS+=(--find-links ./lfx-dist)
-            INSTALL_WHEELS=(./lfx-dist/*.whl "${INSTALL_WHEELS[@]}")
-          fi
-          uv venv core-test-env --seed
-          uv pip install --python core-test-env/bin/python \
-            --prerelease=if-necessary-or-explicit \
-            "${FIND_LINKS[@]}" "${INSTALL_WHEELS[@]}"
-          uv pip check --python core-test-env/bin/python
-          core-test-env/bin/langflow --help
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: dist-nightly-core
-          path: src/langflow-core/dist
-
   build-nightly-main:
     name: Build Langflow Nightly Main
-    needs: [build-nightly-base, build-nightly-core]
+    needs: [build-nightly-base]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.verify.outputs.version }}
@@ -366,12 +281,6 @@ jobs:
           name: dist-nightly-base
           path: base-dist
 
-      - name: Download core artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-core
-          path: core-dist
-
       - name: Install the project
         run: uv sync
 
@@ -385,8 +294,6 @@ jobs:
           fi
           echo "Installing langflow-base from built wheel..."
           uv pip install --force-reinstall --no-deps base-dist/*.whl
-          echo "Installing langflow-core from built wheel..."
-          uv pip install --force-reinstall --no-deps core-dist/*.whl
 
       - name: Verify Nightly Name and Version
         id: verify
@@ -474,11 +381,10 @@ jobs:
 
   test-cross-platform:
     name: Test Cross-Platform Installation
-    needs: [build-nightly-lfx, build-nightly-base, build-nightly-core, build-nightly-main]
+    needs: [build-nightly-lfx, build-nightly-base, build-nightly-main]
     uses: ./.github/workflows/cross-platform-test.yml
     with:
       base-artifact-name: "dist-nightly-base"
-      core-artifact-name: "dist-nightly-core"
       main-artifact-name: "dist-nightly-main"
       lfx-artifact-name: "dist-nightly-lfx"
       sdk-artifact-name: "dist-nightly-sdk"
@@ -543,8 +449,8 @@ jobs:
 
   publish-nightly-base:
     name: Publish Langflow Base Nightly to PyPI
-    needs: [build-nightly-base, test-cross-platform, publish-nightly-lfx]
-    if: ${{ always() && needs.build-nightly-base.result == 'success' && needs.test-cross-platform.result == 'success' && (needs.publish-nightly-lfx.result == 'success' || inputs.build_lfx == false) }}
+    needs: [build-nightly-base, build-nightly-main, test-cross-platform, publish-nightly-bundles]
+    if: ${{ always() && needs.build-nightly-base.result == 'success' && needs.test-cross-platform.result == 'success' && (needs.publish-nightly-bundles.result == 'success' || needs.build-nightly-main.outputs.bundles-found != '1') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -569,33 +475,6 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish base=true
-
-  publish-nightly-core:
-    name: Publish Langflow Core Nightly to PyPI
-    needs: [build-nightly-core, test-cross-platform, publish-nightly-base]
-    if: ${{ always() && needs.build-nightly-core.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.nightly_tag_release }}
-          persist-credentials: true
-      - name: Download core artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-nightly-core
-          path: src/langflow-core/dist
-      - name: Setup Environment
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: false
-          python-version: "3.13"
-      - name: Publish core to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          make publish core=true
 
   publish-nightly-bundles:
     name: Publish Bundle Dependencies to PyPI
@@ -744,8 +623,8 @@ jobs:
 
   check-nightly-main-pypi-dependencies:
     name: Check Main Nightly PyPI Dependencies
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-core, publish-nightly-bundles]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-core.result == 'success' && (needs.publish-nightly-bundles.result == 'success' || needs.build-nightly-main.outputs.bundles-found != '1') }}
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-base, publish-nightly-bundles]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' && (needs.publish-nightly-bundles.result == 'success' || needs.build-nightly-main.outputs.bundles-found != '1') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -758,7 +637,7 @@ jobs:
         with:
           enable-cache: false
           python-version: "3.13"
-      - name: Wait for direct core and bundle dependencies on PyPI
+      - name: Wait for direct base and bundle dependencies on PyPI
         timeout-minutes: 20
         run: |
           uv run --with packaging --no-project python - <<'PY'
@@ -779,11 +658,11 @@ jobs:
           for dependency in data["project"].get("dependencies", []):
             requirement = Requirement(dependency)
             name = canonicalize_name(requirement.name)
-            if name == "langflow-core" or name.startswith("lfx-"):
+            if name == "langflow-base" or name.startswith("lfx-"):
               requirements.append(requirement)
 
           if not requirements:
-            print("No direct langflow-core or lfx-* dependencies found.")
+            print("No direct langflow-base or lfx-* dependencies found.")
             sys.exit(0)
 
           max_attempts = 60
@@ -841,7 +720,7 @@ jobs:
 
             pending = next_pending
             if not pending:
-              print("All direct core and bundle dependencies are available on PyPI.")
+              print("All direct base and bundle dependencies are available on PyPI.")
               break
 
             print(f"PyPI propagation incomplete (attempt {attempt}/{max_attempts}).", file=sys.stderr)
@@ -861,8 +740,8 @@ jobs:
 
   publish-nightly-main:
     name: Publish Langflow Main Nightly to PyPI
-    needs: [build-nightly-main, test-cross-platform, publish-nightly-core, check-nightly-main-pypi-dependencies]
-    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-core.result == 'success' && needs.check-nightly-main-pypi-dependencies.result == 'success' }}
+    needs: [build-nightly-main, test-cross-platform, publish-nightly-base, check-nightly-main-pypi-dependencies]
+    if: ${{ always() && needs.build-nightly-main.result == 'success' && needs.test-cross-platform.result == 'success' && needs.publish-nightly-base.result == 'success' && needs.check-nightly-main-pypi-dependencies.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,7 +179,7 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 899,
+        "line_number": 778,
         "is_secret": false
       }
     ],
@@ -7256,5 +7256,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T01:46:39Z"
+  "generated_at": "2026-07-30T23:53:18Z"
 }

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -36,19 +36,21 @@ def test_bundle_build_only_restamps_unpublished_versions() -> None:
     assert "Relax bundle lfx floor for pre-release" in bundle_job
 
 
-def test_nightly_coordinates_core_from_tag_commit_through_publish() -> None:
+def test_nightly_coordinates_base_from_tag_commit_through_publish() -> None:
     nightly_build = NIGHTLY_BUILD_PATH.read_text(encoding="utf-8")
     nightly_release = NIGHTLY_RELEASE_PATH.read_text(encoding="utf-8")
     cross_platform = CROSS_PLATFORM_PATH.read_text(encoding="utf-8")
 
-    assert "src/langflow-core/pyproject.toml" in nightly_build
-    assert "build-nightly-core:" in nightly_release
-    assert "dist-nightly-core" in nightly_release
-    assert "publish-nightly-core:" in nightly_release
-    assert 'core-artifact-name: "dist-nightly-core"' in nightly_release
-    assert "needs: [build-nightly-main, test-cross-platform, publish-nightly-core" in nightly_release
-    assert "core-artifact-name:" in cross_platform
-    assert "./core-dist" in cross_platform
+    assert "src/langflow-core/pyproject.toml" not in nightly_build
+    assert "build-nightly-core:" not in nightly_release
+    assert "dist-nightly-core" not in nightly_release
+    assert "publish-nightly-core:" not in nightly_release
+    assert 'base-artifact-name: "dist-nightly-base"' in nightly_release
+    assert "publish-nightly-base" in nightly_release
+    assert "core-artifact-name:" not in cross_platform
+    assert "./core-dist" not in cross_platform
+    assert "test-base-runtime:" in cross_platform
+    assert "base-test-env/bin/langflow run" in cross_platform
 
 
 def test_release_docker_builds_consume_built_wheels() -> None:
@@ -68,6 +70,6 @@ def test_release_docker_builds_consume_built_wheels() -> None:
 if __name__ == "__main__":
     test_finalized_bundles_do_not_influence_shared_rc_number()
     test_bundle_build_only_restamps_unpublished_versions()
-    test_nightly_coordinates_core_from_tag_commit_through_publish()
+    test_nightly_coordinates_base_from_tag_commit_through_publish()
     test_release_docker_builds_consume_built_wheels()
     print("All release workflow tests passed.")


### PR DESCRIPTION
## Summary

- port the PR #14339 nightly orchestration changes to the default branch
- remove langflow-core build, artifact, publication, and cross-platform workflow paths
- build nightly base/full images from the shared Dockerfile targets
- validate the langflow-base runtime through the public langflow executable
- make the backend wheel gate read the base version directly from project metadata

## Validation

- actionlint expression/YAML validation passed for all five workflows
- scripts/ci/test_release_workflow.py: 4 passed
- Ruff check and format check passed for the contract test
- detect-secrets baseline validation passed

This is a workflow-only compatibility port for the release-1.12.0 nightly path; it contains no package or runtime implementation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Nightly releases now use a streamlined base-and-main package flow.
  - Base and full bundle builds use standardized build targets.
  - Publishing and cross-platform validation now follow the updated release sequence.

- **Quality Improvements**
  - Runtime checks validate base-only installations, package boundaries, imports, and server startup.
  - Version checks more reliably detect unavailable or unpublished base releases.
  - Automated release tests verify the updated nightly build and publishing coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->