### PR TITLE
fix(tests): stub SSRF transport in spoofed-metadata policy tests

### DIFF
--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -790,6 +790,8 @@ def test_delegating_model_component_skips_outer_provider_gate(monkeypatch):
 
 
 def test_known_llm_provider_ignores_spoofed_runtime_metadata(monkeypatch):
+    from lfx.base.models.unified_models import instantiation
+
     requested_classes = []
     captured = {}
 
@@ -804,6 +806,11 @@ def test_known_llm_provider_ignores_spoofed_runtime_metadata(monkeypatch):
     monkeypatch.setattr("lfx.base.models.unified_models.get_model_class", _get_model_class)
     monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("lfx.base.models.unified_models.get_all_variables_for_provider", lambda *_args: {})
+    # ollama.test (RFC 6761 reserved TLD) never resolves, so the DNS-pinning
+    # SSRF transport for ChatOllama fails in every environment. The URL value
+    # is irrelevant to this test's subject (spoofed metadata being ignored),
+    # so stub the transport factory (same seam test_provider_registry stubs).
+    monkeypatch.setattr(instantiation, "ssrf_protected_httpx_client_kwargs_for_url", lambda _url: ({}, {}))
 
     result = get_llm(
         [
@@ -851,6 +858,9 @@ def test_known_embedding_provider_ignores_spoofed_runtime_metadata(monkeypatch):
     monkeypatch.setattr("lfx.base.models.unified_models.get_api_key_for_provider", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("lfx.base.models.unified_models.get_all_variables_for_provider", lambda *_args: {})
     monkeypatch.setattr(instantiation, "_get_configured_embedding_providers", lambda *_args: [])
+    # See the LLM variant above: ollama.test never resolves, and DNS is not
+    # what this test is about.
+    monkeypatch.setattr(instantiation, "ssrf_protected_httpx_client_kwargs_for_url", lambda _url: ({}, {}))
 
     result = get_embeddings(
         [


### PR DESCRIPTION
## Summary

`test_known_llm_provider_ignores_spoofed_runtime_metadata` and `test_known_embedding_provider_ignores_spoofed_runtime_metadata` (from the catalog-policy work) point ChatOllama at `http://ollama.test` — an RFC 6761 reserved TLD that never resolves publicly. The Ollama branch of `_protect_model_connection` routes that URL through the DNS-pinning SSRF transport (`ssrf_protected_httpx_client_kwargs_for_url`), so in any environment without a wildcard resolver the tests fail with:

```
ValueError: SSRF Protection: DNS resolution failed for ollama.test
```

First surfaced on #14400's `LFX Tests - Python 3.14` job; **reproduces on a pristine `release-1.12.0` checkout** (`4b1dd045b7`), so it is a base-branch issue, not specific to that PR.

## Fix

DNS is not what these tests assert (they verify spoofed runtime metadata is ignored in favor of the catalog identity), so stub `ssrf_protected_httpx_client_kwargs_for_url` on the `instantiation` module — the same seam `test_provider_registry.py` already stubs for the OpenAI variant. The stub returns `({}, {})`, so the existing exact-equality `captured` assertions stay intact.

## Test plan

- [x] `tests/unit/services/model_provider_policy/test_policy.py`: 44 passed on Python 3.14 (previously 2 failed)
- [x] Ruff check/format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Ollama provider tests to run reliably without attempting DNS resolution of reserved test hostnames.
  * Preserved coverage for provider metadata handling and runtime class selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->