### PR TITLE
fix: keep LLM tracing vendors off the global tracer provider, and pin it

### DIFF
--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -79,9 +79,16 @@ class LangSmithTracer(BaseTracer):
         if os.getenv("LANGCHAIN_API_KEY") is None:
             return False
         try:
-            from langsmith import Client
+            from langsmith.run_trees import get_cached_client
+            from opentelemetry.sdk.trace import TracerProvider
 
-            self._client = Client()
+            # LANGSMITH_TRACING_MODE=otel|hybrid makes the client build an OpenTelemetry
+            # pipeline, and a bare Client() registers it as the *global* tracer provider.
+            # set_tracer_provider is one-shot, so whichever runs first wins: LangSmith then
+            # either swallows the service's own HTTP and flow spans or leaves application
+            # observability unable to install at all. Hand it an isolated provider instead,
+            # the same way langfuse.py does. Ignored in the default REST mode.
+            self._client = get_cached_client(otel_tracer_provider=TracerProvider())
         except ImportError:
             logger.exception("Could not import langsmith. Please install it with `pip install langsmith`.")
             return False

--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 import traceback
 import types
 from datetime import datetime, timezone
@@ -22,6 +23,54 @@ if TYPE_CHECKING:
     from lfx.graph.vertex.base import Vertex
 
     from langflow.services.tracing.schema import Log
+
+
+# Built once per process. TracerProvider.__init__ registers an atexit shutdown, so building
+# one per flow run would leave every provider alive for the life of the process.
+_OTEL_PROVIDER: Any = None
+_OTEL_PROVIDER_LOCK = threading.Lock()
+
+
+def _langsmith_otel_provider() -> Any:
+    """An isolated provider exporting to LangSmith's OTLP endpoint and nowhere else.
+
+    ``LANGSMITH_TRACING_MODE=otel|hybrid`` makes the client build an OpenTelemetry pipeline,
+    and a client constructed without a provider registers its own as the *global* one.
+    ``set_tracer_provider`` is one-shot, so whichever side runs first wins: LangSmith either
+    swallows the service's own HTTP and flow spans, or application observability cannot
+    install at all. That is issue #13319 in a different costume.
+
+    Handing over a bare ``TracerProvider()`` does not work, and the resemblance to
+    ``langfuse.py`` is what makes that tempting. The Langfuse SDK calls ``add_span_processor``
+    on the provider it is given; LangSmith only takes tracers from it, so a provider with no
+    processor silently discards every span and tracing looks healthy while nothing is sent.
+
+    This mirrors the SDK's own ``get_otlp_tracer_provider`` with one deliberate difference: it
+    does not honour ``OTEL_EXPORTER_OTLP_ENDPOINT``. That variable points at the operator's
+    APM, which is not where a vendor's prompt-bearing traces belong.
+    """
+    global _OTEL_PROVIDER  # noqa: PLW0603
+
+    with _OTEL_PROVIDER_LOCK:
+        if _OTEL_PROVIDER is None:
+            from langsmith import utils as ls_utils
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            headers = {"x-api-key": ls_utils.get_api_key(None) or ""}
+            project = ls_utils.get_tracer_project()
+            if project:
+                headers["Langsmith-Project"] = project
+
+            provider = TracerProvider(resource=Resource(attributes={"service.name": "langsmith"}))
+            provider.add_span_processor(
+                BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{ls_utils.get_api_url(None)}/otel", headers=headers))
+            )
+            _OTEL_PROVIDER = provider
+
+    return _OTEL_PROVIDER
 
 
 class LangSmithTracer(BaseTracer):
@@ -79,16 +128,19 @@ class LangSmithTracer(BaseTracer):
         if os.getenv("LANGCHAIN_API_KEY") is None:
             return False
         try:
+            from langsmith.client import _resolve_tracing_mode
             from langsmith.run_trees import get_cached_client
-            from opentelemetry.sdk.trace import TracerProvider
 
-            # LANGSMITH_TRACING_MODE=otel|hybrid makes the client build an OpenTelemetry
-            # pipeline, and a bare Client() registers it as the *global* tracer provider.
-            # set_tracer_provider is one-shot, so whichever runs first wins: LangSmith then
-            # either swallows the service's own HTTP and flow spans or leaves application
-            # observability unable to install at all. Hand it an isolated provider instead,
-            # the same way langfuse.py does. Ignored in the default REST mode.
-            self._client = get_cached_client(otel_tracer_provider=TracerProvider())
+            client_kwargs: dict[str, Any] = {}
+            if _resolve_tracing_mode(None) in ("otel", "hybrid"):
+                client_kwargs["otel_tracer_provider"] = _langsmith_otel_provider()
+
+            # get_cached_client honours these kwargs only while its module-level client is
+            # unset, so this holds when we are the first LangSmith user in the process. It is
+            # the same function langchain calls, so seeding it here replaces a redundant
+            # second client rather than adding one. Anything that builds the client before us
+            # (a LangChainTracer, a RunTree) gets the SDK's default global-provider behaviour.
+            self._client = get_cached_client(**client_kwargs)
         except ImportError:
             logger.exception("Could not import langsmith. Please install it with `pip install langsmith`.")
             return False

--- a/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
+++ b/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
@@ -19,6 +19,7 @@ Each case runs in a subprocess: the global provider, and most of these vendors' 
 process-wide singletons that cannot be undone in-process.
 """
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -33,6 +34,7 @@ import pytest
 # global one rather than merely absent.
 _VENDORS = {
     "arize_phoenix": {
+        "requires": "phoenix",
         "module": "langflow.services.tracing.arize_phoenix",
         "cls": "ArizePhoenixTracer",
         "env": {
@@ -42,6 +44,7 @@ _VENDORS = {
         "provider_expr": "tracer.tracer_provider",
     },
     "langfuse": {
+        "requires": "langfuse",
         "module": "langflow.services.tracing.langfuse",
         "cls": "LangFuseTracer",
         "env": {
@@ -54,6 +57,7 @@ _VENDORS = {
         "provider_expr": None,
     },
     "langsmith": {
+        "requires": "langsmith",
         "module": "langflow.services.tracing.langsmith",
         "cls": "LangSmithTracer",
         "env": {
@@ -62,7 +66,30 @@ _VENDORS = {
         },
         "provider_expr": None,
     },
+    "langsmith_otel": {
+        "requires": "langsmith",
+        "module": "langflow.services.tracing.langsmith",
+        "cls": "LangSmithTracer",
+        "env": {
+            "LANGCHAIN_API_KEY": "probe-key",  # pragma: allowlist secret
+            "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
+            "LANGSMITH_TRACING_MODE": "otel",
+        },
+        "provider_expr": None,
+    },
+    "langsmith_hybrid": {
+        "requires": "langsmith",
+        "module": "langflow.services.tracing.langsmith",
+        "cls": "LangSmithTracer",
+        "env": {
+            "LANGCHAIN_API_KEY": "probe-key",  # pragma: allowlist secret
+            "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
+            "LANGSMITH_TRACING_MODE": "hybrid",
+        },
+        "provider_expr": None,
+    },
     "langwatch": {
+        "requires": "langwatch",
         "module": "langflow.services.tracing.langwatch",
         "cls": "LangWatchTracer",
         "env": {
@@ -72,6 +99,7 @@ _VENDORS = {
         "provider_expr": "type(tracer).tracer_provider",
     },
     "openlayer": {
+        "requires": "openlayer",
         "module": "langflow.services.tracing.openlayer",
         "cls": "OpenlayerTracer",
         "env": {
@@ -82,6 +110,7 @@ _VENDORS = {
         "provider_expr": None,
     },
     "opik": {
+        "requires": "opik",
         "module": "langflow.services.tracing.opik",
         "cls": "OpikTracer",
         "env": {
@@ -214,7 +243,19 @@ def _run(vendor: str, probe: str) -> dict:
     return json.loads(line.removeprefix("RESULT "))
 
 
-@pytest.mark.parametrize("vendor", sorted(_VENDORS))
+def _vendor_params():
+    """Skip a vendor whose SDK is not installed here rather than failing the ready guard.
+
+    ``langwatch`` is declared ``python_version < "3.14"``, so on 3.14 it is legitimately
+    absent and its tracer can never report ready.
+    """
+    for name in sorted(_VENDORS):
+        missing = importlib.util.find_spec(_VENDORS[name]["requires"]) is None
+        marks = [pytest.mark.skip(reason=f"{_VENDORS[name]['requires']} is not installed")] if missing else []
+        yield pytest.param(name, marks=marks)
+
+
+@pytest.mark.parametrize("vendor", _vendor_params())
 def test_vendor_does_not_claim_the_global_provider(vendor: str):
     """A vendor that initialises first must still leave the global slot for the bootstrap.
 
@@ -235,7 +276,7 @@ def test_vendor_does_not_claim_the_global_provider(vendor: str):
         assert result["vendor_provider_is_separate"] is True, f"{vendor} is exporting from the global provider"
 
 
-@pytest.mark.parametrize("vendor", sorted(_VENDORS))
+@pytest.mark.parametrize("vendor", _vendor_params())
 def test_application_spans_do_not_reach_the_vendor(vendor: str):
     """The operator's application telemetry must stay out of the vendor's backend.
 

--- a/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
+++ b/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
@@ -1,0 +1,251 @@
+"""Enabling application observability must not disturb any LLM tracing vendor, or vice versa.
+
+There is one global tracer provider per process and ``set_tracer_provider`` is one-shot, so a
+vendor that registers itself globally takes the slot the application bootstrap needs -- and
+then receives every span on it. That is exactly what happened in #13319, where Langfuse claimed
+the global provider and FastAPIInstrumentor's HTTP spans started landing in Langfuse traces.
+
+The vendors that are OpenTelemetry-based avoid this by building their own isolated provider
+(``langfuse.py`` passes ``tracer_provider=``, ``langwatch.py`` sets
+``skip_open_telemetry_setup=True``, ``arize_phoenix.py`` hands its provider to the
+instrumentors). The four that are not OpenTelemetry-based have no provider at all. Either way
+the property is the same and is what this pins: after constructing the vendor's tracer, the
+global provider is still the object the bootstrap installed.
+
+Traceloop is deliberately absent. It is the one vendor that does *not* hold this property -- it
+adopts whichever provider is global -- and it has its own test file.
+
+Each case runs in a subprocess: the global provider, and most of these vendors' clients, are
+process-wide singletons that cannot be undone in-process.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Each vendor's endpoint is pointed at the loopback stub so nothing leaves the machine and no
+# real credential is needed. ``provider_expr`` is evaluated against the constructed tracer for
+# the vendors that expose their own provider, to pin that it is a *different* object from the
+# global one rather than merely absent.
+_VENDORS = {
+    "arize_phoenix": {
+        "module": "langflow.services.tracing.arize_phoenix",
+        "cls": "ArizePhoenixTracer",
+        "env": {
+            "PHOENIX_API_KEY": "probe-key",  # pragma: allowlist secret
+            "PHOENIX_COLLECTOR_ENDPOINT": "http://127.0.0.1:{vendor_port}",
+        },
+        "provider_expr": "tracer.tracer_provider",
+    },
+    "langfuse": {
+        "module": "langflow.services.tracing.langfuse",
+        "cls": "LangFuseTracer",
+        "env": {
+            "LANGFUSE_SECRET_KEY": "sk-probe",  # pragma: allowlist secret
+            "LANGFUSE_PUBLIC_KEY": "pk-probe",  # pragma: allowlist secret
+            "LANGFUSE_BASE_URL": "http://127.0.0.1:{vendor_port}",
+        },
+        # The isolated provider is held inside the shared Langfuse client, so there is no
+        # accessor on the tracer. "the global provider is untouched" is the #13319 property.
+        "provider_expr": None,
+    },
+    "langsmith": {
+        "module": "langflow.services.tracing.langsmith",
+        "cls": "LangSmithTracer",
+        "env": {
+            "LANGCHAIN_API_KEY": "probe-key",  # pragma: allowlist secret
+            "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
+        },
+        "provider_expr": None,
+    },
+    "langwatch": {
+        "module": "langflow.services.tracing.langwatch",
+        "cls": "LangWatchTracer",
+        "env": {
+            "LANGWATCH_API_KEY": "probe-key",  # pragma: allowlist secret
+            "LANGWATCH_ENDPOINT": "http://127.0.0.1:{vendor_port}",
+        },
+        "provider_expr": "type(tracer).tracer_provider",
+    },
+    "openlayer": {
+        "module": "langflow.services.tracing.openlayer",
+        "cls": "OpenlayerTracer",
+        "env": {
+            "OPENLAYER_API_KEY": "probe-key",  # pragma: allowlist secret
+            "OPENLAYER_INFERENCE_PIPELINE_ID": "probe-pipeline",
+            "OPENLAYER_BASE_URL": "http://127.0.0.1:{vendor_port}",
+        },
+        "provider_expr": None,
+    },
+    "opik": {
+        "module": "langflow.services.tracing.opik",
+        "cls": "OpikTracer",
+        "env": {
+            "OPIK_API_KEY": "probe-key",  # pragma: allowlist secret
+            "OPIK_WORKSPACE": "probe-workspace",
+            "OPIK_URL_OVERRIDE": "http://127.0.0.1:{vendor_port}/api",
+        },
+        "provider_expr": None,
+    },
+}
+
+# Two loopback servers: one standing in for the operator's APM, one for the vendor's backend.
+# The vendor stub answers Langfuse's auth_check (GET /api/public/projects, whose response it
+# validates against a model) and returns an empty JSON object to everything else, which is
+# enough for every other vendor's client to consider itself initialised.
+_HARNESS = """
+import json, os, threading, time, uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+bodies = {"apm": [], "vendor": []}
+
+def _collector(which):
+    class Handler(BaseHTTPRequestHandler):
+        def _respond(self):
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            bodies[which].append(self.rfile.read(length))
+            if "/api/public/projects" in self.path:
+                payload = json.dumps({"data": [{
+                    "id": "probe", "name": "probe", "metadata": {},
+                    "organization": {"id": "probe-org", "name": "probe-org", "metadata": {}},
+                }]}).encode()
+            else:
+                payload = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        do_POST = do_GET = do_PUT = do_PATCH = _respond
+        def log_message(self, *args):
+            pass
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server.server_port
+
+apm_port, vendor_port = _collector("apm"), _collector("vendor")
+
+def report(**extra):
+    time.sleep(1)
+    print("RESULT " + json.dumps({
+        "vendor_saw_application_span": any(b"flow.execute" in body for body in bodies["vendor"]),
+        "apm_saw_application_span": any(b"flow.execute" in body for body in bodies["apm"]),
+        **extra,
+    }))
+"""
+
+_SETUP = """
+import importlib
+
+for key, value in {env!r}.items():
+    os.environ[key] = value.format(vendor_port=vendor_port)
+
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{{apm_port}}"
+os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+
+from lfx.observability import bootstrap_application_telemetry, APPLICATION_TRACER_NAME
+from opentelemetry import trace
+
+def build_vendor_tracer():
+    return getattr(importlib.import_module({module!r}), {cls!r})(
+        "probe - 00000000-0000-0000-0000-000000000000", "chain", "probe", uuid.uuid4()
+    )
+"""
+
+# The vendor initialises first and the bootstrap runs after it. This is the order in which the
+# global provider slot is actually contested: set_tracer_provider is one-shot, so a vendor that
+# claims it leaves the bootstrap with nowhere to install and the operator with no telemetry.
+_PROBE_VENDOR_FIRST = """
+tracer = build_vendor_tracer()
+telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+
+vendor_provider = {provider_expr}
+
+report(
+    ready=bool(tracer.ready),
+    bootstrap_installed=telemetry.tracer_provider is not None,
+    bootstrap_owns_global=trace.get_tracer_provider() is telemetry.tracer_provider,
+    vendor_provider_is_separate=(vendor_provider is not trace.get_tracer_provider())
+    if vendor_provider is not None
+    else None,
+    has_vendor_provider=vendor_provider is not None,
+)
+"""
+
+# The bootstrap initialises first, which is the real deployment order: it runs at app startup
+# and a vendor tracer is only built on the first flow run.
+_PROBE_BOOTSTRAP_FIRST = """
+telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+tracer = build_vendor_tracer()
+
+trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+telemetry.tracer_provider.force_flush(5000)
+
+report(ready=bool(tracer.ready))
+"""
+
+
+def _run(vendor: str, probe: str) -> dict:
+    spec = _VENDORS[vendor]
+    body = _SETUP.format(env=spec["env"], module=spec["module"], cls=spec["cls"]) + probe.format(
+        provider_expr=spec["provider_expr"] or "None"
+    )
+    # The probe sets every variable it depends on. Inherited OTEL_ or vendor variables from the
+    # developer's shell (OTEL_TRACES_EXPORTER=none, a real LANGFUSE_HOST) would route exporters
+    # away from the loopback stubs or point a client at a real backend.
+    prefixes = ("OTEL_", "LANGFUSE_", "LANGCHAIN_", "LANGSMITH_", "LANGWATCH_", "PHOENIX_", "ARIZE_")
+    prefixes += ("OPENLAYER_", "OPIK_", "COMET_", "TRACELOOP_")
+    env = {k: v for k, v in os.environ.items() if not k.startswith(prefixes)}
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _HARNESS + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    line = next((ln for ln in completed.stdout.splitlines() if ln.startswith("RESULT ")), None)
+    assert line, f"probe printed no result:\n{completed.stdout[-2000:]}\n{completed.stderr[-2000:]}"
+    return json.loads(line.removeprefix("RESULT "))
+
+
+@pytest.mark.parametrize("vendor", sorted(_VENDORS))
+def test_vendor_does_not_claim_the_global_provider(vendor: str):
+    """A vendor that initialises first must still leave the global slot for the bootstrap.
+
+    Traceloop fails this one, which is why it is not in the table: it claims the global
+    provider, and because ``set_tracer_provider`` is one-shot the bootstrap then cannot install
+    and the operator's APM receives nothing.
+
+    ``ready`` is asserted first and deliberately: a vendor that failed to initialise would leave
+    the global slot free for the trivial reason that it did nothing, and every other assertion
+    here would pass while pinning nothing.
+    """
+    result = _run(vendor, _PROBE_VENDOR_FIRST)
+
+    assert result["ready"] is True, f"{vendor} did not initialise, so this case pins nothing"
+    assert result["bootstrap_installed"] is True, f"{vendor} claimed the global provider, leaving the APM with none"
+    assert result["bootstrap_owns_global"] is True, f"the global provider is not the bootstrap's after {vendor}"
+    if result["has_vendor_provider"]:
+        assert result["vendor_provider_is_separate"] is True, f"{vendor} is exporting from the global provider"
+
+
+@pytest.mark.parametrize("vendor", sorted(_VENDORS))
+def test_application_spans_do_not_reach_the_vendor(vendor: str):
+    """The operator's application telemetry must stay out of the vendor's backend.
+
+    This is the assertion that catches #13319, and it is not implied by the one above. Reverting
+    that fix leaves the global provider's *identity* untouched -- the SDK cannot replace a
+    provider that is already set -- while its exporter still attaches to ours and starts
+    receiving the service's own spans. Identity and export are separate properties.
+    """
+    result = _run(vendor, _PROBE_BOOTSTRAP_FIRST)
+
+    assert result["ready"] is True, f"{vendor} did not initialise, so this case pins nothing"
+    assert result["apm_saw_application_span"] is True, "the APM must receive the application span"
+    assert result["vendor_saw_application_span"] is False, f"application telemetry leaked to {vendor}"

--- a/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
+++ b/src/backend/tests/unit/services/tracing/test_vendor_provider_coexistence.py
@@ -8,12 +8,16 @@ the global provider and FastAPIInstrumentor's HTTP spans started landing in Lang
 The vendors that are OpenTelemetry-based avoid this by building their own isolated provider
 (``langfuse.py`` passes ``tracer_provider=``, ``langwatch.py`` sets
 ``skip_open_telemetry_setup=True``, ``arize_phoenix.py`` hands its provider to the
-instrumentors). The four that are not OpenTelemetry-based have no provider at all. Either way
-the property is the same and is what this pins: after constructing the vendor's tracer, the
-global provider is still the object the bootstrap installed.
+instrumentors), and ``langsmith.py`` does the same for its OpenTelemetry transports. The three
+that are not OpenTelemetry-based in the mode covered here (langsmith over REST, openlayer, opik)
+have no provider at all. Either way the property is the same and is what this pins: after
+constructing the vendor's tracer, the global provider is still the object the bootstrap
+installed, and the vendor is still receiving its own traces.
 
-Traceloop is deliberately absent. It is the one vendor that does *not* hold this property -- it
-adopts whichever provider is global -- and it has its own test file.
+Two of the eight registered tracers are absent. Traceloop is the one vendor that does *not* hold
+this property, since it adopts whichever provider is global, and it has its own test file.
+``native`` writes to Langflow's own database and imports no OpenTelemetry at all, so a case for
+it would pass without exercising anything.
 
 Each case runs in a subprocess: the global provider, and most of these vendors' clients, are
 process-wide singletons that cannot be undone in-process.
@@ -24,14 +28,11 @@ import json
 import os
 import subprocess
 import sys
-import textwrap
 
 import pytest
 
 # Each vendor's endpoint is pointed at the loopback stub so nothing leaves the machine and no
-# real credential is needed. ``provider_expr`` is evaluated against the constructed tracer for
-# the vendors that expose their own provider, to pin that it is a *different* object from the
-# global one rather than merely absent.
+# real credential is needed.
 _VENDORS = {
     "arize_phoenix": {
         "requires": "phoenix",
@@ -41,7 +42,6 @@ _VENDORS = {
             "PHOENIX_API_KEY": "probe-key",  # pragma: allowlist secret
             "PHOENIX_COLLECTOR_ENDPOINT": "http://127.0.0.1:{vendor_port}",
         },
-        "provider_expr": "tracer.tracer_provider",
     },
     "langfuse": {
         "requires": "langfuse",
@@ -52,9 +52,6 @@ _VENDORS = {
             "LANGFUSE_PUBLIC_KEY": "pk-probe",  # pragma: allowlist secret
             "LANGFUSE_BASE_URL": "http://127.0.0.1:{vendor_port}",
         },
-        # The isolated provider is held inside the shared Langfuse client, so there is no
-        # accessor on the tracer. "the global provider is untouched" is the #13319 property.
-        "provider_expr": None,
     },
     "langsmith": {
         "requires": "langsmith",
@@ -64,7 +61,6 @@ _VENDORS = {
             "LANGCHAIN_API_KEY": "probe-key",  # pragma: allowlist secret
             "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
         },
-        "provider_expr": None,
     },
     "langsmith_otel": {
         "requires": "langsmith",
@@ -75,7 +71,6 @@ _VENDORS = {
             "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
             "LANGSMITH_TRACING_MODE": "otel",
         },
-        "provider_expr": None,
     },
     "langsmith_hybrid": {
         "requires": "langsmith",
@@ -86,7 +81,6 @@ _VENDORS = {
             "LANGCHAIN_ENDPOINT": "http://127.0.0.1:{vendor_port}",
             "LANGSMITH_TRACING_MODE": "hybrid",
         },
-        "provider_expr": None,
     },
     "langwatch": {
         "requires": "langwatch",
@@ -96,7 +90,6 @@ _VENDORS = {
             "LANGWATCH_API_KEY": "probe-key",  # pragma: allowlist secret
             "LANGWATCH_ENDPOINT": "http://127.0.0.1:{vendor_port}",
         },
-        "provider_expr": "type(tracer).tracer_provider",
     },
     "openlayer": {
         "requires": "openlayer",
@@ -107,7 +100,6 @@ _VENDORS = {
             "OPENLAYER_INFERENCE_PIPELINE_ID": "probe-pipeline",
             "OPENLAYER_BASE_URL": "http://127.0.0.1:{vendor_port}",
         },
-        "provider_expr": None,
     },
     "opik": {
         "requires": "opik",
@@ -118,7 +110,6 @@ _VENDORS = {
             "OPIK_WORKSPACE": "probe-workspace",
             "OPIK_URL_OVERRIDE": "http://127.0.0.1:{vendor_port}/api",
         },
-        "provider_expr": None,
     },
 }
 
@@ -131,12 +122,19 @@ import json, os, threading, time, uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 bodies = {"apm": [], "vendor": []}
+posted_bytes = {"apm": 0, "vendor": 0}
+
+# Batch processors default to a 5s schedule. A negative assertion that reads the collectors
+# before that has passed for the wrong reason, so shorten the cycle and wait for quiescence.
+os.environ["OTEL_BSP_SCHEDULE_DELAY"] = "500"
 
 def _collector(which):
     class Handler(BaseHTTPRequestHandler):
         def _respond(self):
             length = int(self.headers.get("Content-Length", 0) or 0)
             bodies[which].append(self.rfile.read(length))
+            if self.command == "POST":
+                posted_bytes[which] += length
             if "/api/public/projects" in self.path:
                 payload = json.dumps({"data": [{
                     "id": "probe", "name": "probe", "metadata": {},
@@ -158,11 +156,29 @@ def _collector(which):
 
 apm_port, vendor_port = _collector("apm"), _collector("vendor")
 
+def drain(idle=1.5, cap=30.0):
+    # Return once no collector has seen anything new for `idle` seconds.
+    start = last_change = time.monotonic()
+    seen = (len(bodies["apm"]), len(bodies["vendor"]))
+    while time.monotonic() - start < cap:
+        time.sleep(0.1)
+        now = (len(bodies["apm"]), len(bodies["vendor"]))
+        if now != seen:
+            seen, last_change = now, time.monotonic()
+        elif time.monotonic() - last_change > idle:
+            return
+
+
+def report_no_wait(**extra):
+    print("RESULT " + json.dumps({"vendor_posted_bytes": posted_bytes["vendor"], **extra}))
+
+
 def report(**extra):
-    time.sleep(1)
+    drain()
     print("RESULT " + json.dumps({
         "vendor_saw_application_span": any(b"flow.execute" in body for body in bodies["vendor"]),
         "apm_saw_application_span": any(b"flow.execute" in body for body in bodies["apm"]),
+        "vendor_posted_bytes": posted_bytes["vendor"],
         **extra,
     }))
 """
@@ -192,16 +208,10 @@ _PROBE_VENDOR_FIRST = """
 tracer = build_vendor_tracer()
 telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
 
-vendor_provider = {provider_expr}
-
-report(
+report_no_wait(
     ready=bool(tracer.ready),
     bootstrap_installed=telemetry.tracer_provider is not None,
     bootstrap_owns_global=trace.get_tracer_provider() is telemetry.tracer_provider,
-    vendor_provider_is_separate=(vendor_provider is not trace.get_tracer_provider())
-    if vendor_provider is not None
-    else None,
-    has_vendor_provider=vendor_provider is not None,
 )
 """
 
@@ -210,6 +220,23 @@ report(
 _PROBE_BOOTSTRAP_FIRST = """
 telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
 tracer = build_vendor_tracer()
+
+# Drive a real trace through the vendor so the run below can tell "correctly isolated" apart
+# from "disconnected entirely". Constructing the tracer is not enough: most of these SDKs send
+# nothing until a span closes. The lifecycle calls are best-effort because several vendors
+# validate their stub's responses and raise on the way out; the bytes are what matter here.
+try:
+    tracer.add_trace("step-1", "step", "chain", {"question": "probe"})
+except Exception as exc:
+    print("add_trace:", type(exc).__name__)
+try:
+    tracer.end_trace("step-1", "step")
+except Exception as exc:
+    print("end_trace:", type(exc).__name__)
+try:
+    tracer.end({}, {}, None, {})
+except Exception as exc:
+    print("end:", type(exc).__name__)
 
 trace.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
 telemetry.tracer_provider.force_flush(5000)
@@ -220,17 +247,18 @@ report(ready=bool(tracer.ready))
 
 def _run(vendor: str, probe: str) -> dict:
     spec = _VENDORS[vendor]
-    body = _SETUP.format(env=spec["env"], module=spec["module"], cls=spec["cls"]) + probe.format(
-        provider_expr=spec["provider_expr"] or "None"
-    )
+    body = _SETUP.format(env=spec["env"], module=spec["module"], cls=spec["cls"]) + probe
     # The probe sets every variable it depends on. Inherited OTEL_ or vendor variables from the
     # developer's shell (OTEL_TRACES_EXPORTER=none, a real LANGFUSE_HOST) would route exporters
     # away from the loopback stubs or point a client at a real backend.
     prefixes = ("OTEL_", "LANGFUSE_", "LANGCHAIN_", "LANGSMITH_", "LANGWATCH_", "PHOENIX_", "ARIZE_")
     prefixes += ("OPENLAYER_", "OPIK_", "COMET_", "TRACELOOP_")
     env = {k: v for k, v in os.environ.items() if not k.startswith(prefixes)}
+    # A developer's proxy would swallow the loopback traffic these assertions read.
+    env = {k: v for k, v in env.items() if k.upper() not in {"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"}}
+    env["NO_PROXY"] = "127.0.0.1,localhost"
     completed = subprocess.run(  # noqa: S603
-        [sys.executable, "-c", _HARNESS + textwrap.dedent(body)],
+        [sys.executable, "-c", _HARNESS + body],
         capture_output=True,
         text=True,
         timeout=300,
@@ -272,8 +300,6 @@ def test_vendor_does_not_claim_the_global_provider(vendor: str):
     assert result["ready"] is True, f"{vendor} did not initialise, so this case pins nothing"
     assert result["bootstrap_installed"] is True, f"{vendor} claimed the global provider, leaving the APM with none"
     assert result["bootstrap_owns_global"] is True, f"the global provider is not the bootstrap's after {vendor}"
-    if result["has_vendor_provider"]:
-        assert result["vendor_provider_is_separate"] is True, f"{vendor} is exporting from the global provider"
 
 
 @pytest.mark.parametrize("vendor", _vendor_params())
@@ -290,3 +316,6 @@ def test_application_spans_do_not_reach_the_vendor(vendor: str):
     assert result["ready"] is True, f"{vendor} did not initialise, so this case pins nothing"
     assert result["apm_saw_application_span"] is True, "the APM must receive the application span"
     assert result["vendor_saw_application_span"] is False, f"application telemetry leaked to {vendor}"
+    # Without this, a vendor that was disconnected outright passes exactly like one that is
+    # correctly isolated: bodies["vendor"] is empty either way.
+    assert result["vendor_posted_bytes"] > 0, f"{vendor} received no traces at all, so isolation is not what passed"


### PR DESCRIPTION
## What

One global tracer provider per process, and `set_tracer_provider` is one-shot. A vendor that registers itself globally takes the slot the application observability bootstrap needs, and then receives every span on it. That is [#13319](https://github.com/langflow-ai/langflow/issues/13319): Langfuse claimed the global provider and `FastAPIInstrumentor`'s HTTP spans started showing up in Langfuse traces.

Two parts:

**A fix in `langsmith.py`.** `LANGSMITH_TRACING_MODE=otel|hybrid` makes the LangSmith client build an OpenTelemetry pipeline, and a client constructed without a provider registers its own as the global one. So enabling that mode silently disabled application observability. The tracer now hands LangSmith an isolated provider, built once per process, exporting to LangSmith's own OTLP endpoint.

**Coverage for the rest.** Two tests per vendor across both init orders: vendor-first, where the global slot is actually contested, and bootstrap-first, the real deployment order. Each case runs in its own subprocess against loopback stubs, since the global provider and most of these clients are process-wide singletons. No credentials, no network.

## The isolated provider needs its own exporter

Worth spelling out, because the obvious version is wrong and fails silently.

`langfuse.py` passes `tracer_provider=` and the Langfuse SDK calls `add_span_processor` on what it is given. LangSmith does not: it only takes tracers from the provider. So handing it a bare `TracerProvider()` stops it claiming the global one *and* discards every span, while the tracer still reports ready. In `otel` mode there is no REST fallback, so traces just stop, with no log and no exception.

Measured against a loopback stub bound to `LANGCHAIN_ENDPOINT`:

| | `otel` | `hybrid` |
|---|---|---|
| base | POST `/otel`, 1078 B | `/otel` + `/runs/multipart` |
| bare provider | nothing at all | `/runs/multipart` only |
| this PR | POST `/otel`, 1043 B | `/otel` + `/runs/multipart` |

It deliberately does not honour `OTEL_EXPORTER_OTLP_ENDPOINT`, which the SDK's own factory reads first. That variable points at the operator's APM, which is not where a vendor's prompt-bearing traces belong.

## Why both test directions

They fail independently. Reverting the #13319 fix leaves the provider's *identity* untouched, because the SDK cannot replace a provider that is already set, while its exporter attaches to ours anyway and starts receiving the service's spans.

The suite also asserts the vendor still receives its own traces. Without that, a vendor that was disconnected outright passes exactly like one that is correctly isolated, since the vendor collector is empty either way. That is not hypothetical: it is how the bare-provider bug above got through a green run.

## Verification

Checked against real regressions rather than only observed green:

- Langfuse without its isolated provider: both directions fail, `langfuse claimed the global provider, leaving the APM with none` and `application telemetry leaked to langfuse`.
- LangWatch without `skip_open_telemetry_setup=True`: same two failures.
- LangSmith with a bare provider: `langsmith_otel received no traces at all, so isolation is not what passed`.

A vendor whose SDK is absent on the running interpreter is skipped rather than failing the ready guard, since `langwatch` is declared `python_version < "3.14"`.

## Not covered

Traceloop, which genuinely does not hold this property — that is #14357, with its own test file. And `native`, which writes to Langflow's own database and imports no OpenTelemetry, so a case for it would pass without exercising anything.

Known coarseness: the "vendor still received data" assertion is a byte count, so in `hybrid` mode a broken OTel leg is masked by the REST leg still posting. It catches the fully-silent case, which is the one that ships unnoticed.