### PR TITLE
fix: replace models of disconnected providers

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.disconnected-provider.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.disconnected-provider.test.tsx
@@ -1,0 +1,278 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { BaseInputProps } from "@/components/core/parameterRenderComponent/types";
+import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
+import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import ModelInputComponent from "../index";
+import type { ModelInputComponentType, ModelOption } from "../types";
+
+Element.prototype.scrollIntoView = jest.fn();
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: () => ({ setErrorData: jest.fn() }),
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({
+    refreshAllModelInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("@/stores/flowStore", () => {
+  const state = {
+    getNode: jest.fn(),
+    setNode: jest.fn(),
+    setFilterEdge: jest.fn(),
+    setFilterType: jest.fn(),
+    nodes: [],
+    edges: [],
+  };
+  const hook = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  hook.getState = () => state;
+  return { __esModule: true, default: hook };
+});
+
+jest.mock("@/stores/typesStore", () => ({
+  useTypesStore: { getState: () => ({ data: {} }) },
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-model-providers", () => ({
+  useGetModelProviders: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-enabled-models", () => ({
+  useGetEnabledModels: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/nodes/use-post-template-value", () => ({
+  usePostTemplateValue: jest.fn(() => ({ mutateAsync: jest.fn() })),
+}));
+
+jest.mock("@/CustomNodes/helpers/mutate-template", () => ({
+  mutateTemplate: jest.fn(),
+}));
+
+jest.mock("@/modals/modelProviderModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className}>
+      {name}
+    </span>
+  ),
+}));
+
+jest.mock("@/components/common/loadingTextComponent", () => ({
+  __esModule: true,
+  default: ({ text }: { text: string }) => (
+    <span data-testid="loading-text">{text}</span>
+  ),
+}));
+
+const SAVED_MODEL: ModelOption = {
+  name: "claude-opus-5",
+  icon: "Anthropic",
+  provider: "Anthropic",
+  metadata: { model_type: "llm" },
+};
+
+const baseProps: BaseInputProps & ModelInputComponentType = {
+  id: "test-model-input",
+  value: [SAVED_MODEL],
+  disabled: false,
+  handleOnNewValue: jest.fn(),
+  options: [SAVED_MODEL],
+  placeholder: "Setup Provider",
+  nodeId: "test-node-id",
+  nodeClass: {
+    template: {
+      model: {
+        model_type: "language",
+        type: "",
+        required: false,
+        list: false,
+        show: false,
+        readonly: false,
+      },
+    },
+    description: "",
+    display_name: "",
+    documentation: "",
+  },
+  handleNodeClass: jest.fn(),
+  editNode: false,
+};
+
+const renderWithQueryClient = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,
+  );
+};
+
+/**
+ * Post-disconnect backend shape: the provider stays in the catalog with
+ * `is_configured: false`, and `/enabled_models` reports every one of its
+ * models as `false` (see `get_enabled_models`, which ANDs on provider_status).
+ */
+const mockDisconnectedProvider = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [
+      {
+        provider: "Anthropic",
+        is_enabled: false,
+        is_configured: false,
+        models: [
+          {
+            model_name: "claude-opus-5",
+            metadata: { model_type: "llm" },
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: { enabled_models: { Anthropic: { "claude-opus-5": false } } },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
+/** The user reconnects a different provider while the saved one stays disconnected. */
+const mockConnectedOpenAiAndDisconnectedAnthropic = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [
+      {
+        provider: "Anthropic",
+        is_enabled: false,
+        is_configured: false,
+        models: [
+          {
+            model_name: "claude-opus-5",
+            metadata: { model_type: "llm" },
+          },
+        ],
+      },
+      {
+        provider: "OpenAI",
+        is_enabled: true,
+        is_configured: true,
+        icon: "OpenAI",
+        models: [
+          { model_name: "gpt-5.6-sol", metadata: { model_type: "llm" } },
+        ],
+      },
+    ],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: {
+      enabled_models: {
+        Anthropic: { "claude-opus-5": false },
+        OpenAI: { "gpt-5.6-sol": true },
+      },
+    },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
+describe("ModelInputComponent — provider disconnected after a model was saved", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDisconnectedProvider();
+  });
+
+  it("should_show_setup_provider_state_when_the_saved_model_provider_is_disconnected", () => {
+    renderWithQueryClient(<ModelInputComponent {...baseProps} />);
+
+    expect(screen.getByText("Setup Provider")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("should_not_list_the_saved_model_when_its_provider_is_disconnected", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<ModelInputComponent {...baseProps} />);
+
+    await user.click(screen.getByText("Setup Provider"));
+
+    expect(
+      screen.queryByTestId("Anthropic-claude-opus-5-option"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_not_render_the_configure_wrench_next_to_the_setup_provider_button", () => {
+    renderWithQueryClient(<ModelInputComponent {...baseProps} />);
+
+    expect(
+      screen.queryByTestId(`${baseProps.id}-configure`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_switch_to_a_valid_model_when_another_provider_gets_connected", async () => {
+    mockConnectedOpenAiAndDisconnectedAnthropic();
+
+    const handleOnNewValue = jest.fn();
+    renderWithQueryClient(
+      <ModelInputComponent
+        {...baseProps}
+        handleOnNewValue={handleOnNewValue}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(handleOnNewValue).toHaveBeenCalled();
+    });
+    expect(handleOnNewValue.mock.calls[0][0].value[0].name).toBe("gpt-5.6-sol");
+  });
+
+  it("should_drop_the_configure_wrench_once_the_valid_model_is_applied", () => {
+    mockConnectedOpenAiAndDisconnectedAnthropic();
+
+    renderWithQueryClient(
+      <ModelInputComponent
+        {...baseProps}
+        value={[
+          {
+            name: "gpt-5.6-sol",
+            icon: "OpenAI",
+            provider: "OpenAI",
+            metadata: {},
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("gpt-5.6-sol")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${baseProps.id}-configure`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_keep_the_saved_value_untouched_so_reconnecting_restores_it", () => {
+    const handleOnNewValue = jest.fn();
+    renderWithQueryClient(
+      <ModelInputComponent
+        {...baseProps}
+        handleOnNewValue={handleOnNewValue}
+      />,
+    );
+
+    expect(handleOnNewValue).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -6,6 +6,20 @@ import { PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/utils/utils";
 import { ModelOption, SelectedModel } from "../types";
 
+/**
+ * The trigger collapses into a single "Setup Provider" call to action — which
+ * already opens the provider manager, so no extra affordance belongs next to it.
+ */
+export const isSetupProviderState = ({
+  hasEnabledProviders,
+  showEmptyState,
+  optionCount,
+}: {
+  hasEnabledProviders: boolean;
+  showEmptyState: boolean;
+  optionCount: number;
+}) => !hasEnabledProviders && !showEmptyState && optionCount === 0;
+
 interface ModelTriggerProps {
   open: boolean;
   disabled: boolean;
@@ -50,7 +64,13 @@ const ModelTrigger = ({
   // Check if we're in empty state mode (showEmptyState=true and no options)
   const isEmptyStateMode = showEmptyState && options.length === 0;
 
-  if (!hasEnabledProviders && !showEmptyState && options.length === 0) {
+  if (
+    isSetupProviderState({
+      hasEnabledProviders,
+      showEmptyState,
+      optionCount: options.length,
+    })
+  ) {
     return (
       <Button
         variant="outline"

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -22,7 +22,7 @@ import {
 import type { BaseInputProps } from "../../types";
 import { focusCommandListOnOpen } from "../../utils/focus-command-list-on-open";
 import ModelList from "./components/ModelList";
-import ModelTrigger from "./components/ModelTrigger";
+import ModelTrigger, { isSetupProviderState } from "./components/ModelTrigger";
 import { matchesModelIdentity } from "./helpers/model-option-identity";
 import { recoverModelOption } from "./helpers/recover-model-option";
 import { useModelConnectionLogic } from "./hooks/useModelConnectionLogic";
@@ -177,15 +177,11 @@ export default function ModelInputComponent({
       if (option.metadata?.is_disabled_provider) continue;
       const provider = option.provider || "Unknown";
 
-      const isStickyNotEnabled = option.metadata?.not_enabled_locally === true;
-      if (isStickyNotEnabled) {
-        const providerConfigured = providersData?.some(
-          (p) => p.provider === provider && p.is_configured,
-        );
-        if (providerConfigured) continue;
-      }
+      // Sticky-default entries only let the trigger name the saved model;
+      // they are never selectable, disconnected or merely deactivated.
+      if (option.metadata?.not_enabled_locally === true) continue;
 
-      if (!isStickyNotEnabled && enabledModelsData?.enabled_models) {
+      if (enabledModelsData?.enabled_models) {
         const providerModels = enabledModelsData.enabled_models[provider];
         if (providerModels && providerModels[option.name] !== true) {
           continue;
@@ -248,10 +244,16 @@ export default function ModelInputComponent({
       }
     }
 
+    // Keeps an Assistant-applied registry model selectable while it is missing
+    // from enabled_models; a disconnected provider must inject nothing.
     const savedValue = value?.[0];
     const savedKey = savedValue?.name
       ? `${savedValue.provider || "Unknown"}::${savedValue.name}`
       : null;
+    const savedProviderConfigured =
+      providersData?.some(
+        (p) => p.provider === savedValue?.provider && p.is_configured,
+      ) ?? false;
     const savedInRegistry =
       !!savedValue?.name &&
       (providersData?.some(
@@ -264,7 +266,8 @@ export default function ModelInputComponent({
       !!savedValue?.name &&
       !!savedKey &&
       !seen.has(savedKey) &&
-      (Object.keys(grouped).length === 0 || savedInRegistry);
+      savedProviderConfigured &&
+      savedInRegistry;
     if (shouldInjectSaved && savedValue) {
       const providerName = savedValue.provider || "Unknown";
       grouped[providerName] = grouped[providerName] ?? [];
@@ -351,11 +354,11 @@ export default function ModelInputComponent({
       const inOptions = flatOptions.some((option) =>
         matchesModelIdentity(option, saved),
       );
+      // A known provider that no longer offers the model is stale whether it was
+      // disconnected or the model deactivated; an unknown one we cannot judge.
       if (!inOptions && saved.provider) {
         isSavedValueStale =
-          providersData?.some(
-            (p) => p.provider === saved.provider && p.is_configured,
-          ) ?? false;
+          providersData?.some((p) => p.provider === saved.provider) ?? false;
       }
     }
 
@@ -602,7 +605,12 @@ export default function ModelInputComponent({
   }
 
   const showConfigureAffordance =
-    selectedModel?.metadata?.not_enabled_locally === true;
+    selectedModel?.metadata?.not_enabled_locally === true &&
+    !isSetupProviderState({
+      hasEnabledProviders: hasEnabledProviders ?? false,
+      showEmptyState,
+      optionCount: flatOptions.length,
+    });
 
   // Main render
   return (


### PR DESCRIPTION
Disconnecting a model provider left its models in the Language Model picker, rendered exactly like valid options — provider logo, normal styling, selected checkmark — and still selectable. Connecting a different provider did not clear them either: the trigger kept showing the dead model while the list already listed only the new provider's models.

This makes a disconnected provider's models disappear from the picker, and lets the node fall back to a valid model — or to the **Setup Provider** empty state when there is none.

## Root cause

The backend is correct. `get_enabled_models` ANDs on provider status, so every model of a disconnected provider reports `false`, and `list_models` keeps the provider in the catalog with `is_configured: false`.

Three paths in `ModelInputComponent` kept the dead model alive:

1. **Sticky options survived when the provider was _not_ configured** — the guard was inverted. Sticky entries exist only so the trigger can name the saved model; they were never meant to be selectable.
2. **The saved value was re-injected whenever the resulting list was empty** (`Object.keys(grouped).length === 0`) — exactly the disconnected case.
3. **The stale-value check required `is_configured`**, so a disconnected provider never counted as stale and the auto-select effect returned early, stranding the old model in the trigger.

## Changes

- `index.tsx` — sticky entries never enter the list; the saved-value injection now requires `savedProviderConfigured && savedInRegistry`; the stale check keys off the provider being *known* rather than *configured*.
- `ModelTrigger.tsx` — extracted `isSetupProviderState()` and reused it in both places, so the Configure wrench no longer renders next to the "Setup Provider" button, which already opens the provider manager.

## Preserved behavior

- **Assistant-applied models still survive.** A registry model of a *configured* provider stays selectable while missing from `enabled_models` — covered by `ModelInputComponent.assistant-model-swap.test.tsx`.
- **Unknown providers are left alone.** A provider absent from the registry keeps the saved value plus the wrench rather than being auto-switched; we have no basis to judge it. Covered by the existing `ibm/granite-3` case.

## Behavior change worth a look in review

Opening a flow whose provider was disconnected now rewrites the saved model to the first valid one and persists it. This extends behavior that already existed when a provider was connected but the model deactivated — it now also covers disconnected providers. Flagging it explicitly since it touches saved flows.

## Testing

- New `ModelInputComponent.disconnected-provider.test.tsx` — 6 cases covering the three states: only the saved provider disconnected → Setup Provider; disconnected provider plus a newly connected one → switches to the valid model; valid model applied → no wrench.
- Full frontend suite: **5702 tests / 510 suites green**, including the pre-existing sticky, wrench, and assistant-model-swap tests.
- Biome clean on all changed files; `tsc --noEmit` introduces no new errors.

Verified at the Jest level with mocks mirroring the real backend payloads (`is_configured: false` plus all-`false` `enabled_models`). Not driven through a live browser session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection when a saved model’s provider is disconnected or unavailable.
  * Prevented unavailable local models from appearing as selectable options.
  * Automatically switches to a valid model when another provider becomes available.
  * Preserved saved model values while clearly indicating when setup is required.
  * Configuration controls now appear only when applicable.
* **Tests**
  * Added coverage for disconnected providers, unavailable models, provider setup prompts, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->