### PR TITLE
feat: support externally managed provider and catalog policies

### DIFF
--- a/src/backend/base/langflow/api/v1/authz_role_assignments.py
+++ b/src/backend/base/langflow/api/v1/authz_role_assignments.py
@@ -29,6 +29,7 @@ from langflow.api.v1.schemas.authz_role_assignments import (
     RoleAssignmentRead,
 )
 from langflow.services.authorization.lifecycle import (
+    acquire_identity_mutation_lock,
     safe_identity_mutation_committed,
     stage_identity_mutation,
     validate_identity_mutation,
@@ -144,6 +145,13 @@ async def create_assignment(
 ) -> RoleAssignmentRead:
     """Assign a role to a user. Superuser-only."""
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.ROLE_ASSIGNMENT_CREATED,
+        affected_user_ids=(payload.user_id,),
+    )
 
     user = await session.get(User, payload.user_id)
     if user is None:
@@ -152,17 +160,23 @@ async def create_assignment(
     if role is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="role_id not found")
 
+    # Let authorization plugins acquire their transaction-scoped policy-write
+    # lock before the first assignment read or write. In particular, an
+    # Enterprise compiler may need the same global lock later while staging
+    # derived policy; taking it here prevents a concurrent writer from holding
+    # that lock while waiting on this transaction's unique assignment row.
+    candidate = AuthzRoleAssignment(
+        user_id=payload.user_id,
+        role_id=payload.role_id,
+        domain_type=payload.domain_type,
+        domain_id=payload.domain_id,
+        assigned_at=datetime.now(timezone.utc),
+        assigned_by=current_user.id,
+    )
     assignment = (await session.exec(select(AuthzRoleAssignment).where(*_assignment_match(payload)))).first()
     effective_assignment_created = assignment is None
     if assignment is None:
-        assignment = AuthzRoleAssignment(
-            user_id=payload.user_id,
-            role_id=payload.role_id,
-            domain_type=payload.domain_type,
-            domain_id=payload.domain_id,
-            assigned_at=datetime.now(timezone.utc),
-            assigned_by=current_user.id,
-        )
+        assignment = candidate
         session.add(assignment)
         await session.flush()
     else:
@@ -187,7 +201,6 @@ async def create_assignment(
             administrative_actor=current_user.id,
         )
     )
-    authorization_service = get_authorization_service()
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.ROLE_ASSIGNMENT_CREATED,
         entity_id=assignment.id,
@@ -248,12 +261,33 @@ async def delete_assignment(
 ) -> RoleAssignmentRead | Response:
     """Remove a manual grant, returning the assignment when another source preserves it."""
     _require_superuser(current_user)
-    assignment = await session.get(AuthzRoleAssignment, assignment_id)
+
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.ROLE_ASSIGNMENT_DELETED,
+        entity_id=assignment_id,
+    )
+
+    # Re-read the assignment and all provenance under row locks after the
+    # plugin's lock-only preflight. Validation remains reserved for an actual
+    # effective-row deletion, preserving the existing third-party hook
+    # semantics when only a manual source is removed.
+    assignment = await session.get(
+        AuthzRoleAssignment,
+        assignment_id,
+        populate_existing=True,
+        with_for_update=True,
+    )
     if assignment is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found")
     grants = (
         await session.exec(
-            select(AuthzRoleAssignmentGrant).where(AuthzRoleAssignmentGrant.assignment_id == assignment_id)
+            select(AuthzRoleAssignmentGrant)
+            .where(AuthzRoleAssignmentGrant.assignment_id == assignment_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
         )
     ).all()
     manual_grant = next((grant for grant in grants if grant.source_kind == "manual"), None)
@@ -305,11 +339,11 @@ async def delete_assignment(
         domain_id=domain_id,
         policy_relevant_fields=("user_id", "role_id", "domain_type", "domain_id"),
     )
-    authorization_service = get_authorization_service()
     try:
         await validate_identity_mutation(authorization_service, session, mutation)
     except AuthorizationMutationRejected as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.public_detail) from exc
+
     await session.delete(assignment)
     await session.flush()
     await stage_identity_mutation(authorization_service, session, mutation)

--- a/src/backend/base/langflow/api/v1/authz_role_assignments.py
+++ b/src/backend/base/langflow/api/v1/authz_role_assignments.py
@@ -146,6 +146,9 @@ async def create_assignment(
     """Assign a role to a user. Superuser-only."""
     _require_superuser(current_user)
     authorization_service = get_authorization_service()
+    # Let authorization plugins acquire their transaction-scoped policy-write
+    # lock before the first canonical identity read or write. An external
+    # compiler may need the same global lock later while staging derived policy.
     await acquire_identity_mutation_lock(
         authorization_service,
         session,
@@ -160,11 +163,6 @@ async def create_assignment(
     if role is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="role_id not found")
 
-    # Let authorization plugins acquire their transaction-scoped policy-write
-    # lock before the first assignment read or write. In particular, an
-    # Enterprise compiler may need the same global lock later while staging
-    # derived policy; taking it here prevents a concurrent writer from holding
-    # that lock while waiting on this transaction's unique assignment row.
     candidate = AuthzRoleAssignment(
         user_id=payload.user_id,
         role_id=payload.role_id,
@@ -270,10 +268,10 @@ async def delete_assignment(
         entity_id=assignment_id,
     )
 
-    # Re-read the assignment and all provenance under row locks after the
-    # plugin's lock-only preflight. Validation remains reserved for an actual
-    # effective-row deletion, preserving the existing third-party hook
-    # semantics when only a manual source is removed.
+    # Re-read the assignment and all provenance under row locks on dialects
+    # that support SELECT FOR UPDATE after the plugin's lock-only preflight.
+    # Validation remains reserved for an actual effective-row deletion,
+    # preserving existing hook semantics when only a manual source is removed.
     assignment = await session.get(
         AuthzRoleAssignment,
         assignment_id,

--- a/src/backend/base/langflow/api/v1/authz_roles.py
+++ b/src/backend/base/langflow/api/v1/authz_roles.py
@@ -15,7 +15,11 @@ from sqlmodel import select
 
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.v1.schemas.authz_roles import RoleCreate, RoleRead, RoleUpdate
-from langflow.services.authorization.lifecycle import safe_identity_mutation_committed, stage_identity_mutation
+from langflow.services.authorization.lifecycle import (
+    acquire_identity_mutation_lock,
+    safe_identity_mutation_committed,
+    stage_identity_mutation,
+)
 from langflow.services.authorization.utils import audit_decision
 from langflow.services.database.models.auth import AuthzRole, AuthzRoleAssignment
 from langflow.services.deps import get_authorization_service
@@ -109,6 +113,12 @@ async def create_role(
 ) -> RoleRead:
     """Create a custom (non-system) role. Superuser-only."""
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.ROLE_CREATED,
+    )
 
     if payload.parent_role_id is not None:
         parent = await session.get(AuthzRole, payload.parent_role_id)
@@ -127,7 +137,6 @@ async def create_role(
         created_by=current_user.id,
     )
     session.add(role)
-    authorization_service = get_authorization_service()
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.ROLE_CREATED,
         entity_id=role.id,
@@ -171,6 +180,13 @@ async def update_role(
 ) -> RoleRead:
     """Update fields on a custom role. System roles are read-only."""
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.ROLE_UPDATED,
+        entity_id=role_id,
+    )
 
     role = await session.get(AuthzRole, role_id)
     if role is None:
@@ -244,8 +260,6 @@ async def update_role(
         policy_relevant_fields=tuple(sorted(fields_set & {"name", "permissions", "parent_role_id"})),
         previous_identifier=previous_name if role.name != previous_name else None,
     )
-    authorization_service = get_authorization_service()
-
     try:
         await session.flush()
         await stage_identity_mutation(authorization_service, session, mutation)
@@ -284,6 +298,13 @@ async def delete_role(
     (delete the assignments first).
     """
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.ROLE_DELETED,
+        entity_id=role_id,
+    )
 
     role = await session.get(AuthzRole, role_id)
     if role is None:
@@ -312,7 +333,6 @@ async def delete_role(
         policy_relevant_fields=("name", "permissions", "parent_role_id"),
         previous_identifier=role_name,
     )
-    authorization_service = get_authorization_service()
     await session.delete(role)
     await session.flush()
     await stage_identity_mutation(authorization_service, session, mutation)

--- a/src/backend/base/langflow/api/v1/authz_teams.py
+++ b/src/backend/base/langflow/api/v1/authz_teams.py
@@ -26,7 +26,11 @@ from langflow.api.v1.schemas.authz_teams import (
     TeamRead,
     TeamUpdate,
 )
-from langflow.services.authorization.lifecycle import safe_identity_mutation_committed, stage_identity_mutation
+from langflow.services.authorization.lifecycle import (
+    acquire_identity_mutation_lock,
+    safe_identity_mutation_committed,
+    stage_identity_mutation,
+)
 from langflow.services.authorization.utils import audit_decision
 from langflow.services.database.models.auth import AuthzTeam, AuthzTeamMember
 from langflow.services.database.models.user.model import User
@@ -98,6 +102,12 @@ async def create_team(
     session: DbSession,
 ) -> TeamRead:
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.TEAM_CREATED,
+    )
     team = AuthzTeam(
         team_name=payload.team_name,
         adom_name=payload.adom_name,
@@ -105,7 +115,6 @@ async def create_team(
         is_active=payload.is_active,
     )
     session.add(team)
-    authorization_service = get_authorization_service()
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.TEAM_CREATED,
         entity_id=team.id,
@@ -144,6 +153,13 @@ async def update_team(
     session: DbSession,
 ) -> TeamRead:
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.TEAM_UPDATED,
+        entity_id=team_id,
+    )
     team = await session.get(AuthzTeam, team_id)
     if team is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
@@ -174,8 +190,6 @@ async def update_team(
         policy_relevant_fields=tuple(sorted(set(changed_fields) & {"adom_name", "is_active"})),
         previous_identifier=previous_adom_name if team.adom_name != previous_adom_name else None,
     )
-    authorization_service = get_authorization_service()
-
     try:
         await session.flush()
         await stage_identity_mutation(authorization_service, session, mutation)
@@ -206,6 +220,13 @@ async def delete_team(
     session: DbSession,
 ) -> None:
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.TEAM_DELETED,
+        entity_id=team_id,
+    )
     team = await session.get(AuthzTeam, team_id)
     if team is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
@@ -218,7 +239,6 @@ async def delete_team(
         policy_relevant_fields=("adom_name", "is_active"),
         previous_identifier=team.adom_name,
     )
-    authorization_service = get_authorization_service()
     # Cascade on team_members handles cleanup; share rows targeting this team
     # are left in place (caller may want to migrate them before deleting).
     await session.delete(team)
@@ -278,6 +298,13 @@ async def add_member(
     session: DbSession,
 ) -> TeamMemberRead:
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.TEAM_MEMBER_ADDED,
+        affected_user_ids=(payload.user_id,),
+    )
     team = await session.get(AuthzTeam, team_id)
     if team is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
@@ -291,7 +318,6 @@ async def add_member(
         source=payload.source,
     )
     session.add(member)
-    authorization_service = get_authorization_service()
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.TEAM_MEMBER_ADDED,
         entity_id=member.id,
@@ -338,6 +364,13 @@ async def remove_member(
     session: DbSession,
 ) -> None:
     _require_superuser(current_user)
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.TEAM_MEMBER_REMOVED,
+        affected_user_ids=(user_id,),
+    )
     member = (
         await session.exec(
             select(AuthzTeamMember).where(
@@ -359,7 +392,6 @@ async def remove_member(
         team_id=team_id,
         policy_relevant_fields=("team_id", "user_id", "source"),
     )
-    authorization_service = get_authorization_service()
     await session.delete(member)
     await session.flush()
     await stage_identity_mutation(authorization_service, session, mutation)

--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import Annotated, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicySnapshot
 
-from langflow.api.v1.schemas.catalog_policy import CatalogPolicyBlockedSet
+from langflow.api.v1.schemas.catalog_policy import CatalogPolicyBlockedSet, CatalogPolicyRead
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import audit_decision
 from langflow.services.database.models.user.model import User
@@ -16,8 +17,26 @@ from langflow.services.deps import get_catalog_policy_service
 router = APIRouter(prefix="/catalog-policy", tags=["Catalog Policy"])
 
 
-def _response(blocked: frozenset[str]) -> CatalogPolicyBlockedSet:
-    return CatalogPolicyBlockedSet(blocked=sorted(blocked))
+def _active_snapshot(service: BaseCatalogPolicyService) -> tuple[CatalogPolicySnapshot, bool]:
+    external_snapshot = service.external_policy_snapshot
+    if external_snapshot is not None:
+        return external_snapshot, True
+    return service.snapshot, False
+
+
+def _response(blocked: frozenset[str], *, managed_externally: bool) -> CatalogPolicyRead:
+    return CatalogPolicyRead(
+        blocked=sorted(blocked),
+        managed_externally=managed_externally,
+    )
+
+
+def _raise_if_externally_managed(service: BaseCatalogPolicyService) -> None:
+    if service.external_policy_snapshot is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Catalog policy is externally managed and cannot be changed through this API.",
+        )
 
 
 async def _audit_update(
@@ -52,22 +71,24 @@ async def _audit_update(
         )
 
 
-@router.get("/components", response_model=CatalogPolicyBlockedSet)
+@router.get("/components", response_model=CatalogPolicyRead)
 async def get_component_policy(
     _admin: Annotated[User, Depends(get_current_active_superuser)],
-) -> CatalogPolicyBlockedSet:
+) -> CatalogPolicyRead:
     """Return the complete global component block set."""
     service = get_catalog_policy_service()
-    return _response(service.snapshot.blocked_component_keys)
+    snapshot, managed_externally = _active_snapshot(service)
+    return _response(snapshot.blocked_component_keys, managed_externally=managed_externally)
 
 
-@router.put("/components", response_model=CatalogPolicyBlockedSet)
+@router.put("/components", response_model=CatalogPolicyRead)
 async def replace_component_policy(
     payload: CatalogPolicyBlockedSet,
     admin: Annotated[User, Depends(get_current_active_superuser)],
-) -> CatalogPolicyBlockedSet:
+) -> CatalogPolicyRead:
     """Replace the complete global component block set."""
     service = get_catalog_policy_service()
+    _raise_if_externally_managed(service)
     update = await service.replace_blocked_component_keys(
         payload.blocked,
         actor_user_id=admin.id,
@@ -78,25 +99,27 @@ async def replace_component_policy(
         added=update.added,
         removed=update.removed,
     )
-    return _response(update.snapshot.blocked_component_keys)
+    return _response(update.snapshot.blocked_component_keys, managed_externally=False)
 
 
-@router.get("/templates", response_model=CatalogPolicyBlockedSet)
+@router.get("/templates", response_model=CatalogPolicyRead)
 async def get_template_policy(
     _admin: Annotated[User, Depends(get_current_active_superuser)],
-) -> CatalogPolicyBlockedSet:
+) -> CatalogPolicyRead:
     """Return the complete global template block set."""
     service = get_catalog_policy_service()
-    return _response(service.snapshot.blocked_template_keys)
+    snapshot, managed_externally = _active_snapshot(service)
+    return _response(snapshot.blocked_template_keys, managed_externally=managed_externally)
 
 
-@router.put("/templates", response_model=CatalogPolicyBlockedSet)
+@router.put("/templates", response_model=CatalogPolicyRead)
 async def replace_template_policy(
     payload: CatalogPolicyBlockedSet,
     admin: Annotated[User, Depends(get_current_active_superuser)],
-) -> CatalogPolicyBlockedSet:
+) -> CatalogPolicyRead:
     """Replace the complete global template block set."""
     service = get_catalog_policy_service()
+    _raise_if_externally_managed(service)
     update = await service.replace_blocked_template_keys(
         payload.blocked,
         actor_user_id=admin.id,
@@ -107,7 +130,7 @@ async def replace_template_policy(
         added=update.added,
         removed=update.removed,
     )
-    return _response(update.snapshot.blocked_template_keys)
+    return _response(update.snapshot.blocked_template_keys, managed_externally=False)
 
 
 __all__ = ["router"]

--- a/src/backend/base/langflow/api/v1/model_provider_policy.py
+++ b/src/backend/base/langflow/api/v1/model_provider_policy.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from lfx.base.models.provider_registry import get_registry_snapshot, resolve_provider_id
+from lfx.services.deps import get_model_provider_policy_service
 from pydantic import BaseModel, Field, StringConstraints, field_validator
 
 from langflow.api.utils import DbSession, DbSessionReadOnly
@@ -58,9 +59,14 @@ class ModelProviderPolicyRead(BaseModel):
 
     approved_provider_ids: list[str]
     registered_providers: list[RegisteredModelProviderRead]
+    managed_externally: bool
 
 
-def _build_policy_response(approved_provider_ids: set[str] | frozenset[str]) -> ModelProviderPolicyRead:
+def _build_policy_response(
+    approved_provider_ids: set[str] | frozenset[str],
+    *,
+    managed_externally: bool = False,
+) -> ModelProviderPolicyRead:
     snapshot = get_registry_snapshot()
     registered_providers = [
         RegisteredModelProviderRead(
@@ -74,6 +80,7 @@ def _build_policy_response(approved_provider_ids: set[str] | frozenset[str]) -> 
     return ModelProviderPolicyRead(
         approved_provider_ids=sorted(approved_provider_ids),
         registered_providers=registered_providers,
+        managed_externally=managed_externally,
     )
 
 
@@ -84,6 +91,13 @@ def _policy_unavailable() -> HTTPException:
     )
 
 
+def _externally_managed() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Model-provider policy is externally managed and cannot be changed through this API.",
+    )
+
+
 @router.get("", response_model=ModelProviderPolicyRead)
 @router.get("/", response_model=ModelProviderPolicyRead, include_in_schema=False)
 async def read_model_provider_policy(
@@ -91,6 +105,10 @@ async def read_model_provider_policy(
     session: DbSessionReadOnly,
 ) -> ModelProviderPolicyRead:
     """Read the global provider policy. An empty approved list is unrestricted."""
+    external_provider_ids = get_model_provider_policy_service().external_approved_provider_ids
+    if external_provider_ids is not None:
+        return _build_policy_response(external_provider_ids, managed_externally=True)
+
     try:
         state = await get_model_provider_policy_state(session)
     except ModelProviderPolicyNotInitializedError as exc:
@@ -108,6 +126,9 @@ async def replace_model_provider_policy(
     session: DbSession,
 ) -> ModelProviderPolicyRead:
     """Atomically replace the global provider policy and invalidate snapshots."""
+    if get_model_provider_policy_service().external_approved_provider_ids is not None:
+        raise _externally_managed()
+
     try:
         state = await replace_model_provider_policy_state(session, payload.approved_provider_ids)
     except ModelProviderPolicyNotInitializedError as exc:

--- a/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
@@ -25,3 +25,9 @@ class CatalogPolicyBlockedSet(BaseModel):
                 raise ValueError(msg)
             normalized.add(key)
         return sorted(normalized)
+
+
+class CatalogPolicyRead(CatalogPolicyBlockedSet):
+    """Current catalog block policy and its ownership source."""
+
+    managed_externally: bool

--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -19,6 +19,7 @@ from langflow.api.v1.schemas import PasswordResetRequest, UsersResponse
 from langflow.initial_setup.setup import get_or_create_default_folder
 from langflow.services.auth.utils import get_current_active_superuser, get_current_user_optional
 from langflow.services.authorization.lifecycle import (
+    acquire_identity_mutation_lock,
     safe_identity_mutation_committed,
     stage_identity_mutation,
     validate_identity_mutation,
@@ -66,6 +67,13 @@ async def add_user(
     try:
         new_user.password = get_auth_service().get_password_hash(user.password)
         new_user.is_active = settings_service.auth_settings.NEW_USER_IS_ACTIVE
+        await acquire_identity_mutation_lock(
+            authorization_service,
+            session,
+            kind=AuthorizationMutationKind.USER_CREATED,
+            entity_id=new_user.id,
+            affected_user_ids=(new_user.id,),
+        )
         session.add(new_user)
         await session.flush()
         await session.refresh(new_user)
@@ -165,8 +173,22 @@ async def patch_user(
             raise HTTPException(status_code=400, detail="You can't change your password here")
         user_update.password = get_auth_service().get_password_hash(user_update.password)
 
+    authorization_service = get_authorization_service()
+    possible_lifecycle_kind: AuthorizationMutationKind | None = None
+    if user_update.is_active is False:
+        possible_lifecycle_kind = AuthorizationMutationKind.USER_DISABLED
+    elif user_update.is_superuser is False:
+        possible_lifecycle_kind = AuthorizationMutationKind.USER_SUPERUSER_DEMOTED
+    if possible_lifecycle_kind is not None:
+        await acquire_identity_mutation_lock(
+            authorization_service,
+            session,
+            kind=possible_lifecycle_kind,
+            entity_id=user_id,
+            affected_user_ids=(user_id,),
+        )
+
     if user_db := await get_user_by_id(session, user_id):
-        authorization_service = get_authorization_service()
         lifecycle_mutation: AuthorizationMutation | None = None
         next_is_active = user_db.is_active if user_update.is_active is None else user_update.is_active
         next_is_superuser = user_db.is_superuser if user_update.is_superuser is None else user_update.is_superuser
@@ -266,6 +288,14 @@ async def delete_user(
     if not current_user.is_superuser:
         raise HTTPException(status_code=403, detail="Permission denied")
 
+    authorization_service = get_authorization_service()
+    await acquire_identity_mutation_lock(
+        authorization_service,
+        session,
+        kind=AuthorizationMutationKind.USER_DELETED,
+        entity_id=user_id,
+        affected_user_ids=(user_id,),
+    )
     stmt = select(User).where(User.id == user_id)
     user_db = (await session.exec(stmt)).first()
     if not user_db:
@@ -283,7 +313,6 @@ async def delete_user(
         ),
         user_after=None,
     )
-    authorization_service = get_authorization_service()
     try:
         await validate_identity_mutation(authorization_service, session, lifecycle_mutation)
     except AuthorizationMutationRejected as exc:

--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -174,6 +174,7 @@ async def patch_user(
         user_update.password = get_auth_service().get_password_hash(user_update.password)
 
     authorization_service = get_authorization_service()
+    # Pre-read lock hint; canonical user state may produce a different staged kind.
     possible_lifecycle_kind: AuthorizationMutationKind | None = None
     if user_update.is_active is False:
         possible_lifecycle_kind = AuthorizationMutationKind.USER_DISABLED

--- a/src/backend/base/langflow/services/authorization/lifecycle.py
+++ b/src/backend/base/langflow/services/authorization/lifecycle.py
@@ -9,8 +9,29 @@ from lfx.log.logger import logger
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from lfx.services.authorization.base import AuthorizationMutation, BaseAuthorizationService
+    from lfx.services.authorization.base import (
+        AuthorizationMutation,
+        AuthorizationMutationKind,
+        BaseAuthorizationService,
+    )
     from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def acquire_identity_mutation_lock(
+    service: BaseAuthorizationService,
+    session: AsyncSession,
+    *,
+    kind: AuthorizationMutationKind,
+    entity_id: UUID | None = None,
+    affected_user_ids: tuple[UUID, ...] = (),
+) -> None:
+    """Run the plugin's lock-only preflight before canonical identity reads."""
+    await service.acquire_identity_mutation_lock(
+        session=session,
+        kind=kind,
+        entity_id=entity_id,
+        affected_user_ids=affected_user_ids,
+    )
 
 
 async def validate_identity_mutation(

--- a/src/backend/base/langflow/services/model_provider_policy.py
+++ b/src/backend/base/langflow/services/model_provider_policy.py
@@ -98,12 +98,19 @@ def apply_model_provider_policy_state(
 ) -> bool:
     """Publish committed state locally, returning whether this worker changed."""
     service = get_model_provider_policy_service()
+    # Explicitly external services own both their state and invalidation. This
+    # check is intentionally based on ``is not None`` because an empty external
+    # ceiling still establishes external ownership. Check ownership before the
+    # concrete OSS type so subclasses cannot opt in and still receive DB state.
+    if getattr(service, "external_approved_provider_ids", None) is not None:
+        return False
+
     if isinstance(service, ModelProviderPolicyService):
         return service.set_approved_provider_ids(state.approved_provider_ids, version=state.version)
 
-    # Enterprise services own their policy source. An administrative write can
-    # still invalidate their local snapshot, while the OSS polling worker must
-    # not repeatedly disturb a separately managed policy implementation.
+    # Legacy third-party services predate the explicit ownership contract. An
+    # administrative write still invalidates their local snapshot, while the
+    # OSS polling worker must not repeatedly disturb them.
     if invalidate_external:
         service.invalidate()
         return True

--- a/src/backend/base/langflow/services/model_provider_policy.py
+++ b/src/backend/base/langflow/services/model_provider_policy.py
@@ -102,7 +102,7 @@ def apply_model_provider_policy_state(
     # check is intentionally based on ``is not None`` because an empty external
     # ceiling still establishes external ownership. Check ownership before the
     # concrete OSS type so subclasses cannot opt in and still receive DB state.
-    if getattr(service, "external_approved_provider_ids", None) is not None:
+    if service.external_approved_provider_ids is not None:
         return False
 
     if isinstance(service, ModelProviderPolicyService):

--- a/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
+++ b/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
@@ -41,7 +41,10 @@ class ModelProviderPolicyRefreshWorker:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 self._task.result()
             self._task = None
-        if not isinstance(get_model_provider_policy_service(), ModelProviderPolicyService):
+        service = get_model_provider_policy_service()
+        if getattr(service, "external_approved_provider_ids", None) is not None or not isinstance(
+            service, ModelProviderPolicyService
+        ):
             await logger.adebug("Model-provider policy refresh worker not started: external policy service active")
             return
 
@@ -97,7 +100,10 @@ class ModelProviderPolicyRefreshWorker:
             deny_all_required = deny_all_required or isinstance(exc, ModelProviderPolicyNotInitializedError)
             service = get_model_provider_policy_service()
             changed = False
-            if isinstance(service, ModelProviderPolicyService):
+            if (
+                isinstance(service, ModelProviderPolicyService)
+                and getattr(service, "external_approved_provider_ids", None) is None
+            ):
                 # Install deny-all synchronously before any logging await: a
                 # broken async sink must never preserve broader stale policy.
                 changed = service.fail_closed(deny_all_required=deny_all_required)

--- a/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
+++ b/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
@@ -42,9 +42,7 @@ class ModelProviderPolicyRefreshWorker:
                 self._task.result()
             self._task = None
         service = get_model_provider_policy_service()
-        if getattr(service, "external_approved_provider_ids", None) is not None or not isinstance(
-            service, ModelProviderPolicyService
-        ):
+        if service.external_approved_provider_ids is not None or not isinstance(service, ModelProviderPolicyService):
             await logger.adebug("Model-provider policy refresh worker not started: external policy service active")
             return
 
@@ -100,10 +98,7 @@ class ModelProviderPolicyRefreshWorker:
             deny_all_required = deny_all_required or isinstance(exc, ModelProviderPolicyNotInitializedError)
             service = get_model_provider_policy_service()
             changed = False
-            if (
-                isinstance(service, ModelProviderPolicyService)
-                and getattr(service, "external_approved_provider_ids", None) is None
-            ):
+            if isinstance(service, ModelProviderPolicyService) and service.external_approved_provider_ids is None:
                 # Install deny-all synchronously before any logging await: a
                 # broken async sink must never preserve broader stale policy.
                 changed = service.fail_closed(deny_all_required=deny_all_required)

--- a/src/backend/tests/unit/api/v1/test_authz_admin_routes.py
+++ b/src/backend/tests/unit/api/v1/test_authz_admin_routes.py
@@ -40,8 +40,9 @@ class _FakeAsyncSession:
         self.flushed = 0
         self.committed = 0
         self.rolled_back = 0
+        self.events: list[str] = []
 
-    async def get(self, model: type, key: UUID) -> Any:
+    async def get(self, model: type, key: UUID, **_kwargs: Any) -> Any:
         return self._get_by_type.get((model, key))
 
     def add(self, obj: Any) -> None:
@@ -51,9 +52,11 @@ class _FakeAsyncSession:
         self.deleted.append(obj)
 
     async def flush(self) -> None:
+        self.events.append("flush")
         self.flushed += 1
 
     async def commit(self) -> None:
+        self.events.append("commit")
         self.committed += 1
         if self._commit_raises is not None:
             raise self._commit_raises
@@ -65,6 +68,7 @@ class _FakeAsyncSession:
         return None
 
     async def exec(self, _stmt: Any):
+        self.events.append("exec")
         if not self._exec_results:
             return _ExecResult([])
         return _ExecResult(self._exec_results.pop(0))
@@ -96,6 +100,7 @@ class _StubAuthz:
         self.staged_mutations: list[Any] = []
         self.committed_mutations: list[Any] = []
         self.validated_mutations: list[Any] = []
+        self.lock_requests: list[dict[str, Any]] = []
         self._staged_session: _FakeAsyncSession | None = None
 
     async def supports_cross_user_fetch(self) -> bool:
@@ -122,11 +127,18 @@ class _StubAuthz:
     async def get_effective_permissions(self, **_kwargs) -> dict[UUID, list[str]]:
         return self.effective_perms_payload or {}
 
+    async def acquire_identity_mutation_lock(self, *, session, **request) -> None:
+        session.events.append("lock")
+        self.lock_requests.append(request)
+        assert session.committed == 0
+
     async def validate_identity_mutation(self, *, session, mutation) -> None:
+        session.events.append("validate")
         self.validated_mutations.append(mutation)
         assert session.committed == 0
 
     async def stage_identity_mutation(self, *, session, event) -> None:
+        session.events.append("stage")
         assert session.committed == 0
         self._staged_session = session
         self.staged_mutations.append(event)
@@ -853,9 +865,15 @@ async def test_create_assignment_emits_lifecycle_for_target_user(stub_authz):
     assert session.added[1].assignment_id == session.added[0].id
     assert session.committed == 1
     assert authz.staged_mutations == authz.committed_mutations
+    assert authz.validated_mutations == []
+    assert len(authz.lock_requests) == 1
+    assert authz.lock_requests[0]["affected_user_ids"] == (target_user.id,)
     assert authz.staged_mutations[0].affected_user_ids == (target_user.id,)
+    assert authz.staged_mutations[0].entity_id == session.added[0].id
     assert authz.staged_mutations[0].domain_type == "global"
     assert authz.staged_mutations[0].domain_id is None
+    assert session.events.index("lock") < session.events.index("exec")
+    assert session.events.index("lock") < session.events.index("flush")
 
 
 @pytest.mark.asyncio
@@ -891,6 +909,8 @@ async def test_create_assignment_duplicate_manual_source_is_409(stub_authz):
     assert "Manual assignment already exists" in excinfo.value.detail
     assert session.added == []
     assert session.committed == 0
+    assert authz.validated_mutations == []
+    assert len(authz.lock_requests) == 1
     assert authz.staged_mutations == []
 
 
@@ -937,8 +957,11 @@ async def test_create_assignment_adds_manual_source_to_idp_assignment_without_li
     assert session.added[0].source_kind == "manual"
     assert session.added[0].assignment_id == assignment.id
     assert session.committed == 1
+    assert authz.validated_mutations == []
+    assert len(authz.lock_requests) == 1
     assert authz.staged_mutations == []
     assert authz.committed_mutations == []
+    assert session.events.index("lock") < session.events.index("exec")
     assert result.id == assignment.id
     assert result.assigned_by == original_actor_id
     assert {source.source_kind for source in result.grant_sources} == {"idp", "manual"}
@@ -974,6 +997,8 @@ async def test_delete_assignment_rejects_idp_only_source(stub_authz):
     assert "IdP-derived assignments" in excinfo.value.detail
     assert session.deleted == []
     assert session.committed == 0
+    assert len(authz.lock_requests) == 1
+    assert authz.validated_mutations == []
     assert authz.staged_mutations == []
 
 
@@ -1029,6 +1054,8 @@ async def test_delete_assignment_returns_surviving_idp_assignment(stub_authz, mo
     assert result.grant_sources[0].external_group == "corp-dev"
     assert session.deleted == [manual_grant]
     assert session.committed == 1
+    assert len(authz.lock_requests) == 1
+    assert authz.validated_mutations == []
     assert authz.staged_mutations == []
     assert audit_calls[0]["action"] == "role_assignment:delete_manual_source"
     assert audit_calls[0]["details"] == {
@@ -1073,6 +1100,8 @@ async def test_delete_assignment_manual_only_returns_204(stub_authz):
 
     assert result.status_code == 204
     assert session.deleted == [assignment]
+    assert len(authz.lock_requests) == 1
+    assert len(authz.validated_mutations) == 1
     assert authz.staged_mutations == authz.committed_mutations
 
 
@@ -1098,6 +1127,8 @@ async def test_delete_legacy_assignment_without_grant_rows_returns_204(stub_auth
     assert result.status_code == 204
     assert session.deleted == [assignment]
     assert session.committed == 1
+    assert len(authz.lock_requests) == 1
+    assert len(authz.validated_mutations) == 1
     assert authz.staged_mutations == authz.committed_mutations
 
 

--- a/src/backend/tests/unit/api/v1/test_authz_lifecycle_contract.py
+++ b/src/backend/tests/unit/api/v1/test_authz_lifecycle_contract.py
@@ -115,8 +115,12 @@ async def test_user_disable_validates_and_stages_in_transaction_order(monkeypatc
     async def commit():
         events.append("commit")
 
+    async def get_user_by_id(_session, _user_id):
+        events.append("read")
+        return target
+
     session.commit.side_effect = commit
-    monkeypatch.setattr(users, "get_user_by_id", AsyncMock(return_value=target))
+    monkeypatch.setattr(users, "get_user_by_id", get_user_by_id)
     monkeypatch.setattr(users, "update_user", update_user)
     monkeypatch.setattr(users, "get_authorization_service", lambda: service)
     monkeypatch.setattr(users, "audit_decision", AsyncMock())
@@ -129,12 +133,59 @@ async def test_user_disable_validates_and_stages_in_transaction_order(monkeypatc
     )
 
     assert result is target
-    assert events == ["lock", "validate", "mutate", "stage", "commit", "committed"]
+    assert events == ["lock", "read", "validate", "mutate", "stage", "commit", "committed"]
     assert service.validated == service.staged == service.committed
     mutation = service.staged[0]
     assert mutation.kind is AuthorizationMutationKind.USER_DISABLED
     assert mutation.user_before.is_active is True
     assert mutation.user_after.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_user_patch_lock_kind_is_advisory_before_state_read(monkeypatch):
+    from langflow.api.v1 import users
+    from langflow.services.database.models.user.model import UserUpdate
+
+    events: list[str] = []
+    service = _LifecycleService(events)
+    actor = SimpleNamespace(id=uuid4(), is_superuser=True)
+    target = SimpleNamespace(
+        id=uuid4(),
+        is_active=False,
+        is_superuser=True,
+        password="hashed",  # noqa: S106  # pragma: allowlist secret
+    )
+    session = AsyncMock()
+
+    async def update_user(_target, _update, _session):
+        events.append("mutate")
+        target.is_superuser = False
+        return target
+
+    async def commit():
+        events.append("commit")
+
+    async def get_user_by_id(_session, _user_id):
+        events.append("read")
+        return target
+
+    session.commit.side_effect = commit
+    monkeypatch.setattr(users, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(users, "update_user", update_user)
+    monkeypatch.setattr(users, "get_authorization_service", lambda: service)
+    monkeypatch.setattr(users, "audit_decision", AsyncMock())
+
+    result = await users.patch_user(
+        user_id=target.id,
+        user_update=UserUpdate(is_active=False, is_superuser=False),
+        user=actor,
+        session=session,
+    )
+
+    assert result is target
+    assert events == ["lock", "read", "validate", "mutate", "stage", "commit", "committed"]
+    assert service.lock_requests[0]["kind"] is AuthorizationMutationKind.USER_DISABLED
+    assert service.staged[0].kind is AuthorizationMutationKind.USER_SUPERUSER_DEMOTED
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v1/test_authz_lifecycle_contract.py
+++ b/src/backend/tests/unit/api/v1/test_authz_lifecycle_contract.py
@@ -20,6 +20,11 @@ class _LifecycleService:
         self.validated = []
         self.staged = []
         self.committed = []
+        self.lock_requests = []
+
+    async def acquire_identity_mutation_lock(self, *, session, **request) -> None:  # noqa: ARG002
+        self.events.append("lock")
+        self.lock_requests.append(request)
 
     async def validate_identity_mutation(self, *, session, mutation) -> None:  # noqa: ARG002
         self.events.append("validate")
@@ -75,7 +80,7 @@ async def test_user_create_stages_default_folder_and_identity_in_one_transaction
         current_user=None,
     )
 
-    assert events == ["mutate", "flush", "folder", "stage", "commit", "committed", "audit"]
+    assert events == ["lock", "mutate", "flush", "folder", "stage", "commit", "committed", "audit"]
     assert service.staged == service.committed
     mutation = service.staged[0]
     assert mutation.kind is AuthorizationMutationKind.USER_CREATED
@@ -124,7 +129,7 @@ async def test_user_disable_validates_and_stages_in_transaction_order(monkeypatc
     )
 
     assert result is target
-    assert events == ["validate", "mutate", "stage", "commit", "committed"]
+    assert events == ["lock", "validate", "mutate", "stage", "commit", "committed"]
     assert service.validated == service.staged == service.committed
     mutation = service.staged[0]
     assert mutation.kind is AuthorizationMutationKind.USER_DISABLED
@@ -164,7 +169,7 @@ async def test_user_lifecycle_stage_failure_prevents_commit(monkeypatch):
             session=session,
         )
 
-    assert events == ["validate", "mutate", "stage"]
+    assert events == ["lock", "validate", "mutate", "stage"]
     session.commit.assert_not_awaited()
     assert service.committed == []
 
@@ -205,7 +210,7 @@ async def test_user_lifecycle_policy_rejection_is_409_without_mutation(monkeypat
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == _RECOVERY_DETAIL
-    assert events == ["validate"]
+    assert events == ["lock", "validate"]
     update.assert_not_awaited()
     session.commit.assert_not_awaited()
 
@@ -354,10 +359,14 @@ async def test_assignment_delete_validates_live_row_before_mutation_and_stage(mo
         session=session,
     )
 
-    assert events == ["validate", "mutate", "flush", "stage", "commit", "committed", "audit"]
+    assert events == ["lock", "validate", "mutate", "flush", "stage", "commit", "committed", "audit"]
     assert service.validated == service.staged == service.committed
-    mutation = service.validated[0]
+    assert len(service.staged) == 1
+    assert len(service.lock_requests) == 1
+    mutation = service.staged[0]
     assert mutation.kind is AuthorizationMutationKind.ROLE_ASSIGNMENT_DELETED
+    assert mutation.entity_id == assignment.id
+    assert mutation.affected_user_ids == (assignment.user_id,)
     assert mutation.domain_type == "global"
     assert mutation.domain_id is None
 
@@ -400,7 +409,7 @@ async def test_assignment_delete_policy_rejection_is_409_without_mutation(monkey
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == _RECOVERY_DETAIL
-    assert events == ["validate"]
+    assert events == ["lock", "validate"]
     session.delete.assert_not_awaited()
     session.flush.assert_not_awaited()
     session.commit.assert_not_awaited()

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -23,6 +23,10 @@ class _StubCatalogPolicy:
         self.component_calls = []
         self.template_calls = []
 
+    @property
+    def external_policy_snapshot(self):
+        return None
+
     async def replace_blocked_component_keys(self, keys, *, actor_user_id):
         desired = frozenset(keys)
         current = self.snapshot.blocked_component_keys
@@ -50,6 +54,27 @@ class _StubCatalogPolicy:
             added=desired - current,
             removed=current - desired,
         )
+
+
+class _ExternalCatalogPolicy(_StubCatalogPolicy):
+    def __init__(self, *, external_snapshot: CatalogPolicySnapshot | None = None) -> None:
+        super().__init__()
+        self.snapshot = CatalogPolicySnapshot(
+            blocked_component_keys=frozenset({"StaleInternalComponent"}),
+            blocked_template_keys=frozenset({"StaleInternalTemplate"}),
+        )
+        self._external_snapshot = (
+            external_snapshot
+            if external_snapshot is not None
+            else CatalogPolicySnapshot(
+                blocked_component_keys={"ExternalComponent"},
+                blocked_template_keys={"ExternalTemplate"},
+            )
+        )
+
+    @property
+    def external_policy_snapshot(self):
+        return self._external_snapshot
 
 
 def _client(monkeypatch, *, service=None, superuser=True):
@@ -84,9 +109,36 @@ def test_get_whole_sets_are_sorted_and_superuser_only(monkeypatch):
     templates = client.get("/api/v1/catalog-policy/templates")
 
     assert components.status_code == 200
-    assert components.json() == {"blocked": ["OldComponent"]}
+    assert components.json() == {"blocked": ["OldComponent"], "managed_externally": False}
     assert templates.status_code == 200
-    assert templates.json() == {"blocked": ["OldTemplate"]}
+    assert templates.json() == {"blocked": ["OldTemplate"], "managed_externally": False}
+    audit.assert_not_awaited()
+
+
+def test_external_gets_return_the_active_external_snapshot(monkeypatch):
+    client, _service, _admin, audit = _client(monkeypatch, service=_ExternalCatalogPolicy())
+
+    components = client.get("/api/v1/catalog-policy/components")
+    templates = client.get("/api/v1/catalog-policy/templates")
+
+    assert components.status_code == 200
+    assert components.json() == {"blocked": ["ExternalComponent"], "managed_externally": True}
+    assert templates.status_code == 200
+    assert templates.json() == {"blocked": ["ExternalTemplate"], "managed_externally": True}
+    audit.assert_not_awaited()
+
+
+def test_empty_external_snapshot_still_reports_external_ownership(monkeypatch):
+    client, _service, _admin, audit = _client(
+        monkeypatch,
+        service=_ExternalCatalogPolicy(external_snapshot=CatalogPolicySnapshot()),
+    )
+
+    components = client.get("/api/v1/catalog-policy/components")
+    templates = client.get("/api/v1/catalog-policy/templates")
+
+    assert components.json() == {"blocked": [], "managed_externally": True}
+    assert templates.json() == {"blocked": [], "managed_externally": True}
     audit.assert_not_awaited()
 
 
@@ -119,7 +171,7 @@ def test_put_components_normalizes_whole_set_and_audits_each_delta(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert response.json() == {"blocked": ["Alpha", "zeta"]}
+    assert response.json() == {"blocked": ["Alpha", "zeta"], "managed_externally": False}
     assert service.component_calls == [(["Alpha", "zeta"], admin.id)]
     assert [call.kwargs for call in audit.await_args_list] == [
         {
@@ -155,7 +207,7 @@ def test_put_templates_preserves_case_and_accepts_unknown_keys(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert response.json() == {"blocked": ["Unknown-ID", "unknown-id"]}
+    assert response.json() == {"blocked": ["Unknown-ID", "unknown-id"], "managed_externally": False}
     assert service.template_calls == [(["Unknown-ID", "unknown-id"], admin.id)]
     assert audit.await_count == 3
 
@@ -181,3 +233,24 @@ def test_put_requires_explicit_whole_set_without_writing_or_auditing(monkeypatch
     assert response.status_code == 422
     assert service.component_calls == []
     audit.assert_not_awaited()
+
+
+@pytest.mark.parametrize("resource_kind", ["components", "templates"])
+def test_external_policy_rejects_valid_puts_without_writing_or_auditing(monkeypatch, resource_kind):
+    client, service, _admin, audit = _client(monkeypatch, service=_ExternalCatalogPolicy())
+
+    response = client.put(
+        f"/api/v1/catalog-policy/{resource_kind}",
+        json={"blocked": ["ValidKey"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {"detail": "Catalog policy is externally managed and cannot be changed through this API."}
+    assert service.component_calls == []
+    assert service.template_calls == []
+    audit.assert_not_awaited()
+
+
+def test_managed_marker_is_response_only():
+    assert "managed_externally" not in catalog_policy.CatalogPolicyBlockedSet.model_fields
+    assert "managed_externally" in catalog_policy.CatalogPolicyRead.model_fields

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -59,11 +59,7 @@ class _StubCatalogPolicy:
 class _ExternalCatalogPolicy(_StubCatalogPolicy):
     def __init__(self, *, external_snapshot: CatalogPolicySnapshot | None = None) -> None:
         super().__init__()
-        self.snapshot = CatalogPolicySnapshot(
-            blocked_component_keys=frozenset({"StaleInternalComponent"}),
-            blocked_template_keys=frozenset({"StaleInternalTemplate"}),
-        )
-        self._external_snapshot = (
+        self.snapshot = (
             external_snapshot
             if external_snapshot is not None
             else CatalogPolicySnapshot(
@@ -74,7 +70,7 @@ class _ExternalCatalogPolicy(_StubCatalogPolicy):
 
     @property
     def external_policy_snapshot(self):
-        return self._external_snapshot
+        return self.snapshot
 
 
 def _client(monkeypatch, *, service=None, superuser=True):
@@ -116,7 +112,7 @@ def test_get_whole_sets_are_sorted_and_superuser_only(monkeypatch):
 
 
 def test_external_gets_return_the_active_external_snapshot(monkeypatch):
-    client, _service, _admin, audit = _client(monkeypatch, service=_ExternalCatalogPolicy())
+    client, service, _admin, audit = _client(monkeypatch, service=_ExternalCatalogPolicy())
 
     components = client.get("/api/v1/catalog-policy/components")
     templates = client.get("/api/v1/catalog-policy/templates")
@@ -125,6 +121,7 @@ def test_external_gets_return_the_active_external_snapshot(monkeypatch):
     assert components.json() == {"blocked": ["ExternalComponent"], "managed_externally": True}
     assert templates.status_code == 200
     assert templates.json() == {"blocked": ["ExternalTemplate"], "managed_externally": True}
+    assert service.external_policy_snapshot is service.snapshot
     audit.assert_not_awaited()
 
 
@@ -137,6 +134,8 @@ def test_empty_external_snapshot_still_reports_external_ownership(monkeypatch):
     components = client.get("/api/v1/catalog-policy/components")
     templates = client.get("/api/v1/catalog-policy/templates")
 
+    assert components.status_code == 200
+    assert templates.status_code == 200
     assert components.json() == {"blocked": [], "managed_externally": True}
     assert templates.json() == {"blocked": [], "managed_externally": True}
     audit.assert_not_awaited()

--- a/src/backend/tests/unit/api/v1/test_model_provider_policy.py
+++ b/src/backend/tests/unit/api/v1/test_model_provider_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -12,6 +13,7 @@ from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
 from langflow.services.model_provider_policy import ModelProviderPolicyNotInitializedError
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly
+from lfx.services.model_provider_policy import BaseModelProviderPolicyService, ModelProviderPolicyService
 from pydantic import ValidationError
 
 
@@ -47,6 +49,21 @@ class _WriteSession:
         self.events.append("commit")
 
 
+class _ExternalModelProviderPolicy(BaseModelProviderPolicyService):
+    def __init__(self, provider_ids: set[str]) -> None:
+        super().__init__()
+        self._provider_ids = frozenset(provider_ids)
+        self.set_ready()
+
+    @property
+    def external_approved_provider_ids(self) -> frozenset[str]:
+        return self._provider_ids
+
+    def get_allowed_provider_ids(self, *, context, candidate_provider_ids, purpose):
+        _ = (context, purpose)
+        return candidate_provider_ids & self._provider_ids
+
+
 async def _unused_session():
     yield SimpleNamespace()
 
@@ -62,6 +79,18 @@ def _client_with_rejected_superuser(router: APIRouter) -> TestClient:
         )
 
     app.dependency_overrides[get_current_active_superuser] = reject_superuser
+    app.dependency_overrides[injectable_session_scope] = _unused_session
+    app.dependency_overrides[injectable_session_scope_readonly] = _unused_session
+    return TestClient(app)
+
+
+def _client_with_superuser(router: APIRouter) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_active_superuser] = lambda: SimpleNamespace(
+        id=uuid4(),
+        is_superuser=True,
+    )
     app.dependency_overrides[injectable_session_scope] = _unused_session
     app.dependency_overrides[injectable_session_scope_readonly] = _unused_session
     return TestClient(app)
@@ -103,6 +132,70 @@ def test_trailing_slash_aliases_are_hidden_from_openapi():
     assert {route.path for route in routes if route.include_in_schema} == {"/model-provider-policy"}
 
 
+async def test_read_internal_policy_reports_database_state_as_unmanaged(monkeypatch):
+    state = SimpleNamespace(approved_provider_ids=frozenset({"openai"}), version=4)
+    read_state = AsyncMock(return_value=state)
+    monkeypatch.setattr(
+        policy_api, "get_model_provider_policy_service", lambda: ModelProviderPolicyService(), raising=False
+    )
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_state", read_state)
+
+    response = await policy_api.read_model_provider_policy(
+        _admin=SimpleNamespace(id=uuid4(), is_superuser=True),
+        session=SimpleNamespace(),
+    )
+
+    assert response.approved_provider_ids == ["openai"]
+    assert response.managed_externally is False
+    read_state.assert_awaited_once()
+
+
+@pytest.mark.parametrize("external_ids", [{"anthropic", "openai"}, set()])
+async def test_read_external_policy_uses_active_service_state_without_database_access(monkeypatch, external_ids):
+    service = _ExternalModelProviderPolicy(external_ids)
+    read_state = AsyncMock()
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_service", lambda: service, raising=False)
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_state", read_state)
+
+    response = await policy_api.read_model_provider_policy(
+        _admin=SimpleNamespace(id=uuid4(), is_superuser=True),
+        session=SimpleNamespace(),
+    )
+
+    assert response.approved_provider_ids == sorted(external_ids)
+    assert response.managed_externally is True
+    read_state.assert_not_awaited()
+
+
+@pytest.mark.parametrize("method", ["post", "put"])
+def test_external_policy_rejects_valid_writes_without_side_effects(monkeypatch, method):
+    service = _ExternalModelProviderPolicy({"openai"})
+    invalidate = Mock(wraps=service.invalidate)
+    replace_state = AsyncMock()
+    audit = AsyncMock()
+    apply = Mock()
+    monkeypatch.setattr(service, "invalidate", invalidate)
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_service", lambda: service, raising=False)
+    monkeypatch.setattr(policy_api, "replace_model_provider_policy_state", replace_state)
+    monkeypatch.setattr(policy_api, "audit_decision", audit)
+    monkeypatch.setattr(policy_api, "apply_model_provider_policy_state", apply)
+    client = _client_with_superuser(policy_api.router)
+
+    response = getattr(client, method)(
+        "/model-provider-policy",
+        json={"approved_provider_ids": ["openai"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": "Model-provider policy is externally managed and cannot be changed through this API."
+    }
+    replace_state.assert_not_awaited()
+    audit.assert_not_awaited()
+    apply.assert_not_called()
+    invalidate.assert_not_called()
+
+
 async def test_replace_policy_commits_before_runtime_invalidation(monkeypatch):
     session = _WriteSession()
     admin_id = uuid4()
@@ -142,6 +235,7 @@ async def test_replace_policy_commits_before_runtime_invalidation(monkeypatch):
         ("apply", ["openai", "temporarily-missing.extension"], 3),
     ]
     assert response.approved_provider_ids == ["openai", "temporarily-missing.extension"]
+    assert response.managed_externally is False
     assert any(provider.provider_id == "openai" for provider in response.registered_providers)
 
 

--- a/src/backend/tests/unit/services/test_model_provider_policy_refresh.py
+++ b/src/backend/tests/unit/services/test_model_provider_policy_refresh.py
@@ -9,6 +9,16 @@ from langflow.services.task import model_provider_policy_refresh as refresh_modu
 from lfx.services.model_provider_policy import ModelProviderPolicyService
 
 
+class _ExternalBuiltinPolicyService(ModelProviderPolicyService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_approved_provider_ids({"openai"}, version=2)
+
+    @property
+    def external_approved_provider_ids(self) -> frozenset[str]:
+        return frozenset({"openai"})
+
+
 async def test_refresh_failure_preserves_unrestricted_policy_availability(monkeypatch):
     service = ModelProviderPolicyService()
     error_message = "policy store unavailable"
@@ -153,6 +163,41 @@ async def test_start_uses_configured_interval_and_stop_clears_task(monkeypatch):
     await worker.stop()
 
     assert worker._task is None
+
+
+async def test_start_skips_explicitly_external_builtin_subclass(monkeypatch):
+    service = _ExternalBuiltinPolicyService()
+    worker = refresh_module.ModelProviderPolicyRefreshWorker()
+    debug = AsyncMock()
+    monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(refresh_module.logger, "adebug", debug)
+
+    await worker.start()
+
+    assert worker._task is None
+    debug.assert_awaited_once_with("Model-provider policy refresh worker not started: external policy service active")
+
+
+async def test_refresh_failure_does_not_fail_close_explicitly_external_builtin_subclass(monkeypatch):
+    service = _ExternalBuiltinPolicyService()
+    error_message = "policy store unavailable"
+
+    @asynccontextmanager
+    async def failing_session_scope():
+        raise ConnectionError(error_message)
+        yield
+
+    fail_closed = Mock(wraps=service.fail_closed)
+    monkeypatch.setattr(service, "fail_closed", fail_closed)
+    monkeypatch.setattr(refresh_module, "session_scope", failing_session_scope)
+    monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(refresh_module.logger, "aerror", AsyncMock())
+
+    changed = await refresh_module.ModelProviderPolicyRefreshWorker()._run_once()
+
+    assert changed is False
+    assert service.approved_provider_ids == frozenset({"openai"})
+    fail_closed.assert_not_called()
 
 
 async def test_start_replaces_a_completed_refresh_task(monkeypatch):

--- a/src/backend/tests/unit/services/test_model_provider_policy_store.py
+++ b/src/backend/tests/unit/services/test_model_provider_policy_store.py
@@ -9,7 +9,7 @@ import pytest
 from langflow.services import model_provider_policy as policy_store
 from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
 from langflow.services.task import model_provider_policy_refresh as refresh_module
-from lfx.services.model_provider_policy import ModelProviderPolicyService
+from lfx.services.model_provider_policy import BaseModelProviderPolicyService, ModelProviderPolicyService
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -57,8 +57,15 @@ async def test_hydrate_empty_store_preserves_allow_all(monkeypatch):
     assert service.policy_version == 2
 
 
-def test_enterprise_policy_service_is_invalidated_without_replacing_its_source(monkeypatch):
-    service = SimpleNamespace(invalidate=Mock())
+def test_legacy_third_party_policy_service_is_invalidated_without_replacing_its_source(monkeypatch):
+    class LegacyPolicyService(BaseModelProviderPolicyService):
+        def get_allowed_provider_ids(self, *, context, candidate_provider_ids, purpose):
+            _ = (context, purpose)
+            return candidate_provider_ids
+
+    service = LegacyPolicyService()
+    invalidate = Mock(wraps=service.invalidate)
+    monkeypatch.setattr(service, "invalidate", invalidate)
     monkeypatch.setattr(policy_store, "get_model_provider_policy_service", lambda: service)
     state = policy_store.PersistedModelProviderPolicy(
         approved_provider_ids=frozenset({"openai"}),
@@ -66,7 +73,54 @@ def test_enterprise_policy_service_is_invalidated_without_replacing_its_source(m
     )
 
     assert policy_store.apply_model_provider_policy_state(state)
-    service.invalidate.assert_called_once_with()
+    invalidate.assert_called_once_with()
+
+
+@pytest.mark.parametrize("external_ids", [frozenset({"openai"}), frozenset()])
+def test_explicitly_external_policy_service_is_not_invalidated(monkeypatch, external_ids):
+    class ExternalPolicyService(BaseModelProviderPolicyService):
+        def __init__(self) -> None:
+            super().__init__()
+            self.set_ready()
+
+        @property
+        def external_approved_provider_ids(self) -> frozenset[str]:
+            return external_ids
+
+        def get_allowed_provider_ids(self, *, context, candidate_provider_ids, purpose):
+            _ = (context, purpose)
+            return candidate_provider_ids & external_ids
+
+    service = ExternalPolicyService()
+    invalidate = Mock(wraps=service.invalidate)
+    monkeypatch.setattr(service, "invalidate", invalidate)
+    monkeypatch.setattr(policy_store, "get_model_provider_policy_service", lambda: service)
+    state = policy_store.PersistedModelProviderPolicy(
+        approved_provider_ids=frozenset({"anthropic"}),
+        version=3,
+    )
+
+    assert policy_store.apply_model_provider_policy_state(state) is False
+    invalidate.assert_not_called()
+
+
+def test_explicitly_external_builtin_subclass_does_not_receive_database_state(monkeypatch):
+    class ExternalBuiltinPolicyService(ModelProviderPolicyService):
+        @property
+        def external_approved_provider_ids(self) -> frozenset[str]:
+            return frozenset({"openai"})
+
+    service = ExternalBuiltinPolicyService()
+    service.set_approved_provider_ids({"openai"}, version=2)
+    monkeypatch.setattr(policy_store, "get_model_provider_policy_service", lambda: service)
+    state = policy_store.PersistedModelProviderPolicy(
+        approved_provider_ids=frozenset(),
+        version=3,
+    )
+
+    assert policy_store.apply_model_provider_policy_state(state) is False
+    assert service.approved_provider_ids == frozenset({"openai"})
+    assert service.policy_version == 2
 
 
 def test_replacement_is_one_atomic_versioned_update():

--- a/src/lfx/PLUGGABLE_SERVICES.md
+++ b/src/lfx/PLUGGABLE_SERVICES.md
@@ -260,6 +260,7 @@ Service keys **must** match `ServiceType` enum values exactly:
 
 - `database_service`
 - `auth_service`
+- `authorization_service`
 - `catalog_policy_service`
 - `model_provider_policy_service`
 - `storage_service`
@@ -278,6 +279,12 @@ Service keys **must** match `ServiceType` enum values exactly:
 - `transaction_service`
 
 **Important:** `settings_service` is **not pluggable** and cannot be overridden. It is always created using the built-in factory and provides the foundational configuration for all other services.
+
+### Authorization identity-mutation lock
+
+Authorization plugins can override `acquire_identity_mutation_lock()` to establish transaction ordering before canonical identity reads and writes. The hook is lock-only: it must not persist policy, commit or roll back the caller's transaction, emit audit events, or reject a mutation. Because it runs before canonical state is loaded, `kind` and the other request metadata are advisory estimates and may differ from the mutation eventually staged. Implementations must acquire a lock broad enough for every possible result and must not narrow its scope by `kind`.
+
+The hook can run for unauthenticated public-signup attempts, including requests later rejected by uniqueness checks, so acquisition must remain bounded and deployments should rate-limit public signup. Canonical `SELECT ... FOR UPDATE` locks are dialect-dependent: they serialize row access on PostgreSQL but are ignored by SQLite. Plugins that require cross-writer serialization must use and test a locking mechanism supported by their deployment database.
 
 ### Model-provider policy service
 
@@ -335,7 +342,9 @@ outside Langflow returns its active set from `external_approved_provider_ids`.
 Any non-`None` value, including an empty frozenset, marks external ownership:
 GET returns that set with `managed_externally: true`, and POST/PUT return `409`
 without changing the database, emitting an audit event, applying OSS state, or
-invalidating the external service.
+invalidating the external service. An empty external set is unrestricted; every
+resolution must treat a non-empty set as the deployment ceiling, while
+principal-, attribute-, or purpose-specific policy may narrow it further.
 
 `purpose` identifies the protected operation:
 
@@ -369,7 +378,10 @@ ownership even when both blocked sets are empty. The superuser catalog-policy
 GET endpoints return that external snapshot with `managed_externally: true`;
 their PUT endpoints return `409` without invoking the writable service methods
 or emitting audit events. The default `None` marker keeps the database-backed
-Langflow read/write behavior unchanged.
+Langflow read/write behavior unchanged. External implementations must expose
+value-equivalent active state through both `snapshot` and
+`external_policy_snapshot`: administration reads use the latter while runtime
+enforcement uses the former.
 
 ```toml
 # $LANGFLOW_CONFIG_DIR/lfx.toml

--- a/src/lfx/PLUGGABLE_SERVICES.md
+++ b/src/lfx/PLUGGABLE_SERVICES.md
@@ -260,6 +260,7 @@ Service keys **must** match `ServiceType` enum values exactly:
 
 - `database_service`
 - `auth_service`
+- `catalog_policy_service`
 - `model_provider_policy_service`
 - `storage_service`
 - `cache_service`
@@ -297,7 +298,12 @@ from lfx.services.model_provider_policy import (
 class AcmeModelProviderPolicyService(BaseModelProviderPolicyService):
     def __init__(self) -> None:
         super().__init__()
+        self._deployment_ceiling = frozenset({"openai", "acme.models"})
         self.set_ready()
+
+    @property
+    def external_approved_provider_ids(self) -> frozenset[str]:
+        return self._deployment_ceiling
 
     def get_allowed_provider_ids(
         self,
@@ -306,15 +312,14 @@ class AcmeModelProviderPolicyService(BaseModelProviderPolicyService):
         candidate_provider_ids: frozenset[str],
         purpose: ModelProviderPolicyPurpose,
     ) -> Collection[str]:
-        deployment_ceiling = frozenset({"openai", "acme.models"})
         # A later RBAC implementation can narrow this set using context.user_id,
         # context.attributes, and purpose in the same batch decision.
-        return candidate_provider_ids & deployment_ceiling
+        return candidate_provider_ids & self._deployment_ceiling
 ```
 
 The method receives stable provider IDs for both core and extension-contributed providers and returns the allowed subset. The base service rejects results that widen the candidate set and returns an immutable decision snapshot. `resolve()` is the compatibility bridge used by synchronous model-construction paths; `await aresolve()` is the async boundary for request handlers or implementations that preload policy from an I/O-backed source. Both return the same synchronously consumable snapshot type.
 
-Resolved snapshots are cached in each service process by principal attributes, purpose, and candidate provider IDs. The cache has a five-minute backstop (`SNAPSHOT_CACHE_TTL_SECONDS`); set that class attribute to a shorter interval for stricter revocation requirements, or to `0` to disable caching. Call `invalidate()` after the policy source changes in every worker that may have cached a decision. Multi-worker and multi-pod deployments must broadcast that invalidation (or rely on the bounded TTL); calling it in one process does not clear another process's cache.
+Resolved snapshots are cached in each service process by principal attributes, purpose, and candidate provider IDs. The cache has a five-minute backstop (`SNAPSHOT_CACHE_TTL_SECONDS`); set that class attribute to a shorter interval for stricter revocation requirements, or set `SNAPSHOT_CACHE_MAX_SIZE = 0` to reevaluate every resolution. Call `invalidate()` after the policy source changes in every worker that may have cached a decision. Multi-worker and multi-pod deployments must broadcast that invalidation (or rely on the bounded TTL); calling it in one process does not clear another process's cache.
 
 `aresolve()` remains the cache-owning async wrapper. Implement `aget_allowed_provider_ids()` when policy evaluation requires I/O instead of overriding `aresolve()`. Its default implementation calls the synchronous `get_allowed_provider_ids()` hook on the event loop, so synchronous implementations should keep that hook non-blocking and preload any remote policy state before model construction begins.
 
@@ -323,9 +328,14 @@ The OSS backend persists one install-wide, versioned set of approved
 preserve historical allow-all behavior until a superuser narrows the policy.
 The `/api/v1/model-provider-policy` GET/POST/PUT contract reads or atomically
 replaces that singleton. Writes invalidate the handling process after commit;
-the other backend workers poll its durable version every second and invalidate
-their snapshots when it changes. External policy plugins continue to own their
-source and fleet-wide invalidation.
+the other backend workers poll its durable version on the configurable refresh
+interval (10 seconds by default) and invalidate their snapshots when it changes.
+A plugin that owns the deployment ceiling
+outside Langflow returns its active set from `external_approved_provider_ids`.
+Any non-`None` value, including an empty frozenset, marks external ownership:
+GET returns that set with `managed_externally: true`, and POST/PUT return `409`
+without changing the database, emitting an audit event, applying OSS state, or
+invalidating the external service.
 
 `purpose` identifies the protected operation:
 
@@ -344,6 +354,28 @@ model_provider_policy_service = "acme_langflow.policy:AcmeModelProviderPolicySer
 The equivalent `pyproject.toml` section is `[tool.lfx.services]`. When both files exist, `lfx.toml` is preferred. Config-file registration has higher precedence than the built-in decorator; an `lfx.services` entry point alone does not replace the OSS default. The configured class must inherit `BaseModelProviderPolicyService`; service resolution fails closed for an incompatible implementation.
 
 This policy applies to shared unified model catalogs, configuration APIs, selectors, and runtime helpers. It does not hide provider-specific component classes from the component palette.
+
+### Catalog policy service
+
+`catalog_policy_service` controls the process-local sets of blocked component
+registry keys and starter-template `name_key` values. Implementations subclass
+`BaseCatalogPolicyService`, expose their active immutable
+`CatalogPolicySnapshot` through `snapshot`, and preload any external state
+before calling `set_ready()`.
+
+When a plugin owns this policy outside Langflow, it also returns the active
+snapshot from `external_policy_snapshot`. A non-`None` snapshot marks external
+ownership even when both blocked sets are empty. The superuser catalog-policy
+GET endpoints return that external snapshot with `managed_externally: true`;
+their PUT endpoints return `409` without invoking the writable service methods
+or emitting audit events. The default `None` marker keeps the database-backed
+Langflow read/write behavior unchanged.
+
+```toml
+# $LANGFLOW_CONFIG_DIR/lfx.toml
+[services]
+catalog_policy_service = "acme_langflow.policy:AcmeCatalogPolicyService"
+```
 
 ## Creating Custom Services
 

--- a/src/lfx/src/lfx/services/authorization/base.py
+++ b/src/lfx/src/lfx/services/authorization/base.py
@@ -362,6 +362,24 @@ class BaseAuthorizationService(Service, abc.ABC):
         """Remove policy derived from a deleted share snapshot. Plugin override; OSS no-op."""
         _ = snapshot
 
+    async def acquire_identity_mutation_lock(
+        self,
+        *,
+        session: Any,
+        kind: AuthorizationMutationKind,
+        entity_id: _UUID | None = None,
+        affected_user_ids: tuple[_UUID, ...] = (),
+    ) -> None:
+        """Establish transaction ordering before canonical identity reads.
+
+        This hook is lock-only: implementations must not commit, roll back,
+        persist policy, emit audit events, or reject the requested mutation.
+        Callers can invoke it before they know whether a write will create a
+        row, attach provenance, or return a conflict. The default is a no-op
+        for OSS and existing third-party plugins.
+        """
+        _ = (session, kind, entity_id, affected_user_ids)
+
     async def validate_identity_mutation(
         self,
         *,

--- a/src/lfx/src/lfx/services/authorization/base.py
+++ b/src/lfx/src/lfx/services/authorization/base.py
@@ -377,6 +377,14 @@ class BaseAuthorizationService(Service, abc.ABC):
         Callers can invoke it before they know whether a write will create a
         row, attach provenance, or return a conflict. The default is a no-op
         for OSS and existing third-party plugins.
+
+        Because this hook runs before canonical reads, ``kind`` and the other
+        request metadata are advisory, best-effort descriptions and may differ
+        from the mutation ultimately staged. Implementations must acquire a lock
+        broad enough for every possible result and must not narrow its scope by
+        ``kind``. The hook can run for unauthenticated public-signup attempts and
+        requests later rejected as conflicts, so acquisition must remain bounded
+        and safe under untrusted contention.
         """
         _ = (session, kind, entity_id, affected_user_ids)
 

--- a/src/lfx/src/lfx/services/catalog_policy/base.py
+++ b/src/lfx/src/lfx/services/catalog_policy/base.py
@@ -71,6 +71,15 @@ class BaseCatalogPolicyService(Service, abc.ABC):
     name = ServiceType.CATALOG_POLICY_SERVICE.value
 
     @property
+    def external_policy_snapshot(self) -> CatalogPolicySnapshot | None:
+        """Return the externally owned active snapshot, if one is configured.
+
+        ``None`` means Langflow owns the durable catalog policy. An empty
+        snapshot still represents externally managed policy.
+        """
+        return None
+
+    @property
     @abc.abstractmethod
     def snapshot(self) -> CatalogPolicySnapshot:
         """Return the current immutable process-local snapshot."""

--- a/src/lfx/src/lfx/services/catalog_policy/base.py
+++ b/src/lfx/src/lfx/services/catalog_policy/base.py
@@ -75,7 +75,9 @@ class BaseCatalogPolicyService(Service, abc.ABC):
         """Return the externally owned active snapshot, if one is configured.
 
         ``None`` means Langflow owns the durable catalog policy. An empty
-        snapshot still represents externally managed policy.
+        snapshot still represents externally managed policy. A non-``None``
+        value must be value-equivalent to ``snapshot`` because administration
+        reads use this property while runtime enforcement uses ``snapshot``.
         """
         return None
 

--- a/src/lfx/src/lfx/services/model_provider_policy/base.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/base.py
@@ -145,8 +145,11 @@ class BaseModelProviderPolicyService(Service, abc.ABC):
         """Return the externally owned deployment ceiling, if one is active.
 
         ``None`` means Langflow owns the persisted policy. An empty frozenset
-        still marks the policy as externally managed and must not be treated
-        as the OSS unrestricted-policy sentinel.
+        still marks the policy as externally managed, so administration must not
+        fall back to the OSS database. For decisions, an empty external set is
+        unrestricted; a non-empty set is a deployment ceiling. Every synchronous
+        and asynchronous allowed-provider result must remain within that ceiling,
+        though contextual policy may narrow it further.
         """
         return None
 

--- a/src/lfx/src/lfx/services/model_provider_policy/base.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/base.py
@@ -140,6 +140,16 @@ class BaseModelProviderPolicyService(Service, abc.ABC):
         super().__init__()
         self._ensure_snapshot_cache_state()
 
+    @property
+    def external_approved_provider_ids(self) -> frozenset[str] | None:
+        """Return the externally owned deployment ceiling, if one is active.
+
+        ``None`` means Langflow owns the persisted policy. An empty frozenset
+        still marks the policy as externally managed and must not be treated
+        as the OSS unrestricted-policy sentinel.
+        """
+        return None
+
     def _ensure_snapshot_cache_state(self) -> None:
         """Initialize cache state, including for legacy subclasses that skipped ``super()``."""
         if "_snapshot_cache_lock" in self.__dict__:

--- a/src/lfx/tests/unit/services/authorization/test_default_authorization_service.py
+++ b/src/lfx/tests/unit/services/authorization/test_default_authorization_service.py
@@ -174,6 +174,14 @@ async def test_identity_and_directory_contracts_are_default_noops(service: Autho
     )
     session = object()
 
+    assert (
+        await service.acquire_identity_mutation_lock(
+            session=session,
+            kind=AuthorizationMutationKind.ROLE_ASSIGNMENT_CREATED,
+            affected_user_ids=(user_id,),
+        )
+        is None
+    )
     assert await service.validate_identity_mutation(session=session, mutation=mutation) is None
     assert await service.stage_identity_mutation(session=session, event=mutation) is None
     assert await service.identity_mutation_committed(mutation) is None

--- a/src/lfx/tests/unit/services/catalog_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/catalog_policy/test_policy.py
@@ -11,6 +11,7 @@ def test_empty_default_is_fail_open_for_single_and_batch_decisions():
     service = CatalogPolicyService()
 
     assert service.ready is True
+    assert service.external_policy_snapshot is None
     assert service.enabled is False
     assert service.is_component_blocked("OpenAIModel") is False
     assert service.is_template_blocked("starter-template") is False

--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -61,6 +61,12 @@ def test_default_service_allows_every_candidate():
     assert snapshot.allows("Anthropic")
 
 
+def test_default_service_does_not_claim_an_external_policy_source():
+    service = ModelProviderPolicyService()
+
+    assert service.external_approved_provider_ids is None
+
+
 def test_default_service_allows_every_registered_provider():
     from lfx.base.models.provider_registry import get_registry_snapshot
 
@@ -264,6 +270,23 @@ def test_snapshot_cache_evicts_least_recently_used_entry():
     _resolve("second")
 
     assert service.evaluations == 4
+
+
+def test_zero_sized_snapshot_cache_reevaluates_every_resolution():
+    service = _CountingPolicy()
+    service.SNAPSHOT_CACHE_MAX_SIZE = 0
+    kwargs = {
+        "context": ModelProviderPolicyContext(user_id="user-1"),
+        "candidate_provider_ids": frozenset({"openai"}),
+        "purpose": ModelProviderPolicyPurpose.USE,
+    }
+
+    first = service.resolve(**kwargs)
+    second = service.resolve(**kwargs)
+
+    assert second == first
+    assert second is not first
+    assert service.evaluations == 2
 
 
 def test_unhashable_policy_attributes_bypass_snapshot_cache():


### PR DESCRIPTION
## Summary

- add opt-in ownership capabilities for externally managed model-provider and catalog policies
- expose `managed_externally` on policy reads and reject externally managed writes with the documented `409` contracts
- keep internal database-backed behavior unchanged, while preventing database publication/invalidation from mutating explicitly external provider services
- support `SNAPSHOT_CACHE_MAX_SIZE = 0` as the documented no-cache provider-policy mode
- add an authorization identity-mutation lock hook and acquire it before canonical admin-route reads/writes so external reconcilers can serialize safely with OSS mutations

This is the OSS half of the coordinated IBM Langflow environment-managed policy integration. Existing OSS and third-party implementations remain backward compatible because the new ownership capabilities are non-abstract and default to `None`.

## Validation

- provider/catalog backend tests: 54 passed
- provider/catalog LFX tests: 47 passed
- authorization lifecycle backend tests: 112 passed
- authorization lifecycle LFX tests: 14 passed
- changed-source Ruff and mypy checks passed
- pre-commit passed

## Follow-up

The coordinated IBM Langflow PR registers the environment-backed services and pins this exact commit until the final merged OSS SHA is available: https://github.ibm.com/WatsonOrchestrate/IBM-Langflow/pull/145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for externally managed catalog and model-provider policies.
  * Policy responses now indicate whether management is external.
  * External policy updates are rejected with a conflict response while preserving existing state.
  * Added documented configuration for pluggable policy services and cross-worker refresh behavior.

* **Bug Fixes**
  * Improved authorization mutation ordering and locking for users, teams, roles, and assignments.
  * Prevented policy refresh and invalidation from altering externally managed settings.

* **Tests**
  * Expanded coverage for policy ownership, mutation locking, response metadata, and refresh behavior.

* **Documentation**
  * Updated pluggable service guidance for external policy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->