### PR TITLE
fix: align catalog policy component identities

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -14,6 +14,8 @@ from lfx.log.logger import logger
 from lfx.schema.schema import InputValueRequest, OutputValue
 from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
+    PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,
+    CatalogPolicyIdentityUnavailableError,
     CustomComponentValidationError,
     prepare_public_flow_build,
     validate_catalog_policy_for_flow,
@@ -312,6 +314,8 @@ async def build_flow(
             validate_flow_for_current_settings(data.model_dump())
         elif flow and flow.data:
             validate_flow_for_current_settings(flow.data)
+    except CatalogPolicyIdentityUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except CustomComponentValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
@@ -903,6 +907,9 @@ async def build_public_tmp(
         # started through this public build path, preventing unauthenticated
         # callers from reading or cancelling private-flow builds by job_id.
         await queue_service.register_public_job(job_id)
+    except CatalogPolicyIdentityUnavailableError as exc:
+        await logger.awarning("Public flow component identities are temporarily unavailable")
+        raise HTTPException(status_code=503, detail=PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE) from exc
     except CustomComponentValidationError as exc:
         await logger.awarning(f"Public flow validation failed: {exc}")
         raise HTTPException(status_code=400, detail="This flow cannot be executed.") from exc

--- a/src/backend/base/langflow/api/v1/custom_component_policy.py
+++ b/src/backend/base/langflow/api/v1/custom_component_policy.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException, status
 from lfx.interface.components import component_cache
 from lfx.utils.flow_validation import (
+    CatalogPolicyIdentityUnavailableError,
     CatalogPolicyValidationError,
     code_hash_matches_any_template,
     get_component_hash_lookups_for_validation,
@@ -47,7 +48,7 @@ def resolve_component_code_for_action(
         validate_catalog_policy_for_component_code(code, snapshot=snapshot)
     except CatalogPolicyValidationError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
-    except RuntimeError as exc:
+    except CatalogPolicyIdentityUnavailableError as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
 
     admin_only = getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
@@ -78,8 +79,10 @@ def enforce_catalog_policy_for_component_type(
     *,
     snapshot: CatalogPolicySnapshot,
 ) -> None:
-    """Deny a materialized custom component whose exact runtime type is blocked."""
+    """Deny a materialized custom component whose canonical identity is blocked."""
     try:
         validate_catalog_policy_for_component_type(component_type, snapshot=snapshot)
     except CatalogPolicyValidationError as exc:
         raise CatalogPolicyHTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except CatalogPolicyIdentityUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -32,6 +32,7 @@ from lfx.services.model_provider_policy import (
     set_current_model_provider_policy_context,
 )
 from lfx.services.settings.service import SettingsService
+from lfx.utils.component_aliases import ComponentIdentityIndex, build_component_identity_index
 from lfx.utils.flow_validation import CustomComponentValidationError
 from sqlmodel import select
 
@@ -184,12 +185,13 @@ async def get_all(request: Request, current_user: CurrentActiveUser, *, include_
             detail="Only superusers can include blocked catalog components.",
         )
 
-    from langflow.interface.components import get_and_cache_all_types_dict
+    from langflow.interface.components import get_and_cache_all_types_dict, get_component_identity_index
     from langflow.utils.i18n import build_component_display_names, translate_component_dict
 
     try:
         catalog_policy_snapshot = get_catalog_policy_service().snapshot
         all_types_en = await get_and_cache_all_types_dict(settings_service=get_settings_service())
+        component_identity_index = get_component_identity_index(all_types_en)
         visible_types_en = _filter_component_palette_by_provider_policy(
             all_types_en,
             user_id=current_user.id,
@@ -199,6 +201,7 @@ async def get_all(request: Request, current_user: CurrentActiveUser, *, include_
             visible_types_en = _filter_component_palette_by_catalog_policy(
                 visible_types_en,
                 blocked_component_keys=catalog_policy_snapshot.blocked_component_keys,
+                component_identity_index=component_identity_index,
             )
 
         locale = getattr(request.state, "locale", "en")
@@ -256,19 +259,22 @@ def _filter_component_palette_by_catalog_policy(
     all_types: dict[str, dict[str, dict]],
     *,
     blocked_component_keys: Collection[str],
+    component_identity_index: ComponentIdentityIndex | None = None,
 ) -> dict[str, dict[str, dict]]:
-    """Return shallow category copies with exact blocked component keys removed.
+    """Return shallow category copies with canonically blocked components removed.
 
-    Catalog policy keys match the inner component-registry keys exactly and
-    case-sensitively across every category. Category order, component order,
-    and empty categories are preserved. Component payloads remain shared with
-    the process-wide cache and are never mutated or deep-copied.
+    Policy keys and component-registry keys use the same collision-aware
+    identity resolver as flow/runtime validation. Category order, component
+    order, and empty categories are preserved. Component payloads remain
+    shared with the process-wide cache and are never mutated or deep-copied.
     """
+    identity_index = component_identity_index or build_component_identity_index(all_types)
+    blocked_identities = identity_index.resolve_many(blocked_component_keys)
     return {
         category: {
             component_key: component
             for component_key, component in components.items()
-            if component_key not in blocked_component_keys
+            if identity_index.resolve(component_key).isdisjoint(blocked_identities)
         }
         for category, components in all_types.items()
     }

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -15,7 +15,11 @@ from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlmodel import apaginate
 from lfx.services.cache.utils import CACHE_MISS
 from lfx.services.catalog_policy import CatalogPolicySnapshot
-from lfx.utils.flow_validation import CatalogPolicyValidationError, validate_catalog_policy_for_flow
+from lfx.utils.flow_validation import (
+    CatalogPolicyIdentityUnavailableError,
+    CatalogPolicyValidationError,
+    validate_catalog_policy_for_flow,
+)
 from pydantic import ValidationError
 from sqlalchemy import case
 from sqlmodel import and_, col, select
@@ -117,6 +121,8 @@ def _validate_catalog_policy_for_write(
         validate_catalog_policy_for_flow(flow_data, snapshot=snapshot)
     except CatalogPolicyValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except CatalogPolicyIdentityUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 # build router

--- a/src/backend/base/langflow/api/v2/workflow_public.py
+++ b/src/backend/base/langflow/api/v2/workflow_public.py
@@ -31,6 +31,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.responses import EventSourceResponse
+from lfx.log.logger import logger
 from lfx.schema.workflow import (
     WORKFLOW_EXECUTION_RESPONSES,
     PublicWorkflowRunRequest,
@@ -168,6 +169,7 @@ async def execute_public_workflow(
                 validate_public_flow_no_code_execution(flow.data)
             flow_name = flow.name if flow else None
     except CatalogPolicyIdentityUnavailableError as exc:
+        await logger.awarning("Public workflow component identities are temporarily unavailable: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,

--- a/src/backend/base/langflow/api/v2/workflow_public.py
+++ b/src/backend/base/langflow/api/v2/workflow_public.py
@@ -36,6 +36,8 @@ from lfx.schema.workflow import (
     PublicWorkflowRunRequest,
 )
 from lfx.utils.flow_validation import (
+    PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,
+    CatalogPolicyIdentityUnavailableError,
     CustomComponentValidationError,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
@@ -165,6 +167,11 @@ async def execute_public_workflow(
                 # such a component is an unauthenticated code-execution primitive.
                 validate_public_flow_no_code_execution(flow.data)
             flow_name = flow.name if flow else None
+    except CatalogPolicyIdentityUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,
+        ) from exc
     except CustomComponentValidationError as exc:
         # The raw message embeds the blocked component class names; do
         # not leak it to an anonymous visitor.

--- a/src/backend/base/langflow/api/v2/workflow_validation.py
+++ b/src/backend/base/langflow/api/v2/workflow_validation.py
@@ -9,7 +9,11 @@ route handlers can surface a structured error without running the graph.
 from __future__ import annotations
 
 from fastapi import HTTPException, status
-from lfx.utils.flow_validation import CustomComponentValidationError, validate_flow_for_current_settings
+from lfx.utils.flow_validation import (
+    CatalogPolicyIdentityUnavailableError,
+    CustomComponentValidationError,
+    validate_flow_for_current_settings,
+)
 from lfx.workflow.converters import ParsedWorkflowRun
 
 from langflow.services.authorization.fetch import deny_to_404
@@ -94,7 +98,7 @@ def _validate_flow_data_for_execution(parsed: ParsedWorkflowRun, flow: FlowRead)
             validate_flow_for_current_settings(flow.data)
     except CustomComponentValidationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-    except RuntimeError as exc:
+    except CatalogPolicyIdentityUnavailableError as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
 
 

--- a/src/backend/tests/unit/api/v1/test_custom_component_policy.py
+++ b/src/backend/tests/unit/api/v1/test_custom_component_policy.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import HTTPException, status
 from langflow.api.v1 import custom_component_policy
 from lfx.services.catalog_policy.base import CatalogPolicySnapshot
-from lfx.utils.flow_validation import CatalogPolicyValidationError
+from lfx.utils.flow_validation import CatalogPolicyIdentityUnavailableError, CatalogPolicyValidationError
 
 
 @pytest.mark.parametrize(
@@ -103,3 +103,24 @@ def test_catalog_component_type_denial_has_no_superuser_bypass(monkeypatch):
         )
 
     assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_catalog_component_type_alias_resolution_initialization_maps_to_503(monkeypatch):
+    def identities_unavailable(_component_type, *, snapshot):
+        assert snapshot.blocked_component_keys
+        message = "Catalog policy component identities are still initializing"
+        raise CatalogPolicyIdentityUnavailableError(message)
+
+    monkeypatch.setattr(
+        custom_component_policy,
+        "validate_catalog_policy_for_component_type",
+        identities_unavailable,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        custom_component_policy.enforce_catalog_policy_for_component_type(
+            "PromptComponent",
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"}),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -148,6 +148,39 @@ async def test_create_and_put_flow_enforce_catalog_policy_with_default_allow(
     assert blocked_put.json()["detail"].endswith(blocked_key)
 
 
+async def test_create_flow_maps_catalog_identity_unavailable_to_503(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    from langflow.api.v1 import flows
+    from lfx.services.catalog_policy import CatalogPolicySnapshot
+    from lfx.utils.flow_validation import CatalogPolicyIdentityUnavailableError
+
+    detail = "Catalog policy component identities are still initializing. Please try again in a few seconds."
+
+    def identities_unavailable(_flow_data, *, snapshot):
+        assert snapshot.blocked_component_keys
+        raise CatalogPolicyIdentityUnavailableError(detail)
+
+    service = type(
+        "CatalogPolicyService",
+        (),
+        {"snapshot": CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"})},
+    )()
+    monkeypatch.setattr(flows, "get_catalog_policy_service", lambda: service)
+    monkeypatch.setattr(flows, "validate_catalog_policy_for_flow", identities_unavailable)
+
+    response = await client.post(
+        "api/v1/flows/",
+        json={"name": f"catalog-identities-unavailable-{uuid.uuid4()}", "data": _catalog_flow_data("Prompt")},
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == detail
+
+
 async def test_patch_and_put_metadata_only_updates_validate_stored_graph(
     client: AsyncClient,
     logged_in_headers,

--- a/src/backend/tests/unit/api/v2/test_workflow_agui.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_agui.py
@@ -446,6 +446,43 @@ class TestV2WorkflowAdmission:
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == "custom components are disabled"
 
+    def test_private_route_maps_catalog_identity_unavailable_to_503(self, monkeypatch: pytest.MonkeyPatch):
+        """Authenticated callers retain the retryable identity-initialization detail."""
+        from langflow.api.v2 import workflow as workflow_module
+        from langflow.api.v2 import workflow_validation as wf_val
+        from lfx.schema.workflow import WorkflowRunRequest
+        from lfx.utils.flow_validation import CatalogPolicyIdentityUnavailableError
+        from lfx.workflow.converters import parse_workflow_run_request
+
+        flow_id = uuid4()
+        flow = SimpleNamespace(
+            id=flow_id,
+            user_id=uuid4(),
+            workspace_id=None,
+            folder_id=None,
+            data={"nodes": [], "edges": []},
+            name="private",
+        )
+        detail = "Catalog policy component identities are still initializing. Please try again in a few seconds."
+
+        def _retry(_flow_data):
+            raise CatalogPolicyIdentityUnavailableError(detail)
+
+        monkeypatch.setattr(wf_val, "validate_flow_for_current_settings", _retry)
+        parsed = parse_workflow_run_request(WorkflowRunRequest(flow_id=str(flow_id), input_value="hi", mode="stream"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            workflow_module.build_stream_response(
+                parsed,
+                flow,
+                SimpleNamespace(id=flow.user_id),
+                stream_protocol="langflow",
+                background_tasks=SimpleNamespace(),
+            )
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == detail
+
 
 class TestAGUIStreaming:
     """mode=stream returns an AG-UI server-sent event stream."""

--- a/src/backend/tests/unit/api/v2/test_workflow_public.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_public.py
@@ -389,6 +389,37 @@ async def test_public_endpoint_sanitizes_component_validation_error(client: Asyn
 
 @pytest.mark.benchmark
 @pytest.mark.security
+async def test_public_endpoint_sanitizes_catalog_identity_unavailable_response(
+    client: AsyncClient, public_flow_id, monkeypatch
+):
+    from lfx.utils.flow_validation import (
+        PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,
+        CatalogPolicyIdentityUnavailableError,
+    )
+
+    raw_message = "Catalog identities unavailable: internal generation 42"
+
+    def _raise(*_args, **_kwargs):
+        raise CatalogPolicyIdentityUnavailableError(raw_message)
+
+    import langflow.api.v2.workflow_public as workflow_public_module
+
+    monkeypatch.setattr(workflow_public_module, "validate_flow_for_current_settings", _raise)
+
+    _send_unauthenticated(client, "catalog-identity-unavailable-client")
+    response = await client.post(
+        "api/v2/workflows/public",
+        json={"flow_id": str(public_flow_id), "input_value": "Hi"},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE
+    assert raw_message not in response.text
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
 async def test_public_endpoint_rejects_code_execution_components(
     client: AsyncClient, json_memory_chatbot_no_llm, logged_in_headers
 ):

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -773,6 +773,43 @@ async def test_build_public_tmp_enforces_current_catalog_policy_with_generic_err
     assert "job_id" in allowed_response.json()
 
 
+async def test_build_public_tmp_sanitizes_catalog_identity_unavailable_response(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    from lfx.utils.flow_validation import (
+        PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE,
+        CatalogPolicyIdentityUnavailableError,
+    )
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+    client.cookies.set("client_id", "test-catalog-identity-unavailable-client")
+    raw_message = "Catalog identities unavailable: internal generation 42"
+
+    def identities_unavailable(_target):
+        raise CatalogPolicyIdentityUnavailableError(raw_message)
+
+    monkeypatch.setattr(
+        "langflow.api.v1.chat.validate_catalog_policy_for_flow",
+        identities_unavailable,
+    )
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE
+    assert raw_message not in response.text
+
+
 @pytest.mark.benchmark
 @pytest.mark.security
 async def test_build_public_tmp_rejects_code_execution_components(

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -230,6 +230,33 @@ def test_catalog_policy_filter_is_case_sensitive_and_does_not_mutate_shared_cach
     assert cached["models"]["BlockedAgent"] is blocked_component
 
 
+def test_catalog_policy_filter_resolves_legacy_extension_alias_without_mutating_cache():
+    from langflow.api.v1 import endpoints
+
+    canonical_key = "ext:datastax:AstraDBVectorStoreComponent@official"
+    astra_component = {
+        "name": "AstraDB",
+        "display_name": "Astra DB",
+        "metadata": {"module": "lfx_datastax.components.datastax.astradb_vectorstore.AstraDBVectorStoreComponent"},
+        "template": {"_type": "Component"},
+    }
+    cached = {
+        "datastax": {canonical_key: astra_component},
+        "input_output": {"ChatInput": {"display_name": "Chat Input"}},
+    }
+
+    filtered = endpoints._filter_component_palette_by_catalog_policy(
+        cached,
+        blocked_component_keys=frozenset({"AstraDB"}),
+    )
+
+    assert filtered["datastax"] == {}
+    assert "ChatInput" in filtered["input_output"]
+    assert cached["datastax"][canonical_key] is astra_component
+    assert filtered is not cached
+    assert filtered["datastax"] is not cached["datastax"]
+
+
 async def test_get_all_filters_catalog_policy_and_uses_current_snapshot(
     client: AsyncClient,
     logged_in_headers,

--- a/src/lfx/src/lfx/cli/script_loader.py
+++ b/src/lfx/src/lfx/cli/script_loader.py
@@ -119,6 +119,12 @@ async def load_graph_from_script(script_path: Path) -> "Graph":
             msg = "No 'graph' variable or 'get_graph()' function found in the executed script"
             raise ValueError(msg)
 
+        # Programmatic Graph construction does not pass through the JSON flow
+        # loader's warm-up. Active catalog rules need the same canonical
+        # identity index before synchronous graph validation runs below.
+        from lfx.utils.flow_validation import ensure_component_hash_lookups_loaded
+
+        await ensure_component_hash_lookups_loaded()
         return _validate_graph_instance(graph_obj)
 
     except (

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -6,7 +6,9 @@ import inspect
 import json
 import os
 import pkgutil
+import threading
 import time
+from concurrent.futures import Future
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -27,6 +29,7 @@ from lfx.extension import (
 from lfx.extension.bundle_registry import BundleRecord, get_default_registry
 from lfx.extension.reload import register_post_swap_hook
 from lfx.log.logger import logger
+from lfx.utils.component_aliases import ComponentIdentityIndex, build_component_identity_index
 from lfx.utils.flow_validation import collect_code_by_hash, collect_component_hash_lookups
 from lfx.utils.validate_cloud import (
     filter_disabled_components_from_dict,
@@ -55,9 +58,7 @@ class ComponentCache:
         """
         self.all_types_dict: dict[str, Any] | None = None
         # True only after the built-in, custom, and extension component maps
-        # have been merged. ``_determine_loading_strategy`` temporarily places
-        # partial values (including ``{}``) in ``all_types_dict`` while startup
-        # is still in flight, so presence alone is not a readiness signal.
+        # and every derived lookup have been published atomically.
         self.all_types_ready = False
         self.fully_loaded_components: dict[str, bool] = {}
         # Precomputed code hashes for fast flow validation.
@@ -69,6 +70,24 @@ class ComponentCache:
         # substitute the trusted copy for client bytes once the hash gate
         # passes, so a truncated-hash collision can't run attacker code.
         self.code_by_hash: dict[str, str] | None = None
+        # Collision-aware canonical registry identity lookup used by catalog
+        # palette and runtime policy enforcement.
+        self.component_identity_index: ComponentIdentityIndex | None = None
+        # Registry publication and every process-wide derived lookup share one
+        # lock. Hot reload builds templates outside the lock, then swaps the
+        # registry and invalidates its derived indexes atomically.
+        self.state_lock = threading.RLock()
+        # Cross-event-loop single-flight primitive for async initialization.
+        # ``concurrent.futures.Future`` is not bound to the first caller's loop;
+        # each follower awaits its own shielded ``asyncio.wrap_future`` view.
+        self.initialization_future: Future[dict[str, Any]] | None = None
+        # The elected caller starts cache construction in this independently
+        # owned task. Keeping a strong reference prevents cancellation of that
+        # caller from cancelling or garbage-collecting shared initialization.
+        self.initialization_task: asyncio.Task[None] | None = None
+        # Reloads that complete while initial discovery is in flight are folded
+        # into the local registry before its one atomic publication.
+        self.pending_bundle_updates: dict[str, dict[str, Any]] = {}
 
 
 # Singleton instance
@@ -740,26 +759,39 @@ async def _determine_loading_strategy(settings_service: "SettingsService") -> di
     Returns:
         Dictionary containing loaded component types and templates
     """
-    component_cache.all_types_dict = {}
+    all_types_dict: dict[str, Any] = {}
     if settings_service.settings.lazy_load_components:
         # Partial loading mode - just load component metadata
         await logger.adebug("Using partial component loading")
-        component_cache.all_types_dict = await aget_component_metadata(settings_service.settings.components_path)
+        all_types_dict = await aget_component_metadata(settings_service.settings.components_path)
     elif settings_service.settings.components_path:
         # Traditional full loading - filter out base components path to only load custom components
         custom_paths = [p for p in settings_service.settings.components_path if p != BASE_COMPONENTS_PATH]
         if custom_paths:
-            component_cache.all_types_dict = await aget_all_types_dict(custom_paths)
+            all_types_dict = await aget_all_types_dict(custom_paths)
 
     # Log custom component loading stats
-    components_dict = component_cache.all_types_dict or {}
+    components_dict = all_types_dict or {}
     component_count = sum(len(comps) for comps in components_dict.get("components", {}).values())
     if component_count > 0 and settings_service.settings.components_path:
         await logger.adebug(
             f"Built {component_count} custom components from {settings_service.settings.components_path}"
         )
 
-    return component_cache.all_types_dict or {}
+    return all_types_dict
+
+
+def _collect_component_cache_lookups(
+    all_types_dict: dict[str, Any],
+) -> tuple[dict[str, set[str]], set[str], dict[str, str], ComponentIdentityIndex]:
+    """Build every derived component lookup without mutating shared cache state."""
+    type_to_hash, all_hashes = collect_component_hash_lookups(all_types_dict)
+    return (
+        type_to_hash,
+        all_hashes,
+        collect_code_by_hash(all_types_dict),
+        build_component_identity_index(all_types_dict),
+    )
 
 
 def _build_code_hash_lookups(cache: ComponentCache) -> None:
@@ -769,15 +801,43 @@ def _build_code_hash_lookups(cache: ComponentCache) -> None:
     - type_to_current_hash: {component_type: 12-char SHA256 prefix}
     - all_known_hashes: set of all known code hashes
     """
-    if cache.all_types_dict is None or (not cache.all_types_dict and not cache.all_types_ready):
-        return
+    with cache.state_lock:
+        all_types_dict = cache.all_types_dict
+        if all_types_dict is None or (not all_types_dict and not cache.all_types_ready):
+            return
 
-    type_to_hash, all_hashes = collect_component_hash_lookups(cache.all_types_dict)
+        type_to_hash, all_hashes, code_by_hash, identity_index = _collect_component_cache_lookups(all_types_dict)
 
-    cache.type_to_current_hash = type_to_hash
-    cache.all_known_hashes = all_hashes
-    cache.code_by_hash = collect_code_by_hash(cache.all_types_dict)
-    logger.debug(f"Built code hash lookups: {len(type_to_hash)} types, {len(all_hashes)} unique hashes")
+        cache.type_to_current_hash = type_to_hash
+        cache.all_known_hashes = all_hashes
+        cache.code_by_hash = code_by_hash
+        cache.component_identity_index = identity_index
+        logger.debug(f"Built code hash lookups: {len(type_to_hash)} types, {len(all_hashes)} unique hashes")
+
+
+def get_component_identity_index(
+    all_types_dict: dict[str, Any] | None = None,
+) -> ComponentIdentityIndex | None:
+    """Return a collision-aware identity index for a registry mapping.
+
+    The process-wide component registry reuses the precomputed cache. A
+    request-local or synthetic mapping receives its own index so it can never
+    accidentally resolve against stale identities from another registry.
+    When no mapping is supplied, an incompletely initialized component cache
+    returns ``None`` so active catalog policy can fail closed.
+    """
+    with component_cache.state_lock:
+        if all_types_dict is None:
+            if not component_cache.all_types_ready or component_cache.all_types_dict is None:
+                return None
+            all_types_dict = component_cache.all_types_dict
+
+        if all_types_dict is component_cache.all_types_dict:
+            if component_cache.component_identity_index is None:
+                component_cache.component_identity_index = build_component_identity_index(all_types_dict)
+            return component_cache.component_identity_index
+
+    return build_component_identity_index(all_types_dict)
 
 
 def _components_path_extension_paths(settings_service: "SettingsService") -> list[Path]:
@@ -1184,6 +1244,26 @@ async def import_extension_components(
     return components_dict
 
 
+def _publish_bundle_cache(bundle: str, bundle_dict: dict[str, Any]) -> bool:
+    """Atomically publish one reloaded bundle and invalidate derived lookups."""
+    with component_cache.state_lock:
+        current_types = component_cache.all_types_dict
+        if current_types is None or not component_cache.all_types_ready:
+            if component_cache.initialization_future is not None:
+                component_cache.pending_bundle_updates[bundle] = bundle_dict
+            return False
+
+        # Copy-on-write keeps any reader that already holds the previous
+        # registry paired with its previous immutable identity index.
+        component_cache.all_types_dict = {**current_types, bundle: bundle_dict}
+        component_cache.all_types_ready = True
+        component_cache.type_to_current_hash = None
+        component_cache.all_known_hashes = None
+        component_cache.code_by_hash = None
+        component_cache.component_identity_index = None
+        return True
+
+
 def refresh_bundle_cache_from_record(record: "BundleRecord") -> None:
     """Rebuild ``component_cache.all_types_dict`` for a single bundle after reload.
 
@@ -1197,7 +1277,10 @@ def refresh_bundle_cache_from_record(record: "BundleRecord") -> None:
     Components whose class fails to instantiate or template are skipped
     with a logged warning, mirroring :func:`import_extension_components`.
     """
-    if component_cache.all_types_dict is None:
+    with component_cache.state_lock:
+        cache_ready = component_cache.all_types_dict is not None and component_cache.all_types_ready
+        initialization_in_progress = component_cache.initialization_future is not None
+    if not cache_ready and not initialization_in_progress:
         # Cache hasn't been built yet; nothing to refresh.  The first
         # ``get_and_cache_all_types_dict`` call will see the fresh registry
         # entry and pick up the post-reload class set.
@@ -1260,37 +1343,62 @@ def refresh_bundle_cache_from_record(record: "BundleRecord") -> None:
             failures,
         )
 
-    component_cache.all_types_dict[record.bundle] = bundle_dict
-    component_cache.all_types_ready = True
-
-    # Invalidate the precomputed code-hash lookups so flow validation
-    # picks up the freshly-loaded class bodies instead of comparing
-    # against the pre-reload hashes.  ``get_component_hash_lookups_for_validation``
-    # rebuilds them lazily on the next call when the fields are None.  The
-    # trusted-source map is invalidated too so the endpoint never substitutes
-    # stale source after a bundle reload.
-    component_cache.type_to_current_hash = None
-    component_cache.all_known_hashes = None
-    component_cache.code_by_hash = None
+    # Publish the new registry and invalidate every derived view in one
+    # critical section. Readers therefore observe either the complete old
+    # state or the complete new state, never a new registry with a stale index.
+    _publish_bundle_cache(record.bundle, bundle_dict)
 
 
-async def get_and_cache_all_types_dict(
+def _consume_wrapped_initialization_result(wrapped_future: asyncio.Future[dict[str, Any]]) -> None:
+    """Retrieve a per-loop wrapper exception even if its caller was cancelled."""
+    if not wrapped_future.cancelled():
+        wrapped_future.exception()
+
+
+async def _await_component_cache_initialization(
+    initialization_future: Future[dict[str, Any]],
+) -> dict[str, Any]:
+    """Await process-wide initialization without coupling it to caller cancellation."""
+    wrapped_future = asyncio.wrap_future(initialization_future)
+    wrapped_future.add_done_callback(_consume_wrapped_initialization_result)
+    return await asyncio.shield(wrapped_future)
+
+
+def _finish_component_initialization_task(
+    cache: ComponentCache,
+    initialization_future: Future[dict[str, Any]],
+    initialization_task: asyncio.Task[None],
+) -> None:
+    """Clean up if the background initializer is cancelled or exits unexpectedly."""
+    task_exception = None if initialization_task.cancelled() else initialization_task.exception()
+    with cache.state_lock:
+        if cache.initialization_task is not initialization_task:
+            return
+
+        cache.initialization_task = None
+        if cache.initialization_future is not initialization_future:
+            return
+
+        cache.initialization_future = None
+        cache.pending_bundle_updates.clear()
+        if initialization_future.done():
+            return
+        if initialization_task.cancelled():
+            initialization_future.cancel()
+        elif task_exception is not None:
+            initialization_future.set_exception(task_exception)
+        else:
+            initialization_future.set_exception(RuntimeError("Component cache initialization ended without a result"))
+
+
+async def _initialize_component_cache(
+    cache: ComponentCache,
     settings_service: "SettingsService",
-    telemetry_service: Any | None = None,
-):
-    """Retrieves and caches the complete dictionary of component types and templates.
-
-    Supports both full and partial (lazy) loading. If the cache is empty, loads built-in Langflow
-    components and either fully loads all components or loads only their metadata, depending on the
-    lazy loading setting. Merges built-in, custom, and Extension-System components into the cache
-    and returns the resulting dictionary.
-
-    Args:
-        settings_service: Settings service instance
-        telemetry_service: Optional telemetry service for tracking component loading metrics
-    """
-    if component_cache.all_types_dict is None:
-        component_cache.all_types_ready = False
+    telemetry_service: Any | None,
+    initialization_future: Future[dict[str, Any]],
+) -> None:
+    """Build and atomically publish component state independently of any caller."""
+    try:
         await logger.adebug("Building components cache")
 
         langflow_components = await import_langflow_components(settings_service, telemetry_service)
@@ -1309,19 +1417,100 @@ async def get_and_cache_all_types_dict(
         # Merge built-in, custom, and extension components (no wrapper at cache level).
         # Extension components win on collision so a manifest-shipping bundle
         # supersedes any same-named legacy entry.
-        component_cache.all_types_dict = {
+        merged_types = {
             **langflow_components["components"],
             **custom_flat,
             **extension_components,
         }
-        component_cache.all_types_ready = True
-        component_count = sum(len(comps) for comps in component_cache.all_types_dict.values())
+        component_count = sum(len(comps) for comps in merged_types.values())
         await logger.adebug(f"Loaded {component_count} components")
 
-        # Precompute code hash lookups for fast flow validation
-        _build_code_hash_lookups(component_cache)
+        while True:
+            lookups = _collect_component_cache_lookups(merged_types)
+            with cache.state_lock:
+                if cache.pending_bundle_updates:
+                    pending_updates = dict(cache.pending_bundle_updates)
+                    cache.pending_bundle_updates.clear()
+                else:
+                    type_to_hash, all_hashes, code_by_hash, identity_index = lookups
+                    cache.all_types_dict = merged_types
+                    cache.all_types_ready = True
+                    cache.type_to_current_hash = type_to_hash
+                    cache.all_known_hashes = all_hashes
+                    cache.code_by_hash = code_by_hash
+                    cache.component_identity_index = identity_index
+                    cache.initialization_future = None
+                    cache.initialization_task = None
+                    initialization_future.set_result(merged_types)
+                    return
 
-    return component_cache.all_types_dict
+            # A reload completed while local discovery or lookup construction
+            # was in flight. Its bundle wins over the stale discovered copy;
+            # rebuild all derived maps locally before trying publication again.
+            merged_types = {**merged_types, **pending_updates}
+    except asyncio.CancelledError:
+        with cache.state_lock:
+            if cache.initialization_future is initialization_future:
+                cache.initialization_future = None
+                cache.initialization_task = None
+                cache.pending_bundle_updates.clear()
+            if not initialization_future.done():
+                initialization_future.cancel()
+        raise
+    except Exception as exc:  # noqa: BLE001
+        with cache.state_lock:
+            if cache.initialization_future is initialization_future:
+                cache.initialization_future = None
+                cache.initialization_task = None
+                cache.pending_bundle_updates.clear()
+            if not initialization_future.done():
+                initialization_future.set_exception(exc)
+
+
+async def get_and_cache_all_types_dict(
+    settings_service: "SettingsService",
+    telemetry_service: Any | None = None,
+) -> dict[str, Any]:
+    """Retrieves and caches the complete dictionary of component types and templates.
+
+    Supports both full and partial (lazy) loading. If the cache is empty, loads built-in Langflow
+    components and either fully loads all components or loads only their metadata, depending on the
+    lazy loading setting. Merges built-in, custom, and Extension-System components into the cache
+    and returns the resulting dictionary.
+
+    Args:
+        settings_service: Settings service instance
+        telemetry_service: Optional telemetry service for tracking component loading metrics
+    """
+    cache = component_cache
+    with cache.state_lock:
+        if cache.all_types_ready and cache.all_types_dict is not None:
+            return cache.all_types_dict
+
+        initialization_future = cache.initialization_future
+        if initialization_future is None:
+            initialization_future = Future()
+            cache.initialization_future = initialization_future
+            # Discard any legacy/failed partial state. The initializer keeps all
+            # new registry and lookup data in locals until atomic publication.
+            cache.all_types_dict = None
+            cache.all_types_ready = False
+            cache.type_to_current_hash = None
+            cache.all_known_hashes = None
+            cache.code_by_hash = None
+            cache.component_identity_index = None
+            initialization_task = asyncio.create_task(
+                _initialize_component_cache(cache, settings_service, telemetry_service, initialization_future),
+                name="lfx-component-cache-initialization",
+            )
+            cache.initialization_task = initialization_task
+            initialization_task.add_done_callback(
+                lambda task: _finish_component_initialization_task(cache, initialization_future, task)
+            )
+
+    # Every caller receives a loop-local wrapper. Shielding that wrapper keeps
+    # caller cancellation from reaching either the shared future or its task.
+    return await _await_component_cache_initialization(initialization_future)
 
 
 async def aget_all_types_dict(components_paths: list[str]):

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -823,12 +823,12 @@ def get_component_identity_index(
     The process-wide component registry reuses the precomputed cache. A
     request-local or synthetic mapping receives its own index so it can never
     accidentally resolve against stale identities from another registry.
-    When no mapping is supplied, an incompletely initialized component cache
-    returns ``None`` so active catalog policy can fail closed.
+    When no mapping is supplied, an incompletely initialized or empty process
+    registry returns ``None`` so active catalog policy can fail closed.
     """
     with component_cache.state_lock:
         if all_types_dict is None:
-            if not component_cache.all_types_ready or component_cache.all_types_dict is None:
+            if not component_cache.all_types_ready or not component_cache.all_types_dict:
                 return None
             all_types_dict = component_cache.all_types_dict
 
@@ -1251,6 +1251,12 @@ def _publish_bundle_cache(bundle: str, bundle_dict: dict[str, Any]) -> bool:
         if current_types is None or not component_cache.all_types_ready:
             if component_cache.initialization_future is not None:
                 component_cache.pending_bundle_updates[bundle] = bundle_dict
+                logger.debug("Queued reloaded bundle %r for the in-flight cache initialization", bundle)
+            else:
+                logger.debug(
+                    "Skipped publishing reloaded bundle %r: no component cache is published and none is initializing",
+                    bundle,
+                )
             return False
 
         # Copy-on-write keeps any reader that already holds the previous

--- a/src/lfx/src/lfx/utils/component_aliases.py
+++ b/src/lfx/src/lfx/utils/component_aliases.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 # Explicit fallback aliases for rare cases that cannot be derived from
@@ -24,6 +27,36 @@ LEGACY_TYPE_ALIASES: dict[str, str] = {
 # code stale and the UI reports them as permanently outdated.  Mirrors
 # ``getTemplateAliases`` in the frontend's reactflowUtils.ts.
 _EXT_KEY_RE = re.compile(r"^ext:[^:]+:(?P<class_name>[^@]+)@.+$")
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentIdentityIndex:
+    """Resolve component aliases against the current registry without guessing.
+
+    Registry keys are the canonical component identities for the running
+    release. Aliases may point at one or more canonical keys; keeping every
+    candidate prevents registry iteration order from silently choosing a
+    component when an alias is ambiguous.
+    """
+
+    canonical_keys: frozenset[str]
+    aliases: Mapping[str, frozenset[str]]
+
+    def resolve(self, identity: str) -> frozenset[str]:
+        """Return canonical candidates for ``identity``.
+
+        Exact canonical keys always win over aliases contributed by another
+        component. Unknown strings resolve to themselves so existing exact,
+        case-sensitive policy behavior is preserved for synthetic/custom
+        component identities that are not in the registry.
+        """
+        if identity in self.canonical_keys:
+            return frozenset({identity})
+        return self.aliases.get(identity, frozenset({identity}))
+
+    def resolve_many(self, identities: Iterable[str]) -> frozenset[str]:
+        """Return the union of canonical candidates for ``identities``."""
+        return frozenset(candidate for identity in identities for candidate in self.resolve(identity))
 
 
 def _component_alias_tiers(
@@ -89,6 +122,97 @@ def get_component_type_aliases(
     identity, display = _component_alias_tiers(component_name, component_data)
     deduped_aliases = dict.fromkeys(alias for alias in (*identity, *display) if alias)
     return tuple(deduped_aliases)
+
+
+def _component_identity_index_alias_tiers(
+    component_name: str,
+    component_data: Mapping[str, Any] | None,
+) -> tuple[list[str], list[str]]:
+    """Return aliases used only by the canonical policy identity index.
+
+    Runtime component materialization exposes the Python class name while the
+    registry may use a component's explicit ``name`` (for example,
+    ``PromptComponent`` versus ``Prompt Template``). These class identities
+    are intentionally index-only so the legacy starter-project flattening
+    behavior remains unchanged.
+    """
+    identity, display = _component_alias_tiers(component_name, component_data)
+    if component_data:
+        metadata = component_data.get("metadata")
+        if isinstance(metadata, Mapping):
+            module_value = metadata.get("module")
+            if isinstance(module_value, str) and module_value:
+                module_class_name = module_value.rsplit(".", maxsplit=1)[-1]
+                if module_class_name:
+                    identity.append(module_class_name)
+                    if module_class_name.endswith("Component"):
+                        identity.append(module_class_name.removesuffix("Component"))
+
+        template = component_data.get("template")
+        if isinstance(template, Mapping):
+            template_class_name = template.get("_type")
+            if isinstance(template_class_name, str) and template_class_name and template_class_name != "Component":
+                identity.append(template_class_name)
+                if template_class_name.endswith("Component"):
+                    display.append(template_class_name.removesuffix("Component"))
+
+    return (
+        list(dict.fromkeys(alias for alias in identity if alias)),
+        list(dict.fromkeys(alias for alias in display if alias)),
+    )
+
+
+def build_component_identity_index(all_types_dict: Mapping[str, Any]) -> ComponentIdentityIndex:
+    """Build a collision-aware identity index from a categorized registry.
+
+    Canonical registry keys are collected before aliases so an alias can never
+    shadow an exact key. Unlike :func:`flatten_components_with_aliases`, this
+    index retains all canonical candidates for an ambiguous alias instead of
+    selecting the first component encountered. The legacy flattening helper is
+    intentionally unchanged because starter-project upgrades still depend on
+    its value lookup behavior.
+    """
+    entries: list[tuple[str, Mapping[str, Any] | None]] = []
+    canonical_keys: set[str] = set()
+
+    for category_components in all_types_dict.values():
+        if not isinstance(category_components, Mapping):
+            continue
+        for component_name, component_data in category_components.items():
+            if not isinstance(component_name, str) or not component_name:
+                continue
+            canonical_keys.add(component_name)
+            entries.append(
+                (
+                    component_name,
+                    component_data if isinstance(component_data, Mapping) else None,
+                )
+            )
+
+    identity_candidates: defaultdict[str, set[str]] = defaultdict(set)
+    display_candidates: defaultdict[str, set[str]] = defaultdict(set)
+    for component_name, component_data in entries:
+        identity, display = _component_identity_index_alias_tiers(component_name, component_data)
+        for alias in identity:
+            if alias and alias not in canonical_keys:
+                identity_candidates[alias].add(component_name)
+        for alias in display:
+            if alias and alias not in canonical_keys:
+                display_candidates[alias].add(component_name)
+
+    # Identity aliases outrank display labels, matching the legacy two-pass
+    # precedence without its first-wins behavior. Collisions within the
+    # winning tier retain every candidate.
+    alias_candidates = {
+        alias: identity_candidates.get(alias) or display_candidates[alias]
+        for alias in identity_candidates.keys() | display_candidates.keys()
+    }
+
+    frozen_aliases = MappingProxyType({alias: frozenset(candidates) for alias, candidates in alias_candidates.items()})
+    return ComponentIdentityIndex(
+        canonical_keys=frozenset(canonical_keys),
+        aliases=frozen_aliases,
+    )
 
 
 def flatten_components_with_aliases(

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
-from lfx.utils.component_aliases import get_component_type_aliases
+from lfx.utils.component_aliases import ComponentIdentityIndex, get_component_type_aliases
 
 if TYPE_CHECKING:
     from lfx.services.catalog_policy import CatalogPolicySnapshot
@@ -19,6 +19,7 @@ SETTINGS_SERVICE_REQUIRED_MESSAGE = "Settings service must be initialized before
 CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE = (
     "Catalog policy component identities are still initializing. Please try again in a few seconds."
 )
+PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE = "This flow is temporarily unavailable. Please try again."
 
 # Built-in components that execute user- or model-supplied Python from input fields or during
 # runtime, rather than from the validated class ``code`` field. Their class-code hash is valid,
@@ -67,6 +68,10 @@ class CustomComponentValidationError(ValueError):
 
 class CatalogPolicyValidationError(CustomComponentValidationError):
     """Raised when a flow contains a component blocked by catalog policy."""
+
+
+class CatalogPolicyIdentityUnavailableError(RuntimeError):
+    """Raised when an active catalog rule needs an identity index that is not ready."""
 
 
 class PublicFlowValidationError(CustomComponentValidationError):
@@ -209,6 +214,28 @@ def _collect_catalog_component_keys(nodes: Any) -> set[str]:
     return component_keys
 
 
+def get_component_identity_index_for_validation() -> ComponentIdentityIndex | None:
+    """Return the cached canonical identity index when the registry is ready."""
+    from lfx.interface.components import get_component_identity_index
+
+    return get_component_identity_index()
+
+
+def _resolve_catalog_policy_matches(
+    component_keys: set[str],
+    blocked_component_keys: frozenset[str],
+    identity_index: ComponentIdentityIndex,
+) -> frozenset[str]:
+    """Return canonical identities shared by observed and blocked keys."""
+    blocked_identities = identity_index.resolve_many(blocked_component_keys)
+    return frozenset(
+        canonical_identity
+        for component_key in component_keys
+        for canonical_identity in identity_index.resolve(component_key)
+        if canonical_identity in blocked_identities
+    )
+
+
 def validate_catalog_policy_for_flow(
     target: Mapping[str, Any] | Any | None,
     *,
@@ -216,9 +243,10 @@ def validate_catalog_policy_for_flow(
 ) -> None:
     """Reject a flow containing component keys blocked by the current catalog snapshot.
 
-    Component identity is the exact, case-sensitive ``node.data.type`` value.
-    The immutable snapshot is captured once when the caller does not provide
-    one, so every node in a request is evaluated against the same policy view.
+    Exact, case-sensitive keys are enforced before the current registry's
+    canonical alias index is consulted. The immutable policy snapshot is
+    captured once when the caller does not provide one, so every node in a
+    request is evaluated against the same policy view.
     """
     if snapshot is None:
         from lfx.services.deps import get_catalog_policy_service
@@ -239,7 +267,22 @@ def validate_catalog_policy_for_flow(
         return
 
     component_keys = _collect_catalog_component_keys(normalized_flow_data.get("nodes"))
+    if not component_keys:
+        return
+
+    # Preserve exact matching even when the registry cache is still loading.
+    # This keeps synthetic/custom identities backward-compatible and lets an
+    # exact policy denial fail closed without waiting for alias data.
     blocked = snapshot.blocked_components(component_keys)
+    if not blocked:
+        identity_index = get_component_identity_index_for_validation()
+        if identity_index is None:
+            raise CatalogPolicyIdentityUnavailableError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+        blocked = _resolve_catalog_policy_matches(
+            component_keys,
+            snapshot.blocked_component_keys,
+            identity_index,
+        )
     if not blocked:
         return
 
@@ -467,20 +510,23 @@ def get_trusted_code_for_validation(code: str) -> str | None:
     """
     from lfx.interface.components import component_cache
 
-    # Self-heal: build the lookup lazily if the cache hasn't populated it yet
-    # (e.g. the eager warm-up path didn't run before the first request).
-    if (
-        component_cache.code_by_hash is None
-        and component_cache.all_types_ready
-        and component_cache.all_types_dict is not None
-    ):
-        component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
+    code_hash = _compute_code_hash(code)
+    with component_cache.state_lock:
+        # Self-heal lazily when eager warm-up did not run. Building and
+        # publishing under the same lock as reload prevents an old registry
+        # snapshot from being published after reload invalidates it.
+        if (
+            component_cache.code_by_hash is None
+            and component_cache.all_types_ready
+            and component_cache.all_types_dict is not None
+        ):
+            component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
 
-    code_by_hash = component_cache.code_by_hash
-    if not code_by_hash:
-        return None
+        code_by_hash = component_cache.code_by_hash
+        if not code_by_hash:
+            return None
 
-    return code_by_hash.get(_compute_code_hash(code))
+        return code_by_hash.get(code_hash)
 
 
 def resolve_trusted_code_for_build(code: str) -> str:
@@ -553,19 +599,17 @@ def check_flow_and_raise(
 
 def get_component_hash_lookups_for_validation() -> dict[str, set[str]] | None:
     """Return the cached component hashes, building them synchronously if possible."""
-    from lfx.interface.components import component_cache
+    from lfx.interface.components import _build_code_hash_lookups, component_cache
 
-    if (
-        component_cache.type_to_current_hash is None
-        and component_cache.all_types_ready
-        and component_cache.all_types_dict is not None
-    ):
-        type_to_hash, all_hashes = collect_component_hash_lookups(component_cache.all_types_dict)
-        component_cache.type_to_current_hash = type_to_hash
-        component_cache.all_known_hashes = all_hashes
-        component_cache.code_by_hash = collect_code_by_hash(component_cache.all_types_dict)
+    with component_cache.state_lock:
+        if (
+            component_cache.type_to_current_hash is None
+            and component_cache.all_types_ready
+            and component_cache.all_types_dict is not None
+        ):
+            _build_code_hash_lookups(component_cache)
 
-    return component_cache.type_to_current_hash
+        return component_cache.type_to_current_hash
 
 
 def validate_catalog_policy_for_component_code(
@@ -590,14 +634,25 @@ def validate_catalog_policy_for_component_code(
 
     type_to_current_hash = get_component_hash_lookups_for_validation()
     if type_to_current_hash is None:
-        raise RuntimeError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+        raise CatalogPolicyIdentityUnavailableError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
 
     code_hash = _compute_code_hash(code)
+    # Preserve exact lookup behavior for synthetic/custom identities and
+    # callers that provide a focused hash map in tests.
     blocked = frozenset(
         component_type
         for component_type in snapshot.blocked_component_keys
         if code_hash in type_to_current_hash.get(component_type, set())
     )
+    if not blocked:
+        identity_index = get_component_identity_index_for_validation()
+        if identity_index is None:
+            raise CatalogPolicyIdentityUnavailableError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+        blocked = frozenset(
+            component_type
+            for component_type in identity_index.resolve_many(snapshot.blocked_component_keys)
+            if code_hash in type_to_current_hash.get(component_type, set())
+        )
     if not blocked:
         return
 
@@ -612,17 +667,33 @@ def validate_catalog_policy_for_component_type(
     *,
     snapshot: CatalogPolicySnapshot | None = None,
 ) -> None:
-    """Reject a materialized component whose exact runtime type is blocked."""
+    """Reject a materialized component whose canonical identity is blocked."""
     if snapshot is None:
         from lfx.services.deps import get_catalog_policy_service
 
         snapshot = get_catalog_policy_service().snapshot
 
-    if not snapshot.is_component_blocked(component_type):
+    if not snapshot.blocked_component_keys:
         return
 
-    logger.warning(f"Component action blocked by catalog policy: {component_type}")
-    message = f"Catalog policy blocks components: {component_type}"
+    # Exact identities remain independently enforceable even before component
+    # template initialization completes.
+    if snapshot.is_component_blocked(component_type):
+        blocked = frozenset({component_type})
+    else:
+        identity_index = get_component_identity_index_for_validation()
+        if identity_index is None:
+            raise CatalogPolicyIdentityUnavailableError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+        blocked = identity_index.resolve(component_type).intersection(
+            identity_index.resolve_many(snapshot.blocked_component_keys)
+        )
+
+    if not blocked:
+        return
+
+    blocked_names = ", ".join(sorted(blocked))
+    logger.warning(f"Component action blocked by catalog policy: {blocked_names}")
+    message = f"Catalog policy blocks components: {blocked_names}"
     raise CatalogPolicyValidationError(message)
 
 
@@ -1002,19 +1073,31 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
 
 
 async def ensure_component_hash_lookups_loaded() -> dict[str, set[str]] | None:
-    """Ensure component hash lookups are available for CLI/runtime validation."""
-    from lfx.interface.components import component_cache, get_and_cache_all_types_dict
-    from lfx.services.deps import get_settings_service
+    """Ensure component lookups required by active CLI/runtime policy are available."""
+    from lfx.interface.components import (
+        component_cache,
+        get_and_cache_all_types_dict,
+        get_component_identity_index,
+    )
+    from lfx.services.deps import get_catalog_policy_service, get_settings_service
 
     settings_service = get_settings_service()
     if settings_service is None:
         raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
 
-    if not settings_service.settings.allow_custom_components and component_cache.type_to_current_hash is None:
+    catalog_policy_active = bool(get_catalog_policy_service().snapshot.blocked_component_keys)
+    policy_lookups_required = not settings_service.settings.allow_custom_components or catalog_policy_active
+    with component_cache.state_lock:
+        registry_unavailable = component_cache.all_types_dict is None or not component_cache.all_types_ready
+
+    if policy_lookups_required and registry_unavailable:
         try:
             await get_and_cache_all_types_dict(settings_service)
         except Exception as exc:
             logger.warning("Failed to populate component template hash lookups", exc_info=exc)
             raise
 
-    return component_cache.type_to_current_hash
+    if catalog_policy_active and get_component_identity_index() is None:
+        raise CatalogPolicyIdentityUnavailableError(CATALOG_POLICY_IDENTITIES_UNAVAILABLE_MESSAGE)
+
+    return get_component_hash_lookups_for_validation()

--- a/src/lfx/tests/unit/cli/test_run_real_flows.py
+++ b/src/lfx/tests/unit/cli/test_run_real_flows.py
@@ -226,7 +226,7 @@ class TestExecuteRealFlows:
                 return_value=settings_service,
             ),
             patch(
-                "lfx.utils.flow_validation.ensure_component_hash_lookups_loaded",
+                "lfx.load.load.ensure_component_hash_lookups_loaded",
                 new=AsyncMock(return_value=_builtin_hashes_from_flow(flow)),
             ),
             patch.object(component_cache, "type_to_current_hash", _builtin_hashes_from_flow(flow)),

--- a/src/lfx/tests/unit/cli/test_script_loader.py
+++ b/src/lfx/tests/unit/cli/test_script_loader.py
@@ -3,7 +3,8 @@
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from lfx.cli.script_loader import (
@@ -183,6 +184,70 @@ class TestLoadGraphFromScript:
         component_names = {v.custom_component.__class__.__name__ for v in graph.vertices}
         assert "ChatInput" in component_names
         assert "ChatOutput" in component_names
+
+    @pytest.mark.parametrize(
+        ("blocked_component_keys", "expected_blocked"),
+        [
+            pytest.param({"OtherComponent"}, False, id="unrelated-blocklist-allows-graph"),
+            pytest.param({"Chat Input"}, True, id="legacy-alias-blocks-graph"),
+        ],
+    )
+    async def test_active_catalog_policy_warms_cold_identity_cache_before_validation(
+        self,
+        blocked_component_keys,
+        expected_blocked,
+    ):
+        """Script graphs must resolve active policy aliases on the first cold-cache load."""
+        from lfx.components.input_output import ChatInput, ChatOutput
+        from lfx.graph import Graph
+        from lfx.interface import components as components_module
+        from lfx.services.catalog_policy import CatalogPolicySnapshot
+
+        chat_input = ChatInput()
+        chat_output = ChatOutput().set(input_value=chat_input.message_response)
+        graph = Graph(chat_input, chat_output)
+        graph.raw_graph_data = {
+            "nodes": [{"id": "chat-input", "data": {"id": "chat-input", "type": "ChatInput"}}],
+            "edges": [],
+        }
+        cache = components_module.ComponentCache()
+        settings_service = SimpleNamespace(settings=SimpleNamespace(allow_custom_components=True))
+        catalog_service = SimpleNamespace(
+            snapshot=CatalogPolicySnapshot(blocked_component_keys=blocked_component_keys),
+        )
+        builtins = {
+            "components": {
+                "input_output": {
+                    "ChatInput": {
+                        "display_name": "Chat Input",
+                        "template": {"_type": "Component"},
+                    }
+                }
+            }
+        }
+
+        with (
+            patch("lfx.cli.script_loader._load_module_from_script", return_value=SimpleNamespace(graph=graph)),
+            patch.object(components_module, "component_cache", cache),
+            patch.object(
+                components_module,
+                "import_langflow_components",
+                new=AsyncMock(return_value=builtins),
+            ) as load,
+            patch.object(components_module, "_determine_loading_strategy", new=AsyncMock(return_value={})),
+            patch.object(components_module, "import_extension_components", new=AsyncMock(return_value={})),
+            patch("lfx.services.deps.get_settings_service", return_value=settings_service),
+            patch("lfx.services.deps.get_catalog_policy_service", return_value=catalog_service),
+        ):
+            if expected_blocked:
+                with pytest.raises(RuntimeError, match="catalog policy blocks components: ChatInput"):
+                    await load_graph_from_script(Path("cold-cache-script.py"))
+            else:
+                assert await load_graph_from_script(Path("cold-cache-script.py")) is graph
+
+        load.assert_awaited_once_with(settings_service, None)
+        assert cache.all_types_ready
+        assert cache.component_identity_index is not None
 
     async def test_load_graph_from_script_no_graph_variable(self):
         """Test error when script has no graph variable."""

--- a/src/lfx/tests/unit/extension/test_components_cache_integration.py
+++ b/src/lfx/tests/unit/extension/test_components_cache_integration.py
@@ -14,9 +14,13 @@ positive assertion that the fields are stamped onto the produced template.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import os
+from threading import Event, Thread
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from lfx.interface.components import (
@@ -46,6 +50,280 @@ def _stub_template(*_args, **_kwargs) -> tuple[dict[str, Any], object]:
     decorator, so a sentinel object is sufficient.
     """
     return ({"display_name": "Stub", "type": "stub", "template": {}}, object())
+
+
+@pytest.mark.asyncio
+async def test_component_cache_initialization_is_single_flight_and_atomic() -> None:
+    """Concurrent callers share one load and never observe a partial registry."""
+    from lfx.interface import components as components_module
+
+    cache = components_module.ComponentCache()
+    settings_service = SimpleNamespace(settings=SimpleNamespace())
+    trusted_code = "# trusted ChatInput code"
+    code_hash = hashlib.sha256(trusted_code.encode()).hexdigest()[:12]
+    builtins = {
+        "components": {
+            "input_output": {
+                "ChatInput": {
+                    "display_name": "Chat Input",
+                    "metadata": {"code_hash": code_hash},
+                    "template": {"_type": "Component", "code": {"value": trusted_code}},
+                }
+            }
+        }
+    }
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+
+    async def load_builtins(*_args, **_kwargs):
+        load_started.set()
+        await release_load.wait()
+        return builtins
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(components_module, "import_langflow_components", new=AsyncMock(side_effect=load_builtins)) as load,
+        patch.object(components_module, "_determine_loading_strategy", new=AsyncMock(return_value={})),
+        patch.object(components_module, "import_extension_components", new=AsyncMock(return_value={})),
+    ):
+        leader = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.wait_for(load_started.wait(), timeout=2)
+        follower = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.sleep(0)
+
+        with cache.state_lock:
+            assert cache.all_types_dict is None
+            assert not cache.all_types_ready
+            assert cache.type_to_current_hash is None
+            assert cache.code_by_hash is None
+            assert cache.component_identity_index is None
+        assert not follower.done()
+
+        release_load.set()
+        leader_result, follower_result = await asyncio.wait_for(asyncio.gather(leader, follower), timeout=2)
+
+    assert load.await_count == 1
+    assert leader_result is follower_result
+    assert leader_result is cache.all_types_dict
+    assert cache.all_types_ready
+    assert cache.type_to_current_hash == {"ChatInput": {code_hash}, "Chat Input": {code_hash}}
+    assert cache.code_by_hash == {code_hash: trusted_code}
+    assert cache.component_identity_index is not None
+    assert cache.component_identity_index.resolve("Chat Input") == frozenset({"ChatInput"})
+
+
+@pytest.mark.asyncio
+async def test_cancelled_initiating_caller_does_not_cancel_shared_initialization() -> None:
+    """Cancelling the caller that elected initialization must not strand followers."""
+    from lfx.interface import components as components_module
+
+    cache = components_module.ComponentCache()
+    settings_service = SimpleNamespace(settings=SimpleNamespace())
+    builtins = {
+        "components": {
+            "input_output": {
+                "ChatInput": {
+                    "display_name": "Chat Input",
+                    "template": {"_type": "Component"},
+                }
+            }
+        }
+    }
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+
+    async def load_builtins(*_args, **_kwargs):
+        load_started.set()
+        await release_load.wait()
+        return builtins
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(components_module, "import_langflow_components", new=AsyncMock(side_effect=load_builtins)) as load,
+        patch.object(components_module, "_determine_loading_strategy", new=AsyncMock(return_value={})),
+        patch.object(components_module, "import_extension_components", new=AsyncMock(return_value={})),
+    ):
+        initiating_caller = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.wait_for(load_started.wait(), timeout=2)
+        follower = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.sleep(0)
+
+        with cache.state_lock:
+            initialization_task = cache.initialization_task
+            initialization_future = cache.initialization_future
+        assert initialization_task is not None
+        assert initialization_task is not initiating_caller
+        assert initialization_future is not None
+
+        initiating_caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await initiating_caller
+
+        assert not initialization_task.done()
+        assert not initialization_future.cancelled()
+        assert not follower.done()
+
+        release_load.set()
+        follower_result = await asyncio.wait_for(follower, timeout=2)
+
+    load.assert_awaited_once_with(settings_service, None)
+    assert follower_result is cache.all_types_dict
+    assert cache.all_types_ready
+    assert cache.initialization_future is None
+    assert cache.initialization_task is None
+
+
+@pytest.mark.asyncio
+async def test_failed_background_initialization_cleans_state_and_can_retry() -> None:
+    """Initializer failure reaches its caller and leaves no stale single-flight state."""
+    from lfx.interface import components as components_module
+
+    cache = components_module.ComponentCache()
+    settings_service = SimpleNamespace(settings=SimpleNamespace())
+    builtins = {"components": {}}
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(
+            components_module,
+            "import_langflow_components",
+            new=AsyncMock(side_effect=[RuntimeError("component import failed"), builtins]),
+        ) as load,
+        patch.object(components_module, "_determine_loading_strategy", new=AsyncMock(return_value={})),
+        patch.object(components_module, "import_extension_components", new=AsyncMock(return_value={})),
+    ):
+        with pytest.raises(RuntimeError, match="component import failed"):
+            await components_module.get_and_cache_all_types_dict(settings_service)
+
+        with cache.state_lock:
+            assert cache.initialization_future is None
+            assert cache.initialization_task is None
+            assert not cache.pending_bundle_updates
+
+        assert await components_module.get_and_cache_all_types_dict(settings_service) == {}
+
+    assert load.await_count == 2
+    assert cache.all_types_ready
+
+
+@pytest.mark.asyncio
+async def test_cancelled_background_initialization_cleans_shared_state() -> None:
+    """Explicit initializer cancellation wakes waiters and clears retry state."""
+    from lfx.interface import components as components_module
+
+    cache = components_module.ComponentCache()
+    settings_service = SimpleNamespace(settings=SimpleNamespace())
+    load_started = asyncio.Event()
+
+    async def load_builtins(*_args, **_kwargs):
+        load_started.set()
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(components_module, "import_langflow_components", new=AsyncMock(side_effect=load_builtins)),
+    ):
+        caller = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.wait_for(load_started.wait(), timeout=2)
+        with cache.state_lock:
+            initialization_task = cache.initialization_task
+        assert initialization_task is not None
+
+        initialization_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(caller, timeout=2)
+
+    with cache.state_lock:
+        assert cache.initialization_future is None
+        assert cache.initialization_task is None
+        assert not cache.pending_bundle_updates
+
+
+@pytest.mark.asyncio
+async def test_reload_completed_during_initialization_wins_at_atomic_publication(tmp_path: Path) -> None:
+    """A post-swap reload cannot be overwritten by stale in-flight discovery."""
+    from lfx.extension.bundle_registry import BundleRecord
+    from lfx.extension.loader._types import LoadedComponent
+    from lfx.interface import components as components_module
+
+    cache = components_module.ComponentCache()
+    settings_service = SimpleNamespace(settings=SimpleNamespace())
+    stale_id = "ext:delta:OldThing@official"
+    current_id = "ext:delta:DeltaThing@official"
+    stale_extension = {
+        "delta": {
+            stale_id: {
+                "name": "OldThing",
+                "display_name": "Old Thing",
+                "template": {"_type": "Component"},
+            }
+        }
+    }
+    stale_discovery_ready = asyncio.Event()
+    release_discovery = asyncio.Event()
+
+    async def load_stale_extension(_settings_service):
+        stale_discovery_ready.set()
+        await release_discovery.wait()
+        return stale_extension
+
+    class _DeltaThing:
+        display_name = "Delta"
+
+        def build(self) -> None:
+            return None
+
+    record = BundleRecord(
+        bundle="delta",
+        extension_id="lfx-delta",
+        extension_version="1.0.0",
+        slot="official",
+        components=(
+            LoadedComponent(
+                extension_id="lfx-delta",
+                extension_version="1.0.0",
+                bundle="delta",
+                class_name="DeltaThing",
+                slot="official",
+                klass=_DeltaThing,
+                module_name="_lfx_ext.official.delta.thing",
+                file_path=tmp_path / "thing.py",
+                distribution=None,
+            ),
+        ),
+    )
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(
+            components_module,
+            "import_langflow_components",
+            new=AsyncMock(return_value={"components": {}}),
+        ),
+        patch.object(components_module, "_determine_loading_strategy", new=AsyncMock(return_value={})),
+        patch.object(
+            components_module,
+            "import_extension_components",
+            new=AsyncMock(side_effect=load_stale_extension),
+        ),
+        patch.object(components_module, "create_component_template", side_effect=_stub_template),
+    ):
+        initialization = asyncio.create_task(components_module.get_and_cache_all_types_dict(settings_service))
+        await asyncio.wait_for(stale_discovery_ready.wait(), timeout=2)
+
+        components_module.refresh_bundle_cache_from_record(record)
+        with cache.state_lock:
+            assert current_id in cache.pending_bundle_updates["delta"]
+            assert cache.all_types_dict is None
+
+        release_discovery.set()
+        result = await asyncio.wait_for(initialization, timeout=2)
+
+    assert current_id in result["delta"]
+    assert stale_id not in result["delta"]
+    assert result is cache.all_types_dict
+    assert cache.component_identity_index is not None
+    assert cache.component_identity_index.resolve("DeltaThing") == frozenset({current_id})
 
 
 def test_decorate_template_stamps_required_fields() -> None:
@@ -528,6 +806,7 @@ def test_post_swap_hook_refreshes_component_cache(tmp_path: Path) -> None:
 
     # Seed the cache with a placeholder pre-reload template for bundle 'gamma'.
     component_cache.all_types_dict = {"gamma": {"old": {"display_name": "old"}}}
+    component_cache.all_types_ready = True
 
     # Build a BundleRecord with a fake LoadedComponent.  We use the same
     # toy Component shim the other tests use; create_component_template
@@ -585,6 +864,7 @@ def test_post_swap_hook_noop_when_cache_not_built() -> None:
     )
 
     component_cache.all_types_dict = None
+    component_cache.all_types_ready = False
     record = BundleRecord(
         bundle="empty",
         extension_id="lfx-empty",
@@ -613,8 +893,10 @@ def test_post_swap_hook_invalidates_hash_lookups(tmp_path: Path) -> None:
     )
 
     component_cache.all_types_dict = {"delta": {"old": {"display_name": "old"}}}
+    component_cache.all_types_ready = True
     component_cache.type_to_current_hash = {"DeltaThing": {"abc123def456"}}  # pragma: allowlist secret
     component_cache.all_known_hashes = {"abc123def456"}  # pragma: allowlist secret
+    component_cache.component_identity_index = object()
 
     class _Component:
         pass
@@ -649,6 +931,239 @@ def test_post_swap_hook_invalidates_hash_lookups(tmp_path: Path) -> None:
 
     assert component_cache.type_to_current_hash is None
     assert component_cache.all_known_hashes is None
+    assert component_cache.component_identity_index is None
+
+
+def test_identity_index_read_cannot_publish_stale_state_after_reload(tmp_path: Path) -> None:
+    """A reader building the old index must linearize before reload invalidates it."""
+    from lfx.extension.bundle_registry import BundleRecord
+    from lfx.extension.loader._types import LoadedComponent
+    from lfx.interface import components as components_module
+
+    old_id = "ext:delta:OldThing@official"
+    new_id = "ext:delta:DeltaThing@official"
+    component_cache = components_module.component_cache
+    with component_cache.state_lock:
+        component_cache.all_types_dict = {
+            "delta": {
+                old_id: {
+                    "name": "OldThing",
+                    "display_name": "Old Thing",
+                    "template": {"_type": "Component"},
+                }
+            }
+        }
+        component_cache.all_types_ready = True
+        component_cache.component_identity_index = None
+
+    class _DeltaThing:
+        display_name = "Delta"
+
+        def build(self) -> None:
+            return None
+
+    record = BundleRecord(
+        bundle="delta",
+        extension_id="lfx-delta",
+        extension_version="1.0.0",
+        slot="official",
+        components=(
+            LoadedComponent(
+                extension_id="lfx-delta",
+                extension_version="1.0.0",
+                bundle="delta",
+                class_name="DeltaThing",
+                slot="official",
+                klass=_DeltaThing,
+                module_name="_lfx_ext.official.delta.thing",
+                file_path=tmp_path / "thing.py",
+                distribution=None,
+            ),
+        ),
+    )
+
+    build_started = Event()
+    release_build = Event()
+    refresh_started = Event()
+    refresh_finished = Event()
+    reader_results = []
+    thread_errors: list[Exception] = []
+    real_build = components_module.build_component_identity_index
+
+    def delayed_build(all_types_dict):
+        result = real_build(all_types_dict)
+        build_started.set()
+        if not release_build.wait(timeout=2):
+            message = "identity-index test did not release the reader"
+            raise TimeoutError(message)
+        return result
+
+    def read_identity_index() -> None:
+        try:
+            reader_results.append(components_module.get_component_identity_index())
+        except Exception as exc:
+            thread_errors.append(exc)
+
+    def refresh_cache() -> None:
+        refresh_started.set()
+        try:
+            components_module.refresh_bundle_cache_from_record(record)
+        except Exception as exc:
+            thread_errors.append(exc)
+        finally:
+            refresh_finished.set()
+
+    with (
+        patch.object(components_module, "build_component_identity_index", side_effect=delayed_build),
+        patch.object(components_module, "create_component_template", side_effect=_stub_template),
+    ):
+        reader = Thread(target=read_identity_index)
+        reader.start()
+        assert build_started.wait(timeout=2)
+
+        refresher = Thread(target=refresh_cache)
+        refresher.start()
+        assert refresh_started.wait(timeout=2)
+        assert not refresh_finished.wait(timeout=0.1), "reload published while an old index read held the state lock"
+
+        release_build.set()
+        reader.join(timeout=2)
+        refresher.join(timeout=2)
+        assert not reader.is_alive()
+        assert not refresher.is_alive()
+
+    assert not thread_errors
+    assert reader_results[0].resolve("OldThing") == frozenset({old_id})
+    assert component_cache.component_identity_index is None
+
+    current_index = components_module.get_component_identity_index()
+    assert current_index is not None
+    assert current_index.resolve("DeltaThing") == frozenset({new_id})
+    assert old_id not in current_index.canonical_keys
+
+
+def test_trusted_code_read_cannot_republish_stale_state_after_reload(tmp_path: Path) -> None:
+    """Lazy trusted-code construction linearizes before reload invalidation."""
+    from lfx.extension.bundle_registry import BundleRecord
+    from lfx.extension.loader._types import LoadedComponent
+    from lfx.interface import components as components_module
+    from lfx.utils import flow_validation
+
+    cache = components_module.ComponentCache()
+    old_id = "ext:delta:OldThing@official"
+    new_id = "ext:delta:DeltaThing@official"
+    old_code = "# trusted old code"
+    new_code = "# trusted new code"
+    old_hash = hashlib.sha256(old_code.encode()).hexdigest()[:12]
+    new_hash = hashlib.sha256(new_code.encode()).hexdigest()[:12]
+    with cache.state_lock:
+        cache.all_types_dict = {
+            "delta": {
+                old_id: {
+                    "name": "OldThing",
+                    "metadata": {"code_hash": old_hash},
+                    "template": {"_type": "Component", "code": {"value": old_code}},
+                }
+            }
+        }
+        cache.all_types_ready = True
+        cache.code_by_hash = None
+
+    class _DeltaThing:
+        display_name = "Delta"
+
+        def build(self) -> None:
+            return None
+
+    record = BundleRecord(
+        bundle="delta",
+        extension_id="lfx-delta",
+        extension_version="1.0.0",
+        slot="official",
+        components=(
+            LoadedComponent(
+                extension_id="lfx-delta",
+                extension_version="1.0.0",
+                bundle="delta",
+                class_name="DeltaThing",
+                slot="official",
+                klass=_DeltaThing,
+                module_name="_lfx_ext.official.delta.thing",
+                file_path=tmp_path / "thing.py",
+                distribution=None,
+            ),
+        ),
+    )
+
+    def new_template(*_args, **_kwargs):
+        return (
+            {
+                "display_name": "Delta",
+                "metadata": {"code_hash": new_hash},
+                "template": {"_type": "Component", "code": {"value": new_code}},
+            },
+            object(),
+        )
+
+    build_started = Event()
+    release_build = Event()
+    refresh_started = Event()
+    refresh_finished = Event()
+    reader_results: list[str | None] = []
+    thread_errors: list[Exception] = []
+    real_collect = flow_validation.collect_code_by_hash
+
+    def delayed_collect(all_types_dict):
+        result = real_collect(all_types_dict)
+        build_started.set()
+        if not release_build.wait(timeout=2):
+            message = "trusted-code test did not release the reader"
+            raise TimeoutError(message)
+        return result
+
+    def read_trusted_code() -> None:
+        try:
+            reader_results.append(flow_validation.get_trusted_code_for_validation(old_code))
+        except Exception as exc:
+            thread_errors.append(exc)
+
+    def refresh_cache() -> None:
+        refresh_started.set()
+        try:
+            components_module.refresh_bundle_cache_from_record(record)
+        except Exception as exc:
+            thread_errors.append(exc)
+        finally:
+            refresh_finished.set()
+
+    with (
+        patch.object(components_module, "component_cache", cache),
+        patch.object(flow_validation, "collect_code_by_hash", side_effect=delayed_collect),
+        patch.object(components_module, "create_component_template", side_effect=new_template),
+    ):
+        reader = Thread(target=read_trusted_code)
+        reader.start()
+        assert build_started.wait(timeout=2)
+
+        refresher = Thread(target=refresh_cache)
+        refresher.start()
+        assert refresh_started.wait(timeout=2)
+        assert not refresh_finished.wait(timeout=0.1), "reload passed a trusted-code read holding the state lock"
+
+        release_build.set()
+        reader.join(timeout=2)
+        refresher.join(timeout=2)
+        assert not reader.is_alive()
+        assert not refresher.is_alive()
+
+        assert cache.code_by_hash is None
+        assert flow_validation.get_trusted_code_for_validation(new_code) == new_code
+        assert flow_validation.get_trusted_code_for_validation(old_code) is None
+
+    assert not thread_errors
+    assert reader_results == [old_code]
+    assert cache.all_types_dict is not None
+    assert new_id in cache.all_types_dict["delta"]
 
 
 def test_refresh_cache_preserves_entry_on_total_failure(tmp_path: Path) -> None:
@@ -669,6 +1184,7 @@ def test_refresh_cache_preserves_entry_on_total_failure(tmp_path: Path) -> None:
 
     pre_existing = {"ext:zeta:OldThing@official": {"display_name": "old", "extension": "lfx-zeta"}}
     component_cache.all_types_dict = {"zeta": dict(pre_existing)}
+    component_cache.all_types_ready = True
 
     class _Component:
         pass
@@ -727,6 +1243,7 @@ def test_refresh_cache_writes_partial_on_partial_failure(tmp_path: Path) -> None
     )
 
     component_cache.all_types_dict = {"eta": {}}
+    component_cache.all_types_ready = True
 
     class _Component:
         pass

--- a/src/lfx/tests/unit/extension/test_components_cache_integration.py
+++ b/src/lfx/tests/unit/extension/test_components_cache_integration.py
@@ -942,9 +942,9 @@ def test_identity_index_read_cannot_publish_stale_state_after_reload(tmp_path: P
 
     old_id = "ext:delta:OldThing@official"
     new_id = "ext:delta:DeltaThing@official"
-    component_cache = components_module.component_cache
-    with component_cache.state_lock:
-        component_cache.all_types_dict = {
+    cache = components_module.ComponentCache()
+    with cache.state_lock:
+        cache.all_types_dict = {
             "delta": {
                 old_id: {
                     "name": "OldThing",
@@ -953,8 +953,8 @@ def test_identity_index_read_cannot_publish_stale_state_after_reload(tmp_path: P
                 }
             }
         }
-        component_cache.all_types_ready = True
-        component_cache.component_identity_index = None
+        cache.all_types_ready = True
+        cache.component_identity_index = None
 
     class _DeltaThing:
         display_name = "Delta"
@@ -1014,6 +1014,7 @@ def test_identity_index_read_cannot_publish_stale_state_after_reload(tmp_path: P
             refresh_finished.set()
 
     with (
+        patch.object(components_module, "component_cache", cache),
         patch.object(components_module, "build_component_identity_index", side_effect=delayed_build),
         patch.object(components_module, "create_component_template", side_effect=_stub_template),
     ):
@@ -1032,14 +1033,14 @@ def test_identity_index_read_cannot_publish_stale_state_after_reload(tmp_path: P
         assert not reader.is_alive()
         assert not refresher.is_alive()
 
-    assert not thread_errors
-    assert reader_results[0].resolve("OldThing") == frozenset({old_id})
-    assert component_cache.component_identity_index is None
+        assert not thread_errors
+        assert reader_results[0].resolve("OldThing") == frozenset({old_id})
+        assert cache.component_identity_index is None
 
-    current_index = components_module.get_component_identity_index()
-    assert current_index is not None
-    assert current_index.resolve("DeltaThing") == frozenset({new_id})
-    assert old_id not in current_index.canonical_keys
+        current_index = components_module.get_component_identity_index()
+        assert current_index is not None
+        assert current_index.resolve("DeltaThing") == frozenset({new_id})
+        assert old_id not in current_index.canonical_keys
 
 
 def test_trusted_code_read_cannot_republish_stale_state_after_reload(tmp_path: Path) -> None:

--- a/src/lfx/tests/unit/load/test_load.py
+++ b/src/lfx/tests/unit/load/test_load.py
@@ -56,7 +56,7 @@ async def test_aload_flow_from_json_fail_closed_when_hashes_are_unavailable():
             return_value=_settings_service(allow_custom_components=False),
         ),
         patch(
-            "lfx.utils.flow_validation.ensure_component_hash_lookups_loaded",
+            "lfx.load.load.ensure_component_hash_lookups_loaded",
             new=AsyncMock(return_value=None),
         ),
         patch.object(component_cache, "type_to_current_hash", None),
@@ -97,7 +97,7 @@ async def test_aload_flow_from_json_allows_legacy_url_aliases():
             return_value=_settings_service(allow_custom_components=False),
         ),
         patch(
-            "lfx.utils.flow_validation.ensure_component_hash_lookups_loaded",
+            "lfx.load.load.ensure_component_hash_lookups_loaded",
             new=AsyncMock(return_value=type_to_current_hash),
         ),
         patch.object(component_cache, "type_to_current_hash", type_to_current_hash),

--- a/src/lfx/tests/unit/run/test_base.py
+++ b/src/lfx/tests/unit/run/test_base.py
@@ -227,7 +227,7 @@ class TestRunFlowJsonInput:
                 return_value=settings_service,
             ),
             patch(
-                "lfx.utils.flow_validation.ensure_component_hash_lookups_loaded",
+                "lfx.load.load.ensure_component_hash_lookups_loaded",
                 new=AsyncMock(return_value={"ChatInput": {"knownhash1234"}}),
             ),
             patch.object(component_cache, "type_to_current_hash", {"ChatInput": {"knownhash1234"}}),

--- a/src/lfx/tests/unit/utils/test_component_aliases.py
+++ b/src/lfx/tests/unit/utils/test_component_aliases.py
@@ -8,7 +8,9 @@ come from parsing the key itself.  Without it, the starter-project updater
 pre-move node types like ``TavilySearchComponent``.
 """
 
+import pytest
 from lfx.utils.component_aliases import (
+    build_component_identity_index,
     flatten_components_with_aliases,
     get_component_type_aliases,
 )
@@ -93,3 +95,101 @@ def test_identity_alias_beats_display_name_collision_composio_first():
     all_types_dict = {"c": dict([_AGENTQL_COMPOSIO, _AGENTQL_STANDALONE])}
     flat = flatten_components_with_aliases(all_types_dict)
     assert flat["AgentQL"] is flat[_AGENTQL_STANDALONE[0]]
+
+
+ASTRADB_KEY = "ext:datastax:AstraDBVectorStoreComponent@official"  # pragma: allowlist secret
+IDENTITY_COMPONENTS = {
+    "models_and_agents": {
+        "Prompt Template": {
+            "name": "Prompt Template",
+            "display_name": "Prompt Template",
+            "metadata": {"module": "lfx.components.models_and_agents.prompt.PromptComponent"},
+            "template": {"_type": "Component"},
+        },
+        "LangChain Hub Prompt": {
+            "name": "LangChain Hub Prompt",
+            "display_name": "Prompt Hub",
+            "metadata": {"module": "lfx.components.langchain_utilities.langchain_hub.LangChainHubPromptComponent"},
+            "template": {"_type": "Component"},
+        },
+    },
+    "llm_operations": {
+        "Smart Transform": {
+            "name": "Smart Transform",
+            "display_name": "Smart Transform",
+            "metadata": {"module": "lfx.components.llm_operations.lambda_filter.LambdaFilterComponent"},
+            "template": {"_type": "Component"},
+        },
+    },
+    "input_output": {
+        "ChatInput": {
+            "display_name": "Chat Input",
+            "metadata": {"module": "lfx.components.input_output.chat.ChatInput"},
+            "template": {"_type": "Component"},
+        }
+    },
+    "datastax": {
+        ASTRADB_KEY: {
+            "name": "AstraDB",
+            "display_name": "Astra DB",
+            "metadata": {"module": "lfx_datastax.components.datastax.astradb_vectorstore.AstraDBVectorStoreComponent"},
+            "template": {"_type": "Component"},
+        }
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("identity", "canonical"),
+    [
+        ("Prompt Template", "Prompt Template"),
+        ("Prompt", "Prompt Template"),
+        ("PromptComponent", "Prompt Template"),
+        (ASTRADB_KEY, ASTRADB_KEY),
+        ("AstraDB", ASTRADB_KEY),
+        ("AstraDBVectorStoreComponent", ASTRADB_KEY),
+        ("AstraDBVectorStore", ASTRADB_KEY),
+        ("ChatInput", "ChatInput"),
+        ("Chat Input", "ChatInput"),
+        ("LambdaFilter", "Smart Transform"),
+        ("LambdaFilterComponent", "Smart Transform"),
+        ("LangChainHubPrompt", "LangChain Hub Prompt"),
+        ("LangChainHubPromptComponent", "LangChain Hub Prompt"),
+    ],
+)
+def test_component_identity_index_resolves_current_and_legacy_identities(identity, canonical):
+    identity_index = build_component_identity_index(IDENTITY_COMPONENTS)
+    assert identity_index.resolve(identity) == frozenset({canonical})
+
+
+def test_component_identity_index_keeps_same_tier_collisions_ambiguous():
+    components = {
+        "one": {"First": {"name": "Shared"}},
+        "two": {"Second": {"name": "Shared"}},
+    }
+    identity_index = build_component_identity_index(components)
+    assert identity_index.resolve("Shared") == frozenset({"First", "Second"})
+
+
+def test_component_identity_index_canonical_and_identity_tiers_win_without_first_wins():
+    identity_index = build_component_identity_index(
+        {
+            "canonical": {"AgentQL": {"display_name": "Canonical"}},
+            "extensions": dict([_AGENTQL_COMPOSIO, _AGENTQL_STANDALONE]),
+        }
+    )
+
+    # An exact registry key wins over every alias with the same spelling.
+    assert identity_index.resolve("AgentQL") == frozenset({"AgentQL"})
+
+    extension_only_index = build_component_identity_index(
+        {"extensions": dict([_AGENTQL_COMPOSIO, _AGENTQL_STANDALONE])}
+    )
+    # The standalone class identity wins over the Composio display label,
+    # independent of iteration order.
+    assert extension_only_index.resolve("AgentQL") == frozenset({_AGENTQL_STANDALONE[0]})
+
+
+def test_component_identity_index_preserves_unknown_exact_identity():
+    identity_index = build_component_identity_index(IDENTITY_COMPONENTS)
+    assert identity_index.resolve("UnknownComponent") == frozenset({"UnknownComponent"})

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -179,6 +179,33 @@ async def test_standalone_warmup_loads_catalog_identities_when_custom_components
         validate_catalog_policy_for_flow(_catalog_flow("PromptComponent"), snapshot=snapshot)
 
 
+@pytest.mark.asyncio
+async def test_standalone_warmup_fails_closed_when_published_registry_is_empty(monkeypatch):
+    """An empty published registry cannot satisfy active alias-aware catalog policy."""
+    from lfx.interface.components import component_cache
+
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"})
+    settings_service = SimpleNamespace(settings=SimpleNamespace(allow_custom_components=True))
+    catalog_service = SimpleNamespace(snapshot=snapshot)
+
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(component_cache, "all_types_dict", {})
+    monkeypatch.setattr(component_cache, "all_types_ready", True)
+    monkeypatch.setattr(component_cache, "type_to_current_hash", {})
+    monkeypatch.setattr(component_cache, "all_known_hashes", set())
+    monkeypatch.setattr(component_cache, "code_by_hash", {})
+    monkeypatch.setattr(component_cache, "component_identity_index", None)
+
+    with (
+        patch("lfx.interface.components.get_and_cache_all_types_dict", new=AsyncMock()) as loader,
+        pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"),
+    ):
+        await ensure_component_hash_lookups_loaded()
+
+    loader.assert_not_awaited()
+
+
 def test_catalog_policy_validation_blocks_top_level_components_deterministically():
     snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"Zed", "Agent"}))
 
@@ -251,6 +278,21 @@ def test_catalog_policy_alias_validation_fails_closed_without_component_identity
 
     # A non-exact decision needs the canonical alias index and fails closed
     # under the same initialization contract as component-code validation.
+    with pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"):
+        validate_catalog_policy_for_flow(
+            _catalog_flow("Prompt"),
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"}),
+        )
+
+
+def test_catalog_policy_alias_validation_fails_closed_with_empty_published_registry(monkeypatch):
+    """A ready-but-empty registry cannot satisfy alias-aware catalog policy."""
+    from lfx.interface.components import component_cache
+
+    monkeypatch.setattr(component_cache, "all_types_dict", {})
+    monkeypatch.setattr(component_cache, "all_types_ready", True)
+    monkeypatch.setattr(component_cache, "component_identity_index", None)
+
     with pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"):
         validate_catalog_policy_for_flow(
             _catalog_flow("Prompt"),

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from lfx.services.catalog_policy import CatalogPolicySnapshot
+from lfx.utils.component_aliases import build_component_identity_index
 from lfx.utils.flow_validation import (
     CODE_EXECUTION_COMPONENT_TYPES,
     FLOW_REFERENCE_COMPONENT_TYPES,
+    CatalogPolicyIdentityUnavailableError,
     CatalogPolicyValidationError,
     CustomComponentValidationError,
     PublicFlowValidationError,
@@ -64,6 +66,8 @@ async def test_ensure_component_hash_lookups_loaded_surfaces_loader_failures(mon
         settings=SimpleNamespace(allow_custom_components=False),
     )
     monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(component_cache, "all_types_dict", None)
+    monkeypatch.setattr(component_cache, "all_types_ready", False)
     monkeypatch.setattr(component_cache, "type_to_current_hash", None)
 
     with (
@@ -102,6 +106,79 @@ def _catalog_flow(*component_types: str) -> dict:
     }
 
 
+ASTRADB_KEY = "ext:datastax:AstraDBVectorStoreComponent@official"  # pragma: allowlist secret
+
+
+def _catalog_registry() -> dict:
+    return {
+        "models_and_agents": {
+            "Prompt Template": {
+                "name": "Prompt Template",
+                "display_name": "Prompt Template",
+                "metadata": {"module": "lfx.components.models_and_agents.prompt.PromptComponent"},
+                "template": {"_type": "Component"},
+            }
+        },
+        "input_output": {
+            "ChatInput": {
+                "display_name": "Chat Input",
+                "metadata": {"module": "lfx.components.input_output.chat.ChatInput"},
+                "template": {"_type": "Component"},
+            }
+        },
+        "datastax": {
+            ASTRADB_KEY: {
+                "name": "AstraDB",
+                "display_name": "Astra DB",
+                "metadata": {
+                    "module": "lfx_datastax.components.datastax.astradb_vectorstore.AstraDBVectorStoreComponent"
+                },
+                "template": {"_type": "Component"},
+            }
+        },
+    }
+
+
+def _catalog_identity_index():
+    return build_component_identity_index(_catalog_registry())
+
+
+@pytest.mark.asyncio
+async def test_standalone_warmup_loads_catalog_identities_when_custom_components_are_allowed(monkeypatch):
+    """An active catalog rule must warm aliases even in permissive custom-code mode."""
+    from lfx.interface.components import component_cache
+
+    snapshot = CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"})
+    settings_service = SimpleNamespace(settings=SimpleNamespace(allow_custom_components=True))
+    catalog_service = SimpleNamespace(snapshot=snapshot)
+
+    async def populate_component_cache(_settings_service):
+        with component_cache.state_lock:
+            component_cache.all_types_dict = _catalog_registry()
+            component_cache.all_types_ready = True
+        return component_cache.all_types_dict
+
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(component_cache, "all_types_dict", None)
+    monkeypatch.setattr(component_cache, "all_types_ready", False)
+    monkeypatch.setattr(component_cache, "type_to_current_hash", None)
+    monkeypatch.setattr(component_cache, "all_known_hashes", None)
+    monkeypatch.setattr(component_cache, "code_by_hash", None)
+    monkeypatch.setattr(component_cache, "component_identity_index", None)
+
+    with patch(
+        "lfx.interface.components.get_and_cache_all_types_dict",
+        new=AsyncMock(side_effect=populate_component_cache),
+    ) as loader:
+        assert await ensure_component_hash_lookups_loaded() == {}
+
+    loader.assert_awaited_once_with(settings_service)
+    validate_catalog_policy_for_flow(_catalog_flow("Chat Input"), snapshot=snapshot)
+    with pytest.raises(CatalogPolicyValidationError, match="Prompt Template"):
+        validate_catalog_policy_for_flow(_catalog_flow("PromptComponent"), snapshot=snapshot)
+
+
 def test_catalog_policy_validation_blocks_top_level_components_deterministically():
     snapshot = CatalogPolicySnapshot(blocked_component_keys=frozenset({"Zed", "Agent"}))
 
@@ -118,12 +195,82 @@ def test_catalog_policy_validation_blocks_nested_components():
         validate_catalog_policy_for_flow(flow, snapshot=snapshot)
 
 
-def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_allows():
+def test_catalog_policy_validation_is_exact_case_sensitive_and_empty_snapshot_allows(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: _catalog_identity_index(),
+    )
     validate_catalog_policy_for_flow(
         _catalog_flow("agent"),
         snapshot=CatalogPolicySnapshot(blocked_component_keys=frozenset({"Agent"})),
     )
     validate_catalog_policy_for_flow(_catalog_flow("Agent"), snapshot=CatalogPolicySnapshot())
+
+
+@pytest.mark.parametrize(
+    ("blocked_identity", "flow_identity", "canonical"),
+    [
+        ("Prompt Template", "Prompt", "Prompt Template"),
+        ("Prompt", "PromptComponent", "Prompt Template"),
+        ("PromptComponent", "Prompt Template", "Prompt Template"),
+        (ASTRADB_KEY, "AstraDB", ASTRADB_KEY),
+        ("AstraDB", ASTRADB_KEY, ASTRADB_KEY),
+        ("Chat Input", "ChatInput", "ChatInput"),
+    ],
+)
+def test_catalog_policy_flow_validation_resolves_canonical_and_legacy_identities(
+    monkeypatch,
+    blocked_identity,
+    flow_identity,
+    canonical,
+):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: _catalog_identity_index(),
+    )
+
+    with pytest.raises(CatalogPolicyValidationError, match=canonical):
+        validate_catalog_policy_for_flow(
+            _catalog_flow(flow_identity),
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={blocked_identity}),
+        )
+
+
+def test_catalog_policy_alias_validation_fails_closed_without_component_identity_cache(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: None,
+    )
+
+    # Exact identities remain enforceable without the registry cache.
+    with pytest.raises(CatalogPolicyValidationError, match="ExactBlocked"):
+        validate_catalog_policy_for_flow(
+            _catalog_flow("ExactBlocked"),
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"ExactBlocked"}),
+        )
+
+    # A non-exact decision needs the canonical alias index and fails closed
+    # under the same initialization contract as component-code validation.
+    with pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"):
+        validate_catalog_policy_for_flow(
+            _catalog_flow("Prompt"),
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Prompt Template"}),
+        )
+
+
+def test_catalog_policy_validation_blocks_nested_legacy_alias(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: _catalog_identity_index(),
+    )
+    flow = _catalog_flow("Group")
+    flow["nodes"][0]["data"]["node"]["flow"] = {"data": _catalog_flow("PromptComponent")}
+
+    with pytest.raises(CatalogPolicyValidationError, match="Prompt Template"):
+        validate_catalog_policy_for_flow(
+            flow,
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={"Prompt"}),
+        )
 
 
 def test_catalog_policy_component_code_blocks_known_alias_before_execution(monkeypatch):
@@ -160,7 +307,7 @@ def test_catalog_policy_component_code_fails_closed_while_identities_initialize(
         lambda: None,
     )
 
-    with pytest.raises(RuntimeError, match="identities are still initializing"):
+    with pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"):
         validate_catalog_policy_for_component_code(
             "arbitrary code",
             snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
@@ -176,7 +323,7 @@ def test_catalog_policy_component_code_does_not_build_from_transient_component_c
     monkeypatch.setattr(component_cache, "all_known_hashes", None)
     monkeypatch.setattr(component_cache, "code_by_hash", None)
 
-    with pytest.raises(RuntimeError, match="identities are still initializing"):
+    with pytest.raises(CatalogPolicyIdentityUnavailableError, match="identities are still initializing"):
         validate_catalog_policy_for_component_code(
             "arbitrary code",
             snapshot=CatalogPolicySnapshot(blocked_component_keys={"Agent"}),
@@ -187,13 +334,45 @@ def test_catalog_policy_component_code_does_not_build_from_transient_component_c
     assert component_cache.code_by_hash is None
 
 
-def test_catalog_policy_component_type_is_exact_and_empty_snapshot_allows():
+def test_catalog_policy_component_type_is_exact_and_empty_snapshot_allows(monkeypatch):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: _catalog_identity_index(),
+    )
     snapshot = CatalogPolicySnapshot(blocked_component_keys={"Agent"})
 
     validate_catalog_policy_for_component_type("agent", snapshot=snapshot)
     validate_catalog_policy_for_component_type("Agent", snapshot=CatalogPolicySnapshot())
     with pytest.raises(CatalogPolicyValidationError, match="Agent"):
         validate_catalog_policy_for_component_type("Agent", snapshot=snapshot)
+
+
+@pytest.mark.parametrize(
+    ("blocked_identity", "runtime_identity", "canonical"),
+    [
+        ("Prompt Template", "PromptComponent", "Prompt Template"),
+        ("PromptComponent", "Prompt Template", "Prompt Template"),
+        (ASTRADB_KEY, "AstraDB", ASTRADB_KEY),
+        ("AstraDB", "AstraDBVectorStoreComponent", ASTRADB_KEY),
+        ("Chat Input", "ChatInput", "ChatInput"),
+    ],
+)
+def test_catalog_policy_materialized_component_resolves_canonical_identity(
+    monkeypatch,
+    blocked_identity,
+    runtime_identity,
+    canonical,
+):
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: _catalog_identity_index(),
+    )
+
+    with pytest.raises(CatalogPolicyValidationError, match=canonical):
+        validate_catalog_policy_for_component_type(
+            runtime_identity,
+            snapshot=CatalogPolicySnapshot(blocked_component_keys={blocked_identity}),
+        )
 
 
 def test_validate_flow_for_current_settings_captures_one_catalog_snapshot(monkeypatch):


### PR DESCRIPTION
## Summary

- introduce one collision-aware canonical component identity index shared by palette filtering, saved-flow validation, trusted code-hash enforcement, and materialized runtime-type checks
- resolve registry keys, legacy class names, display names, and extension IDs consistently without renaming component classes or changing extension canonical IDs
- make registry/derived-cache initialization single-flight and atomic, serialize trusted-code reads with hot reload, and preserve reload updates that complete during initialization
- warm catalog identities for standalone JSON and Python-script execution, and return retryable 503s while identities initialize (sanitized on public APIs)

## Identity contract

For the 1.12 runtime, current component-registry keys are canonical. Resolution precedence is:

1. exact canonical key
2. identity aliases (class/name/extension aliases)
3. display aliases

Same-tier collisions retain every candidate and therefore fail closed; unknown identities preserve existing exact, case-sensitive behavior.

## Cache and availability contract

- component registry plus hash/code/identity views publish atomically
- hot reload uses copy-on-write publication and cannot republish stale identity or trusted-code maps
- initialization runs in an independently owned cross-loop single-flight task; cancelling one caller does not cancel followers
- public v1/v2 routes expose a static 503 message and do not leak internal identity/cache details

## Validation

- focused LFX suite: 182 passed
- focused backend route-contract suite: 14 passed
- final added backend regression selection: 6 passed
- MyPy: all 10 changed production modules passed
- Ruff, formatting, `git diff --check`, secret scan, and all configured pre-commit hooks passed
- independent code, Python, and security reviews: no remaining findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Catalog policies now reliably recognize canonical component identities and legacy aliases, including ambiguous names.
  - Flow and workflow validation failures caused by unavailable catalog information now return retryable HTTP 503 responses.
  - Public endpoints show a standardized message without exposing internal error details.
  - Component catalog filtering preserves ordering, removes blocked items correctly, and avoids mutating cached data.

- **Reliability**
  - Improved component loading, caching, reload behavior, and concurrent initialization for more consistent validation and startup results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->