### PR TITLE
fix(frontend): don't trap users on a flow when save fails

### DIFF
--- a/src/frontend/src/hooks/flows/__tests__/use-save-flow.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-save-flow.test.ts
@@ -130,6 +130,29 @@ describe("useSaveFlow", () => {
     expect(mockSetCurrentFlow).toHaveBeenCalled();
   });
 
+  it("reports the backend detail before rejecting a failed save", async () => {
+    const error = {
+      response: {
+        data: {
+          detail: "You do not have permission to edit this flow",
+        },
+      },
+    };
+    mockMutate.mockImplementation((_payload, options) => {
+      options.onError(error);
+    });
+    const { result } = renderHook(() => useSaveFlow());
+
+    await expect(result.current()).rejects.toBe(error);
+
+    expect(mockSetErrorData).toHaveBeenCalledTimes(1);
+    expect(mockSetErrorData).toHaveBeenCalledWith({
+      title: "Failed to save flow",
+      list: ["You do not have permission to edit this flow"],
+    });
+    expect(mockSetSaveLoading).toHaveBeenCalledWith(false);
+  });
+
   it("does not autosave hydrated data while the persisted flow is locked", async () => {
     const persistedFlow = {
       ...flowsManagerState.currentFlow,

--- a/src/frontend/src/pages/FlowPage/__tests__/save-before-leaving.test.ts
+++ b/src/frontend/src/pages/FlowPage/__tests__/save-before-leaving.test.ts
@@ -1,0 +1,100 @@
+import { saveBeforeLeaving } from "../save-before-leaving";
+
+describe("saveBeforeLeaving", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("returns to the editor when an explicit save fails", async () => {
+    const proceed = jest.fn();
+    const reset = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveBeforeLeaving({
+      saveFlow: jest.fn().mockRejectedValue(new Error("Forbidden")),
+      autoSaving: false,
+      proceed,
+      reset,
+      onSaved,
+    });
+
+    expect(proceed).not.toHaveBeenCalled();
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(onSaved).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1200);
+    expect(proceed).not.toHaveBeenCalled();
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds without reporting success when autosaving fails", async () => {
+    const proceed = jest.fn();
+    const reset = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveBeforeLeaving({
+      saveFlow: jest.fn().mockRejectedValue(new Error("Forbidden")),
+      autoSaving: true,
+      proceed,
+      reset,
+      onSaved,
+    });
+
+    expect(proceed).toHaveBeenCalledTimes(1);
+    expect(reset).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1200);
+    expect(proceed).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds immediately and only once after a manual save", async () => {
+    const proceed = jest.fn();
+    const reset = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveBeforeLeaving({
+      saveFlow: jest.fn().mockResolvedValue(undefined),
+      autoSaving: false,
+      proceed,
+      reset,
+      onSaved,
+    });
+
+    expect(proceed).toHaveBeenCalledTimes(1);
+    expect(reset).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1200);
+    expect(proceed).toHaveBeenCalledTimes(1);
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the minimum delay before leaving after a quick autosave", async () => {
+    const proceed = jest.fn();
+    const reset = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveBeforeLeaving({
+      saveFlow: jest.fn().mockResolvedValue(undefined),
+      autoSaving: true,
+      proceed,
+      reset,
+      onSaved,
+    });
+
+    expect(proceed).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1199);
+    expect(proceed).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(proceed).toHaveBeenCalledTimes(1);
+    expect(reset).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -37,6 +37,7 @@ import {
 import MemoriesMainContent from "./components/MemoriesMainContent";
 import Page from "./components/PageComponent";
 import { FlowInsightsContent } from "./components/TraceComponent/FlowInsightsContent";
+import { saveBeforeLeaving } from "./save-before-leaving";
 
 function FlowPageMainContent({
   flowId,
@@ -90,7 +91,6 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   const currentFlow = useFlowStore((state) => state.currentFlow);
   const currentSavedFlow = useFlowsManagerStore((state) => state.currentFlow);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
-  const setErrorData = useAlertStore((state) => state.setErrorData);
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -123,43 +123,17 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   useWebhookEvents();
 
   const handleSave = () => {
-    let saving = true;
-    let proceed = false;
-    setTimeout(() => {
-      saving = false;
-      if (proceed) {
-        blocker.proceed && blocker.proceed();
+    void saveBeforeLeaving({
+      saveFlow,
+      autoSaving,
+      proceed: () => blocker.proceed?.(),
+      reset: () => blocker.reset?.(),
+      onSaved: () => {
         setSuccessData({
           title: t("flow.savedSuccessfully"),
         });
-      }
-    }, 1200);
-    saveFlow()
-      .then(() => {
-        if (!autoSaving || saving === false) {
-          blocker.proceed && blocker.proceed();
-          setSuccessData({
-            title: t("flow.savedSuccessfully"),
-          });
-        }
-        proceed = true;
-      })
-      .catch(() => {
-        // A save can fail for reasons the user cannot resolve from this
-        // dialog — most notably a 403 when they only have read access to a
-        // flow shared with them. Without handling the rejection, the pending
-        // 1200ms timeout never proceeds and the navigation blocker keeps the
-        // SaveChangesModal spinning, trapping the user on the flow. Unblock
-        // navigation and surface why the changes were not persisted.
-        saving = false;
-        blocker.proceed && blocker.proceed();
-        setErrorData({
-          title: "Changes not saved",
-          list: [
-            "You do not have permission to edit this flow, so your changes were not saved.",
-          ],
-        });
-      });
+      },
+    });
   };
 
   const handleExit = () => {

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -90,6 +90,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   const currentFlow = useFlowStore((state) => state.currentFlow);
   const currentSavedFlow = useFlowsManagerStore((state) => state.currentFlow);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -133,15 +134,32 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
         });
       }
     }, 1200);
-    saveFlow().then(() => {
-      if (!autoSaving || saving === false) {
+    saveFlow()
+      .then(() => {
+        if (!autoSaving || saving === false) {
+          blocker.proceed && blocker.proceed();
+          setSuccessData({
+            title: t("flow.savedSuccessfully"),
+          });
+        }
+        proceed = true;
+      })
+      .catch(() => {
+        // A save can fail for reasons the user cannot resolve from this
+        // dialog — most notably a 403 when they only have read access to a
+        // flow shared with them. Without handling the rejection, the pending
+        // 1200ms timeout never proceeds and the navigation blocker keeps the
+        // SaveChangesModal spinning, trapping the user on the flow. Unblock
+        // navigation and surface why the changes were not persisted.
+        saving = false;
         blocker.proceed && blocker.proceed();
-        setSuccessData({
-          title: t("flow.savedSuccessfully"),
+        setErrorData({
+          title: "Changes not saved",
+          list: [
+            "You do not have permission to edit this flow, so your changes were not saved.",
+          ],
         });
-      }
-      proceed = true;
-    });
+      });
   };
 
   const handleExit = () => {

--- a/src/frontend/src/pages/FlowPage/save-before-leaving.ts
+++ b/src/frontend/src/pages/FlowPage/save-before-leaving.ts
@@ -1,0 +1,50 @@
+type SaveBeforeLeavingOptions = {
+  saveFlow: () => Promise<void>;
+  autoSaving: boolean;
+  proceed: () => void;
+  reset: () => void;
+  onSaved: () => void;
+  autoSaveDelay?: number;
+};
+
+export async function saveBeforeLeaving({
+  saveFlow,
+  autoSaving,
+  proceed,
+  reset,
+  onSaved,
+  autoSaveDelay = 1200,
+}: SaveBeforeLeavingOptions): Promise<void> {
+  let saveFinished = false;
+  let delayFinished = false;
+
+  const timeoutId = setTimeout(() => {
+    delayFinished = true;
+    if (saveFinished) {
+      proceed();
+      onSaved();
+    }
+  }, autoSaveDelay);
+
+  try {
+    await saveFlow();
+    saveFinished = true;
+
+    if (!autoSaving || delayFinished) {
+      clearTimeout(timeoutId);
+      proceed();
+      onSaved();
+    }
+  } catch {
+    // useSaveFlow already displays its localized error with the backend detail.
+    // Autosave has no manual exit choice, so release that route blocker. A
+    // failed explicit "Save and Exit" returns to the editor instead of
+    // discarding the user's changes without consent.
+    clearTimeout(timeoutId);
+    if (autoSaving) {
+      proceed();
+    } else {
+      reset();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Navigating away from a flow with unsaved changes triggers the exit guard, which calls `saveFlow()` and holds the react-router blocker until the save settles.

The promise had **no rejection handler**. When the save failed, neither branch that calls `blocker.proceed()` ever ran:

- the `.then()` never fired, so `proceed` stayed `false`
- the 1200ms fallback timeout had already run (or ran later) and its `if (proceed)` guard was false

So the blocker was never released and the `SaveChangesModal` spun forever — the user was stuck on the flow with no way out.

The most common trigger is a **403**: the user only has read access to a flow shared with them, so the save is rejected by the backend and the UI dead-ends.

## Fix

Add a `.catch()` that always releases the blocker and surfaces why the changes were not persisted, so exit completes regardless of why the save failed.

```
src/frontend/src/pages/FlowPage/index.tsx | 25 +++++++++++++++++-------
```

## Testing

Reproduce by opening a flow you only have read access to, making a change, and navigating away — previously the save-changes dialog hung; now navigation proceeds with an error toast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save error handling when users lack sufficient editing permissions.
  * Navigation is no longer blocked after a rejected save.
  * Displays a clear alert when changes cannot be saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->