### PR TITLE
fix: serialize model provider variable writes

### DIFF
--- a/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
@@ -32,6 +32,7 @@ const mockDeleteMutateAsync = jest.fn((params: { id: string | undefined }) => {
   deleteCalls.push(params);
   return Promise.resolve(undefined);
 });
+const mockCreateMutateAsync = jest.fn();
 
 const mockSetSuccessData = jest.fn();
 const mockSetErrorData = jest.fn();
@@ -56,7 +57,7 @@ jest.mock("@/controllers/API/queries/variables", () => ({
     isPending: false,
   }),
   usePostGlobalVariables: () => ({
-    mutateAsync: jest.fn(),
+    mutateAsync: mockCreateMutateAsync,
     isPending: false,
   }),
 }));
@@ -310,5 +311,103 @@ describe("useProviderConfiguration.handleDisconnect", () => {
 
     await waitFor(() => expect(mockSetErrorData).toHaveBeenCalled());
     expect(mockSetSuccessData).not.toHaveBeenCalled();
+  });
+});
+
+describe("useProviderConfiguration.handleSaveAllVariables", () => {
+  beforeEach(() => {
+    mockGlobalVariables.length = 0;
+    Object.keys(mockProviderVariablesMapping).forEach(
+      (k) => delete mockProviderVariablesMapping[k],
+    );
+    mockModelProviders = [];
+    mockCreateMutateAsync.mockReset();
+    mockSetSuccessData.mockClear();
+    mockSetErrorData.mockClear();
+    mockInvalidateQueries.mockClear();
+    mockRefetchQueries.mockClear();
+  });
+
+  it("waits for the base URL write before creating the API key", async () => {
+    mockProviderVariablesMapping["OpenAI Compatible"] = [
+      {
+        variable_name: "Base URL",
+        variable_key: "OPENAI_COMPATIBLE_BASE_URL",
+        required: true,
+        is_secret: false,
+        is_list: false,
+        options: [],
+      },
+      {
+        variable_name: "API Key",
+        variable_key: "OPENAI_COMPATIBLE_API_KEY",
+        required: false,
+        is_secret: true,
+        is_list: false,
+        options: [],
+      },
+    ];
+
+    let resolveBaseUrl!: () => void;
+    mockCreateMutateAsync.mockImplementation(({ name }: { name: string }) => {
+      if (name === "OPENAI_COMPATIBLE_BASE_URL") {
+        return new Promise<void>((resolve) => {
+          resolveBaseUrl = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    const { result } = renderProviderConfiguration({
+      provider: "OpenAI Compatible",
+      icon: "Plug",
+      is_enabled: false,
+      is_configured: false,
+      models: [],
+    });
+
+    act(() => {
+      result.current.handleVariableChange(
+        "OPENAI_COMPATIBLE_BASE_URL",
+        "https://api.openai.com/v1",
+      );
+      result.current.handleVariableChange(
+        "OPENAI_COMPATIBLE_API_KEY",
+        "test-api-key",
+      );
+    });
+
+    const dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0)
+      .mockImplementation(() => 500);
+    let savePromise!: Promise<void>;
+
+    try {
+      await act(async () => {
+        savePromise = result.current.handleSaveAllVariables();
+        await Promise.resolve();
+      });
+
+      expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+      expect(mockCreateMutateAsync).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ name: "OPENAI_COMPATIBLE_BASE_URL" }),
+      );
+
+      await act(async () => {
+        resolveBaseUrl();
+        await savePromise;
+      });
+
+      expect(mockCreateMutateAsync).toHaveBeenCalledTimes(2);
+      expect(mockCreateMutateAsync).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ name: "OPENAI_COMPATIBLE_API_KEY" }),
+      );
+      expect(mockSetErrorData).not.toHaveBeenCalled();
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 });

--- a/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
@@ -410,4 +410,83 @@ describe("useProviderConfiguration.handleSaveAllVariables", () => {
       dateNowSpy.mockRestore();
     }
   });
+
+  it("persists the OpenAI base URL before its primary credential", async () => {
+    mockProviderVariablesMapping.OpenAI = [
+      {
+        variable_name: "OpenAI API Key",
+        variable_key: "OPENAI_API_KEY",
+        required: true,
+        is_secret: true,
+        is_list: false,
+        options: [],
+      },
+      {
+        variable_name: "OpenAI Base URL",
+        variable_key: "OPENAI_BASE_URL",
+        required: false,
+        is_secret: false,
+        is_list: false,
+        options: [],
+      },
+    ];
+
+    let resolveFirstWrite!: () => void;
+    mockCreateMutateAsync
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstWrite = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+
+    const { result } = renderProviderConfiguration({
+      provider: "OpenAI",
+      icon: "OpenAI",
+      is_enabled: false,
+      is_configured: false,
+      models: [],
+    });
+
+    act(() => {
+      result.current.handleVariableChange(
+        "OPENAI_API_KEY",
+        "custom-endpoint-key",
+      );
+      result.current.handleVariableChange(
+        "OPENAI_BASE_URL",
+        "https://example.com/v1",
+      );
+    });
+
+    const dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0)
+      .mockImplementation(() => 500);
+    let savePromise!: Promise<void>;
+
+    try {
+      await act(async () => {
+        savePromise = result.current.handleSaveAllVariables();
+        await Promise.resolve();
+      });
+
+      const callsBeforeFirstWriteResolved =
+        mockCreateMutateAsync.mock.calls.map(([{ name }]) => name);
+
+      await act(async () => {
+        resolveFirstWrite();
+        await savePromise;
+      });
+
+      expect(callsBeforeFirstWriteResolved).toEqual(["OPENAI_BASE_URL"]);
+      expect(
+        mockCreateMutateAsync.mock.calls.map(([{ name }]) => name),
+      ).toEqual(["OPENAI_BASE_URL", "OPENAI_API_KEY"]);
+      expect(mockSetErrorData).not.toHaveBeenCalled();
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
 });

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -395,13 +395,25 @@ export const useProviderConfiguration = ({
     }));
   }, []);
 
-  // Save all variables in provider order — validates first, then saves if valid
+  // Save all variables with the primary provider variable last — validates first,
+  // then saves if valid
   const handleSaveAllVariables = useCallback(async () => {
     if (!selectedProvider) return;
 
-    const variablesToSave = providerVariables.filter((v) =>
-      variableValues[v.variable_key]?.trim(),
-    );
+    // Match the backend's primary-variable selection: required secret, then
+    // any secret, then the first provider variable. The variables API validates
+    // that field against companion values already in storage, so persist it last.
+    const primaryVariableKey =
+      providerVariables.find((v) => v.required && v.is_secret)?.variable_key ??
+      providerVariables.find((v) => v.is_secret)?.variable_key ??
+      providerVariables[0]?.variable_key;
+    const variablesToSave = providerVariables
+      .filter((v) => variableValues[v.variable_key]?.trim())
+      .sort(
+        (a, b) =>
+          Number(a.variable_key === primaryVariableKey) -
+          Number(b.variable_key === primaryVariableKey),
+      );
 
     if (variablesToSave.length === 0) return;
 
@@ -412,8 +424,7 @@ export const useProviderConfiguration = ({
     setValidationFailed(false);
 
     try {
-      // Provider credentials can depend on connection fields that precede them
-      // in the provider metadata. Persist each field before starting the next
+      // Persist each companion field before starting the primary-variable
       // request so backend validation can read the complete configuration.
       for (const variable of variablesToSave) {
         const value = variableValues[variable.variable_key].trim();

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -395,7 +395,7 @@ export const useProviderConfiguration = ({
     }));
   }, []);
 
-  // Save all variables in parallel — validates first, then saves if valid
+  // Save all variables in provider order — validates first, then saves if valid
   const handleSaveAllVariables = useCallback(async () => {
     if (!selectedProvider) return;
 
@@ -412,30 +412,30 @@ export const useProviderConfiguration = ({
     setValidationFailed(false);
 
     try {
-      // Fire all mutations in parallel
-      await Promise.all(
-        variablesToSave.map(async (variable) => {
-          const value = variableValues[variable.variable_key].trim();
-          const existingVariable = globalVariables.find(
-            (v) => v.name === variable.variable_key,
-          );
-          const variableType = variable.is_secret
-            ? VARIABLE_CATEGORY.CREDENTIAL
-            : VARIABLE_CATEGORY.GLOBAL;
+      // Provider credentials can depend on connection fields that precede them
+      // in the provider metadata. Persist each field before starting the next
+      // request so backend validation can read the complete configuration.
+      for (const variable of variablesToSave) {
+        const value = variableValues[variable.variable_key].trim();
+        const existingVariable = globalVariables.find(
+          (v) => v.name === variable.variable_key,
+        );
+        const variableType = variable.is_secret
+          ? VARIABLE_CATEGORY.CREDENTIAL
+          : VARIABLE_CATEGORY.GLOBAL;
 
-          if (existingVariable) {
-            return updateGlobalVariable({ id: existingVariable.id, value });
-          } else {
-            return createGlobalVariable({
-              name: variable.variable_key,
-              value,
-              type: variableType,
-              category: VARIABLE_CATEGORY.GLOBAL,
-              default_fields: [],
-            });
-          }
-        }),
-      );
+        if (existingVariable) {
+          await updateGlobalVariable({ id: existingVariable.id, value });
+        } else {
+          await createGlobalVariable({
+            name: variable.variable_key,
+            value,
+            type: variableType,
+            category: VARIABLE_CATEGORY.GLOBAL,
+            default_fields: [],
+          });
+        }
+      }
 
       // All succeeded — defer toast and value clear until after models refetch
       hasUserMadeChangesRef.current = true;


### PR DESCRIPTION
## Summary

- persist Model Provider variables sequentially with the backend-selected primary variable last
- commit companion connection fields first even when provider metadata lists the credential first, including OpenAI custom Base URLs
- cover both the OpenAI Compatible concurrency race and OpenAI's reversed metadata order with regression tests

## Root cause

The Model Provider save path used `Promise.all` for every variable mutation, while the variables API validates a provider's primary credential by reading companion variables from storage. Serialization fixes that race, but provider metadata order is not itself a dependency contract: OpenAI lists `OPENAI_API_KEY` before `OPENAI_BASE_URL`.

The save path now mirrors the backend's primary-variable selection (required secret, then any secret, then the first provider variable), preserves metadata order for all companion fields, and persists the primary variable last. This fixes OpenAI Compatible and vLLM without making OpenAI custom Base URLs validate against `api.openai.com` first.

## Validation

- `jest src/modals/modelProviderModal --runInBand` (6 suites, 91 tests)
- Biome check on the two changed frontend files
- pre-commit hooks, including detect-secrets, staged Biome, and no-any checks
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider configuration saving by processing settings in the correct order.
  * Ensured the base URL is saved before the API key for OpenAI-compatible providers.
  * Prevented configuration saves from proceeding until each preceding setting completes successfully.
  * Maintained existing validation, error handling, and success behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->