### PR TITLE
fix(policies): prevent guarded tool serialization recursion

### DIFF
--- a/src/backend/base/langflow/serialization/serialization.py
+++ b/src/backend/base/langflow/serialization/serialization.py
@@ -304,7 +304,7 @@ def serialize(
             try:
                 return repr(obj)
             except Exception as e:  # noqa: BLE001
-                logger.debug(f"Cannot serialize object {obj}: {e!s}")
+                logger.debug(f"Cannot serialize object of type {type(obj).__name__}: {e!s}")
 
         # Fallback to common serialization patterns
         if hasattr(obj, "model_dump"):
@@ -317,7 +317,7 @@ def serialize(
             return str(obj)
 
     except Exception as e:  # noqa: BLE001
-        logger.debug(f"Cannot serialize object {obj}: {e!s}")
+        logger.debug(f"Cannot serialize object of type {type(obj).__name__}: {e!s}")
         return "[Unserializable Object]"
     return obj
 

--- a/src/backend/tests/unit/components/models_and_agents/policies/test_guarded_tool.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/test_guarded_tool.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain_core.tools import StructuredTool
+from langflow.api.v1.schemas import ResultDataResponse, VertexBuildResponse
 from lfx.components.models_and_agents.policies.guarded_tool import GuardedTool
 from pydantic import BaseModel
 from toolguard.runtime import PolicyViolationException
@@ -38,7 +39,7 @@ async def test_guarded_tool_successful_execution():
     guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
 
     # Test with dict input
-    result = await guarded_tool.arun({"person": {"name": "Alice", "age": 30}})
+    result = await guarded_tool.ainvoke({"person": {"name": "Alice", "age": 30}})
 
     # Verify guard_toolcall was called
     mock_toolguard.guard_toolcall.assert_called_once()
@@ -128,3 +129,19 @@ def test_guarded_tool_run_not_implemented():
 
     with pytest.raises(NotImplementedError):
         guarded_tool.run({"person": {"name": "Test", "age": 20}})
+
+
+def test_guarded_tool_can_be_serialized_in_vertex_response():
+    """GuardedTool's bound callables must not create a recursive representation."""
+    lc_tool = StructuredTool.from_function(my_function)
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], MagicMock())
+
+    for representation in (repr(guarded_tool), str(guarded_tool)):
+        assert "func=" not in representation
+        assert "coroutine=" not in representation
+
+    response = VertexBuildResponse(valid=True, data=ResultDataResponse(results={"tool": guarded_tool}))
+    serialized_response = response.model_dump_json()
+
+    assert '"valid":true' in serialized_response
+    assert '"name":"my_function"' in serialized_response

--- a/src/backend/tests/unit/serialization/test_serialization.py
+++ b/src/backend/tests/unit/serialization/test_serialization.py
@@ -208,6 +208,16 @@ class TestSerializationHypothesis:
         result: str = serialize(instance)
         assert result == str(instance)
 
+    def test_recursive_string_serialization_returns_sentinel(self) -> None:
+        class RecursiveString:
+            def __str__(self) -> str:
+                return str(self)
+
+        obj = RecursiveString()
+
+        assert serialize(obj) == "[Unserializable Object]"
+        assert serialize_or_str(obj) == "[Unserializable Object]"
+
     def test_pydantic_class_serialization(self) -> None:
         result: str = serialize(ModernModel)
         assert result == repr(ModernModel)

--- a/src/lfx/src/lfx/components/models_and_agents/policies/guarded_tool.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/guarded_tool.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable  # noqa: TC003
 from typing import TYPE_CHECKING
+
+from pydantic import Field
 
 from lfx.field_typing import Tool
 from lfx.log.logger import logger
@@ -33,6 +36,11 @@ class GuardedTool(Tool):
     _orig_tool: Tool
     _tool_invoker: ToolInvoker
     _toolguard: ToolguardRuntime
+
+    # These callables are bound to this instance, so including them in the model
+    # representation would recursively render the GuardedTool itself.
+    func: Callable[..., str] | None = Field(repr=False)
+    coroutine: Callable[..., Awaitable[str]] | None = Field(default=None, repr=False)
 
     def __init__(self, tool: Tool, all_tools: list[Tool], toolguard: ToolguardRuntime):
         from lfx.components.models_and_agents.policies.tool_invoker import ToolInvoker


### PR DESCRIPTION
## Summary

- keep `GuardedTool` self-bound `func` and `coroutine` callables out of its Pydantic representation
- make backend serialization failure logs type-only so the fallback cannot re-render the object that just failed
- cover `ainvoke`, direct repr/str, the `VertexBuildResponse.model_dump_json()` build boundary, and recursive string fallbacks

## Context

Policies Guard mode returns `GuardedTool` instances whose callable fields point back to the same instance. Pydantic includes those fields in the model representation, so rendering the tool recurses. The backend serializer catches that failure, but its exception log interpolates the offending object and triggers the same recursion again.

This addresses the Guard-mode serialization portion of #14050 and follows #14388. It does not address the separate Anthropic extended-thinking error reported in #14050.

The unfixed vertex response boundary raised `PydanticSerializationError` wrapping `RecursionError` in the local reproduction. With this patch, the same response serializes successfully in about 8 ms.

## Validation

- targeted Ruff format and lint checks
- 54 focused Policies, serializer, and API-schema tests passed
- all applicable pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization error handling for objects with problematic string representations.
  * Prevented recursive serialization errors from propagating.
  * Guarded tools can now be represented and serialized safely without exposing internal callable details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->