### PR TITLE
fix(agent): exclude callback latency from tool duration

### DIFF
--- a/src/lfx/src/lfx/base/agents/events.py
+++ b/src/lfx/src/lfx/base/agents/events.py
@@ -310,7 +310,6 @@ async def handle_on_tool_start(
 
     # Fallback path — append the ToolContent ourselves.
     duration = _calculate_duration(start_time)
-    new_start_time = perf_counter()
     tool_content = ToolContent(
         type="tool_use",
         name=tool_name,
@@ -325,7 +324,8 @@ async def handle_on_tool_start(
     agent_message = await send_message_callback(message=agent_message, skip_db_update=True)
     if agent_message.content_blocks and isinstance(agent_message.content_blocks[-1], ToolContent):
         tool_blocks_map[tool_key] = agent_message.content_blocks[-1]
-    return agent_message, new_start_time
+    # The tool cannot run until this handler returns, so start timing after publication.
+    return agent_message, perf_counter()
 
 
 async def handle_on_tool_end(

--- a/src/lfx/src/lfx/base/agents/events.py
+++ b/src/lfx/src/lfx/base/agents/events.py
@@ -341,6 +341,11 @@ async def handle_on_tool_end(
     tool_content = tool_blocks_map.get(tool_key)
 
     if tool_content and isinstance(tool_content, ToolContent):
+        # Stop the tool timer before publishing the result. The callback can
+        # include transport or persistence work that is not part of the tool's
+        # execution time and must not inflate the duration shown to clients.
+        duration = _calculate_duration(start_time)
+
         # Call send_message_callback first to get the updated message structure
         agent_message = await send_message_callback(message=agent_message, skip_db_update=True)
         new_start_time = perf_counter()
@@ -348,8 +353,6 @@ async def handle_on_tool_end(
         # Now find and update the tool content in the current message. With
         # flat content_blocks we walk the list directly instead of indexing
         # into a single group's .contents.
-        duration = _calculate_duration(start_time)
-
         updated_tool_content = None
         for content in agent_message.content_blocks or []:
             if (

--- a/src/lfx/tests/unit/base/agents/test_events_handlers.py
+++ b/src/lfx/tests/unit/base/agents/test_events_handlers.py
@@ -1,15 +1,16 @@
 """Regression tests for the agent event-loop handlers in lfx.base.agents.events.
 
-These pin two interleaving-preservation behaviors:
+These pin focused event-loop behaviors:
 - handle_on_chain_stream must not run the Message.text setter (which collapses
   interleaved text + tool_use blocks); it stashes the extracted answer in
   data["text"] instead.
 - handle_on_tool_start must not clobber a model-end tool_input snapshot with an
   empty on_tool_start payload.
+- tool timing must exclude message-publication latency at both the start and
+  end boundaries.
 
-The async ``send_message_callback`` here is a passthrough test harness for the
-handler's callback boundary, not a behavior mock; the code paths under test
-return before invoking it.
+The async callbacks are small in-memory harnesses. The timing regression test
+advances a deterministic clock while each callback runs.
 """
 
 from time import perf_counter
@@ -83,26 +84,47 @@ async def test_tool_start_overwrites_with_real_input_when_present():
     assert bound.tool_input == {"q": "streamed"}
 
 
-async def test_tool_end_duration_excludes_message_callback_latency(monkeypatch):
-    """Tool duration must stop before the result message is published."""
-    now = [100.025]
+async def test_tool_duration_excludes_message_callback_latency(monkeypatch):
+    """Tool timing must start after and stop before message publication."""
+    now = [100.0]
     monkeypatch.setattr(agent_events, "perf_counter", lambda: now[0])
 
-    tool = ToolContent(name="search", tool_input={"q": "latency"}, output=None)
-    msg = Message(content_blocks=[tool], sender="Machine", sender_name="AI")
-    tool_blocks_map = {"search_run-1": tool}
+    msg = Message(content_blocks=[], sender="Machine", sender_name="AI")
+    tool_blocks_map = {}
 
     async def _slow_message_callback(*, message: Message, **_kwargs) -> Message:
         now[0] += 5
         return message
 
-    event = {
+    start_event = {
+        "name": "search",
+        "run_id": "run-1",
+        "data": {"input": {"q": "latency"}},
+    }
+    end_event = {
         "name": "search",
         "run_id": "run-1",
         "data": {"output": "result"},
     }
 
-    result, _ = await handle_on_tool_end(event, msg, tool_blocks_map, _slow_message_callback, 100.0)
+    msg, tool_start = await handle_on_tool_start(
+        start_event,
+        msg,
+        tool_blocks_map,
+        _slow_message_callback,
+        100.0,
+    )
+    assert tool_start == 105.0
+
+    now[0] += 0.025
+    result, new_start = await handle_on_tool_end(
+        end_event,
+        msg,
+        tool_blocks_map,
+        _slow_message_callback,
+        tool_start,
+    )
 
     completed_tool = next(block for block in result.content_blocks if isinstance(block, ToolContent))
     assert completed_tool.duration == 25
+    assert new_start == 110.025

--- a/src/lfx/tests/unit/base/agents/test_events_handlers.py
+++ b/src/lfx/tests/unit/base/agents/test_events_handlers.py
@@ -14,7 +14,8 @@ return before invoking it.
 
 from time import perf_counter
 
-from lfx.base.agents.events import handle_on_chain_stream, handle_on_tool_start
+import lfx.base.agents.events as agent_events
+from lfx.base.agents.events import handle_on_chain_stream, handle_on_tool_end, handle_on_tool_start
 from lfx.schema.content_types import TextContent, ToolContent
 from lfx.schema.message import Message
 
@@ -80,3 +81,28 @@ async def test_tool_start_overwrites_with_real_input_when_present():
 
     bound = next(b for b in result.content_blocks if isinstance(b, ToolContent))
     assert bound.tool_input == {"q": "streamed"}
+
+
+async def test_tool_end_duration_excludes_message_callback_latency(monkeypatch):
+    """Tool duration must stop before the result message is published."""
+    now = [100.025]
+    monkeypatch.setattr(agent_events, "perf_counter", lambda: now[0])
+
+    tool = ToolContent(name="search", tool_input={"q": "latency"}, output=None)
+    msg = Message(content_blocks=[tool], sender="Machine", sender_name="AI")
+    tool_blocks_map = {"search_run-1": tool}
+
+    async def _slow_message_callback(*, message: Message, **_kwargs) -> Message:
+        now[0] += 5
+        return message
+
+    event = {
+        "name": "search",
+        "run_id": "run-1",
+        "data": {"output": "result"},
+    }
+
+    result, _ = await handle_on_tool_end(event, msg, tool_blocks_map, _slow_message_callback, 100.0)
+
+    completed_tool = next(block for block in result.content_blocks if isinstance(block, ToolContent))
+    assert completed_tool.duration == 25


### PR DESCRIPTION
## Summary

- start fallback tool timing only after the start message is published
- stop tool timing before the result message is published
- exclude transport and persistence overhead from the duration reported to clients
- add an integrated regression covering a 25 ms tool call with 5 seconds of publication latency at both boundaries

## Root cause

The fallback `handle_on_tool_start` path captured the tool's start cursor before awaiting `send_message_callback`, while `handle_on_tool_end` calculated duration after awaiting the result callback. Message publication overhead could therefore be charged to tool execution at either boundary.

This change places both timing boundaries immediately around the actual tool call, consistent with the error path's accounting.

## Scope

This corrects tool-duration attribution; it does not reduce end-to-end transport or persistence latency. Parallel tool calls have a separate shared-cursor accounting problem tracked in #14356.

Addresses the timing misattribution reported in #14224.

Jira: [LE-2085](https://datastax.jira.com/browse/LE-2085)

## Testing

- `uv run pytest tests/unit/base/agents/test_events_handlers.py -q` (4 passed)
- `uv run pytest src/backend/tests/unit/components/models_and_agents/test_agent_events.py -q` (52 passed)
- `uv run ruff check src/lfx/src/lfx/base/agents/events.py src/lfx/tests/unit/base/agents/test_events_handlers.py`
- `uv run ruff format --check src/lfx/src/lfx/base/agents/events.py src/lfx/tests/unit/base/agents/test_events_handlers.py`
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution timing accuracy by excluding message callback delays from reported durations.
  * Tool duration records now reflect the actual time spent executing the tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[LE-2085]: https://datastax.jira.com/browse/LE-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ