### PR TITLE
fix(milvus): filter unsupported document metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ Documentation = "https://docs.langflow.org"
 
 [project.optional-dependencies]
 bundles = [
-    "lfx-bundles[all-no-torch]>=1.1.6,<2.0",
+    "lfx-bundles[all-no-torch]>=1.1.7,<2.0",
     "lfx-arxiv>=0.1.0,<1.0.0",
     "lfx-duckduckgo>=0.1.0,<1.0.0",
     "lfx-empiriolabs>=0.1.0,<1.0.0",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-bundles"
-version = "1.1.6"
+version = "1.1.7"
 description = "Langflow's long-tail provider bundles as a single manifest-less metapackage (the langchain-community model)."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/lfx-bundles/src/lfx_bundles/milvus/milvus.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/milvus/milvus.py
@@ -13,6 +13,8 @@ from lfx.io import (
 from lfx.schema.data import Data
 from lfx.utils.ssrf_protection import validate_connector_url_for_ssrf
 
+_SCHEMA_FREE_METADATA_TYPES = (str, bool, int, float, dict)
+
 
 class MilvusVectorStoreComponent(LCVectorStoreComponent):
     """Milvus vector store with search capabilities."""
@@ -99,6 +101,14 @@ class MilvusVectorStoreComponent(LCVectorStoreComponent):
                 documents.append(_input)
 
         if documents:
+            # Milvus infers scalar and JSON fields without field configuration;
+            # other metadata requires an explicit schema.
+            for document in documents:
+                document.metadata = {
+                    key: value
+                    for key, value in document.metadata.items()
+                    if isinstance(value, _SCHEMA_FREE_METADATA_TYPES)
+                }
             milvus_store.add_documents(documents)
 
         return milvus_store

--- a/src/bundles/lfx-bundles/tests/test_milvus.py
+++ b/src/bundles/lfx-bundles/tests/test_milvus.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+from lfx.schema.data import Data
+from lfx_bundles.milvus import milvus as milvus_module
+
+if TYPE_CHECKING:
+    import pytest
+
+_DEFAULT_METADATA_TYPES = (str, bool, int, float, dict)
+
+
+class _RejectingMilvus:
+    """Model Milvus' default scalar and JSON metadata contract."""
+
+    def __init__(self, **_kwargs: Any) -> None:
+        self.documents: list[Any] = []
+
+    def add_documents(self, documents: list[Any]) -> None:
+        for document in documents:
+            for field_name, value in document.metadata.items():
+                if not isinstance(value, _DEFAULT_METADATA_TYPES):
+                    msg = f"Unrecognized datatype for {field_name}."
+                    raise ValueError(msg)  # noqa: TRY004 - Match the provider error reported in #9936.
+        self.documents.extend(documents)
+
+
+def _install_fake_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    package = ModuleType("langchain_milvus")
+    package.__path__ = []
+    vectorstores = ModuleType("langchain_milvus.vectorstores")
+    vectorstores.Milvus = _RejectingMilvus
+    package.vectorstores = vectorstores
+
+    monkeypatch.setitem(sys.modules, "langchain_milvus", package)
+    monkeypatch.setitem(sys.modules, "langchain_milvus.vectorstores", vectorstores)
+
+
+def test_build_vector_store_filters_metadata_requiring_explicit_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_provider(monkeypatch)
+    monkeypatch.setattr(milvus_module, "validate_connector_url_for_ssrf", lambda _uri: None)
+
+    component = milvus_module.MilvusVectorStoreComponent().set(
+        uri="milvus_demo.db",
+        password="",
+        connection_args={},
+        collection_name="langflow",
+        collection_description="",
+        consistency_level="Session",
+        index_params={},
+        search_params={},
+        drop_old=False,
+        embedding=MagicMock(name="embedding"),
+        primary_field="pk",
+        text_field="text",
+        vector_field="vector",
+        timeout=None,
+        ingest_data=[
+            Data(
+                data={
+                    "text": "document",
+                    "files": [],
+                    "tags": ["one"],
+                    "nested": {"key": "value"},
+                    "nullable": None,
+                    "source": "fixture.txt",
+                    "page": 1,
+                    "verified": True,
+                    "score": 0.5,
+                }
+            )
+        ],
+    )
+
+    store = component.build_vector_store()
+
+    assert len(store.documents) == 1
+    document = store.documents[0]
+    assert document.page_content == "document"
+    assert document.metadata == {
+        "source": "fixture.txt",
+        "page": 1,
+        "verified": True,
+        "score": 0.5,
+        "nested": {"key": "value"},
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -9283,7 +9283,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-bundles"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "src/bundles/lfx-bundles" }
 dependencies = [
     { name = "lfx" },


### PR DESCRIPTION
## Summary

- filter document metadata before sending documents to Milvus when no metadata field schema is configured
- preserve schema-free scalar values and JSON objects while omitting values that require an explicit Milvus schema
- add a regression test covering the reported `files=[]` failure, other unsupported values, and preserved metadata
- bump `lfx-bundles` to `1.1.7` and synchronize its root dependency floor and lockfile metadata

## Root cause

`Data.to_lc_document()` keeps non-text fields as document metadata, including the file loader's empty `files` list. The Milvus integration currently relies on dynamic field inference and does not provide a metadata schema. PyMilvus cannot infer a datatype from an empty list, so `add_documents()` raises `ValueError: Unrecognized datatype for files.`

Filtering at the provider boundary keeps metadata that Milvus can infer without field configuration and prevents schema-dependent values from reaching dynamic inference.

## Validation

- `make init`
- `make lint`
- `make format_frontend`
- bundle release plan validation (`lfx-bundles: 1.1.6 -> 1.1.7 (ready)`)
- repository-wide Ruff check and format check (ignoring only `EXE002`, because the Windows bind mount presents every file as executable)
- clean Cross-Bundle CI-equivalent installs and contract smoke checks on Python 3.10 and 3.13 (67 providers discovered on each)
- clean `lfx-bundles` test runs on Python 3.10 and 3.13 (`16 passed, 1 skipped` on each)
- pinned provider reproduction with `langchain-milvus==0.3.3`, `pymilvus==2.6.17`, and `milvus-lite==3.1.1`: reproduced the reported error before the change; the same metadata no longer reaches that datatype error after the change

## Scope

This change addresses the reported metadata ingestion error only. It does not alter URI validation or local Milvus Lite connection setup.

Related to #9936.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Milvus vector-store ingestion by filtering document metadata to supported scalar and JSON-compatible values.
  * Preserved valid metadata and document content while preventing unsupported metadata types from causing ingestion failures.

* **Maintenance**
  * Updated the bundled LFX package to version 1.1.7 for improved compatibility and access to the latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->