### PR TITLE
fix: release SQLite lock after API key auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1068,7 +1068,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 173,
         "is_secret": false
       }
     ],
@@ -7203,5 +7203,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T18:58:00Z"
+  "generated_at": "2026-08-03T20:07:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1068,7 +1068,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 139,
+        "line_number": 141,
         "is_secret": false
       }
     ],
@@ -7203,5 +7203,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T21:43:28Z"
+  "generated_at": "2026-08-03T18:58:00Z"
 }

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -918,17 +918,13 @@ async def _create_superuser(username: str, password: str, auth_token: str | None
         # Validate the auth token
         try:
             auth_user = None
-            async with session_scope() as session:
-                # Try JWT first
-                user = None
-                try:
-                    user = await get_current_user_from_access_token(auth_token, session)
-                except (InvalidTokenError, HTTPException):
-                    # Try API key
-                    api_key_result = await check_key(session, auth_token)
-                    if api_key_result and hasattr(api_key_result, "is_superuser"):
-                        user = api_key_result
-                auth_user = user
+            # Try JWT first, closing its session before falling back to API-key
+            # authentication, which owns a separate database transaction.
+            try:
+                async with session_scope() as session:
+                    auth_user = await get_current_user_from_access_token(auth_token, session)
+            except (InvalidTokenError, HTTPException):
+                auth_user = await check_key(auth_token)
 
             if not auth_user or not auth_user.is_superuser:
                 typer.echo(

--- a/src/backend/base/langflow/api/v1/a2a.py
+++ b/src/backend/base/langflow/api/v1/a2a.py
@@ -124,41 +124,41 @@ async def _enforce_a2a_auth(flow: Flow, request: Request) -> User | None:
     - anything else (an auth type A2A doesn't understand) -> fail closed with 403: treating a
       *protected* folder as public would expose an owner-identity run anonymously.
 
-    Uses ``check_key`` directly, NOT ``api_key_security``: under AUTO_LOGIN the latter
+    Uses ``authenticate_api_key`` directly, NOT ``api_key_security``: under AUTO_LOGIN the latter
     returns the superuser for a *missing* key, which would silently bypass this gate.
     """
-    # Short writable session (check_key flushes usage counters), closed before
-    # dispatch so no lock is held across the up-to-300s run.
-    async with session_scope() as session:
+    # Resolve the folder policy first, then close that read session before API-key
+    # authentication opens its owned write transaction.
+    async with session_scope_readonly() as session:
         auth_type = await folder_auth_type(flow, session)
-        if auth_type == "none":
-            return None  # public agent
-        if auth_type not in ("apikey", "oauth"):
-            # Protected folder with a scheme A2A can't enforce: fail closed, never public.
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"A2A access is disabled for this agent: unsupported folder auth type {auth_type!r}.",
-            )
-        api_key = request.headers.get(A2A_APIKEY_HEADER)
-        if not api_key:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key required")
-        api_key_result = await authenticate_api_key(session, api_key)
-        # Same message for invalid and wrong-owner: don't reveal a key is valid for another user.
-        if api_key_result is None or api_key_result.user.id != flow.user_id:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-        user = api_key_result.user
-        set_current_auth_context(AuthCredentialContext.from_api_key_result(api_key_result))
-        try:
-            await ensure_flow_permission(
-                user,
-                FlowAction.EXECUTE,
-                flow_id=flow.id,
-                flow_user_id=flow.user_id,
-                folder_id=flow.folder_id,
-            )
-        except HTTPException as exc:
-            raise deny_to_404(exc, detail="Not Found") from exc
-        return user
+    if auth_type == "none":
+        return None  # public agent
+    if auth_type not in ("apikey", "oauth"):
+        # Protected folder with a scheme A2A can't enforce: fail closed, never public.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"A2A access is disabled for this agent: unsupported folder auth type {auth_type!r}.",
+        )
+    api_key = request.headers.get(A2A_APIKEY_HEADER)
+    if not api_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key required")
+    api_key_result = await authenticate_api_key(api_key)
+    # Same message for invalid and wrong-owner: don't reveal a key is valid for another user.
+    if api_key_result is None or api_key_result.user.id != flow.user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+    user = api_key_result.user
+    set_current_auth_context(AuthCredentialContext.from_api_key_result(api_key_result))
+    try:
+        await ensure_flow_permission(
+            user,
+            FlowAction.EXECUTE,
+            flow_id=flow.id,
+            flow_user_id=flow.user_id,
+            folder_id=flow.folder_id,
+        )
+    except HTTPException as exc:
+        raise deny_to_404(exc, detail="Not Found") from exc
+    return user
 
 
 class _FlowContextBuilder(DefaultServerCallContextBuilder):

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -34,7 +34,6 @@ from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.api.utils import (
     CurrentActiveMCPUser,
@@ -91,7 +90,6 @@ router = APIRouter(prefix="/mcp/project", tags=["mcp_projects"])
 
 
 async def verify_project_auth(
-    db: AsyncSession,
     project_id: UUID,
     query_param: str | None,
     header_param: str | None,
@@ -110,15 +108,14 @@ async def verify_project_auth(
 
     settings_service = get_settings_service()
 
-    project = (await db.exec(select(Folder).where(Folder.id == project_id))).first()
-
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    auth_settings: AuthSettings | None = None
-    # Check if this project requires API key only authentication
-    if project.auth_settings:
-        auth_settings = AuthSettings(**project.auth_settings)
+    # Resolve project authentication policy before API-key authentication opens
+    # its owned transaction. Keep only scalar values after this scope exits.
+    async with session_scope() as db:
+        project = (await db.exec(select(Folder).where(Folder.id == project_id))).first()
+        if not project:
+            raise HTTPException(status_code=404, detail="Project not found")
+        project_user_id = project.user_id
+        auth_settings = AuthSettings(**project.auth_settings) if project.auth_settings else None
 
     project_auth_type = auth_settings.auth_type if auth_settings else None
     if project_auth_type == "oauth" and composer_backend_token:
@@ -126,10 +123,11 @@ async def verify_project_auth(
             MCPComposerService, get_service(ServiceType.MCP_COMPOSER_SERVICE)
         )
         if mcp_composer_service.validate_backend_auth_token(str(project_id), composer_backend_token):
-            if project.user_id:
-                project_user = await db.get(User, project.user_id)
-                if project_user:
-                    return project_user
+            if project_user_id:
+                async with session_scope() as db:
+                    project_user = await db.get(User, project_user_id)
+                    if project_user:
+                        return project_user
             raise HTTPException(status_code=404, detail="Project owner not found")
 
     # OAuth projects must present a valid API key at the Langflow transport endpoint: network-level
@@ -159,33 +157,30 @@ async def verify_project_auth(
             )
 
         # Validate the API key
-        api_key_result = await authenticate_api_key(db, api_key)
+        api_key_result = await authenticate_api_key(api_key)
         if not api_key_result:
             raise HTTPException(status_code=401, detail="Invalid API key")
         set_current_auth_context(AuthCredentialContext.from_api_key_result(api_key_result))
         user = api_key_result.user
 
         # Verify user has access to the project
-        project_access = (
-            await db.exec(select(Folder).where(Folder.id == project_id, Folder.user_id == user.id))
-        ).first()
-
-        if not project_access:
+        if project_user_id != user.id:
             raise HTTPException(status_code=404, detail="Project not found")
 
         return user
 
-    return await _superuser_fallback(db, settings_service)
+    return await _superuser_fallback(settings_service)
 
 
-async def _superuser_fallback(db: AsyncSession, settings_service) -> User:
+async def _superuser_fallback(settings_service) -> User:
     """Resolve the configured superuser for unauthenticated MCP paths that allow fallback."""
     if not settings_service.auth_settings.SUPERUSER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Missing superuser username in auth settings",
         )
-    result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+    async with session_scope() as db:
+        result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
     if result:
         logger.warning(AUTO_LOGIN_WARNING)
         set_current_auth_context(AuthCredentialContext(method=AUTH_METHOD_AUTO_LOGIN))
@@ -206,51 +201,47 @@ async def verify_project_auth_conditional(
     - MCP Composer enabled + API key auth: Only allow API keys
     - All other cases: Use standard MCP auth (JWT + API keys)
     """
-    async with session_scope() as session:
-        # Get project to check auth settings
-        project = (await session.exec(select(Folder).where(Folder.id == project_id))).first()
+    # Extract token
+    token: str | None = None
+    auth_header = request.headers.get("authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header[7:]
 
+    # Extract API keys
+    api_key_query_value = request.query_params.get("x-api-key")
+    api_key_header_value = request.headers.get("x-api-key")
+    composer_backend_token = request.headers.get(COMPOSER_BACKEND_AUTH_HEADER)
+
+    # The composer path performs its own short project-policy read before auth.
+    if get_settings_service().settings.mcp_composer_enabled:
+        return await verify_project_auth(
+            project_id,
+            api_key_query_value,
+            api_key_header_value,
+            composer_backend_token,
+        )
+
+    # Preserve the existing not-found-before-auth behavior, but close this read
+    # scope before API-key authentication opens its owned transaction.
+    async with session_scope() as session:
+        project = (await session.exec(select(Folder).where(Folder.id == project_id))).first()
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
+        project_user_id = project.user_id
 
-        # Extract token
-        token: str | None = None
-        auth_header = request.headers.get("authorization")
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header[7:]
+    # For all other cases, use standard MCP authentication (allows JWT + API keys).
+    # This session has not executed a query before API-key authentication.
+    from langflow.services.auth.utils import get_current_user_mcp
 
-        # Extract API keys
-        api_key_query_value = request.query_params.get("x-api-key")
-        api_key_header_value = request.headers.get("x-api-key")
-        composer_backend_token = request.headers.get(COMPOSER_BACKEND_AUTH_HEADER)
-
-        # Check if this project requires API key only authentication
-        if get_settings_service().settings.mcp_composer_enabled:
-            return await verify_project_auth(
-                session,
-                project_id,
-                api_key_query_value,
-                api_key_header_value,
-                composer_backend_token,
-            )
-
-        # For all other cases, use standard MCP authentication (allows JWT + API keys)
-        # Call the MCP auth function directly
-        from langflow.services.auth.utils import get_current_user_mcp
-
+    async with session_scope() as session:
         user = await get_current_user_mcp(
             token=token or "", query_param=api_key_query_value, header_param=api_key_header_value, db=session
         )
 
-        # Verify project access
-        project_access = (
-            await session.exec(select(Folder).where(Folder.id == project_id, Folder.user_id == user.id))
-        ).first()
+    if project_user_id != user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
 
-        if not project_access:
-            raise HTTPException(status_code=404, detail="Project not found")
-
-        return user
+    return user
 
 
 # Create project-specific context variable

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -183,10 +183,23 @@ class AuthService(BaseAuthService):
                 # Token auth failed for an unexpected reason; try the distinct
                 # external credential first, then fall back to API key if provided.
                 if external_token and external_token != token:
+                    # Token authentication can delegate to external JIT
+                    # provisioning, which may flush user/profile state before a
+                    # later step fails. Give the distinct external credential a
+                    # clean transaction and authentication context.
+                    await db.rollback()
+                    clear_current_auth_context()
+                    clear_current_external_access_context()
                     external_user = await self._authenticate_with_external_token(external_token, db)
                     if external_user is not None:
                         return external_user
                 if api_key:
+                    # API-key authentication commits its usage bookkeeping. Roll
+                    # back both prior credential attempts immediately before it so
+                    # that commit cannot persist state they left in the session.
+                    await db.rollback()
+                    clear_current_auth_context()
+                    clear_current_external_access_context()
                     try:
                         user = await self._authenticate_with_api_key(api_key, db)
                         if user:

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -201,7 +201,7 @@ class AuthService(BaseAuthService):
                     clear_current_auth_context()
                     clear_current_external_access_context()
                     try:
-                        user = await self._authenticate_with_api_key(api_key, db)
+                        user = await self._authenticate_with_api_key(api_key)
                         if user:
                             return user
                         msg = "Invalid API key"
@@ -225,8 +225,14 @@ class AuthService(BaseAuthService):
 
         # Try API key authentication
         if api_key:
+            if external_token:
+                # The owned API-key transaction must not coexist with state or
+                # a checked-out connection left by the failed external attempt.
+                await db.rollback()
+                clear_current_auth_context()
+                clear_current_external_access_context()
             try:
-                user = await self._authenticate_with_api_key(api_key, db)
+                user = await self._authenticate_with_api_key(api_key)
                 if user:
                     return user
                 msg = "Invalid API key"
@@ -542,7 +548,7 @@ class AuthService(BaseAuthService):
             changed=changed,
         )
 
-    async def _authenticate_with_api_key(self, api_key: str, db: AsyncSession) -> UserRead | None:
+    async def _authenticate_with_api_key(self, api_key: str) -> UserRead | None:
         """Internal method to authenticate with API key (raises generic exceptions).
 
         The EXTERNAL_AUTH access ceiling block for externally-managed users is
@@ -550,7 +556,7 @@ class AuthService(BaseAuthService):
         returns ``None`` for a blocked user so every caller treats it as an auth
         failure. No additional ceiling check is needed here.
         """
-        result = await authenticate_api_key(db, api_key)
+        result = await authenticate_api_key(api_key)
         if not result:
             return None
 
@@ -695,20 +701,13 @@ class AuthService(BaseAuthService):
     async def api_key_security(
         self, query_param: str | None, header_param: str | None, db: AsyncSession | None = None
     ) -> UserRead | None:
-        settings_service = self.settings
-
-        # Use provided session or create a new one
-        if db is not None:
-            return await self._api_key_security_impl(query_param, header_param, db, settings_service)
-
-        async with session_scope() as new_db:
-            return await self._api_key_security_impl(query_param, header_param, new_db, settings_service)
+        return await self._api_key_security_impl(query_param, header_param, db, self.settings)
 
     async def _api_key_security_impl(
         self,
         query_param: str | None,
         header_param: str | None,
-        db: AsyncSession,
+        db: AsyncSession | None,
         settings_service,
     ) -> UserRead | None:
         clear_current_auth_context()
@@ -722,7 +721,11 @@ class AuthService(BaseAuthService):
                 )
             if not query_param and not header_param:
                 if settings_service.auth_settings.skip_auth_auto_login:
-                    result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+                    if db is not None:
+                        result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+                    else:
+                        async with session_scope() as auto_login_db:
+                            result = await get_user_by_username(auto_login_db, settings_service.auth_settings.SUPERUSER)
                     if result is None:
                         raise HTTPException(
                             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -744,7 +747,7 @@ class AuthService(BaseAuthService):
             api_key = query_param or header_param
             if api_key is None:  # pragma: no cover - guaranteed by the if-condition above
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid or missing API key")
-            api_key_result = await authenticate_api_key(db, api_key)
+            api_key_result = await authenticate_api_key(api_key)
 
         elif not query_param and not header_param:
             raise HTTPException(
@@ -757,7 +760,7 @@ class AuthService(BaseAuthService):
             api_key = query_param or header_param
             if api_key is None:  # pragma: no cover - guaranteed by the elif-condition above
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid or missing API key")
-            api_key_result = await authenticate_api_key(db, api_key)
+            api_key_result = await authenticate_api_key(api_key)
 
         if not api_key_result:
             raise HTTPException(
@@ -776,57 +779,57 @@ class AuthService(BaseAuthService):
         settings = self.settings
         clear_current_auth_context()
         clear_current_external_access_context()
-        async with session_scope() as db:
-            api_key_result = None
-            if settings.auth_settings.AUTO_LOGIN:
-                if not settings.auth_settings.SUPERUSER:
-                    raise WebSocketException(
-                        code=status.WS_1011_INTERNAL_ERROR,
-                        reason="Missing first superuser credentials",
-                    )
-                if not api_key:
-                    if settings.auth_settings.skip_auth_auto_login:
+        api_key_result = None
+        if settings.auth_settings.AUTO_LOGIN:
+            if not settings.auth_settings.SUPERUSER:
+                raise WebSocketException(
+                    code=status.WS_1011_INTERNAL_ERROR,
+                    reason="Missing first superuser credentials",
+                )
+            if not api_key:
+                if settings.auth_settings.skip_auth_auto_login:
+                    async with session_scope() as db:
                         result = await get_user_by_username(db, settings.auth_settings.SUPERUSER)
-                        if result is None:
-                            raise WebSocketException(
-                                code=status.WS_1011_INTERNAL_ERROR,
-                                reason="Superuser not found",
-                            )
-                        if not result.is_active:
-                            raise WebSocketException(
-                                code=status.WS_1008_POLICY_VIOLATION,
-                                reason="User account is inactive",
-                            )
-                        logger.warning(AUTO_LOGIN_WARNING)
-                        set_current_auth_context(AuthCredentialContext(method=AUTH_METHOD_AUTO_LOGIN))
-                    else:
+                    if result is None:
+                        raise WebSocketException(
+                            code=status.WS_1011_INTERNAL_ERROR,
+                            reason="Superuser not found",
+                        )
+                    if not result.is_active:
                         raise WebSocketException(
                             code=status.WS_1008_POLICY_VIOLATION,
-                            reason=AUTO_LOGIN_ERROR,
+                            reason="User account is inactive",
                         )
+                    logger.warning(AUTO_LOGIN_WARNING)
+                    set_current_auth_context(AuthCredentialContext(method=AUTH_METHOD_AUTO_LOGIN))
                 else:
-                    api_key_result = await authenticate_api_key(db, api_key)
-                    result = api_key_result.user if api_key_result is not None else None
-
-            else:
-                if not api_key:
                     raise WebSocketException(
                         code=status.WS_1008_POLICY_VIOLATION,
-                        reason="An API key must be passed as query or header",
+                        reason=AUTO_LOGIN_ERROR,
                     )
-                api_key_result = await authenticate_api_key(db, api_key)
+            else:
+                api_key_result = await authenticate_api_key(api_key)
                 result = api_key_result.user if api_key_result is not None else None
 
-            if not result:
+        else:
+            if not api_key:
                 raise WebSocketException(
                     code=status.WS_1008_POLICY_VIOLATION,
-                    reason="Invalid or missing API key",
+                    reason="An API key must be passed as query or header",
                 )
+            api_key_result = await authenticate_api_key(api_key)
+            result = api_key_result.user if api_key_result is not None else None
 
-            if isinstance(result, User):
-                if api_key_result is not None:
-                    set_current_auth_context(AuthCredentialContext.from_api_key_result(api_key_result))
-                return UserRead.model_validate(result, from_attributes=True)
+        if not result:
+            raise WebSocketException(
+                code=status.WS_1008_POLICY_VIOLATION,
+                reason="Invalid or missing API key",
+            )
+
+        if isinstance(result, User):
+            if api_key_result is not None:
+                set_current_auth_context(AuthCredentialContext.from_api_key_result(api_key_result))
+            return UserRead.model_validate(result, from_attributes=True)
 
         raise WebSocketException(
             code=status.WS_1011_INTERNAL_ERROR,
@@ -970,15 +973,14 @@ class AuthService(BaseAuthService):
         api_key = api_key_header_val or api_key_query_val
 
         try:
-            async with session_scope() as db:
-                result = await authenticate_api_key(db, api_key)
-                if not result:
-                    logger.warning("Invalid API key provided for webhook")
-                    raise HTTPException(status_code=403, detail="Invalid API key")
+            result = await authenticate_api_key(api_key)
+            if not result:
+                logger.warning("Invalid API key provided for webhook")
+                raise HTTPException(status_code=403, detail="Invalid API key")
 
-                set_current_auth_context(AuthCredentialContext.from_api_key_result(result))
-                authenticated_user = UserRead.model_validate(result.user, from_attributes=True)
-                logger.info("Webhook API key validated successfully")
+            set_current_auth_context(AuthCredentialContext.from_api_key_result(result))
+            authenticated_user = UserRead.model_validate(result.user, from_attributes=True)
+            logger.info("Webhook API key validated successfully")
         except HTTPException:
             raise
         except Exception as exc:
@@ -1328,7 +1330,7 @@ class AuthService(BaseAuthService):
                 api_key = query_param or header_param
                 if api_key is None:  # pragma: no cover - guaranteed by the if-condition above
                     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid or missing API key")
-                api_key_result = await authenticate_api_key(db, api_key)
+                api_key_result = await authenticate_api_key(api_key)
                 result = api_key_result.user if api_key_result is not None else None
 
         elif not query_param and not header_param:
@@ -1338,14 +1340,14 @@ class AuthService(BaseAuthService):
             )
 
         elif query_param:
-            api_key_result = await authenticate_api_key(db, query_param)
+            api_key_result = await authenticate_api_key(query_param)
             result = api_key_result.user if api_key_result is not None else None
 
         else:
             # header_param must be truthy here (query_param is falsy, and we passed the not-both-None check)
             if header_param is None:  # pragma: no cover - guaranteed by the elif chain above
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid or missing API key")
-            api_key_result = await authenticate_api_key(db, header_param)
+            api_key_result = await authenticate_api_key(header_param)
             result = api_key_result.user if api_key_result is not None else None
 
         if not result:

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -3,21 +3,21 @@ import datetime
 import hashlib
 import os
 import secrets
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from cryptography.fernet import InvalidToken
 from lfx.log.logger import logger
-from sqlalchemy.ext.asyncio import AsyncConnection
-from sqlalchemy.pool import StaticPool
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.auth import utils as auth_utils
 from langflow.services.database.models.api_key.model import ApiKey, ApiKeyCreate, ApiKeyRead, UnmaskedApiKeyRead
 from langflow.services.database.models.user.model import User
-from langflow.services.deps import get_settings_service
+from langflow.services.deps import get_settings_service, session_scope
 
 if TYPE_CHECKING:
     from sqlmodel.sql.expression import SelectOfScalar
@@ -30,6 +30,9 @@ class ApiKeyAuthResult:
     user: User
     api_key_source: str
     api_key_id: UUID | None = None
+
+
+SessionScopeFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
 
 
 def hash_api_key(api_key: str) -> str:
@@ -127,7 +130,7 @@ async def delete_api_key(session: AsyncSession, api_key_id: UUID, user_id: UUID)
     await session.delete(api_key)
 
 
-async def check_key(session: AsyncSession, api_key: str) -> User | None:
+async def check_key(api_key: str) -> User | None:
     """Check if the API key is valid.
 
     Validates API keys based on the LANGFLOW_API_KEY_SOURCE setting:
@@ -135,21 +138,36 @@ async def check_key(session: AsyncSession, api_key: str) -> User | None:
     - 'env': Validates against the LANGFLOW_API_KEY environment variable,
              falls back to database if env validation fails
     """
-    settings_service = get_settings_service()
-    api_key_source = settings_service.auth_settings.API_KEY_SOURCE
-
-    if api_key_source == "env":
-        user = await _check_key_from_env(session, api_key, settings_service)
-        if user is not None:
-            return user
-        # Fallback to database if env validation fails
-    result = await _check_key_from_db_in_isolated_session(session, api_key, settings_service)
+    result = await authenticate_api_key(api_key)
     return result.user if result is not None else None
 
 
-async def authenticate_api_key(session: AsyncSession, api_key: str) -> ApiKeyAuthResult | None:
-    """Validate an API key and return the user plus non-secret key metadata."""
+async def authenticate_api_key(api_key: str) -> ApiKeyAuthResult | None:
+    """Validate an API key in an owned transaction and return non-secret metadata."""
+    return await _authenticate_api_key_in_owned_scope(api_key, session_scope)
+
+
+async def _authenticate_api_key_in_owned_scope(
+    api_key: str,
+    scope_factory: SessionScopeFactory,
+) -> ApiKeyAuthResult | None:
+    """Authenticate and durably persist bookkeeping in a top-level transaction."""
     settings_service = get_settings_service()
+    async with scope_factory() as auth_session:
+        result = await _authenticate_api_key_with_session(auth_session, api_key, settings_service)
+        if result is not None and result.user in auth_session:
+            # Keep scalar user fields available after the owned scope commits and
+            # closes, independent of the session maker's expire_on_commit value.
+            auth_session.expunge(result.user)
+        return result
+
+
+async def _authenticate_api_key_with_session(
+    session: AsyncSession,
+    api_key: str,
+    settings_service,
+) -> ApiKeyAuthResult | None:
+    """Transaction-local API-key authentication implementation."""
     api_key_source = settings_service.auth_settings.API_KEY_SOURCE
 
     if api_key_source == "env":
@@ -157,41 +175,7 @@ async def authenticate_api_key(session: AsyncSession, api_key: str) -> ApiKeyAut
         if user is not None:
             return ApiKeyAuthResult(user=user, api_key_source="env")
         # Fallback to database if env validation fails
-    return await _check_key_from_db_in_isolated_session(session, api_key, settings_service)
-
-
-async def _check_key_from_db_in_isolated_session(
-    caller_session: AsyncSession,
-    api_key: str,
-    settings_service,
-) -> ApiKeyAuthResult | None:
-    """Authenticate a database API key without committing the caller's session."""
-    bind = caller_session.bind
-    if bind is None:
-        msg = "API key authentication requires a bound database session"
-        raise RuntimeError(msg)
-
-    if isinstance(bind, AsyncConnection) or isinstance(bind.sync_engine.pool, StaticPool):
-        # A single physical connection cannot provide an independent transaction.
-        # Keep bookkeeping in the caller's transaction, but never commit it here.
-        return await _check_key_from_db_with_context(caller_session, api_key, settings_service)
-
-    async with AsyncSession(bind=bind, expire_on_commit=False) as auth_session:
-        result = await _check_key_from_db_with_context(auth_session, api_key, settings_service)
-        if result is None:
-            return None
-        user_id = result.user.id
-        api_key_source = result.api_key_source
-        api_key_id = result.api_key_id
-        await auth_session.commit()
-
-    # Preserve the existing contract that the returned User belongs to the
-    # caller's session without flushing or committing any caller-owned state.
-    with caller_session.no_autoflush:
-        user = await caller_session.get(User, user_id)
-    if user is None:
-        return None
-    return ApiKeyAuthResult(user=user, api_key_source=api_key_source, api_key_id=api_key_id)
+    return await _check_key_from_db_with_context(session, api_key, settings_service)
 
 
 async def _external_access_ceiling_blocks_user(session: AsyncSession, user: User, settings_service) -> bool:
@@ -253,7 +237,7 @@ async def _check_key_from_db_with_context(
         # authentication (missing user or blocked external user) does not bump
         # total_uses / last_used_at.
         user = await session.get(User, api_key_obj.user_id)
-        if user is None:
+        if user is None or not user.is_active:
             return None
         if await _external_access_ceiling_blocks_user(session, user, settings_service):
             logger.info("API key rejected for externally managed user while external access ceiling is enabled")
@@ -298,7 +282,7 @@ async def _check_key_from_db_with_context(
             # backfill so a denied authentication (missing user or blocked
             # external user) does not bump total_uses / last_used_at.
             user = await session.get(User, api_key_obj.user_id)
-            if user is None:
+            if user is None or not user.is_active:
                 return None
             if await _external_access_ceiling_blocks_user(session, user, settings_service):
                 logger.info("API key rejected for externally managed user while external access ceiling is enabled")

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -225,7 +225,9 @@ async def _check_key_from_db_with_context(
             api_key_obj.total_uses += 1
             api_key_obj.last_used_at = datetime.datetime.now(datetime.timezone.utc)
             session.add(api_key_obj)
-            await session.flush()
+            # API-key auth owns this mutation; finish it before a downstream handler
+            # opens a separate SQLite write transaction in the same request.
+            await session.commit()
         return ApiKeyAuthResult(user=user, api_key_source="db", api_key_id=api_key_obj.id)  # pragma: allowlist secret
 
     if len(matches) > 1:
@@ -272,7 +274,9 @@ async def _check_key_from_db_with_context(
                 api_key_obj.total_uses += 1
                 api_key_obj.last_used_at = datetime.datetime.now(datetime.timezone.utc)
             session.add(api_key_obj)
-            await session.flush()
+            # The auth-owned hash backfill must release SQLite's write lock even
+            # when usage tracking itself is disabled.
+            await session.commit()
             return ApiKeyAuthResult(
                 user=user,
                 api_key_source="db",  # pragma: allowlist secret

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from cryptography.fernet import InvalidToken
 from lfx.log.logger import logger
+from sqlalchemy.ext.asyncio import AsyncConnection
+from sqlalchemy.pool import StaticPool
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -141,7 +143,8 @@ async def check_key(session: AsyncSession, api_key: str) -> User | None:
         if user is not None:
             return user
         # Fallback to database if env validation fails
-    return await _check_key_from_db(session, api_key, settings_service)
+    result = await _check_key_from_db_in_isolated_session(session, api_key, settings_service)
+    return result.user if result is not None else None
 
 
 async def authenticate_api_key(session: AsyncSession, api_key: str) -> ApiKeyAuthResult | None:
@@ -154,7 +157,41 @@ async def authenticate_api_key(session: AsyncSession, api_key: str) -> ApiKeyAut
         if user is not None:
             return ApiKeyAuthResult(user=user, api_key_source="env")
         # Fallback to database if env validation fails
-    return await _check_key_from_db_with_context(session, api_key, settings_service)
+    return await _check_key_from_db_in_isolated_session(session, api_key, settings_service)
+
+
+async def _check_key_from_db_in_isolated_session(
+    caller_session: AsyncSession,
+    api_key: str,
+    settings_service,
+) -> ApiKeyAuthResult | None:
+    """Authenticate a database API key without committing the caller's session."""
+    bind = caller_session.bind
+    if bind is None:
+        msg = "API key authentication requires a bound database session"
+        raise RuntimeError(msg)
+
+    if isinstance(bind, AsyncConnection) or isinstance(bind.sync_engine.pool, StaticPool):
+        # A single physical connection cannot provide an independent transaction.
+        # Keep bookkeeping in the caller's transaction, but never commit it here.
+        return await _check_key_from_db_with_context(caller_session, api_key, settings_service)
+
+    async with AsyncSession(bind=bind, expire_on_commit=False) as auth_session:
+        result = await _check_key_from_db_with_context(auth_session, api_key, settings_service)
+        if result is None:
+            return None
+        user_id = result.user.id
+        api_key_source = result.api_key_source
+        api_key_id = result.api_key_id
+        await auth_session.commit()
+
+    # Preserve the existing contract that the returned User belongs to the
+    # caller's session without flushing or committing any caller-owned state.
+    with caller_session.no_autoflush:
+        user = await caller_session.get(User, user_id)
+    if user is None:
+        return None
+    return ApiKeyAuthResult(user=user, api_key_source=api_key_source, api_key_id=api_key_id)
 
 
 async def _external_access_ceiling_blocks_user(session: AsyncSession, user: User, settings_service) -> bool:
@@ -225,9 +262,7 @@ async def _check_key_from_db_with_context(
             api_key_obj.total_uses += 1
             api_key_obj.last_used_at = datetime.datetime.now(datetime.timezone.utc)
             session.add(api_key_obj)
-            # API-key auth owns this mutation; finish it before a downstream handler
-            # opens a separate SQLite write transaction in the same request.
-            await session.commit()
+            await session.flush()
         return ApiKeyAuthResult(user=user, api_key_source="db", api_key_id=api_key_obj.id)  # pragma: allowlist secret
 
     if len(matches) > 1:
@@ -274,9 +309,7 @@ async def _check_key_from_db_with_context(
                 api_key_obj.total_uses += 1
                 api_key_obj.last_used_at = datetime.datetime.now(datetime.timezone.utc)
             session.add(api_key_obj)
-            # The auth-owned hash backfill must release SQLite's write lock even
-            # when usage tracking itself is disabled.
-            await session.commit()
+            await session.flush()
             return ApiKeyAuthResult(
                 user=user,
                 api_key_source="db",  # pragma: allowlist secret

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -265,7 +265,7 @@ async def test_x_api_key_puts_complete_and_persist_on_file_backed_sqlite(client,
             json={"blocked": [component_key]},
         )
     assert components.status_code == 200
-    assert components.json() == {"blocked": [component_key]}
+    assert components.json() == {"blocked": [component_key], "managed_externally": False}
 
     with anyio.fail_after(10):
         templates = await client.put(
@@ -274,7 +274,7 @@ async def test_x_api_key_puts_complete_and_persist_on_file_backed_sqlite(client,
             json={"blocked": [template_key]},
         )
     assert templates.status_code == 200
-    assert templates.json() == {"blocked": [template_key]}
+    assert templates.json() == {"blocked": [template_key], "managed_externally": False}
 
     async with session_scope_readonly() as session:
         rows = (

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
+import anyio
 import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 from langflow.api.v1 import catalog_policy
 from langflow.services.auth.utils import get_current_active_superuser
+from langflow.services.database.models.api_key.model import ApiKey
+from langflow.services.database.models.catalog_policy import CatalogPolicyRule
 from lfx.services.catalog_policy import CatalogPolicySnapshot, CatalogPolicyUpdate
+from lfx.services.deps import session_scope_readonly
+from sqlmodel import select
 
 
 class _StubCatalogPolicy:
@@ -181,3 +186,57 @@ def test_put_requires_explicit_whole_set_without_writing_or_auditing(monkeypatch
     assert response.status_code == 422
     assert service.component_calls == []
     audit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_x_api_key_puts_complete_and_persist_on_file_backed_sqlite(client, logged_in_headers_super_user):
+    """API-key usage writes must not lock the policy service's separate SQLite transaction."""
+    component_key = f"LE2097Component-{uuid4().hex}"
+    template_key = f"LE2097Template-{uuid4().hex}"
+    create_key = await client.post(
+        "/api/v1/api_key/",
+        headers=logged_in_headers_super_user,
+        json={"name": "le-2097-sqlite-lock-regression"},
+    )
+    assert create_key.status_code == 200
+    created_key = create_key.json()
+    plaintext = created_key["api_key"]
+    api_key_id = UUID(created_key["id"])
+
+    # The login fixture sets an access-token cookie. Remove it so the policy
+    # requests authenticate exclusively through the API-key path under test.
+    client.cookies.clear()
+
+    with anyio.fail_after(10):
+        components = await client.put(
+            "/api/v1/catalog-policy/components",
+            headers={"x-api-key": plaintext},
+            json={"blocked": [component_key]},
+        )
+    assert components.status_code == 200
+    assert components.json() == {"blocked": [component_key]}
+
+    with anyio.fail_after(10):
+        templates = await client.put(
+            "/api/v1/catalog-policy/templates",
+            headers={"x-api-key": plaintext},
+            json={"blocked": [template_key]},
+        )
+    assert templates.status_code == 200
+    assert templates.json() == {"blocked": [template_key]}
+
+    async with session_scope_readonly() as session:
+        rows = (
+            await session.exec(
+                select(CatalogPolicyRule).where(CatalogPolicyRule.resource_key.in_([component_key, template_key]))
+            )
+        ).all()
+        persisted_key = await session.get(ApiKey, api_key_id)
+
+    assert {(row.resource_kind, row.resource_key) for row in rows} == {
+        ("component", component_key),
+        ("template", template_key),
+    }
+    assert persisted_key is not None
+    assert persisted_key.total_uses == 2
+    assert persisted_key.last_used_at is not None

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -291,6 +291,8 @@ async def test_x_api_key_puts_complete_and_persist_on_file_backed_sqlite(client,
     assert persisted_key is not None
     assert persisted_key.total_uses == 2
     assert persisted_key.last_used_at is not None
+
+
 @pytest.mark.parametrize("resource_kind", ["components", "templates"])
 def test_external_policy_rejects_valid_puts_without_writing_or_auditing(monkeypatch, resource_kind):
     client, service, _admin, audit = _client(monkeypatch, service=_ExternalCatalogPolicy())

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -14,8 +14,12 @@ from fastapi import HTTPException, WebSocketException, status
 from langflow.services.auth.constants import AUTO_LOGIN_WARNING
 from langflow.services.auth.context import (
     AUTH_METHOD_API_KEY,
+    AUTH_METHOD_EXTERNAL,
+    AUTH_METHOD_JWT,
+    AuthCredentialContext,
     clear_current_auth_context,
     get_current_auth_context,
+    set_current_auth_context,
 )
 from langflow.services.auth.exceptions import (
     InactiveUserError,
@@ -24,7 +28,8 @@ from langflow.services.auth.exceptions import (
     TokenExpiredError,
 )
 from langflow.services.auth.service import AuthService
-from langflow.services.database.models.api_key.crud import ApiKeyAuthResult
+from langflow.services.database.models.api_key.crud import ApiKeyAuthResult, hash_api_key
+from langflow.services.database.models.api_key.model import ApiKey
 from langflow.services.database.models.user.model import User
 from lfx.services.settings.auth import AuthSettings
 from lfx.services.settings.constants import DEFAULT_SUPERUSER, LEGACY_DEFAULT_SUPERUSER_PASSWORD
@@ -157,6 +162,75 @@ async def test_authenticate_with_api_key_sets_auth_context(auth_service: AuthSer
     assert context.method == AUTH_METHOD_API_KEY
     assert context.api_key_id == api_key_id
     assert context.api_key_source == "db"  # pragma: allowlist secret
+
+
+@pytest.mark.anyio
+async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
+    auth_service: AuthService,
+    async_session,
+    monkeypatch,
+):
+    """The API-key usage commit must not persist state flushed by failed token auth."""
+    from sqlmodel import select
+
+    api_user = _dummy_user(uuid4())
+    api_user.username = "api-key-user"
+    plaintext = "sk-valid-fallback-key"  # pragma: allowlist secret
+    api_key = ApiKey(
+        api_key="encrypted-value",  # pragma: allowlist secret
+        api_key_hash=hash_api_key(plaintext),
+        name="fallback",
+        user_id=api_user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    async_session.add(api_user)
+    async_session.add(api_key)
+    await async_session.commit()
+
+    auth_service.settings.settings.disable_track_apikey_usage = False
+    monkeypatch.setattr(
+        "langflow.services.database.models.api_key.crud.get_settings_service",
+        lambda: auth_service.settings,
+    )
+
+    failed_token_user = _dummy_user(uuid4())
+    failed_token_user.username = "failed-token-user"
+    failed_external_user = _dummy_user(uuid4())
+    failed_external_user.username = "failed-external-user"
+
+    async def stage_user_then_fail(_token: str, db) -> None:
+        db.add(failed_token_user)
+        await db.flush()
+        msg = "external reconciliation failed"
+        raise RuntimeError(msg)
+
+    async def stage_user_then_decline(_token: str, db) -> None:
+        db.add(failed_external_user)
+        await db.flush()
+
+    with (
+        patch.object(auth_service, "_authenticate_with_token", new=stage_user_then_fail),
+        patch.object(auth_service, "_authenticate_with_external_token", new=stage_user_then_decline),
+    ):
+        result = await auth_service.authenticate_with_credentials(
+            token="native-token",  # noqa: S106
+            api_key=plaintext,
+            db=async_session,
+            external_token="external-token",  # noqa: S106
+        )
+
+    persisted_failed_token_user = (
+        await async_session.exec(select(User).where(User.id == failed_token_user.id))
+    ).first()
+    persisted_failed_external_user = (
+        await async_session.exec(select(User).where(User.id == failed_external_user.id))
+    ).first()
+    await async_session.refresh(api_key)
+
+    assert result.id == api_user.id
+    assert persisted_failed_token_user is None
+    assert persisted_failed_external_user is None
+    assert api_key.total_uses == 1
 
 
 @pytest.mark.anyio
@@ -1396,6 +1470,93 @@ async def test_invalid_native_token_falls_back_to_external_credential(
         clear_current_auth_context()
 
     assert result.id == user.id
+
+
+@pytest.mark.anyio
+async def test_external_fallback_rolls_back_and_replaces_failed_native_state(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+    async_session,
+):
+    """A successful distinct external fallback starts after a clean native-auth boundary."""
+    from langflow.services.auth.external import (
+        ExternalAccessContext,
+        get_current_external_access_context,
+        identity_from_claims,
+        set_current_external_access_context,
+    )
+    from sqlmodel import select
+
+    auth_settings.EXTERNAL_AUTH_ENABLED = True
+    auth_settings.EXTERNAL_AUTH_TRUSTED_JWT_DECODE = True
+    auth_settings.EXTERNAL_AUTH_PROVIDER = "external"
+    auth_settings.EXTERNAL_AUTH_ACCESS_CEILING_ENABLED = True
+    auth_settings.EXTERNAL_AUTH_ACCESS_CLAIM = "access"
+
+    external_claims = {
+        "sub": "external-boundary-subject",
+        "preferred_username": "external-boundary-user",
+        "access": "editor",
+    }
+    identity = identity_from_claims(external_claims, auth_settings)
+    external_user = await auth_service._materialize_external_user(identity, async_session)
+    await async_session.commit()
+
+    failed_native_user = _dummy_user(uuid4())
+    failed_native_user.username = "failed-native-boundary-user"
+
+    async def stage_native_state_then_fail(_token: str, db) -> None:
+        db.add(failed_native_user)
+        await db.flush()
+        set_current_auth_context(AuthCredentialContext(method=AUTH_METHOD_JWT))
+        set_current_external_access_context(
+            ExternalAccessContext(provider="stale-native", subject="stale-subject", level="viewer")
+        )
+        msg = "native authentication failed after staging state"
+        raise RuntimeError(msg)
+
+    real_external_auth = auth_service._authenticate_with_external_token
+
+    async def authenticate_external_from_clean_boundary(token: str, db):
+        assert get_current_auth_context() is None
+        assert get_current_external_access_context() is None
+        return await real_external_auth(token, db)
+
+    external_token = _external_jwt(auth_service, external_claims)
+
+    try:
+        with (
+            patch.object(auth_service, "_authenticate_with_token", new=stage_native_state_then_fail),
+            patch.object(
+                auth_service,
+                "_authenticate_with_external_token",
+                new=authenticate_external_from_clean_boundary,
+            ),
+        ):
+            result = await auth_service.authenticate_with_credentials(
+                token="native-token",  # noqa: S106
+                api_key=None,
+                db=async_session,
+                external_token=external_token,
+            )
+
+        await async_session.commit()
+        persisted_failed_native_user = (
+            await async_session.exec(select(User).where(User.id == failed_native_user.id))
+        ).first()
+        auth_context = get_current_auth_context()
+        external_context = get_current_external_access_context()
+
+        assert result.id == external_user.id
+        assert persisted_failed_native_user is None
+        assert auth_context == AuthCredentialContext(method=AUTH_METHOD_EXTERNAL, external_provider="external")
+        assert external_context is not None
+        assert external_context.provider == "external"
+        assert external_context.subject == "external-boundary-subject"
+        assert external_context.level == "editor"
+    finally:
+        clear_current_auth_context()
+        set_current_external_access_context(None)
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -23,6 +23,7 @@ from langflow.services.auth.context import (
 )
 from langflow.services.auth.exceptions import (
     InactiveUserError,
+    InvalidCredentialsError,
     InvalidTokenError,
     MissingCredentialsError,
     TokenExpiredError,
@@ -34,6 +35,9 @@ from langflow.services.database.models.user.model import User
 from lfx.services.settings.auth import AuthSettings
 from lfx.services.settings.constants import DEFAULT_SUPERUSER, LEGACY_DEFAULT_SUPERUSER_PASSWORD
 from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 @pytest.fixture
@@ -165,12 +169,86 @@ async def test_authenticate_with_api_key_sets_auth_context(auth_service: AuthSer
 
 
 @pytest.mark.anyio
+async def test_inactive_user_api_key_rejection_does_not_persist_usage(
+    auth_service: AuthService,
+    tmp_path,
+    monkeypatch,
+):
+    """A rejected inactive-user credential must not record a successful API-key use."""
+    plaintext = "sk-inactive-user"  # pragma: allowlist secret
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'inactive-user-api-key.db'}")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: SQLModel.metadata.create_all(
+                    sync_connection,
+                    tables=[User.__table__, ApiKey.__table__],
+                )
+            )
+
+        inactive_user = _dummy_user(uuid4(), active=False)
+        inactive_user.username = "inactive-api-key-user"
+        api_key = ApiKey(
+            api_key="encrypted-inactive-user",  # pragma: allowlist secret
+            api_key_hash=hash_api_key(plaintext),
+            name="inactive-user",
+            user_id=inactive_user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        async with AsyncSession(engine, expire_on_commit=False) as seed_session:
+            seed_session.add(inactive_user)
+            seed_session.add(api_key)
+            await seed_session.commit()
+            api_key_id = api_key.id
+
+        auth_service.settings.settings.disable_track_apikey_usage = False
+        monkeypatch.setattr(
+            "langflow.services.database.models.api_key.crud.get_settings_service",
+            lambda: auth_service.settings,
+        )
+
+        @asynccontextmanager
+        async def owned_auth_scope():
+            async with AsyncSession(engine, expire_on_commit=False) as auth_session:
+                try:
+                    yield auth_session
+                    await auth_session.commit()
+                except Exception:
+                    await auth_session.rollback()
+                    raise
+
+        monkeypatch.setattr(
+            "langflow.services.database.models.api_key.crud.session_scope",
+            owned_auth_scope,
+        )
+        async with AsyncSession(engine, expire_on_commit=False) as caller_session:
+            with pytest.raises(InvalidCredentialsError):
+                await auth_service.authenticate_with_credentials(
+                    token=None,
+                    api_key=plaintext,
+                    db=caller_session,
+                )
+            await caller_session.rollback()
+
+        async with AsyncSession(engine, expire_on_commit=False) as verification_session:
+            persisted_api_key = await verification_session.get(ApiKey, api_key_id)
+    finally:
+        await engine.dispose()
+
+    assert persisted_api_key is not None
+    assert persisted_api_key.total_uses == 0
+    assert persisted_api_key.last_used_at is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("token", [None, "native-token"], ids=["external-only", "native-and-external"])
 async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
     auth_service: AuthService,
     async_session,
     monkeypatch,
+    token,
 ):
-    """The API-key usage commit must not persist state flushed by failed token auth."""
+    """API-key fallback discards state flushed by every earlier credential attempt."""
     from sqlmodel import select
 
     api_user = _dummy_user(uuid4())
@@ -194,6 +272,21 @@ async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
         lambda: auth_service.settings,
     )
 
+    @asynccontextmanager
+    async def owned_auth_scope():
+        async with AsyncSession(bind=async_session.bind, expire_on_commit=False) as auth_session:
+            try:
+                yield auth_session
+                await auth_session.commit()
+            except Exception:
+                await auth_session.rollback()
+                raise
+
+    monkeypatch.setattr(
+        "langflow.services.database.models.api_key.crud.session_scope",
+        owned_auth_scope,
+    )
+
     failed_token_user = _dummy_user(uuid4())
     failed_token_user.username = "failed-token-user"
     failed_external_user = _dummy_user(uuid4())
@@ -214,7 +307,7 @@ async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
         patch.object(auth_service, "_authenticate_with_external_token", new=stage_user_then_decline),
     ):
         result = await auth_service.authenticate_with_credentials(
-            token="native-token",  # noqa: S106
+            token=token,
             api_key=plaintext,
             db=async_session,
             external_token="external-token",  # noqa: S106

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -186,6 +186,7 @@ async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
     async_session.add(api_user)
     async_session.add(api_key)
     await async_session.commit()
+    api_user_id = api_user.id
 
     auth_service.settings.settings.disable_track_apikey_usage = False
     monkeypatch.setattr(
@@ -227,7 +228,7 @@ async def test_api_key_fallback_rolls_back_failed_token_and_external_state(
     ).first()
     await async_session.refresh(api_key)
 
-    assert result.id == api_user.id
+    assert result.id == api_user_id
     assert persisted_failed_token_user is None
     assert persisted_failed_external_user is None
     assert api_key.total_uses == 1

--- a/src/backend/tests/unit/services/database/models/api_key/test_crud.py
+++ b/src/backend/tests/unit/services/database/models/api_key/test_crud.py
@@ -6,7 +6,7 @@ import hashlib
 import secrets
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -18,6 +18,9 @@ from langflow.services.database.models.api_key.crud import (
 )
 from langflow.services.database.models.api_key.model import ApiKey, ApiKeyCreate
 from langflow.services.database.models.user.model import User
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 _TEST_PASSWORD = "hashed"  # noqa: S105  # pragma: allowlist secret
 
@@ -113,7 +116,7 @@ async def test_check_key_finds_by_hash(async_session, mock_settings):
         created_at=datetime.now(timezone.utc),
     )
     async_session.add(api_key)
-    await async_session.flush()
+    await async_session.commit()
 
     result = await _check_key_from_db(async_session, plaintext, mock_settings)
     assert result is not None
@@ -136,7 +139,7 @@ async def test_authenticate_api_key_returns_db_key_metadata(async_session, mock_
         created_at=datetime.now(timezone.utc),
     )
     async_session.add(api_key)
-    await async_session.flush()
+    await async_session.commit()
 
     result = await authenticate_api_key(async_session, plaintext)
 
@@ -463,7 +466,7 @@ async def _seed_external_user_with_key(async_session, *, provider: str = "extern
             created_at=datetime.now(timezone.utc),
         )
     )
-    await async_session.flush()
+    await async_session.commit()
     return user, plaintext
 
 
@@ -524,7 +527,7 @@ async def test_authenticate_api_key_allows_non_external_user_when_ceiling_enable
             created_at=datetime.now(timezone.utc),
         )
     )
-    await async_session.flush()
+    await async_session.commit()
 
     result = await authenticate_api_key(async_session, plaintext)
     assert result is not None
@@ -599,7 +602,7 @@ async def test_blocked_external_user_legacy_key_does_not_increment_usage(async_s
         created_at=datetime.now(timezone.utc),
     )
     async_session.add(legacy)
-    await async_session.flush()
+    await async_session.commit()
 
     monkeypatch.setattr(
         "langflow.services.database.models.api_key.crud.auth_utils.decrypt_api_key",
@@ -634,11 +637,12 @@ async def test_allowed_user_key_still_increments_usage(async_session, mock_setti
             created_at=datetime.now(timezone.utc),
         )
     )
-    await async_session.flush()
+    await async_session.commit()
 
     result = await authenticate_api_key(async_session, plaintext)
     assert result is not None
 
+    async_session.expire_all()
     row = (await async_session.exec(select(ApiKey).where(ApiKey.api_key_hash == hash_api_key(plaintext)))).first()
     assert row is not None
     assert row.total_uses == 1
@@ -667,81 +671,134 @@ async def _seed_key_for_transaction_test(async_session, *, plaintext: str, hashe
     return api_key
 
 
-def _spy_on_session_writes(async_session, monkeypatch):
-    commit = AsyncMock(wraps=async_session.commit)
-    flush = AsyncMock(wraps=async_session.flush)
-    monkeypatch.setattr(async_session, "commit", commit)
-    monkeypatch.setattr(async_session, "flush", flush)
-    return commit, flush
-
-
+@pytest.mark.parametrize(
+    ("hashed", "disable_tracking", "expected_uses"),
+    [(True, False, 1), (False, True, 0)],
+)
 @pytest.mark.anyio
-async def test_hashed_key_tracking_commits_usage_transaction(async_session, mock_settings, monkeypatch):
-    """Tracked hash-path usage must commit so SQLite releases its write lock."""
-    plaintext = "sk-hashed-tracked"  # pragma: allowlist secret
-    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=True)
-    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+async def test_api_key_bookkeeping_commits_only_its_isolated_session(
+    mock_settings,
+    tmp_path,
+    *,
+    hashed,
+    disable_tracking,
+    expected_uses,
+):
+    """Usage writes and legacy backfills persist without committing caller state."""
+    mock_settings.settings.disable_track_apikey_usage = disable_tracking
+    plaintext = f"sk-isolated-{'hashed' if hashed else 'legacy'}"  # pragma: allowlist secret
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'api-key-isolation.db'}")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: SQLModel.metadata.create_all(
+                    sync_connection,
+                    tables=[User.__table__, ApiKey.__table__],
+                )
+            )
 
-    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+        async with AsyncSession(engine, expire_on_commit=False) as caller_session:
+            api_key = await _seed_key_for_transaction_test(caller_session, plaintext=plaintext, hashed=hashed)
+            api_key_id = api_key.id
 
-    assert result is not None
-    commit.assert_awaited_once_with()
-    flush.assert_not_awaited()
-    assert api_key.total_uses == 1
-    assert api_key.last_used_at is not None
+            caller_owned_user = _make_user(username=f"caller-owned-{uuid4().hex[:8]}")
+            caller_owned_user_id = caller_owned_user.id
+            caller_session.add(caller_owned_user)
+
+            result = await authenticate_api_key(caller_session, plaintext)
+            assert result is not None
+            assert caller_owned_user in caller_session
+            assert result.user in caller_session
+
+            await caller_session.rollback()
+
+        async with AsyncSession(engine, expire_on_commit=False) as verification_session:
+            persisted_caller_user = await verification_session.get(User, caller_owned_user_id)
+            persisted_api_key = await verification_session.get(ApiKey, api_key_id)
+    finally:
+        await engine.dispose()
+
+    assert persisted_caller_user is None
+    assert persisted_api_key is not None
+    assert persisted_api_key.api_key_hash == hash_api_key(plaintext)
+    assert persisted_api_key.total_uses == expected_uses
+    assert (persisted_api_key.last_used_at is not None) is (expected_uses == 1)
 
 
+@pytest.mark.parametrize(("hashed", "disable_tracking"), [(True, False), (False, True)])
 @pytest.mark.anyio
-async def test_hashed_key_with_tracking_disabled_does_not_write(async_session, mock_settings, monkeypatch):
-    """The hash fast path remains read-only when usage tracking is disabled."""
-    mock_settings.settings.disable_track_apikey_usage = True
-    plaintext = "sk-hashed-untracked"  # pragma: allowlist secret
-    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=True)
-    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
-
-    result = await _check_key_from_db(async_session, plaintext, mock_settings)
-
-    assert result is not None
-    commit.assert_not_awaited()
-    flush.assert_not_awaited()
-    assert api_key.total_uses == 0
-    assert api_key.last_used_at is None
-
-
-@pytest.mark.anyio
-async def test_legacy_hashless_key_tracking_commits_usage_and_backfill(async_session, mock_settings, monkeypatch):
-    """Tracked legacy-key usage and its hash backfill commit together."""
-    plaintext = "sk-legacy-tracked"  # pragma: allowlist secret
-    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=False)
-    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
-
-    result = await _check_key_from_db(async_session, plaintext, mock_settings)
-
-    assert result is not None
-    commit.assert_awaited_once_with()
-    flush.assert_not_awaited()
-    assert api_key.api_key_hash == hash_api_key(plaintext)
-    assert api_key.total_uses == 1
-    assert api_key.last_used_at is not None
-
-
-@pytest.mark.anyio
-async def test_legacy_hashless_key_with_tracking_disabled_commits_backfill(
+async def test_single_connection_bookkeeping_never_commits_flushed_caller_state(
     async_session,
     mock_settings,
-    monkeypatch,
+    *,
+    hashed,
+    disable_tracking,
 ):
-    """A legacy hash backfill still commits when usage tracking is disabled."""
-    mock_settings.settings.disable_track_apikey_usage = True
-    plaintext = "sk-legacy-untracked"  # pragma: allowlist secret
-    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=False)
-    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+    """StaticPool bookkeeping stays inside the caller-owned transaction."""
+    mock_settings.settings.disable_track_apikey_usage = disable_tracking
+    plaintext = f"sk-single-connection-{'hashed' if hashed else 'legacy'}"  # pragma: allowlist secret
+    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=hashed)
+    api_key_id = api_key.id
 
-    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+    caller_owned_user = _make_user(username=f"flushed-caller-{uuid4().hex[:8]}")
+    caller_owned_user_id = caller_owned_user.id
+    async_session.add(caller_owned_user)
+    await async_session.flush()
 
+    result = await authenticate_api_key(async_session, plaintext)
     assert result is not None
-    commit.assert_awaited_once_with()
-    flush.assert_not_awaited()
-    assert api_key.api_key_hash == hash_api_key(plaintext)
-    assert api_key.total_uses == 0
-    assert api_key.last_used_at is None
+
+    await async_session.rollback()
+    async with AsyncSession(bind=async_session.bind, expire_on_commit=False) as verification_session:
+        persisted_caller_user = await verification_session.get(User, caller_owned_user_id)
+        persisted_api_key = await verification_session.get(ApiKey, api_key_id)
+
+    assert persisted_caller_user is None
+    assert persisted_api_key is not None
+    assert persisted_api_key.api_key_hash == (hash_api_key(plaintext) if hashed else None)
+    assert persisted_api_key.total_uses == 0
+    assert persisted_api_key.last_used_at is None
+
+
+@pytest.mark.anyio
+async def test_connection_bound_bookkeeping_never_commits_flushed_caller_state(mock_settings, tmp_path):  # noqa: ARG001
+    """A session bound to one connection keeps bookkeeping caller-owned."""
+    plaintext = "sk-connection-bound"  # pragma: allowlist secret
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'connection-bound.db'}")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: SQLModel.metadata.create_all(
+                    sync_connection,
+                    tables=[User.__table__, ApiKey.__table__],
+                )
+            )
+
+        async with AsyncSession(engine, expire_on_commit=False) as seed_session:
+            api_key = await _seed_key_for_transaction_test(seed_session, plaintext=plaintext, hashed=True)
+            api_key_id = api_key.id
+
+        async with (
+            engine.connect() as connection,
+            AsyncSession(bind=connection, expire_on_commit=False) as caller_session,
+        ):
+            caller_owned_user = _make_user(username=f"connection-caller-{uuid4().hex[:8]}")
+            caller_owned_user_id = caller_owned_user.id
+            caller_session.add(caller_owned_user)
+            await caller_session.flush()
+
+            result = await authenticate_api_key(caller_session, plaintext)
+            assert result is not None
+
+            await caller_session.rollback()
+
+        async with AsyncSession(engine, expire_on_commit=False) as verification_session:
+            persisted_caller_user = await verification_session.get(User, caller_owned_user_id)
+            persisted_api_key = await verification_session.get(ApiKey, api_key_id)
+    finally:
+        await engine.dispose()
+
+    assert persisted_caller_user is None
+    assert persisted_api_key is not None
+    assert persisted_api_key.total_uses == 0
+    assert persisted_api_key.last_used_at is None

--- a/src/backend/tests/unit/services/database/models/api_key/test_crud.py
+++ b/src/backend/tests/unit/services/database/models/api_key/test_crud.py
@@ -6,7 +6,7 @@ import hashlib
 import secrets
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -643,3 +643,105 @@ async def test_allowed_user_key_still_increments_usage(async_session, mock_setti
     assert row is not None
     assert row.total_uses == 1
     assert row.last_used_at is not None
+
+
+# =============================================================================
+# LE-2097: successful API-key writes must finish their transaction
+# =============================================================================
+
+
+async def _seed_key_for_transaction_test(async_session, *, plaintext: str, hashed: bool) -> ApiKey:
+    user = _make_user(username=f"transaction-{uuid4().hex[:8]}")
+    async_session.add(user)
+    await async_session.flush()
+
+    api_key = ApiKey(
+        api_key=plaintext,
+        api_key_hash=hash_api_key(plaintext) if hashed else None,
+        name="transaction-test",
+        user_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    async_session.add(api_key)
+    await async_session.commit()
+    return api_key
+
+
+def _spy_on_session_writes(async_session, monkeypatch):
+    commit = AsyncMock(wraps=async_session.commit)
+    flush = AsyncMock(wraps=async_session.flush)
+    monkeypatch.setattr(async_session, "commit", commit)
+    monkeypatch.setattr(async_session, "flush", flush)
+    return commit, flush
+
+
+@pytest.mark.anyio
+async def test_hashed_key_tracking_commits_usage_transaction(async_session, mock_settings, monkeypatch):
+    """Tracked hash-path usage must commit so SQLite releases its write lock."""
+    plaintext = "sk-hashed-tracked"  # pragma: allowlist secret
+    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=True)
+    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+
+    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+
+    assert result is not None
+    commit.assert_awaited_once_with()
+    flush.assert_not_awaited()
+    assert api_key.total_uses == 1
+    assert api_key.last_used_at is not None
+
+
+@pytest.mark.anyio
+async def test_hashed_key_with_tracking_disabled_does_not_write(async_session, mock_settings, monkeypatch):
+    """The hash fast path remains read-only when usage tracking is disabled."""
+    mock_settings.settings.disable_track_apikey_usage = True
+    plaintext = "sk-hashed-untracked"  # pragma: allowlist secret
+    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=True)
+    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+
+    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+
+    assert result is not None
+    commit.assert_not_awaited()
+    flush.assert_not_awaited()
+    assert api_key.total_uses == 0
+    assert api_key.last_used_at is None
+
+
+@pytest.mark.anyio
+async def test_legacy_hashless_key_tracking_commits_usage_and_backfill(async_session, mock_settings, monkeypatch):
+    """Tracked legacy-key usage and its hash backfill commit together."""
+    plaintext = "sk-legacy-tracked"  # pragma: allowlist secret
+    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=False)
+    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+
+    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+
+    assert result is not None
+    commit.assert_awaited_once_with()
+    flush.assert_not_awaited()
+    assert api_key.api_key_hash == hash_api_key(plaintext)
+    assert api_key.total_uses == 1
+    assert api_key.last_used_at is not None
+
+
+@pytest.mark.anyio
+async def test_legacy_hashless_key_with_tracking_disabled_commits_backfill(
+    async_session,
+    mock_settings,
+    monkeypatch,
+):
+    """A legacy hash backfill still commits when usage tracking is disabled."""
+    mock_settings.settings.disable_track_apikey_usage = True
+    plaintext = "sk-legacy-untracked"  # pragma: allowlist secret
+    api_key = await _seed_key_for_transaction_test(async_session, plaintext=plaintext, hashed=False)
+    commit, flush = _spy_on_session_writes(async_session, monkeypatch)
+
+    result = await _check_key_from_db(async_session, plaintext, mock_settings)
+
+    assert result is not None
+    commit.assert_awaited_once_with()
+    flush.assert_not_awaited()
+    assert api_key.api_key_hash == hash_api_key(plaintext)
+    assert api_key.total_uses == 0
+    assert api_key.last_used_at is None

--- a/src/backend/tests/unit/services/database/models/api_key/test_crud.py
+++ b/src/backend/tests/unit/services/database/models/api_key/test_crud.py
@@ -4,20 +4,24 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import anyio
 import pytest
 from langflow.services.database.models.api_key.crud import (
+    _authenticate_api_key_in_owned_scope,
+    _authenticate_api_key_with_session,
     _check_key_from_db,
-    authenticate_api_key,
+    _check_key_from_db_with_context,
     create_api_key,
     hash_api_key,
 )
 from langflow.services.database.models.api_key.model import ApiKey, ApiKeyCreate
-from langflow.services.database.models.user.model import User
+from langflow.services.database.models.user.model import User, UserRead
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -124,7 +128,7 @@ async def test_check_key_finds_by_hash(async_session, mock_settings):
 
 
 @pytest.mark.anyio
-async def test_authenticate_api_key_returns_db_key_metadata(async_session, mock_settings):  # noqa: ARG001
+async def test_authenticate_api_key_returns_db_key_metadata(async_session, mock_settings):
     """The richer resolver preserves the DB API-key id for authorization context."""
     user = _make_user()
     async_session.add(user)
@@ -141,7 +145,7 @@ async def test_authenticate_api_key_returns_db_key_metadata(async_session, mock_
     async_session.add(api_key)
     await async_session.commit()
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
 
     assert result is not None
     assert result.user.id == user.id
@@ -479,7 +483,7 @@ async def test_authenticate_api_key_rejects_external_user_when_ceiling_enabled(a
     _user, plaintext = await _seed_external_user_with_key(async_session)
 
     # authenticate_api_key is the shared chokepoint used by every API-key caller.
-    assert await authenticate_api_key(async_session, plaintext) is None
+    assert await _authenticate_api_key_with_session(async_session, plaintext, mock_settings) is None
 
 
 @pytest.mark.anyio
@@ -490,7 +494,7 @@ async def test_authenticate_api_key_allows_external_user_when_ceiling_disabled(a
 
     user, plaintext = await _seed_external_user_with_key(async_session)
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
     assert result is not None
     assert result.user.id == user.id
 
@@ -503,7 +507,7 @@ async def test_authenticate_api_key_allows_external_user_when_disable_keys_disab
 
     user, plaintext = await _seed_external_user_with_key(async_session)
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
     assert result is not None
     assert result.user.id == user.id
 
@@ -529,7 +533,7 @@ async def test_authenticate_api_key_allows_non_external_user_when_ceiling_enable
     )
     await async_session.commit()
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
     assert result is not None
     assert result.user.id == user.id
 
@@ -544,7 +548,7 @@ async def test_authenticate_api_key_ignores_profile_for_other_provider(async_ses
     # Profile is stored under "some-other-provider", not the configured "external".
     user, plaintext = await _seed_external_user_with_key(async_session, provider="some-other-provider")
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
     assert result is not None
     assert result.user.id == user.id
 
@@ -565,7 +569,7 @@ async def test_blocked_external_user_key_does_not_increment_usage(async_session,
     _user, plaintext = await _seed_external_user_with_key(async_session)
 
     # Denied auth.
-    assert await authenticate_api_key(async_session, plaintext) is None
+    assert await _authenticate_api_key_with_session(async_session, plaintext, mock_settings) is None
 
     row = (await async_session.exec(select(ApiKey).where(ApiKey.api_key_hash == hash_api_key(plaintext)))).first()
     assert row is not None
@@ -609,7 +613,7 @@ async def test_blocked_external_user_legacy_key_does_not_increment_usage(async_s
         lambda val, **_kwargs: val,
     )
 
-    assert await authenticate_api_key(async_session, plaintext) is None
+    assert await _authenticate_api_key_with_session(async_session, plaintext, mock_settings) is None
 
     row = (await async_session.exec(select(ApiKey).where(ApiKey.id == legacy.id))).first()
     assert row is not None
@@ -620,7 +624,7 @@ async def test_blocked_external_user_legacy_key_does_not_increment_usage(async_s
 
 
 @pytest.mark.anyio
-async def test_allowed_user_key_still_increments_usage(async_session, mock_settings):  # noqa: ARG001
+async def test_allowed_user_key_still_increments_usage(async_session, mock_settings):
     """Sanity: a non-blocked user's key still records usage (success-path unchanged)."""
     from sqlmodel import select
 
@@ -639,7 +643,7 @@ async def test_allowed_user_key_still_increments_usage(async_session, mock_setti
     )
     await async_session.commit()
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
     assert result is not None
 
     async_session.expire_all()
@@ -647,6 +651,34 @@ async def test_allowed_user_key_still_increments_usage(async_session, mock_setti
     assert row is not None
     assert row.total_uses == 1
     assert row.last_used_at is not None
+
+
+@pytest.mark.parametrize("hashed", [True, False])
+@pytest.mark.anyio
+async def test_inactive_user_key_does_not_mutate_bookkeeping(async_session, mock_settings, *, hashed):
+    """Inactive users are rejected before usage tracking or legacy hash backfill."""
+    user = _make_user(is_active=False)
+    async_session.add(user)
+    await async_session.flush()
+
+    plaintext = f"sk-inactive-{'hashed' if hashed else 'legacy'}"  # pragma: allowlist secret
+    api_key = ApiKey(
+        api_key=plaintext,
+        api_key_hash=hash_api_key(plaintext) if hashed else None,
+        name="inactive-user-key",
+        user_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    async_session.add(api_key)
+    await async_session.commit()
+
+    result = await _authenticate_api_key_with_session(async_session, plaintext, mock_settings)
+    assert result is None
+
+    await async_session.refresh(api_key)
+    assert api_key.api_key_hash == (hash_api_key(plaintext) if hashed else None)
+    assert api_key.total_uses == 0
+    assert api_key.last_used_at is None
 
 
 # =============================================================================
@@ -671,12 +703,26 @@ async def _seed_key_for_transaction_test(async_session, *, plaintext: str, hashe
     return api_key
 
 
+def _session_scope_factory(engine):
+    @asynccontextmanager
+    async def owned_scope():
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    return owned_scope
+
+
 @pytest.mark.parametrize(
     ("hashed", "disable_tracking", "expected_uses"),
     [(True, False, 1), (False, True, 0)],
 )
 @pytest.mark.anyio
-async def test_api_key_bookkeeping_commits_only_its_isolated_session(
+async def test_api_key_bookkeeping_commits_only_its_owned_session(
     mock_settings,
     tmp_path,
     *,
@@ -684,7 +730,7 @@ async def test_api_key_bookkeeping_commits_only_its_isolated_session(
     disable_tracking,
     expected_uses,
 ):
-    """Usage writes and legacy backfills persist without committing caller state."""
+    """Owned auth writes persist without flushing or committing pending caller state."""
     mock_settings.settings.disable_track_apikey_usage = disable_tracking
     plaintext = f"sk-isolated-{'hashed' if hashed else 'legacy'}"  # pragma: allowlist secret
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'api-key-isolation.db'}")
@@ -705,10 +751,12 @@ async def test_api_key_bookkeeping_commits_only_its_isolated_session(
             caller_owned_user_id = caller_owned_user.id
             caller_session.add(caller_owned_user)
 
-            result = await authenticate_api_key(caller_session, plaintext)
+            result = await _authenticate_api_key_in_owned_scope(plaintext, _session_scope_factory(engine))
             assert result is not None
             assert caller_owned_user in caller_session
-            assert result.user in caller_session
+            assert result.user.id == api_key.user_id
+            assert result.user not in caller_session
+            assert UserRead.model_validate(result.user).id == api_key.user_id
 
             await caller_session.rollback()
 
@@ -723,6 +771,48 @@ async def test_api_key_bookkeeping_commits_only_its_isolated_session(
     assert persisted_api_key.api_key_hash == hash_api_key(plaintext)
     assert persisted_api_key.total_uses == expected_uses
     assert (persisted_api_key.last_used_at is not None) is (expected_uses == 1)
+
+
+@pytest.mark.anyio
+async def test_owned_auth_completes_after_pre_read_releases_only_pool_connection(mock_settings, tmp_path):  # noqa: ARG001
+    """Pre-read scopes release the sole connection before owned authentication."""
+    plaintext = "sk-single-pool-held"  # pragma: allowlist secret
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'api-key-single-pool.db'}",
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.1,
+    )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                lambda sync_connection: SQLModel.metadata.create_all(
+                    sync_connection,
+                    tables=[User.__table__, ApiKey.__table__],
+                )
+            )
+
+        async with AsyncSession(engine, expire_on_commit=False) as seed_session:
+            api_key = await _seed_key_for_transaction_test(seed_session, plaintext=plaintext, hashed=True)
+            api_key_id = api_key.id
+            user_id = api_key.user_id
+
+        async with AsyncSession(engine, expire_on_commit=False) as pre_read_session, pre_read_session.begin():
+            assert await pre_read_session.get(User, user_id) is not None
+
+        with anyio.fail_after(1):
+            result = await _authenticate_api_key_in_owned_scope(plaintext, _session_scope_factory(engine))
+        assert result is not None
+        assert result.user.id == user_id
+
+        async with AsyncSession(engine, expire_on_commit=False) as verification_session:
+            persisted_api_key = await verification_session.get(ApiKey, api_key_id)
+    finally:
+        await engine.dispose()
+
+    assert persisted_api_key is not None
+    assert persisted_api_key.total_uses == 1
+    assert persisted_api_key.last_used_at is not None
 
 
 @pytest.mark.parametrize(("hashed", "disable_tracking"), [(True, False), (False, True)])
@@ -745,7 +835,7 @@ async def test_single_connection_bookkeeping_never_commits_flushed_caller_state(
     async_session.add(caller_owned_user)
     await async_session.flush()
 
-    result = await authenticate_api_key(async_session, plaintext)
+    result = await _check_key_from_db_with_context(async_session, plaintext, mock_settings)
     assert result is not None
 
     await async_session.rollback()
@@ -761,7 +851,7 @@ async def test_single_connection_bookkeeping_never_commits_flushed_caller_state(
 
 
 @pytest.mark.anyio
-async def test_connection_bound_bookkeeping_never_commits_flushed_caller_state(mock_settings, tmp_path):  # noqa: ARG001
+async def test_connection_bound_bookkeeping_never_commits_flushed_caller_state(mock_settings, tmp_path):
     """A session bound to one connection keeps bookkeeping caller-owned."""
     plaintext = "sk-connection-bound"  # pragma: allowlist secret
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'connection-bound.db'}")
@@ -787,7 +877,7 @@ async def test_connection_bound_bookkeeping_never_commits_flushed_caller_state(m
             caller_session.add(caller_owned_user)
             await caller_session.flush()
 
-            result = await authenticate_api_key(caller_session, plaintext)
+            result = await _check_key_from_db_with_context(caller_session, plaintext, mock_settings)
             assert result is not None
 
             await caller_session.rollback()

--- a/src/backend/tests/unit/test_api_key_source.py
+++ b/src/backend/tests/unit/test_api_key_source.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 import pytest
 from langflow.services.database.models.api_key.crud import (
+    ApiKeyAuthResult,
     _check_key_from_db,
     _check_key_from_env,
     check_key,
@@ -96,7 +97,7 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_db,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db",
+                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -121,7 +122,7 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db",
+                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -147,7 +148,7 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db",
+                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -156,7 +157,7 @@ class TestCheckKeyRouting:
             ) as mock_env_check,
         ):
             mock_env_check.return_value = None  # env validation fails
-            mock_db_check.return_value = mock_user  # db has the key
+            mock_db_check.return_value = ApiKeyAuthResult(user=mock_user, api_key_source="db")
 
             result = await check_key(mock_session, "sk-test-key")
 
@@ -173,7 +174,7 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db",
+                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -447,20 +448,21 @@ class TestCheckKeyIntegration:
         """Full flow test: env mode with invalid key that's also not in db returns None."""
         monkeypatch.setenv("LANGFLOW_API_KEY", "sk-correct-key")
 
-        # Setup mock for db - key not found
-        mock_result = MagicMock()
-        mock_result.all.return_value = []
-        mock_session.exec = AsyncMock(return_value=mock_result)
-
         mock_settings = MagicMock()
         mock_settings.auth_settings.API_KEY_SOURCE = "env"
         mock_settings.auth_settings.SUPERUSER = "langflow"
         mock_settings.auth_settings.SECRET_KEY.get_secret_value.return_value = "test-secret-key-for-unit-tests"
         mock_settings.settings.disable_track_apikey_usage = False
 
-        with patch(
-            "langflow.services.database.models.api_key.crud.get_settings_service",
-            return_value=mock_settings,
+        with (
+            patch(
+                "langflow.services.database.models.api_key.crud.get_settings_service",
+                return_value=mock_settings,
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             # Key doesn't match env AND not in db
             result = await check_key(mock_session, "sk-wrong-key")

--- a/src/backend/tests/unit/test_api_key_source.py
+++ b/src/backend/tests/unit/test_api_key_source.py
@@ -6,6 +6,7 @@ This module tests the check_key function behavior when:
 """
 
 import secrets
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -17,6 +18,16 @@ from langflow.services.database.models.api_key.crud import (
     check_key,
 )
 from langflow.services.database.models.user.model import User
+
+
+def _scope_for_session(session):
+    """Return an owned-session scope backed by the supplied test session."""
+
+    @asynccontextmanager
+    async def scope():
+        yield session
+
+    return scope
 
 
 @pytest.fixture
@@ -97,7 +108,11 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_db,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_with_context",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -107,9 +122,9 @@ class TestCheckKeyRouting:
         ):
             mock_db_check.return_value = None
 
-            await check_key(mock_session, "sk-test-key")
+            await check_key("sk-test-key")
 
-            mock_db_check.assert_called_once()
+            mock_db_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_db)
             mock_env_check.assert_not_called()
 
     @pytest.mark.asyncio
@@ -122,7 +137,11 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_with_context",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -132,9 +151,9 @@ class TestCheckKeyRouting:
         ):
             mock_env_check.return_value = mock_user
 
-            result = await check_key(mock_session, "sk-test-key")
+            result = await check_key("sk-test-key")
 
-            mock_env_check.assert_called_once()
+            mock_env_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_env)
             mock_db_check.assert_not_called()
             assert result == mock_user
 
@@ -148,7 +167,11 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_with_context",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -159,10 +182,10 @@ class TestCheckKeyRouting:
             mock_env_check.return_value = None  # env validation fails
             mock_db_check.return_value = ApiKeyAuthResult(user=mock_user, api_key_source="db")
 
-            result = await check_key(mock_session, "sk-test-key")
+            result = await check_key("sk-test-key")
 
-            mock_env_check.assert_called_once()
-            mock_db_check.assert_called_once()  # Should fallback to db
+            mock_env_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_env)
+            mock_db_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_env)
             assert result == mock_user
 
     @pytest.mark.asyncio
@@ -174,7 +197,11 @@ class TestCheckKeyRouting:
                 return_value=mock_settings_service_env,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_with_context",
                 new_callable=AsyncMock,
             ) as mock_db_check,
             patch(
@@ -185,10 +212,10 @@ class TestCheckKeyRouting:
             mock_env_check.return_value = None  # env validation fails
             mock_db_check.return_value = None  # db validation also fails
 
-            result = await check_key(mock_session, "sk-test-key")
+            result = await check_key("sk-test-key")
 
-            mock_env_check.assert_called_once()
-            mock_db_check.assert_called_once()
+            mock_env_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_env)
+            mock_db_check.assert_awaited_once_with(mock_session, "sk-test-key", mock_settings_service_env)
             assert result is None
 
 
@@ -436,10 +463,14 @@ class TestCheckKeyIntegration:
                 "langflow.services.database.models.user.crud.get_user_by_username",
                 new_callable=AsyncMock,
             ) as mock_get_user,
+            patch(
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
         ):
             mock_get_user.return_value = mock_superuser
 
-            result = await check_key(mock_session, "sk-env-secret")
+            result = await check_key("sk-env-secret")
 
             assert result == mock_superuser
 
@@ -460,12 +491,16 @@ class TestCheckKeyIntegration:
                 return_value=mock_settings,
             ),
             patch(
-                "langflow.services.database.models.api_key.crud._check_key_from_db_in_isolated_session",
+                "langflow.services.database.models.api_key.crud.session_scope",
+                new=_scope_for_session(mock_session),
+            ),
+            patch(
+                "langflow.services.database.models.api_key.crud._check_key_from_db_with_context",
                 new=AsyncMock(return_value=None),
             ),
         ):
             # Key doesn't match env AND not in db
-            result = await check_key(mock_session, "sk-wrong-key")
+            result = await check_key("sk-wrong-key")
 
             # Should return None since both failed
             assert result is None


### PR DESCRIPTION
## Summary

- commit API-key usage tracking and legacy hash backfill at the authentication-owned transaction boundary, releasing SQLite's writer lock before downstream handlers open an independent write session
- roll back and clear state from failed native/external credential attempts before API-key fallback so bookkeeping cannot commit unrelated authentication state
- cover hashed and legacy keys with tracking enabled/disabled, plus real file-backed SQLite catalog-policy PUTs authenticated only by API key

## Root cause

API-key validation updated usage metadata and only flushed it. On SQLite, that kept the authentication session's write transaction open through the request. Catalog-policy PUT then opened a second write session in the same request and waited on the lock held by the first session, producing a self-deadlock/timeout.

## Transaction semantics

Successful API-key authentication owns and durably records its usage bookkeeping before request handling continues. Failed prior credential attempts are explicitly rolled back and their auth contexts cleared before any fallback that can commit.

## Validation

- affected 3-module suite: 117 passed
- full auth-service suite: 78 passed
- final rollback/context regressions: 2 passed
- focused security regression subset: 8 passed
- Ruff, formatting, `git diff --check`, secret scan, and all configured pre-commit hooks passed

## Jira

- [LE-2097](https://datastax.jira.com/browse/LE-2097)
- split from [LE-1933](https://datastax.jira.com/browse/LE-1933)

[LE-2097]: https://datastax.jira.com/browse/LE-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication fallback handling by isolating failed credential attempts and preventing stale session data from affecting subsequent authentication.
  * Ensured API-key usage tracking and legacy key updates are saved reliably before subsequent requests.
  * Improved API-key authentication behavior for SQLite-backed workflows.

* **Tests**
  * Added coverage for authentication fallback scenarios, API-key persistence, usage tracking, and transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->