### PR TITLE
fix(playground): align shared message namespaces

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -510,6 +510,11 @@ async def delete_messages_sessions(
     }
 
 
+def _compute_shared_message_flow_id(user_id: UUID, source_flow_id: UUID) -> UUID:
+    """Derive the authenticated user's virtual flow ID for shared-message storage."""
+    return compute_virtual_flow_id(user_id, source_flow_id, principal_type="user")
+
+
 @router.get("/messages/shared/sessions")
 async def get_shared_message_sessions(
     session: DbSession,
@@ -522,7 +527,7 @@ async def get_shared_message_sessions(
     original flow ID. Only messages stored under this virtual flow_id are returned.
     """
     try:
-        virtual_flow_id = compute_virtual_flow_id(current_user.id, source_flow_id)
+        virtual_flow_id = _compute_shared_message_flow_id(current_user.id, source_flow_id)
         stmt = select(MessageTable.session_id).distinct()
         stmt = stmt.where(MessageTable.flow_id == virtual_flow_id)
         stmt = stmt.where(col(MessageTable.session_id).isnot(None))
@@ -550,7 +555,7 @@ async def get_shared_messages(
     original flow ID. Only messages stored under this virtual flow_id are returned.
     """
     try:
-        virtual_flow_id = compute_virtual_flow_id(current_user.id, source_flow_id)
+        virtual_flow_id = _compute_shared_message_flow_id(current_user.id, source_flow_id)
         stmt = select(MessageTable)
         stmt = stmt.where(MessageTable.flow_id == virtual_flow_id)
 
@@ -590,7 +595,7 @@ async def delete_shared_messages_session(
 ):
     """Delete messages for a session on a shared/public flow, scoped to the authenticated user."""
     try:
-        virtual_flow_id = compute_virtual_flow_id(current_user.id, source_flow_id)
+        virtual_flow_id = _compute_shared_message_flow_id(current_user.id, source_flow_id)
         stmt = (
             delete(MessageTable)
             .where(MessageTable.flow_id == virtual_flow_id)
@@ -612,7 +617,7 @@ async def update_shared_message(
 ):
     """Update a message on a shared/public flow, scoped to the authenticated user."""
     try:
-        virtual_flow_id = compute_virtual_flow_id(current_user.id, source_flow_id)
+        virtual_flow_id = _compute_shared_message_flow_id(current_user.id, source_flow_id)
         db_message = (
             await session.exec(
                 select(MessageTable).where(
@@ -650,7 +655,7 @@ async def rename_shared_session(
 ) -> list[MessageResponse]:
     """Rename a session on a shared/public flow, scoped to the authenticated user."""
     try:
-        virtual_flow_id = compute_virtual_flow_id(current_user.id, source_flow_id)
+        virtual_flow_id = _compute_shared_message_flow_id(current_user.id, source_flow_id)
         stmt = select(MessageTable).where(
             MessageTable.flow_id == virtual_flow_id,
             MessageTable.session_id == old_session_id,

--- a/src/backend/tests/unit/api/v1/test_monitor_shared.py
+++ b/src/backend/tests/unit/api/v1/test_monitor_shared.py
@@ -123,7 +123,7 @@ async def test_update_shared_message_requires_auth(client: AsyncClient):
 async def shared_messages_setup(active_user):
     """Create test messages with a virtual flow_id scoped to active_user."""
     source_flow_id = uuid.uuid4()
-    virtual_flow_id = compute_virtual_flow_id(active_user.id, source_flow_id)
+    virtual_flow_id = compute_virtual_flow_id(active_user.id, source_flow_id, principal_type="user")
     base_timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
     async with session_scope() as session:


### PR DESCRIPTION
## Summary

- route all authenticated `/messages/shared*` operations through the `user:`-prefixed virtual flow namespace introduced in #14345
- centralize the shared-message namespace derivation so new handlers cannot omit the principal type
- seed the monitor endpoint tests with the authenticated storage namespace

## Root cause

#14345 domain-separated authenticated user IDs from anonymous client IDs for public-flow writes, but the five shared-message handlers retained the legacy unprefixed derivation. Logged-in shareable-playground messages were therefore written under one virtual flow ID and read or mutated under another.

## Impact

Restores persistent history listing, retrieval, deletion, session rename, and message-property updates for logged-in shareable-playground users when `AUTO_LOGIN=false`. The fix does not fall back to the legacy namespace, so the original user/client collision remains closed.

## Validation

- `uv run pytest src/backend/tests/unit/api/v1/test_monitor_shared.py -q -o log_cli=false` — 24 passed
- `uv run ruff check src/backend/base/langflow/api/v1/monitor.py src/backend/tests/unit/api/v1/test_monitor_shared.py`
- `uv run ruff format --check src/backend/base/langflow/api/v1/monitor.py src/backend/tests/unit/api/v1/test_monitor_shared.py`
- repository pre-commit hooks, including secrets scanning

Follow-up to #14345.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when listing, retrieving, updating, renaming, and deleting shared-message sessions.
  * Ensured shared-message data is correctly associated with the appropriate user-scoped flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->