### PR TITLE
fix: preserve custom component input values

### DIFF
--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -205,7 +205,6 @@ class Component(CustomComponent):
                 inputs[key] = value
 
         self._parameters = inputs or {}
-        self.set_attributes(self._parameters)
 
         # Store original inputs and config for reference
         self.__inputs = inputs
@@ -228,6 +227,7 @@ class Component(CustomComponent):
         self.reset_all_output_values()
         if self.inputs is not None:
             self.map_inputs(self.inputs)
+            self.set_attributes(self._parameters)
         self.map_outputs()
 
         # Final setup

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1220,8 +1220,22 @@ class Component(CustomComponent):
                 continue
             input_ = self._inputs[key]
             # BaseInputMixin has a `validate_assignment=True`
+            original_value = input_.value
 
-            input_.value = value
+            # Some components expose a structured UI input while retaining a
+            # backwards-compatible scalar or mapping constructor API.
+            if getattr(input_, "field_type", None) == "table" and not isinstance(value, list):
+                continue
+
+            try:
+                input_.value = value
+            except ValidationError:
+                # Component constructors historically accepted provider-specific values
+                # that are normalized later by the component (for example, Ollama's
+                # legacy string format values). Keep the raw constructor attribute while
+                # leaving the typed input at its declared default.
+                object.__setattr__(input_, "value", original_value)
+                continue
             params[input_.name] = input_.value
 
     def set_attributes(self, params: dict) -> None:

--- a/src/lfx/tests/unit/custom/component/test_component_instance_attributes.py
+++ b/src/lfx/tests/unit/custom/component/test_component_instance_attributes.py
@@ -1,5 +1,7 @@
 import pytest
 from lfx.components.input_output.chat import ChatInput
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import StrInput
 from lfx.schema.message import Message
 
 
@@ -23,6 +25,15 @@ def test_input_value_independence(chat_input_instances):
     assert chat1.input_value != chat2.input_value
     assert chat1.input_value == "Hello from chat1"
     assert chat2.input_value == "Hello from chat2"
+
+
+def test_constructor_parameters_are_applied_to_declared_inputs():
+    class TestComponent(Component):
+        inputs = [StrInput(name="custom_value", value="default")]
+
+    component = TestComponent(custom_value="from-ui")
+
+    assert component.custom_value == "from-ui"
 
 
 def test_sender_name_independence(chat_input_instances):

--- a/src/lfx/tests/unit/custom/component/test_component_instance_attributes.py
+++ b/src/lfx/tests/unit/custom/component/test_component_instance_attributes.py
@@ -1,7 +1,7 @@
 import pytest
 from lfx.components.input_output.chat import ChatInput
 from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import StrInput
+from lfx.inputs.inputs import BoolInput, IntInput, StrInput
 from lfx.schema.message import Message
 
 
@@ -33,7 +33,22 @@ def test_constructor_parameters_are_applied_to_declared_inputs():
 
     component = TestComponent(custom_value="from-ui")
 
-    assert component.custom_value == "from-ui"
+    assert component.get_input("custom_value").value == "from-ui"
+
+
+def test_declared_falsy_input_defaults_are_preserved():
+    class TestComponent(Component):
+        inputs = [
+            BoolInput(name="false_value", value=False),
+            IntInput(name="zero_value", value=0),
+            StrInput(name="empty_value", value=""),
+        ]
+
+    component = TestComponent()
+
+    assert component.get_input("false_value").value is False
+    assert component.get_input("zero_value").value == 0
+    assert component.get_input("empty_value").value == ""
 
 
 def test_sender_name_independence(chat_input_instances):


### PR DESCRIPTION
## Summary

Apply constructor parameters after declared inputs are mapped so custom component input values are validated and retained at runtime.

## Testing

- `uv run pytest -q tests/unit/custom/component/test_component_instance_attributes.py tests/unit/custom/component/test_inputs_class_isolation.py tests/unit/inputs/test_inputs_schema.py` (from `src/lfx`)
- `uv run ruff check ...`
- `uv run ruff format --check ...`

Fixes #13977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Component inputs are now mapped before attributes are applied, ensuring constructor-provided values are correctly reflected.
  * Falsy declared input defaults, such as `false`, `0`, and empty strings, are preserved when no constructor values are provided.
* **Tests**
  * Added coverage for constructor parameter overrides and preservation of falsy input defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->