### PR TITLE
fix(agentic): harden assistant code extraction

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_extraction.py
+++ b/src/backend/base/langflow/agentic/helpers/code_extraction.py
@@ -97,7 +97,7 @@ def _contains_component_class(code: str) -> bool:
     """Return True when code defines a class inheriting from Component."""
     try:
         tree = ast.parse(code)
-    except SyntaxError:
+    except (SyntaxError, TypeError, ValueError, UnicodeError):
         return _contains_component_class_header(code)
 
     return any(

--- a/src/backend/base/langflow/agentic/helpers/code_extraction.py
+++ b/src/backend/base/langflow/agentic/helpers/code_extraction.py
@@ -1,17 +1,17 @@
 """Code and data extraction from markdown responses."""
 
+import ast
 import json
 import logging
 import re
 
 logger = logging.getLogger(__name__)
 
-PYTHON_CODE_BLOCK_PATTERN = r"```python\s*([\s\S]*?)```"
 FLOW_JSON_BLOCK_PATTERN = r"```flow_json\s*([\s\S]*?)```"
-GENERIC_CODE_BLOCK_PATTERN = r"```\s*([\s\S]*?)```"
-UNCLOSED_PYTHON_BLOCK_PATTERN = r"```python\s*([\s\S]*)$"
-UNCLOSED_GENERIC_BLOCK_PATTERN = r"```\s*([\s\S]*)$"
 ANY_CODE_BLOCK_PATTERN = r"```[\s\S]*?```|```[\s\S]*$"
+_OPENING_FENCE_RE = re.compile(r"^\s*```\s*([A-Za-z0-9_-]+)?\s*$")
+_CLOSING_FENCE_RE = re.compile(r"^\s*```\s*$")
+_COMPONENT_CLASS_RE = re.compile(r"^\s*class\s+\w+\s*\((?P<bases>[^)]*)\)", re.MULTILINE)
 
 
 def extract_python_code(text: str) -> str | None:
@@ -24,43 +24,109 @@ def extract_python_code(text: str) -> str | None:
     if not matches:
         return None
 
-    return _find_component_code(matches) or matches[0].strip()
+    component_code = _find_component_code(matches)
+    if component_code:
+        return component_code
+
+    first_block = matches[0].strip()
+    return first_block or None
 
 
 def _find_code_blocks(text: str) -> list[str]:
     """Find all code blocks in text, handling both closed and unclosed blocks."""
-    matches = re.findall(PYTHON_CODE_BLOCK_PATTERN, text, re.IGNORECASE)
-    if matches:
-        return matches
+    python_blocks, generic_blocks, unclosed_blocks = _parse_code_fences(text)
+    return python_blocks or generic_blocks or unclosed_blocks
 
-    matches = re.findall(GENERIC_CODE_BLOCK_PATTERN, text)
-    if matches:
-        return matches
 
-    return _find_unclosed_code_block(text)
+def _parse_code_fences(text: str) -> tuple[list[str], list[str], list[str]]:
+    """Parse markdown fences, treating only a standalone ``` line as a closing fence."""
+    python_blocks: list[str] = []
+    generic_blocks: list[str] = []
+    unclosed_blocks: list[str] = []
+    current_language: str | None = None
+    current_lines: list[str] = []
+
+    for line in text.splitlines(keepends=True):
+        if current_language is None:
+            match = _OPENING_FENCE_RE.match(line)
+            if not match:
+                continue
+            language = (match.group(1) or "").lower()
+            if language in {"", "python"}:
+                current_language = language or "generic"
+                current_lines = []
+            continue
+
+        if _CLOSING_FENCE_RE.match(line):
+            block = "".join(current_lines).strip()
+            if block:
+                if current_language == "python":
+                    python_blocks.append(block)
+                elif current_language == "generic":
+                    generic_blocks.append(block)
+            current_language = None
+            current_lines = []
+            continue
+
+        current_lines.append(line)
+
+    if current_language in {"python", "generic"}:
+        block = "".join(current_lines).strip()
+        if block:
+            unclosed_blocks.append(block)
+
+    return python_blocks, generic_blocks, unclosed_blocks
 
 
 def _find_unclosed_code_block(text: str) -> list[str]:
     """Handle LLM responses that don't close the code block with ```."""
-    for pattern in [UNCLOSED_PYTHON_BLOCK_PATTERN, UNCLOSED_GENERIC_BLOCK_PATTERN]:
-        match = re.search(pattern, text, re.IGNORECASE)
-        if match:
-            code = match.group(1).rstrip("`").strip()
-            return [code] if code else []
-
-    return []
+    _python_blocks, _generic_blocks, unclosed_blocks = _parse_code_fences(text)
+    return unclosed_blocks
 
 
 def _find_component_code(matches: list[str]) -> str | None:
     """Find the first match that looks like a Langflow component."""
     for match in matches:
-        if "class " in match and "Component" in match:
-            return match.strip()
+        code = match.strip()
+        if code and _contains_component_class(code):
+            return code
     return None
 
 
-# Alias for backward compatibility
-extract_component_code = extract_python_code
+def _contains_component_class(code: str) -> bool:
+    """Return True when code defines a class inheriting from Component."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return _contains_component_class_header(code)
+
+    return any(
+        isinstance(node, ast.ClassDef) and any(_is_component_base(base) for base in node.bases)
+        for node in ast.walk(tree)
+    )
+
+
+def _is_component_base(base: ast.expr) -> bool:
+    if isinstance(base, ast.Name):
+        return base.id == "Component"
+    if isinstance(base, ast.Attribute):
+        return base.attr == "Component"
+    if isinstance(base, ast.Subscript):
+        return _is_component_base(base.value)
+    return False
+
+
+def _contains_component_class_header(code: str) -> bool:
+    for match in _COMPONENT_CLASS_RE.finditer(code):
+        bases = [base.strip() for base in match.group("bases").split(",")]
+        if any(base == "Component" or base.endswith(".Component") for base in bases):
+            return True
+    return False
+
+
+def extract_component_code(text: str) -> str | None:
+    """Extract the first code block that defines a Langflow component."""
+    return _find_component_code(_find_code_blocks(text))
 
 
 def extract_flow_json(text: str) -> dict | None:

--- a/src/backend/tests/unit/agentic/api/test_code_extraction.py
+++ b/src/backend/tests/unit/agentic/api/test_code_extraction.py
@@ -4,7 +4,6 @@ Tests extract_python_code, helper functions (_find_code_blocks, _find_unclosed_c
 _find_component_code), validate_component_code, and the extract-validate integration flow.
 """
 
-import pytest
 from langflow.agentic.helpers.code_extraction import (
     _find_code_blocks,
     _find_component_code,

--- a/src/backend/tests/unit/agentic/api/test_code_extraction.py
+++ b/src/backend/tests/unit/agentic/api/test_code_extraction.py
@@ -441,28 +441,16 @@ Let me know if you need any modifications!"""
 class TestBugsAndEdgeCases:
     """Tests that challenge the code — exposing real bugs and untested edge cases."""
 
-    @pytest.mark.xfail(
-        reason="BUG: extract_component_code overwritten by extract_python_code alias at L96",
-        strict=True,
-    )
     def test_extract_component_code_should_reject_non_component(self):
         """extract_component_code should return None for non-component code."""
         result = extract_component_code("```python\nx = 1\n```")
         assert result is None
 
-    @pytest.mark.xfail(
-        reason="BUG: empty code block returns '' instead of None (L60 matches[0].strip())",
-        strict=True,
-    )
     def test_should_return_none_for_empty_code_block(self):
         """extract_python_code should return None for empty code blocks."""
         result = extract_python_code("```python\n\n```")
         assert result is None
 
-    @pytest.mark.xfail(
-        reason="BUG: rstrip('`') at L81 strips ALL trailing backticks, corrupting code",
-        strict=True,
-    )
     def test_rstrip_should_not_corrupt_code_with_backticks(self):
         """Unclosed blocks should not strip backticks that are part of the code."""
         text = '```python\nmarkdown_var = "```"'
@@ -470,23 +458,18 @@ class TestBugsAndEdgeCases:
         assert result is not None
         assert '```"' in result
 
-    @pytest.mark.xfail(
-        reason="BUG: L90 'Component' in match matches ComponentFactory, not just inheritance",
-        strict=True,
-    )
     def test_find_component_code_false_positive_substring(self):
         """_find_component_code should not match non-Component classes."""
         non_component = "class ComponentFactory:\n    pass"
         result = _find_component_code([non_component])
         assert result is None
 
-    def test_nested_code_blocks_truncate_content(self):
-        """Non-greedy regex truncates code with embedded triple backticks."""
+    def test_nested_code_blocks_preserve_content(self):
+        """Line-aware fences preserve embedded triple backticks in code strings."""
         text = '```python\ncode = """Example:\n```python\ninner\n```\n"""\n```'
         result = extract_python_code(text)
         assert result is not None
-        # Documents: non-greedy regex stops at first ```, truncating inner content
-        assert "inner" not in result
+        assert "inner" in result
 
     def test_extract_python_code_whitespace_only_block(self):
         """Whitespace-only code block should be falsy."""


### PR DESCRIPTION
## Summary

Harden assistant code block extraction by replacing fragile regex/string matching with line-aware markdown fence parsing and AST-backed Component detection.

This fixes:
- empty Python code blocks returning `""` instead of `None`
- `extract_component_code` accepting ordinary non-component Python snippets
- false positives such as `class ComponentFactory`
- embedded triple backticks corrupting or truncating extracted code

##  Tests

- `python -m py_compile src/backend/base/langflow/agentic/helpers/code_extraction.py`
- `python -m py_compile src/backend/tests/unit/agentic/api/test_code_extraction.py`
- Local smoke test for empty blocks, non-component rejection, Component extraction, ComponentFactory rejection, and embedded backtick preservation

Could not run the full pytest target locally because this machine does not have `uv` or `pytest` installed in a Langflow-compatible environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP servers now use configurable SDK compatibility settings, with improved configuration updates and validation.
  * Component search now includes display names and descriptions.
  * Agent conversations better handle messages passed between chained agents.
  * Improved code extraction identifies component code more reliably.
  * A2A publishing uses the configured browser origin.

* **Bug Fixes**
  * Updated starter projects and component metadata for improved dependency compatibility.
  * Added guidance for resolving `get_body_field` startup errors.

* **Chores**
  * Improved nightly builds, release validation, and cross-platform runtime checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->