### PR TITLE
feat(catalog): close remaining enforcement paths

### DIFF
--- a/docs/docs/Deployment/deployment-block-custom-components.mdx
+++ b/docs/docs/Deployment/deployment-block-custom-components.mdx
@@ -31,6 +31,23 @@ LANGFLOW_CUSTOM_COMPONENT_ADMIN_ONLY=true
 
 When set to `true`, non-superusers can still view and use custom components in flows, but they cannot create new custom components or edit custom component code.
 
+## Interaction with catalog governance
+
+Catalog governance takes precedence over the custom-code settings on the custom-component create, update, and code-validation endpoints. A catalog block has no superuser bypass.
+
+| Submitted source | Catalog policy | Custom components | Admin-only mode | Result |
+|---|---|---|---|---|
+| Known server template | Blocked | Either | Either | Denied for every user |
+| Known server template | Allowed | Disabled | Either | Allowed using the trusted server source |
+| Known server template | Allowed | Enabled | Non-superuser | Allowed using the trusted server source |
+| Unknown custom source | Not blocked | Disabled | Either | Denied |
+| Unknown custom source | Not blocked | Enabled | Non-superuser | Denied |
+| Unknown custom source | Not blocked | Enabled | Superuser or admin-only disabled | Allowed |
+
+For `POST /api/v1/validate/code`, this policy runs before the source is parsed or imports are inspected. In a restricted custom-code mode, known templates are validated from the trusted server copy, while unknown source follows the same disabled or admin-only rule as the component editor. On custom-component create and update, known blocked template source is rejected before the component is built, and the resolved component type is checked again before request-supplied frontend updates are applied.
+
+An active catalog policy fails closed with a temporary `503` response while server template identities are still initializing. An empty catalog policy preserves the default behavior and does not require template identity lookups.
+
 ## Configure a custom component allow-list
 
 `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` works together with optional paths that define which component templates the server loads, and which code hashes are trusted.

--- a/src/backend/base/langflow/api/v1/custom_component_policy.py
+++ b/src/backend/base/langflow/api/v1/custom_component_policy.py
@@ -1,0 +1,85 @@
+"""Shared catalog and custom-code policy for component source entry points."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, status
+from lfx.interface.components import component_cache
+from lfx.utils.flow_validation import (
+    CatalogPolicyValidationError,
+    code_hash_matches_any_template,
+    get_component_hash_lookups_for_validation,
+    get_trusted_code_for_validation,
+    validate_catalog_policy_for_component_code,
+    validate_catalog_policy_for_component_type,
+)
+
+if TYPE_CHECKING:
+    from lfx.services.catalog_policy.base import CatalogPolicySnapshot
+
+    from langflow.services.database.models.user.model import User
+
+
+_TEMPLATES_INITIALIZING_MESSAGE = "Component templates are still initializing. Please try again in a few seconds."
+
+
+class CatalogPolicyHTTPException(HTTPException):
+    """HTTP denial raised specifically by custom-component catalog policy."""
+
+
+def resolve_component_code_for_action(
+    code: str,
+    *,
+    user: User,
+    settings: object,
+    snapshot: CatalogPolicySnapshot,
+    disabled_detail: str,
+    admin_only_detail: str,
+) -> str:
+    """Return executable/validated source after applying catalog and custom-code policy.
+
+    Catalog denial is evaluated first and has no superuser bypass. Restricted
+    custom-code modes continue to permit known server templates, but callers
+    receive the trusted server copy instead of executing client-submitted bytes.
+    """
+    try:
+        validate_catalog_policy_for_component_code(code, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    admin_only = getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
+    custom_code_disabled = not getattr(settings, "allow_custom_components", True)
+    if not custom_code_disabled and not admin_only:
+        return code
+
+    get_component_hash_lookups_for_validation()
+    all_known = component_cache.all_known_hashes
+    if all_known is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_TEMPLATES_INITIALIZING_MESSAGE,
+        )
+
+    if not code_hash_matches_any_template(code, all_known):
+        detail = disabled_detail if custom_code_disabled else admin_only_detail
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+    trusted_code = get_trusted_code_for_validation(code)
+    if trusted_code is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=disabled_detail)
+    return trusted_code
+
+
+def enforce_catalog_policy_for_component_type(
+    component_type: str,
+    *,
+    snapshot: CatalogPolicySnapshot,
+) -> None:
+    """Deny a materialized custom component whose exact runtime type is blocked."""
+    try:
+        validate_catalog_policy_for_component_type(component_type, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise CatalogPolicyHTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -22,7 +22,6 @@ from lfx.custom.utils import (
 )
 from lfx.graph.graph.base import Graph
 from lfx.graph.schema import RunOutputs
-from lfx.interface.components import component_cache
 from lfx.log.logger import logger
 from lfx.schema.legacy_render import project_payload_to_v1
 from lfx.schema.schema import InputValueRequest
@@ -33,15 +32,15 @@ from lfx.services.model_provider_policy import (
     set_current_model_provider_policy_context,
 )
 from lfx.services.settings.service import SettingsService
-from lfx.utils.flow_validation import (
-    CustomComponentValidationError,
-    code_hash_matches_any_template,
-    get_component_hash_lookups_for_validation,
-    get_trusted_code_for_validation,
-)
+from lfx.utils.flow_validation import CustomComponentValidationError
 from sqlmodel import select
 
 from langflow.api.utils import CurrentActiveUser, DbSession, extract_global_variables_from_headers, parse_value
+from langflow.api.v1.custom_component_policy import (
+    CatalogPolicyHTTPException,
+    enforce_catalog_policy_for_component_type,
+    resolve_component_code_for_action,
+)
 from langflow.api.v1.files import get_flow
 from langflow.api.v1.global_variable_defaults import apply_global_variable_defaults
 from langflow.api.v1.run_validation import raise_if_hitl_unsupported
@@ -92,14 +91,6 @@ from langflow.services.event_manager import create_webhook_event_manager, webhoo
 from langflow.services.telemetry.schema import RunPayload
 from langflow.utils.compression import compress_response
 from langflow.utils.version import get_version_info
-
-
-def _requires_component_hash_lookups(settings: object, user: CurrentActiveUser) -> bool:
-    requires_admin_only_hashes = (
-        getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
-    )
-    return requires_admin_only_hashes or not settings.allow_custom_components
-
 
 if TYPE_CHECKING:
     from langflow.events.event_manager import EventManager
@@ -1444,55 +1435,21 @@ async def custom_component(
 
     settings_service = get_settings_service()
     settings = settings_service.settings
-    all_known = None
-    if _requires_component_hash_lookups(settings, user):
-        # Lazily compute hash lookups if they haven't been built yet
-        # (e.g. during startup before the cache is fully populated).
-        get_component_hash_lookups_for_validation()
-        all_known = component_cache.all_known_hashes
-        if all_known is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Component templates are still initializing. Please try again in a few seconds.",
-            )
-
-    # In admin-only mode, non-admin users may create/refresh only known server
-    # templates. Truly custom code creation remains restricted to administrators.
-    if (
-        getattr(settings, "custom_component_admin_only", False) is True
-        and not user.is_superuser
-        and not code_hash_matches_any_template(raw_code.code, all_known)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is restricted to administrators",
-        )
-
-    if not settings.allow_custom_components and not code_hash_matches_any_template(raw_code.code, all_known):
-        # Allow updating to a known server template (core component update),
-        # but block truly custom code.
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is disabled",
-        )
-
-    # In restricted mode the request only reached here by matching a known
-    # template hash. That hash is a truncated digest, so a second-preimage
-    # collision could clear the gate with attacker-controlled bytes. Execute
-    # the server's trusted copy keyed by the same hash instead of the client
-    # bytes, and fail closed if no trusted source can be recovered.
-    effective_code = raw_code.code
-    if _requires_component_hash_lookups(settings, user):
-        effective_code = get_trusted_code_for_validation(raw_code.code)
-        if effective_code is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    effective_code = resolve_component_code_for_action(
+        raw_code.code,
+        user=user,
+        settings=settings,
+        snapshot=catalog_policy_snapshot,
+        disabled_detail="Custom component creation is disabled",
+        admin_only_detail="Custom component creation is restricted to administrators",
+    )
 
     component = Component(_code=effective_code)
 
     built_frontend_node, component_instance = build_custom_component_template(component, user_id=user.id)
+    type_ = get_instance_name(component_instance)
+    enforce_catalog_policy_for_component_type(type_, snapshot=catalog_policy_snapshot)
     if raw_code.frontend_node is not None:
         built_frontend_node = await component_instance.update_frontend_node(built_frontend_node, raw_code.frontend_node)
 
@@ -1503,7 +1460,6 @@ async def custom_component(
             field_name="tool_mode",
             field_value=tool_mode,
         )
-    type_ = get_instance_name(component_instance)
     locale = getattr(request.state, "locale", "en")
     if locale != "en":
         from langflow.utils.i18n import translate_component_node
@@ -1543,48 +1499,15 @@ async def custom_component_update(
         )
 
     settings_service = get_settings_service()
-    all_known = None
-    if _requires_component_hash_lookups(settings_service.settings, user):
-        get_component_hash_lookups_for_validation()
-        all_known = component_cache.all_known_hashes
-        if all_known is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Component templates are still initializing. Please try again in a few seconds.",
-            )
-
-    # In admin-only mode, non-admin users may refresh/update only known server
-    # templates. Truly custom code edits remain restricted to administrators.
-    if (
-        getattr(settings_service.settings, "custom_component_admin_only", False) is True
-        and not user.is_superuser
-        and not code_hash_matches_any_template(code_request.code, all_known)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component editing is restricted to administrators",
-        )
-
-    if not settings_service.settings.allow_custom_components and not code_hash_matches_any_template(
-        code_request.code, all_known
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is disabled",
-        )
-
-    # In restricted mode the request only reached here by matching a known
-    # template hash. Because that hash is a truncated digest, execute the
-    # server's trusted copy keyed by the same hash rather than the client
-    # bytes (defeats a hash collision), failing closed if it can't be found.
-    effective_code = code_request.code
-    if _requires_component_hash_lookups(settings_service.settings, user):
-        effective_code = get_trusted_code_for_validation(code_request.code)
-        if effective_code is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    effective_code = resolve_component_code_for_action(
+        code_request.code,
+        user=user,
+        settings=settings_service.settings,
+        snapshot=catalog_policy_snapshot,
+        disabled_detail="Custom component creation is disabled",
+        admin_only_detail="Custom component editing is restricted to administrators",
+    )
 
     policy_context_token = set_current_model_provider_policy_context(
         user_id=user.id,
@@ -1596,6 +1519,8 @@ async def custom_component_update(
             component,
             user_id=user.id,
         )
+        component_type = get_instance_name(cc_instance)
+        enforce_catalog_policy_for_component_type(component_type, snapshot=catalog_policy_snapshot)
 
         if isinstance(cc_instance, Component):
             # Dynamic configuration may resolve DB-backed credentials or call
@@ -1664,6 +1589,8 @@ async def custom_component_update(
                 field_value=code_request.field_value,
             )
 
+    except CatalogPolicyHTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     finally:
@@ -1674,7 +1601,7 @@ async def custom_component_update(
         from langflow.utils.i18n import translate_component_node
 
         try:
-            component_node = translate_component_node(get_instance_name(cc_instance), component_node, locale)
+            component_node = translate_component_node(component_type, component_node, locale)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to translate component node", extra={"locale": locale})
 

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -14,6 +14,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlmodel import apaginate
 from lfx.services.cache.utils import CACHE_MISS
+from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError, validate_catalog_policy_for_flow
 from pydantic import ValidationError
 from sqlalchemy import case
 from sqlmodel import and_, col, select
@@ -43,7 +45,6 @@ from langflow.api.v1.flows_helpers import (
     _resolve_flow_destination,
     _save_flow_to_fs,
     _update_existing_flow,
-    _upsert_flow_list,
     _validate_and_assign_folder,
     _verify_fs_path,
 )
@@ -106,6 +107,18 @@ def _handle_unique_constraint_error(exc: Exception, *, status_code: int = 400) -
     return HTTPException(status_code=status_code, detail=f"{column.capitalize().replace('_', ' ')} must be unique")
 
 
+def _validate_catalog_policy_for_write(
+    flow_data: dict | None,
+    *,
+    snapshot: CatalogPolicySnapshot,
+) -> None:
+    """Validate one effective flow graph and expose policy denials as client errors."""
+    try:
+        validate_catalog_policy_for_flow(flow_data, snapshot=snapshot)
+    except CatalogPolicyValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 # build router
 router = APIRouter(prefix="/flows", tags=["Flows"])
 
@@ -120,6 +133,8 @@ async def create_flow(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
 ):
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
+        _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
         # FastAPI builds the dependency's body model independently from the
         # handler's body model. Carry the exact destination that was authorized
         # into the row we persist so stale caller scope fields cannot retarget
@@ -349,6 +364,7 @@ async def update_flow(
 ):
     """Update a flow."""
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         # Destination check: resolve the actual owner-folder/workspace tuple
         # before authorizing a move. ``_patch_flow`` applies payload values via
         # ``model_dump(exclude_unset=True, exclude_none=True)``, so None means
@@ -427,6 +443,8 @@ async def update_flow(
                     )
                 except HTTPException as exc:
                     raise deny_to_404(exc, detail="Flow not found") from exc
+            effective_flow_data = flow.data if flow.data is not None else db_flow_for_attempt.data
+            _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
             return await _patch_flow(
                 session=session,
                 db_flow=db_flow_for_attempt,
@@ -468,6 +486,7 @@ async def upsert_flow(
     from fastapi.responses import JSONResponse
 
     try:
+        catalog_policy_snapshot = get_catalog_policy_service().snapshot
         # Check if flow exists (without user filter to distinguish ownership vs CREATE)
         existing_flow = (await session.exec(select(Flow).where(Flow.id == flow_id))).first()
 
@@ -577,6 +596,8 @@ async def upsert_flow(
                         )
                     except HTTPException as exc:
                         raise deny_to_404(exc, detail="Flow not found") from exc
+                effective_flow_data = flow.data if flow.data is not None else existing_flow_for_attempt.data
+                _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
                 return await _update_existing_flow(
                     session=session,
                     existing_flow=existing_flow_for_attempt,
@@ -600,6 +621,7 @@ async def upsert_flow(
             await ensure_flow_permission(
                 current_user, FlowAction.CREATE, workspace_id=flow.workspace_id, folder_id=flow.folder_id
             )
+            _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
             flow_read = await _new_flow(
                 session=session,
                 flow=flow,
@@ -648,6 +670,12 @@ async def create_flows(
     current_user: CurrentActiveUser,
 ):
     """Create multiple new flows."""
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+    # Validate the complete request before adding or flushing any rows. This
+    # keeps a denial in a later item from partially applying an earlier item.
+    for flow in flow_list.flows:
+        _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
+
     # Resolve and authorize every flow's canonical project/workspace instead of
     # trusting caller-supplied denormalized scope fields.
     for flow in flow_list.flows:
@@ -759,17 +787,42 @@ async def upload_file(
     # When implemented, extract raw flow dicts here to read embedded "version"
     # arrays and create FlowVersion entries for each imported flow.
 
+    catalog_policy_snapshot = get_catalog_policy_service().snapshot
+
+    requested_id_list = [flow.id for flow in flow_list.flows if flow.id is not None]
+    requested_ids = set(requested_id_list)
+    if len(requested_ids) != len(requested_id_list):
+        raise HTTPException(status_code=422, detail="Invalid upload: duplicate flow IDs are not allowed")
+
+    # Lock only rows this request can update. Missing IDs remain classified as
+    # creates for the whole request; if one appears concurrently, the planned
+    # insert conflicts instead of silently becoming an unvalidated update.
+    owned_existing_flows_by_id: dict[UUID, Flow] = {}
+    foreign_existing_ids: set[UUID] = set()
+    if requested_ids:
+        owned_existing_flows = (
+            await session.exec(
+                select(Flow).where(col(Flow.id).in_(requested_ids), Flow.user_id == current_user.id).with_for_update()
+            )
+        ).all()
+        owned_existing_flows_by_id = {existing_flow.id: existing_flow for existing_flow in owned_existing_flows}
+        remaining_ids = requested_ids - owned_existing_flows_by_id.keys()
+        if remaining_ids:
+            other_existing_flows = (await session.exec(select(Flow).where(col(Flow.id).in_(remaining_ids)))).all()
+            foreign_existing_ids = {
+                existing_flow.id for existing_flow in other_existing_flows if existing_flow.user_id != current_user.id
+            }
+
     # Per-flow CREATE check on the effective canonical destination. For owned
     # upserts with no destination in the payload, preserve the existing project;
     # new or stale destinations fall back to the user's default project.
     for flow in flow_list.flows:
         fallback_folder_id = None
+        existing_flow = owned_existing_flows_by_id.get(flow.id) if flow.id is not None else None
         if folder_id is not None:
             flow.folder_id = folder_id
-        elif flow.folder_id is None and flow.id is not None:
-            existing_flow = (await session.exec(select(Flow).where(Flow.id == flow.id))).first()
-            if existing_flow is not None and existing_flow.user_id == current_user.id:
-                fallback_folder_id = existing_flow.folder_id
+        elif flow.folder_id is None and existing_flow is not None and existing_flow.user_id == current_user.id:
+            fallback_folder_id = existing_flow.folder_id
         await _canonicalize_flow_destination(
             session,
             flow,
@@ -783,18 +836,52 @@ async def upload_file(
             folder_id=flow.folder_id,
         )
 
+        # Upload upserts ignore omitted/null data. Validate the stored graph in
+        # that case so a metadata-only write cannot bypass a newly blocked
+        # component. Rows owned by another user are copied as new flows and do
+        # not inherit that user's stored graph.
+        effective_flow_data = flow.data
+        if effective_flow_data is None and existing_flow is not None and existing_flow.user_id == current_user.id:
+            effective_flow_data = existing_flow.data
+        _validate_catalog_policy_for_write(effective_flow_data, snapshot=catalog_policy_snapshot)
+
     try:
-        return await _upsert_flow_list(
-            session=session,
-            flows=flow_list.flows,
-            current_user=current_user,
-            storage_service=storage_service,
-            folder_id=folder_id,
-        )
+        flow_reads: list[FlowRead] = []
+        for flow in flow_list.flows:
+            flow.user_id = current_user.id
+            stable_id = flow.id
+            existing_flow = owned_existing_flows_by_id.get(stable_id) if stable_id is not None else None
+            if existing_flow is not None:
+                flow_read = await _update_existing_flow(
+                    session=session,
+                    existing_flow=existing_flow,
+                    flow=flow,
+                    current_user=current_user,
+                    storage_service=storage_service,
+                )
+            elif stable_id is not None and stable_id in foreign_existing_ids:
+                flow.id = None
+                flow_read = await _new_flow(
+                    session=session,
+                    flow=flow,
+                    user_id=current_user.id,
+                    storage_service=storage_service,
+                )
+            else:
+                flow_read = await _new_flow(
+                    session=session,
+                    flow=flow,
+                    user_id=current_user.id,
+                    storage_service=storage_service,
+                    flow_id=stable_id,
+                )
+            flow_reads.append(flow_read)
     except HTTPException:
         raise
     except Exception as e:
         raise _handle_unique_constraint_error(e) from e
+    else:
+        return flow_reads
 
 
 @router.delete("/")

--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -685,60 +685,6 @@ async def _patch_flow(
     return FlowRead.model_validate(db_flow, from_attributes=True)
 
 
-async def _upsert_flow_list(
-    *,
-    session: AsyncSession,
-    flows: list[FlowCreate],
-    current_user: User,
-    storage_service: StorageService,
-    folder_id: UUID | None = None,
-) -> list[FlowRead]:
-    """Import a list of flows with upsert semantics (used by the upload endpoint).
-
-    For each flow:
-    - If it has an ID matching an existing flow owned by the user, update in place.
-    - If it has an ID claimed by another user, mint a fresh UUID.
-    - Otherwise create with the provided or generated ID.
-    """
-    flow_reads: list[FlowRead] = []
-    for flow in flows:
-        flow.user_id = current_user.id
-        if folder_id:
-            flow.folder_id = folder_id
-
-        if flow.id is not None:
-            existing = (await session.exec(select(Flow).where(Flow.id == flow.id))).first()
-
-            if existing is not None and existing.user_id == current_user.id:
-                flow_read = await _update_existing_flow(
-                    session=session,
-                    existing_flow=existing,
-                    flow=flow,
-                    current_user=current_user,
-                    storage_service=storage_service,
-                )
-            elif existing is not None:
-                flow.id = None
-                flow_read = await _new_flow(
-                    session=session, flow=flow, user_id=current_user.id, storage_service=storage_service
-                )
-            else:
-                flow_read = await _new_flow(
-                    session=session,
-                    flow=flow,
-                    user_id=current_user.id,
-                    storage_service=storage_service,
-                    flow_id=flow.id,
-                )
-        else:
-            flow_read = await _new_flow(
-                session=session, flow=flow, user_id=current_user.id, storage_service=storage_service
-            )
-
-        flow_reads.append(flow_read)
-    return flow_reads
-
-
 def _sanitize_flow_filename(raw_name: str, fallback_id: str = "flow") -> str:
     """Return a filesystem-safe filename from a flow name.
 

--- a/src/backend/base/langflow/api/v1/validate.py
+++ b/src/backend/base/langflow/api/v1/validate.py
@@ -3,17 +3,28 @@ from lfx.base.prompts.api_utils import process_prompt_template
 from lfx.custom.validate import validate_code
 from lfx.log.logger import logger
 
+from langflow.api.utils import CurrentActiveUser
 from langflow.api.v1.base import Code, CodeValidationResponse, PromptValidationResponse, ValidatePromptRequest
+from langflow.api.v1.custom_component_policy import resolve_component_code_for_action
 from langflow.services.auth.utils import get_current_active_user
+from langflow.services.deps import get_catalog_policy_service, get_settings_service
 
 # build router
 router = APIRouter(prefix="/validate", tags=["Validate"])
 
 
-@router.post("/code", status_code=200, dependencies=[Depends(get_current_active_user)], include_in_schema=False)
-async def post_validate_code(code: Code) -> CodeValidationResponse:
+@router.post("/code", status_code=200, include_in_schema=False)
+async def post_validate_code(code: Code, user: CurrentActiveUser) -> CodeValidationResponse:
+    effective_code = resolve_component_code_for_action(
+        code.code,
+        user=user,
+        settings=get_settings_service().settings,
+        snapshot=get_catalog_policy_service().snapshot,
+        disabled_detail="Custom component validation is disabled",
+        admin_only_detail="Custom component validation is restricted to administrators",
+    )
     try:
-        errors = validate_code(code.code)
+        errors = validate_code(effective_code)
         return CodeValidationResponse(
             imports=errors.get("imports", {}),
             function=errors.get("function", {}),

--- a/src/backend/tests/unit/api/v1/test_custom_component_policy.py
+++ b/src/backend/tests/unit/api/v1/test_custom_component_policy.py
@@ -1,0 +1,105 @@
+"""Tests for the custom-component/catalog policy interaction matrix."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+from langflow.api.v1 import custom_component_policy
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
+from lfx.utils.flow_validation import CatalogPolicyValidationError
+
+
+@pytest.mark.parametrize(
+    (
+        "catalog_blocked",
+        "known_template",
+        "allow_custom_components",
+        "admin_only",
+        "is_superuser",
+        "expected_status",
+        "expected_code",
+        "expected_detail",
+    ),
+    [
+        (True, True, True, False, True, status.HTTP_403_FORBIDDEN, None, "Agent"),
+        (True, True, False, True, False, status.HTTP_403_FORBIDDEN, None, "Agent"),
+        (False, True, False, False, False, None, "trusted server code", None),
+        (False, True, True, True, False, None, "trusted server code", None),
+        (False, False, False, False, True, status.HTTP_403_FORBIDDEN, None, "disabled"),
+        (False, False, True, True, False, status.HTTP_403_FORBIDDEN, None, "admin only"),
+        (False, False, True, True, True, None, "submitted code", None),
+        (False, False, True, False, False, None, "submitted code", None),
+    ],
+)
+def test_resolve_component_code_interaction_matrix(
+    monkeypatch,
+    catalog_blocked,
+    known_template,
+    allow_custom_components,
+    admin_only,
+    is_superuser,
+    expected_status,
+    expected_code,
+    expected_detail,
+):
+    """Catalog denial wins; otherwise known templates and custom lockdown compose."""
+
+    def validate_catalog(_code, *, snapshot):
+        assert isinstance(snapshot, CatalogPolicySnapshot)
+        if catalog_blocked:
+            message = "Catalog policy blocks components: Agent"
+            raise CatalogPolicyValidationError(message)
+
+    monkeypatch.setattr(custom_component_policy, "validate_catalog_policy_for_component_code", validate_catalog)
+    monkeypatch.setattr(custom_component_policy, "get_component_hash_lookups_for_validation", dict)
+    monkeypatch.setattr(custom_component_policy.component_cache, "all_known_hashes", {"known-hash"})
+    monkeypatch.setattr(
+        custom_component_policy,
+        "code_hash_matches_any_template",
+        lambda _code, _all_known: known_template,
+    )
+    monkeypatch.setattr(
+        custom_component_policy,
+        "get_trusted_code_for_validation",
+        lambda _code: "trusted server code" if known_template else None,
+    )
+
+    call = lambda: custom_component_policy.resolve_component_code_for_action(  # noqa: E731
+        "submitted code",
+        user=SimpleNamespace(is_superuser=is_superuser),
+        settings=SimpleNamespace(
+            allow_custom_components=allow_custom_components,
+            custom_component_admin_only=admin_only,
+        ),
+        snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+        if catalog_blocked
+        else CatalogPolicySnapshot(),
+        disabled_detail="disabled",
+        admin_only_detail="admin only",
+    )
+
+    if expected_status is None:
+        assert call() == expected_code
+    else:
+        with pytest.raises(HTTPException) as exc_info:
+            call()
+        assert exc_info.value.status_code == expected_status
+        assert expected_detail in exc_info.value.detail
+
+
+def test_catalog_component_type_denial_has_no_superuser_bypass(monkeypatch):
+    def deny_agent(component_type, *, snapshot):
+        assert component_type == "Agent"
+        assert snapshot.is_component_blocked("Agent")
+        message = "Catalog policy blocks components: Agent"
+        raise CatalogPolicyValidationError(message)
+
+    monkeypatch.setattr(custom_component_policy, "validate_catalog_policy_for_component_type", deny_agent)
+
+    with pytest.raises(HTTPException) as exc_info:
+        custom_component_policy.enforce_catalog_policy_for_component_type(
+            "Agent",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,14 +1,17 @@
 import asyncio
+import hashlib
 import inspect
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from anyio import Path
 from fastapi import status
 from httpx import AsyncClient
 from langflow.api.v1.schemas import CustomComponentRequest, UpdateCustomComponentRequest
 from lfx.components.models_and_agents.agent import AgentComponent
 from lfx.custom.utils import build_custom_component_template
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
 
 
 async def test_get_version(client: AsyncClient):
@@ -33,6 +36,97 @@ async def test_get_config_basic(client: AsyncClient, logged_in_headers: dict):
     assert "auto_saving" in result, "The dictionary must contain a key called 'auto_saving'"
     assert "health_check_max_retries" in result, "The dictionary must contain a 'health_check_max_retries' key"
     assert "max_file_size_upload" in result, "The dictionary must contain a key called 'max_file_size_upload'"
+
+
+@pytest.mark.parametrize("path", ["api/v1/custom_component", "api/v1/custom_component/update"])
+async def test_catalog_blocks_known_template_before_custom_component_build(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+    path: str,
+):
+    """A blocked built-in cannot be reintroduced through either custom-component path."""
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+
+    def fail_if_built(*_args, **_kwargs):
+        msg = "catalog policy must deny known blocked source before component build"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.endpoints.build_custom_component_template", fail_if_built)
+    if path.endswith("/update"):
+        request = UpdateCustomComponentRequest(
+            code=code,
+            frontend_node={"outputs": []},
+            field="",
+            field_value="",
+            template={},
+        )
+    else:
+        request = CustomComponentRequest(code=code)
+
+    response = await client.post(path, json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("path", ["api/v1/custom_component", "api/v1/custom_component/update"])
+async def test_catalog_blocks_resolved_custom_component_type(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+    path: str,
+):
+    """A modified custom component cannot assume an exact blocked runtime type."""
+    code = """
+from lfx.custom import Component
+from lfx.template.field.base import Output
+
+class CatalogLookalikeComponent(Component):
+    name = "Agent"
+    display_name = "Catalog Lookalike"
+    outputs = [Output(display_name="Output", name="output", method="get_result")]
+
+    def get_result(self) -> str:
+        return "blocked"
+"""
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {"different-template-hash"}},
+    )
+
+    if path.endswith("/update"):
+        request = UpdateCustomComponentRequest(
+            code=code,
+            frontend_node={"outputs": []},
+            field="",
+            field_value="",
+            template={},
+        )
+    else:
+        request = CustomComponentRequest(code=code)
+
+    response = await client.post(path, json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
 
 
 async def test_update_component_outputs(client: AsyncClient, logged_in_headers: dict):

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -6,6 +6,13 @@ from fastapi import status
 from httpx import AsyncClient
 
 
+def _catalog_flow_data(component_key: str) -> dict:
+    return {
+        "nodes": [{"id": f"{component_key}-node", "data": {"type": component_key}}],
+        "edges": [],
+    }
+
+
 async def _attach_deployment_to_flow(*, user_id: UUID, flow_id: UUID, project_id: UUID) -> None:
     from langflow.services.database.models.deployment.model import Deployment
     from langflow.services.database.models.deployment_provider_account.model import (
@@ -97,6 +104,106 @@ async def test_create_flow(client: AsyncClient, logged_in_headers):
     assert "updated_at" in result, "The result must have a 'updated_at' key"
     assert "user_id" in result, "The result must have a 'user_id' key"
     assert "webhook" in result, "The result must have a 'webhook' key"
+
+
+async def test_create_and_put_flow_enforce_catalog_policy_with_default_allow(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedForFlowWrites"
+    graph = _catalog_flow_data(blocked_key)
+
+    allowed_response = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-default-allow-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert allowed_response.status_code == status.HTTP_201_CREATED, allowed_response.text
+
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    blocked_create = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-blocked-create-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert blocked_create.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_create.json()["detail"].endswith(blocked_key)
+
+    put_flow_id = uuid.uuid4()
+    blocked_put = await client.put(
+        f"api/v1/flows/{put_flow_id}",
+        json={"name": f"catalog-blocked-put-{uuid.uuid4()}", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert blocked_put.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_put.json()["detail"].endswith(blocked_key)
+
+
+async def test_patch_and_put_metadata_only_updates_validate_stored_graph(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedStoredGraph"
+    graph = _catalog_flow_data(blocked_key)
+
+    patch_source = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-patch-source-{uuid.uuid4()}", "description": "original", "data": graph},
+        headers=logged_in_headers,
+    )
+    put_source = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-put-source-{uuid.uuid4()}", "description": "original", "data": graph},
+        headers=logged_in_headers,
+    )
+    assert patch_source.status_code == status.HTTP_201_CREATED, patch_source.text
+    assert put_source.status_code == status.HTTP_201_CREATED, put_source.text
+
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    patch_response = await client.patch(
+        f"api/v1/flows/{patch_source.json()['id']}",
+        json={"description": "metadata-only patch"},
+        headers=logged_in_headers,
+    )
+    put_response = await client.put(
+        f"api/v1/flows/{put_source.json()['id']}",
+        json={"name": put_source.json()["name"], "description": "metadata-only put"},
+        headers=logged_in_headers,
+    )
+
+    assert patch_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert patch_response.json()["detail"].endswith(blocked_key)
+    assert put_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert put_response.json()["detail"].endswith(blocked_key)
+
+    unchanged_patch = await client.get(
+        f"api/v1/flows/{patch_source.json()['id']}",
+        headers=logged_in_headers,
+    )
+    unchanged_put = await client.get(
+        f"api/v1/flows/{put_source.json()['id']}",
+        headers=logged_in_headers,
+    )
+    assert unchanged_patch.json()["description"] == "original"
+    assert unchanged_put.json()["description"] == "original"
 
 
 async def test_read_flows(client: AsyncClient, logged_in_headers):
@@ -522,6 +629,52 @@ async def test_create_flows(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_201_CREATED
     assert isinstance(result, list), "The result must be a list"
     assert len(result) == amount_flows, "The result must have the same amount of flows"
+
+
+async def test_create_flows_catalog_policy_preflight_is_atomic_and_uses_one_snapshot(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    blocked_key = "BlockedLateInBatch"
+
+    class RotatingCatalogPolicyService:
+        calls = 0
+
+        @property
+        def snapshot(self):
+            self.calls += 1
+            if self.calls == 1:
+                return CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+            return CatalogPolicySnapshot()
+
+    service = RotatingCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    allowed_name = f"catalog-batch-allowed-{uuid.uuid4()}"
+    blocked_name = f"catalog-batch-blocked-{uuid.uuid4()}"
+
+    response = await client.post(
+        "api/v1/flows/batch/",
+        json={
+            "flows": [
+                {"name": allowed_name, "data": _catalog_flow_data("AllowedInBatch")},
+                {"name": blocked_name, "data": _catalog_flow_data(blocked_key)},
+            ]
+        },
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith(blocked_key)
+    assert service.calls == 1
+
+    listed = await client.get("api/v1/flows/", headers=logged_in_headers)
+    persisted_names = {flow["name"] for flow in listed.json()}
+    assert allowed_name not in persisted_names
+    assert blocked_name not in persisted_names
 
 
 async def test_create_flows_with_explicit_folder(client: AsyncClient, logged_in_headers):
@@ -1013,6 +1166,72 @@ async def test_upload_flow_accepts_valid_endpoint_name(client: AsyncClient, logg
     assert isinstance(body, list)
     assert len(body) == 1
     assert body[0]["name"] == "neuro-vision"
+
+
+async def test_upload_catalog_policy_preflights_all_effective_graphs_before_upsert(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    import json
+
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+    class MutableCatalogPolicyService:
+        snapshot = CatalogPolicySnapshot()
+
+    service = MutableCatalogPolicyService()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    blocked_key = "BlockedStoredUploadGraph"
+    original_name = f"catalog-upload-source-{uuid.uuid4()}"
+    source = await client.post(
+        "api/v1/flows/",
+        json={"name": original_name, "description": "original", "data": _catalog_flow_data(blocked_key)},
+        headers=logged_in_headers,
+    )
+    assert source.status_code == status.HTTP_201_CREATED, source.text
+
+    mutation_calls = 0
+
+    async def track_unexpected_mutation(**_kwargs):
+        nonlocal mutation_calls
+        mutation_calls += 1
+        return []
+
+    monkeypatch.setattr(flows, "_new_flow", track_unexpected_mutation)
+    monkeypatch.setattr(flows, "_update_existing_flow", track_unexpected_mutation)
+    service.snapshot = CatalogPolicySnapshot(blocked_component_keys={blocked_key})
+    allowed_name = f"catalog-upload-allowed-{uuid.uuid4()}"
+    changed_name = f"catalog-upload-changed-{uuid.uuid4()}"
+    file_content = json.dumps(
+        {
+            "flows": [
+                {"name": allowed_name, "data": _catalog_flow_data("AllowedInUpload")},
+                {
+                    "id": source.json()["id"],
+                    "name": changed_name,
+                    "description": "metadata-only upload update",
+                },
+            ]
+        }
+    )
+
+    response = await client.post(
+        "api/v1/flows/upload/",
+        files={"file": ("flows.json", file_content, "application/json")},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"].endswith(blocked_key)
+    assert mutation_calls == 0
+
+    unchanged = await client.get(f"api/v1/flows/{source.json()['id']}", headers=logged_in_headers)
+    assert unchanged.status_code == status.HTTP_200_OK
+    assert unchanged.json()["name"] == original_name
+    listed = await client.get("api/v1/flows/", headers=logged_in_headers)
+    assert allowed_name not in {flow["name"] for flow in listed.json()}
 
 
 async def test_upload_flow_rejects_absolute_path(client: AsyncClient, logged_in_headers):

--- a/src/backend/tests/unit/api/v1/test_validate.py
+++ b/src/backend/tests/unit/api/v1/test_validate.py
@@ -1,6 +1,15 @@
+import asyncio
+import hashlib
+import inspect
+from types import SimpleNamespace
+
 import pytest
+from anyio import Path
 from fastapi import status
 from httpx import AsyncClient
+from lfx.components.models_and_agents.agent import AgentComponent
+from lfx.interface.components import component_cache
+from lfx.services.catalog_policy.base import CatalogPolicySnapshot
 
 
 @pytest.mark.usefixtures("active_user")
@@ -17,6 +26,126 @@ pprint(var)
     assert isinstance(result, dict), "The result must be a dictionary"
     assert "imports" in result, "The result must have an 'imports' key"
     assert "function" in result, "The result must have a 'function' key"
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_blocks_catalog_template_before_validation(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=snapshot),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+
+    def fail_if_validated(_code):
+        msg = "blocked source must be denied before validate_code inspects imports"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", fail_if_validated)
+
+    response = await client.post("api/v1/validate/code", json={"code": code}, headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Agent" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("allow_custom_components", "admin_only", "expected_detail"),
+    [
+        (False, False, "disabled"),
+        (True, True, "restricted to administrators"),
+    ],
+)
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_applies_custom_code_lockdown_before_validation(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+    allow_custom_components,
+    admin_only,
+    expected_detail: str,
+):
+    from langflow.services.deps import get_settings_service
+
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "allow_custom_components", allow_custom_components)
+    monkeypatch.setattr(settings, "custom_component_admin_only", admin_only)
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=CatalogPolicySnapshot()),
+    )
+    monkeypatch.setattr(
+        "langflow.api.v1.custom_component_policy.get_component_hash_lookups_for_validation",
+        dict,
+    )
+    monkeypatch.setattr(component_cache, "all_known_hashes", set())
+
+    def fail_if_validated(_code):
+        msg = "restricted unknown source must be denied before validation"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", fail_if_validated)
+
+    response = await client.post(
+        "api/v1/validate/code",
+        json={"code": "import definitely_untrusted_module"},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert expected_detail in response.json()["detail"]
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_post_validate_code_uses_trusted_template_source_in_restricted_mode(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.services.deps import get_settings_service
+
+    submitted_code = "known template source"
+    trusted_code = "trusted server source"
+    code_hash = hashlib.sha256(submitted_code.encode()).hexdigest()[:12]
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "allow_custom_components", False)
+    monkeypatch.setattr(settings, "custom_component_admin_only", False)
+    monkeypatch.setattr(
+        "langflow.api.v1.validate.get_catalog_policy_service",
+        lambda: SimpleNamespace(snapshot=CatalogPolicySnapshot()),
+    )
+    monkeypatch.setattr(
+        "langflow.api.v1.custom_component_policy.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}},
+    )
+    monkeypatch.setattr(component_cache, "all_known_hashes", {code_hash})
+    monkeypatch.setattr(component_cache, "code_by_hash", {code_hash: trusted_code})
+    validated_codes = []
+
+    def capture_validated_code(code):
+        validated_codes.append(code)
+        return {"imports": {}, "function": {}}
+
+    monkeypatch.setattr("langflow.api.v1.validate.validate_code", capture_validated_code)
+
+    response = await client.post(
+        "api/v1/validate/code",
+        json={"code": submitted_code},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert validated_codes == [trusted_code]
 
 
 @pytest.mark.usefixtures("active_user")

--- a/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_flow_route_guards.py
@@ -176,9 +176,9 @@ def test_create_flows_guards_each_flow_with_its_destination(routes):
 def test_upload_file_guards_each_flow_with_effective_destination(routes):
     """POST /upload/ adds a per-flow check after parsing.
 
-    `_upsert_flow_list` lets the query ``folder_id`` override each flow's folder_id but
-    preserves each flow's workspace_id, so the per-flow check must use
-    ``workspace_id=flow.workspace_id`` and live inside a loop over ``flow_list.flows``.
+    The query ``folder_id`` overrides each flow's folder_id while preserving
+    each flow's workspace_id, so the per-flow check must use
+    ``workspace_id=flow.workspace_id`` inside a loop over ``flow_list.flows``.
     """
     func = routes["upload_file"]
     calls = _ensure_flow_permission_calls(func)

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -89,30 +89,32 @@ async def test_build_flow_validates_request_data_instead_of_stale_db_flow(
     assert "job_id" in response.json()
 
 
-async def test_build_flow_maps_catalog_policy_validation_to_bad_request(
-    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+async def test_build_flow_enforces_current_catalog_policy_and_recovers_when_cleared(
+    client, json_memory_chatbot_no_llm, logged_in_headers
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
-    validation_message = "Flow build blocked: catalog policy blocks components: Agent"
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
 
-    def reject_catalog_component(_target):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_flow_for_current_settings",
-        reject_catalog_component,
+    blocked_response = await client.post(
+        f"api/v1/build/{flow_id}/flow",
+        json={},
+        headers=logged_in_headers,
     )
-
-    response = await client.post(
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
         f"api/v1/build/{flow_id}/flow",
         json={},
         headers=logged_in_headers,
     )
 
-    assert response.status_code == codes.BAD_REQUEST
-    assert response.json()["detail"].endswith("Agent")
+    assert blocked_response.status_code == codes.BAD_REQUEST
+    assert blocked_response.json()["detail"].endswith("ChatInput")
+    assert allowed_response.status_code == codes.OK
+    assert "job_id" in allowed_response.json()
 
 
 async def test_build_flow_with_frozen_path(client, json_memory_chatbot_no_llm, logged_in_headers):
@@ -735,11 +737,13 @@ async def test_build_public_tmp_checks_public_access_before_validation(
     assert response.json()["detail"] == "Flow is not public"
 
 
-async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_request(
-    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+async def test_build_public_tmp_enforces_current_catalog_policy_with_generic_error(
+    client, json_memory_chatbot_no_llm, logged_in_headers
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
     flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
     response = await client.patch(
         f"api/v1/flows/{flow_id}",
@@ -747,26 +751,26 @@ async def test_build_public_tmp_maps_catalog_policy_validation_to_generic_bad_re
         headers=logged_in_headers,
     )
     assert response.status_code == codes.OK
-    validation_message = "Flow build blocked: catalog policy blocks components: SecretComponent"
-
-    def reject_catalog_component(_target):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
-        reject_catalog_component,
-    )
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
     client.cookies.set("client_id", "test-catalog-policy-client")
 
-    response = await client.post(
+    blocked_response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
         f"api/v1/build_public_tmp/{flow_id}/flow",
         json={},
         headers={"Content-Type": "application/json"},
     )
 
-    assert response.status_code == codes.BAD_REQUEST
-    assert response.json()["detail"] == "This flow cannot be executed."
-    assert "SecretComponent" not in response.text
+    assert blocked_response.status_code == codes.BAD_REQUEST
+    assert blocked_response.json()["detail"] == "This flow cannot be executed."
+    assert "ChatInput" not in blocked_response.text
+    assert allowed_response.status_code == codes.OK
+    assert "job_id" in allowed_response.json()
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -702,28 +702,37 @@ async def test_successful_run_no_payload(client, simple_api_test, created_api_ke
     assert all(result is not None for result in inner_results), (outputs_dict, output_results_has_results)
 
 
-async def test_run_by_id_maps_catalog_policy_validation_to_bad_request(
-    client, simple_api_test, created_api_key, monkeypatch
+async def test_run_by_id_enforces_current_catalog_policy_and_recovers_when_cleared(
+    client, json_simple_api_test, logged_in_headers, created_api_key
 ):
-    from lfx.utils.flow_validation import CatalogPolicyValidationError
+    from lfx.services.deps import get_catalog_policy_service
 
-    validation_message = "Flow build blocked: catalog policy blocks components: ChatInput"
-
-    def reject_catalog_component(_target, **_kwargs):
-        raise CatalogPolicyValidationError(validation_message)
-
-    monkeypatch.setattr(
-        "lfx.utils.flow_validation.validate_flow_for_current_settings",
-        reject_catalog_component,
+    catalog_policy_service = get_catalog_policy_service()
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    flow_payload = orjson.loads(json_simple_api_test)
+    flow = FlowCreate(
+        name="Catalog Policy Run Test",
+        data=flow_payload["data"],
+        description="Catalog policy route test",
     )
+    create_response = await client.post("api/v1/flows/", json=flow.model_dump(), headers=logged_in_headers)
+    assert create_response.status_code == status.HTTP_201_CREATED
+    flow_id = create_response.json()["id"]
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
 
-    response = await client.post(
-        f"/api/v1/run/{simple_api_test['id']}",
+    blocked_response = await client.post(
+        f"/api/v1/run/{flow_id}",
+        headers={"x-api-key": created_api_key.api_key},
+    )
+    await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+    allowed_response = await client.post(
+        f"/api/v1/run/{flow_id}",
         headers={"x-api-key": created_api_key.api_key},
     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"].endswith("ChatInput")
+    assert blocked_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert blocked_response.json()["detail"].endswith("ChatInput")
+    assert allowed_response.status_code == status.HTTP_200_OK, allowed_response.text
 
 
 async def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):

--- a/src/backend/tests/unit/test_flow_validation.py
+++ b/src/backend/tests/unit/test_flow_validation.py
@@ -838,6 +838,7 @@ class TestGetTrustedCodeForValidation:
     def test_self_heals_from_all_types_dict_when_map_unbuilt(self, monkeypatch):
         trusted = "class Heal:\n    pass\n"
         monkeypatch.setattr(component_cache, "code_by_hash", None)
+        monkeypatch.setattr(component_cache, "all_types_ready", True)
         monkeypatch.setattr(
             component_cache,
             "all_types_dict",

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -54,6 +54,11 @@ class ComponentCache:
         Creates empty storage for all component types and tracking of fully loaded components.
         """
         self.all_types_dict: dict[str, Any] | None = None
+        # True only after the built-in, custom, and extension component maps
+        # have been merged. ``_determine_loading_strategy`` temporarily places
+        # partial values (including ``{}``) in ``all_types_dict`` while startup
+        # is still in flight, so presence alone is not a readiness signal.
+        self.all_types_ready = False
         self.fully_loaded_components: dict[str, bool] = {}
         # Precomputed code hashes for fast flow validation.
         # Populated by get_and_cache_all_types_dict() via _build_code_hash_lookups().
@@ -764,7 +769,7 @@ def _build_code_hash_lookups(cache: ComponentCache) -> None:
     - type_to_current_hash: {component_type: 12-char SHA256 prefix}
     - all_known_hashes: set of all known code hashes
     """
-    if not cache.all_types_dict:
+    if cache.all_types_dict is None or (not cache.all_types_dict and not cache.all_types_ready):
         return
 
     type_to_hash, all_hashes = collect_component_hash_lookups(cache.all_types_dict)
@@ -1256,6 +1261,7 @@ def refresh_bundle_cache_from_record(record: "BundleRecord") -> None:
         )
 
     component_cache.all_types_dict[record.bundle] = bundle_dict
+    component_cache.all_types_ready = True
 
     # Invalidate the precomputed code-hash lookups so flow validation
     # picks up the freshly-loaded class bodies instead of comparing
@@ -1284,6 +1290,7 @@ async def get_and_cache_all_types_dict(
         telemetry_service: Optional telemetry service for tracking component loading metrics
     """
     if component_cache.all_types_dict is None:
+        component_cache.all_types_ready = False
         await logger.adebug("Building components cache")
 
         langflow_components = await import_langflow_components(settings_service, telemetry_service)
@@ -1307,6 +1314,7 @@ async def get_and_cache_all_types_dict(
             **custom_flat,
             **extension_components,
         }
+        component_cache.all_types_ready = True
         component_count = sum(len(comps) for comps in component_cache.all_types_dict.values())
         await logger.adebug(f"Loaded {component_count} components")
 

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -16,6 +16,9 @@ INITIALIZING_COMPONENT_TEMPLATES_MESSAGE = (
     "Flow build blocked: component templates are still initializing. Please try again in a few seconds."
 )
 SETTINGS_SERVICE_REQUIRED_MESSAGE = "Settings service must be initialized before validating flows."
+CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE = (
+    "Catalog policy component identities are still initializing. Please try again in a few seconds."
+)
 
 # Built-in components that execute user- or model-supplied Python from input fields or during
 # runtime, rather than from the validated class ``code`` field. Their class-code hash is valid,
@@ -466,7 +469,11 @@ def get_trusted_code_for_validation(code: str) -> str | None:
 
     # Self-heal: build the lookup lazily if the cache hasn't populated it yet
     # (e.g. the eager warm-up path didn't run before the first request).
-    if component_cache.code_by_hash is None and component_cache.all_types_dict is not None:
+    if (
+        component_cache.code_by_hash is None
+        and component_cache.all_types_ready
+        and component_cache.all_types_dict is not None
+    ):
         component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
 
     code_by_hash = component_cache.code_by_hash
@@ -548,13 +555,75 @@ def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     """Return the cached component hashes, building them synchronously if possible."""
     from lfx.interface.components import component_cache
 
-    if component_cache.type_to_current_hash is None and component_cache.all_types_dict is not None:
+    if (
+        component_cache.type_to_current_hash is None
+        and component_cache.all_types_ready
+        and component_cache.all_types_dict is not None
+    ):
         type_to_hash, all_hashes = collect_component_hash_lookups(component_cache.all_types_dict)
         component_cache.type_to_current_hash = type_to_hash
         component_cache.all_known_hashes = all_hashes
         component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
 
     return component_cache.type_to_current_hash
+
+
+def validate_catalog_policy_for_component_code(
+    code: str,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject source that matches a blocked server component template.
+
+    The code hash is checked against every exact catalog key's existing alias
+    lookup before custom-component source is parsed or executed. An active
+    policy fails closed while those trusted template identities are unavailable;
+    an empty snapshot remains the documented default-allow behavior.
+    """
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.blocked_component_keys:
+        return
+
+    type_to_current_hash = get_component_hash_lookups_for_validation()
+    if type_to_current_hash is None:
+        raise RuntimeError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+
+    code_hash = _compute_code_hash(code)
+    blocked = frozenset(
+        component_type
+        for component_type in snapshot.blocked_component_keys
+        if code_hash in type_to_current_hash.get(component_type, set())
+    )
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Component action blocked by catalog policy: {blocked_names}")
+    message = f"Catalog policy blocks components: {blocked_names}"
+    raise CatalogPolicyValidationError(message)
+
+
+def validate_catalog_policy_for_component_type(
+    component_type: str,
+    *,
+    snapshot: CatalogPolicySnapshot | None = None,
+) -> None:
+    """Reject a materialized component whose exact runtime type is blocked."""
+    if snapshot is None:
+        from lfx.services.deps import get_catalog_policy_service
+
+        snapshot = get_catalog_policy_service().snapshot
+
+    if not snapshot.is_component_blocked(component_type):
+        return
+
+    logger.warning(f"Component action blocked by catalog policy: {component_type}")
+    message = f"Catalog policy blocks components: {component_type}"
+    raise CatalogPolicyValidationError(message)
 
 
 def validate_flow_for_current_settings(
@@ -932,7 +1001,7 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
         raise PublicFlowValidationError(message)
 
 
-async def ensure_component_hash_lookups_loaded() -> dict[str, str] | None:
+async def ensure_component_hash_lookups_loaded() -> dict[str, set[str]] | None:
     """Ensure component hash lookups are available for CLI/runtime validation."""
     from lfx.interface.components import component_cache, get_and_cache_all_types_dict
     from lfx.services.deps import get_settings_service

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -1,5 +1,6 @@
 """Unit tests for LFX flow validation helpers."""
 
+import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,8 @@ from lfx.utils.flow_validation import (
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
+    validate_catalog_policy_for_component_code,
+    validate_catalog_policy_for_component_type,
     validate_catalog_policy_for_flow,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
@@ -121,6 +124,76 @@ def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_al
         snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
     )
     validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+def test_catalog_policy_component_code_blocks_known_alias_before_execution(monkeypatch):
+    code = "# trusted Agent component"
+    code_hash = hashlib.sha256(code.encode()).hexdigest()[:12]
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: {"Agent": {code_hash}, "AgentComponent": {code_hash}},
+    )
+
+    with pytest.raises(CatalogPolicyValidationError, match="AgentComponent"):
+        validate_catalog_policy_for_component_code(
+            code,
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"AgentComponent"}),
+        )
+
+
+def test_catalog_policy_component_code_empty_snapshot_does_not_require_template_identities(monkeypatch):
+    def fail_if_called():
+        msg = "empty policy should not load component identities"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        fail_if_called,
+    )
+
+    validate_catalog_policy_for_component_code("arbitrary code", snapshot=CatalogPolicySnapshot())
+
+
+def test_catalog_policy_component_code_fails_closed_while_identities_initialize(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_hash_lookups_for_validation",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="identities are still initializing"):
+        validate_catalog_policy_for_component_code(
+            "arbitrary code",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+
+def test_catalog_policy_component_code_does_not_build_from_transient_component_cache(monkeypatch):
+    from lfx.interface.components import component_cache
+
+    monkeypatch.setattr(component_cache, "all_types_dict", {})
+    monkeypatch.setattr(component_cache, "all_types_ready", False)
+    monkeypatch.setattr(component_cache, "type_to_current_hash", None)
+    monkeypatch.setattr(component_cache, "all_known_hashes", None)
+    monkeypatch.setattr(component_cache, "code_by_hash", None)
+
+    with pytest.raises(RuntimeError, match="identities are still initializing"):
+        validate_catalog_policy_for_component_code(
+            "arbitrary code",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
+        )
+
+    assert component_cache.type_to_current_hash is None
+    assert component_cache.all_known_hashes is None
+    assert component_cache.code_by_hash is None
+
+
+def test_catalog_policy_component_type_is_exact_and_empty_snapshot_allows():
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
+
+    validate_catalog_policy_for_component_type("agent", snapshot=snapshot)
+    validate_catalog_policy_for_component_type("Agent", snapshot=CatalogPolicySnapshot())
+    with pytest.raises(CatalogPolicyValidationError, match="Agent"):
+        validate_catalog_policy_for_component_type("Agent", snapshot=snapshot)
 
 
 def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):


### PR DESCRIPTION
## Summary

- enforce catalog policy across every flow save/import path, with whole-request preflight for batch and upload writes
- align custom-component create/update and `/validate/code` with catalog governance and the existing custom-code settings
- replace mocked enforcement checks with real policy-service coverage for authenticated build, public build, and run-by-ID
- fail closed while component identities are still loading, and document the catalog/custom-code interaction matrix

## Jira

- LE-1938
- LE-1940
- LE-1942
- Epic: LE-1864

## Stack

Base: #14316 (`feat/agent-catalog`)

## Validation

- full flow API unit file: 61 passed
- LFX flow-validation unit file: 83 passed
- LFX extension-cache integration file: 17 passed
- focused catalog policy, custom-component, validation, build/run, cache, and route-guard tests: passed
- Ruff format/check, targeted mypy, `git diff --check`, and commit hooks: passed
