### PR TITLE
fix(agent): track parallel tool durations per run

### DIFF
--- a/src/lfx/src/lfx/base/agents/events.py
+++ b/src/lfx/src/lfx/base/agents/events.py
@@ -531,6 +531,9 @@ async def process_agent_events(
                     agent_message, _ = await tool_handler(
                         event, agent_message, tool_blocks_map, send_message_callback, tool_start_time
                     )
+                    # Start timing the next model round after terminal handling and result publication.
+                    # A fresh clock also avoids rewinding to tool_start_time when no ToolContent was bound.
+                    start_time = perf_counter()
             elif event["event"] in CHAIN_EVENT_HANDLERS:
                 chain_handler = CHAIN_EVENT_HANDLERS[event["event"]]
 

--- a/src/lfx/src/lfx/base/agents/events.py
+++ b/src/lfx/src/lfx/base/agents/events.py
@@ -511,18 +511,26 @@ async def process_agent_events(
     # Message may not contain id if the Agent is not connected to a Chat Output (_should_skip_message is True)
     initial_message_id = agent_message.get_id()
     try:
-        # Create a mapping of run_ids to tool contents
+        # Track tool content and start times by the same name + run_id key.
         tool_blocks_map: dict[str, ToolContent] = {}
+        tool_start_times: dict[str, float] = {}
         had_streaming = False
         start_time = perf_counter()
 
         async for event in agent_executor:
             if event["event"] in TOOL_EVENT_HANDLERS:
                 tool_handler = TOOL_EVENT_HANDLERS[event["event"]]
+                tool_key = f"{event.get('name', '')}_{event.get('run_id', '')}"
                 # Use skip_db_update=True during streaming to avoid DB round-trips
-                agent_message, start_time = await tool_handler(
-                    event, agent_message, tool_blocks_map, send_message_callback, start_time
-                )
+                if event["event"] == "on_tool_start":
+                    agent_message, tool_start_times[tool_key] = await tool_handler(
+                        event, agent_message, tool_blocks_map, send_message_callback, start_time
+                    )
+                else:
+                    tool_start_time = tool_start_times.pop(tool_key, start_time)
+                    agent_message, _ = await tool_handler(
+                        event, agent_message, tool_blocks_map, send_message_callback, tool_start_time
+                    )
             elif event["event"] in CHAIN_EVENT_HANDLERS:
                 chain_handler = CHAIN_EVENT_HANDLERS[event["event"]]
 

--- a/src/lfx/tests/unit/base/agents/test_events_handlers.py
+++ b/src/lfx/tests/unit/base/agents/test_events_handlers.py
@@ -8,6 +8,7 @@ These pin focused event-loop behaviors:
   empty on_tool_start payload.
 - tool timing must exclude message-publication latency at both the start and
   end boundaries.
+- parallel tools must be timed from the matching run's own start event.
 
 The async callbacks are small in-memory harnesses. The timing regression test
 advances a deterministic clock while each callback runs.
@@ -16,7 +17,13 @@ advances a deterministic clock while each callback runs.
 from time import perf_counter
 
 import lfx.base.agents.events as agent_events
-from lfx.base.agents.events import handle_on_chain_stream, handle_on_tool_end, handle_on_tool_start
+import pytest
+from lfx.base.agents.events import (
+    handle_on_chain_stream,
+    handle_on_tool_end,
+    handle_on_tool_start,
+    process_agent_events,
+)
 from lfx.schema.content_types import TextContent, ToolContent
 from lfx.schema.message import Message
 
@@ -128,3 +135,59 @@ async def test_tool_duration_excludes_message_callback_latency(monkeypatch):
     completed_tool = next(block for block in result.content_blocks if isinstance(block, ToolContent))
     assert completed_tool.duration == 25
     assert new_start == 110.025
+
+
+@pytest.mark.parametrize(
+    ("terminal_events", "expected_durations"),
+    [
+        ((("run-a", "on_tool_end"), ("run-b", "on_tool_end")), {"a": 3000, "b": 3000}),
+        ((("run-b", "on_tool_end"), ("run-a", "on_tool_end")), {"a": 4000, "b": 2000}),
+        ((("run-a", "on_tool_error"), ("run-b", "on_tool_end")), {"a": 3000, "b": 3000}),
+    ],
+)
+async def test_parallel_tool_durations_use_matching_run_start(monkeypatch, terminal_events, expected_durations):
+    """Each parallel tool must be timed from its own on_tool_start event."""
+    now = [0.0]
+    monkeypatch.setattr(agent_events, "perf_counter", lambda: now[0])
+
+    start_events = {
+        "run-a": {
+            "event": "on_tool_start",
+            "name": "search",
+            "run_id": "run-a",
+            "data": {"input": {"q": "a"}},
+        },
+        "run-b": {
+            "event": "on_tool_start",
+            "name": "search",
+            "run_id": "run-b",
+            "data": {"input": {"q": "b"}},
+        },
+    }
+
+    def _terminal_event(run_id, event_type):
+        data = {"error": f"error {run_id}"} if event_type == "on_tool_error" else {"output": f"result {run_id}"}
+        return {
+            "event": event_type,
+            "name": "search",
+            "run_id": run_id,
+            "data": data,
+        }
+
+    timed_events = [
+        (1.0, start_events["run-a"]),
+        (2.0, start_events["run-b"]),
+        (4.0, _terminal_event(*terminal_events[0])),
+        (5.0, _terminal_event(*terminal_events[1])),
+    ]
+
+    async def _event_iterator():
+        for event_time, event in timed_events:
+            now[0] = event_time
+            yield event
+
+    message = Message(content_blocks=[], sender="Machine", sender_name="AI")
+    result = await process_agent_events(_event_iterator(), message, _passthrough)
+
+    durations = {block.tool_input["q"]: block.duration for block in result.content_blocks}
+    assert durations == expected_durations

--- a/src/lfx/tests/unit/base/agents/test_events_handlers.py
+++ b/src/lfx/tests/unit/base/agents/test_events_handlers.py
@@ -18,6 +18,7 @@ from time import perf_counter
 
 import lfx.base.agents.events as agent_events
 import pytest
+from langchain_core.messages import AIMessage
 from lfx.base.agents.events import (
     handle_on_chain_stream,
     handle_on_tool_end,
@@ -191,3 +192,72 @@ async def test_parallel_tool_durations_use_matching_run_start(monkeypatch, termi
 
     durations = {block.tool_input["q"]: block.duration for block in result.content_blocks}
     assert durations == expected_durations
+
+
+@pytest.mark.parametrize("terminal_event", ["on_tool_end", "on_tool_error"])
+@pytest.mark.parametrize("has_tool_start", [True, False], ids=["bound", "unbound"])
+async def test_terminal_tool_event_restarts_narration_timer(monkeypatch, terminal_event, has_tool_start):
+    """A later model response must not include the preceding tool's execution time."""
+    now = [0.0]
+    monkeypatch.setattr(agent_events, "perf_counter", lambda: now[0])
+
+    terminal_data = {"error": "tool failed"} if terminal_event == "on_tool_error" else {"output": "result"}
+    timed_events = [
+        (
+            10.0,
+            {
+                "event": "on_chat_model_end",
+                "data": {
+                    "output": AIMessage(
+                        content=[
+                            {"type": "text", "text": "First round"},
+                            {"type": "tool_use", "name": "search", "input": {}, "id": "tool-1"},
+                        ]
+                    )
+                },
+            },
+        ),
+    ]
+    if has_tool_start:
+        timed_events.append(
+            (
+                10.0,
+                {
+                    "event": "on_tool_start",
+                    "name": "search",
+                    "run_id": "run-1",
+                    "data": {"input": {"q": "timing"}},
+                },
+            )
+        )
+    timed_events.extend(
+        [
+            (
+                20.0,
+                {
+                    "event": terminal_event,
+                    "name": "search",
+                    "run_id": "run-1",
+                    "data": terminal_data,
+                },
+            ),
+            (
+                25.0,
+                {
+                    "event": "on_chat_model_end",
+                    "data": {"output": AIMessage(content=[{"type": "text", "text": "Second round"}])},
+                },
+            ),
+        ]
+    )
+
+    async def _event_iterator():
+        for event_time, event in timed_events:
+            now[0] = event_time
+            yield event
+
+    message = Message(content_blocks=[], sender="Machine", sender_name="AI")
+    result = await process_agent_events(_event_iterator(), message, _passthrough)
+
+    text_durations = [block.duration for block in result.content_blocks if isinstance(block, TextContent)]
+    assert text_durations == [10000, 5000]


### PR DESCRIPTION
## Summary

- track each tool's execution start time by its existing `name + run_id` key
- consume the matching timestamp on tool end or error while keeping the chain/model timing cursor independent
- restart narration timing after terminal tool handling so later model durations exclude preceding tool execution
- add deterministic coverage for in-order, out-of-order, and mixed error/success parallel completions

## Root cause

`process_agent_events` passed one mutable `start_time` through every tool event. When calls overlapped, a later start or an earlier completion replaced the timestamp needed by another run, so durations were calculated from the wrong event.

The event processor now stores the post-publication timestamp returned by each `on_tool_start` handler and passes only that run's timestamp to its terminal handler. Missing start events retain the previous fallback behavior.

After each terminal tool event completes, the processor samples a fresh narration cursor. This preserves the prior model-timing boundary without reusing or rewinding to a per-tool timestamp when no `ToolContent` was bound.

## Impact

Parallel tool calls now report durations from their own start events, regardless of completion order. Tool start timestamps are removed on both success and error, and subsequent model content excludes the preceding tool interval.

## Testing

- `uv run pytest tests/unit/base/agents/test_events_handlers.py -q` from `src/lfx` in an isolated LFX environment (11 passed)
- `uv run pytest src/backend/tests/unit/components/models_and_agents/test_agent_events.py -q` (52 passed)
- `uv run ruff check src/lfx/base/agents/events.py tests/unit/base/agents/test_events_handlers.py`
- `uv run ruff format --check src/lfx/base/agents/events.py tests/unit/base/agents/test_events_handlers.py`
- repository pre-commit hooks

Fixes #14356
