### PR TITLE
fix(docker): use writable runtime home

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -123,6 +123,7 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""
@@ -134,15 +135,15 @@ ENV BASH_ENV="" \
 # write secret_key, profile_pictures, etc. Without this, the volume is created
 # as root:root and Langflow crashes during startup with PermissionError on
 # /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
-RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+RUN mkdir -p /app/data /app/langflow \
+    && chown -R 1000:0 /app/data /app/langflow \
+    && chmod -R g+rwX /app/data /app/langflow
 
 # Give the runtime user (uid 1000) a writable npm cache. The image ships Node so
-# users can spawn stdio MCP servers via `npx`, but on the ubi10 base
-# HOME=/opt/app-root/src is not owned by uid 1000, so npx otherwise fails with
-# `EACCES` on ~/.npm/_cacache and every stdio MCP server registers but never
-# lists any tools (toolsCount stays null). Pin npm's cache to a
-# uid-1000-owned dir (immune to the base image's HOME) and hand ownership of the
-# default HOME cache to the runtime user as a fallback.
+# users can spawn stdio MCP servers via `npx`. Pin npm's cache to a
+# uid-1000-owned dir so callers that override HOME cannot make the cache
+# read-only, and keep the UBI base image's default HOME cache writable as a
+# fallback.
 # See https://github.com/langflow-ai/langflow/pull/13893 (ubi10 base change).
 ENV NPM_CONFIG_CACHE=/app/.npm
 RUN mkdir -p /app/.npm /opt/app-root/src/.npm \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -105,7 +105,7 @@ ENV BASH_ENV="" \
 # Note: .venv is already owned by 1000:0 via COPY --chown above, so no recursive chown needed
 RUN mkdir -p /app/data /app/langflow \
     && chown -R 1000:0 /app/data /app/langflow \
-    && chmod -R g+rwX /app/langflow \
+    && chmod -R g+rwX /app/data /app/langflow \
     && chown 1000:0 /app
 
 LABEL org.opencontainers.image.title=langflow-backend

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -89,6 +89,7 @@ RUN useradd --uid 1000 --gid 0 --no-create-home --home-dir /app/data user
 # Copy only the virtual environment
 COPY --from=builder --chown=1000:0 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -126,6 +126,7 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""
@@ -137,14 +138,15 @@ ENV BASH_ENV="" \
 # write secret_key, profile_pictures, etc. Without this, the volume is created
 # as root:root and Langflow crashes during startup with PermissionError on
 # /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
-RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+RUN mkdir -p /app/data /app/langflow \
+    && chown -R 1000:0 /app/data /app/langflow \
+    && chmod -R g+rwX /app/data /app/langflow
 
 # Give the runtime user (uid 1000) a writable npm cache. The image ships Node so
-# users can spawn stdio MCP servers via `npx`, but on the ubi10 base
-# HOME=/opt/app-root/src is not owned by uid 1000, so npx otherwise fails with
-# `EACCES` on ~/.npm/_cacache and stdio MCP servers never list any tools. Pin
-# npm's cache to a uid-1000-owned dir (immune to the base image's HOME) and hand
-# ownership of the default HOME cache to the runtime user as a fallback.
+# users can spawn stdio MCP servers via `npx`. Pin npm's cache to a
+# uid-1000-owned dir so callers that override HOME cannot make the cache
+# read-only, and keep the UBI base image's default HOME cache writable as a
+# fallback.
 # See https://github.com/langflow-ai/langflow/pull/13893 (ubi10 base change).
 ENV NPM_CONFIG_CACHE=/app/.npm
 RUN mkdir -p /app/.npm /opt/app-root/src/.npm \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -114,6 +114,7 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""
@@ -125,7 +126,9 @@ ENV BASH_ENV="" \
 # write secret_key, profile_pictures, etc. Without this, the volume is created
 # as root:root and Langflow crashes during startup with PermissionError on
 # /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
-RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+RUN mkdir -p /app/data /app/langflow \
+    && chown -R 1000:0 /app/data /app/langflow \
+    && chmod -R g+rwX /app/data /app/langflow
 
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -114,6 +114,7 @@ RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""
@@ -125,14 +126,15 @@ ENV BASH_ENV="" \
 # write secret_key, profile_pictures, etc. Without this, the volume is created
 # as root:root and Langflow crashes during startup with PermissionError on
 # /app/langflow/secret_key. See https://github.com/langflow-ai/langflow/issues/10437
-RUN mkdir -p /app/langflow && chown -R 1000:0 /app/langflow && chmod -R g+rwX /app/langflow
+RUN mkdir -p /app/data /app/langflow \
+    && chown -R 1000:0 /app/data /app/langflow \
+    && chmod -R g+rwX /app/data /app/langflow
 
 # Give the runtime user (uid 1000) a writable npm cache. The image ships Node so
-# users can spawn stdio MCP servers via `npx`, but on the ubi10 base
-# HOME=/opt/app-root/src is not owned by uid 1000, so npx otherwise fails with
-# `EACCES` on ~/.npm/_cacache and stdio MCP servers never list any tools. Pin
-# npm's cache to a uid-1000-owned dir (immune to the base image's HOME) and hand
-# ownership of the default HOME cache to the runtime user as a fallback.
+# users can spawn stdio MCP servers via `npx`. Pin npm's cache to a
+# uid-1000-owned dir so callers that override HOME cannot make the cache
+# read-only, and keep the UBI base image's default HOME cache writable as a
+# fallback.
 # See https://github.com/langflow-ai/langflow/pull/13893 (ubi10 base change).
 ENV NPM_CONFIG_CACHE=/app/.npm
 RUN mkdir -p /app/.npm /opt/app-root/src/.npm \

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -104,6 +104,12 @@ If Langflow fails to start with a `get_body_field` error after installing versio
 
     For more information, see [Docker image defaults](/deployment-docker#docker-image-security-defaults).
 
+- Docker runtime home moved to `/app/data`
+
+    Patched 1.11 Docker images set `HOME=/app/data` so the non-root runtime user has a writable home directory.
+    When `LANGFLOW_CONFIG_DIR` isn't set, the default config directory therefore changes from `/opt/app-root/src/.cache/langflow` to `/app/data/.cache/langflow`; SQLite follows that directory when `LANGFLOW_SAVE_DB_IN_CONFIG_DIR=true`.
+    Persist `/app/data` or set `LANGFLOW_CONFIG_DIR` to your existing writable data directory before upgrading to preserve existing data.
+
 - Ongoing breaking changes: bundle separation
 
     Langflow 1.10.x introduced the Extension bundles model.

--- a/src/backend/tests/unit/test_docker_security_defaults.py
+++ b/src/backend/tests/unit/test_docker_security_defaults.py
@@ -43,14 +43,19 @@ def _logical_instructions(dockerfile: Path) -> list[str]:
     return instructions
 
 
-def _final_stage_env(dockerfile: Path) -> dict[str, str]:
-    """Return active ENV assignments from the final image stage."""
+def _final_stage_instructions(dockerfile: Path) -> list[str]:
+    """Return the logical instructions from the final image stage."""
     instructions = _logical_instructions(dockerfile)
     final_stage_start = max(
         index for index, instruction in enumerate(instructions) if instruction.split(maxsplit=1)[0].upper() == "FROM"
     )
+    return instructions[final_stage_start + 1 :]
+
+
+def _final_stage_env(dockerfile: Path) -> dict[str, str]:
+    """Return active ENV assignments from the final image stage."""
     env: dict[str, str] = {}
-    for instruction in instructions[final_stage_start + 1 :]:
+    for instruction in _final_stage_instructions(dockerfile):
         parts = instruction.split(maxsplit=1)
         if len(parts) != 2 or parts[0].upper() != "ENV":
             continue
@@ -70,14 +75,30 @@ def _final_stage_env(dockerfile: Path) -> dict[str, str]:
 def test_published_images_use_writable_runtime_home(dockerfile: str) -> None:
     dockerfile_path = REPO_ROOT / "docker" / dockerfile
     runtime_env = _final_stage_env(dockerfile_path)
-    instructions = _logical_instructions(dockerfile_path)
+    runtime_instructions = _final_stage_instructions(dockerfile_path)
 
-    assert runtime_env["HOME"] == "/app/data"
+    assert runtime_env.get("HOME") == "/app/data"
     assert any(
         instruction.startswith("RUN ")
         and "mkdir -p /app/data /app/langflow" in instruction
         and "chown -R 1000:0 /app/data /app/langflow" in instruction
-        for instruction in instructions
+        and "chmod -R g+rwX /app/data /app/langflow" in instruction
+        for instruction in runtime_instructions
+    )
+
+
+def test_lfx_image_uses_writable_runtime_home() -> None:
+    dockerfile_path = REPO_ROOT / "src" / "lfx" / "docker" / "Dockerfile"
+    runtime_env = _final_stage_env(dockerfile_path)
+    runtime_instructions = _final_stage_instructions(dockerfile_path)
+
+    assert runtime_env.get("HOME") == "/app/data"
+    assert any(
+        instruction.startswith("RUN ")
+        and "mkdir -p /app/data" in instruction
+        and "chown -R 1000:0 /app/data" in instruction
+        and "chmod -R g+rwX /app/data" in instruction
+        for instruction in runtime_instructions
     )
 
 

--- a/src/backend/tests/unit/test_docker_security_defaults.py
+++ b/src/backend/tests/unit/test_docker_security_defaults.py
@@ -67,6 +67,21 @@ def _final_stage_env(dockerfile: Path) -> dict[str, str]:
 
 
 @pytest.mark.parametrize("dockerfile", PUBLISHED_DOCKERFILES)
+def test_published_images_use_writable_runtime_home(dockerfile: str) -> None:
+    dockerfile_path = REPO_ROOT / "docker" / dockerfile
+    runtime_env = _final_stage_env(dockerfile_path)
+    instructions = _logical_instructions(dockerfile_path)
+
+    assert runtime_env["HOME"] == "/app/data"
+    assert any(
+        instruction.startswith("RUN ")
+        and "mkdir -p /app/data /app/langflow" in instruction
+        and "chown -R 1000:0 /app/data /app/langflow" in instruction
+        for instruction in instructions
+    )
+
+
+@pytest.mark.parametrize("dockerfile", PUBLISHED_DOCKERFILES)
 def test_published_images_do_not_force_restrictive_runtime_defaults(dockerfile: str) -> None:
     runtime_env = _final_stage_env(REPO_ROOT / "docker" / dockerfile)
 

--- a/src/lfx/docker/Dockerfile
+++ b/src/lfx/docker/Dockerfile
@@ -66,9 +66,14 @@ COPY --from=builder --chown=1000 /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+ENV HOME=/app/data
 ENV BASH_ENV="" \
     ENV="" \
     PROMPT_COMMAND=""
+
+RUN mkdir -p /app/data \
+    && chown -R 1000:0 /app/data \
+    && chmod -R g+rwX /app/data
 
 LABEL org.opencontainers.image.title=lfx
 LABEL org.opencontainers.image.authors=['Langflow']


### PR DESCRIPTION
## Summary

- override the UBI runtime image's inherited `HOME` with the UID 1000 user's `/app/data` home
- pre-create `/app/data` with UID 1000, GID 0, and group-write permissions in all five published Langflow application images and the published LFX image
- scope regression coverage to final runtime stages and verify the full home-directory permission contract
- document the 1.11 Docker data-path change for upgrades

## Root cause

The UBI 10 Python base image exports `HOME=/opt/app-root/src`. Although Langflow creates its runtime user with `/app/data` as the passwd home, the inherited environment variable takes precedence. When `LANGFLOW_CONFIG_DIR` is not set, `platformdirs` therefore resolves the default Langflow cache to `/opt/app-root/src/.cache/langflow`, and startup fails because that path is read-only for UID 1000.

Setting `HOME=/app/data` restores the intended runtime-user home while preserving explicit `LANGFLOW_CONFIG_DIR` overrides. Group-write permissions keep the path usable when OpenShift supplies an arbitrary UID in GID 0.

## Upgrade note

For patched 1.11 Docker images without `LANGFLOW_CONFIG_DIR`, the default config directory moves from `/opt/app-root/src/.cache/langflow` to `/app/data/.cache/langflow`. Persist `/app/data` or set `LANGFLOW_CONFIG_DIR` to an existing writable data directory before upgrading. SQLite follows the config directory when `LANGFLOW_SAVE_DB_IN_CONFIG_DIR=true`.

## Validation

- `pytest src/backend/tests/unit/test_docker_security_defaults.py -q` — 12 passed
- `pytest scripts/ci/test_release_workflow.py -q` — 4 passed
- `ruff check src/backend/tests/unit/test_docker_security_defaults.py`
- `ruff format --check src/backend/tests/unit/test_docker_security_defaults.py`
- repository pre-commit hooks

Refs #14334.