### PR TITLE
fix(crewai): support crewai 1.x LLM factory in convert_llm

### DIFF
--- a/src/lfx/src/lfx/base/agents/crewai/crew.py
+++ b/src/lfx/src/lfx/base/agents/crewai/crew.py
@@ -52,7 +52,7 @@ def convert_llm(llm: Any, excluded_keys=None):
         A CrewAI-compatible LLM object
     """
     try:
-        from crewai import LLM
+        from crewai import LLM, BaseLLM
     except ImportError as e:
         msg = "CrewAI is not installed. Please install it with `uv pip install crewai`."
         raise ImportError(msg) from e
@@ -60,8 +60,8 @@ def convert_llm(llm: Any, excluded_keys=None):
     if not llm:
         return None
 
-    # Check if this is already an LLM object
-    if isinstance(llm, LLM):
+    # From crewai 1.0 `LLM(...)` returns provider-specific BaseLLM subclasses, not LLM instances.
+    if isinstance(llm, BaseLLM):
         return llm
 
     # Check if we should use model_name model, or something else

--- a/src/lfx/tests/unit/base/agents/test_crewai_convert_llm.py
+++ b/src/lfx/tests/unit/base/agents/test_crewai_convert_llm.py
@@ -1,0 +1,78 @@
+"""Tests for CrewAI LLM conversion across supported crewai versions.
+
+Regression coverage for LE-2092: with crewai >= 1.0, ``crewai.LLM(...)`` is a
+factory that returns provider-specific subclasses of ``BaseLLM`` (for example
+``OpenAICompletion``) which are *not* instances of ``crewai.LLM``. A guard that
+tests ``isinstance(llm, LLM)`` therefore stops being idempotent, and the second
+conversion pass performed by ``BaseCrewComponent.get_tasks_and_agents`` falls
+through to the LangChain branch and raises
+``AttributeError: 'OpenAICompletion' object has no attribute 'get_lc_namespace'``.
+
+crewai is an optional dependency that is not installable in the default
+workspace (documented httpx conflict), so these tests skip when it is absent.
+They were run against crewai 0.126.0, 0.134.0 and 1.15.10.
+"""
+
+import pytest
+
+pytest.importorskip("crewai", reason="crewai is an optional dependency")
+
+from crewai import BaseLLM
+from lfx.base.agents.crewai.crew import convert_llm
+
+API_KEY = "sk-component-level-key"
+MODEL_NAME = "gpt-4o-mini"
+
+
+@pytest.fixture
+def langchain_model():
+    langchain_openai = pytest.importorskip("langchain_openai")
+    return langchain_openai.ChatOpenAI(model=MODEL_NAME, api_key=API_KEY)
+
+
+def test_should_build_crewai_llm_when_given_langchain_model(langchain_model):
+    # Act
+    converted = convert_llm(langchain_model)
+
+    # Assert
+    assert isinstance(converted, BaseLLM)
+    assert converted.api_key == API_KEY
+
+
+def test_should_return_same_object_when_llm_is_already_crewai_native(langchain_model):
+    """The crew re-converts every agent LLM, so conversion must be idempotent."""
+    # Arrange
+    converted = convert_llm(langchain_model)
+
+    # Act
+    reconverted = convert_llm(converted)
+
+    # Assert
+    assert reconverted is converted
+    assert reconverted.api_key == API_KEY
+
+
+def test_should_preserve_agent_llm_when_crew_reconverts_it(langchain_model):
+    """Reproduces the Sequential Task Agent -> Sequential Crew failure path."""
+    # Arrange
+    from crewai import Agent
+    from lfx.components.crewai.sequential_crew import SequentialCrewComponent
+
+    agent = Agent(
+        role="Researcher",
+        goal="Research the topic",
+        backstory="An experienced researcher",
+        llm=convert_llm(langchain_model),
+    )
+    crew_component = SequentialCrewComponent()
+
+    # Act
+    _tasks, agents = crew_component.get_tasks_and_agents(agents_list=[agent])
+
+    # Assert
+    assert isinstance(agents[0].llm, BaseLLM)
+    assert agents[0].llm.api_key == API_KEY
+
+
+def test_should_return_none_when_llm_is_missing():
+    assert convert_llm(None) is None

--- a/src/lfx/tests/unit/base/agents/test_crewai_convert_llm_mocked.py
+++ b/src/lfx/tests/unit/base/agents/test_crewai_convert_llm_mocked.py
@@ -1,0 +1,27 @@
+"""Dependency-free regression tests for CrewAI LLM conversion."""
+
+import sys
+from types import ModuleType
+
+from lfx.base.agents.crewai.crew import convert_llm
+
+
+def test_should_return_same_object_for_crewai_base_llm(monkeypatch):
+    class FakeBaseLLM:
+        pass
+
+    class FakeLLM(FakeBaseLLM):
+        pass
+
+    class FakeProviderLLM(FakeBaseLLM):
+        pass
+
+    fake_crewai = ModuleType("crewai")
+    fake_crewai.BaseLLM = FakeBaseLLM
+    fake_crewai.LLM = FakeLLM
+    monkeypatch.setitem(sys.modules, "crewai", fake_crewai)
+
+    provider_llm = FakeProviderLLM()
+
+    assert not isinstance(provider_llm, FakeLLM)
+    assert convert_llm(provider_llm) is provider_llm


### PR DESCRIPTION
## Summary

With `crewai >= 1.0`, running a `Sequential Task Agent -> Sequential Crew` flow fails at execution with:

```
AttributeError: 'OpenAICompletion' object has no attribute 'get_lc_namespace'
```

The cause is that `crewai.LLM` stopped being a plain class. From crewai 1.0 it is a **factory** that returns provider-specific subclasses of `BaseLLM`:

```
crewai 0.134.0:  LLM(model=...) -> crewai.llm.LLM                    isinstance(x, LLM) = True
crewai 1.15.10:  LLM(model=...) -> ...providers.openai.completion.OpenAICompletion   isinstance(x, LLM) = False
```

`convert_llm` guards its already-converted case with `isinstance(llm, LLM)`, so on crewai 1.x that guard silently stops matching. The flow performs **two** conversion passes:

1. `SequentialTaskAgentComponent.build_agent_and_task` converts the LangChain handle — fine.
2. `BaseCrewComponent.get_tasks_and_agents` re-converts every `agent.llm` — now a `crewai` object, the guard misses, execution falls through to the LangChain branch and calls `llm.get_lc_namespace()`.

That is why the failure surfaces at the Crew and not at the Agent, and why it is crewai-1.x-only.

## Changes

`src/lfx/src/lfx/base/agents/crewai/crew.py` — guard on `BaseLLM` instead of `LLM`. `LLM` subclasses `BaseLLM` in every supported version, so this is strictly wider and version-agnostic:

```python
from crewai import LLM, BaseLLM
...
if isinstance(llm, BaseLLM):
    return llm
```

`from crewai import BaseLLM` and `isinstance(LLM(...), BaseLLM) is True` were verified on **0.126.0** (the declared minimum), **0.134.0** and **1.15.10**. The fix lives in the shared helper, so Hierarchical Crew and `CrewAIAgentComponent` are covered as well. `convert_tools` was checked and is already idempotent — no change needed.

## Verification

New test `src/lfx/tests/unit/base/agents/test_crewai_convert_llm.py` (4 tests). crewai is an optional dependency that is not installable in the default workspace (documented `httpx` conflict), so the module uses `importorskip`; it was run against real crewai installs in isolated environments:

| | crewai 1.15.10 | crewai 0.134.0 |
| --- | --- | --- |
| before the fix | 2 failed with the exact `AttributeError`, 2 passed | — |
| after the fix | 4 passed | 4 passed |

End-to-end, on a running Langflow with crewai 1.15.10 installed — flow `Chat Input -> Language Model -> Sequential Task Agent -> Sequential Crew -> Chat Output`, executed through `POST /api/v1/run/{flow_id}`:

- before: `AttributeError: 'OpenAICompletion' object has no attribute 'get_lc_namespace'`
- after: `HTTP 200`, `error: false`, the crew's answer returned through `Chat Output`

The component-level API key still reaches the provider (`Authorization: Bearer sk-component-level-key`), confirming #14379 continues to hold on crewai 1.x.

Also run: `tests/unit/base/agents/` 68 passed / 1 skipped (clean skip without crewai), `test_component_index.py` + `test_check_components_frozen.py` 34 passed — no index regeneration needed, since this is a base module rather than a component. `ruff check` and `ruff format --check` clean.

## Compatibility

- No class name, input name, or output name changed — saved flows are unaffected.
- `BaseLLM` is imported lazily inside the function, so the module stays importable without `crewai`.
- No behavior change on crewai 0.x: `LLM` already subclasses `BaseLLM` there, so the widened guard matches exactly the same objects.

## Note for a follow-up

`crew.py` still calls `llm.dict()`, which langchain-core 1.4.2 deprecates and removes in 2.0.0 (`Use asdict instead`). It works today but will break the same function later. Left out of this PR because a version-guarded shim is a separate change.

Fixes LE-2092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with CrewAI 1.0 provider-specific language model types.
  * Prevented repeated model conversion issues in sequential task and crew workflows.
  * Preserved correct handling for converted models and empty inputs.

* **Tests**
  * Added regression coverage for model conversion, repeated conversions, sequential workflows, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->