### PR TITLE
fix: stop shipping application telemetry to the LLM tracing vendor

### DIFF
--- a/src/backend/base/langflow/services/tracing/traceloop.py
+++ b/src/backend/base/langflow/services/tracing/traceloop.py
@@ -84,32 +84,38 @@ def _application_telemetry_withheld():
     attaches to, and its exporter then sees every span on it -- including the service's own
     HTTP and flow spans, which the operator pointed at their APM and not at Traceloop.
 
-    Wrapping ``add_span_processor`` for the duration of ``init`` rather than passing
-    ``processor=`` leaves the SDK's own pipeline alone. Supplying a processor also turns off
-    its metrics, drops the ``TRACELOOP_HEADERS`` auth the Instana integration depends on,
-    makes ``disable_batch`` inert and skips prompt sync, none of which this needs to touch.
-    It also fails the right way: a span can only reach the vendor via a processor added to
-    our provider, and that is the one call intercepted here.
+    When no OTLP endpoint is configured the bootstrap installs nothing and the global provider
+    is still a proxy, which does not make the problem go away: the SDK then creates a concrete
+    provider and registers it globally, the proxy resolves onto it, and the service's spans
+    reach the vendor by the same route. So the filter has to apply in both cases.
 
-    Serialised because flows run concurrently and the patch is on a process-wide object: two
+    It is applied to the SDK's own processor factory rather than to the provider. Patching the
+    provider's ``add_span_processor`` only covers the case where a provider already exists, and
+    it is a shared object -- a processor another integration registers while ``init`` is running
+    would be wrapped too, and would then have this filter's boundary applied backwards.
+
+    Passing ``processor=`` to ``init`` is the other obvious hook and is worse: it turns off the
+    SDK's metrics, drops the ``TRACELOOP_HEADERS`` auth the Instana integration depends on,
+    makes ``disable_batch`` inert and skips prompt sync. Wrapping the factory leaves all of
+    that alone, because from ``init``'s point of view no processor was supplied.
+
+    Serialised because flows run concurrently and the patch is on a module attribute: two
     tracers initialising at once would otherwise have the first one's restore run while the
     second is still inside init, leaving that run's processor unwrapped.
     """
+    from traceloop.sdk.tracing import tracing as traceloop_tracing
+
     with _INIT_LOCK:
-        provider = trace.get_tracer_provider()
-        if not hasattr(provider, "add_span_processor"):
-            # A proxy provider: the SDK builds its own, which carries nothing of ours.
-            yield
-            return
+        original = traceloop_tracing.get_default_span_processor
 
-        def add_span_processor(processor: SpanProcessor) -> None:
-            type(provider).add_span_processor(provider, _ApplicationScopeFilter(processor))
+        def get_default_span_processor(*args, **kwargs) -> SpanProcessor:
+            return _ApplicationScopeFilter(original(*args, **kwargs))
 
-        provider.add_span_processor = add_span_processor
+        traceloop_tracing.get_default_span_processor = get_default_span_processor
         try:
             yield
         finally:
-            del provider.add_span_processor
+            traceloop_tracing.get_default_span_processor = original
 
 
 class TraceloopTracer(BaseTracer):

--- a/src/backend/base/langflow/services/tracing/traceloop.py
+++ b/src/backend/base/langflow/services/tracing/traceloop.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import json
 import math
 import os
+import threading
 import types
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from lfx.log.logger import logger
+from lfx.observability import APPLICATION_INSTRUMENTATION_SCOPES
 from opentelemetry import trace
+from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.trace import Span, use_span
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from traceloop.sdk import Traceloop
@@ -28,6 +32,84 @@ if TYPE_CHECKING:
 
     from langflow.graph.vertex.base import Vertex
     from langflow.services.tracing.schema import Log
+
+
+# Traceloop.init is not reentrant (TracerWrapper is a singleton built in __new__) and the patch
+# below is on a process-wide object, so concurrent flow runs are serialised through this.
+_INIT_LOCK = threading.Lock()
+
+
+class _ApplicationScopeFilter(SpanProcessor):
+    """Delegates to a Traceloop processor, minus the spans that belong to the operator's APM.
+
+    Everything the application allowlist does not claim is passed through, so the vendor keeps
+    its own LLM spans and anything else it instruments. The default falls towards the vendor
+    deliberately: the allowlist is the set we know the APM exports, and dropping only that is
+    what makes this safe to wrap around a pipeline whose contents we do not control.
+    """
+
+    def __init__(self, wrapped: SpanProcessor) -> None:
+        self._wrapped = wrapped
+        self._dropped_scopes: set[str] = set()
+
+    @override
+    def on_start(self, span, parent_context=None) -> None:
+        self._wrapped.on_start(span, parent_context)
+
+    @override
+    def on_end(self, span) -> None:
+        scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
+        if scope not in APPLICATION_INSTRUMENTATION_SCOPES:
+            self._wrapped.on_end(span)
+            return
+        if scope not in self._dropped_scopes:
+            self._dropped_scopes.add(scope)
+            logger.debug(f"Not sending {scope!r} spans to Traceloop; that is application telemetry.")
+
+    @override
+    def shutdown(self) -> None:
+        self._wrapped.shutdown()
+
+    @override
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._wrapped.force_flush(timeout_millis)
+
+
+@contextmanager
+def _application_telemetry_withheld():
+    """Keep the service's own telemetry out of whatever exporter Traceloop attaches.
+
+    The SDK takes no tracer provider. It adopts whichever provider is global and adds its
+    exporter to that, so when application observability is enabled it is our provider it
+    attaches to, and its exporter then sees every span on it -- including the service's own
+    HTTP and flow spans, which the operator pointed at their APM and not at Traceloop.
+
+    Wrapping ``add_span_processor`` for the duration of ``init`` rather than passing
+    ``processor=`` leaves the SDK's own pipeline alone. Supplying a processor also turns off
+    its metrics, drops the ``TRACELOOP_HEADERS`` auth the Instana integration depends on,
+    makes ``disable_batch`` inert and skips prompt sync, none of which this needs to touch.
+    It also fails the right way: a span can only reach the vendor via a processor added to
+    our provider, and that is the one call intercepted here.
+
+    Serialised because flows run concurrently and the patch is on a process-wide object: two
+    tracers initialising at once would otherwise have the first one's restore run while the
+    second is still inside init, leaving that run's processor unwrapped.
+    """
+    with _INIT_LOCK:
+        provider = trace.get_tracer_provider()
+        if not hasattr(provider, "add_span_processor"):
+            # A proxy provider: the SDK builds its own, which carries nothing of ours.
+            yield
+            return
+
+        def add_span_processor(processor: SpanProcessor) -> None:
+            type(provider).add_span_processor(provider, _ApplicationScopeFilter(processor))
+
+        provider.add_span_processor = add_span_processor
+        try:
+            yield
+        finally:
+            del provider.add_span_processor
 
 
 class TraceloopTracer(BaseTracer):
@@ -55,14 +137,16 @@ class TraceloopTracer(BaseTracer):
             return
 
         api_key = os.getenv("TRACELOOP_API_KEY", "").strip()
+        api_endpoint = os.getenv("TRACELOOP_BASE_URL", "https://api.traceloop.com")
         try:
-            Traceloop.init(
-                block_instruments={Instruments.PYMYSQL},
-                app_name=project_name,
-                disable_batch=True,
-                api_key=api_key,
-                api_endpoint=os.getenv("TRACELOOP_BASE_URL", "https://api.traceloop.com"),
-            )
+            with _application_telemetry_withheld():
+                Traceloop.init(
+                    block_instruments={Instruments.PYMYSQL},
+                    app_name=project_name,
+                    disable_batch=True,
+                    api_key=api_key,
+                    api_endpoint=api_endpoint,
+                )
             self._ready = True
             self._tracer = trace.get_tracer("langflow")
             self.propagator = TraceContextTextMapPropagator()

--- a/src/backend/base/langflow/services/tracing/traceloop.py
+++ b/src/backend/base/langflow/services/tracing/traceloop.py
@@ -23,7 +23,7 @@ from typing_extensions import override
 from langflow.services.tracing.base import BaseTracer
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
     from uuid import UUID
 
     from langchain_core.callbacks.base import BaseCallbackHandler
@@ -34,9 +34,23 @@ if TYPE_CHECKING:
     from langflow.services.tracing.schema import Log
 
 
-# Traceloop.init is not reentrant (TracerWrapper is a singleton built in __new__) and the patch
-# below is on a process-wide object, so concurrent flow runs are serialised through this.
+# ---------------------------------------------------------------------------------------------
+# Keeping the service's own telemetry out of Traceloop's exporter.
+#
+# The SDK takes no tracer provider. It adopts whichever provider is global and attaches its
+# exporter to that, so its exporter sees every span on that provider -- including the service's
+# own HTTP and flow spans. ``instrument_fastapi_app`` runs unconditionally at startup, so those
+# HTTP spans exist in every install, whether or not an APM is configured. Without a filter they
+# are shipped to the vendor along with the LLM traces the operator actually asked for.
+# ---------------------------------------------------------------------------------------------
+
+# Traceloop.init is not reentrant (TracerWrapper is a singleton built in __new__) and the hook
+# below is on a module attribute, so concurrent flow runs are serialised through this.
 _INIT_LOCK = threading.Lock()
+
+# Set once the filter has been observed to install. Only the init that actually builds the
+# SDK's pipeline runs the factory; later ones are no-ops and must not be read as a failure.
+_boundary_installed = False
 
 
 class _ApplicationScopeFilter(SpanProcessor):
@@ -46,6 +60,10 @@ class _ApplicationScopeFilter(SpanProcessor):
     its own LLM spans and anything else it instruments. The default falls towards the vendor
     deliberately: the allowlist is the set we know the APM exports, and dropping only that is
     what makes this safe to wrap around a pipeline whose contents we do not control.
+
+    Note that ``APPLICATION_INSTRUMENTATION_SCOPES`` is therefore load-bearing in two
+    directions. Adding a scope to it enriches the APM *and* removes that scope from every
+    Traceloop trace.
     """
 
     def __init__(self, wrapped: SpanProcessor) -> None:
@@ -76,46 +94,61 @@ class _ApplicationScopeFilter(SpanProcessor):
 
 
 @contextmanager
-def _application_telemetry_withheld():
-    """Keep the service's own telemetry out of whatever exporter Traceloop attaches.
+def _application_telemetry_withheld() -> Iterator[None]:
+    """Wrap the SDK's span processor factory for the duration of ``Traceloop.init``.
 
-    The SDK takes no tracer provider. It adopts whichever provider is global and adds its
-    exporter to that, so when application observability is enabled it is our provider it
-    attaches to, and its exporter then sees every span on it -- including the service's own
-    HTTP and flow spans, which the operator pointed at their APM and not at Traceloop.
-
-    When no OTLP endpoint is configured the bootstrap installs nothing and the global provider
-    is still a proxy, which does not make the problem go away: the SDK then creates a concrete
-    provider and registers it globally, the proxy resolves onto it, and the service's spans
-    reach the vendor by the same route. So the filter has to apply in both cases.
-
-    It is applied to the SDK's own processor factory rather than to the provider. Patching the
-    provider's ``add_span_processor`` only covers the case where a provider already exists, and
-    it is a shared object -- a processor another integration registers while ``init`` is running
-    would be wrapped too, and would then have this filter's boundary applied backwards.
+    The factory is the hook because it is the one place every export path goes through. The
+    provider is not: patching ``add_span_processor`` only covers the case where a provider
+    already exists, and misses the far more common one where no APM is configured, the global
+    provider is still a proxy, and the SDK creates and registers its own concrete provider that
+    the proxy then resolves onto. The provider is also shared, so a processor another
+    integration registered during ``init`` would be wrapped and have this boundary applied
+    backwards.
 
     Passing ``processor=`` to ``init`` is the other obvious hook and is worse: it turns off the
     SDK's metrics, drops the ``TRACELOOP_HEADERS`` auth the Instana integration depends on,
-    makes ``disable_batch`` inert and skips prompt sync. Wrapping the factory leaves all of
-    that alone, because from ``init``'s point of view no processor was supplied.
+    makes ``disable_batch`` inert and skips prompt sync. Wrapping the factory leaves all of that
+    alone, because from ``init``'s point of view no processor was supplied.
 
-    Serialised because flows run concurrently and the patch is on a module attribute: two
-    tracers initialising at once would otherwise have the first one's restore run while the
-    second is still inside init, leaving that run's processor unwrapped.
+    Fails closed. ``traceloop-sdk`` is depended on across a wide range, and if a release stops
+    routing through this factory the filter stops applying with no other symptom. A silent leak
+    is the one failure mode an export boundary must not have, so an init that builds the SDK's
+    pipeline without installing the filter raises instead of exporting unfiltered.
+
+    Serialised because flows run concurrently and the hook is on a module attribute: two tracers
+    initialising at once would otherwise have the first one's restore run while the second is
+    still inside init, leaving that run's processor unwrapped.
     """
+    global _boundary_installed  # noqa: PLW0603
     from traceloop.sdk.tracing import tracing as traceloop_tracing
 
     with _INIT_LOCK:
         original = traceloop_tracing.get_default_span_processor
+        installed: list[_ApplicationScopeFilter] = []
 
         def get_default_span_processor(*args, **kwargs) -> SpanProcessor:
-            return _ApplicationScopeFilter(original(*args, **kwargs))
+            span_processor = _ApplicationScopeFilter(original(*args, **kwargs))
+            installed.append(span_processor)
+            return span_processor
 
         traceloop_tracing.get_default_span_processor = get_default_span_processor
         try:
             yield
         finally:
             traceloop_tracing.get_default_span_processor = original
+
+        if installed:
+            _boundary_installed = True
+        elif not _boundary_installed:
+            msg = (
+                "Traceloop was initialised without the filter that keeps Langflow's own "
+                "telemetry out of its exporter, so the integration has been disabled rather "
+                "than shipping the service's HTTP and flow spans to the vendor. This means the "
+                "installed traceloop-sdk no longer builds its exporter through "
+                "get_default_span_processor; pin traceloop-sdk to a version that does."
+            )
+            logger.error(msg)
+            raise RuntimeError(msg)
 
 
 class TraceloopTracer(BaseTracer):

--- a/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
+++ b/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
@@ -1,0 +1,165 @@
+"""Traceloop attaches to the global tracer provider, so it must not receive our own telemetry.
+
+The Traceloop SDK takes no ``tracer_provider``. It adopts whichever provider is global and adds
+its exporter to it, so when application observability is enabled it is *our* provider it attaches
+to -- and its exporter then sees every span on it, including the service's own HTTP and flow
+spans. Those belong in the operator's APM, which is not where Traceloop points.
+
+Both the global provider and Traceloop's ``TracerWrapper`` are process-wide singletons that
+cannot be undone in-process, so every case runs in its own subprocess against two real loopback
+collectors. Span names are matched in the raw OTLP payload: counting requests is not enough,
+because "one batch each" looks identical whether the split is correct or exactly inverted.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytest.importorskip("traceloop.sdk", reason="requires the traceloop extra")
+
+# Two loopback collectors standing in for the operator's APM and api.traceloop.com, plus the
+# harness that reports which span names reached which one.
+_HARNESS = """
+import json, os, threading, time, uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+bodies = {"apm": [], "traceloop": []}
+
+def _collector(which):
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            bodies[which].append(body)
+            self.send_response(200); self.send_header("Content-Length", "0"); self.end_headers()
+        def log_message(self, *args):
+            pass
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server.server_port
+
+apm_port, traceloop_port = _collector("apm"), _collector("traceloop")
+os.environ["TRACELOOP_BASE_URL"] = f"http://127.0.0.1:{traceloop_port}"
+os.environ["TRACELOOP_API_KEY"] = "test-key"  # pragma: allowlist secret
+
+def report(**extra):
+    time.sleep(1)
+    seen = {}
+    for target in ("apm", "traceloop"):
+        seen[target] = sorted(
+            name.decode()
+            for name in (b"flow.execute", b"llm.call")
+            if any(name in body for body in bodies[target])
+        )
+    print("RESULT " + json.dumps({**seen, **extra}))
+"""
+
+
+def _run(body: str) -> dict:
+    # The probe sets every variable it depends on. An OTEL_ or TRACELOOP_ variable inherited
+    # from the developer's shell (OTEL_TRACES_EXPORTER=none, OTEL_EXPORTER_OTLP_PROTOCOL=grpc)
+    # would route the exporters away from the loopback collectors and fail all three.
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "TRACELOOP_"))}
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _HARNESS + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    line = next((ln for ln in completed.stdout.splitlines() if ln.startswith("RESULT ")), None)
+    assert line, f"probe printed no result:\n{completed.stdout[-2000:]}\n{completed.stderr[-2000:]}"
+    return json.loads(line.removeprefix("RESULT "))
+
+
+def test_application_spans_do_not_reach_the_llm_vendor():
+    """The service's own telemetry must not be shipped to Traceloop's backend.
+
+    Without the filter this fails with flow.execute present in BOTH lists: our provider fans
+    out to the APM and to Traceloop, and only the APM leg is filtered.
+    """
+    result = _run("""
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{apm_port}"
+        os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+
+        from lfx.observability import bootstrap_application_telemetry, APPLICATION_TRACER_NAME
+        telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+        from langflow.services.tracing.traceloop import TraceloopTracer
+        tracer = TraceloopTracer(
+            trace_name="probe", trace_type="chain", project_name="probe", trace_id=uuid.uuid4()
+        )
+
+        from opentelemetry import trace
+        trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+        telemetry.tracer_provider.force_flush(5000)
+        report(ready=tracer._ready)
+    """)
+
+    assert result["ready"] is True, "the vendor integration must still initialise"
+    assert result["apm"] == ["flow.execute"], "application telemetry belongs in the operator's APM"
+    assert result["traceloop"] == [], "application telemetry leaked to the LLM vendor"
+
+
+def test_vendor_spans_still_reach_the_vendor():
+    """Filtering our telemetry out must not cost Traceloop its own spans.
+
+    The vendor span is emitted on the tracer TraceloopTracer itself uses ("langflow"), which is
+    the scope the real integration puts flow content on and the nearest neighbour of the
+    application allowlist. Asserted separately from the case above so a regression that
+    silently drops everything cannot pass by looking like a successful filter.
+    """
+    result = _run("""
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{apm_port}"
+        os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+
+        from lfx.observability import bootstrap_application_telemetry
+        telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+        from langflow.services.tracing.traceloop import TraceloopTracer
+        TraceloopTracer(trace_name="probe", trace_type="chain", project_name="probe", trace_id=uuid.uuid4())
+
+        from opentelemetry import trace
+        trace.get_tracer("langflow").start_span("llm.call").end()
+        telemetry.tracer_provider.force_flush(5000)
+        report()
+    """)
+
+    assert result["traceloop"] == ["llm.call"], "the vendor must still receive its own spans"
+    assert result["apm"] == [], "vendor spans must not reach the operator's APM"
+
+
+def test_vendor_first_leaves_the_operator_without_application_telemetry():
+    """Characterises the reverse order, which this change does not fix.
+
+    When Traceloop initialises before the bootstrap it claims the global provider, and OTel's
+    set_tracer_provider is one-shot, so enabling OTLP afterwards in the same process cannot
+    install ours. The filter goes on our provider, so with Traceloop owning the global one
+    there is nothing to put it on and application spans still reach the vendor.
+
+    In practice the bootstrap runs at app startup and Traceloop only on the first flow run, so
+    our provider wins. This pins the limitation rather than asserting it is acceptable: if the
+    ordering is ever made robust, traceloop becomes empty and this test should say so.
+    """
+    result = _run("""
+        from langflow.services.tracing.traceloop import TraceloopTracer
+        TraceloopTracer(trace_name="probe", trace_type="chain", project_name="probe", trace_id=uuid.uuid4())
+
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{apm_port}"
+        os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+        from lfx.observability import bootstrap_application_telemetry, APPLICATION_TRACER_NAME
+        telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+        from opentelemetry import trace
+        trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+        report(installed=telemetry.tracer_provider is not None)
+    """)
+
+    assert result["installed"] is False, "the bootstrap must decline rather than fight for the global"
+    assert result["apm"] == [], "known limitation: the APM receives nothing when the vendor initialises first"
+    assert result["traceloop"] == ["flow.execute"], "known limitation: the vendor receives it instead"

--- a/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
+++ b/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
@@ -133,6 +133,47 @@ def test_application_spans_do_not_reach_the_vendor_without_an_apm():
     assert result["traceloop"] == [], "application telemetry leaked to the LLM vendor"
 
 
+def test_the_integration_is_disabled_when_the_filter_cannot_be_installed():
+    """A future SDK that stops using the factory must break the integration, not the boundary.
+
+    ``traceloop-sdk`` is depended on across a wide range, and the filter is installed by wrapping
+    a function of theirs. If a release stops routing through it, nothing else changes: spans keep
+    flowing and the only difference is that the service's own telemetry is in them. So a run that
+    builds the SDK's pipeline without installing the filter has to fail loudly instead.
+
+    Simulated by making the factory unreachable under the name the wrapper replaces, which is
+    what any rename or inlining upstream would look like from here.
+    """
+    result = _run("""
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{apm_port}"
+        os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+
+        from lfx.observability import bootstrap_application_telemetry, APPLICATION_TRACER_NAME
+        telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+        # Stand in for an upstream release that builds its exporter some other way: the name the
+        # wrapper replaces is still there, but init no longer calls it.
+        from traceloop.sdk.tracing import tracing as traceloop_tracing
+        real = traceloop_tracing.get_default_span_processor
+        traceloop_tracing.TracerWrapper.__new__ = (
+            lambda cls, *a, **kw: object.__new__(cls) if not hasattr(cls, "instance") else cls.instance
+        )
+
+        from langflow.services.tracing.traceloop import TraceloopTracer
+        tracer = TraceloopTracer(
+            trace_name="probe", trace_type="chain", project_name="probe", trace_id=uuid.uuid4()
+        )
+
+        from opentelemetry import trace
+        trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+        telemetry.tracer_provider.force_flush(5000)
+        report(ready=tracer.ready)
+    """)
+
+    assert result["ready"] is False, "the integration must refuse to run without the filter"
+    assert result["traceloop"] == [], "application telemetry leaked to the LLM vendor"
+
+
 def test_vendor_spans_still_reach_the_vendor():
     """Filtering our telemetry out must not cost Traceloop its own spans.
 

--- a/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
+++ b/src/backend/tests/unit/services/tracing/test_traceloop_application_telemetry.py
@@ -106,6 +106,33 @@ def test_application_spans_do_not_reach_the_llm_vendor():
     assert result["traceloop"] == [], "application telemetry leaked to the LLM vendor"
 
 
+def test_application_spans_do_not_reach_the_vendor_without_an_apm():
+    """The filter must also apply when no APM is configured, which is the common setup.
+
+    With no OTLP endpoint the bootstrap installs nothing and the global provider is still a
+    proxy. That does not mean there is nothing to filter: Traceloop then creates the concrete
+    provider and registers it globally, the proxy resolves onto it, and the service's own spans
+    reach the vendor by exactly the same route.
+    """
+    result = _run("""
+        from lfx.observability import bootstrap_application_telemetry, APPLICATION_TRACER_NAME
+        telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+        from langflow.services.tracing.traceloop import TraceloopTracer
+        tracer = TraceloopTracer(
+            trace_name="probe", trace_type="chain", project_name="probe", trace_id=uuid.uuid4()
+        )
+
+        from opentelemetry import trace
+        trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+        report(ready=tracer._ready, installed=telemetry.tracer_provider is not None)
+    """)
+
+    assert result["installed"] is False, "no OTLP endpoint means the bootstrap installs no provider"
+    assert result["ready"] is True, "the vendor integration must still initialise"
+    assert result["traceloop"] == [], "application telemetry leaked to the LLM vendor"
+
+
 def test_vendor_spans_still_reach_the_vendor():
     """Filtering our telemetry out must not cost Traceloop its own spans.
 
@@ -135,16 +162,19 @@ def test_vendor_spans_still_reach_the_vendor():
 
 
 def test_vendor_first_leaves_the_operator_without_application_telemetry():
-    """Characterises the reverse order, which this change does not fix.
+    """Characterises the reverse order: no leak, but no application telemetry either.
 
     When Traceloop initialises before the bootstrap it claims the global provider, and OTel's
     set_tracer_provider is one-shot, so enabling OTLP afterwards in the same process cannot
-    install ours. The filter goes on our provider, so with Traceloop owning the global one
-    there is nothing to put it on and application spans still reach the vendor.
+    install ours. The operator's APM therefore receives nothing, and that part is a real
+    limitation rather than something this change fixes.
+
+    What it does fix is the direction that matters: the filter is on Traceloop's own processor,
+    so it applies whichever provider Traceloop ended up with. The application span is dropped
+    rather than shipped to the vendor.
 
     In practice the bootstrap runs at app startup and Traceloop only on the first flow run, so
-    our provider wins. This pins the limitation rather than asserting it is acceptable: if the
-    ordering is ever made robust, traceloop becomes empty and this test should say so.
+    this ordering does not arise in a deployed process.
     """
     result = _run("""
         from langflow.services.tracing.traceloop import TraceloopTracer
@@ -162,4 +192,4 @@ def test_vendor_first_leaves_the_operator_without_application_telemetry():
 
     assert result["installed"] is False, "the bootstrap must decline rather than fight for the global"
     assert result["apm"] == [], "known limitation: the APM receives nothing when the vendor initialises first"
-    assert result["traceloop"] == ["flow.execute"], "known limitation: the vendor receives it instead"
+    assert result["traceloop"] == [], "but application telemetry must still not reach the vendor"


### PR DESCRIPTION
## What

The Traceloop SDK takes no tracer provider. It adopts whichever provider is global and attaches its exporter to that, so its exporter sees every span on that provider, including the service's own HTTP and flow spans. `instrument_fastapi_app` runs unconditionally at startup, so those HTTP spans exist in **every** install, whether or not an APM is configured. They were being shipped to `api.traceloop.com` alongside the LLM traces the operator actually asked for.

The fix wraps the SDK's own span processor factory for the duration of `Traceloop.init`, so whatever it builds is filtered: spans whose instrumentation scope is in the application allowlist are dropped, everything else passes through untouched.

## Why the factory and not the provider

The factory is the one place every export path goes through.

Patching the provider's `add_span_processor` only covers the case where a provider already exists. It misses the more common one: with no OTLP endpoint the bootstrap installs nothing, the global provider is still a proxy, the SDK creates and registers its own concrete provider, and the proxy resolves onto it. Same leak, different route. The provider is also a shared object, so a processor another integration registered during `init` would have been wrapped too and had this boundary applied backwards.

Passing `processor=` to `init` is the other obvious hook and is worse. It turns off the SDK's metrics, drops the `TRACELOOP_HEADERS` auth the [Instana integration](https://docs.langflow.org/integrations-instana-traceloop) depends on, makes `disable_batch` inert, and skips config/prompt sync. Wrapping the factory leaves all of that alone, because from `init`'s point of view no processor was supplied.

## Fail-closed

`traceloop-sdk` is depended on across `>=0.43.1,<1.0.0` and the filter is installed by wrapping a function of theirs. If a release stops routing through `get_default_span_processor`, the filter stops applying and there is no other symptom: spans keep flowing, and the only difference is that the service's telemetry is in them. CI will not catch it either, since CI resolves the lockfile while the version that breaks it is the one a user installs.

So the integration now records whether the filter actually installed, and disables itself with an explanatory error if an init that built the SDK's pipeline did not get one. A broken LLM tracing integration is recoverable; silently shipping the operator's HTTP and flow spans to a third party is not. Happy to be argued out of the severity of that response.

## Verification

Every test was checked against the failure it claims to catch, not just observed green:

- Leak reproduced with two loopback collectors: without the filter, one `flow.execute` span arrives at *both* the APM and the vendor. With it, the APM gets `flow.execute` and the vendor gets only `llm.call`.
- The no-APM case is covered separately, since that is the configuration the provider-patching approach missed.
- Disabling the filter turns three of the four boundary tests red; the fourth asserts pass-through, so it correctly stays green.
- Removing the fail-closed raise turns the fail-closed test red.
- Instana's `TRACELOOP_HEADERS` still reaches the collector, metrics stay enabled, and 200 tracer constructions add one thread rather than 200.
- 330 passed, 3 skipped in `src/backend/tests/unit/services/tracing/`.

## Known gap

If Traceloop initialises *before* the bootstrap it owns the global provider and `set_tracer_provider` is one-shot, so the operator's APM receives nothing. That part is not fixed here and cannot be from our side in the same process. The leak direction *is* fixed in that ordering, because the filter is on Traceloop's own processor rather than on a provider. There is a test pinning both halves.

## Note on direction

This is a workaround for one SDK's design choice. Seven of the eight tracing vendors either accept a `tracer_provider=` or build their own; Traceloop is the only one that adopts the global. The durable fix is upstream, and this should be deletable once it lands.

Companion: #14359 pins that the other six vendors coexist with the bootstrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented application telemetry from being sent to external tracing vendors.
  * Preserved vendor-specific telemetry routing while keeping application spans available to configured monitoring systems.
  * Disabled tracing integration safely when telemetry filtering cannot be installed.

* **Tests**
  * Added coverage for telemetry routing, missing monitoring configuration, initialization order, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->