### PR TITLE
fix: stop CI Success passing over a job set that never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ on:
           - '["self-hosted", "linux", "ARM64", "langflow-ai-arm64-40gb-ephemeral"]'
         default: ubuntu-latest
   pull_request:
-    types: [opened, synchronize, labeled]
+    # ready_for_review matters: every job below is gated on the PR not being a draft, so a PR
+    # opened as a draft and later marked ready has no run where that gate was ever true.
+    types: [opened, synchronize, labeled, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -490,8 +492,13 @@ jobs:
       RESULTS_JSON: ${{ toJSON(needs.*.result) }}
       # Skip nightly build check if only docs files changed
       DOCS_ONLY: ${{ needs.path-filter.outputs.docs-only }}
+      # A skipped need is not counted as a failure, which is correct when path-filter ran and
+      # decided nothing relevant changed. It is not correct when path-filter itself never
+      # produced a decision: every dependent job is then skipped for want of its outputs, and
+      # this gate would report success over a job set that never ran. Require the decision.
       EXIT_CODE: ${{ (contains(needs.*.result, 'failure') ||
         contains(needs.*.result, 'cancelled') ||
+        (needs.set-ci-condition.outputs.should-run-ci == 'true' && !inputs.run-all-tests && needs.path-filter.result != 'success') ||
         (needs.check-nightly-status.outputs.should-proceed != 'true' && github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' && needs.path-filter.outputs.docs-only != 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-nightly-check')))
         && '1' || '0' }}
     steps:
@@ -503,6 +510,7 @@ jobs:
           echo "Nightly build status: ${{ needs.check-nightly-status.outputs.should-proceed }}"
           echo "Event type: ${{ github.event_name }}"
           echo "Docs only changes: $DOCS_ONLY"
+          echo "Path filter decision: ${{ needs.path-filter.result }}"
           echo "Python changes: ${{ needs.path-filter.outputs.python }}"
           echo "Frontend changes: ${{ needs.path-filter.outputs.frontend }}"
           echo "Docs changes: ${{ needs.path-filter.outputs.docs }}"


### PR DESCRIPTION
## What

There are two ways a PR reaches a green `CI Success` without its tests having run.

**No `ready_for_review` trigger.** Every job in this workflow is gated on `should-run-ci`, which is `github.event.pull_request.draft == false`. But `pull_request` only listens for `opened`, `synchronize` and `labeled`. A PR opened as a draft and later marked ready therefore has no run in which that gate was ever true — the most recent run still carries the draft payload (`IsDraft -> true`), so `path-filter` is skipped and every job depending on its outputs is skipped with it.

**`CI Success` does not notice.** Its exit code counts only `failure` and `cancelled`. A `skipped` need is not a failure — correct when `path-filter` ran and decided nothing relevant changed, wrong when `path-filter` produced no decision at all. The same hole covers a `path-filter` that fails outright, since a failed job publishes no outputs and its dependents skip.

Net effect: green means "everything passed" and also "nothing ran", and the merge queue cannot tell them apart.

## Observed

On #14357, after marking it ready for review:

```
CI Success            pass   4s
Filter Paths          skipping
Run Backend Tests     skipping
Run Frontend Tests    skipping
Test Docker Images    skipping
```

Approved, mergeable, required checks green, backend tests never executed. Adding a label (a trigger that *is* listened for) produced a run with `draft=false`, at which point `Filter Paths` ran and the tests actually executed.

## The change

Listen for `ready_for_review`, and require a `path-filter` decision whenever CI was supposed to run and the `run-all-tests` bypass is not in play. `!inputs.run-all-tests` is the same guard `path-filter`'s own `if:` already uses on these events.

Also echoes `path-filter.result` in the status summary, since a red `CI Success` with no failed job underneath is otherwise hard to read.

## Verification

`actionlint` reports the same 7 pre-existing shellcheck findings before and after, none in the changed lines. YAML parses.

This PR was opened as a draft and then marked ready on purpose: that is the exact scenario, so the checks on it are the end-to-end test. What happens is reported in a comment below rather than asserted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - CI checks now run when a draft pull request becomes ready for review.
  - Status reporting now clearly indicates whether required change detection completed successfully.
  - Prevented misleading successful checks when required validation steps were skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->