### PR TITLE
feat: add Scavio bundle (188 endpoints, 32 platforms)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "lfx-vllm>=0.1.0,<1.0.0",
     "lfx-openai-compatible>=0.1.0,<1.0.0",
     "lfx-google>=0.1.0,<1.0.0",
+    "lfx-scavio>=0.1.0,<1.0.0",
     # langflow-extensions:bundle-deps-end
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ lfx-openai-compatible = { workspace = true }
 lfx-exa = { workspace = true }
 lfx-valkey = { workspace = true }
 lfx-google = { workspace = true }
+lfx-scavio = { workspace = true }
 # langflow-extensions:bundle-sources-end
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
@@ -157,6 +158,7 @@ members = [
     "src/bundles/exa",
     "src/bundles/valkey",
     "src/bundles/google",
+    "src/bundles/scavio",
     # langflow-extensions:bundle-members-end
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "lfx-vllm>=0.1.0,<1.0.0",
     "lfx-openai-compatible>=0.1.0,<1.0.0",
     "lfx-google>=0.1.0,<1.0.0",
-    "lfx-scavio>=0.1.0,<1.0.0",
+    "lfx-scavio>=0.2.0,<1.0.0",
     # langflow-extensions:bundle-deps-end
 ]
 

--- a/src/bundles/scavio/README.md
+++ b/src/bundles/scavio/README.md
@@ -5,8 +5,10 @@ Extension Bundle.
 
 ## What it ships
 
-Seventeen components, registered under the `scavio` bundle group, covering all
-97 live Scavio endpoints across ten platforms:
+Thirty-nine components, registered under the `scavio` bundle group, covering all
+188 live Scavio endpoints across 32 platforms.
+
+### Search
 
 | Component | Endpoints | Covers |
 |---|---|---|
@@ -18,19 +20,67 @@ Seventeen components, registered under the `scavio` bundle group, covering all
 | **Scavio Google Trends** | 2 | Interest over time, trending now |
 | **Scavio Google Flights** | 1 | Flight search |
 | **Scavio Google Hotels** | 2 | Hotel search and property detail |
-| **Scavio YouTube** | 15 | Search, shorts, video, comments, transcript, channel feeds, streams |
+| **Scavio Extract** | 1 | Read any URL back as HTML, Markdown or plain text |
+
+### Retail and marketplaces
+
+| Component | Endpoints | Covers |
+|---|---|---|
 | **Scavio Amazon** | 3 | Product search, product detail, seller offers |
-| **Scavio Walmart** | 2 | Product search, product detail |
+| **Scavio Walmart** | 7 | Search, product, reviews, category, offers, seller, seller catalogue |
+| **Scavio eBay** | 3 | Live and **sold** listing search, listing detail, seller profile |
+| **Scavio Target** | 4 | Search, category, product, reviews |
+| **Scavio Home Depot** | 3 | Search, product, reviews |
+
+### Real estate, travel and local
+
+| Component | Endpoints | Covers |
+|---|---|---|
+| **Scavio Zillow** | 3 | Listing search, property detail, agent reviews |
+| **Scavio Redfin** | 3 | Listing search, property detail, market stats |
+| **Scavio Booking.com** | 3 | Property search, hotel detail, reviews |
+| **Scavio Airbnb** | 3 | Listing search, listing detail, reviews |
+| **Scavio TripAdvisor** | 4 | Location lookup, search, location detail, reviews |
+| **Scavio Yelp** | 3 | Business search, business detail, reviews |
+
+### Jobs, companies and software
+
+| Component | Endpoints | Covers |
+|---|---|---|
+| **Scavio Indeed** | 4 | Job search, job detail, company, company reviews |
+| **Scavio Glassdoor** | 4 | Company search, company, reviews, salaries |
+| **Scavio SEC EDGAR** | 6 | Ticker lookup, company, filings, XBRL concept and facts, full-text search |
+| **Scavio Companies House** | 4 | UK company search, company, officers, filing history |
+| **Scavio G2** | 3 | Software search, product, reviews |
+| **Scavio Capterra** | 3 | Software search, product, reviews |
+
+### App stores and advertising
+
+| Component | Endpoints | Covers |
+|---|---|---|
+| **Scavio App Store** | 3 | Search, app detail, reviews |
+| **Scavio Google Play** | 3 | Search, app detail, reviews |
+| **Scavio Google Ads** | 3 | Ads Transparency search, advertiser lookup, creative |
+| **Scavio Meta Ad Library** | 3 | Ad search, advertiser, single ad |
+
+### Social
+
+| Component | Endpoints | Covers |
+|---|---|---|
+| **Scavio YouTube** | 15 | Search, shorts, video, comments, transcript, channel feeds, streams |
 | **Scavio Reddit** | 12 | Search, post, comments, subreddit and user feeds, popular, trending |
 | **Scavio TikTok** | 11 | Profile, posts, video, comments, search, hashtags, follow graph |
 | **Scavio TikTok Shop** | 8 | Product search, detail, reviews, categories, shop catalog |
 | **Scavio Instagram** | 12 | Profile, posts, reels, stories, comments, search, follow graph |
+| **Scavio Threads** | 6 | Profile, posts, replies, post, comments, user search |
 | **Scavio X** | 11 | Search, post, comments, user timelines, follow graph, trending |
 | **Scavio LinkedIn** | 9 | Person, company, their posts, job search and detail, post comments |
+| **Scavio Kuaishou** | 14 | Profile, posts, video, comments, search, tag feed, trending |
 
-Components that serve several endpoints use a **Endpoint** dropdown with
+Components that serve several endpoints use an **Endpoint** dropdown with
 `real_time_refresh`, so only the fields the selected endpoint accepts are shown
-and required.
+and required. Every component has a **Table** output and a **Raw JSON** output;
+the raw output is the untouched response body, credit counters included.
 
 ## Setup
 
@@ -48,8 +98,12 @@ Cost is per endpoint and **not** uniform. Every component states its own cost.
 
 | Call | Credits |
 |---|---|
-| Google (all verticals), Amazon, Walmart, Reddit, TikTok, TikTok Shop, X | 1 |
-| YouTube search, shorts search | 2 |
+| Google (all verticals), Google Ads Transparency, Meta Ad Library | 1 |
+| Amazon, eBay, Target, Zillow, Redfin, Booking, Airbnb, Glassdoor, App Store | 1 |
+| SEC EDGAR, Companies House, Reddit, TikTok, TikTok Shop, X | 1 |
+| Home Depot, TripAdvisor, Yelp, Indeed, Google Play, Capterra | 2 |
+| G2 | 5 |
+| YouTube search and shorts search | 2 |
 | YouTube streams | 3 |
 | YouTube transcript | 8 |
 | Instagram user posts | 2 |
@@ -58,6 +112,17 @@ Cost is per endpoint and **not** uniform. Every component states its own cost.
 | LinkedIn person, company, post | 1 |
 | LinkedIn posts feeds, job search, post comments | 10 |
 | LinkedIn job detail | 30 |
+| Threads | 2 by `user_id`, 4 by `username` |
+| Kuaishou | 1, 2, 10 or 40 depending on the endpoint |
+
+Three surfaces are priced from the **request body** rather than the path, and
+say so instead of quoting a flat number:
+
+- **Walmart** search and category — 1 credit on `domain` `com`/`ca`, 2 on `com.mx`.
+- **Threads** profile, user posts and user replies — 2 credits addressed by
+  `user_id`, 4 by `username`, because the handle needs a second upstream lookup.
+- **Extract** — 1 credit in `normal` or `advanced` mode, 2 in `ultra`, and billed
+  only on a successful extraction.
 
 ## Deliberately not exposed
 
@@ -77,16 +142,38 @@ Cost is per endpoint and **not** uniform. Every component states its own cost.
 
 - Google v2 returns its payload **flat**; every other product nests it under
   `data`.
+- The Meta Ad Library lives at `/api/v1/meta-ads/*` — hyphenated. Do not derive
+  that URL from the platform name.
 - `/reddit/search` returns `data.results` with `next_cursor` and `has_more`.
   `/reddit/post` returns a **flat post object with no comments** — use the
   Post Comments endpoint for those. Subreddit and user feeds return `data.posts`.
-- TikTok and Instagram responses are raw upstream passthrough, so their exact
-  keys vary with which provider leg answered. The Raw JSON output is the
+- eBay's sold-listing view publishes no headline count, so `total_results` is
+  null there. Listing a seller's whole catalogue is done with a keyword-less
+  search scoped by `seller`, not through the seller profile endpoint.
+- Meta Ad Library `spend`, `reach` and `impressions` are null on commercial ads;
+  only political and issue ads carry them.
+- TikTok, Instagram and Kuaishou responses are raw upstream passthrough, so their
+  exact keys vary with which provider leg answered. The Raw JSON output is the
   reliable surface there.
 - TikTok `cursor` is a **string**, not a number.
+
+## Notes on input names
+
+Two API fields cannot be used as input names because `Component` already owns the
+attribute: `start` is a method and `user_id` is set by the runtime. They are
+exposed as **Start Offset** (`start_offset`) and **User ID** (`target_user_id`)
+and mapped back to their wire names through `Endpoint.wire`, so the API still
+receives `start` and `user_id`.
 
 ## Tests
 
 ```bash
 uv run pytest src/bundles/scavio/tests -q
+uv run lfx extension validate src/bundles/scavio/src/lfx_scavio
+uv run ruff check src/bundles/scavio && uv run ruff format --check src/bundles/scavio
 ```
+
+The suite is fully offline (`httpx.Client` is patched) and guards endpoint
+coverage, per-endpoint credit costs, the body-priced endpoints, the wire quirks
+above, the flat-vs-`data` envelope split, and that no input name is shadowed by a
+`Component` attribute.

--- a/src/bundles/scavio/README.md
+++ b/src/bundles/scavio/README.md
@@ -1,0 +1,92 @@
+# lfx-scavio
+
+[Scavio](https://scavio.dev) real-time search as a standalone Langflow
+Extension Bundle.
+
+## What it ships
+
+Seventeen components, registered under the `scavio` bundle group, covering all
+97 live Scavio endpoints across ten platforms:
+
+| Component | Endpoints | Covers |
+|---|---|---|
+| **Scavio Search** (`ScavioSearch`) | 1 | Google web search (v2) |
+| **Scavio Google AI Mode** | 1 | Google's AI-generated answer with cited sources |
+| **Scavio Google Maps** | 3 | Place search, place detail, reviews |
+| **Scavio Google Shopping** | 3 | Product search, product detail, seller listings |
+| **Scavio Google News** | 1 | News results |
+| **Scavio Google Trends** | 2 | Interest over time, trending now |
+| **Scavio Google Flights** | 1 | Flight search |
+| **Scavio Google Hotels** | 2 | Hotel search and property detail |
+| **Scavio YouTube** | 15 | Search, shorts, video, comments, transcript, channel feeds, streams |
+| **Scavio Amazon** | 3 | Product search, product detail, seller offers |
+| **Scavio Walmart** | 2 | Product search, product detail |
+| **Scavio Reddit** | 12 | Search, post, comments, subreddit and user feeds, popular, trending |
+| **Scavio TikTok** | 11 | Profile, posts, video, comments, search, hashtags, follow graph |
+| **Scavio TikTok Shop** | 8 | Product search, detail, reviews, categories, shop catalog |
+| **Scavio Instagram** | 12 | Profile, posts, reels, stories, comments, search, follow graph |
+| **Scavio X** | 11 | Search, post, comments, user timelines, follow graph, trending |
+| **Scavio LinkedIn** | 9 | Person, company, their posts, job search and detail, post comments |
+
+Components that serve several endpoints use a **Endpoint** dropdown with
+`real_time_refresh`, so only the fields the selected endpoint accepts are shown
+and required.
+
+## Setup
+
+Create a free key at the [Scavio Dashboard](https://dashboard.scavio.dev) — new
+accounts get 50 one-time credits and no card is required. Set it on the
+component, or export it:
+
+```bash
+export SCAVIO_API_KEY=sk_live_your_key
+```
+
+## Credits
+
+Cost is per endpoint and **not** uniform. Every component states its own cost.
+
+| Call | Credits |
+|---|---|
+| Google (all verticals), Amazon, Walmart, Reddit, TikTok, TikTok Shop, X | 1 |
+| YouTube search, shorts search | 2 |
+| YouTube streams | 3 |
+| YouTube transcript | 8 |
+| Instagram user posts | 2 |
+| Instagram post, comment replies | 8 |
+| Instagram everything else | 10 |
+| LinkedIn person, company, post | 1 |
+| LinkedIn posts feeds, job search, post comments | 10 |
+| LinkedIn job detail | 30 |
+
+## Deliberately not exposed
+
+- `POST /api/v1/google` — Google v1 was retired on 2026-08-04 and returns 410.
+  Every Google component targets `/api/v2/google*`, whose parameters are `gl`,
+  `hl`, `start`, `google_domain` and `device`. Note `start` is a 0-based result
+  offset, not a page number: page 2 is `start=10`.
+- `POST /api/v1/youtube/metadata` — a deprecated alias of
+  `/api/v1/youtube/video`. The Video Details endpoint targets `/video` directly
+  rather than shipping a duplicate.
+- Five LinkedIn endpoints whose upstream dataset was withdrawn and which now
+  answer 410 unbilled: `/person/contact`, `/company/people`, `/company/jobs`,
+  `/search/people`, `/search/posts`. Use `/linkedin/company`, which returns a
+  small `featured_employees` sample, and `/linkedin/search/jobs` instead.
+
+## Response shapes worth knowing
+
+- Google v2 returns its payload **flat**; every other product nests it under
+  `data`.
+- `/reddit/search` returns `data.results` with `next_cursor` and `has_more`.
+  `/reddit/post` returns a **flat post object with no comments** — use the
+  Post Comments endpoint for those. Subreddit and user feeds return `data.posts`.
+- TikTok and Instagram responses are raw upstream passthrough, so their exact
+  keys vary with which provider leg answered. The Raw JSON output is the
+  reliable surface there.
+- TikTok `cursor` is a **string**, not a number.
+
+## Tests
+
+```bash
+uv run pytest src/bundles/scavio/tests -q
+```

--- a/src/bundles/scavio/README.md
+++ b/src/bundles/scavio/README.md
@@ -6,7 +6,7 @@ Extension Bundle.
 ## What it ships
 
 Thirty-nine components, registered under the `scavio` bundle group, covering all
-188 live Scavio endpoints across 32 platforms.
+188 live Scavio endpoints across 31 platforms plus extract.
 
 ### Search
 

--- a/src/bundles/scavio/pyproject.toml
+++ b/src/bundles/scavio/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "lfx-scavio"
-version = "0.1.0"
-description = "Scavio search API components (Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X, LinkedIn) as a standalone Langflow Extension Bundle."
+version = "0.2.0"
+description = "Scavio search API components - search, retail, real estate, travel, jobs, app stores, company filings, software reviews, ad libraries, social and URL extraction - as a standalone Langflow Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 license = { text = "MIT" }
 authors = [
     { name = "Scavio", email = "support@scavio.dev" },
 ]
-keywords = ["langflow", "lfx", "extension", "bundle", "scavio", "search", "serp"]
+keywords = ["langflow", "lfx", "extension", "bundle", "scavio", "search", "serp", "scraping", "ecommerce", "real-estate", "jobs", "reviews", "ads"]
 
 # Runtime deps: lfx (the BUNDLE_API surface) plus httpx, which the components use
 # directly to call https://api.scavio.dev. There is no vendor SDK - every endpoint
@@ -41,7 +41,7 @@ build-backend = "hatchling.build"
 # ``importlib.metadata.files(dist)`` finds them and the loader resolves
 # bundles[].path relative to the manifest's directory.
 packages = ["src/lfx_scavio"]
-include = ["src/lfx_scavio/extension.json", "src/lfx_scavio/components/**/*.py"]
+include = ["src/lfx_scavio/extension.json", "src/lfx_scavio/*.py", "src/lfx_scavio/components/**/*.py"]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/bundles/scavio/pyproject.toml
+++ b/src/bundles/scavio/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "lfx-scavio"
+version = "0.1.0"
+description = "Scavio search API components (Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X, LinkedIn) as a standalone Langflow Extension Bundle."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = { text = "MIT" }
+authors = [
+    { name = "Scavio", email = "support@scavio.dev" },
+]
+keywords = ["langflow", "lfx", "extension", "bundle", "scavio", "search", "serp"]
+
+# Runtime deps: lfx (the BUNDLE_API surface) plus httpx, which the components use
+# directly to call https://api.scavio.dev. There is no vendor SDK - every endpoint
+# is a plain JSON POST with a bearer token.
+# lfx is floored at the current major.minor line and capped below the next lfx
+# major; `make patch` re-syncs the pin via scripts/ci/sync_bundle_lfx_pin.py.
+dependencies = [
+    "lfx>=1.12.0.dev0,<2.0.0",
+    "httpx>=0.27,<1",
+]
+
+[project.urls]
+Homepage = "https://scavio.dev"
+Documentation = "https://scavio.dev/docs/langflow"
+Repository = "https://github.com/langflow-ai/langflow"
+
+# Manifest-shipping distributions are discovered via the
+# ``langflow.extensions`` entry-point. Editable installs whose
+# ``dist.files`` only surfaces dist-info entries fall back to this
+# entry-point to find the manifest.
+[project.entry-points."langflow.extensions"]
+lfx-scavio = "lfx_scavio"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# extension.json + components live inside the lfx_scavio package so
+# ``importlib.metadata.files(dist)`` finds them and the loader resolves
+# bundles[].path relative to the manifest's directory.
+packages = ["src/lfx_scavio"]
+include = ["src/lfx_scavio/extension.json", "src/lfx_scavio/components/**/*.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/lfx_scavio",
+    "extension.json",
+    "README.md",
+    "pyproject.toml",
+]

--- a/src/bundles/scavio/src/lfx_scavio/__init__.py
+++ b/src/bundles/scavio/src/lfx_scavio/__init__.py
@@ -4,44 +4,89 @@ This package is the distribution unit ``lfx-scavio``. At runtime Langflow's
 loader discovers ``extension.json`` shipped alongside this ``__init__.py`` and
 registers each component under ``ext:scavio:<Class>@official``.
 
-Seventeen components cover the 97 live Scavio endpoints across Google, YouTube,
-Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn.
+39 components cover the 188 live Scavio endpoints across 32 platforms - search,
+retail, real estate, travel, jobs, app stores, company filings, software
+reviews, ad libraries and social - plus the generic URL extraction endpoint.
 """
 
+from lfx_scavio.components.scavio.scavio_airbnb import ScavioAirbnbComponent
 from lfx_scavio.components.scavio.scavio_amazon import ScavioAmazonComponent
+from lfx_scavio.components.scavio.scavio_app_store import ScavioAppStoreComponent
+from lfx_scavio.components.scavio.scavio_booking import ScavioBookingComponent
+from lfx_scavio.components.scavio.scavio_capterra import ScavioCapterraComponent
+from lfx_scavio.components.scavio.scavio_companies_house import ScavioCompaniesHouseComponent
+from lfx_scavio.components.scavio.scavio_ebay import ScavioEbayComponent
+from lfx_scavio.components.scavio.scavio_extract import ScavioExtractComponent
+from lfx_scavio.components.scavio.scavio_g2 import ScavioG2Component
+from lfx_scavio.components.scavio.scavio_glassdoor import ScavioGlassdoorComponent
+from lfx_scavio.components.scavio.scavio_google_ads import ScavioGoogleAdsComponent
 from lfx_scavio.components.scavio.scavio_google_ai_mode import ScavioGoogleAIModeComponent
 from lfx_scavio.components.scavio.scavio_google_flights import ScavioGoogleFlightsComponent
 from lfx_scavio.components.scavio.scavio_google_hotels import ScavioGoogleHotelsComponent
 from lfx_scavio.components.scavio.scavio_google_maps import ScavioGoogleMapsComponent
 from lfx_scavio.components.scavio.scavio_google_news import ScavioGoogleNewsComponent
+from lfx_scavio.components.scavio.scavio_google_play import ScavioGooglePlayComponent
 from lfx_scavio.components.scavio.scavio_google_shopping import ScavioGoogleShoppingComponent
 from lfx_scavio.components.scavio.scavio_google_trends import ScavioGoogleTrendsComponent
+from lfx_scavio.components.scavio.scavio_home_depot import ScavioHomeDepotComponent
+from lfx_scavio.components.scavio.scavio_indeed import ScavioIndeedComponent
 from lfx_scavio.components.scavio.scavio_instagram import ScavioInstagramComponent
+from lfx_scavio.components.scavio.scavio_kuaishou import ScavioKuaishouComponent
 from lfx_scavio.components.scavio.scavio_linkedin import ScavioLinkedInComponent
+from lfx_scavio.components.scavio.scavio_meta_ads import ScavioMetaAdsComponent
 from lfx_scavio.components.scavio.scavio_reddit import ScavioRedditComponent
+from lfx_scavio.components.scavio.scavio_redfin import ScavioRedfinComponent
 from lfx_scavio.components.scavio.scavio_search import ScavioSearchComponent
+from lfx_scavio.components.scavio.scavio_sec import ScavioSecComponent
+from lfx_scavio.components.scavio.scavio_target import ScavioTargetComponent
+from lfx_scavio.components.scavio.scavio_threads import ScavioThreadsComponent
 from lfx_scavio.components.scavio.scavio_tiktok import ScavioTikTokComponent
 from lfx_scavio.components.scavio.scavio_tiktok_shop import ScavioTikTokShopComponent
+from lfx_scavio.components.scavio.scavio_tripadvisor import ScavioTripAdvisorComponent
 from lfx_scavio.components.scavio.scavio_walmart import ScavioWalmartComponent
 from lfx_scavio.components.scavio.scavio_x import ScavioXComponent
+from lfx_scavio.components.scavio.scavio_yelp import ScavioYelpComponent
 from lfx_scavio.components.scavio.scavio_youtube import ScavioYouTubeComponent
+from lfx_scavio.components.scavio.scavio_zillow import ScavioZillowComponent
 
 __all__ = [
+    "ScavioAirbnbComponent",
     "ScavioAmazonComponent",
+    "ScavioAppStoreComponent",
+    "ScavioBookingComponent",
+    "ScavioCapterraComponent",
+    "ScavioCompaniesHouseComponent",
+    "ScavioEbayComponent",
+    "ScavioExtractComponent",
+    "ScavioG2Component",
+    "ScavioGlassdoorComponent",
     "ScavioGoogleAIModeComponent",
+    "ScavioGoogleAdsComponent",
     "ScavioGoogleFlightsComponent",
     "ScavioGoogleHotelsComponent",
     "ScavioGoogleMapsComponent",
     "ScavioGoogleNewsComponent",
+    "ScavioGooglePlayComponent",
     "ScavioGoogleShoppingComponent",
     "ScavioGoogleTrendsComponent",
+    "ScavioHomeDepotComponent",
+    "ScavioIndeedComponent",
     "ScavioInstagramComponent",
+    "ScavioKuaishouComponent",
     "ScavioLinkedInComponent",
+    "ScavioMetaAdsComponent",
     "ScavioRedditComponent",
+    "ScavioRedfinComponent",
     "ScavioSearchComponent",
+    "ScavioSecComponent",
+    "ScavioTargetComponent",
+    "ScavioThreadsComponent",
     "ScavioTikTokComponent",
     "ScavioTikTokShopComponent",
+    "ScavioTripAdvisorComponent",
     "ScavioWalmartComponent",
     "ScavioXComponent",
+    "ScavioYelpComponent",
     "ScavioYouTubeComponent",
+    "ScavioZillowComponent",
 ]

--- a/src/bundles/scavio/src/lfx_scavio/__init__.py
+++ b/src/bundles/scavio/src/lfx_scavio/__init__.py
@@ -1,0 +1,47 @@
+"""lfx-scavio: the Scavio search API for AI agents, as a Langflow Extension Bundle.
+
+This package is the distribution unit ``lfx-scavio``. At runtime Langflow's
+loader discovers ``extension.json`` shipped alongside this ``__init__.py`` and
+registers each component under ``ext:scavio:<Class>@official``.
+
+Seventeen components cover the 97 live Scavio endpoints across Google, YouTube,
+Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn.
+"""
+
+from lfx_scavio.components.scavio.scavio_amazon import ScavioAmazonComponent
+from lfx_scavio.components.scavio.scavio_google_ai_mode import ScavioGoogleAIModeComponent
+from lfx_scavio.components.scavio.scavio_google_flights import ScavioGoogleFlightsComponent
+from lfx_scavio.components.scavio.scavio_google_hotels import ScavioGoogleHotelsComponent
+from lfx_scavio.components.scavio.scavio_google_maps import ScavioGoogleMapsComponent
+from lfx_scavio.components.scavio.scavio_google_news import ScavioGoogleNewsComponent
+from lfx_scavio.components.scavio.scavio_google_shopping import ScavioGoogleShoppingComponent
+from lfx_scavio.components.scavio.scavio_google_trends import ScavioGoogleTrendsComponent
+from lfx_scavio.components.scavio.scavio_instagram import ScavioInstagramComponent
+from lfx_scavio.components.scavio.scavio_linkedin import ScavioLinkedInComponent
+from lfx_scavio.components.scavio.scavio_reddit import ScavioRedditComponent
+from lfx_scavio.components.scavio.scavio_search import ScavioSearchComponent
+from lfx_scavio.components.scavio.scavio_tiktok import ScavioTikTokComponent
+from lfx_scavio.components.scavio.scavio_tiktok_shop import ScavioTikTokShopComponent
+from lfx_scavio.components.scavio.scavio_walmart import ScavioWalmartComponent
+from lfx_scavio.components.scavio.scavio_x import ScavioXComponent
+from lfx_scavio.components.scavio.scavio_youtube import ScavioYouTubeComponent
+
+__all__ = [
+    "ScavioAmazonComponent",
+    "ScavioGoogleAIModeComponent",
+    "ScavioGoogleFlightsComponent",
+    "ScavioGoogleHotelsComponent",
+    "ScavioGoogleMapsComponent",
+    "ScavioGoogleNewsComponent",
+    "ScavioGoogleShoppingComponent",
+    "ScavioGoogleTrendsComponent",
+    "ScavioInstagramComponent",
+    "ScavioLinkedInComponent",
+    "ScavioRedditComponent",
+    "ScavioSearchComponent",
+    "ScavioTikTokComponent",
+    "ScavioTikTokShopComponent",
+    "ScavioWalmartComponent",
+    "ScavioXComponent",
+    "ScavioYouTubeComponent",
+]

--- a/src/bundles/scavio/src/lfx_scavio/__init__.py
+++ b/src/bundles/scavio/src/lfx_scavio/__init__.py
@@ -4,7 +4,7 @@ This package is the distribution unit ``lfx-scavio``. At runtime Langflow's
 loader discovers ``extension.json`` shipped alongside this ``__init__.py`` and
 registers each component under ``ext:scavio:<Class>@official``.
 
-39 components cover the 188 live Scavio endpoints across 32 platforms - search,
+39 components cover the 188 live Scavio endpoints across 31 platforms - search,
 retail, real estate, travel, jobs, app stores, company filings, software
 reviews, ad libraries and social - plus the generic URL extraction endpoint.
 """

--- a/src/bundles/scavio/src/lfx_scavio/_component.py
+++ b/src/bundles/scavio/src/lfx_scavio/_component.py
@@ -1,0 +1,32 @@
+"""The ``Component`` base every Scavio component derives from.
+
+It deliberately lives *outside* ``components/scavio``. The bundle loader scans
+``extension.json``'s ``bundles[].path`` and registers every ``Component`` subclass it
+finds there, so a shared base inside that directory would show up in the palette as a
+phantom node. Keeping it one level up gives the components a real base class - which is
+also what supplies their output methods - without adding anything to the palette.
+
+This module is also the bundle's single entry point into ``lfx``, and ``Output`` is
+re-exported for that reason rather than for convenience. Importing
+``lfx.template.field.base`` before ``lfx.custom.custom_component.component`` raises
+``ImportError: cannot import name 'Component' from partially initialized module``, so
+the component modules import both names from here and never reach into ``lfx``
+themselves. That keeps the order below the only one that matters.
+"""
+
+from __future__ import annotations
+
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import ScavioAPIMixin
+
+__all__ = ["Output", "ScavioBaseComponent"]
+
+
+class ScavioBaseComponent(ScavioAPIMixin, Component):
+    """Carries the Scavio request plumbing and the ``Table`` / ``Raw JSON`` output methods.
+
+    Subclasses supply ``ENDPOINTS``, ``MANAGED_FIELDS``, ``DEFAULT_ENDPOINT``, their
+    ``inputs`` and their ``outputs``; everything else is inherited.
+    """

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/__init__.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/__init__.py
@@ -1,37 +1,81 @@
+from .scavio_airbnb import ScavioAirbnbComponent
 from .scavio_amazon import ScavioAmazonComponent
+from .scavio_app_store import ScavioAppStoreComponent
+from .scavio_booking import ScavioBookingComponent
+from .scavio_capterra import ScavioCapterraComponent
+from .scavio_companies_house import ScavioCompaniesHouseComponent
+from .scavio_ebay import ScavioEbayComponent
+from .scavio_extract import ScavioExtractComponent
+from .scavio_g2 import ScavioG2Component
+from .scavio_glassdoor import ScavioGlassdoorComponent
+from .scavio_google_ads import ScavioGoogleAdsComponent
 from .scavio_google_ai_mode import ScavioGoogleAIModeComponent
 from .scavio_google_flights import ScavioGoogleFlightsComponent
 from .scavio_google_hotels import ScavioGoogleHotelsComponent
 from .scavio_google_maps import ScavioGoogleMapsComponent
 from .scavio_google_news import ScavioGoogleNewsComponent
+from .scavio_google_play import ScavioGooglePlayComponent
 from .scavio_google_shopping import ScavioGoogleShoppingComponent
 from .scavio_google_trends import ScavioGoogleTrendsComponent
+from .scavio_home_depot import ScavioHomeDepotComponent
+from .scavio_indeed import ScavioIndeedComponent
 from .scavio_instagram import ScavioInstagramComponent
+from .scavio_kuaishou import ScavioKuaishouComponent
 from .scavio_linkedin import ScavioLinkedInComponent
+from .scavio_meta_ads import ScavioMetaAdsComponent
 from .scavio_reddit import ScavioRedditComponent
+from .scavio_redfin import ScavioRedfinComponent
 from .scavio_search import ScavioSearchComponent
+from .scavio_sec import ScavioSecComponent
+from .scavio_target import ScavioTargetComponent
+from .scavio_threads import ScavioThreadsComponent
 from .scavio_tiktok import ScavioTikTokComponent
 from .scavio_tiktok_shop import ScavioTikTokShopComponent
+from .scavio_tripadvisor import ScavioTripAdvisorComponent
 from .scavio_walmart import ScavioWalmartComponent
 from .scavio_x import ScavioXComponent
+from .scavio_yelp import ScavioYelpComponent
 from .scavio_youtube import ScavioYouTubeComponent
+from .scavio_zillow import ScavioZillowComponent
 
 __all__ = [
+    "ScavioAirbnbComponent",
     "ScavioAmazonComponent",
+    "ScavioAppStoreComponent",
+    "ScavioBookingComponent",
+    "ScavioCapterraComponent",
+    "ScavioCompaniesHouseComponent",
+    "ScavioEbayComponent",
+    "ScavioExtractComponent",
+    "ScavioG2Component",
+    "ScavioGlassdoorComponent",
     "ScavioGoogleAIModeComponent",
+    "ScavioGoogleAdsComponent",
     "ScavioGoogleFlightsComponent",
     "ScavioGoogleHotelsComponent",
     "ScavioGoogleMapsComponent",
     "ScavioGoogleNewsComponent",
+    "ScavioGooglePlayComponent",
     "ScavioGoogleShoppingComponent",
     "ScavioGoogleTrendsComponent",
+    "ScavioHomeDepotComponent",
+    "ScavioIndeedComponent",
     "ScavioInstagramComponent",
+    "ScavioKuaishouComponent",
     "ScavioLinkedInComponent",
+    "ScavioMetaAdsComponent",
     "ScavioRedditComponent",
+    "ScavioRedfinComponent",
     "ScavioSearchComponent",
+    "ScavioSecComponent",
+    "ScavioTargetComponent",
+    "ScavioThreadsComponent",
     "ScavioTikTokComponent",
     "ScavioTikTokShopComponent",
+    "ScavioTripAdvisorComponent",
     "ScavioWalmartComponent",
     "ScavioXComponent",
+    "ScavioYelpComponent",
     "ScavioYouTubeComponent",
+    "ScavioZillowComponent",
 ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/__init__.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/__init__.py
@@ -1,0 +1,37 @@
+from .scavio_amazon import ScavioAmazonComponent
+from .scavio_google_ai_mode import ScavioGoogleAIModeComponent
+from .scavio_google_flights import ScavioGoogleFlightsComponent
+from .scavio_google_hotels import ScavioGoogleHotelsComponent
+from .scavio_google_maps import ScavioGoogleMapsComponent
+from .scavio_google_news import ScavioGoogleNewsComponent
+from .scavio_google_shopping import ScavioGoogleShoppingComponent
+from .scavio_google_trends import ScavioGoogleTrendsComponent
+from .scavio_instagram import ScavioInstagramComponent
+from .scavio_linkedin import ScavioLinkedInComponent
+from .scavio_reddit import ScavioRedditComponent
+from .scavio_search import ScavioSearchComponent
+from .scavio_tiktok import ScavioTikTokComponent
+from .scavio_tiktok_shop import ScavioTikTokShopComponent
+from .scavio_walmart import ScavioWalmartComponent
+from .scavio_x import ScavioXComponent
+from .scavio_youtube import ScavioYouTubeComponent
+
+__all__ = [
+    "ScavioAmazonComponent",
+    "ScavioGoogleAIModeComponent",
+    "ScavioGoogleFlightsComponent",
+    "ScavioGoogleHotelsComponent",
+    "ScavioGoogleMapsComponent",
+    "ScavioGoogleNewsComponent",
+    "ScavioGoogleShoppingComponent",
+    "ScavioGoogleTrendsComponent",
+    "ScavioInstagramComponent",
+    "ScavioLinkedInComponent",
+    "ScavioRedditComponent",
+    "ScavioSearchComponent",
+    "ScavioTikTokComponent",
+    "ScavioTikTokShopComponent",
+    "ScavioWalmartComponent",
+    "ScavioXComponent",
+    "ScavioYouTubeComponent",
+]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/_base.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/_base.py
@@ -1,0 +1,347 @@
+"""Shared plumbing for the Scavio bundle components.
+
+Nothing in this module subclasses ``Component`` on purpose: the bundle loader
+registers every ``Component`` subclass it finds, so a shared base class would
+show up in the palette as a phantom component. The components mix this class in
+alongside ``Component`` instead.
+
+Every Scavio data endpoint is a POST with a JSON body and an
+``Authorization: Bearer <key>`` header. Credit costs are per endpoint and are
+carried on each :class:`Endpoint` so the UI can state them up front.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from lfx.inputs.inputs import DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+
+BASE_URL = "https://api.scavio.dev"
+REQUEST_TIMEOUT = 90.0
+DOCUMENTATION = "https://scavio.dev/docs/langflow"
+
+# Google is the one product that does not wrap its payload: the provider body is
+# spread at the top level and response_time / credits_used / credits_remaining
+# are appended next to it. Every other product answers
+# {data, response_time, credits_used, credits_remaining}.
+FLAT_ENVELOPE_PREFIX = "/api/v2/google"
+
+# Keys tried, in order, when picking the human-readable text for a result row.
+TEXT_KEYS = ("title", "text", "snippet", "name", "full_name", "query", "description")
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """One Scavio API endpoint, as offered by a component's Endpoint dropdown.
+
+    Attributes:
+        path: Public API path, e.g. ``/api/v2/google/maps/search``.
+        credits: Credits a successful call costs.
+        fields: Input names this endpoint accepts, in UI order.
+        required: Subset of ``fields`` the API refuses to run without.
+        result_keys: Payload keys tried, in order, to find the row list for the
+            table output. Dotted keys walk nested objects. Empty (or no match)
+            renders the whole payload as a single row.
+        wire: Input name -> API field name, for the few inputs whose UI name has
+            to differ from the wire name because two endpoints in the same
+            component reuse one wire name with different types.
+        send_false: Boolean inputs whose ``False`` is meaningful and must be
+            transmitted instead of omitted.
+    """
+
+    path: str
+    credits: int
+    fields: tuple[str, ...] = ()
+    required: tuple[str, ...] = ()
+    result_keys: tuple[str, ...] = ()
+    wire: dict[str, str] = field(default_factory=dict)
+    send_false: tuple[str, ...] = ()
+
+
+def managed_fields(endpoints: dict[str, Endpoint]) -> tuple[str, ...]:
+    """Return every input name any endpoint in the map can show."""
+    names: set[str] = set()
+    for endpoint in endpoints.values():
+        names.update(endpoint.fields)
+    return tuple(sorted(names))
+
+
+def default_visibility(inputs: list, endpoints: dict[str, Endpoint], default_label: str) -> list:
+    """Set the initial ``show``/``required`` of every managed input from the default endpoint.
+
+    ``update_build_config`` handles this once the user picks an endpoint, but it only
+    fires on interaction - without this the node would open showing the fields of no
+    endpoint at all.
+    """
+    managed = set(managed_fields(endpoints))
+    endpoint = endpoints[default_label]
+    for item in inputs:
+        if item.name in managed:
+            item.show = item.name in endpoint.fields
+            item.required = item.name in endpoint.required
+    return inputs
+
+
+def api_key_input() -> SecretStrInput:
+    """Return the Scavio API key input shared by every component."""
+    return SecretStrInput(
+        name="api_key",
+        display_name="Scavio API Key",
+        required=True,
+        info="Your Scavio API key. Get one at https://dashboard.scavio.dev - the free plan ships 50 one-time credits.",
+    )
+
+
+def endpoint_input(endpoints: dict[str, Endpoint], value: str) -> DropdownInput:
+    """Return the Endpoint dropdown for a multi-endpoint component."""
+    options = list(endpoints)
+    return DropdownInput(
+        name="endpoint",
+        display_name="Endpoint",
+        info="Which Scavio endpoint to call. The fields below change with this selection.",
+        options=options,
+        value=value,
+        real_time_refresh=True,
+        required=True,
+    )
+
+
+def max_results_input() -> IntInput:
+    """Return the client-side row cap input."""
+    return IntInput(
+        name="max_results",
+        display_name="Max Results",
+        info="Client-side cap on the rows returned. 0 keeps everything the API sent.",
+        value=0,
+        advanced=True,
+    )
+
+
+def cursor_input(info: str = "Pagination cursor echoed from a previous response.") -> MessageTextInput:
+    """Return a pagination cursor input."""
+    return MessageTextInput(name="cursor", display_name="Cursor", info=info, advanced=True, dynamic=True, show=False)
+
+
+def text_input(
+    name: str,
+    display_name: str,
+    info: str,
+    *,
+    tool_mode: bool = False,
+    advanced: bool = False,
+) -> MessageTextInput:
+    """Return a dynamic free-text input managed by ``update_build_config``."""
+    return MessageTextInput(
+        name=name,
+        display_name=display_name,
+        info=info,
+        tool_mode=tool_mode,
+        advanced=advanced,
+        dynamic=True,
+        show=False,
+    )
+
+
+def choice_input(
+    name: str,
+    display_name: str,
+    info: str,
+    options: list[str],
+    *,
+    advanced: bool = False,
+) -> DropdownInput:
+    """Return a dynamic dropdown whose empty first option means "let the API decide"."""
+    return DropdownInput(
+        name=name,
+        display_name=display_name,
+        info=info,
+        options=options,
+        value="",
+        advanced=advanced,
+        dynamic=True,
+        show=False,
+    )
+
+
+def number_input(
+    name: str,
+    display_name: str,
+    info: str,
+    value: int = 0,
+    *,
+    advanced: bool = True,
+) -> IntInput:
+    """Return a dynamic integer input. Zero always means "not set"."""
+    return IntInput(
+        name=name,
+        display_name=display_name,
+        info=info,
+        value=value,
+        advanced=advanced,
+        dynamic=True,
+        show=False,
+    )
+
+
+class ScavioAPIMixin:
+    """Call one Scavio endpoint and shape the answer into ``Data`` / ``DataFrame``."""
+
+    ENDPOINTS: dict[str, Endpoint] = {}
+    MANAGED_FIELDS: tuple[str, ...] = ()
+    DEFAULT_ENDPOINT: str = ""
+
+    def _endpoint(self) -> Endpoint:
+        label = getattr(self, "endpoint", None) or self.DEFAULT_ENDPOINT
+        endpoint = self.ENDPOINTS.get(label)
+        if endpoint is None:
+            msg = f"Unknown Scavio endpoint '{label}'. Pick one of: {', '.join(self.ENDPOINTS)}."
+            raise ValueError(msg)
+        return endpoint
+
+    @staticmethod
+    def _clean(value: Any) -> Any:
+        """Drop empty values so optional params are omitted rather than sent blank."""
+        if isinstance(value, bool):
+            return value or None
+        if isinstance(value, int | float):
+            return value or None
+        if isinstance(value, str):
+            return value.strip() or None
+        if isinstance(value, list | tuple):
+            items = [item for item in value if item not in (None, "")]
+            return items or None
+        return value or None
+
+    def _payload(self, endpoint: Endpoint) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        missing: list[str] = []
+        for name in endpoint.fields:
+            raw = getattr(self, name, None)
+            wire_name = endpoint.wire.get(name, name)
+            if isinstance(raw, bool) and name in endpoint.send_false:
+                payload[wire_name] = raw
+                continue
+            cleaned = self._clean(raw)
+            if cleaned is None:
+                if name in endpoint.required:
+                    missing.append(name)
+                continue
+            payload[wire_name] = cleaned
+        if missing:
+            verb = "is" if len(missing) == 1 else "are"
+            msg = f"{', '.join(missing)} {verb} required for {endpoint.path}."
+            raise ValueError(msg)
+        return payload
+
+    def _request(self, endpoint: Endpoint, payload: dict[str, Any]) -> dict[str, Any]:
+        headers = {
+            "content-type": "application/json",
+            "accept": "application/json",
+            "authorization": f"Bearer {self.api_key}",
+        }
+        with httpx.Client(timeout=REQUEST_TIMEOUT) as client:
+            response = client.post(f"{BASE_URL}{endpoint.path}", json=payload, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    def _safe_call(self) -> tuple[Endpoint | None, dict[str, Any] | None, str | None]:
+        """Run the request, converting every failure into a message instead of raising."""
+        try:
+            endpoint = self._endpoint()
+            body = self._request(endpoint, self._payload(endpoint))
+        except httpx.TimeoutException:
+            message = f"Request timed out after {int(REQUEST_TIMEOUT)}s. Try again or narrow the request."
+        except httpx.HTTPStatusError as exc:
+            message = f"HTTP error occurred: {exc.response.status_code} - {exc.response.text}"
+        except httpx.RequestError as exc:
+            message = f"Request error occurred: {exc}"
+        except ValueError as exc:
+            message = str(exc)
+        else:
+            return endpoint, body, None
+        logger.error(message)
+        return None, None, message
+
+    @staticmethod
+    def _unwrap(body: dict[str, Any], endpoint: Endpoint) -> Any:
+        """Return the payload inside the response envelope."""
+        if endpoint.path.startswith(FLAT_ENVELOPE_PREFIX):
+            return body
+        return body.get("data", body)
+
+    @staticmethod
+    def _lookup(payload: Any, dotted: str) -> Any:
+        current = payload
+        for part in dotted.split("."):
+            if not isinstance(current, dict):
+                return None
+            current = current.get(part)
+        return current
+
+    def _rows(self, payload: Any, endpoint: Endpoint) -> list[dict[str, Any]]:
+        for key in endpoint.result_keys:
+            found = self._lookup(payload, key)
+            if isinstance(found, list):
+                return [item if isinstance(item, dict) else {"value": item} for item in found]
+            if isinstance(found, dict):
+                return [found]
+        if isinstance(payload, list):
+            return [item if isinstance(item, dict) else {"value": item} for item in payload]
+        if isinstance(payload, dict):
+            return [payload]
+        return [{"value": payload}]
+
+    @staticmethod
+    def _row_text(row: dict[str, Any]) -> str:
+        for key in TEXT_KEYS:
+            value = row.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return json.dumps(row, ensure_ascii=False, default=str)
+
+    def fetch_content(self) -> list[Data]:
+        """Return one ``Data`` per result row, or a single error row."""
+        endpoint, body, error = self._safe_call()
+        if error is not None or endpoint is None or body is None:
+            message = error or "Scavio request failed."
+            return [Data(text=message, data={"error": message})]
+        rows = self._rows(self._unwrap(body, endpoint), endpoint)
+        limit = getattr(self, "max_results", 0) or 0
+        if limit > 0:
+            rows = rows[:limit]
+        results = [Data(text=self._row_text(row), data=row) for row in rows]
+        self.status = results
+        return results
+
+    def fetch_content_dataframe(self) -> DataFrame:
+        """Return the result rows as a table."""
+        return DataFrame(self.fetch_content())
+
+    def fetch_raw(self) -> Data:
+        """Return the untouched response body, including the credit counters."""
+        _endpoint, body, error = self._safe_call()
+        if error is not None or body is None:
+            message = error or "Scavio request failed."
+            return Data(text=message, data={"error": message})
+        self.status = body
+        return Data(data=body)
+
+    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None) -> dict:
+        """Show only the fields the selected endpoint accepts."""
+        if field_name not in {"endpoint", None}:
+            return build_config
+        label = field_value if field_name == "endpoint" else build_config.get("endpoint", {}).get("value")
+        endpoint = self.ENDPOINTS.get(label) or self.ENDPOINTS.get(self.DEFAULT_ENDPOINT)
+        if endpoint is None:
+            return build_config
+        for name in self.MANAGED_FIELDS:
+            if name in build_config:
+                build_config[name]["show"] = name in endpoint.fields
+                build_config[name]["required"] = name in endpoint.required
+        return build_config

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/_base.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/_base.py
@@ -17,7 +17,15 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
-from lfx.inputs.inputs import DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.inputs.inputs import (
+    BoolInput,
+    DropdownInput,
+    FloatInput,
+    IntInput,
+    MessageTextInput,
+    MultiselectInput,
+    SecretStrInput,
+)
 from lfx.log.logger import logger
 from lfx.schema.data import Data
 from lfx.schema.dataframe import DataFrame
@@ -34,6 +42,34 @@ FLAT_ENVELOPE_PREFIX = "/api/v2/google"
 
 # Keys tried, in order, when picking the human-readable text for a result row.
 TEXT_KEYS = ("title", "text", "snippet", "name", "full_name", "query", "description")
+
+# Re-exported so the component modules never import ``lfx`` directly. See the note in
+# ``lfx_scavio._component``: reaching into ``lfx.inputs`` or ``lfx.template`` before
+# ``lfx.custom.custom_component.component`` trips a circular import inside lfx itself.
+__all__ = [
+    "BASE_URL",
+    "DOCUMENTATION",
+    "BoolInput",
+    "Data",
+    "DataFrame",
+    "DropdownInput",
+    "Endpoint",
+    "IntInput",
+    "MessageTextInput",
+    "MultiselectInput",
+    "ScavioAPIMixin",
+    "api_key_input",
+    "choice_input",
+    "cursor_input",
+    "decimal_input",
+    "default_visibility",
+    "endpoint_input",
+    "flag_input",
+    "managed_fields",
+    "max_results_input",
+    "number_input",
+    "text_input",
+]
 
 
 @dataclass(frozen=True)
@@ -53,6 +89,12 @@ class Endpoint:
             component reuse one wire name with different types.
         send_false: Boolean inputs whose ``False`` is meaningful and must be
             transmitted instead of omitted.
+        csv_fields: Text inputs the API wants as a JSON array of strings. The
+            user types a comma-separated list; the payload builder splits it.
+        csv_int_fields: The same, for arrays of integers.
+        credit_note: Set only where the credit cost is a function of the request
+            body rather than of the path, in which case it replaces ``credits``
+            everywhere a cost is shown. ``credits`` then carries the floor.
     """
 
     path: str
@@ -62,6 +104,15 @@ class Endpoint:
     result_keys: tuple[str, ...] = ()
     wire: dict[str, str] = field(default_factory=dict)
     send_false: tuple[str, ...] = ()
+    csv_fields: tuple[str, ...] = ()
+    csv_int_fields: tuple[str, ...] = ()
+    credit_note: str = ""
+
+    def cost_text(self) -> str:
+        """Return the human-readable cost of one call to this endpoint."""
+        if self.credit_note:
+            return self.credit_note
+        return f"{self.credits} credit" if self.credits == 1 else f"{self.credits} credits"
 
 
 def managed_fields(endpoints: dict[str, Endpoint]) -> tuple[str, ...]:
@@ -189,6 +240,49 @@ def number_input(
     )
 
 
+def decimal_input(
+    name: str,
+    display_name: str,
+    info: str,
+    *,
+    advanced: bool = True,
+) -> FloatInput:
+    """Return a dynamic float input. Zero always means "not set"."""
+    return FloatInput(
+        name=name,
+        display_name=display_name,
+        info=info,
+        value=0.0,
+        advanced=advanced,
+        dynamic=True,
+        show=False,
+    )
+
+
+def flag_input(
+    name: str,
+    display_name: str,
+    info: str,
+    *,
+    advanced: bool = True,
+) -> BoolInput:
+    """Return a dynamic boolean input.
+
+    These are filters, so ``False`` means "do not filter" and is omitted from the
+    payload rather than sent. An endpoint that needs a literal ``false`` on the
+    wire lists the input in :attr:`Endpoint.send_false`.
+    """
+    return BoolInput(
+        name=name,
+        display_name=display_name,
+        info=info,
+        value=False,
+        advanced=advanced,
+        dynamic=True,
+        show=False,
+    )
+
+
 class ScavioAPIMixin:
     """Call one Scavio endpoint and shape the answer into ``Data`` / ``DataFrame``."""
 
@@ -218,6 +312,24 @@ class ScavioAPIMixin:
             return items or None
         return value or None
 
+    @staticmethod
+    def _split_csv(value: Any, *, as_int: bool) -> list | None:
+        """Turn a comma-separated string into the JSON array these endpoints expect."""
+        if isinstance(value, list | tuple):
+            items: list[Any] = list(value)
+        else:
+            items = [part.strip() for part in str(value).split(",")]
+        items = [item for item in items if item not in (None, "")]
+        if as_int:
+            numbers = []
+            for item in items:
+                try:
+                    numbers.append(int(item))
+                except (TypeError, ValueError):
+                    continue
+            items = numbers
+        return items or None
+
     def _payload(self, endpoint: Endpoint) -> dict[str, Any]:
         payload: dict[str, Any] = {}
         missing: list[str] = []
@@ -232,6 +344,10 @@ class ScavioAPIMixin:
                 if name in endpoint.required:
                     missing.append(name)
                 continue
+            if name in endpoint.csv_fields or name in endpoint.csv_int_fields:
+                cleaned = self._split_csv(cleaned, as_int=name in endpoint.csv_int_fields)
+                if cleaned is None:
+                    continue
             payload[wire_name] = cleaned
         if missing:
             verb = "is" if len(missing) == 1 else "are"

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_airbnb.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_airbnb.py
@@ -1,0 +1,230 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/airbnb/search",
+        credits=1,
+        fields=(
+            "location",
+            "check_in",
+            "check_out",
+            "adults",
+            "children",
+            "infants",
+            "pets",
+            "min_price",
+            "max_price",
+            "room_type",
+            "min_bedrooms",
+            "min_beds",
+            "min_bathrooms",
+            "superhost",
+            "instant_book",
+            "guest_favorite",
+            "free_cancellation",
+            "amenities",
+            "currency",
+            "page",
+            "cursor",
+        ),
+        required=("location",),
+        result_keys=("listings",),
+    ),
+    "Listing Details": Endpoint(
+        path="/api/v1/airbnb/listing",
+        credits=1,
+        fields=("listing_id", "check_in", "check_out", "adults", "children", "infants", "pets", "currency"),
+        required=("listing_id",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/airbnb/reviews",
+        credits=1,
+        fields=("listing_id", "currency", "limit", "offset"),
+        required=("listing_id",),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioAirbnbComponent(ScavioBaseComponent):
+    display_name = "Scavio Airbnb"
+    description = (
+        "Airbnb through Scavio: search, listing details, reviews (`/api/v1/airbnb/*`, 1 credit each). Airbnb stays: "
+        "stay-total and per-night price with the full discount ledger, rating, bedrooms/beds/baths, coordinates, "
+        "badges, images. Pagination: page XOR cursor -- `cursor` WINS over `page`, so sending both is REJECTED. 18 "
+        "listings per page."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioAirbnb"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "location",
+            "Location",
+            "City, region, ZIP, or a pasted airbnb.com/s/ URL. An unresolvable place is a 404.",
+            tool_mode=True,
+        ),
+        text_input(
+            "check_in",
+            "Check In",
+            (
+                "Check-in date, YYYY-MM-DD. Must be sent with check_out. Omitting both makes Airbnb A/B both the "
+                "window AND the prices -- the response flags that as dates_are_defaulted. Default: +30d when "
+                "omitted (transport)."
+            ),
+        ),
+        text_input(
+            "check_out",
+            "Check Out",
+            "Check-out date, YYYY-MM-DD. Must be sent with check_in. Default: check_in + 5 nights when omitted.",
+        ),
+        number_input(
+            "adults",
+            "Adults",
+            "Number of adult guests.",
+        ),
+        number_input(
+            "children",
+            "Children",
+            "Number of children in the party (ages 2-12).",
+        ),
+        number_input(
+            "infants",
+            "Infants",
+            "Number of infants in the party.",
+        ),
+        number_input(
+            "pets",
+            "Pets",
+            "Number of pets travelling.",
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum WHOLE-STAY total, not a per-night rate.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum WHOLE-STAY total, not a per-night rate.",
+        ),
+        choice_input(
+            "room_type",
+            "Room Type",
+            "Room type filter. Options: entire_home, private_room, shared_room, hotel_room.",
+            ["", "entire_home", "private_room", "shared_room", "hotel_room"],
+            advanced=True,
+        ),
+        number_input(
+            "min_bedrooms",
+            "Min Bedrooms",
+            "Minimum number of bedrooms.",
+        ),
+        number_input(
+            "min_beds",
+            "Min Beds",
+            "Minimum number of beds.",
+        ),
+        number_input(
+            "min_bathrooms",
+            "Min Bathrooms",
+            "Minimum number of bathrooms.",
+        ),
+        flag_input(
+            "superhost",
+            "Superhost",
+            "Only return Superhost listings.",
+        ),
+        flag_input(
+            "instant_book",
+            "Instant Book",
+            "Only return instant-book listings.",
+        ),
+        flag_input(
+            "guest_favorite",
+            "Guest Favorite",
+            "Only return Guest Favourite listings.",
+        ),
+        flag_input(
+            "free_cancellation",
+            "Free Cancellation",
+            "Only return listings with free cancellation.",
+        ),
+        text_input(
+            "amenities",
+            "Amenities",
+            (
+                "Comma-separated amenity filter. Named vocabulary: wifi, air_conditioning, pool, kitchen, "
+                "free_parking, washer, self_check_in, tv -- or raw numeric Airbnb amenity ids. An unrecognised NAME "
+                "is rejected before the scrape. Options: wifi, air_conditioning, pool, kitchen, free_parking, "
+                "washer, self_check_in, tv."
+            ),
+        ),
+        text_input(
+            "currency",
+            "Currency",
+            "ISO 4217 currency code the prices come back in. Default: USD.",
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 18 listings per page. Cannot be combined with cursor.",
+        ),
+        cursor_input(
+            "next_cursor from a previous response. Wins over page, so sending both is rejected.",
+        ),
+        text_input(
+            "listing_id",
+            "Listing ID",
+            (
+                "Airbnb listing id or a full /rooms/ URL. Query parameters are discarded because they carry someone "
+                "else's dates."
+            ),
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            (
+                "Reviews per page, 1-50. Airbnb returns a fixed 7 when no explicit limit is sent, so always set it. "
+                "Default: 30."
+            ),
+        ),
+        number_input(
+            "offset",
+            "Offset",
+            "Zero-based review offset for paging. Default: 0.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
@@ -1,0 +1,84 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Product Search": Endpoint(
+        path="/api/v1/amazon/search",
+        credits=1,
+        fields=("query", "country", "page"),
+        required=("query",),
+        result_keys=("products",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/amazon/product",
+        credits=1,
+        fields=("asin", "country"),
+        required=("asin",),
+    ),
+    "Offer Listing": Endpoint(
+        path="/api/v1/amazon/offers",
+        credits=1,
+        fields=("asin", "country"),
+        required=("asin",),
+        result_keys=("offers",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioAmazonComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Amazon"
+    description = (
+        "Amazon through Scavio: keyword search, product details and the offer listing that carries the "
+        "buy box (`/api/v1/amazon/*`, 1 credit each). Marketplace is picked with a two-letter country "
+        "code - amazon.com is us and amazon.co.uk is gb."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioAmazon"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Product Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Product Search"),
+        text_input("query", "Search Query", "Keywords to search the marketplace for.", tool_mode=True),
+        text_input(
+            "asin",
+            "ASIN",
+            "The product ASIN, e.g. B09V3KXJPB. Older Scavio clients send this in query; both are accepted.",
+            tool_mode=True,
+        ),
+        text_input(
+            "country",
+            "Marketplace Country",
+            "Two-letter marketplace code, e.g. us, gb, de, jp. Defaults to us. Not a zip and not a domain.",
+            advanced=True,
+        ),
+        number_input("page", "Page", "1-based results page for Product Search."),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     default_visibility,
     endpoint_input,
@@ -38,7 +36,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioAmazonComponent(ScavioAPIMixin, Component):
+class ScavioAmazonComponent(ScavioBaseComponent):
     display_name = "Scavio Amazon"
     description = (
         "Amazon through Scavio: keyword search, product details and the offer listing that carries the "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_amazon.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_app_store.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_app_store.py
@@ -1,0 +1,135 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/appstore/search",
+        credits=1,
+        fields=("term", "limit", "country", "entity", "lang"),
+        required=("term",),
+        result_keys=("apps",),
+    ),
+    "App Details": Endpoint(
+        path="/api/v1/appstore/app",
+        credits=1,
+        fields=("app_id", "country"),
+        required=("app_id",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/appstore/reviews",
+        credits=1,
+        fields=("app_id", "country", "page", "sort"),
+        required=("app_id",),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioAppStoreComponent(ScavioBaseComponent):
+    display_name = "Scavio App Store"
+    description = (
+        "App Store through Scavio: search, app details, reviews (`/api/v1/appstore/*`, 1 credit each). Up to 200 "
+        "fully-shaped App Store apps (the same 43-field row as /app). Doubles as a bulk metadata fetch and a "
+        "publisher lookup."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioAppStore"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "term",
+            "Term",
+            (
+                "Search term. Matches the app name, a keyword, OR a publisher name -- searching a developer returns "
+                "their catalogue."
+            ),
+            tool_mode=True,
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            (
+                "Apps to return, 1-200. This is the ONLY lever on result volume: App Store search has no pagination "
+                "and every offset spelling is silently ignored. Default: 25."
+            ),
+        ),
+        text_input(
+            "country",
+            "Country",
+            (
+                "Two-letter storefront code. It decides price, currency, localised title and whether the app is "
+                "sold there at all. Anything that is not exactly two letters silently falls back to us. Default: "
+                "us."
+            ),
+        ),
+        choice_input(
+            "entity",
+            "Entity",
+            "Which App Store catalogue to search. Options: software, ipad_software, mac_software. Default: software.",
+            ["", "software", "ipad_software", "mac_software"],
+            advanced=True,
+        ),
+        text_input(
+            "lang",
+            "Lang",
+            (
+                "Five-letter locale, e.g. en_us. Independent of country: the storefront sets the price, this sets "
+                "the words."
+            ),
+        ),
+        text_input(
+            "app_id",
+            "App ID",
+            (
+                "Numeric App Store id OR a bundle id (notion.id, com.burbn.instagram). A pasted apps.apple.com URL "
+                "is rejected with a free 400."
+            ),
+        ),
+        number_input(
+            "page",
+            "Page",
+            (
+                "Result page, 1-10, at 50 reviews each. Apple hard-stops at page 10; reach further by asking a "
+                "different country. Default: 1."
+            ),
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Review sort order. Under most_recent almost every review is too new to have been voted on, so the "
+                "vote fields come back as zeroes. Options: most_recent, most_helpful. Default: most_recent."
+            ),
+            ["", "most_recent", "most_helpful"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_booking.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_booking.py
@@ -1,0 +1,232 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/booking/search",
+        credits=1,
+        fields=(
+            "destination",
+            "dest_id",
+            "dest_type",
+            "page",
+            "sort_by",
+            "min_price",
+            "max_price",
+            "stars",
+            "min_review_score",
+            "property_type",
+            "free_cancellation",
+            "no_prepayment",
+            "breakfast_included",
+            "checkin",
+            "checkout",
+            "adults",
+            "children_ages",
+            "rooms",
+            "currency",
+        ),
+        result_keys=("properties",),
+        csv_int_fields=("stars", "children_ages"),
+    ),
+    "Hotel Details": Endpoint(
+        path="/api/v1/booking/hotel",
+        credits=1,
+        fields=("hotel", "country_code", "checkin", "checkout", "adults", "children_ages", "rooms", "currency"),
+        required=("hotel",),
+        csv_int_fields=("children_ages",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/booking/reviews",
+        credits=1,
+        fields=("hotel", "country_code", "checkin", "checkout", "adults", "children_ages", "rooms", "currency"),
+        required=("hotel",),
+        csv_int_fields=("children_ages",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioBookingComponent(ScavioBaseComponent):
+    display_name = "Scavio Booking.com"
+    description = (
+        "Booking.com through Scavio: search, hotel details, reviews (`/api/v1/booking/*`, 1 credit each). Booking.com "
+        "properties for a destination and stay: live nightly price, review score, star rating, room type, deal "
+        "badges. Pagination: page -- 25 properties per page."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioBooking"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "destination",
+            "Destination",
+            (
+                "Destination name. Either destination or dest_id is required -- a search with neither returns "
+                "Booking's homepage and still costs a credit."
+            ),
+            tool_mode=True,
+        ),
+        text_input(
+            "dest_id",
+            "Dest ID",
+            "Booking's numeric destination id.",
+        ),
+        choice_input(
+            "dest_type",
+            "Dest Type",
+            (
+                "What dest_id refers to. Requires dest_id. Options: city, region, country, district, landmark, "
+                "airport, hotel."
+            ),
+            ["", "city", "region", "country", "district", "landmark", "airport", "hotel"],
+            advanced=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 25 properties per page.",
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            (
+                "Sort order for the results. Options: popularity, price_low, price_high, stars_high, stars_low, "
+                "stars_and_price, distance, review_score. Default: popularity."
+            ),
+            [
+                "",
+                "popularity",
+                "price_low",
+                "price_high",
+                "stars_high",
+                "stars_low",
+                "stars_and_price",
+                "distance",
+                "review_score",
+            ],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price PER NIGHT, in `currency`.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price PER NIGHT, in `currency`.",
+        ),
+        text_input(
+            "stars",
+            "Stars",
+            "Star ratings to include. Values are OR'd together.",
+        ),
+        choice_input(
+            "min_review_score",
+            "Min Review Score",
+            (
+                "Minimum guest review score. Only 6, 7, 8 and 9 are accepted -- any other threshold is silently "
+                "dropped upstream. Options: 6, 7, 8, 9."
+            ),
+            ["", "6", "7", "8", "9"],
+            advanced=True,
+        ),
+        text_input(
+            "property_type",
+            "Property Type",
+            (
+                "Accommodation type: one of the named values, or a raw numeric Booking accommodation-type id. "
+                "Options: apartments, hostels, hotels, motels, resorts, bed_and_breakfasts, villas, campgrounds, "
+                "vacation_homes, lodges, homestays."
+            ),
+        ),
+        flag_input(
+            "free_cancellation",
+            "Free Cancellation",
+            "Only return rates with free cancellation.",
+        ),
+        flag_input(
+            "no_prepayment",
+            "No Prepayment",
+            "Only return rates with no prepayment.",
+        ),
+        flag_input(
+            "breakfast_included",
+            "Breakfast Included",
+            "Only return rates that include breakfast.",
+        ),
+        text_input(
+            "checkin",
+            "Checkin",
+            "Check-in date, YYYY-MM-DD. Must be sent together with checkout.",
+        ),
+        text_input(
+            "checkout",
+            "Checkout",
+            "Check-out date, YYYY-MM-DD. Must be sent together with checkin.",
+        ),
+        number_input(
+            "adults",
+            "Adults",
+            "Number of adult guests. Default: 2.",
+        ),
+        text_input(
+            "children_ages",
+            "Children Ages",
+            "Ages of the children in the party, one entry per child. Ages, not a count.",
+        ),
+        number_input(
+            "rooms",
+            "Rooms",
+            "Number of rooms required. Default: 1.",
+        ),
+        text_input(
+            "currency",
+            "Currency",
+            "ISO 4217 currency code the prices come back in. Default: USD.",
+        ),
+        text_input(
+            "hotel",
+            "Hotel",
+            "booking.com property URL or the bare page slug. Query parameters are discarded.",
+        ),
+        text_input(
+            "country_code",
+            "Country Code",
+            (
+                "Two-letter country code. Only consulted when `hotel` is a bare slug; a wrong one is a real, BILLED "
+                "404. Default: us."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_capterra.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_capterra.py
@@ -1,0 +1,92 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/capterra/search",
+        credits=2,
+        fields=("query", "url"),
+        result_keys=("products",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/capterra/product",
+        credits=2,
+        fields=("product_id", "slug", "url"),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/capterra/reviews",
+        credits=2,
+        fields=("product_id", "slug", "url", "page"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioCapterraComponent(ScavioBaseComponent):
+    display_name = "Scavio Capterra"
+    description = (
+        "Capterra through Scavio: search, product details, reviews (`/api/v1/capterra/*`, 2 credits each). Search "
+        "Capterra for B2B software: 20 ranked products with name, vendor description, rating, review count, logo, "
+        "paid-placement flag; each row carries product_id and slug."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioCapterra"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            (
+                "Software product or category. Required unless you pass a url: a term-less search serves a fixed "
+                "popular-products list that has nothing to do with the caller."
+            ),
+            tool_mode=True,
+        ),
+        text_input(
+            "url",
+            "URL",
+            "Full capterra.com/search URL. capterra.co.uk and capterra.com.br are accepted.",
+        ),
+        text_input(
+            "product_id",
+            "Product ID",
+            "The number in /p/186596/Notion/, as a STRING -- a JSON number is rejected.",
+        ),
+        text_input(
+            "slug",
+            "Slug",
+            "Product slug. Cosmetic here: /p/186596/Zzzjunk/ returns Notion's profile byte for byte.",
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-100, at 25 reviews each. Past page 100 Capterra answers 200 with page ONE.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_companies_house.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_companies_house.py
@@ -1,0 +1,96 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/companieshouse/search",
+        credits=1,
+        fields=("query", "page"),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "Company Details": Endpoint(
+        path="/api/v1/companieshouse/company",
+        credits=1,
+        fields=("company_number",),
+        required=("company_number",),
+    ),
+    "Officers": Endpoint(
+        path="/api/v1/companieshouse/officers",
+        credits=1,
+        fields=("company_number", "page"),
+        required=("company_number",),
+    ),
+    "Filing History": Endpoint(
+        path="/api/v1/companieshouse/filing-history",
+        credits=1,
+        fields=("company_number", "page"),
+        required=("company_number",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioCompaniesHouseComponent(ScavioBaseComponent):
+    display_name = "Scavio Companies House"
+    description = (
+        "Companies House through Scavio: search, company details, officers, filing history "
+        "(`/api/v1/companieshouse/*`, 1 credit each). START HERE. Search the UK register by name and get the "
+        "company_number every other endpoint is keyed by, plus status, incorporation date and registered office. "
+        "Pagination: page -- 20 per page, CAPPED AT PAGE 50. The register serves a 1000-result WINDOW per term "
+        "whatever hit count it prints (it claims 10,000 for a broad term then answers page 51 with HTTP 416)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioCompaniesHouse"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Company name or number. Matches CURRENT AND FORMER names.",
+            tool_mode=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            (
+                "Result page, 1-50, at 20 rows each. Capped at 50 because the register only serves the first 1000 "
+                "matches per term whatever hit count it prints. Default: 1."
+            ),
+        ),
+        text_input(
+            "company_number",
+            "Company Number",
+            (
+                "Company number. Zero-padded and upper-cased for you, so numbers off a letterhead or a spreadsheet "
+                "that ate leading zeros still resolve. SC, NI, OC, SO, NC, FC, BR and CE prefixes are supported."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_ebay.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_ebay.py
@@ -1,0 +1,168 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/ebay/search",
+        credits=1,
+        fields=(
+            "query",
+            "seller",
+            "page",
+            "sort_by",
+            "min_price",
+            "max_price",
+            "condition",
+            "buying_format",
+            "free_shipping",
+            "sold",
+            "category_id",
+            "per_page",
+        ),
+        result_keys=("products",),
+    ),
+    "Listing Details": Endpoint(
+        path="/api/v1/ebay/product",
+        credits=1,
+        fields=("item_id",),
+        required=("item_id",),
+    ),
+    "Seller Profile": Endpoint(
+        path="/api/v1/ebay/seller",
+        credits=1,
+        fields=("seller",),
+        required=("seller",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioEbayComponent(ScavioBaseComponent):
+    display_name = "Scavio eBay"
+    description = (
+        "eBay through Scavio: search, listing details, seller profile (`/api/v1/ebay/*`, 1 credit each). Search live "
+        "or SOLD eBay listings: price, condition, bids, shipping, seller, feedback. Pagination: page; per_page "
+        "accepts ONLY 60, 120 or 240 (silent fallback to 60)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioEbay"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Keyword query. Optional: a seller-scoped search works with no query at all.",
+            tool_mode=True,
+        ),
+        text_input(
+            "seller",
+            "Seller",
+            (
+                "Scope the search to one seller. Works with no query, which is the only paginated way to list a "
+                "seller's whole catalogue."
+            ),
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            (
+                "Sort order for the results. Options: best_match, ending_soonest, newly_listed, price_low, "
+                "price_high. Default: best_match."
+            ),
+            ["", "best_match", "ending_soonest", "newly_listed", "price_low", "price_high"],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price filter.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price filter.",
+        ),
+        choice_input(
+            "condition",
+            "Condition",
+            (
+                "Item condition. refurbished is eBay's parent condition, not one of its three graded tiers. "
+                "Options: new, open_box, refurbished, used, for_parts."
+            ),
+            ["", "new", "open_box", "refurbished", "used", "for_parts"],
+            advanced=True,
+        ),
+        choice_input(
+            "buying_format",
+            "Buying Format",
+            "Listing format filter. Options: auction, buy_it_now, best_offer.",
+            ["", "auction", "buy_it_now", "best_offer"],
+            advanced=True,
+        ),
+        flag_input(
+            "free_shipping",
+            "Free Shipping",
+            "Only return listings with free shipping.",
+        ),
+        flag_input(
+            "sold",
+            "Sold",
+            (
+                "Search completed listings that actually SOLD -- the price-research view. eBay publishes no "
+                "headline count there, so total_results comes back null."
+            ),
+        ),
+        text_input(
+            "category_id",
+            "Category ID",
+            "Numeric eBay category id. A non-numeric value returns the UNFILTERED set under a 200.",
+        ),
+        number_input(
+            "per_page",
+            "Per Page",
+            (
+                "Listings per page. eBay accepts only 60, 120 or 240 and silently falls back to 60 for anything "
+                "else. Options: 60, 120, 240. Default: 60."
+            ),
+        ),
+        text_input(
+            "item_id",
+            "Item ID",
+            "eBay item number or a full ebay.com/itm/... URL. Tracking parameters are discarded.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_extract.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_extract.py
@@ -1,0 +1,88 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Extract URL": Endpoint(
+        path="/api/v1/extract",
+        credits=1,
+        fields=("url", "format", "mode"),
+        required=("url",),
+        credit_note=(
+            "Costs 1 credit in normal or advanced mode and 2 credits in ultra mode, and is billed only on a "
+            "successful extraction."
+        ),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioExtractComponent(ScavioBaseComponent):
+    display_name = "Scavio Extract"
+    description = (
+        "Extract through Scavio: extract url (`/api/v1/extract`; costs 1 credit in normal or advanced mode and 2 "
+        "credits in ultra mode, and is billed only on a successful extraction). Read ANY URL and get it back as raw "
+        "HTML, readability Markdown, or plain text. The read-a-page primitive: { url, format, mode, content, "
+        "content_length }."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioExtract"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Extract URL"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Extract URL"),
+        text_input(
+            "url",
+            "URL",
+            (
+                "Page to read. http(s) only; a bare host is upgraded to https. Loopback, private, link-local and "
+                "metadata hosts are rejected with a 400."
+            ),
+            tool_mode=True,
+        ),
+        choice_input(
+            "format",
+            "Format",
+            (
+                "Output format: html is the raw page, markdown is a readability extraction, text is that markdown "
+                "flattened to plain text. Options: html, markdown, text. Default: markdown."
+            ),
+            ["", "html", "markdown", "text"],
+            advanced=True,
+        ),
+        choice_input(
+            "mode",
+            "Mode",
+            (
+                "Fetch tier and THE PRICE-BEARING PARAMETER: normal and advanced cost 1 credit, ultra costs 2. "
+                "Escalate only when a plain fetch comes back empty. Options: normal, advanced, ultra. Default: "
+                "normal."
+            ),
+            ["", "normal", "advanced", "ultra"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_g2.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_g2.py
@@ -1,0 +1,143 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/g2/search",
+        credits=5,
+        fields=("query", "page", "limit", "sort", "rating", "url"),
+        result_keys=("products",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/g2/product",
+        credits=5,
+        fields=("product_id", "url"),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/g2/reviews",
+        credits=5,
+        fields=("product_id", "url", "page", "sort", "rating", "company_size", "role", "region", "query"),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioG2Component(ScavioBaseComponent):
+    display_name = "Scavio G2"
+    description = (
+        "G2 through Scavio: search, product details, reviews (`/api/v1/g2/*`, 5 credits each). Search G2 for B2B "
+        "software products: star rating, review count, vendor, categories, seller description, logo; each row carries "
+        "product_id and slug. Pagination: page + limit -- `limit` capped at 100 on our side; G2 itself keeps "
+        "paginating at any size."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioG2"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Software product or category to search for.",
+            tool_mode=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 20 per page unless limit says otherwise.",
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            (
+                "Products per page, 1-100. Capped at 100 so one request cannot ask for a multi-megabyte page. "
+                "Default: 20."
+            ),
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            "Sort order for the results. Options: relevance, popular, alphabetical, rating. Default: relevance.",
+            ["", "relevance", "popular", "alphabetical", "rating"],
+            advanced=True,
+        ),
+        number_input(
+            "rating",
+            "Rating",
+            "Only return products at or above this star rating. Options: 1, 2, 3, 4, 5.",
+        ),
+        text_input(
+            "url",
+            "URL",
+            "Full g2.com/search URL, usable instead of query.",
+        ),
+        text_input(
+            "product_id",
+            "Product ID",
+            "G2 slug (notion) or the numeric G2 id (82623) as a string. Both resolve on the same upstream path.",
+        ),
+        choice_input(
+            "company_size",
+            "Company Size",
+            (
+                "Reviewer company size: small_business (<=50), mid_market (51-1000), enterprise (>1000). Options: "
+                "small_business, mid_market, enterprise."
+            ),
+            ["", "small_business", "mid_market", "enterprise"],
+            advanced=True,
+        ),
+        choice_input(
+            "role",
+            "Role",
+            (
+                "Reviewer role filter. Options: user, administrator, executive_sponsor, internal_consultant, "
+                "consultant, agency, industry_analyst."
+            ),
+            [
+                "",
+                "user",
+                "administrator",
+                "executive_sponsor",
+                "internal_consultant",
+                "consultant",
+                "agency",
+                "industry_analyst",
+            ],
+            advanced=True,
+        ),
+        choice_input(
+            "region",
+            "Region",
+            "Reviewer region filter. Options: north_america, europe, asia, latin_america, anz, middle_east, africa.",
+            ["", "north_america", "europe", "asia", "latin_america", "anz", "middle_east", "africa"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_glassdoor.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_glassdoor.py
@@ -1,0 +1,128 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Company Search": Endpoint(
+        path="/api/v1/glassdoor/companies",
+        credits=1,
+        fields=("query",),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "Company Details": Endpoint(
+        path="/api/v1/glassdoor/company",
+        credits=1,
+        fields=("employer_id", "company", "url"),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/glassdoor/reviews",
+        credits=1,
+        fields=("employer_id", "company", "url", "category", "employment_status"),
+    ),
+    "Salaries": Endpoint(
+        path="/api/v1/glassdoor/salaries",
+        credits=1,
+        fields=("employer_id", "company", "url", "page"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGlassdoorComponent(ScavioBaseComponent):
+    display_name = "Scavio Glassdoor"
+    description = (
+        "Glassdoor through Scavio: company search, company details, reviews, salaries (`/api/v1/glassdoor/*`, 1 "
+        "credit each). START HERE. Search Glassdoor by company NAME and resolve it to the employer_id every other "
+        "endpoint needs."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGlassdoor"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Company Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Company Search"),
+        text_input(
+            "query",
+            "Query",
+            "Company NAME to resolve into an employer_id.",
+            tool_mode=True,
+        ),
+        text_input(
+            "employer_id",
+            "Employer ID",
+            "Glassdoor employer id as a STRING -- a JSON number is rejected. Accepts 1699, E1699 or IE1699.",
+        ),
+        text_input(
+            "company",
+            "Company",
+            (
+                "Company name. COSMETIC only: the profile resolves on employer_id alone, it is ignored entirely "
+                "when url is set, and it does not satisfy the required-identifier rule."
+            ),
+        ),
+        text_input(
+            "url",
+            "URL",
+            "Any glassdoor.com employer URL (/Overview/, /Reviews/, /Salary/). Non-glassdoor.com hosts are rejected.",
+        ),
+        choice_input(
+            "category",
+            "Category",
+            (
+                "Review category filter. Closed set: Glassdoor IGNORES an unknown value and returns the unfiltered "
+                "set under a 200. Options: career_development, compensation, culture, diversity_and_inclusion, "
+                "management, work_life_balance."
+            ),
+            [
+                "",
+                "career_development",
+                "compensation",
+                "culture",
+                "diversity_and_inclusion",
+                "management",
+                "work_life_balance",
+            ],
+            advanced=True,
+        ),
+        choice_input(
+            "employment_status",
+            "Employment Status",
+            (
+                "Reviewer employment status filter. Closed set for the same reason as category. Options: full_time, "
+                "part_time, contract, intern."
+            ),
+            ["", "full_time", "part_time", "contract", "intern"],
+            advanced=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 10 job titles per page; page_count on the response says how many exist.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ads.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ads.py
@@ -1,0 +1,145 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/googleads/search",
+        credits=1,
+        fields=("domain", "advertiser_id", "region", "format", "platform", "topic", "limit", "cursor"),
+        result_keys=("creatives",),
+    ),
+    "Advertiser Lookup": Endpoint(
+        path="/api/v1/googleads/advertisers",
+        credits=1,
+        fields=("query", "region", "limit"),
+        required=("query",),
+        result_keys=("suggestions",),
+    ),
+    "Creative Details": Endpoint(
+        path="/api/v1/googleads/creative",
+        credits=1,
+        fields=("advertiser_id", "creative_id"),
+        required=("advertiser_id", "creative_id"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGoogleAdsComponent(ScavioBaseComponent):
+    display_name = "Scavio Google Ads"
+    description = (
+        "Google Ads through Scavio: search, advertiser lookup, creative details (`/api/v1/googleads/*`, 1 credit "
+        "each). Every ad Google is running for one advertiser: the creative, advertiser id and name, format, "
+        "first/last seen dates, days actually run, plus total_ads_min/total_ads_max. Pagination: cursor -> "
+        "next_cursor, 100 creatives per page. Re-send the SAME filters alongside the cursor."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleAds"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "domain",
+            "Domain",
+            (
+                "Advertiser website: bare host, www host or full URL, reduced to the registrable host. This is the "
+                "ONLY way to get the `domain` field back on each row."
+            ),
+            tool_mode=True,
+        ),
+        text_input(
+            "advertiser_id",
+            "Advertiser ID",
+            (
+                "Google advertiser id, e.g. AR16735076323512287233. The shape is checked before any request, so a "
+                "typo costs nothing."
+            ),
+        ),
+        text_input(
+            "region",
+            "Region",
+            (
+                "ISO alpha-2 country (US, GB, DE) or a Google geo criteria id as a string. It also scopes the deep "
+                "links on every row. Default: worldwide."
+            ),
+        ),
+        choice_input(
+            "format",
+            "Format",
+            (
+                "Creative format. The three sets are DISJOINT -- an advertiser's text, image and video ads share no "
+                "creatives. Default: all formats. Options: text, image, video."
+            ),
+            ["", "text", "image", "video"],
+            advanced=True,
+        ),
+        choice_input(
+            "platform",
+            "Platform",
+            "Surface the ad ran on. Default: all surfaces. Options: play, maps, search, shopping, youtube.",
+            ["", "play", "maps", "search", "shopping", "youtube"],
+            advanced=True,
+        ),
+        choice_input(
+            "topic",
+            "Topic",
+            "Ad topic filter. Options: all, political. Default: all.",
+            ["", "all", "political"],
+            advanced=True,
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            (
+                "Creatives per page, 1-100. 100 is a HARD UPSTREAM CEILING, not our policy: Google answers a larger "
+                "request with ZERO rows rather than an error. Default: 40."
+            ),
+        ),
+        cursor_input(
+            (
+                "next_cursor from the previous response. Re-send the SAME filters alongside it. Null once the "
+                "result set is exhausted."
+            ),
+        ),
+        text_input(
+            "query",
+            "Query",
+            "Advertiser name or domain to resolve.",
+        ),
+        text_input(
+            "creative_id",
+            "Creative ID",
+            (
+                "Creative id. It must belong to the advertiser_id sent with it -- the lookup is keyed by the pair "
+                "and a mismatch is a 404."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import BoolInput, DropdownInput, MessageTextInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
@@ -1,0 +1,104 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput, DropdownInput, MessageTextInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    max_results_input,
+)
+
+ENDPOINTS = {
+    "Google AI Mode": Endpoint(
+        path="/api/v2/google/ai-mode",
+        credits=1,
+        fields=("query", "device", "hl", "gl", "google_domain", "location", "uule", "safe", "include_html"),
+        required=("query",),
+        result_keys=("references",),
+    ),
+}
+
+
+class ScavioGoogleAIModeComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google AI Mode"
+    description = (
+        "Run a Google AI Mode query through Scavio (`POST /api/v2/google/ai-mode`, 1 credit) and get the "
+        "generated answer blocks plus the references Google cited."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleAIMode"
+
+    ENDPOINTS = ENDPOINTS
+    DEFAULT_ENDPOINT = "Google AI Mode"
+
+    inputs = [
+        api_key_input(),
+        MessageTextInput(
+            name="query",
+            display_name="Query",
+            info="The question to send to Google AI Mode.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="gl",
+            display_name="Country (gl)",
+            info="Two-letter geo country code, e.g. us.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="hl",
+            display_name="Language (hl)",
+            info="Two-letter interface language code, e.g. en.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="google_domain",
+            display_name="Google Domain",
+            info="Google domain to query, e.g. google.co.uk.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="location",
+            display_name="Location",
+            info="Canonical location name, e.g. Austin, Texas, United States.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="uule",
+            display_name="UULE",
+            info="Pre-encoded UULE location string. Takes priority over Location.",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="device",
+            display_name="Device",
+            info="Device profile to emulate.",
+            options=["", "desktop", "mobile"],
+            value="",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="safe",
+            display_name="Safe Search",
+            info="Set to active to turn SafeSearch on.",
+            options=["", "active"],
+            value="",
+            advanced=True,
+        ),
+        BoolInput(
+            name="include_html",
+            display_name="Include Raw HTML",
+            info="Add Google's raw HTML to the response under the html key.",
+            value=False,
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_ai_mode.py
@@ -1,10 +1,10 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import BoolInput, DropdownInput, MessageTextInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
+    BoolInput,
+    DropdownInput,
     Endpoint,
-    ScavioAPIMixin,
+    MessageTextInput,
     api_key_input,
     max_results_input,
 )
@@ -20,7 +20,7 @@ ENDPOINTS = {
 }
 
 
-class ScavioGoogleAIModeComponent(ScavioAPIMixin, Component):
+class ScavioGoogleAIModeComponent(ScavioBaseComponent):
     display_name = "Scavio Google AI Mode"
     description = (
         "Run a Google AI Mode query through Scavio (`POST /api/v2/google/ai-mode`, 1 credit) and get the "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import IntInput, MessageTextInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
@@ -1,0 +1,173 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import IntInput, MessageTextInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    max_results_input,
+)
+
+ENDPOINTS = {
+    "Google Flights": Endpoint(
+        path="/api/v2/google/flights",
+        credits=1,
+        fields=(
+            "departure_id",
+            "arrival_id",
+            "outbound_date",
+            "return_date",
+            "type",
+            "adults",
+            "children",
+            "infants_in_seat",
+            "infants_on_lap",
+            "travel_class",
+            "stops",
+            "sort_by",
+            "include_airlines",
+            "exclude_airlines",
+            "hl",
+            "gl",
+            "currency",
+        ),
+        required=("departure_id", "arrival_id", "outbound_date"),
+        result_keys=("best_flights", "other_flights"),
+    ),
+}
+
+
+class ScavioGoogleFlightsComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google Flights"
+    description = (
+        "Google Flights through Scavio (`POST /api/v2/google/flights`, 1 credit). Returns the best and "
+        "other itineraries for a route and date."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleFlights"
+
+    ENDPOINTS = ENDPOINTS
+    DEFAULT_ENDPOINT = "Google Flights"
+
+    inputs = [
+        api_key_input(),
+        MessageTextInput(
+            name="departure_id",
+            display_name="Departure",
+            info="Origin IATA code, e.g. JFK. Comma-separated codes are allowed.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="arrival_id",
+            display_name="Arrival",
+            info="Destination IATA code, e.g. LHR. Comma-separated codes are allowed.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="outbound_date",
+            display_name="Outbound Date",
+            info="Departure date as YYYY-MM-DD.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="return_date",
+            display_name="Return Date",
+            info="Return date as YYYY-MM-DD. Required when Trip Type is 1 (round trip).",
+            tool_mode=True,
+        ),
+        IntInput(
+            name="type",
+            display_name="Trip Type",
+            info="1 round trip, 2 one way, 3 multi-city. 0 leaves it to Google.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="adults",
+            display_name="Adults",
+            info="Number of adults, 1 to 9. 0 leaves it to Google.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="children",
+            display_name="Children",
+            info="Number of children, 0 to 9.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="infants_in_seat",
+            display_name="Infants In Seat",
+            info="Number of infants in their own seat, 0 to 4.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="infants_on_lap",
+            display_name="Infants On Lap",
+            info="Number of lap infants, 0 to 4.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="travel_class",
+            display_name="Travel Class",
+            info="1 economy, 2 premium economy, 3 business, 4 first. 0 leaves it to Google.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="stops",
+            display_name="Stops",
+            info="0 any, 1 nonstop, 2 one stop or fewer, 3 two stops or fewer.",
+            value=0,
+            advanced=True,
+        ),
+        IntInput(
+            name="sort_by",
+            display_name="Sort By",
+            info="1 top flights, 2 price, 3 departure, 4 arrival, 5 duration, 6 emissions.",
+            value=0,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="include_airlines",
+            display_name="Include Airlines",
+            info="Comma-separated airline or alliance codes to keep.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="exclude_airlines",
+            display_name="Exclude Airlines",
+            info="Comma-separated airline or alliance codes to drop.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="currency",
+            display_name="Currency",
+            info="Three-letter currency code, e.g. USD.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="gl",
+            display_name="Country (gl)",
+            info="Two-letter geo country code, e.g. us.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="hl",
+            display_name="Language (hl)",
+            info="Two-letter interface language code, e.g. en.",
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_flights.py
@@ -1,10 +1,9 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import IntInput, MessageTextInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
+    IntInput,
+    MessageTextInput,
     api_key_input,
     max_results_input,
 )
@@ -38,7 +37,7 @@ ENDPOINTS = {
 }
 
 
-class ScavioGoogleFlightsComponent(ScavioAPIMixin, Component):
+class ScavioGoogleFlightsComponent(ScavioBaseComponent):
     display_name = "Scavio Google Flights"
     description = (
         "Google Flights through Scavio (`POST /api/v2/google/flights`, 1 credit). Returns the best and "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
@@ -1,10 +1,8 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import BoolInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
+    BoolInput,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     default_visibility,
     endpoint_input,
@@ -52,7 +50,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioGoogleHotelsComponent(ScavioAPIMixin, Component):
+class ScavioGoogleHotelsComponent(ScavioBaseComponent):
     display_name = "Scavio Google Hotels"
     description = (
         "Google Hotels through Scavio: property search and the booking sources behind a single property "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import BoolInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_hotels.py
@@ -1,0 +1,142 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Hotels Search": Endpoint(
+        path="/api/v2/google/hotels",
+        credits=1,
+        fields=(
+            "query",
+            "check_in_date",
+            "check_out_date",
+            "hl",
+            "gl",
+            "currency",
+            "sort_by",
+            "min_price",
+            "max_price",
+            "rating",
+            "hotel_class",
+            "amenities",
+            "property_types",
+            "free_cancellation",
+            "eco_certified",
+            "special_offers",
+            "next_page_token",
+            "limit",
+        ),
+        required=("query", "check_in_date", "check_out_date"),
+        result_keys=("properties",),
+    ),
+    "Hotel Detail": Endpoint(
+        path="/api/v2/google/hotels/detail",
+        credits=1,
+        fields=("detail_token", "check_in_date", "check_out_date", "currency", "gl", "hl"),
+        required=("detail_token", "check_in_date", "check_out_date"),
+        result_keys=("property.booking_sources",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGoogleHotelsComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google Hotels"
+    description = (
+        "Google Hotels through Scavio: property search and the booking sources behind a single property "
+        "(`/api/v2/google/hotels`, `/api/v2/google/hotels/detail`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleHotels"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Hotels Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Hotels Search"),
+        text_input(
+            "query",
+            "Query",
+            "Where to stay. Use the '<City> hotels' form. Max 200 characters.",
+            tool_mode=True,
+        ),
+        text_input("check_in_date", "Check In", "Check-in date as YYYY-MM-DD.", tool_mode=True),
+        text_input("check_out_date", "Check Out", "Check-out date as YYYY-MM-DD.", tool_mode=True),
+        text_input(
+            "detail_token",
+            "Detail Token",
+            "detail_token taken from a property in a Hotels Search response. Both dates must be resent with it.",
+        ),
+        number_input("sort_by", "Sort By", "3 lowest price, 8 highest rating, 13 most reviewed."),
+        number_input("min_price", "Min Price", "Lower nightly price bound. 0 means no bound."),
+        number_input("max_price", "Max Price", "Upper nightly price bound. 0 means no bound."),
+        number_input("rating", "Minimum Rating", "7 for 3.5+, 8 for 4.0+, 9 for 4.5+."),
+        number_input("limit", "Limit", "Properties per page, 1 to 20."),
+        text_input("hotel_class", "Hotel Class", "Comma-separated star classes from 2 to 5, e.g. 4,5.", advanced=True),
+        text_input("amenities", "Amenities", "Comma-separated amenity ids.", advanced=True),
+        text_input(
+            "property_types",
+            "Property Types",
+            "Comma-separated property type ids. 12 is vacation rentals.",
+            advanced=True,
+        ),
+        text_input(
+            "next_page_token", "Next Page Token", "Cursor from a previous Hotels Search response.", advanced=True
+        ),
+        text_input("currency", "Currency", "Three-letter currency code, e.g. USD.", advanced=True),
+        text_input("gl", "Country (gl)", "Two-letter geo country code, e.g. us.", advanced=True),
+        text_input("hl", "Language (hl)", "Two-letter interface language code, e.g. en.", advanced=True),
+        BoolInput(
+            name="free_cancellation",
+            display_name="Free Cancellation",
+            info="Only properties offering free cancellation.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="eco_certified",
+            display_name="Eco Certified",
+            info="Only eco-certified properties.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="special_offers",
+            display_name="Special Offers",
+            info="Only properties currently running a special offer.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
@@ -1,0 +1,99 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Maps Search": Endpoint(
+        path="/api/v2/google/maps/search",
+        credits=1,
+        fields=("query", "start", "ll", "hl", "gl", "google_domain"),
+        required=("query",),
+        result_keys=("local_results",),
+    ),
+    "Place Details": Endpoint(
+        path="/api/v2/google/maps/place",
+        credits=1,
+        fields=("place_id", "data_cid"),
+        result_keys=("place_results",),
+    ),
+    "Place Reviews": Endpoint(
+        path="/api/v2/google/maps/reviews",
+        credits=1,
+        fields=("data_id", "place_id", "num", "next_page_token", "reviews_sort_by", "hl", "gl", "google_domain"),
+        result_keys=("reviews",),
+        wire={"reviews_sort_by": "sort_by"},
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGoogleMapsComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google Maps"
+    description = (
+        "Google Maps through Scavio: local search, place details and place reviews "
+        "(`/api/v2/google/maps/*`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleMaps"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Maps Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Maps Search"),
+        text_input("query", "Query", "What to look for, e.g. coffee shops in Austin.", tool_mode=True),
+        text_input(
+            "place_id",
+            "Place ID",
+            "A Google place id (ChIJ...). Place Details needs this or a Data CID; Reviews accepts it too.",
+            tool_mode=True,
+        ),
+        text_input("data_cid", "Data CID", "Numeric Google CID, an alternative to Place ID on Place Details."),
+        text_input("data_id", "Data ID", "Reviews identifier in 0xHEX:0xHEX form. Use it or Place ID."),
+        text_input(
+            "ll",
+            "Map Center (ll)",
+            "Map center as @lat,lng,zoomz. Maps localizes by map center, not by gl - Scavio derives a "
+            "city-level center from gl when this is empty.",
+            advanced=True,
+        ),
+        number_input("start", "Start Offset", "Result offset. Must be a multiple of 20, max 100. 0 is page 1."),
+        number_input("num", "Number of Reviews", "Reviews per call, 1 to 20."),
+        text_input("next_page_token", "Next Page Token", "Reviews cursor from a previous response.", advanced=True),
+        choice_input(
+            "reviews_sort_by",
+            "Reviews Sort",
+            "Review ordering. Sent to the API as sort_by.",
+            ["", "relevance", "newest", "highest_rating", "lowest_rating"],
+            advanced=True,
+        ),
+        text_input("gl", "Country (gl)", "Two-letter geo country code, e.g. us.", advanced=True),
+        text_input("hl", "Language (hl)", "Two-letter interface language code, e.g. en.", advanced=True),
+        text_input("google_domain", "Google Domain", "Google domain to query, e.g. google.co.uk.", advanced=True),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     default_visibility,
@@ -18,7 +16,8 @@ ENDPOINTS = {
     "Maps Search": Endpoint(
         path="/api/v2/google/maps/search",
         credits=1,
-        fields=("query", "start", "ll", "hl", "gl", "google_domain"),
+        fields=("query", "start_offset", "ll", "hl", "gl", "google_domain"),
+        wire={"start_offset": "start"},
         required=("query",),
         result_keys=("local_results",),
     ),
@@ -39,7 +38,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioGoogleMapsComponent(ScavioAPIMixin, Component):
+class ScavioGoogleMapsComponent(ScavioBaseComponent):
     display_name = "Scavio Google Maps"
     description = (
         "Google Maps through Scavio: local search, place details and place reviews "
@@ -72,7 +71,11 @@ class ScavioGoogleMapsComponent(ScavioAPIMixin, Component):
             "city-level center from gl when this is empty.",
             advanced=True,
         ),
-        number_input("start", "Start Offset", "Result offset. Must be a multiple of 20, max 100. 0 is page 1."),
+        number_input(
+            "start_offset",
+            "Start Offset",
+            "Result offset. Must be a multiple of 20, max 100. 0 is page 1.",
+        ),
         number_input("num", "Number of Reviews", "Reviews per call, 1 to 20."),
         text_input("next_page_token", "Next Page Token", "Reviews cursor from a previous response.", advanced=True),
         choice_input(

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_maps.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import IntInput, MessageTextInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
@@ -1,0 +1,116 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import IntInput, MessageTextInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    max_results_input,
+)
+
+ENDPOINTS = {
+    "Google News": Endpoint(
+        path="/api/v2/google/news",
+        credits=1,
+        fields=(
+            "query",
+            "topic_token",
+            "section_token",
+            "story_token",
+            "publication_token",
+            "kgmid",
+            "hl",
+            "gl",
+            "google_domain",
+            "so",
+        ),
+        result_keys=("news_results",),
+    ),
+}
+
+
+class ScavioGoogleNewsComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google News"
+    description = (
+        "Google News through Scavio (`POST /api/v2/google/news`, 1 credit). Drive it with exactly one of "
+        "Query, Topic Token, Section Token, Story Token, Publication Token or KGMID."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleNews"
+
+    ENDPOINTS = ENDPOINTS
+    DEFAULT_ENDPOINT = "Google News"
+
+    inputs = [
+        api_key_input(),
+        MessageTextInput(
+            name="query",
+            display_name="Query",
+            info="News search keywords. Supply exactly one driver: this, a token, or a KGMID.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="topic_token",
+            display_name="Topic Token",
+            info="Topic token from a previous News response.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="section_token",
+            display_name="Section Token",
+            info="Section token from a previous News response.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="story_token",
+            display_name="Story Token",
+            info="Story token from a previous News response.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="publication_token",
+            display_name="Publication Token",
+            info="Publication token from a previous News response.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="kgmid",
+            display_name="KGMID",
+            info="Knowledge Graph entity id, e.g. /m/02_286.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="gl",
+            display_name="Country (gl)",
+            info="Two-letter geo country code, e.g. us.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="hl",
+            display_name="Language (hl)",
+            info="Two-letter interface language code, e.g. en.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="google_domain",
+            display_name="Google Domain",
+            info="Google domain to query, e.g. google.co.uk.",
+            advanced=True,
+        ),
+        IntInput(
+            name="so",
+            display_name="Sort Order",
+            info="1 sorts by date. 0 (the default) sorts by relevance. Only valid with Query or KGMID.",
+            value=0,
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_news.py
@@ -1,10 +1,9 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import IntInput, MessageTextInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
+    IntInput,
+    MessageTextInput,
     api_key_input,
     max_results_input,
 )
@@ -30,7 +29,7 @@ ENDPOINTS = {
 }
 
 
-class ScavioGoogleNewsComponent(ScavioAPIMixin, Component):
+class ScavioGoogleNewsComponent(ScavioBaseComponent):
     display_name = "Scavio Google News"
     description = (
         "Google News through Scavio (`POST /api/v2/google/news`, 1 credit). Drive it with exactly one of "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_play.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_play.py
@@ -1,0 +1,111 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/googleplay/search",
+        credits=2,
+        fields=("query", "hl", "gl"),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "App Details": Endpoint(
+        path="/api/v1/googleplay/app",
+        credits=2,
+        fields=("app_id", "hl", "gl"),
+        required=("app_id",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/googleplay/reviews",
+        credits=2,
+        fields=("app_id", "sort", "count", "cursor", "hl", "gl"),
+        required=("app_id",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGooglePlayComponent(ScavioBaseComponent):
+    display_name = "Scavio Google Play"
+    description = (
+        "Google Play through Scavio: search, app details, reviews (`/api/v1/googleplay/*`, 2 credits each). Ranked "
+        "Google Play apps: package name, title, developer, rating, install count, price and IAP range, content "
+        "rating, icon, screenshots."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGooglePlay"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Search query. There is no pagination -- one shelf of ~30 apps.",
+            tool_mode=True,
+        ),
+        text_input(
+            "hl",
+            "Language",
+            (
+                "Interface language. It moves the whole storefront, not only the strings: title, description, "
+                "install formatting and content rating all follow it. Default: en."
+            ),
+        ),
+        text_input(
+            "gl",
+            "Country",
+            "Storefront country code. Default: us.",
+        ),
+        text_input(
+            "app_id",
+            "App ID",
+            "Android package name, or any play.google.com URL carrying one in its id parameter.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            "Review sort order. Options: relevance, newest, rating. Default: newest.",
+            ["", "relevance", "newest", "rating"],
+            advanced=True,
+        ),
+        number_input(
+            "count",
+            "Count",
+            "Reviews to return, 1-200. Default: 50.",
+        ),
+        cursor_input(
+            (
+                "next_cursor from a previous response. OPAQUE and SINGLE-USE, and it encodes the sort as well as "
+                "the position -- send it back with the SAME sort it came from. A cursor past the last review is a "
+                "404."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
@@ -1,10 +1,8 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import BoolInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
+    BoolInput,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     default_visibility,
@@ -22,7 +20,7 @@ ENDPOINTS = {
         fields=(
             "query",
             "device",
-            "start",
+            "start_offset",
             "min_price",
             "max_price",
             "sort_by",
@@ -35,6 +33,7 @@ ENDPOINTS = {
             "location",
             "uule",
         ),
+        wire={"start_offset": "start"},
         required=("query",),
         result_keys=("shopping_results",),
     ),
@@ -71,7 +70,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioGoogleShoppingComponent(ScavioAPIMixin, Component):
+class ScavioGoogleShoppingComponent(ScavioBaseComponent):
     display_name = "Scavio Google Shopping"
     description = (
         "Google Shopping through Scavio: product search, product details and the full store list for a "
@@ -115,7 +114,11 @@ class ScavioGoogleShoppingComponent(ScavioAPIMixin, Component):
             ["", "desktop", "mobile", "tablet"],
             advanced=True,
         ),
-        number_input("start", "Start Offset", "Shopping result offset. Follow pagination.next."),
+        number_input(
+            "start_offset",
+            "Start Offset",
+            "Shopping result offset. Follow pagination.next.",
+        ),
         number_input("min_price", "Min Price", "Lower price bound. 0 means no bound."),
         number_input("max_price", "Max Price", "Upper price bound. 0 means no bound."),
         number_input(

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import BoolInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_shopping.py
@@ -1,0 +1,188 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Shopping Search": Endpoint(
+        path="/api/v2/google/shopping",
+        credits=1,
+        fields=(
+            "query",
+            "device",
+            "start",
+            "min_price",
+            "max_price",
+            "sort_by",
+            "free_shipping",
+            "on_sale",
+            "shoprs",
+            "hl",
+            "gl",
+            "google_domain",
+            "location",
+            "uule",
+        ),
+        required=("query",),
+        result_keys=("shopping_results",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v2/google/shopping/product",
+        credits=1,
+        fields=(
+            "catalog_id",
+            "query",
+            "product_id",
+            "immersive_product_page_token",
+            "page_token",
+            "device",
+            "product_sort_by",
+            "load_all_stores",
+            "more_stores",
+            "hl",
+            "gl",
+            "google_domain",
+            "location",
+            "uule",
+        ),
+        result_keys=("product_results",),
+        wire={"product_sort_by": "sort_by"},
+    ),
+    "Product Stores": Endpoint(
+        path="/api/v2/google/shopping/product/stores",
+        credits=1,
+        fields=("catalog_id", "next_page_token"),
+        required=("catalog_id", "next_page_token"),
+        result_keys=("product_results.stores",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGoogleShoppingComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google Shopping"
+    description = (
+        "Google Shopping through Scavio: product search, product details and the full store list for a "
+        "product (`/api/v2/google/shopping*`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleShopping"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Shopping Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Shopping Search"),
+        text_input(
+            "query",
+            "Query",
+            "Product keywords. On Product Details this is mandatory whenever a Catalog ID is supplied.",
+            tool_mode=True,
+        ),
+        text_input("catalog_id", "Catalog ID", "Durable catalog id. Requires Query on Product Details."),
+        text_input("product_id", "Product ID", "Google product id, an alternative driver on Product Details."),
+        text_input(
+            "immersive_product_page_token",
+            "Immersive Product Page Token",
+            "Token lifted from a shopping result. Page Token is an alias of this field.",
+            advanced=True,
+        ),
+        text_input("page_token", "Page Token", "Alias of Immersive Product Page Token.", advanced=True),
+        text_input(
+            "next_page_token",
+            "Next Page Token",
+            "Store-list continuation cursor from a previous response.",
+        ),
+        choice_input(
+            "device",
+            "Device",
+            "Device profile. tablet is accepted on Product Details only.",
+            ["", "desktop", "mobile", "tablet"],
+            advanced=True,
+        ),
+        number_input("start", "Start Offset", "Shopping result offset. Follow pagination.next."),
+        number_input("min_price", "Min Price", "Lower price bound. 0 means no bound."),
+        number_input("max_price", "Max Price", "Upper price bound. 0 means no bound."),
+        number_input(
+            "sort_by", "Sort By", "Shopping search order: 1 price ascending, 2 price descending. 0 relevance."
+        ),
+        choice_input(
+            "product_sort_by",
+            "Store Sort",
+            "Seller ordering on Product Details. Sent to the API as sort_by.",
+            ["", "base_price", "total_price", "promotion", "seller_rating"],
+            advanced=True,
+        ),
+        text_input(
+            "shoprs", "Shoprs Filter", "Opaque filter token taken from filters[] in a prior response.", advanced=True
+        ),
+        BoolInput(
+            name="free_shipping",
+            display_name="Free Shipping Only",
+            info="Restrict shopping results to free-shipping offers.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="on_sale",
+            display_name="On Sale Only",
+            info="Restrict shopping results to discounted offers.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="load_all_stores",
+            display_name="Load All Stores",
+            info="Ask Product Details for the full store list rather than the first page.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="more_stores",
+            display_name="More Stores",
+            info="Ask Product Details for the extended store list.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        text_input("gl", "Country (gl)", "Two-letter geo country code, e.g. us.", advanced=True),
+        text_input("hl", "Language (hl)", "Two-letter interface language code, e.g. en.", advanced=True),
+        text_input("google_domain", "Google Domain", "Google domain to query, e.g. google.co.uk.", advanced=True),
+        text_input(
+            "location", "Location", "Canonical location name, e.g. Austin, Texas, United States.", advanced=True
+        ),
+        text_input("uule", "UULE", "Pre-encoded UULE string. Takes priority over Location.", advanced=True),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     default_visibility,
@@ -34,7 +32,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioGoogleTrendsComponent(ScavioAPIMixin, Component):
+class ScavioGoogleTrendsComponent(ScavioBaseComponent):
     display_name = "Scavio Google Trends"
     description = (
         "Google Trends through Scavio: interest over time and by region for a term, plus the Trending Now "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_google_trends.py
@@ -1,0 +1,119 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Trends": Endpoint(
+        path="/api/v2/google/trends",
+        credits=1,
+        fields=("query", "geo", "hl", "date", "tz", "data_type", "cat", "gprop", "region"),
+        required=("query",),
+        result_keys=("interest_by_region", "interest_over_time.timeline_data"),
+    ),
+    "Trending Now": Endpoint(
+        path="/api/v2/google/trending",
+        credits=1,
+        fields=("geo", "hl", "hours", "trending_cat", "sort", "trend_status"),
+        required=("geo",),
+        result_keys=("trends",),
+        wire={"trending_cat": "cat", "trend_status": "status"},
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioGoogleTrendsComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Google Trends"
+    description = (
+        "Google Trends through Scavio: interest over time and by region for a term, plus the Trending Now "
+        "board for a country (`/api/v2/google/trends`, `/api/v2/google/trending`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioGoogleTrends"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Trends"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Trends"),
+        text_input("query", "Query", "The term to chart interest for.", tool_mode=True),
+        text_input(
+            "geo",
+            "Geo",
+            "Uppercase region code, e.g. US, GB or US-CA. Trends is worldwide when empty; Trending Now "
+            "requires it. This endpoint family uses geo, not gl.",
+            tool_mode=True,
+        ),
+        text_input("hl", "Language (hl)", "Two-letter interface language code, e.g. en.", advanced=True),
+        text_input(
+            "date",
+            "Date Range",
+            "Free-text time range, e.g. today 12-m or 2024-01-01 2024-12-31.",
+            advanced=True,
+        ),
+        text_input("tz", "Timezone Offset", "Timezone offset in minutes, sent as a string.", advanced=True),
+        choice_input(
+            "data_type",
+            "Data Type",
+            "Which Trends dataset to return. Empty returns the upstream default (timeseries plus geo map).",
+            ["", "TIMESERIES", "GEO_MAP", "GEO_MAP_0", "RELATED_QUERIES", "RELATED_TOPICS"],
+            advanced=True,
+        ),
+        text_input("cat", "Category", "Trends category id as a string, e.g. 71.", advanced=True),
+        choice_input(
+            "gprop",
+            "Property",
+            "Google property to chart. Empty means web search.",
+            ["", "images", "news", "youtube", "froogle"],
+            advanced=True,
+        ),
+        choice_input(
+            "region",
+            "Region Breakdown",
+            "Granularity of the interest-by-region breakdown.",
+            ["", "COUNTRY", "REGION", "DMA", "CITY"],
+            advanced=True,
+        ),
+        number_input("hours", "Hours", "Trending Now window in hours: 4, 24, 48 or 168."),
+        number_input("trending_cat", "Trending Category", "Trending Now category id, 0 to 20. 0 is all."),
+        choice_input(
+            "sort",
+            "Sort",
+            "Trending Now ordering. The field is sort here, not sort_by.",
+            ["", "relevance", "search_volume", "recency", "title"],
+            advanced=True,
+        ),
+        choice_input(
+            "trend_status",
+            "Status",
+            "Trending Now status filter. Sent to the API as status.",
+            ["", "all", "active"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_home_depot.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_home_depot.py
@@ -1,0 +1,106 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/homedepot/search",
+        credits=2,
+        fields=("query", "page", "sort_by", "min_price", "max_price"),
+        required=("query",),
+        result_keys=("products",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/homedepot/product",
+        credits=2,
+        fields=("item_id",),
+        required=("item_id",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/homedepot/reviews",
+        credits=2,
+        fields=("item_id", "page"),
+        required=("item_id",),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioHomeDepotComponent(ScavioBaseComponent):
+    display_name = "Scavio Home Depot"
+    description = (
+        "Home Depot through Scavio: search, product details, reviews (`/api/v1/homedepot/*`, 2 credits each). Search "
+        "Home Depot: price and promotions, brand and model, ratings, badges, per-store pickup/delivery. Pagination: "
+        "page -- page size is FIXED at 12 and cannot be changed."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioHomeDepot"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Product search query.",
+            tool_mode=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 12 products per page, fixed.",
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            (
+                "Sort order. The set is closed because Home Depot answers an unknown sort with an empty page rather "
+                "than falling back. Options: best_match, top_sellers, top_rated, price_low, price_high. Default: "
+                "best_match."
+            ),
+            ["", "best_match", "top_sellers", "top_rated", "price_low", "price_high"],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price filter.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price filter.",
+        ),
+        text_input(
+            "item_id",
+            "Item ID",
+            "Home Depot item id or a full homedepot.com/p/... URL. Tracking parameters are discarded.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_indeed.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_indeed.py
@@ -1,0 +1,143 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/indeed/search",
+        credits=2,
+        fields=("query", "location", "page", "radius", "max_age_days", "job_type", "min_salary", "remote"),
+        result_keys=("jobs",),
+    ),
+    "Job Details": Endpoint(
+        path="/api/v1/indeed/job",
+        credits=2,
+        fields=("job_id",),
+        required=("job_id",),
+    ),
+    "Company Details": Endpoint(
+        path="/api/v1/indeed/company",
+        credits=2,
+        fields=("company",),
+        required=("company",),
+    ),
+    "Company Reviews": Endpoint(
+        path="/api/v1/indeed/company/reviews",
+        credits=2,
+        fields=("company", "page"),
+        required=("company",),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioIndeedComponent(ScavioBaseComponent):
+    display_name = "Scavio Indeed"
+    description = (
+        "Indeed through Scavio: search, job details, company details, company reviews (`/api/v1/indeed/*`, 2 credits "
+        "each). Indeed job postings: title, employer, rating, location, salary range, job type, benefits, posting "
+        "age, apply route. Pagination: page -- 10 postings per page."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioIndeed"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Job title, keyword or company. Optional if location is set.",
+            tool_mode=True,
+        ),
+        text_input(
+            "location",
+            "Location",
+            (
+                "City and state, postal code, state, country or 'Remote'. Usable with no query at all -- that "
+                "returns every posting in a metro."
+            ),
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 10 postings per page.",
+        ),
+        number_input(
+            "radius",
+            "Radius",
+            (
+                "Search radius in miles. Closed set: Indeed IGNORES any other value and returns the unfiltered set, "
+                "so asking for 7 would silently buy 50. Options: 0, 5, 10, 15, 25, 35, 50, 100. Default: 50."
+            ),
+        ),
+        number_input(
+            "max_age_days",
+            "Max Age Days",
+            (
+                "Only postings published within this many days. Closed set for the same reason as radius. Options: "
+                "1, 3, 7, 14."
+            ),
+        ),
+        choice_input(
+            "job_type",
+            "Job Type",
+            "Employment type filter. Options: full_time, part_time, contract, temporary, internship.",
+            ["", "full_time", "part_time", "contract", "temporary", "internship"],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_salary",
+            "Min Salary",
+            (
+                "Minimum salary. This filters on INDEED'S OWN ESTIMATE for the role, not a posted figure, so "
+                "postings that publish no salary still match."
+            ),
+        ),
+        flag_input(
+            "remote",
+            "Remote",
+            "Only return remote roles.",
+        ),
+        text_input(
+            "job_id",
+            "Job ID",
+            "16-hex Indeed job key, or any indeed.com URL carrying jk= (/viewjob, /rc/clk, /pagead/clk).",
+        ),
+        text_input(
+            "company",
+            "Company",
+            (
+                "indeed.com/cmp/<slug> slug or a full profile URL. Slugs are untidy, e.g. "
+                "'Tata-Consultancy-Services-(tcs)'."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -21,43 +19,50 @@ ENDPOINTS = {
     "User Profile": Endpoint(
         path="/api/v1/instagram/profile",
         credits=10,
-        fields=("username", "user_id"),
+        fields=("username", "target_user_id"),
+        wire={"target_user_id": "user_id"},
     ),
     "User Posts": Endpoint(
         path="/api/v1/instagram/user/posts",
         credits=2,
-        fields=("username", "user_id", "count", "cursor"),
+        fields=("username", "target_user_id", "count", "cursor"),
         result_keys=("items", "data"),
+        wire={"target_user_id": "user_id"},
     ),
     "User Reels": Endpoint(
         path="/api/v1/instagram/user/reels",
         credits=10,
-        fields=("username", "user_id", "count", "cursor"),
+        fields=("username", "target_user_id", "count", "cursor"),
         result_keys=("items", "data"),
+        wire={"target_user_id": "user_id"},
     ),
     "User Tagged": Endpoint(
         path="/api/v1/instagram/user/tagged",
         credits=10,
-        fields=("username", "user_id", "count", "cursor"),
+        fields=("username", "target_user_id", "count", "cursor"),
         result_keys=("items",),
+        wire={"target_user_id": "user_id"},
     ),
     "User Stories": Endpoint(
         path="/api/v1/instagram/user/stories",
         credits=10,
-        fields=("username", "user_id"),
+        fields=("username", "target_user_id"),
         result_keys=("items",),
+        wire={"target_user_id": "user_id"},
     ),
     "User Followers": Endpoint(
         path="/api/v1/instagram/user/followers",
         credits=10,
-        fields=("username", "user_id", "count", "cursor"),
+        fields=("username", "target_user_id", "count", "cursor"),
         result_keys=("users",),
+        wire={"target_user_id": "user_id"},
     ),
     "User Followings": Endpoint(
         path="/api/v1/instagram/user/followings",
         credits=10,
-        fields=("username", "user_id", "count", "cursor"),
+        fields=("username", "target_user_id", "count", "cursor"),
         result_keys=("users",),
+        wire={"target_user_id": "user_id"},
     ),
     "Post Details": Endpoint(
         path="/api/v1/instagram/post",
@@ -96,7 +101,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioInstagramComponent(ScavioAPIMixin, Component):
+class ScavioInstagramComponent(ScavioBaseComponent):
     display_name = "Scavio Instagram"
     description = (
         "The full Scavio Instagram surface: profiles, posts, reels, tagged posts, stories, followers and "
@@ -115,7 +120,11 @@ class ScavioInstagramComponent(ScavioAPIMixin, Component):
         api_key_input(),
         endpoint_input(ENDPOINTS, "User Profile"),
         text_input("username", "Username", "Instagram handle without the @.", tool_mode=True),
-        text_input("user_id", "User ID", "Numeric Instagram user id as a string. Takes precedence over Username."),
+        text_input(
+            "target_user_id",
+            "User ID",
+            "Numeric Instagram user id as a string. Takes precedence over Username.",
+        ),
         text_input("keyword", "Keyword", "Search term. Instagram search takes keyword, not query.", tool_mode=True),
         text_input(
             "shortcode",

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
@@ -1,0 +1,159 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+# Instagram credits are per endpoint, never a flat rate: 10 for the hedged V3
+# endpoints, 8 for the two with no fallback leg, 2 for the V2-primary feed.
+ENDPOINTS = {
+    "User Profile": Endpoint(
+        path="/api/v1/instagram/profile",
+        credits=10,
+        fields=("username", "user_id"),
+    ),
+    "User Posts": Endpoint(
+        path="/api/v1/instagram/user/posts",
+        credits=2,
+        fields=("username", "user_id", "count", "cursor"),
+        result_keys=("items", "data"),
+    ),
+    "User Reels": Endpoint(
+        path="/api/v1/instagram/user/reels",
+        credits=10,
+        fields=("username", "user_id", "count", "cursor"),
+        result_keys=("items", "data"),
+    ),
+    "User Tagged": Endpoint(
+        path="/api/v1/instagram/user/tagged",
+        credits=10,
+        fields=("username", "user_id", "count", "cursor"),
+        result_keys=("items",),
+    ),
+    "User Stories": Endpoint(
+        path="/api/v1/instagram/user/stories",
+        credits=10,
+        fields=("username", "user_id"),
+        result_keys=("items",),
+    ),
+    "User Followers": Endpoint(
+        path="/api/v1/instagram/user/followers",
+        credits=10,
+        fields=("username", "user_id", "count", "cursor"),
+        result_keys=("users",),
+    ),
+    "User Followings": Endpoint(
+        path="/api/v1/instagram/user/followings",
+        credits=10,
+        fields=("username", "user_id", "count", "cursor"),
+        result_keys=("users",),
+    ),
+    "Post Details": Endpoint(
+        path="/api/v1/instagram/post",
+        credits=8,
+        fields=("url", "media_id", "shortcode"),
+        result_keys=("items",),
+    ),
+    "Post Comments": Endpoint(
+        path="/api/v1/instagram/post/comments",
+        credits=10,
+        fields=("shortcode", "url", "cursor", "sort_order"),
+        result_keys=("comments",),
+    ),
+    "Comment Replies": Endpoint(
+        path="/api/v1/instagram/post/comments/replies",
+        credits=8,
+        fields=("media_id", "comment_id", "cursor"),
+        required=("media_id", "comment_id"),
+        result_keys=("child_comments",),
+    ),
+    "Search Users": Endpoint(
+        path="/api/v1/instagram/search/users",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("users", "items"),
+    ),
+    "Search Hashtags": Endpoint(
+        path="/api/v1/instagram/search/hashtags",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("hashtags", "items"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioInstagramComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Instagram"
+    description = (
+        "The full Scavio Instagram surface: profiles, posts, reels, tagged posts, stories, followers and "
+        "followings, post detail, comments and replies, and user and hashtag search. Credits are per "
+        "endpoint - 10 for the hedged endpoints, 8 for post and comment replies, 2 for user posts."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioInstagram"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "User Profile"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "User Profile"),
+        text_input("username", "Username", "Instagram handle without the @.", tool_mode=True),
+        text_input("user_id", "User ID", "Numeric Instagram user id as a string. Takes precedence over Username."),
+        text_input("keyword", "Keyword", "Search term. Instagram search takes keyword, not query.", tool_mode=True),
+        text_input(
+            "shortcode",
+            "Shortcode",
+            "Post shortcode, e.g. DUajw4YkorV. Accepted by Post Details and Post Comments.",
+            tool_mode=True,
+        ),
+        text_input("url", "Post URL", "Full post URL. Accepted by Post Details and Post Comments."),
+        text_input(
+            "media_id",
+            "Media ID",
+            "Numeric media id. Post Details accepts it, and Comment Replies requires it - resolve it "
+            "through Post Details first, because Post Comments does not return one.",
+        ),
+        text_input("comment_id", "Comment ID", "Numeric comment id to fetch replies for."),
+        cursor_input("Pagination cursor echoed from a previous response."),
+        number_input(
+            "count",
+            "Count",
+            "Items per page. Feeds cap at 50, follow lists at 100. Defaults to 12 when left at 0.",
+            value=12,
+        ),
+        choice_input(
+            "sort_order",
+            "Comment Sort",
+            "Comment ordering. Empty keeps the API default of popular.",
+            ["", "popular", "newest"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_instagram.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_kuaishou.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_kuaishou.py
@@ -1,0 +1,204 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Profile Details": Endpoint(
+        path="/api/v1/kuaishou/profile",
+        credits=10,
+        fields=("target_user_id",),
+        required=("target_user_id",),
+        wire={"target_user_id": "user_id"},
+    ),
+    "User Posts": Endpoint(
+        path="/api/v1/kuaishou/user/posts",
+        credits=1,
+        fields=("target_user_id", "cursor"),
+        required=("target_user_id",),
+        wire={"target_user_id": "user_id"},
+    ),
+    "User Live": Endpoint(
+        path="/api/v1/kuaishou/user/live",
+        credits=1,
+        fields=("target_user_id",),
+        required=("target_user_id",),
+        wire={"target_user_id": "user_id"},
+    ),
+    "Resolve Share Link": Endpoint(
+        path="/api/v1/kuaishou/user/resolve",
+        credits=1,
+        fields=("share_link",),
+        required=("share_link",),
+    ),
+    "Video Details": Endpoint(
+        path="/api/v1/kuaishou/video",
+        credits=2,
+        fields=("photo_id", "url"),
+    ),
+    "Video Comments": Endpoint(
+        path="/api/v1/kuaishou/video/comments",
+        credits=1,
+        fields=("photo_id", "cursor"),
+        required=("photo_id",),
+    ),
+    "Comment Replies": Endpoint(
+        path="/api/v1/kuaishou/video/sub-comments",
+        credits=1,
+        fields=("photo_id", "root_comment_id", "cursor", "count"),
+        required=("photo_id", "root_comment_id"),
+    ),
+    "Videos In Batch": Endpoint(
+        path="/api/v1/kuaishou/videos/batch",
+        credits=40,
+        fields=("photo_ids",),
+        required=("photo_ids",),
+        csv_fields=("photo_ids",),
+    ),
+    "Search": Endpoint(
+        path="/api/v1/kuaishou/search",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("mixFeeds",),
+    ),
+    "Search Videos": Endpoint(
+        path="/api/v1/kuaishou/search/videos",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("mixFeeds",),
+    ),
+    "Search Users": Endpoint(
+        path="/api/v1/kuaishou/search/users",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("mixFeeds",),
+    ),
+    "Search Live": Endpoint(
+        path="/api/v1/kuaishou/search/live",
+        credits=10,
+        fields=("keyword", "cursor"),
+        required=("keyword",),
+        result_keys=("mixFeeds",),
+    ),
+    "Tag Feed": Endpoint(
+        path="/api/v1/kuaishou/tag/feed",
+        credits=1,
+        fields=("tag", "cursor"),
+        required=("tag",),
+        result_keys=("mixFeeds",),
+    ),
+    "Trending": Endpoint(
+        path="/api/v1/kuaishou/trending",
+        credits=1,
+        fields=("board",),
+        result_keys=("hots",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioKuaishouComponent(ScavioBaseComponent):
+    display_name = "Scavio Kuaishou"
+    description = (
+        "Kuaishou through Scavio: profile details, user posts, user live, resolve share link, video details, video "
+        "comments, comment replies, videos in batch, search, search videos, search users, search live, tag feed, "
+        "trending (`/api/v1/kuaishou/*`, 1-40 credits depending on the endpoint). Profile details for a Kuaishou "
+        "user."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioKuaishou"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Profile Details"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Profile Details"),
+        text_input(
+            "target_user_id",
+            "User ID",
+            "Kuaishou user id.",
+        ),
+        cursor_input(
+            (
+                "Pagination cursor taken from a previous response's next_cursor. Keep the other arguments identical "
+                "across paginated calls."
+            ),
+        ),
+        text_input(
+            "share_link",
+            "Share Link",
+            (
+                "A kuaishou.com or v.kuaishou.com share link. kwai.com links are NOT supported -- TikHub does not "
+                "serve Kwai international."
+            ),
+        ),
+        text_input(
+            "photo_id",
+            "Photo ID",
+            "Kuaishou photo (video) id.",
+        ),
+        text_input(
+            "url",
+            "URL",
+            "A kuaishou.com video URL, usable instead of photo_id.",
+            tool_mode=True,
+        ),
+        text_input(
+            "root_comment_id",
+            "Root Comment ID",
+            "Id of the root comment whose replies you want.",
+        ),
+        number_input(
+            "count",
+            "Count",
+            "Replies to return in this page, 1-50.",
+        ),
+        text_input(
+            "photo_ids",
+            "Photo Ids",
+            "Kuaishou photo ids to fetch in one call. Hard cap of 20 ids.",
+        ),
+        text_input(
+            "keyword",
+            "Keyword",
+            "Search keyword.",
+        ),
+        text_input(
+            "tag",
+            "Tag",
+            "Hashtag to read the feed for, without the leading #.",
+        ),
+        choice_input(
+            "board",
+            "Board",
+            "Which leaderboard to return. Options: hot, live, shopping, brand, music. Default: hot.",
+            ["", "hot", "live", "shopping", "brand", "music"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_kuaishou.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_kuaishou.py
@@ -144,8 +144,8 @@ class ScavioKuaishouComponent(ScavioBaseComponent):
             "share_link",
             "Share Link",
             (
-                "A kuaishou.com or v.kuaishou.com share link. kwai.com links are NOT supported -- TikHub does not "
-                "serve Kwai international."
+                "A kuaishou.com or v.kuaishou.com share link. kwai.com links are NOT supported: Kwai "
+                "international is a separate property and is not covered."
             ),
         ),
         text_input(

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
@@ -1,0 +1,139 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+# Only the nine live endpoints are offered. person/contact, company/people,
+# company/jobs, search/people and search/posts were retired upstream: they always
+# answer 410 and are never billed, so there is nothing to expose.
+ENDPOINTS = {
+    "Person Profile": Endpoint(
+        path="/api/v1/linkedin/person",
+        credits=1,
+        fields=("username", "url"),
+    ),
+    "Person About": Endpoint(
+        path="/api/v1/linkedin/person/about",
+        credits=1,
+        fields=("username", "url"),
+    ),
+    "Person Posts": Endpoint(
+        path="/api/v1/linkedin/person/posts",
+        credits=10,
+        fields=("username", "url", "type", "cursor"),
+        result_keys=("data",),
+    ),
+    "Company Profile": Endpoint(
+        path="/api/v1/linkedin/company",
+        credits=1,
+        fields=("company", "url"),
+    ),
+    "Company Posts": Endpoint(
+        path="/api/v1/linkedin/company/posts",
+        credits=10,
+        fields=("company", "url", "cursor"),
+        result_keys=("data",),
+    ),
+    "Job Search": Endpoint(
+        path="/api/v1/linkedin/search/jobs",
+        credits=10,
+        fields=("search", "location", "cursor"),
+        required=("search",),
+        result_keys=("data",),
+    ),
+    "Job Details": Endpoint(
+        path="/api/v1/linkedin/job",
+        credits=30,
+        fields=("job_id", "url"),
+    ),
+    "Post Details": Endpoint(
+        path="/api/v1/linkedin/post",
+        credits=1,
+        fields=("post_id", "url"),
+    ),
+    "Post Comments": Endpoint(
+        path="/api/v1/linkedin/post/comments",
+        credits=10,
+        fields=("post_id", "url", "page"),
+        result_keys=("data",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioLinkedInComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio LinkedIn"
+    description = (
+        "The nine live Scavio LinkedIn endpoints: person profile, about and posts, company profile and "
+        "posts, job search and job detail, post detail and post comments. Credits are tiered - 1 for the "
+        "profile-shaped calls, 10 for the feeds and job search, 30 for job detail, the most expensive "
+        "endpoint in the API."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioLinkedIn"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Person Profile"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Person Profile"),
+        text_input("username", "Person Username", "Public profile identifier, e.g. williamhgates.", tool_mode=True),
+        text_input("company", "Company", "Company universal name or slug, e.g. microsoft.", tool_mode=True),
+        text_input(
+            "search", "Job Search", "Job search terms. LinkedIn's wire field is search, not query.", tool_mode=True
+        ),
+        text_input("location", "Location", "Geographic filter for Job Search. Leave empty to search everywhere."),
+        text_input("job_id", "Job ID", "Numeric LinkedIn job id, e.g. 4415427228.", tool_mode=True),
+        text_input(
+            "post_id",
+            "Post ID",
+            "Post id or activity urn, e.g. 7488618410256523265 or urn:li:activity:7488618410256523265.",
+            tool_mode=True,
+        ),
+        text_input(
+            "url",
+            "URL",
+            "A full LinkedIn URL, usable in place of the identifier on every endpoint. A member urn is "
+            "never a valid input.",
+        ),
+        cursor_input("Opaque cursor echoed from a previous response's next_cursor."),
+        number_input(
+            "page",
+            "Comments Page",
+            "1-based page for Post Comments - the one LinkedIn endpoint that pages by number, not cursor.",
+            value=1,
+        ),
+        choice_input(
+            "type",
+            "Person Feed Type",
+            "Which person feed to read: their own posts, posts they commented on, or posts they reacted to.",
+            ["", "posts", "comments", "reactions"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_linkedin.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -73,7 +71,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioLinkedInComponent(ScavioAPIMixin, Component):
+class ScavioLinkedInComponent(ScavioBaseComponent):
     display_name = "Scavio LinkedIn"
     description = (
         "The nine live Scavio LinkedIn endpoints: person profile, about and posts, company profile and "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_meta_ads.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_meta_ads.py
@@ -1,0 +1,130 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/meta-ads/search",
+        credits=1,
+        fields=("query", "country", "active_status", "ad_type", "media_type", "search_type", "cursor"),
+        required=("query",),
+        result_keys=("ads",),
+    ),
+    "Advertiser": Endpoint(
+        path="/api/v1/meta-ads/advertiser",
+        credits=1,
+        fields=("page_id", "country", "active_status", "ad_type", "media_type", "cursor"),
+        required=("page_id",),
+        result_keys=("ads",),
+    ),
+    "Ad Details": Endpoint(
+        path="/api/v1/meta-ads/ad",
+        credits=1,
+        fields=("ad_archive_id",),
+        required=("ad_archive_id",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioMetaAdsComponent(ScavioBaseComponent):
+    display_name = "Scavio Meta Ad Library"
+    description = (
+        "Meta Ad Library through Scavio: search, advertiser, ad details (`/api/v1/meta-ads/*`, 1 credit each). Search "
+        "the Meta Ad Library: 30 ads on page 1 with full creative (page name, ad copy, headline, CTA, images and "
+        "videos, platforms, run dates), then cursor-paginated. Pagination: cursor -> next_cursor. Page 1 is 30 ads, "
+        "then 10 per page; walk has_next_page to read a whole query."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioMetaAds"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Keyword, brand or advertiser name to search the library for.",
+            tool_mode=True,
+        ),
+        text_input(
+            "country",
+            "Country",
+            "Two-letter country code for the ad library storefront. Default: US.",
+        ),
+        choice_input(
+            "active_status",
+            "Active Status",
+            "Whether to return running, stopped or all ads. Options: all, active, inactive. Default: all.",
+            ["", "all", "active", "inactive"],
+            advanced=True,
+        ),
+        choice_input(
+            "ad_type",
+            "Ad Type",
+            (
+                "Set to political_and_issue_ads to expose spend, reach, impressions and the paid-for-by disclosure. "
+                "Commercial ads leave those null. Options: all, political_and_issue_ads. Default: all."
+            ),
+            ["", "all", "political_and_issue_ads"],
+            advanced=True,
+        ),
+        choice_input(
+            "media_type",
+            "Media Type",
+            "Creative media type filter. Options: all, image, video, meme, image_and_meme, none.",
+            ["", "all", "image", "video", "meme", "image_and_meme", "none"],
+            advanced=True,
+        ),
+        choice_input(
+            "search_type",
+            "Search Type",
+            (
+                "Whether the query is matched as an exact phrase. Options: keyword_unordered, keyword_exact_phrase. "
+                "Default: keyword_unordered."
+            ),
+            ["", "keyword_unordered", "keyword_exact_phrase"],
+            advanced=True,
+        ),
+        cursor_input(
+            (
+                "next_cursor from the previous response. Page 1 is 30 ads, then 10 per page. ALL OTHER FILTERS ARE "
+                "IGNORED when a cursor is present -- the cursor already carries them."
+            ),
+        ),
+        text_input(
+            "page_id",
+            "Page ID",
+            "The advertiser's numeric Facebook Page id.",
+        ),
+        text_input(
+            "ad_archive_id",
+            "Ad Archive ID",
+            "The ad's numeric archive id.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
@@ -1,0 +1,159 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+# Reddit search takes query and cursor and nothing else: the backend strips any
+# type or sort key it is sent, so exposing one would be a dead control.
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/reddit/search",
+        credits=1,
+        fields=("query", "cursor"),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "Search Suggestions": Endpoint(
+        path="/api/v1/reddit/search/suggestions",
+        credits=1,
+        fields=("query",),
+        required=("query",),
+        result_keys=("suggestions",),
+    ),
+    "Post Details": Endpoint(
+        path="/api/v1/reddit/post",
+        credits=1,
+        fields=("post_id", "url"),
+    ),
+    "Post Comments": Endpoint(
+        path="/api/v1/reddit/post/comments",
+        credits=1,
+        fields=("post_id", "sort", "cursor"),
+        required=("post_id",),
+        result_keys=("comments",),
+    ),
+    "Comment Replies": Endpoint(
+        path="/api/v1/reddit/post/comments/replies",
+        credits=1,
+        fields=("post_id", "cursor", "sort"),
+        required=("post_id", "cursor"),
+        result_keys=("replies",),
+    ),
+    "Subreddit Details": Endpoint(
+        path="/api/v1/reddit/subreddit",
+        credits=1,
+        fields=("subreddit",),
+        required=("subreddit",),
+    ),
+    "Subreddit Posts": Endpoint(
+        path="/api/v1/reddit/subreddit/posts",
+        credits=1,
+        fields=("subreddit", "feed_sort", "cursor"),
+        required=("subreddit",),
+        result_keys=("posts",),
+        wire={"feed_sort": "sort"},
+    ),
+    "User Profile": Endpoint(
+        path="/api/v1/reddit/user",
+        credits=1,
+        fields=("username",),
+        required=("username",),
+    ),
+    "User Posts": Endpoint(
+        path="/api/v1/reddit/user/posts",
+        credits=1,
+        fields=("username", "sort", "cursor"),
+        required=("username",),
+        result_keys=("posts",),
+    ),
+    "User Comments": Endpoint(
+        path="/api/v1/reddit/user/comments",
+        credits=1,
+        fields=("username", "sort", "cursor"),
+        required=("username",),
+        result_keys=("comments",),
+    ),
+    "Popular": Endpoint(
+        path="/api/v1/reddit/popular",
+        credits=1,
+        fields=("cursor",),
+        result_keys=("posts",),
+    ),
+    "Trending": Endpoint(
+        path="/api/v1/reddit/trending",
+        credits=1,
+        result_keys=("trending",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioRedditComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Reddit"
+    description = (
+        "The full Scavio Reddit surface: search, suggestions, post details, comments and replies, "
+        "subreddit profile and feed, user profile, posts and comments, plus the popular and trending "
+        "boards (`/api/v1/reddit/*`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioReddit"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input("query", "Query", "What to search Reddit for.", tool_mode=True),
+        text_input(
+            "post_id",
+            "Post ID",
+            "A t3_ fullname, a bare base-36 id, or a post URL. Post Details returns the post on its own - "
+            "call Post Comments for the thread.",
+            tool_mode=True,
+        ),
+        text_input("url", "Post URL", "Full Reddit post URL, an alternative to Post ID on Post Details."),
+        text_input("subreddit", "Subreddit", "Bare subreddit name, e.g. AskReddit.", tool_mode=True),
+        text_input("username", "Username", "Bare Reddit handle, e.g. spez.", tool_mode=True),
+        cursor_input(
+            "Pagination cursor. Comment Replies requires a reply_cursor taken from a comment in Post Comments."
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            "Ordering. Empty keeps the API default, which is TOP for comments and NEW for user feeds.",
+            ["", "HOT", "NEW", "TOP", "BEST", "CONTROVERSIAL"],
+            advanced=True,
+        ),
+        choice_input(
+            "feed_sort",
+            "Feed Sort",
+            "Subreddit feed ordering. This is the only endpoint that accepts RISING. Sent as sort.",
+            ["", "BEST", "HOT", "NEW", "TOP", "CONTROVERSIAL", "RISING"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_reddit.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -99,7 +97,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioRedditComponent(ScavioAPIMixin, Component):
+class ScavioRedditComponent(ScavioBaseComponent):
     display_name = "Scavio Reddit"
     description = (
         "The full Scavio Reddit surface: search, suggestions, post details, comments and replies, "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_redfin.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_redfin.py
@@ -1,0 +1,249 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/redfin/search",
+        credits=1,
+        fields=(
+            "location",
+            "region_id",
+            "region_type",
+            "listing_status",
+            "sold_within_days",
+            "page",
+            "limit",
+            "sort",
+            "min_price",
+            "max_price",
+            "beds_min",
+            "beds_max",
+            "baths_min",
+            "sqft_min",
+            "sqft_max",
+            "lot_size_min",
+            "year_built_min",
+            "year_built_max",
+            "max_hoa",
+            "property_type",
+            "has_pool",
+            "max_days_on_market",
+            "min_days_on_market",
+        ),
+    ),
+    "Property Details": Endpoint(
+        path="/api/v1/redfin/property",
+        credits=1,
+        fields=("property_id",),
+        required=("property_id",),
+    ),
+    "Market": Endpoint(
+        path="/api/v1/redfin/market",
+        credits=1,
+        fields=("location", "region_id", "region_type"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioRedfinComponent(ScavioBaseComponent):
+    display_name = "Scavio Redfin"
+    description = (
+        "Redfin through Scavio: search, property details, market (`/api/v1/redfin/*`, 1 credit each). Redfin "
+        "listings: price, price per sqft, beds, baths, living area, lot size, year built, coordinates, listing "
+        "remarks, full photo galleries. Pagination: page + limit -- up to 350 per page."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioRedfin"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "location",
+            "Location",
+            (
+                "A redfin.com region URL (/city/, /neighborhood/, /county/, /zipcode/) or a bare 5-digit ZIP. CITY "
+                "NAMES ARE NOT ACCEPTED."
+            ),
+            tool_mode=True,
+        ),
+        number_input(
+            "region_id",
+            "Region ID",
+            (
+                "Redfin's own numeric region id. NOT a ZIP code -- different number spaces, and a ZIP here resolves "
+                "to another city rather than failing. Must be sent together with region_type."
+            ),
+        ),
+        number_input(
+            "region_type",
+            "Region Type",
+            (
+                "What region_id refers to: 1 neighborhood, 2 ZIP, 5 county, 6 city. Must be sent together with "
+                "region_id. Options: 1, 2, 5, 6."
+            ),
+        ),
+        choice_input(
+            "listing_status",
+            "Listing Status",
+            "Which listing state to return. Options: for_sale, sold, for_rent. Default: for_sale.",
+            ["", "for_sale", "sold", "for_rent"],
+            advanced=True,
+        ),
+        number_input(
+            "sold_within_days",
+            "Sold Within Days",
+            (
+                "How far back to look for sold homes. Only valid with listing_status=sold, where it defaults to 90. "
+                "Default: 90."
+            ),
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            "Listings per page, 1-350. Default: 100.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Sort order for the results. Options: recommended, price_low, price_high, newest, oldest, sqft_low, "
+                "sqft_high, price_per_sqft_low, price_per_sqft_high. Default: recommended."
+            ),
+            [
+                "",
+                "recommended",
+                "price_low",
+                "price_high",
+                "newest",
+                "oldest",
+                "sqft_low",
+                "sqft_high",
+                "price_per_sqft_low",
+                "price_per_sqft_high",
+            ],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price. On listing_status=for_rent this means MONTHLY RENT.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price. On listing_status=for_rent this means MONTHLY RENT.",
+        ),
+        number_input(
+            "beds_min",
+            "Beds Min",
+            "Minimum number of bedrooms.",
+        ),
+        number_input(
+            "beds_max",
+            "Beds Max",
+            "Maximum number of bedrooms.",
+        ),
+        number_input(
+            "baths_min",
+            "Baths Min",
+            (
+                "Minimum number of bathrooms. WHOLE baths only -- fractional bounds are rejected because Redfin "
+                "truncates them."
+            ),
+        ),
+        number_input(
+            "sqft_min",
+            "Sq Ft Min",
+            "Minimum living area in square feet.",
+        ),
+        number_input(
+            "sqft_max",
+            "Sq Ft Max",
+            "Maximum living area in square feet.",
+        ),
+        number_input(
+            "lot_size_min",
+            "Lot Size Min",
+            "Minimum lot size in square feet.",
+        ),
+        number_input(
+            "year_built_min",
+            "Year Built Min",
+            "Earliest year built.",
+        ),
+        number_input(
+            "year_built_max",
+            "Year Built Max",
+            "Latest year built.",
+        ),
+        decimal_input(
+            "max_hoa",
+            "Max HOA",
+            "Maximum monthly HOA fee.",
+        ),
+        choice_input(
+            "property_type",
+            "Property Type",
+            "Property type filter. Options: house, condo, townhouse, multi_family, land, other, co_op.",
+            ["", "house", "condo", "townhouse", "multi_family", "land", "other", "co_op"],
+            advanced=True,
+        ),
+        flag_input(
+            "has_pool",
+            "Has Pool",
+            "Only return properties with a pool.",
+        ),
+        number_input(
+            "max_days_on_market",
+            "Max Days On Market",
+            (
+                "Maximum days on market. Cannot be combined with min_days_on_market: Redfin expresses both through "
+                "one parameter."
+            ),
+        ),
+        number_input(
+            "min_days_on_market",
+            "Min Days On Market",
+            "Minimum days on market. Cannot be combined with max_days_on_market.",
+        ),
+        text_input(
+            "property_id",
+            "Property ID",
+            "Redfin property id or any redfin.com listing URL carrying one.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
@@ -1,9 +1,15 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInput
-from lfx.schema.data import Data
-from lfx.schema.dataframe import DataFrame
-from lfx.template.field.base import Output
-from lfx_scavio.components.scavio._base import DOCUMENTATION, Endpoint, ScavioAPIMixin, api_key_input
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    BoolInput,
+    Data,
+    DataFrame,
+    DropdownInput,
+    Endpoint,
+    IntInput,
+    MessageTextInput,
+    api_key_input,
+)
 
 ENDPOINTS = {
     "Google Search": Endpoint(
@@ -12,7 +18,7 @@ ENDPOINTS = {
         fields=(
             "query",
             "device",
-            "start",
+            "start_offset",
             "hl",
             "gl",
             "google_domain",
@@ -27,6 +33,7 @@ ENDPOINTS = {
             "include_html",
             "resolve_ai_overview",
         ),
+        wire={"start_offset": "start"},
         required=("query",),
         result_keys=("organic_results",),
         send_false=("resolve_ai_overview",),
@@ -34,7 +41,7 @@ ENDPOINTS = {
 }
 
 
-class ScavioSearchComponent(ScavioAPIMixin, Component):
+class ScavioSearchComponent(ScavioBaseComponent):
     display_name = "Scavio Search API"
     description = (
         "**Scavio** is a real-time search API for AI agents - a unified API over Google, "
@@ -84,7 +91,7 @@ class ScavioSearchComponent(ScavioAPIMixin, Component):
             advanced=True,
         ),
         IntInput(
-            name="start",
+            name="start_offset",
             display_name="Start Offset",
             info="Result offset, not a page number: 0 is page 1, 10 is page 2, and so on. Max 990.",
             value=0,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
@@ -3,7 +3,6 @@ from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInp
 from lfx.schema.data import Data
 from lfx.schema.dataframe import DataFrame
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import DOCUMENTATION, Endpoint, ScavioAPIMixin, api_key_input
 
 ENDPOINTS = {

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_search.py
@@ -1,0 +1,207 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInput
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import DOCUMENTATION, Endpoint, ScavioAPIMixin, api_key_input
+
+ENDPOINTS = {
+    "Google Search": Endpoint(
+        path="/api/v2/google",
+        credits=1,
+        fields=(
+            "query",
+            "device",
+            "start",
+            "hl",
+            "gl",
+            "google_domain",
+            "location",
+            "uule",
+            "lr",
+            "cr",
+            "safe",
+            "nfpr",
+            "filter",
+            "time_period",
+            "include_html",
+            "resolve_ai_overview",
+        ),
+        required=("query",),
+        result_keys=("organic_results",),
+        send_false=("resolve_ai_overview",),
+    ),
+}
+
+
+class ScavioSearchComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Search API"
+    description = (
+        "**Scavio** is a real-time search API for AI agents - a unified API over Google, "
+        "YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn. "
+        "A cost-effective Tavily and SerpAPI alternative that returns clean JSON. "
+        "This component runs a Google web search (`POST /api/v2/google`, 1 credit)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioSearch"
+
+    ENDPOINTS = ENDPOINTS
+    DEFAULT_ENDPOINT = "Google Search"
+
+    inputs = [
+        api_key_input(),
+        MessageTextInput(
+            name="query",
+            display_name="Search Query",
+            info="The search query you want to execute with Scavio.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="gl",
+            display_name="Country (gl)",
+            info="Two-letter geo country code, e.g. us. Replaces v1's country_code.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="hl",
+            display_name="Language (hl)",
+            info="Two-letter interface language code, e.g. en. Replaces v1's language.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="google_domain",
+            display_name="Google Domain",
+            info="Google domain to search, e.g. google.co.uk.",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="device",
+            display_name="Device",
+            info="Device profile to emulate.",
+            options=["", "desktop", "mobile"],
+            value="",
+            advanced=True,
+        ),
+        IntInput(
+            name="start",
+            display_name="Start Offset",
+            info="Result offset, not a page number: 0 is page 1, 10 is page 2, and so on. Max 990.",
+            value=0,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="location",
+            display_name="Location",
+            info="Canonical location name, e.g. Austin, Texas, United States.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="uule",
+            display_name="UULE",
+            info="Pre-encoded UULE location string. Takes priority over Location.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="lr",
+            display_name="Language Restrict (lr)",
+            info="Restrict results to a language, e.g. lang_en.",
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="cr",
+            display_name="Country Restrict (cr)",
+            info="Restrict results to a country, e.g. countryUS.",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="safe",
+            display_name="Safe Search",
+            info="Set to active to turn SafeSearch on. Leave empty to turn it off.",
+            options=["", "active"],
+            value="",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="filter",
+            display_name="Similar Results Filter",
+            info="0 disables Google's similar and omitted result filtering. 1 keeps it on.",
+            options=["", "0", "1"],
+            value="",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="time_period",
+            display_name="Time Period",
+            info="Restrict results to a recent time window.",
+            options=["", "last_hour", "last_day", "last_week", "last_month", "last_year"],
+            value="",
+            advanced=True,
+        ),
+        BoolInput(
+            name="nfpr",
+            display_name="No Autocorrect",
+            info="Disable Google's spelling autocorrection.",
+            value=False,
+            advanced=True,
+        ),
+        BoolInput(
+            name="include_html",
+            display_name="Include Raw HTML",
+            info="Add Google's raw HTML to the response under the html key.",
+            value=False,
+            advanced=True,
+        ),
+        BoolInput(
+            name="resolve_ai_overview",
+            display_name="Resolve AI Overview",
+            info="Resolve a deferred AI Overview with a follow-up call. Turn off to keep the deferred stub.",
+            value=True,
+            advanced=True,
+        ),
+        IntInput(
+            name="max_results",
+            display_name="Max Results",
+            info="The maximum number of search results to return.",
+            value=10,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]
+
+    def fetch_content(self) -> list[Data]:
+        """Return the organic results as `title` / `url` / `content` / `position` rows."""
+        endpoint, body, error = self._safe_call()
+        if error is not None or endpoint is None or body is None:
+            message = error or "Scavio request failed."
+            return [Data(text=message, data={"error": message})]
+
+        # /api/v2/google answers flat: organic_results sits at the top level and each
+        # item carries link + snippet (v1's results[] with url + content is retired).
+        results = body.get("organic_results", []) or []
+        limit = self.max_results or len(results)
+        data_results = []
+        for result in results[:limit]:
+            content = result.get("snippet", "")
+            data_results.append(
+                Data(
+                    text=content,
+                    data={
+                        "title": result.get("title"),
+                        "url": result.get("link"),
+                        "content": content,
+                        "position": result.get("position"),
+                    },
+                )
+            )
+        self.status = data_results
+        return data_results
+
+    def fetch_content_dataframe(self) -> DataFrame:
+        """Return the organic results as a table."""
+        return DataFrame(self.fetch_content())

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_sec.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_sec.py
@@ -1,0 +1,179 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Ticker Lookup": Endpoint(
+        path="/api/v1/sec/lookup",
+        credits=1,
+        fields=("query", "limit", "exchange"),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "Company Details": Endpoint(
+        path="/api/v1/sec/company",
+        credits=1,
+        fields=("cik", "ticker"),
+    ),
+    "Filings": Endpoint(
+        path="/api/v1/sec/filings",
+        credits=1,
+        fields=("cik", "ticker", "form", "date_from", "date_to", "page", "limit", "include_history"),
+        result_keys=("filings",),
+    ),
+    "Concept": Endpoint(
+        path="/api/v1/sec/concept",
+        credits=1,
+        fields=("cik", "ticker", "concept", "taxonomy", "unit", "form", "limit"),
+        required=("concept",),
+        result_keys=("facts",),
+    ),
+    "Facts": Endpoint(
+        path="/api/v1/sec/facts",
+        credits=1,
+        fields=("cik", "ticker", "taxonomy", "query", "limit"),
+        result_keys=("concepts",),
+    ),
+    "Search": Endpoint(
+        path="/api/v1/sec/search",
+        credits=1,
+        fields=("query", "cik", "ticker", "form", "date_from", "date_to", "location", "sort", "page"),
+        result_keys=("results",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioSecComponent(ScavioBaseComponent):
+    display_name = "Scavio SEC EDGAR"
+    description = (
+        "SEC EDGAR through Scavio: ticker lookup, company details, filings, concept, facts, search (`/api/v1/sec/*`, "
+        "1 credit each). START HERE. Resolve a company name or ticker (AAPL) to the CIK (0000320193) every other SEC "
+        "EDGAR endpoint is keyed by."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioSec"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Ticker Lookup"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Ticker Lookup"),
+        text_input(
+            "query",
+            "Query",
+            "Ticker, company name, or a fragment of either.",
+            tool_mode=True,
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            "Maximum filers to return, 1-100. Default: 10.",
+        ),
+        text_input(
+            "exchange",
+            "Exchange",
+            (
+                "Listing exchange filter, matched case-insensitively. Filers listed with no exchange are excluded "
+                "by any value. Options: NASDAQ, NYSE, OTC, CBOE."
+            ),
+        ),
+        text_input(
+            "cik",
+            "CIK",
+            "Central Index Key: 320193, 0000320193 or CIK0000320193. A ticker is accepted here too.",
+        ),
+        text_input(
+            "ticker",
+            "Ticker",
+            "Stock ticker, dotted or dashed (BRK.B / BRK-B). WINS over cik when both are given.",
+        ),
+        text_input(
+            "form",
+            "Form",
+            (
+                'Form filter: "10-K", ["10-K", "10-Q"] or "10-K,8-K". Matched against the form AND its root form, '
+                "so 10-K also returns 10-K/A amendments."
+            ),
+        ),
+        text_input(
+            "date_from",
+            "Date From",
+            "Earliest date to include, YYYY-MM-DD.",
+        ),
+        text_input(
+            "date_to",
+            "Date To",
+            "Latest date to include, YYYY-MM-DD.",
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        flag_input(
+            "include_history",
+            "Include History",
+            (
+                "Also read the archived filing shards (up to 10). Still one credit; history_truncated flags a filer "
+                "that had more. Default: False."
+            ),
+        ),
+        text_input(
+            "concept",
+            "Concept",
+            (
+                "XBRL tag, CASE-SENSITIVE: 'netincomeloss' is a 404 upstream, not a match. Use the facts endpoint "
+                "to list what a filer actually reports."
+            ),
+        ),
+        text_input(
+            "taxonomy",
+            "Taxonomy",
+            "XBRL taxonomy: us-gaap, dei, ifrs-full or srt. Default: us-gaap.",
+        ),
+        text_input(
+            "unit",
+            "Unit",
+            "Unit of measure to filter on, e.g. USD or USD/shares.",
+        ),
+        text_input(
+            "location",
+            "Location",
+            (
+                "EDGAR's own jurisdiction codes: CA, NY, and alphanumeric codes for foreign jurisdictions. One code "
+                "or a list."
+            ),
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            "Sort order for the results. Options: relevance, newest, oldest. Default: relevance.",
+            ["", "relevance", "newest", "oldest"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_target.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_target.py
@@ -1,0 +1,126 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/target/search",
+        credits=1,
+        fields=("keyword", "page", "count", "sort", "store_id"),
+        required=("keyword",),
+    ),
+    "Category": Endpoint(
+        path="/api/v1/target/category",
+        credits=1,
+        fields=("category_id", "page", "count", "sort", "store_id"),
+        required=("category_id",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/target/product",
+        credits=1,
+        fields=("tcin", "store_id"),
+        required=("tcin",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/target/reviews",
+        credits=1,
+        fields=("tcin", "limit", "store_id"),
+        required=("tcin",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioTargetComponent(ScavioBaseComponent):
+    display_name = "Scavio Target"
+    description = (
+        "Target through Scavio: search, category, product details, reviews (`/api/v1/target/*`, 1 credit each). "
+        "Search Target.com: prices, ratings, badges and promotions. Pagination: page + count."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioTarget"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "keyword",
+            "Keyword",
+            "Product search query.",
+            tool_mode=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        number_input(
+            "count",
+            "Count",
+            "Products per page. Target rejects anything above 28 outright. Default: 24.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Sort order for the results. Options: relevance, featured, price_low, price_high, rating_high, "
+                "best_seller, newest. Default: relevance."
+            ),
+            ["", "relevance", "featured", "price_low", "price_high", "rating_high", "best_seller", "newest"],
+            advanced=True,
+        ),
+        text_input(
+            "store_id",
+            "Store ID",
+            (
+                "Numeric Target store id. Unlike Walmart this is a real request parameter: it decides prices and "
+                "availability. Default: 3991."
+            ),
+        ),
+        text_input(
+            "category_id",
+            "Category ID",
+            "The segment after `N-` in a target.com /c/ URL.",
+        ),
+        text_input(
+            "tcin",
+            "TCIN",
+            (
+                "Target catalog item number. A child TCIN is answered by its variation parent, with the child "
+                "present under variants."
+            ),
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            (
+                "TRIMS the returned bodies only. Target publishes 8 reviews anonymously and offers no paging, so "
+                "this cannot fetch more."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_threads.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_threads.py
@@ -1,0 +1,127 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Profile Details": Endpoint(
+        path="/api/v1/threads/profile",
+        credits=2,
+        fields=("username", "target_user_id"),
+        wire={"target_user_id": "user_id"},
+        credit_note=(
+            "Costs 2 credits when addressed by user_id and 4 credits when addressed by username -- the handle needs "
+            "a second upstream lookup, so prefer user_id."
+        ),
+    ),
+    "User Posts": Endpoint(
+        path="/api/v1/threads/user/posts",
+        credits=2,
+        fields=("username", "target_user_id", "cursor"),
+        result_keys=("posts",),
+        wire={"target_user_id": "user_id"},
+        credit_note="Costs 2 credits when addressed by user_id and 4 credits when addressed by username.",
+    ),
+    "User Replies": Endpoint(
+        path="/api/v1/threads/user/replies",
+        credits=2,
+        fields=("username", "target_user_id", "cursor"),
+        result_keys=("posts",),
+        wire={"target_user_id": "user_id"},
+        credit_note="Costs 2 credits when addressed by user_id and 4 credits when addressed by username.",
+    ),
+    "Post Details": Endpoint(
+        path="/api/v1/threads/post",
+        credits=2,
+        fields=("post_id", "url"),
+    ),
+    "Post Comments": Endpoint(
+        path="/api/v1/threads/post/comments",
+        credits=2,
+        fields=("post_id", "cursor"),
+        required=("post_id",),
+        result_keys=("comments",),
+    ),
+    "User Search": Endpoint(
+        path="/api/v1/threads/search/users",
+        credits=2,
+        fields=("query",),
+        required=("query",),
+        result_keys=("users",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioThreadsComponent(ScavioBaseComponent):
+    display_name = "Scavio Threads"
+    description = (
+        "Threads through Scavio: profile details, user posts, user replies, post details, post comments, user search "
+        "(`/api/v1/threads/*`; credit cost depends on the request body - see each endpoint). Profile details for a "
+        "Threads user, by user_id (2cr) or username (4cr)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioThreads"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Profile Details"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Profile Details"),
+        text_input(
+            "username",
+            "Username",
+            (
+                "Threads handle without the @. Costs 2 extra credits because the handle has to be resolved with a "
+                "second upstream call -- prefer user_id."
+            ),
+        ),
+        text_input(
+            "target_user_id",
+            "User ID",
+            "Numeric Threads user id, e.g. 63625256886. This is the cheap path.",
+        ),
+        cursor_input(
+            (
+                "Pagination cursor taken from a previous response's next_cursor. Keep the other arguments identical "
+                "across paginated calls."
+            ),
+        ),
+        text_input(
+            "post_id",
+            "Post ID",
+            "Threads post id.",
+        ),
+        text_input(
+            "url",
+            "URL",
+            "A threads.net post URL, usable instead of post_id.",
+            tool_mode=True,
+        ),
+        text_input(
+            "query",
+            "Query",
+            "Name or handle to look for.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -95,7 +93,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioTikTokComponent(ScavioAPIMixin, Component):
+class ScavioTikTokComponent(ScavioBaseComponent):
     display_name = "Scavio TikTok"
     description = (
         "The full Scavio TikTok surface: profiles, user posts, followers and followings, video detail, "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok.py
@@ -1,0 +1,172 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "User Profile": Endpoint(
+        path="/api/v1/tiktok/profile",
+        credits=1,
+        fields=("username", "sec_user_id"),
+        result_keys=("user",),
+    ),
+    "User Posts": Endpoint(
+        path="/api/v1/tiktok/user/posts",
+        credits=1,
+        fields=("sec_user_id", "cursor", "count", "sort_type"),
+        required=("sec_user_id",),
+        result_keys=("aweme_list",),
+    ),
+    "User Followers": Endpoint(
+        path="/api/v1/tiktok/user/followers",
+        credits=1,
+        fields=("sec_user_id", "count", "page_token", "min_time"),
+        required=("sec_user_id",),
+        result_keys=("followers",),
+    ),
+    "User Followings": Endpoint(
+        path="/api/v1/tiktok/user/followings",
+        credits=1,
+        fields=("sec_user_id", "count", "page_token", "min_time"),
+        required=("sec_user_id",),
+        result_keys=("followings",),
+    ),
+    "Video Detail": Endpoint(
+        path="/api/v1/tiktok/video",
+        credits=1,
+        fields=("video_id",),
+        required=("video_id",),
+        result_keys=("aweme_detail",),
+    ),
+    "Video Comments": Endpoint(
+        path="/api/v1/tiktok/video/comments",
+        credits=1,
+        fields=("video_id", "cursor", "count"),
+        required=("video_id",),
+        result_keys=("comments",),
+    ),
+    "Comment Replies": Endpoint(
+        path="/api/v1/tiktok/video/comments/replies",
+        credits=1,
+        fields=("video_id", "comment_id", "cursor", "count"),
+        required=("video_id", "comment_id"),
+        result_keys=("comments",),
+    ),
+    "Search Videos": Endpoint(
+        path="/api/v1/tiktok/search/videos",
+        credits=1,
+        fields=("keyword", "cursor", "count", "sort_type", "publish_time"),
+        required=("keyword",),
+        result_keys=("aweme_list",),
+    ),
+    "Search Users": Endpoint(
+        path="/api/v1/tiktok/search/users",
+        credits=1,
+        fields=("keyword", "cursor", "count"),
+        required=("keyword",),
+        result_keys=("user_list",),
+    ),
+    "Hashtag Info": Endpoint(
+        path="/api/v1/tiktok/hashtag",
+        credits=1,
+        fields=("hashtag_name", "hashtag_id"),
+        result_keys=("challengeInfo",),
+    ),
+    "Hashtag Videos": Endpoint(
+        path="/api/v1/tiktok/hashtag/videos",
+        credits=1,
+        fields=("hashtag_id", "cursor", "count"),
+        required=("hashtag_id",),
+        result_keys=("aweme_list",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioTikTokComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio TikTok"
+    description = (
+        "The full Scavio TikTok surface: profiles, user posts, followers and followings, video detail, "
+        "comments and replies, video and user search, and hashtag lookups (`/api/v1/tiktok/*`, 1 credit "
+        "each). Identity is sec_user_id everywhere except the profile endpoint - resolve it there first."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioTikTok"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "User Profile"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "User Profile"),
+        text_input(
+            "username",
+            "Username",
+            "TikTok handle without the @. Accepted on User Profile only.",
+            tool_mode=True,
+        ),
+        text_input(
+            "sec_user_id",
+            "Sec User ID",
+            "TikTok sec_user_id. Required by user posts, followers and followings - read it off a "
+            "User Profile response first.",
+            tool_mode=True,
+        ),
+        text_input("video_id", "Video ID", "Numeric TikTok video id.", tool_mode=True),
+        text_input("comment_id", "Comment ID", "Numeric comment id to fetch replies for."),
+        text_input("keyword", "Keyword", "Search term. TikTok's wire field is keyword, not query.", tool_mode=True),
+        text_input("hashtag_name", "Hashtag Name", "Hashtag without the leading #, e.g. fyp.", tool_mode=True),
+        text_input(
+            "hashtag_id",
+            "Hashtag ID",
+            "Numeric hashtag id. Hashtag Videos accepts only this - get it from Hashtag Info.",
+        ),
+        cursor_input('Pagination cursor as a STRING, e.g. "0". Sending a number is rejected.'),
+        number_input(
+            "count",
+            "Count",
+            "Items per page. Caps differ per endpoint: 30 feeds, 50 comments, 20 follow lists.",
+            value=20,
+        ),
+        text_input("page_token", "Page Token", "Follow-list pagination token from a previous response.", advanced=True),
+        number_input("min_time", "Min Time", "Follow-list pagination timestamp from a previous response."),
+        choice_input(
+            "sort_type",
+            "Sort Type",
+            "0 relevance or latest, 1 most liked or popular. Digit strings, not numbers.",
+            ["", "0", "1"],
+            advanced=True,
+        ),
+        choice_input(
+            "publish_time",
+            "Publish Time",
+            "Video age filter in days: 0 all time, 1, 7, 30, 90 or 180.",
+            ["", "0", "1", "7", "30", "90", "180"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
@@ -1,10 +1,8 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import BoolInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
+    BoolInput,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -73,7 +71,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioTikTokShopComponent(ScavioAPIMixin, Component):
+class ScavioTikTokShopComponent(ScavioBaseComponent):
     display_name = "Scavio TikTok Shop"
     description = (
         "The full Scavio TikTok Shop surface: catalog search, suggestions, product details and reviews, "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
@@ -1,0 +1,163 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/tiktok-shop/search",
+        credits=1,
+        fields=("search", "cursor"),
+        required=("search",),
+        result_keys=("products",),
+    ),
+    "Search Suggestions": Endpoint(
+        path="/api/v1/tiktok-shop/search/suggestions",
+        credits=1,
+        fields=("search", "region"),
+        required=("search",),
+        result_keys=("suggestions",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/tiktok-shop/product",
+        credits=1,
+        fields=("product_id", "region"),
+        required=("product_id",),
+    ),
+    "Product Reviews": Endpoint(
+        path="/api/v1/tiktok-shop/product/reviews",
+        credits=1,
+        fields=("product_id", "page", "page_size", "sort", "rating", "has_media", "verified_only", "region"),
+        required=("product_id",),
+        result_keys=("reviews",),
+    ),
+    "Categories": Endpoint(
+        path="/api/v1/tiktok-shop/categories",
+        credits=1,
+        result_keys=("categories",),
+    ),
+    "Category Products": Endpoint(
+        path="/api/v1/tiktok-shop/category/products",
+        credits=1,
+        fields=("category_id", "cursor", "region"),
+        required=("category_id",),
+        result_keys=("products",),
+    ),
+    "Shop Products": Endpoint(
+        path="/api/v1/tiktok-shop/shop/products",
+        credits=1,
+        fields=("shop_id", "cursor", "region"),
+        required=("shop_id",),
+        result_keys=("products",),
+    ),
+    "Resolve URL": Endpoint(
+        path="/api/v1/tiktok-shop/resolve",
+        credits=1,
+        fields=("url",),
+        required=("url",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioTikTokShopComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio TikTok Shop"
+    description = (
+        "The full Scavio TikTok Shop surface: catalog search, suggestions, product details and reviews, "
+        "the category tree, category and shop listings, and the share-link resolver "
+        "(`/api/v1/tiktok-shop/*`, 1 credit each). Prices on Product Details are masked upstream and come "
+        "back null - use Search or Shop Products for exact prices."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioTikTokShop"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "search",
+            "Search",
+            "The keyword. TikTok Shop's wire field is search, not query. Search itself is US-catalog only.",
+            tool_mode=True,
+        ),
+        text_input("product_id", "Product ID", "Numeric TikTok Shop product id.", tool_mode=True),
+        text_input(
+            "category_id",
+            "Category ID",
+            "Category id from the Categories endpoint. Level 1 or 2 both work.",
+            tool_mode=True,
+        ),
+        text_input("shop_id", "Shop ID", "TikTok Shop seller id.", tool_mode=True),
+        text_input(
+            "url",
+            "URL",
+            "A shop.tiktok.com product or store page, a tiktok.com/view link, an affiliate share link, or a "
+            "vt.tiktok.com short link.",
+            tool_mode=True,
+        ),
+        cursor_input("Opaque cursor echoed from a previous response's next_cursor."),
+        choice_input(
+            "region",
+            "Region",
+            "Marketplace region. Category Products supports US and GB only; Search takes no region at all.",
+            ["", "US", "GB", "SG", "MY", "PH", "TH", "VN", "ID"],
+            advanced=True,
+        ),
+        number_input("page", "Page", "1-based review page, 1 to 500.", value=1),
+        number_input("page_size", "Page Size", "Reviews per page, 1 to 200.", value=20),
+        choice_input(
+            "sort",
+            "Review Sort",
+            "relevant returns text-complete, image-heavy reviews; recent is fresher but sparser.",
+            ["", "relevant", "recent"],
+            advanced=True,
+        ),
+        number_input("rating", "Rating Filter", "Keep only reviews with this star rating, 1 to 5. 0 means no filter."),
+        BoolInput(
+            name="has_media",
+            display_name="Has Media",
+            info="Only reviews with a photo or video. Wins over Verified Only - they share one upstream slot.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="verified_only",
+            display_name="Verified Only",
+            info="Only verified purchases. Ignored when Has Media is on.",
+            value=False,
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tiktok_shop.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import BoolInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tripadvisor.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_tripadvisor.py
@@ -1,0 +1,112 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Location Lookup": Endpoint(
+        path="/api/v1/tripadvisor/locations",
+        credits=2,
+        fields=("query", "limit"),
+        required=("query",),
+        result_keys=("results",),
+    ),
+    "Search": Endpoint(
+        path="/api/v1/tripadvisor/search",
+        credits=2,
+        fields=("geo_id", "category", "page", "url"),
+    ),
+    "Location": Endpoint(
+        path="/api/v1/tripadvisor/location",
+        credits=2,
+        fields=("location_id", "geo_id", "category", "url"),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/tripadvisor/reviews",
+        credits=2,
+        fields=("location_id", "geo_id", "category", "url", "page"),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioTripAdvisorComponent(ScavioBaseComponent):
+    display_name = "Scavio TripAdvisor"
+    description = (
+        "TripAdvisor through Scavio: location lookup, search, location, reviews (`/api/v1/tripadvisor/*`, 2 credits "
+        "each). Tripadvisor: START HERE. Resolve a place or business NAME to the TripAdvisor geo_id / location_id "
+        "pair every other endpoint needs."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioTripAdvisor"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Location Lookup"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Location Lookup"),
+        text_input(
+            "query",
+            "Query",
+            "Place or business NAME to resolve into TripAdvisor ids.",
+            tool_mode=True,
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            "Maximum rows to return, 1-20. Default: 12.",
+        ),
+        text_input(
+            "geo_id",
+            "Geo ID",
+            "TripAdvisor geo id. Accepts 30196, g30196, or a URL carrying one.",
+        ),
+        choice_input(
+            "category",
+            "Category",
+            (
+                "Which family the location belongs to. On reviews it also sets the page size (15 for restaurants, "
+                "10 for hotels and attractions), so it must match the location's own type on any page past the "
+                "first. Options: restaurants, hotels, attractions. Default: restaurants."
+            ),
+            ["", "restaurants", "hotels", "attractions"],
+            advanced=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. 30 locations per page; a page beyond the last is a 404, not an empty result.",
+        ),
+        text_input(
+            "url",
+            "URL",
+            "Full tripadvisor.com listing URL, usable instead of the ids. Country sites are accepted.",
+        ),
+        text_input(
+            "location_id",
+            "Location ID",
+            "TripAdvisor location id. Accepts 1899234, d1899234, or a full _Review URL.",
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
@@ -1,11 +1,10 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
+    decimal_input,
     default_visibility,
     endpoint_input,
     managed_fields,
@@ -15,40 +14,73 @@ from lfx_scavio.components.scavio._base import (
 )
 
 ENDPOINTS = {
-    "Product Search": Endpoint(
+    "Search": Endpoint(
         path="/api/v1/walmart/search",
         credits=1,
         fields=(
             "query",
-            "domain",
-            "device",
-            "sort_by",
             "start_page",
-            "min_price",
-            "max_price",
             "fulfillment_speed",
             "fulfillment_type",
-            "delivery_zip",
-            "store_id",
+            "domain",
+            "page",
+            "sort_by",
+            "min_price",
+            "max_price",
         ),
         required=("query",),
         result_keys=("products",),
+        credit_note="Costs 1 credit on domain com or ca and 2 credits on com.mx.",
     ),
     "Product Details": Endpoint(
         path="/api/v1/walmart/product",
         credits=1,
-        fields=("product_id", "domain", "device", "delivery_zip", "store_id"),
+        fields=("product_id",),
         required=("product_id",),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/walmart/reviews",
+        credits=1,
+        fields=("product_id", "page", "sort"),
+        required=("product_id",),
+    ),
+    "Category": Endpoint(
+        path="/api/v1/walmart/category",
+        credits=1,
+        fields=("category_id", "limit", "fulfillment_speed", "domain", "page", "sort_by", "min_price", "max_price"),
+        required=("category_id",),
+        result_keys=("products",),
+        credit_note="Costs 1 credit on domain com or ca and 2 credits on com.mx.",
+    ),
+    "Offers": Endpoint(
+        path="/api/v1/walmart/offers",
+        credits=1,
+        fields=("product_id",),
+        required=("product_id",),
+    ),
+    "Seller": Endpoint(
+        path="/api/v1/walmart/seller",
+        credits=1,
+        fields=("seller_id",),
+        required=("seller_id",),
+    ),
+    "Seller Products": Endpoint(
+        path="/api/v1/walmart/seller-products",
+        credits=1,
+        fields=("seller_id",),
+        required=("seller_id",),
     ),
 }
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioWalmartComponent(ScavioAPIMixin, Component):
+class ScavioWalmartComponent(ScavioBaseComponent):
     display_name = "Scavio Walmart"
     description = (
-        "Walmart through Scavio: keyword search and product details (`/api/v1/walmart/*`, 1 credit each). "
-        "Product details is keyed on product_id, and search pages with start_page - there is no page field."
+        "Walmart through Scavio: search, product details, reviews, category, offers, seller, seller products "
+        "(`/api/v1/walmart/*`; costs 1 credit on domain com or ca and 2 credits on com.mx). Search Walmart and get "
+        "structured product rows (products[] + products_count + location). Pagination: page (integer >= 1); "
+        "start_page is a deprecated alias."
     )
     documentation = DOCUMENTATION
     icon = "Scavio"
@@ -56,43 +88,101 @@ class ScavioWalmartComponent(ScavioAPIMixin, Component):
 
     ENDPOINTS = ENDPOINTS
     MANAGED_FIELDS = MANAGED
-    DEFAULT_ENDPOINT = "Product Search"
+    DEFAULT_ENDPOINT = "Search"
 
     inputs = [
         api_key_input(),
-        endpoint_input(ENDPOINTS, "Product Search"),
-        text_input("query", "Search Query", "Keywords to search Walmart for.", tool_mode=True),
-        text_input("product_id", "Product ID", "Walmart product id, e.g. 123456789.", tool_mode=True),
-        choice_input(
-            "device", "Device", "Device profile to emulate.", ["", "desktop", "mobile", "tablet"], advanced=True
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "query",
+            "Query",
+            "Product search query.",
+            tool_mode=True,
         ),
-        choice_input(
-            "sort_by",
-            "Sort By",
-            "Result ordering for Product Search.",
-            ["", "best_match", "price_low", "price_high", "best_seller"],
-            advanced=True,
+        number_input(
+            "start_page",
+            "Start Page",
+            "Deprecated alias for page.",
         ),
-        number_input("start_page", "Start Page", "1-based results page. Walmart has no page field."),
-        number_input("min_price", "Min Price", "Lower price bound. 0 means no bound."),
-        number_input("max_price", "Max Price", "Upper price bound. 0 means no bound."),
         choice_input(
             "fulfillment_speed",
             "Fulfillment Speed",
-            "How fast the item must be available.",
-            ["", "today", "tomorrow", "2_days", "anytime"],
+            (
+                "Delivery-speed filter. 2_days and anytime are deliberately not offered: 2_days leaks 3-4 day items "
+                "and anytime is a no-op, so omit the parameter instead. Options: today, tomorrow."
+            ),
+            ["", "today", "tomorrow"],
             advanced=True,
         ),
         choice_input(
             "fulfillment_type",
             "Fulfillment Type",
-            "Restrict to in-store availability.",
+            "Set to in_store to only return pickup stock. Options: in_store.",
             ["", "in_store"],
             advanced=True,
         ),
-        text_input("delivery_zip", "Delivery ZIP", "ZIP code used for delivery and availability.", advanced=True),
-        text_input("store_id", "Store ID", "Walmart store id used for availability.", advanced=True),
-        text_input("domain", "Domain", "Walmart domain override.", advanced=True),
+        choice_input(
+            "domain",
+            "Domain",
+            "Walmart storefront. com and ca cost 1 credit, com.mx costs 2. Options: com, ca, com.mx. Default: com.",
+            ["", "com", "ca", "com.mx"],
+            advanced=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            (
+                "Sort order for the results. Options: best_match, price_low, price_high, best_seller, rating_high, "
+                "new. Default: best_match."
+            ),
+            ["", "best_match", "price_low", "price_high", "best_seller", "rating_high", "new"],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price filter.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price filter.",
+        ),
+        text_input(
+            "product_id",
+            "Product ID",
+            "Walmart item id (usItemId), e.g. 13544111159.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Review sort order. Options: relevancy, submission-desc, submission-asc, rating-desc, rating-asc, "
+                "helpful-desc."
+            ),
+            ["", "relevancy", "submission-desc", "submission-asc", "rating-desc", "rating-asc", "helpful-desc"],
+            advanced=True,
+        ),
+        text_input(
+            "category_id",
+            "Category ID",
+            "Leaf category id (1095191) or the full underscore path (3944_133251_1095191).",
+        ),
+        number_input(
+            "limit",
+            "Limit",
+            "Trims the products list after fetching. It does NOT reduce the credit cost.",
+        ),
+        text_input(
+            "seller_id",
+            "Seller ID",
+            "NUMERIC catalog seller id (the seller_catalog_id field). The GUID form of seller_id returns 404.",
+        ),
         max_results_input(),
     ]
 

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_walmart.py
@@ -1,0 +1,107 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Product Search": Endpoint(
+        path="/api/v1/walmart/search",
+        credits=1,
+        fields=(
+            "query",
+            "domain",
+            "device",
+            "sort_by",
+            "start_page",
+            "min_price",
+            "max_price",
+            "fulfillment_speed",
+            "fulfillment_type",
+            "delivery_zip",
+            "store_id",
+        ),
+        required=("query",),
+        result_keys=("products",),
+    ),
+    "Product Details": Endpoint(
+        path="/api/v1/walmart/product",
+        credits=1,
+        fields=("product_id", "domain", "device", "delivery_zip", "store_id"),
+        required=("product_id",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioWalmartComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio Walmart"
+    description = (
+        "Walmart through Scavio: keyword search and product details (`/api/v1/walmart/*`, 1 credit each). "
+        "Product details is keyed on product_id, and search pages with start_page - there is no page field."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioWalmart"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Product Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Product Search"),
+        text_input("query", "Search Query", "Keywords to search Walmart for.", tool_mode=True),
+        text_input("product_id", "Product ID", "Walmart product id, e.g. 123456789.", tool_mode=True),
+        choice_input(
+            "device", "Device", "Device profile to emulate.", ["", "desktop", "mobile", "tablet"], advanced=True
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            "Result ordering for Product Search.",
+            ["", "best_match", "price_low", "price_high", "best_seller"],
+            advanced=True,
+        ),
+        number_input("start_page", "Start Page", "1-based results page. Walmart has no page field."),
+        number_input("min_price", "Min Price", "Lower price bound. 0 means no bound."),
+        number_input("max_price", "Max Price", "Upper price bound. 0 means no bound."),
+        choice_input(
+            "fulfillment_speed",
+            "Fulfillment Speed",
+            "How fast the item must be available.",
+            ["", "today", "tomorrow", "2_days", "anytime"],
+            advanced=True,
+        ),
+        choice_input(
+            "fulfillment_type",
+            "Fulfillment Type",
+            "Restrict to in-store availability.",
+            ["", "in_store"],
+            advanced=True,
+        ),
+        text_input("delivery_zip", "Delivery ZIP", "ZIP code used for delivery and availability.", advanced=True),
+        text_input("store_id", "Store ID", "Walmart store id used for availability.", advanced=True),
+        text_input("domain", "Domain", "Walmart domain override.", advanced=True),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
@@ -1,6 +1,5 @@
 from lfx.custom.custom_component.component import Component
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
@@ -1,9 +1,7 @@
-from lfx.custom.custom_component.component import Component
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
     api_key_input,
     choice_input,
     cursor_input,
@@ -94,7 +92,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioXComponent(ScavioAPIMixin, Component):
+class ScavioXComponent(ScavioBaseComponent):
     display_name = "Scavio X"
     description = (
         "The full Scavio X (Twitter) surface: search, tweet detail, comments and retweeters, user profile, "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_x.py
@@ -1,0 +1,155 @@
+from lfx.custom.custom_component.component import Component
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/x/search",
+        credits=1,
+        fields=("search", "search_type", "cursor"),
+        required=("search",),
+        result_keys=("timeline",),
+    ),
+    "Tweet Details": Endpoint(
+        path="/api/v1/x/tweet",
+        credits=1,
+        fields=("tweet_id",),
+        required=("tweet_id",),
+    ),
+    "Tweet Comments": Endpoint(
+        path="/api/v1/x/tweet/comments",
+        credits=1,
+        fields=("tweet_id", "rank", "cursor"),
+        required=("tweet_id",),
+        result_keys=("timeline",),
+    ),
+    "Tweet Retweeters": Endpoint(
+        path="/api/v1/x/tweet/retweeters",
+        credits=1,
+        fields=("tweet_id", "cursor"),
+        required=("tweet_id",),
+        result_keys=("retweeters",),
+    ),
+    "User Profile": Endpoint(
+        path="/api/v1/x/user",
+        credits=1,
+        fields=("screen_name",),
+        required=("screen_name",),
+    ),
+    "User Tweets": Endpoint(
+        path="/api/v1/x/user/tweets",
+        credits=1,
+        fields=("screen_name", "cursor"),
+        required=("screen_name",),
+        result_keys=("timeline",),
+    ),
+    "User Replies": Endpoint(
+        path="/api/v1/x/user/replies",
+        credits=1,
+        fields=("screen_name", "cursor"),
+        required=("screen_name",),
+        result_keys=("timeline",),
+    ),
+    "User Media": Endpoint(
+        path="/api/v1/x/user/media",
+        credits=1,
+        fields=("screen_name", "cursor"),
+        required=("screen_name",),
+        result_keys=("timeline",),
+    ),
+    "User Followers": Endpoint(
+        path="/api/v1/x/user/followers",
+        credits=1,
+        fields=("screen_name", "cursor"),
+        required=("screen_name",),
+        result_keys=("followers",),
+    ),
+    "User Followings": Endpoint(
+        path="/api/v1/x/user/followings",
+        credits=1,
+        fields=("screen_name", "cursor"),
+        required=("screen_name",),
+        # The response array is `following`, not `followings`.
+        result_keys=("following",),
+    ),
+    "Trending": Endpoint(
+        path="/api/v1/x/trending",
+        credits=1,
+        fields=("country",),
+        result_keys=("trends",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioXComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio X"
+    description = (
+        "The full Scavio X (Twitter) surface: search, tweet detail, comments and retweeters, user profile, "
+        "tweets, replies and media, followers and followings, and the trending board "
+        "(`/api/v1/x/*`, 1 credit each)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioX"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "search",
+            "Search",
+            "The query. X search's wire field is literally named search, not query.",
+            tool_mode=True,
+        ),
+        text_input("tweet_id", "Tweet ID", "Numeric tweet id as a string.", tool_mode=True),
+        text_input("screen_name", "Screen Name", "X handle without the @, e.g. elonmusk.", tool_mode=True),
+        text_input(
+            "country",
+            "Country",
+            "Trending board country as a NAME, not an ISO code, e.g. UnitedStates. Defaults to UnitedStates.",
+            tool_mode=True,
+        ),
+        cursor_input("Pagination cursor echoed from a previous response."),
+        choice_input(
+            "search_type",
+            "Search Type",
+            "Search tab. Values are capitalized. Empty keeps the API default of Top.",
+            ["", "Top", "Latest", "People", "Photos", "Videos"],
+            advanced=True,
+        ),
+        choice_input(
+            "rank",
+            "Comment Rank",
+            "Comment ordering. Lowercase here, unlike Search Type. Empty keeps the API default of top.",
+            ["", "top", "latest"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_yelp.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_yelp.py
@@ -1,0 +1,134 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/yelp/search",
+        credits=2,
+        fields=("term", "location", "page", "sort", "price", "open_now", "attributes", "url"),
+        result_keys=("businesses",),
+        csv_fields=("attributes",),
+        csv_int_fields=("price",),
+    ),
+    "Business Details": Endpoint(
+        path="/api/v1/yelp/business",
+        credits=2,
+        fields=("business_id", "url"),
+    ),
+    "Reviews": Endpoint(
+        path="/api/v1/yelp/reviews",
+        credits=2,
+        fields=("business_id", "url", "page", "sort", "rating"),
+        result_keys=("reviews",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioYelpComponent(ScavioBaseComponent):
+    display_name = "Scavio Yelp"
+    description = (
+        "Yelp through Scavio: search, business details, reviews (`/api/v1/yelp/*`, 2 credits each). Businesses in "
+        "Yelp's ranked order: rating, review count, price band, categories, address, contact rails, hours, photos, "
+        "review snippet. Pagination: page -- Yelp fixes the page size at 10."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioYelp"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "term",
+            "Term",
+            "What to look for, e.g. 'coffee' or a business name.",
+            tool_mode=True,
+        ),
+        text_input(
+            "location",
+            "Location",
+            (
+                "City, neighbourhood or address. Effectively required: without it Yelp geolocates off the proxy "
+                "exit and the same request answers about a different metro run to run."
+            ),
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page, 1-based. Yelp fixes the page size at 10.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Sort order. Closed set: Yelp IGNORES an unrecognised value and serves default ranking under a "
+                "billed 200. Options: recommended, rating, review_count. Default: recommended."
+            ),
+            ["", "recommended", "rating", "review_count"],
+            advanced=True,
+        ),
+        text_input(
+            "price",
+            "Price",
+            "Price bands to include, 1 (cheapest) to 4 (priciest). Options: 1, 2, 3, 4.",
+        ),
+        flag_input(
+            "open_now",
+            "Open Now",
+            "Only return businesses open right now.",
+        ),
+        text_input(
+            "attributes",
+            "Attributes",
+            (
+                "Raw Yelp filter aliases sent through as attrs, e.g. RestaurantsDelivery, GoodForKids, "
+                "WheelchairAccessible. This is a passthrough, not a closed enum: an alias Yelp does not know is "
+                "ignored and results come back unfiltered."
+            ),
+        ),
+        text_input(
+            "url",
+            "URL",
+            "Full yelp.com/search URL, usable instead of term plus location.",
+        ),
+        text_input(
+            "business_id",
+            "Business ID",
+            "Yelp alias (desnudo-coffee-austin-2), opaque encid, or a yelp.com/biz URL.",
+        ),
+        number_input(
+            "rating",
+            "Rating",
+            (
+                "Only return reviews with this star rating. Changes filtered_review_count, not review_count. "
+                "Options: 1, 2, 3, 4, 5."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
@@ -1,7 +1,6 @@
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import MultiselectInput
 from lfx.template.field.base import Output
-
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
@@ -1,0 +1,236 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import MultiselectInput
+from lfx.template.field.base import Output
+
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    ScavioAPIMixin,
+    api_key_input,
+    choice_input,
+    cursor_input,
+    default_visibility,
+    endpoint_input,
+    managed_fields,
+    max_results_input,
+    text_input,
+)
+
+# /api/v1/youtube/metadata is a deprecated alias of /api/v1/youtube/video and is
+# deliberately not offered here - "Video Details" targets /video directly.
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/youtube/search",
+        credits=2,
+        fields=("search", "upload_date", "type", "duration", "sort_by", "features", "cursor"),
+        required=("search",),
+        result_keys=("results",),
+    ),
+    "Shorts Search": Endpoint(
+        path="/api/v1/youtube/shorts",
+        credits=2,
+        fields=("search", "sort_by", "cursor"),
+        required=("search",),
+        result_keys=("results",),
+    ),
+    "Search Suggestions": Endpoint(
+        path="/api/v1/youtube/suggestions",
+        credits=1,
+        fields=("search", "language", "region"),
+        required=("search",),
+        result_keys=("suggestions",),
+    ),
+    "Video Details": Endpoint(
+        path="/api/v1/youtube/video",
+        credits=1,
+        fields=("video_id",),
+        required=("video_id",),
+    ),
+    "Video Comments": Endpoint(
+        path="/api/v1/youtube/comments",
+        credits=1,
+        fields=("video_id", "cursor"),
+        required=("video_id",),
+        result_keys=("comments",),
+    ),
+    "Comment Replies": Endpoint(
+        path="/api/v1/youtube/comments/replies",
+        credits=1,
+        fields=("video_id", "reply_cursor", "cursor"),
+        required=("video_id", "reply_cursor"),
+        result_keys=("replies",),
+    ),
+    "Transcript": Endpoint(
+        path="/api/v1/youtube/transcript",
+        credits=8,
+        fields=("video_id", "language", "format"),
+        required=("video_id",),
+    ),
+    "Related Videos": Endpoint(
+        path="/api/v1/youtube/related",
+        credits=1,
+        fields=("video_id", "cursor"),
+        required=("video_id",),
+        result_keys=("results",),
+    ),
+    "Video Streams": Endpoint(
+        path="/api/v1/youtube/streams",
+        credits=3,
+        fields=("video_id",),
+        required=("video_id",),
+        result_keys=("formats",),
+    ),
+    "Channel Search": Endpoint(
+        path="/api/v1/youtube/channel/search",
+        credits=1,
+        fields=("search", "cursor"),
+        required=("search",),
+        result_keys=("results",),
+    ),
+    "Channel Details": Endpoint(
+        path="/api/v1/youtube/channel",
+        credits=1,
+        fields=("channel_id",),
+        required=("channel_id",),
+    ),
+    "Channel Videos": Endpoint(
+        path="/api/v1/youtube/channel/videos",
+        credits=1,
+        fields=("channel_id", "cursor"),
+        required=("channel_id",),
+        result_keys=("results",),
+    ),
+    "Channel Shorts": Endpoint(
+        path="/api/v1/youtube/channel/shorts",
+        credits=1,
+        fields=("channel_id", "cursor"),
+        required=("channel_id",),
+        result_keys=("results",),
+    ),
+    "Channel Community": Endpoint(
+        path="/api/v1/youtube/channel/community",
+        credits=1,
+        fields=("channel_id", "cursor"),
+        required=("channel_id",),
+        result_keys=("posts",),
+    ),
+    "Channel Resolve": Endpoint(
+        path="/api/v1/youtube/channel/resolve",
+        credits=1,
+        fields=("channel",),
+        required=("channel",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioYouTubeComponent(ScavioAPIMixin, Component):
+    display_name = "Scavio YouTube"
+    description = (
+        "The full Scavio YouTube surface: search, shorts, suggestions, video details, comments, replies, "
+        "transcripts, related videos, stream URLs and the five channel endpoints. Costs vary per endpoint "
+        "(search and shorts 2, streams 3, transcript 8, everything else 1)."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioYouTube"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "search",
+            "Search",
+            "The query. YouTube's wire field is literally named search, not query.",
+            tool_mode=True,
+        ),
+        text_input(
+            "video_id",
+            "Video ID or URL",
+            "A bare 11-character video id or any watch, shorts, embed or youtu.be URL.",
+            tool_mode=True,
+        ),
+        text_input(
+            "channel_id",
+            "Channel ID, Handle or URL",
+            "A UC... channel id, an @handle, a bare name or a channel URL.",
+            tool_mode=True,
+        ),
+        text_input(
+            "channel",
+            "Channel to Resolve",
+            "A channel @handle or URL to resolve to an id. Channel Resolve is the one endpoint whose field "
+            "is named channel rather than channel_id.",
+            tool_mode=True,
+        ),
+        text_input(
+            "reply_cursor",
+            "Reply Cursor",
+            "reply_cursor taken from a comment returned by Video Comments. Comment Replies cannot run "
+            "from a video id alone.",
+        ),
+        cursor_input("Pagination cursor. Echo next_cursor from a previous response."),
+        choice_input(
+            "upload_date",
+            "Upload Date",
+            "Restrict search results to a recent upload window.",
+            ["", "last_hour", "today", "this_week", "this_month", "this_year"],
+            advanced=True,
+        ),
+        choice_input(
+            "type",
+            "Result Type",
+            "Restrict search results to one kind of result.",
+            ["", "video", "channel", "playlist", "movie"],
+            advanced=True,
+        ),
+        choice_input(
+            "duration",
+            "Duration",
+            "Restrict search results by video length.",
+            ["", "short", "medium", "long"],
+            advanced=True,
+        ),
+        choice_input(
+            "sort_by",
+            "Sort By",
+            "Ordering for Search and Shorts Search.",
+            ["", "relevance", "date", "view_count", "rating"],
+            advanced=True,
+        ),
+        MultiselectInput(
+            name="features",
+            display_name="Features",
+            info="Feature filters applied to Search.",
+            options=["hd", "4k", "subtitles", "creative_commons", "live", "360", "3d", "hdr", "vr180"],
+            value=[],
+            advanced=True,
+            dynamic=True,
+            show=False,
+        ),
+        text_input(
+            "language", "Language", "Language code, e.g. en. Used by Suggestions and Transcript.", advanced=True
+        ),
+        text_input("region", "Region", "Region code for Suggestions, e.g. US.", advanced=True),
+        choice_input(
+            "format",
+            "Transcript Format",
+            "text returns plain text, srt returns timed captions. Empty means plain text.",
+            ["", "text", "srt"],
+            advanced=True,
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_youtube.py
@@ -1,10 +1,8 @@
-from lfx.custom.custom_component.component import Component
-from lfx.inputs.inputs import MultiselectInput
-from lfx.template.field.base import Output
+from lfx_scavio._component import Output, ScavioBaseComponent
 from lfx_scavio.components.scavio._base import (
     DOCUMENTATION,
     Endpoint,
-    ScavioAPIMixin,
+    MultiselectInput,
     api_key_input,
     choice_input,
     cursor_input,
@@ -123,7 +121,7 @@ ENDPOINTS = {
 MANAGED = managed_fields(ENDPOINTS)
 
 
-class ScavioYouTubeComponent(ScavioAPIMixin, Component):
+class ScavioYouTubeComponent(ScavioBaseComponent):
     display_name = "Scavio YouTube"
     description = (
         "The full Scavio YouTube surface: search, shorts, suggestions, video details, comments, replies, "

--- a/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_zillow.py
+++ b/src/bundles/scavio/src/lfx_scavio/components/scavio/scavio_zillow.py
@@ -1,0 +1,298 @@
+from lfx_scavio._component import Output, ScavioBaseComponent
+from lfx_scavio.components.scavio._base import (
+    DOCUMENTATION,
+    Endpoint,
+    api_key_input,
+    choice_input,
+    decimal_input,
+    default_visibility,
+    endpoint_input,
+    flag_input,
+    managed_fields,
+    max_results_input,
+    number_input,
+    text_input,
+)
+
+ENDPOINTS = {
+    "Search": Endpoint(
+        path="/api/v1/zillow/search",
+        credits=1,
+        fields=(
+            "location",
+            "listing_status",
+            "page",
+            "sort",
+            "min_price",
+            "max_price",
+            "beds_min",
+            "beds_max",
+            "baths_min",
+            "baths_max",
+            "sqft_min",
+            "sqft_max",
+            "lot_size_min",
+            "lot_size_max",
+            "year_built_min",
+            "year_built_max",
+            "max_hoa",
+            "home_type",
+            "days_on_zillow",
+            "keywords",
+            "has_pool",
+            "has_garage",
+            "has_air_conditioning",
+            "is_waterfront",
+            "has_basement",
+            "is_new_construction",
+            "has_open_house",
+            "price_reduced",
+            "is_3d_tour",
+        ),
+        required=("location",),
+        result_keys=("properties",),
+    ),
+    "Property Details": Endpoint(
+        path="/api/v1/zillow/property",
+        credits=1,
+        fields=("zpid",),
+        required=("zpid",),
+    ),
+    "Agent Reviews": Endpoint(
+        path="/api/v1/zillow/reviews",
+        credits=1,
+        fields=("screen_name",),
+        required=("screen_name",),
+    ),
+}
+MANAGED = managed_fields(ENDPOINTS)
+
+
+class ScavioZillowComponent(ScavioBaseComponent):
+    display_name = "Scavio Zillow"
+    description = (
+        "Zillow through Scavio: search, property details, agent reviews (`/api/v1/zillow/*`, 1 credit each). Zillow "
+        "listings in a region: price, beds, baths, living area, Zestimate, coordinates, images, days on market. "
+        "Pagination: page."
+    )
+    documentation = DOCUMENTATION
+    icon = "Scavio"
+    name = "ScavioZillow"
+
+    ENDPOINTS = ENDPOINTS
+    MANAGED_FIELDS = MANAGED
+    DEFAULT_ENDPOINT = "Search"
+
+    inputs = [
+        api_key_input(),
+        endpoint_input(ENDPOINTS, "Search"),
+        text_input(
+            "location",
+            "Location",
+            (
+                "Zillow region slug, human city name, ZIP, or a pasted search URL. A bare ZIP works alone but "
+                "CANNOT be combined with a filter or a sort -- use the city name there."
+            ),
+            tool_mode=True,
+        ),
+        choice_input(
+            "listing_status",
+            "Listing Status",
+            "Which listing state to return. Options: for_sale, for_rent, sold. Default: for_sale.",
+            ["", "for_sale", "for_rent", "sold"],
+            advanced=True,
+        ),
+        number_input(
+            "page",
+            "Page",
+            "Result page number, 1-based.",
+        ),
+        choice_input(
+            "sort",
+            "Sort",
+            (
+                "Sort order for the results. Options: relevance, recommended, newest, price_low, price_high, "
+                "payment_low, payment_high, beds, baths, sqft, lot_size, zestimate_low, zestimate_high, "
+                "recent_change."
+            ),
+            [
+                "",
+                "relevance",
+                "recommended",
+                "newest",
+                "price_low",
+                "price_high",
+                "payment_low",
+                "payment_high",
+                "beds",
+                "baths",
+                "sqft",
+                "lot_size",
+                "zestimate_low",
+                "zestimate_high",
+                "recent_change",
+            ],
+            advanced=True,
+        ),
+        decimal_input(
+            "min_price",
+            "Min Price",
+            "Minimum price. On listing_status=for_rent this means MONTHLY RENT.",
+        ),
+        decimal_input(
+            "max_price",
+            "Max Price",
+            "Maximum price. On listing_status=for_rent this means MONTHLY RENT.",
+        ),
+        number_input(
+            "beds_min",
+            "Beds Min",
+            "Minimum number of bedrooms.",
+        ),
+        number_input(
+            "beds_max",
+            "Beds Max",
+            "Maximum number of bedrooms.",
+        ),
+        decimal_input(
+            "baths_min",
+            "Baths Min",
+            "Minimum number of bathrooms. Half-baths allowed (1.5).",
+        ),
+        decimal_input(
+            "baths_max",
+            "Baths Max",
+            "Maximum number of bathrooms.",
+        ),
+        number_input(
+            "sqft_min",
+            "Sq Ft Min",
+            "Minimum living area in square feet.",
+        ),
+        number_input(
+            "sqft_max",
+            "Sq Ft Max",
+            "Maximum living area in square feet.",
+        ),
+        number_input(
+            "lot_size_min",
+            "Lot Size Min",
+            "Minimum lot size in square feet.",
+        ),
+        number_input(
+            "lot_size_max",
+            "Lot Size Max",
+            "Maximum lot size in square feet.",
+        ),
+        number_input(
+            "year_built_min",
+            "Year Built Min",
+            "Earliest year built.",
+        ),
+        number_input(
+            "year_built_max",
+            "Year Built Max",
+            "Latest year built.",
+        ),
+        decimal_input(
+            "max_hoa",
+            "Max HOA",
+            "Maximum monthly HOA fee.",
+        ),
+        choice_input(
+            "home_type",
+            "Home Type",
+            (
+                "Property type filter. Options: houses, townhomes, multi_family, condos, apartments, manufactured, "
+                "lots_land."
+            ),
+            ["", "houses", "townhomes", "multi_family", "condos", "apartments", "manufactured", "lots_land"],
+            advanced=True,
+        ),
+        choice_input(
+            "days_on_zillow",
+            "Days On Zillow",
+            (
+                "How recently the listing appeared. Closed set: an unrecognised value returns the UNFILTERED result "
+                "set under a 200. Options: 1, 7, 14, 30, 90, 6m, 12m, 24m, 36m."
+            ),
+            ["", "1", "7", "14", "30", "90", "6m", "12m", "24m", "36m"],
+            advanced=True,
+        ),
+        text_input(
+            "keywords",
+            "Keywords",
+            "Extra keywords to match inside the listing text.",
+        ),
+        flag_input(
+            "has_pool",
+            "Has Pool",
+            "Only return properties with a pool.",
+        ),
+        flag_input(
+            "has_garage",
+            "Has Garage",
+            "Only return properties with a garage.",
+        ),
+        flag_input(
+            "has_air_conditioning",
+            "Has Air Conditioning",
+            "Only return properties with air conditioning.",
+        ),
+        flag_input(
+            "is_waterfront",
+            "Is Waterfront",
+            "Only return waterfront properties.",
+        ),
+        flag_input(
+            "has_basement",
+            "Has Basement",
+            "Only return properties with a basement.",
+        ),
+        flag_input(
+            "is_new_construction",
+            "Is New Construction",
+            "Only return new construction.",
+        ),
+        flag_input(
+            "has_open_house",
+            "Has Open House",
+            "Only return listings with an open house scheduled.",
+        ),
+        flag_input(
+            "price_reduced",
+            "Price Reduced",
+            "Only return listings whose price was reduced.",
+        ),
+        flag_input(
+            "is_3d_tour",
+            "Is 3d Tour",
+            "Only return listings with a 3D tour.",
+        ),
+        text_input(
+            "zpid",
+            "ZPID",
+            (
+                "Zillow property id, a /homedetails/ URL, or a zillow.com/apartments/ building URL. Rental "
+                "buildings have no visible zpid -- pass the URL."
+            ),
+        ),
+        text_input(
+            "screen_name",
+            "Screen Name",
+            (
+                "The AGENT's zillow.com/profile/<name>/ screen name, or the full profile URL. This endpoint "
+                "addresses an agent, not a property."
+            ),
+        ),
+        max_results_input(),
+    ]
+
+    # The endpoint dropdown's default decides what is visible before the user
+    # touches anything; update_build_config takes over from there.
+    default_visibility(inputs, ENDPOINTS, DEFAULT_ENDPOINT)
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        Output(display_name="Raw JSON", name="raw", method="fetch_raw"),
+    ]

--- a/src/bundles/scavio/src/lfx_scavio/extension.json
+++ b/src/bundles/scavio/src/lfx_scavio/extension.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schemas.langflow.org/extension/v1.json",
+  "id": "lfx-scavio",
+  "version": "0.1.0",
+  "name": "Scavio",
+  "description": "Scavio search API for AI agents: Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn behind one key.",
+  "lfx": {
+    "compat": ["1"]
+  },
+  "bundles": [
+    {
+      "name": "scavio",
+      "path": "components/scavio"
+    }
+  ]
+}

--- a/src/bundles/scavio/src/lfx_scavio/extension.json
+++ b/src/bundles/scavio/src/lfx_scavio/extension.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://schemas.langflow.org/extension/v1.json",
   "id": "lfx-scavio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "Scavio",
-  "description": "Scavio search API for AI agents: Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn behind one key.",
+  "description": "Scavio search API for AI agents: 32 platforms across search, retail, real estate, travel, jobs, app stores, company filings, software reviews, ad libraries and social, plus URL extraction, behind one key.",
   "lfx": {
     "compat": ["1"]
   },

--- a/src/bundles/scavio/src/lfx_scavio/extension.json
+++ b/src/bundles/scavio/src/lfx_scavio/extension.json
@@ -3,7 +3,7 @@
   "id": "lfx-scavio",
   "version": "0.2.0",
   "name": "Scavio",
-  "description": "Scavio search API for AI agents: 32 platforms across search, retail, real estate, travel, jobs, app stores, company filings, software reviews, ad libraries and social, plus URL extraction, behind one key.",
+  "description": "Scavio search API for AI agents: 31 platforms across search, retail, real estate, travel, jobs, app stores, company filings, software reviews, ad libraries and social, plus URL extraction, behind one key.",
   "lfx": {
     "compat": ["1"]
   },

--- a/src/bundles/scavio/tests/test_scavio_components.py
+++ b/src/bundles/scavio/tests/test_scavio_components.py
@@ -16,46 +16,90 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from lfx.custom.custom_component.component import Component
 from lfx.schema.dataframe import DataFrame
-
 from lfx_scavio import (
+    ScavioAirbnbComponent,
     ScavioAmazonComponent,
+    ScavioAppStoreComponent,
+    ScavioBookingComponent,
+    ScavioCapterraComponent,
+    ScavioCompaniesHouseComponent,
+    ScavioEbayComponent,
+    ScavioExtractComponent,
+    ScavioG2Component,
+    ScavioGlassdoorComponent,
+    ScavioGoogleAdsComponent,
     ScavioGoogleAIModeComponent,
     ScavioGoogleFlightsComponent,
     ScavioGoogleHotelsComponent,
     ScavioGoogleMapsComponent,
     ScavioGoogleNewsComponent,
+    ScavioGooglePlayComponent,
     ScavioGoogleShoppingComponent,
     ScavioGoogleTrendsComponent,
+    ScavioHomeDepotComponent,
+    ScavioIndeedComponent,
     ScavioInstagramComponent,
+    ScavioKuaishouComponent,
     ScavioLinkedInComponent,
+    ScavioMetaAdsComponent,
     ScavioRedditComponent,
+    ScavioRedfinComponent,
     ScavioSearchComponent,
+    ScavioSecComponent,
+    ScavioTargetComponent,
+    ScavioThreadsComponent,
     ScavioTikTokComponent,
     ScavioTikTokShopComponent,
+    ScavioTripAdvisorComponent,
     ScavioWalmartComponent,
     ScavioXComponent,
+    ScavioYelpComponent,
     ScavioYouTubeComponent,
+    ScavioZillowComponent,
 )
 
 ALL_COMPONENTS = (
-    ScavioSearchComponent,
+    ScavioAirbnbComponent,
+    ScavioAmazonComponent,
+    ScavioAppStoreComponent,
+    ScavioBookingComponent,
+    ScavioCapterraComponent,
+    ScavioCompaniesHouseComponent,
+    ScavioEbayComponent,
+    ScavioExtractComponent,
+    ScavioG2Component,
+    ScavioGlassdoorComponent,
     ScavioGoogleAIModeComponent,
-    ScavioGoogleMapsComponent,
-    ScavioGoogleShoppingComponent,
-    ScavioGoogleNewsComponent,
-    ScavioGoogleTrendsComponent,
+    ScavioGoogleAdsComponent,
     ScavioGoogleFlightsComponent,
     ScavioGoogleHotelsComponent,
-    ScavioYouTubeComponent,
-    ScavioAmazonComponent,
-    ScavioWalmartComponent,
+    ScavioGoogleMapsComponent,
+    ScavioGoogleNewsComponent,
+    ScavioGooglePlayComponent,
+    ScavioGoogleShoppingComponent,
+    ScavioGoogleTrendsComponent,
+    ScavioHomeDepotComponent,
+    ScavioIndeedComponent,
+    ScavioInstagramComponent,
+    ScavioKuaishouComponent,
+    ScavioLinkedInComponent,
+    ScavioMetaAdsComponent,
     ScavioRedditComponent,
+    ScavioRedfinComponent,
+    ScavioSearchComponent,
+    ScavioSecComponent,
+    ScavioTargetComponent,
+    ScavioThreadsComponent,
     ScavioTikTokComponent,
     ScavioTikTokShopComponent,
-    ScavioInstagramComponent,
+    ScavioTripAdvisorComponent,
+    ScavioWalmartComponent,
     ScavioXComponent,
-    ScavioLinkedInComponent,
+    ScavioYelpComponent,
+    ScavioYouTubeComponent,
+    ScavioZillowComponent,
 )
 
 # The live billable surface, taken from the Scavio route definitions.
@@ -63,6 +107,122 @@ ALL_COMPONENTS = (
 # LinkedIn paths answer 410 and are never billed; /api/v1/youtube/metadata is a
 # deprecated alias of /api/v1/youtube/video. None of them belong here.
 LIVE_ENDPOINTS = {
+    # Walmart - 7
+    "/api/v1/walmart/search": 1,  # floor; cost is a function of the body
+    "/api/v1/walmart/product": 1,
+    "/api/v1/walmart/reviews": 1,
+    "/api/v1/walmart/category": 1,  # floor; cost is a function of the body
+    "/api/v1/walmart/offers": 1,
+    "/api/v1/walmart/seller": 1,
+    "/api/v1/walmart/seller-products": 1,
+    # Threads - 6
+    "/api/v1/threads/profile": 2,  # floor; cost is a function of the body
+    "/api/v1/threads/user/posts": 2,  # floor; cost is a function of the body
+    "/api/v1/threads/user/replies": 2,  # floor; cost is a function of the body
+    "/api/v1/threads/post": 2,
+    "/api/v1/threads/post/comments": 2,
+    "/api/v1/threads/search/users": 2,
+    # Kuaishou (China) - 14
+    "/api/v1/kuaishou/profile": 10,
+    "/api/v1/kuaishou/user/posts": 1,
+    "/api/v1/kuaishou/user/live": 1,
+    "/api/v1/kuaishou/user/resolve": 1,
+    "/api/v1/kuaishou/video": 2,
+    "/api/v1/kuaishou/video/comments": 1,
+    "/api/v1/kuaishou/video/sub-comments": 1,
+    "/api/v1/kuaishou/videos/batch": 40,
+    "/api/v1/kuaishou/search": 10,
+    "/api/v1/kuaishou/search/videos": 10,
+    "/api/v1/kuaishou/search/users": 10,
+    "/api/v1/kuaishou/search/live": 10,
+    "/api/v1/kuaishou/tag/feed": 1,
+    "/api/v1/kuaishou/trending": 1,
+    # eBay - 3
+    "/api/v1/ebay/search": 1,
+    "/api/v1/ebay/product": 1,
+    "/api/v1/ebay/seller": 1,
+    # Target - 4
+    "/api/v1/target/search": 1,
+    "/api/v1/target/category": 1,
+    "/api/v1/target/product": 1,
+    "/api/v1/target/reviews": 1,
+    # Home Depot - 3
+    "/api/v1/homedepot/search": 2,
+    "/api/v1/homedepot/product": 2,
+    "/api/v1/homedepot/reviews": 2,
+    # Zillow - 3
+    "/api/v1/zillow/search": 1,
+    "/api/v1/zillow/property": 1,
+    "/api/v1/zillow/reviews": 1,
+    # Booking.com - 3
+    "/api/v1/booking/search": 1,
+    "/api/v1/booking/hotel": 1,
+    "/api/v1/booking/reviews": 1,
+    # TripAdvisor - 4
+    "/api/v1/tripadvisor/locations": 2,
+    "/api/v1/tripadvisor/search": 2,
+    "/api/v1/tripadvisor/location": 2,
+    "/api/v1/tripadvisor/reviews": 2,
+    # Indeed - 4
+    "/api/v1/indeed/search": 2,
+    "/api/v1/indeed/job": 2,
+    "/api/v1/indeed/company": 2,
+    "/api/v1/indeed/company/reviews": 2,
+    # Airbnb - 3
+    "/api/v1/airbnb/search": 1,
+    "/api/v1/airbnb/listing": 1,
+    "/api/v1/airbnb/reviews": 1,
+    # Glassdoor - 4
+    "/api/v1/glassdoor/companies": 1,
+    "/api/v1/glassdoor/company": 1,
+    "/api/v1/glassdoor/reviews": 1,
+    "/api/v1/glassdoor/salaries": 1,
+    # Yelp - 3
+    "/api/v1/yelp/search": 2,
+    "/api/v1/yelp/business": 2,
+    "/api/v1/yelp/reviews": 2,
+    # Apple App Store - 3
+    "/api/v1/appstore/search": 1,
+    "/api/v1/appstore/app": 1,
+    "/api/v1/appstore/reviews": 1,
+    # Google Play - 3
+    "/api/v1/googleplay/search": 2,
+    "/api/v1/googleplay/app": 2,
+    "/api/v1/googleplay/reviews": 2,
+    # SEC EDGAR - 6
+    "/api/v1/sec/lookup": 1,
+    "/api/v1/sec/company": 1,
+    "/api/v1/sec/filings": 1,
+    "/api/v1/sec/concept": 1,
+    "/api/v1/sec/facts": 1,
+    "/api/v1/sec/search": 1,
+    # Redfin - 3
+    "/api/v1/redfin/search": 1,
+    "/api/v1/redfin/property": 1,
+    "/api/v1/redfin/market": 1,
+    # Companies House - 4
+    "/api/v1/companieshouse/search": 1,
+    "/api/v1/companieshouse/company": 1,
+    "/api/v1/companieshouse/officers": 1,
+    "/api/v1/companieshouse/filing-history": 1,
+    # G2 - 3
+    "/api/v1/g2/search": 5,
+    "/api/v1/g2/product": 5,
+    "/api/v1/g2/reviews": 5,
+    # Capterra - 3
+    "/api/v1/capterra/search": 2,
+    "/api/v1/capterra/product": 2,
+    "/api/v1/capterra/reviews": 2,
+    # Google Ads Transparency - 3
+    "/api/v1/googleads/search": 1,
+    "/api/v1/googleads/advertisers": 1,
+    "/api/v1/googleads/creative": 1,
+    # Meta Ad Library - 3
+    "/api/v1/meta-ads/search": 1,
+    "/api/v1/meta-ads/advertiser": 1,
+    "/api/v1/meta-ads/ad": 1,
+    # Extract - 1
+    "/api/v1/extract": 1,  # floor; cost is a function of the body
     # Google v2 - 14 endpoints, 1 credit each
     "/api/v2/google": 1,
     "/api/v2/google/ai-mode": 1,
@@ -98,9 +258,6 @@ LIVE_ENDPOINTS = {
     "/api/v1/amazon/search": 1,
     "/api/v1/amazon/product": 1,
     "/api/v1/amazon/offers": 1,
-    # Walmart - 2
-    "/api/v1/walmart/search": 1,
-    "/api/v1/walmart/product": 1,
     # Reddit - 12, 1 credit each (it was 2 before Reddit moved providers)
     "/api/v1/reddit/search": 1,
     "/api/v1/reddit/search/suggestions": 1,
@@ -218,6 +375,24 @@ def run(component, json_data=None, status_code=200, text=""):
     return results, url, payload
 
 
+BODY_PRICED_PATHS = {
+    # Cost is a function of the request body, not of the path: Walmart bills by
+    # storefront domain, Threads by whether the caller passed user_id or username,
+    # and extract by fetch mode.
+    "/api/v1/walmart/search",
+    "/api/v1/walmart/category",
+    "/api/v1/threads/profile",
+    "/api/v1/threads/user/posts",
+    "/api/v1/threads/user/replies",
+    "/api/v1/extract",
+}
+
+
+def endpoint_by_path():
+    """Return {path: Endpoint} across every component."""
+    return {ep.path: ep for component in ALL_COMPONENTS for ep in component.ENDPOINTS.values()}
+
+
 def endpoint_map():
     """Return {path: credits} for every endpoint the bundle offers, asserting no path repeats."""
     seen: dict[str, int] = {}
@@ -233,7 +408,7 @@ class TestEndpointCoverage:
         assert set(endpoint_map()) == set(LIVE_ENDPOINTS)
 
     def test_endpoint_count_is_the_full_live_surface(self):
-        assert len(endpoint_map()) == 97
+        assert len(endpoint_map()) == 188
 
     def test_credit_costs_match_the_api(self):
         assert endpoint_map() == LIVE_ENDPOINTS
@@ -254,6 +429,28 @@ class TestEndpointCoverage:
             "/api/v1/instagram/",
             "/api/v1/x/",
             "/api/v1/linkedin/",
+            "/api/v1/threads/",
+            "/api/v1/kuaishou/",
+            "/api/v1/ebay/",
+            "/api/v1/target/",
+            "/api/v1/homedepot/",
+            "/api/v1/zillow/",
+            "/api/v1/booking/",
+            "/api/v1/tripadvisor/",
+            "/api/v1/indeed/",
+            "/api/v1/airbnb/",
+            "/api/v1/glassdoor/",
+            "/api/v1/yelp/",
+            "/api/v1/appstore/",
+            "/api/v1/googleplay/",
+            "/api/v1/sec/",
+            "/api/v1/redfin/",
+            "/api/v1/companieshouse/",
+            "/api/v1/g2/",
+            "/api/v1/capterra/",
+            "/api/v1/googleads/",
+            "/api/v1/meta-ads/",
+            "/api/v1/extract",
         ):
             assert any(path.startswith(prefix) for path in paths), prefix
 
@@ -269,6 +466,101 @@ class TestEndpointCoverage:
         for component in ALL_COMPONENTS:
             assert component.DEFAULT_ENDPOINT in component.ENDPOINTS, component.name
 
+    def test_no_input_is_shadowed_by_a_component_attribute(self):
+        """An input named after a Component attribute never receives the user's value.
+
+        ``Component`` owns ``start`` (a method) and ``user_id``, so an input of either
+        name silently sends the base-class value instead. Both are exposed under a
+        different input name and mapped back with ``Endpoint.wire``.
+        """
+        reserved = set(dir(Component))
+        for component in ALL_COMPONENTS:
+            shadowed = {field.name for field in component.inputs} & reserved
+            assert not shadowed, f"{component.name} declares shadowed inputs {shadowed}"
+
+    def test_wire_targets_are_real_api_fields(self):
+        for component in ALL_COMPONENTS:
+            for label, endpoint in component.ENDPOINTS.items():
+                assert set(endpoint.wire) <= set(endpoint.fields), f"{component.name}/{label}"
+
+    def test_body_priced_endpoints_never_quote_a_flat_cost(self):
+        """Walmart bills by domain, Threads by user_id-vs-username, extract by mode."""
+        for path in BODY_PRICED_PATHS:
+            endpoint = endpoint_by_path()[path]
+            assert endpoint.credit_note, f"{path} must carry a credit_note"
+            assert endpoint.cost_text() == endpoint.credit_note
+        for component in ALL_COMPONENTS:
+            for endpoint in component.ENDPOINTS.values():
+                if endpoint.path not in BODY_PRICED_PATHS:
+                    assert not endpoint.credit_note, endpoint.path
+                    assert endpoint.cost_text().endswith("credit") or endpoint.cost_text().endswith("credits")
+
+    def test_meta_ad_library_paths_are_hyphenated(self):
+        """The route key is metaads; the public URL segment is meta-ads."""
+        paths = set(endpoint_map())
+        assert {"/api/v1/meta-ads/search", "/api/v1/meta-ads/advertiser", "/api/v1/meta-ads/ad"} <= paths
+        assert not any(path.startswith("/api/v1/metaads") for path in paths)
+
+
+class TestNewPlatformWires:
+    def test_ebay_sold_search_sends_the_flag(self):
+        component = ScavioEbayComponent(api_key="k", query="airpods", sold=True)  # pragma: allowlist secret
+        _results, url, payload = run(component, {"data": {"products": []}})
+        assert url == "https://api.scavio.dev/api/v1/ebay/search"
+        assert payload["sold"] is True
+
+    def test_ebay_seller_only_search_needs_no_query(self):
+        component = ScavioEbayComponent(api_key="k", seller="some_seller")  # pragma: allowlist secret
+        _results, _url, payload = run(component, {"data": {"products": []}})
+        assert payload == {"seller": "some_seller"}
+
+    def test_threads_user_id_reaches_the_wire(self):
+        component = ScavioThreadsComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Profile Details",
+            target_user_id="314216",
+        )
+        _results, url, payload = run(component, {"data": {"username": "a"}})
+        assert url == "https://api.scavio.dev/api/v1/threads/profile"
+        assert payload == {"user_id": "314216"}
+
+    def test_extract_defaults_to_a_single_credit_tier(self):
+        component = ScavioExtractComponent(
+            api_key="k",  # pragma: allowlist secret
+            url="https://example.com",
+            format="text",
+        )
+        _results, endpoint_url, payload = run(component, {"data": {"content": "hi"}})
+        assert endpoint_url == "https://api.scavio.dev/api/v1/extract"
+        assert payload == {"url": "https://example.com", "format": "text"}
+
+    def test_comma_separated_inputs_become_json_arrays(self):
+        """Booking wants children_ages as an array of integers, Yelp attributes as strings."""
+        component = ScavioBookingComponent(
+            api_key="k",  # pragma: allowlist secret
+            destination="Paris",
+            children_ages="4, 7",
+        )
+        _results, _url, payload = run(component, {"data": {"properties": []}})
+        assert payload["children_ages"] == [4, 7]
+
+        component = ScavioYelpComponent(
+            api_key="k",  # pragma: allowlist secret
+            term="coffee",
+            location="Austin, TX",
+            attributes="dogs_allowed,outdoor_seating",
+        )
+        _results, _url, payload = run(component, {"data": {"businesses": []}})
+        assert payload["attributes"] == ["dogs_allowed", "outdoor_seating"]
+
+    def test_table_output_uses_the_observed_row_key(self):
+        component = ScavioG2Component(api_key="k", endpoint="Reviews", product_id="1")  # pragma: allowlist secret
+        body = {"data": {"reviews": [{"title": "Good"}, {"title": "Bad"}], "rating_distribution": [1, 2, 3, 4, 5]}}
+        results, _url, _payload = run(component, body)
+        # rating_distribution is the longer list; reviews is the one that holds the rows.
+        assert len(results) == 2
+        assert results[0].data["title"] == "Good"
+
 
 class TestGoogleSearch:
     def test_targets_v2_and_sends_v2_params_only(self):
@@ -279,7 +571,7 @@ class TestGoogleSearch:
             hl="en",
             google_domain="google.com",
             device="desktop",
-            start=10,
+            start_offset=10,
         )
         _results, url, payload = run(component, {"organic_results": []})
 
@@ -288,7 +580,10 @@ class TestGoogleSearch:
         assert payload["gl"] == "us"
         assert payload["hl"] == "en"
         assert payload["google_domain"] == "google.com"
+        # `start` is the wire name; the input is called start_offset because Component
+        # already owns a `start` attribute.
         assert payload["start"] == 10
+        assert "start_offset" not in payload
         # Google v1 is gone; none of its params may leak onto the v2 call.
         assert GOOGLE_V1_ONLY_PARAMS.isdisjoint(payload)
 
@@ -594,7 +889,9 @@ class TestEnvelopes:
         component = ScavioXComponent(api_key="k", endpoint="User Profile", screen_name="a")  # pragma: allowlist secret
         body = {"data": {"screen_name": "a", "followers_count": 5}, "response_time": 1, "credits_used": 1}
         results, _url, _payload = run(component, body)
-        assert results[0].data == {"screen_name": "a", "followers_count": 5}
+        # Data folds its text kwarg into .data, so compare the payload keys we set.
+        assert results[0].data["screen_name"] == "a"
+        assert results[0].data["followers_count"] == 5
 
     def test_raw_output_keeps_the_credit_counters(self):
         component = ScavioXComponent(api_key="k", endpoint="Trending")  # pragma: allowlist secret

--- a/src/bundles/scavio/tests/test_scavio_components.py
+++ b/src/bundles/scavio/tests/test_scavio_components.py
@@ -1,0 +1,645 @@
+"""Unit tests for the Scavio extension bundle (``lfx-scavio``).
+
+Everything runs offline: ``httpx.Client`` is patched, so no key and no network
+access are needed. The suite guards three things the API has already broken once:
+
+1. Endpoint coverage - the bundle exposes every live billable Scavio endpoint,
+   at the right credit cost, and none of the retired ones.
+2. Wire names - the handful of endpoints whose field name is not what a caller
+   would guess (``search`` on YouTube/X/LinkedIn job search, the ASIN in
+   ``asin`` on Amazon, ``product_id`` on Walmart, ``keyword`` on Instagram, a
+   string ``cursor`` on TikTok).
+3. Envelopes - Google answers flat, every other product wraps in ``data``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from lfx.schema.dataframe import DataFrame
+
+from lfx_scavio import (
+    ScavioAmazonComponent,
+    ScavioGoogleAIModeComponent,
+    ScavioGoogleFlightsComponent,
+    ScavioGoogleHotelsComponent,
+    ScavioGoogleMapsComponent,
+    ScavioGoogleNewsComponent,
+    ScavioGoogleShoppingComponent,
+    ScavioGoogleTrendsComponent,
+    ScavioInstagramComponent,
+    ScavioLinkedInComponent,
+    ScavioRedditComponent,
+    ScavioSearchComponent,
+    ScavioTikTokComponent,
+    ScavioTikTokShopComponent,
+    ScavioWalmartComponent,
+    ScavioXComponent,
+    ScavioYouTubeComponent,
+)
+
+ALL_COMPONENTS = (
+    ScavioSearchComponent,
+    ScavioGoogleAIModeComponent,
+    ScavioGoogleMapsComponent,
+    ScavioGoogleShoppingComponent,
+    ScavioGoogleNewsComponent,
+    ScavioGoogleTrendsComponent,
+    ScavioGoogleFlightsComponent,
+    ScavioGoogleHotelsComponent,
+    ScavioYouTubeComponent,
+    ScavioAmazonComponent,
+    ScavioWalmartComponent,
+    ScavioRedditComponent,
+    ScavioTikTokComponent,
+    ScavioTikTokShopComponent,
+    ScavioInstagramComponent,
+    ScavioXComponent,
+    ScavioLinkedInComponent,
+)
+
+# The live billable surface, taken from the Scavio route definitions.
+# /api/v1/google was retired on 2026-08-04 and now answers 410; the five retired
+# LinkedIn paths answer 410 and are never billed; /api/v1/youtube/metadata is a
+# deprecated alias of /api/v1/youtube/video. None of them belong here.
+LIVE_ENDPOINTS = {
+    # Google v2 - 14 endpoints, 1 credit each
+    "/api/v2/google": 1,
+    "/api/v2/google/ai-mode": 1,
+    "/api/v2/google/maps/search": 1,
+    "/api/v2/google/maps/place": 1,
+    "/api/v2/google/maps/reviews": 1,
+    "/api/v2/google/shopping": 1,
+    "/api/v2/google/shopping/product": 1,
+    "/api/v2/google/shopping/product/stores": 1,
+    "/api/v2/google/flights": 1,
+    "/api/v2/google/hotels": 1,
+    "/api/v2/google/hotels/detail": 1,
+    "/api/v2/google/news": 1,
+    "/api/v2/google/trends": 1,
+    "/api/v2/google/trending": 1,
+    # YouTube - 15 exposed endpoints
+    "/api/v1/youtube/search": 2,
+    "/api/v1/youtube/shorts": 2,
+    "/api/v1/youtube/suggestions": 1,
+    "/api/v1/youtube/video": 1,
+    "/api/v1/youtube/comments": 1,
+    "/api/v1/youtube/comments/replies": 1,
+    "/api/v1/youtube/transcript": 8,
+    "/api/v1/youtube/related": 1,
+    "/api/v1/youtube/streams": 3,
+    "/api/v1/youtube/channel/search": 1,
+    "/api/v1/youtube/channel": 1,
+    "/api/v1/youtube/channel/videos": 1,
+    "/api/v1/youtube/channel/shorts": 1,
+    "/api/v1/youtube/channel/community": 1,
+    "/api/v1/youtube/channel/resolve": 1,
+    # Amazon - 3 billable endpoints
+    "/api/v1/amazon/search": 1,
+    "/api/v1/amazon/product": 1,
+    "/api/v1/amazon/offers": 1,
+    # Walmart - 2
+    "/api/v1/walmart/search": 1,
+    "/api/v1/walmart/product": 1,
+    # Reddit - 12, 1 credit each (it was 2 before Reddit moved providers)
+    "/api/v1/reddit/search": 1,
+    "/api/v1/reddit/search/suggestions": 1,
+    "/api/v1/reddit/post": 1,
+    "/api/v1/reddit/post/comments": 1,
+    "/api/v1/reddit/post/comments/replies": 1,
+    "/api/v1/reddit/subreddit": 1,
+    "/api/v1/reddit/subreddit/posts": 1,
+    "/api/v1/reddit/user": 1,
+    "/api/v1/reddit/user/posts": 1,
+    "/api/v1/reddit/user/comments": 1,
+    "/api/v1/reddit/popular": 1,
+    "/api/v1/reddit/trending": 1,
+    # TikTok - 11
+    "/api/v1/tiktok/profile": 1,
+    "/api/v1/tiktok/user/posts": 1,
+    "/api/v1/tiktok/user/followers": 1,
+    "/api/v1/tiktok/user/followings": 1,
+    "/api/v1/tiktok/video": 1,
+    "/api/v1/tiktok/video/comments": 1,
+    "/api/v1/tiktok/video/comments/replies": 1,
+    "/api/v1/tiktok/search/videos": 1,
+    "/api/v1/tiktok/search/users": 1,
+    "/api/v1/tiktok/hashtag": 1,
+    "/api/v1/tiktok/hashtag/videos": 1,
+    # TikTok Shop - 8
+    "/api/v1/tiktok-shop/search": 1,
+    "/api/v1/tiktok-shop/search/suggestions": 1,
+    "/api/v1/tiktok-shop/product": 1,
+    "/api/v1/tiktok-shop/product/reviews": 1,
+    "/api/v1/tiktok-shop/categories": 1,
+    "/api/v1/tiktok-shop/category/products": 1,
+    "/api/v1/tiktok-shop/shop/products": 1,
+    "/api/v1/tiktok-shop/resolve": 1,
+    # Instagram - 12, per-endpoint credits, never a flat rate
+    "/api/v1/instagram/profile": 10,
+    "/api/v1/instagram/user/posts": 2,
+    "/api/v1/instagram/user/reels": 10,
+    "/api/v1/instagram/user/tagged": 10,
+    "/api/v1/instagram/user/stories": 10,
+    "/api/v1/instagram/post": 8,
+    "/api/v1/instagram/post/comments": 10,
+    "/api/v1/instagram/post/comments/replies": 8,
+    "/api/v1/instagram/search/users": 10,
+    "/api/v1/instagram/search/hashtags": 10,
+    "/api/v1/instagram/user/followers": 10,
+    "/api/v1/instagram/user/followings": 10,
+    # X - 11
+    "/api/v1/x/search": 1,
+    "/api/v1/x/tweet": 1,
+    "/api/v1/x/tweet/comments": 1,
+    "/api/v1/x/tweet/retweeters": 1,
+    "/api/v1/x/user": 1,
+    "/api/v1/x/user/tweets": 1,
+    "/api/v1/x/user/replies": 1,
+    "/api/v1/x/user/media": 1,
+    "/api/v1/x/user/followers": 1,
+    "/api/v1/x/user/followings": 1,
+    "/api/v1/x/trending": 1,
+    # LinkedIn - the 9 live endpoints, three credit tiers
+    "/api/v1/linkedin/person": 1,
+    "/api/v1/linkedin/person/about": 1,
+    "/api/v1/linkedin/person/posts": 10,
+    "/api/v1/linkedin/company": 1,
+    "/api/v1/linkedin/company/posts": 10,
+    "/api/v1/linkedin/search/jobs": 10,
+    "/api/v1/linkedin/job": 30,
+    "/api/v1/linkedin/post": 1,
+    "/api/v1/linkedin/post/comments": 10,
+}
+
+RETIRED_PATHS = {
+    "/api/v1/google",
+    "/api/v1/youtube/metadata",
+    "/api/v1/linkedin/person/contact",
+    "/api/v1/linkedin/company/people",
+    "/api/v1/linkedin/company/jobs",
+    "/api/v1/linkedin/search/people",
+    "/api/v1/linkedin/search/posts",
+}
+
+GOOGLE_V1_ONLY_PARAMS = {"light_request", "country_code", "language", "search_type", "page"}
+
+
+def mock_client(json_data=None, status_code=200, text=""):
+    """Return a MagicMock standing in for ``httpx.Client`` used as a context manager."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = {} if json_data is None else json_data
+    response.text = text
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=MagicMock(), response=response)
+    else:
+        response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.__enter__.return_value.post.return_value = response
+    return client
+
+
+def call_args(client):
+    """Return (url, payload) from the single POST the component made."""
+    post = client.__enter__.return_value.post
+    post.assert_called_once()
+    return post.call_args.args[0], post.call_args.kwargs["json"]
+
+
+def run(component, json_data=None, status_code=200, text=""):
+    """Run ``fetch_content`` against a mocked transport and return (results, url, payload)."""
+    client = mock_client(json_data, status_code, text)
+    with patch("httpx.Client", return_value=client):
+        results = component.fetch_content()
+    if status_code >= 400:
+        return results, None, None
+    url, payload = call_args(client)
+    return results, url, payload
+
+
+def endpoint_map():
+    """Return {path: credits} for every endpoint the bundle offers, asserting no path repeats."""
+    seen: dict[str, int] = {}
+    for component in ALL_COMPONENTS:
+        for endpoint in component.ENDPOINTS.values():
+            assert endpoint.path not in seen, f"{endpoint.path} is offered by two components"
+            seen[endpoint.path] = endpoint.credits
+    return seen
+
+
+class TestEndpointCoverage:
+    def test_every_live_endpoint_is_exposed(self):
+        assert set(endpoint_map()) == set(LIVE_ENDPOINTS)
+
+    def test_endpoint_count_is_the_full_live_surface(self):
+        assert len(endpoint_map()) == 97
+
+    def test_credit_costs_match_the_api(self):
+        assert endpoint_map() == LIVE_ENDPOINTS
+
+    def test_no_retired_endpoint_is_exposed(self):
+        assert set(endpoint_map()).isdisjoint(RETIRED_PATHS)
+
+    def test_every_platform_has_a_component(self):
+        paths = set(endpoint_map())
+        for prefix in (
+            "/api/v2/google",
+            "/api/v1/youtube/",
+            "/api/v1/amazon/",
+            "/api/v1/walmart/",
+            "/api/v1/reddit/",
+            "/api/v1/tiktok/",
+            "/api/v1/tiktok-shop/",
+            "/api/v1/instagram/",
+            "/api/v1/x/",
+            "/api/v1/linkedin/",
+        ):
+            assert any(path.startswith(prefix) for path in paths), prefix
+
+    def test_required_fields_are_declared_fields(self):
+        for component in ALL_COMPONENTS:
+            declared = {field.name for field in component.inputs}
+            for label, endpoint in component.ENDPOINTS.items():
+                missing = set(endpoint.fields) - declared
+                assert not missing, f"{component.name}/{label} references undeclared inputs {missing}"
+                assert set(endpoint.required) <= set(endpoint.fields), f"{component.name}/{label}"
+
+    def test_default_endpoint_exists(self):
+        for component in ALL_COMPONENTS:
+            assert component.DEFAULT_ENDPOINT in component.ENDPOINTS, component.name
+
+
+class TestGoogleSearch:
+    def test_targets_v2_and_sends_v2_params_only(self):
+        component = ScavioSearchComponent(
+            api_key="sk_live_test",  # pragma: allowlist secret
+            query="serpapi alternative",
+            gl="us",
+            hl="en",
+            google_domain="google.com",
+            device="desktop",
+            start=10,
+        )
+        _results, url, payload = run(component, {"organic_results": []})
+
+        assert url == "https://api.scavio.dev/api/v2/google"
+        assert payload["query"] == "serpapi alternative"
+        assert payload["gl"] == "us"
+        assert payload["hl"] == "en"
+        assert payload["google_domain"] == "google.com"
+        assert payload["start"] == 10
+        # Google v1 is gone; none of its params may leak onto the v2 call.
+        assert GOOGLE_V1_ONLY_PARAMS.isdisjoint(payload)
+
+    def test_parses_flat_organic_results(self):
+        body = {
+            "search_parameters": {"q": "openai"},
+            "organic_results": [
+                {
+                    "title": f"Result {i}",
+                    "link": f"https://example.com/{i}",
+                    "snippet": f"Description {i}",
+                    "position": i,
+                }
+                for i in range(1, 6)
+            ],
+            "credits_used": 1,
+        }
+        component = ScavioSearchComponent(api_key="k", query="openai")  # pragma: allowlist secret
+        results, _url, _payload = run(component, body)
+
+        assert len(results) == 5
+        assert results[0].data["title"] == "Result 1"
+        assert results[0].data["url"] == "https://example.com/1"
+        assert results[0].data["content"] == "Description 1"
+        assert results[0].text == "Description 1"
+
+    def test_respects_max_results(self):
+        body = {"organic_results": [{"title": str(i), "link": "u", "snippet": "s"} for i in range(10)]}
+        component = ScavioSearchComponent(api_key="k", query="openai", max_results=2)  # pragma: allowlist secret
+        results, _url, _payload = run(component, body)
+        assert len(results) == 2
+
+    def test_dataframe_output(self):
+        body = {"organic_results": [{"title": "a", "link": "u", "snippet": "s"}]}
+        component = ScavioSearchComponent(api_key="k", query="openai")  # pragma: allowlist secret
+        client = mock_client(body)
+        with patch("httpx.Client", return_value=client):
+            assert isinstance(component.fetch_content_dataframe(), DataFrame)
+
+    def test_resolve_ai_overview_false_is_transmitted(self):
+        component = ScavioSearchComponent(
+            api_key="k",  # pragma: allowlist secret
+            query="openai",
+            resolve_ai_overview=False,
+        )
+        _results, _url, payload = run(component, {"organic_results": []})
+        assert payload["resolve_ai_overview"] is False
+
+    def test_http_error_is_handled(self):
+        component = ScavioSearchComponent(api_key="bad", query="openai")  # pragma: allowlist secret
+        results, _url, _payload = run(component, status_code=401, text="unauthorized")
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+
+class TestGoogleVerticals:
+    def test_maps_reviews_sort_is_sent_as_sort_by(self):
+        component = ScavioGoogleMapsComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Place Reviews",
+            place_id="ChIJtest",
+            reviews_sort_by="newest",
+        )
+        _results, url, payload = run(component, {"reviews": []})
+        assert url.endswith("/api/v2/google/maps/reviews")
+        assert payload["sort_by"] == "newest"
+        assert "reviews_sort_by" not in payload
+
+    def test_shopping_stores_uses_nested_result_key(self):
+        body = {"product_results": {"stores": [{"name": "Store A"}, {"name": "Store B"}]}}
+        component = ScavioGoogleShoppingComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Product Stores",
+            catalog_id="cat1",
+            next_page_token="tok",  # noqa: S106 - a pagination cursor, not a credential
+        )
+        results, _url, _payload = run(component, body)
+        assert [row.data["name"] for row in results] == ["Store A", "Store B"]
+
+    def test_trending_uses_geo_and_renamed_cat_and_status(self):
+        component = ScavioGoogleTrendsComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Trending Now",
+            geo="US",
+            trending_cat=3,
+            trend_status="active",
+        )
+        _results, url, payload = run(component, {"trends": []})
+        assert url.endswith("/api/v2/google/trending")
+        assert payload == {"geo": "US", "cat": 3, "status": "active"}
+
+    def test_ai_mode_reads_references(self):
+        body = {"references": [{"title": "Ref", "link": "https://example.com"}]}
+        component = ScavioGoogleAIModeComponent(api_key="k", query="what is rag")  # pragma: allowlist secret
+        results, url, _payload = run(component, body)
+        assert url.endswith("/api/v2/google/ai-mode")
+        assert results[0].data["title"] == "Ref"
+
+    def test_news_and_flights_and_hotels_paths(self):
+        news = ScavioGoogleNewsComponent(api_key="k", query="ai")  # pragma: allowlist secret
+        _r, url, _p = run(news, {"news_results": []})
+        assert url.endswith("/api/v2/google/news")
+
+        flights = ScavioGoogleFlightsComponent(
+            api_key="k",  # pragma: allowlist secret
+            departure_id="JFK",
+            arrival_id="LHR",
+            outbound_date="2026-09-01",
+        )
+        _r, url, payload = run(flights, {"best_flights": []})
+        assert url.endswith("/api/v2/google/flights")
+        assert payload["departure_id"] == "JFK"
+
+        hotels = ScavioGoogleHotelsComponent(
+            api_key="k",  # pragma: allowlist secret
+            query="Austin hotels",
+            check_in_date="2026-09-01",
+            check_out_date="2026-09-03",
+        )
+        _r, url, _p = run(hotels, {"properties": []})
+        assert url.endswith("/api/v2/google/hotels")
+
+
+class TestReddit:
+    def test_search_sends_only_query_and_cursor(self):
+        component = ScavioRedditComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search",
+            query="serpapi alternative",
+            cursor="abc",
+            sort="TOP",
+            feed_sort="RISING",
+        )
+        _results, url, payload = run(component, {"results": []})
+        assert url.endswith("/api/v1/reddit/search")
+        # The backend silently strips anything else, so the component must not send it.
+        assert payload == {"query": "serpapi alternative", "cursor": "abc"}
+
+    def test_search_reads_results_not_posts(self):
+        body = {"data": {"results": [{"title": "A post"}], "next_cursor": "n", "has_more": True}}
+        component = ScavioRedditComponent(api_key="k", endpoint="Search", query="x")  # pragma: allowlist secret
+        results, _url, _payload = run(component, body)
+        assert len(results) == 1
+        assert results[0].data["title"] == "A post"
+
+    def test_post_is_a_flat_object_with_no_comments(self):
+        body = {"data": {"post_id": "t3_1", "title": "Flat post", "num_comments": 12}}
+        component = ScavioRedditComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Post Details",
+            post_id="t3_1",
+        )
+        results, _url, _payload = run(component, body)
+        assert len(results) == 1
+        assert results[0].data["post_id"] == "t3_1"
+        assert "comments" not in results[0].data
+
+    def test_subreddit_feed_reads_posts(self):
+        body = {"data": {"posts": [{"title": "One"}, {"title": "Two"}]}}
+        component = ScavioRedditComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Subreddit Posts",
+            subreddit="AskReddit",
+            feed_sort="RISING",
+        )
+        results, _url, payload = run(component, body)
+        assert len(results) == 2
+        assert payload["sort"] == "RISING"
+
+    def test_reply_cursor_is_required(self):
+        component = ScavioRedditComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Comment Replies",
+            post_id="t3_1",
+        )
+        client = mock_client({})
+        with patch("httpx.Client", return_value=client):
+            results = component.fetch_content()
+
+        # The request never leaves the component: a reply_cursor is mandatory here.
+        client.__enter__.return_value.post.assert_not_called()
+        assert "cursor" in results[0].data["error"]
+
+
+class TestWireQuirks:
+    def test_youtube_search_uses_the_search_field(self):
+        component = ScavioYouTubeComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search",
+            search="python tutorial",
+        )
+        _results, url, payload = run(component, {"data": {"results": []}})
+        assert url.endswith("/api/v1/youtube/search")
+        assert payload == {"search": "python tutorial"}
+        assert "query" not in payload
+
+    def test_youtube_features_is_a_list(self):
+        component = ScavioYouTubeComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search",
+            search="drone",
+            features=["4k", "hdr"],
+        )
+        _results, _url, payload = run(component, {"data": {"results": []}})
+        assert payload["features"] == ["4k", "hdr"]
+
+    def test_amazon_product_sends_the_asin(self):
+        component = ScavioAmazonComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Product Details",
+            asin="B09V3KXJPB",
+            country="gb",
+        )
+        _results, url, payload = run(component, {"data": {}})
+        assert url.endswith("/api/v1/amazon/product")
+        assert payload == {"asin": "B09V3KXJPB", "country": "gb"}
+
+    def test_walmart_product_sends_product_id(self):
+        component = ScavioWalmartComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Product Details",
+            product_id="123456789",
+        )
+        _results, url, payload = run(component, {"data": {}})
+        assert url.endswith("/api/v1/walmart/product")
+        assert payload == {"product_id": "123456789"}
+
+    def test_tiktok_cursor_stays_a_string(self):
+        component = ScavioTikTokComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="User Posts",
+            sec_user_id="MS4wLjAB",
+            cursor="20",
+            count=30,
+        )
+        _results, _url, payload = run(component, {"data": {"aweme_list": []}})
+        assert payload["cursor"] == "20"
+        assert isinstance(payload["cursor"], str)
+        assert payload["count"] == 30
+
+    def test_instagram_search_uses_keyword(self):
+        component = ScavioInstagramComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search Users",
+            keyword="fashion",
+        )
+        _results, url, payload = run(component, {"data": {"users": []}})
+        assert url.endswith("/api/v1/instagram/search/users")
+        assert payload == {"keyword": "fashion"}
+        assert "query" not in payload
+
+    def test_x_search_uses_the_search_field(self):
+        component = ScavioXComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search",
+            search="langflow",
+            search_type="Latest",
+        )
+        _results, url, payload = run(component, {"data": {"timeline": []}})
+        assert url.endswith("/api/v1/x/search")
+        assert payload == {"search": "langflow", "search_type": "Latest"}
+
+    def test_x_followings_reads_the_following_array(self):
+        body = {"data": {"following": [{"screen_name": "a"}, {"screen_name": "b"}]}}
+        component = ScavioXComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="User Followings",
+            screen_name="elonmusk",
+        )
+        results, _url, _payload = run(component, body)
+        assert len(results) == 2
+
+    def test_linkedin_job_search_uses_the_search_field(self):
+        component = ScavioLinkedInComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Job Search",
+            search="software engineer",
+            location="Berlin",
+        )
+        _results, url, payload = run(component, {"data": {"data": []}})
+        assert url.endswith("/api/v1/linkedin/search/jobs")
+        assert payload == {"search": "software engineer", "location": "Berlin"}
+
+    def test_tiktok_shop_search_uses_the_search_field(self):
+        component = ScavioTikTokShopComponent(
+            api_key="k",  # pragma: allowlist secret
+            endpoint="Search",
+            search="phone case",
+        )
+        _results, url, payload = run(component, {"data": {"products": []}})
+        assert url.endswith("/api/v1/tiktok-shop/search")
+        # Search is US-catalog only: there is no region param on this endpoint.
+        assert payload == {"search": "phone case"}
+
+
+class TestEnvelopes:
+    def test_google_is_flat(self):
+        component = ScavioGoogleNewsComponent(api_key="k", query="ai")  # pragma: allowlist secret
+        results, _url, _payload = run(component, {"news_results": [{"title": "Headline"}], "credits_used": 1})
+        assert results[0].data["title"] == "Headline"
+
+    def test_other_products_unwrap_data(self):
+        component = ScavioXComponent(api_key="k", endpoint="User Profile", screen_name="a")  # pragma: allowlist secret
+        body = {"data": {"screen_name": "a", "followers_count": 5}, "response_time": 1, "credits_used": 1}
+        results, _url, _payload = run(component, body)
+        assert results[0].data == {"screen_name": "a", "followers_count": 5}
+
+    def test_raw_output_keeps_the_credit_counters(self):
+        component = ScavioXComponent(api_key="k", endpoint="Trending")  # pragma: allowlist secret
+        body = {"data": {"trends": []}, "response_time": 12, "credits_used": 1, "credits_remaining": 49}
+        client = mock_client(body)
+        with patch("httpx.Client", return_value=client):
+            raw = component.fetch_raw()
+        assert raw.data["credits_remaining"] == 49
+
+
+class TestBuildConfig:
+    @pytest.mark.parametrize(
+        ("component_cls", "label"),
+        [
+            (ScavioRedditComponent, "Subreddit Posts"),
+            (ScavioYouTubeComponent, "Transcript"),
+            (ScavioLinkedInComponent, "Job Details"),
+            (ScavioInstagramComponent, "Comment Replies"),
+        ],
+    )
+    def test_only_the_selected_endpoints_fields_are_shown(self, component_cls, label):
+        component = component_cls()
+        build_config = {name: {"show": True, "required": False} for name in component_cls.MANAGED_FIELDS}
+        build_config["endpoint"] = {"value": label}
+
+        updated = component.update_build_config(build_config, label, "endpoint")
+
+        endpoint = component_cls.ENDPOINTS[label]
+        for name in component_cls.MANAGED_FIELDS:
+            assert updated[name]["show"] is (name in endpoint.fields), name
+            assert updated[name]["required"] is (name in endpoint.required), name
+
+    def test_unrelated_field_updates_are_ignored(self):
+        component = ScavioRedditComponent()
+        build_config = {"query": {"show": False, "required": False}, "endpoint": {"value": "Search"}}
+        assert component.update_build_config(build_config, "x", "query") == build_config
+
+    def test_fresh_node_shows_the_default_endpoints_fields(self):
+        """A node dropped on the canvas must be usable before the dropdown is touched."""
+        for component_cls in ALL_COMPONENTS:
+            managed = set(component_cls.MANAGED_FIELDS)
+            if not managed:
+                continue
+            endpoint = component_cls.ENDPOINTS[component_cls.DEFAULT_ENDPOINT]
+            for field in component_cls.inputs:
+                if field.name in managed:
+                    assert field.show is (field.name in endpoint.fields), f"{component_cls.name}.{field.name}"
+                    assert field.required is (field.name in endpoint.required), f"{component_cls.name}.{field.name}"

--- a/src/frontend/src/icons/Scavio/Scavio.jsx
+++ b/src/frontend/src/icons/Scavio/Scavio.jsx
@@ -1,0 +1,18 @@
+const Scavio = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 32 32"
+    fill="none"
+    {...props}
+  >
+    <rect width="32" height="32" rx="8" fill="#1D4ED8" />
+    <circle cx="14" cy="14" r="5.5" stroke="white" strokeWidth="2" />
+    <line x1="18" y1="18" x2="23" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round" />
+    <circle cx="14" cy="11.5" r="1" fill="white" />
+    <circle cx="12" cy="14.5" r="1" fill="white" />
+    <circle cx="16" cy="14.5" r="1" fill="white" />
+  </svg>
+);
+export default Scavio;

--- a/src/frontend/src/icons/Scavio/Scavio.jsx
+++ b/src/frontend/src/icons/Scavio/Scavio.jsx
@@ -9,7 +9,15 @@ const Scavio = (props) => (
   >
     <rect width="32" height="32" rx="8" fill="#1D4ED8" />
     <circle cx="14" cy="14" r="5.5" stroke="white" strokeWidth="2" />
-    <line x1="18" y1="18" x2="23" y2="23" stroke="white" strokeWidth="2" strokeLinecap="round" />
+    <line
+      x1="18"
+      y1="18"
+      x2="23"
+      y2="23"
+      stroke="white"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
     <circle cx="14" cy="11.5" r="1" fill="white" />
     <circle cx="12" cy="14.5" r="1" fill="white" />
     <circle cx="16" cy="14.5" r="1" fill="white" />

--- a/src/frontend/src/icons/Scavio/index.tsx
+++ b/src/frontend/src/icons/Scavio/index.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import { forwardRef } from "react";
+import Scavio from "./Scavio";
+
+export const ScavioIcon = forwardRef<
+  SVGSVGElement,
+  React.PropsWithChildren<{ isDark?: boolean }>
+>((props, ref) => {
+  const { isDark, ...rest } = props;
+  return <Scavio ref={ref} isdark={isDark?.toString()} {...rest} />;
+});
+
+ScavioIcon.displayName = "ScavioIcon";

--- a/src/frontend/src/icons/lazyIconImports.ts
+++ b/src/frontend/src/icons/lazyIconImports.ts
@@ -433,6 +433,8 @@ export const lazyIconsMapping = {
     import("@/icons/SearchVector").then((mod) => ({
       default: mod.SearchVectorIcon,
     })),
+  Scavio: () =>
+    import("@/icons/Scavio").then((mod) => ({ default: mod.ScavioIcon })),
   Searx: () =>
     import("@/icons/Searx").then((mod) => ({ default: mod.SearxIcon })),
   SerpSearch: () =>

--- a/uv.lock
+++ b/uv.lock
@@ -94,8 +94,8 @@ wheels = [
 
 [package.optional-dependencies]
 http-server = [
-    { name = "sse-starlette" },
-    { name = "starlette" },
+    { name = "sse-starlette", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "starlette", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ name = "a2wsgi"
 version = "1.10.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/cb/822c56fbea97e9eee201a2e434a80437f6750ebcb1ed307ee3a0a7505b14/a2wsgi-1.10.10.tar.gz", hash = "sha256:a5bcffb52081ba39df0d5e9a884fc6f819d92e3a42389343ba77cbf809fe1f45", size = 18799, upload-time = "2025-06-18T09:00:10.843Z" }
 wheels = [
@@ -232,7 +232,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -261,7 +261,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -428,7 +428,7 @@ name = "aiohttp-retry"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
 wheels = [
@@ -467,9 +467,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -494,8 +494,8 @@ name = "aiosmtpd"
 version = "1.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "atpublic" },
-    { name = "attrs" },
+    { name = "atpublic", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "attrs", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/ca/b2b7cc880403ef24be77383edaadfcf0098f5d7b9ddbf3e2c17ef0a6af0d/aiosmtpd-1.4.6.tar.gz", hash = "sha256:5a811826e1a5a06c25ebc3e6c4a704613eb9a1bcf6b78428fbe865f4f6c9a4b8", size = 152775, upload-time = "2024-05-18T11:37:50.029Z" }
 wheels = [
@@ -603,10 +603,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "apify-shared" },
-    { name = "colorama" },
-    { name = "impit" },
-    { name = "more-itertools" },
+    { name = "apify-shared", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11'" },
+    { name = "impit", marker = "python_full_version < '3.11'" },
+    { name = "more-itertools", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/e4/1eaee14189886362a7d5629c362fb1bdc5bb36d506c99e97e866eea5a0e9/apify_client-2.5.1.tar.gz", hash = "sha256:ff8457c9cc14cbfe0eefb337a8c0a33f4d81e7760768bdd036e7470a5bc63c24", size = 380576, upload-time = "2026-05-20T09:43:36.461Z" }
 wheels = [
@@ -635,10 +635,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama" },
-    { name = "impit" },
-    { name = "more-itertools" },
-    { name = "pydantic", extra = ["email"] },
+    { name = "colorama", marker = "python_full_version >= '3.11'" },
+    { name = "impit", marker = "python_full_version >= '3.11'" },
+    { name = "more-itertools", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/c8/6aaee683e2c94b6545dbf76ac361a7fa0866531a7747a2de15bc2a97162b/apify_client-3.1.0.tar.gz", hash = "sha256:08c2b31f7f74a36ab2abc6235bb118bb4d522a84e65a3f0b75c452c4872aa4fe", size = 128468, upload-time = "2026-07-20T07:07:06.601Z" }
 wheels = [
@@ -823,7 +823,7 @@ name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", version = "4.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "async-timeout", version = "4.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
 wheels = [
@@ -1225,15 +1225,15 @@ name = "bert-score"
 version = "0.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "tqdm" },
-    { name = "transformers" },
+    { name = "matplotlib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/93/2c97a85cbb66a8a256a13176e11c9c4508074e2341299fe75ee955c81eff/bert_score-0.3.13.tar.gz", hash = "sha256:8ffe5838eac8cdd988b8b1a896af7f49071188c8c011a1ed160d71a9899a2ba4", size = 48621, upload-time = "2023-02-20T21:07:29.477Z" }
 wheels = [
@@ -1545,14 +1545,14 @@ name = "browsergym-core"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "gymnasium" },
-    { name = "lxml" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pillow" },
-    { name = "playwright" },
-    { name = "pyparsing" },
+    { name = "beautifulsoup4", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "gymnasium", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "lxml", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "playwright", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pyparsing", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/5b/d2285220dbcd74f18ab91fa823792fc0f1672bba569cf8f576c5eb5a79a5/browsergym_core-0.13.0.tar.gz", hash = "sha256:cd9caaaaf5738e84134b4c562a2118cb26cd9caf38a8cba50b9226db0f839d8f", size = 178581, upload-time = "2024-11-07T20:35:08.908Z" }
 wheels = [
@@ -1919,9 +1919,9 @@ name = "choreographer"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "logistro" },
-    { name = "platformdirs" },
-    { name = "simplejson" },
+    { name = "logistro", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "simplejson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
 wheels = [
@@ -2204,7 +2204,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -2293,7 +2293,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -2780,7 +2780,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -2848,8 +2848,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "cffi", marker = "(python_full_version < '3.11' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -2918,57 +2918,57 @@ name = "cuga"
 version = "0.2.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "a2a-sdk", extra = ["http-server"] },
-    { name = "aiohttp" },
-    { name = "aiosmtpd" },
-    { name = "asyncpg" },
-    { name = "beautifulsoup4" },
-    { name = "boto3" },
-    { name = "browsergym-core" },
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "cuga-oak-health", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "docker" },
-    { name = "dynaconf" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "fastembed" },
-    { name = "fastmcp" },
-    { name = "httpx" },
-    { name = "hvac" },
-    { name = "langchain" },
-    { name = "langchain-core" },
-    { name = "langchain-docling" },
-    { name = "langchain-groq" },
-    { name = "langchain-ibm" },
-    { name = "langchain-litellm", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-mcp-adapters" },
-    { name = "langchain-ollama" },
-    { name = "langchain-openai" },
-    { name = "langchain-text-splitters" },
-    { name = "langfuse" },
-    { name = "langgraph" },
-    { name = "litellm" },
-    { name = "loguru" },
-    { name = "markdownify" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "pgvector" },
-    { name = "playwright" },
-    { name = "psutil" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "pymilvus", extra = ["milvus-lite"] },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "sqlite-vec" },
-    { name = "tavily-python" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "typer" },
-    { name = "typer-slim" },
-    { name = "uvicorn" },
+    { name = "a2a-sdk", extra = ["http-server"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "aiohttp", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "aiosmtpd", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "asyncpg", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "beautifulsoup4", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "boto3", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "browsergym-core", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "cuga-oak-health", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "docker", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "dynaconf", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastapi", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastembed", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastmcp", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "hvac", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-core", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-docling", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-groq", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-ibm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-litellm", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-mcp-adapters", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-ollama", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-openai", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langchain-text-splitters", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langfuse", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "langgraph", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "litellm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "loguru", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "markdownify", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "mcp", extra = ["cli"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pgvector", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "playwright", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "psutil", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "psycopg", extra = ["binary"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pymilvus", extra = ["milvus-lite"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "python-dotenv", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "sqlite-vec", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tavily-python", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typer-slim", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/93/a64555661bc99c1ae06347df5ff63bbfc593f98a391e2ff905cb8f6553a3/cuga-0.2.28.tar.gz", hash = "sha256:aa28ab4dce691783ff0e2a3a6f0eff3dcb978080269d08cad9581f0bdd49e377", size = 3140162, upload-time = "2026-05-10T13:25:22.039Z" }
 wheels = [
@@ -2980,9 +2980,9 @@ name = "cuga-oak-health"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi" },
-    { name = "pydantic" },
-    { name = "uvicorn" },
+    { name = "fastapi", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pydantic", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/b94a6ee122d09e7a0aa12ddb964a2a3c769f98149f68ae8654a55e4f64c3/cuga_oak_health-1.3.0.tar.gz", hash = "sha256:53800bcfc30a89d7046dfcc8225f746f81077fd9816b0cd88f215506775b37b9", size = 79358, upload-time = "2026-03-22T15:30:43.666Z" }
 wheels = [
@@ -3000,8 +3000,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic" },
-    { name = "typing-extensions" },
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -3775,12 +3775,12 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "httpx", marker = "python_full_version == '3.12.*'" },
+    { name = "pydantic", marker = "python_full_version == '3.12.*'" },
+    { name = "pydantic-core", marker = "python_full_version == '3.12.*'" },
+    { name = "requests", marker = "python_full_version == '3.12.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "websockets", marker = "python_full_version == '3.12.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/83/fd165b38a69a4a40746926a908ea92e456a0e0dd5b6038836c9cc94a3487/elevenlabs-1.58.1.tar.gz", hash = "sha256:e9f723a528c1bbd80605e639e858f7a58f204860faa9417305a4083508c7c0fb", size = 185830, upload-time = "2025-05-07T13:54:37.814Z" }
 wheels = [
@@ -3809,12 +3809,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "httpx", marker = "python_full_version != '3.12.*'" },
+    { name = "pydantic", marker = "python_full_version != '3.12.*'" },
+    { name = "pydantic-core", marker = "python_full_version != '3.12.*'" },
+    { name = "requests", marker = "python_full_version != '3.12.*'" },
+    { name = "typing-extensions", marker = "python_full_version != '3.12.*'" },
+    { name = "websockets", marker = "python_full_version != '3.12.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/5f/01197145be5be258abdce254010eb300868b85fbf6cf1c6c1538a68caef4/elevenlabs-1.59.0.tar.gz", hash = "sha256:16e735bd594e86d415dd445d249c8cc28b09996cfd627fbc10102c0a84698859", size = 200549, upload-time = "2025-05-15T12:19:28.868Z" }
 wheels = [
@@ -3857,17 +3857,17 @@ name = "evaluate"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "dill" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
+    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "dill", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "fsspec", extra = ["http"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "multiprocess", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "xxhash", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/d0/0c17a8e6e8dc7245f22dea860557c32bae50fc4d287ae030cb0e8ab8720f/evaluate-0.4.6.tar.gz", hash = "sha256:e07036ca12b3c24331f83ab787f21cc2dbf3631813a1631e63e40897c69a3f21", size = 65716, upload-time = "2025-09-18T13:06:30.581Z" }
 wheels = [
@@ -3956,7 +3956,7 @@ name = "face"
 version = "26.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boltons" },
+    { name = "boltons", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/fd/f84f0600bd72953d5a322f0dedbd4f900e2cedab718e6b6a093ae2d16aae/face-26.0.1.tar.gz", hash = "sha256:8183d94bc248baaea855a9f8445f97a22a9988908e60abddccc6e251da77c4c6", size = 51754, upload-time = "2026-06-17T23:14:39.938Z" }
 wheels = [
@@ -3986,9 +3986,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/85/ee4bafafa70bc99904a61f06e7f5e36d06ab6b37335e687085786f9a248d/faiss_cpu-1.9.0.post1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e18602465f5a96c3c973ab440f9263a0881034fb54810be20bc8cdb8b069456d", size = 7672124, upload-time = "2024-11-20T02:20:02.33Z" },
@@ -4023,8 +4023,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -4120,15 +4120,15 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"] },
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "pydantic-extra-types" },
-    { name = "pydantic-settings" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "email-validator", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastar", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "jinja2", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pydantic-extra-types", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pydantic-settings", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "python-multipart", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 
 [[package]]
@@ -4136,10 +4136,10 @@ name = "fastapi-cli"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit" },
-    { name = "tomli", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "rich-toolkit", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/eb/3b534c6f8e157f9ddbf2a153512307c886cad0b258739c200dd8ff8c4452/fastapi_cli-0.0.32.tar.gz", hash = "sha256:38024d2345275e1b37ce8848727a580d84901b570e96b3256d9d36a9a5039424", size = 26636, upload-time = "2026-07-16T12:16:58.678Z" }
 wheels = [
@@ -4148,8 +4148,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "fastapi-cloud-cli", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 
 [[package]]
@@ -4157,15 +4157,15 @@ name = "fastapi-cloud-cli"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "detect-installer" },
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "rich-toolkit" },
-    { name = "rignore" },
-    { name = "sentry-sdk" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "detect-installer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastar", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "rich-toolkit", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "rignore", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "sentry-sdk", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/f2/36bfe990baa656de89a2b98a77a15dcd018474f7245c8e4a10cada0553c5/fastapi_cloud_cli-0.22.2.tar.gz", hash = "sha256:7ec78c1fed58f578af5eb1fb54ec4b456eba4dc1eaca1c3a93cf499a7cbc7ab3", size = 94480, upload-time = "2026-07-14T09:27:01.349Z" }
 wheels = [
@@ -4401,17 +4401,17 @@ name = "fastembed"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "loguru" },
-    { name = "mmh3" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "py-rust-stemmers" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
+    { name = "huggingface-hub", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "loguru", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "mmh3", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "py-rust-stemmers", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tokenizers", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tqdm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
@@ -4599,7 +4599,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future" },
+    { name = "future", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -4935,10 +4935,10 @@ name = "gassist"
 version = "0.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama" },
-    { name = "flask" },
-    { name = "flask-cors" },
-    { name = "tqdm" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "flask", marker = "sys_platform == 'win32'" },
+    { name = "flask-cors", marker = "sys_platform == 'win32'" },
+    { name = "tqdm", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/2e/f79632d7300874f7f0e60b61a6ab22455a245e1556116a1729542a77b0da/gassist-0.0.1-py3-none-any.whl", hash = "sha256:bb0fac74b453153a6c74b2db40a14fdde7879cbc10ec692ed170e576c8e2b6aa", size = 23819, upload-time = "2025-05-09T18:22:23.609Z" },
@@ -4949,11 +4949,11 @@ name = "gdown"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "filelock" },
-    { name = "requests", extra = ["socks"] },
-    { name = "tqdm" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "beautifulsoup4", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", extra = ["socks"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
 wheels = [
@@ -5142,9 +5142,9 @@ name = "glom"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "boltons" },
-    { name = "face" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "boltons", marker = "python_full_version >= '3.12'" },
+    { name = "face", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/74/8387f95565ba7c30cd152a585b275ebb9a834d1d32782425c5d2fe0a102c/glom-25.12.0.tar.gz", hash = "sha256:1ae7da88be3693df40ad27bdf57a765a55c075c86c971bcddd67927403eb0069", size = 196128, upload-time = "2025-12-29T06:29:07.274Z" }
 wheels = [
@@ -5701,11 +5701,11 @@ name = "gymnasium"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle" },
-    { name = "farama-notifications" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions" },
+    { name = "cloudpickle", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "farama-notifications", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
 wheels = [
@@ -5916,7 +5916,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -5937,7 +5937,7 @@ name = "hvac"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
 wheels = [
@@ -6123,16 +6123,16 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "ibm-cos-sdk" },
-    { name = "lomond" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "urllib3" },
+    { name = "cachetools", marker = "python_full_version < '3.11'" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "httpx", marker = "python_full_version < '3.11'" },
+    { name = "ibm-cos-sdk", marker = "python_full_version < '3.11'" },
+    { name = "lomond", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "tabulate", marker = "python_full_version < '3.11'" },
+    { name = "urllib3", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/56/2e3df38a1f13062095d7bde23c87a92f3898982993a15186b1bfecbd206f/ibm_watsonx_ai-1.3.42.tar.gz", hash = "sha256:ee5be59009004245d957ce97d1227355516df95a2640189749487614fef674ff", size = 688651, upload-time = "2025-10-01T13:35:41.527Z" }
 wheels = [
@@ -6161,16 +6161,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "ibm-cos-sdk" },
-    { name = "lomond" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "urllib3" },
+    { name = "cachetools", marker = "python_full_version >= '3.11'" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-cos-sdk", marker = "python_full_version >= '3.11'" },
+    { name = "lomond", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "tabulate", marker = "python_full_version >= '3.11'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/23/e47882874980299fda04aec031926fc52b6ea1a7e0f4be66d3108decf664/ibm_watsonx_ai-1.6.0.tar.gz", hash = "sha256:707dbfe8c641a0053114037c2e56f85fa20028c50af20d96338c3ac92185e0d7", size = 739403, upload-time = "2026-07-15T11:58:24.115Z" }
 wheels = [
@@ -6182,9 +6182,9 @@ name = "ibm-watsonx-orchestrate-clients"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cloud-sdk-core" },
-    { name = "ibm-watsonx-orchestrate-core" },
-    { name = "websocket-client" },
+    { name = "ibm-cloud-sdk-core", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/80/778542ed944c64792c26fe453ebd257ddd766c1aefd8827a9fceda4618b9/ibm_watsonx_orchestrate_clients-2.12.0.tar.gz", hash = "sha256:fc2bb4444dca1e73a5f937f79a5a268196e7678d7164eb32e418f70570cbf71a", size = 1889, upload-time = "2026-06-26T23:50:05.922Z" }
 wheels = [
@@ -6196,8 +6196,8 @@ name = "ibm-watsonx-orchestrate-core"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "pyyaml" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/ed/6f0d7222d14aa9edae04c7148a2640dc2bb1792cf3e03ec7c86956376cbb/ibm_watsonx_orchestrate_core-2.12.0.tar.gz", hash = "sha256:3cd07e9a51bfb55fe672fb3baab4cd7d94c04aa3ce0bc024c5921811788b2bbb", size = 1227, upload-time = "2026-06-26T23:50:06.601Z" }
 wheels = [
@@ -6492,17 +6492,17 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -6531,18 +6531,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -6554,7 +6554,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -7029,10 +7029,10 @@ name = "kaleido"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "choreographer" },
-    { name = "logistro" },
-    { name = "orjson" },
-    { name = "packaging" },
+    { name = "choreographer", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "logistro", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "orjson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
 wheels = [
@@ -7208,7 +7208,7 @@ name = "lance-namespace"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lance-namespace-urllib3-client" },
+    { name = "lance-namespace-urllib3-client", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
 wheels = [
@@ -7220,10 +7220,10 @@ name = "lance-namespace-urllib3-client"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "urllib3", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
 wheels = [
@@ -7235,14 +7235,14 @@ name = "lancedb"
 version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "lance-namespace" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "lance-namespace", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging" },
-    { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "tqdm" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pyarrow", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
@@ -7314,7 +7314,7 @@ wheels = [
 
 [package.optional-dependencies]
 valkey = [
-    { name = "valkey-glide-sync" },
+    { name = "valkey-glide-sync", marker = "sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -7621,9 +7621,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx" },
-    { name = "langchain-core" },
-    { name = "litellm" },
+    { name = "httpx", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "langchain-core", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "litellm", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/fa/088dd2e3426aa413991afb67aef4c4e79ff3c0e4c25f753842bfaf4ec43f/langchain_litellm-0.5.1.tar.gz", hash = "sha256:1af5743c424456ce12c59cbf08b4774fbc9025124b6de8249713864242db57e1", size = 18869, upload-time = "2026-02-11T00:56:40.631Z" }
 wheels = [
@@ -7649,10 +7649,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "httpx" },
-    { name = "langchain-core" },
-    { name = "litellm" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/24/473283e69791fb35e11126c11e7347ffbf110c2dfcebebe90bd974bc7348/langchain_litellm-0.7.0.tar.gz", hash = "sha256:d3b8d0e6f65132f048fbe9d706e5334d45830e3c49aa033d32c37c6683ad2ceb", size = 345959, upload-time = "2026-06-15T10:00:36.437Z" }
 wheels = [
@@ -7800,14 +7800,14 @@ name = "langchain-pinecone"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "langchain-core" },
-    { name = "langchain-openai" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "langchain-core", marker = "python_full_version < '3.14'" },
+    { name = "langchain-openai", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pinecone", extra = ["asyncio"] },
-    { name = "pydantic" },
-    { name = "simsimd" },
+    { name = "pinecone", extra = ["asyncio"], marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "simsimd", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/e9/b52029651f6f8c0c585f26ae665a8ef34cd36a47b2590a2cd3a1a0b11d9d/langchain_pinecone-0.2.13.tar.gz", hash = "sha256:294a6da7e1a81d5805060e37639d3e4fb72cb239d651a34a4d1f81ba096f473a", size = 40655, upload-time = "2025-11-02T19:11:45.842Z" }
 wheels = [
@@ -9101,26 +9101,26 @@ name = "langwatch"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "coolname" },
-    { name = "deprecated" },
-    { name = "httpx" },
-    { name = "langchain-core" },
-    { name = "nanoid" },
-    { name = "openinference-instrumentation-haystack" },
-    { name = "openinference-instrumentation-langchain" },
-    { name = "openinference-instrumentation-openai" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-crewai" },
-    { name = "opentelemetry-sdk" },
-    { name = "pksuid" },
-    { name = "pydantic" },
-    { name = "python-liquid" },
-    { name = "pyyaml" },
-    { name = "retry" },
-    { name = "termcolor" },
+    { name = "attrs", marker = "python_full_version < '3.14'" },
+    { name = "coolname", marker = "python_full_version < '3.14'" },
+    { name = "deprecated", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "langchain-core", marker = "python_full_version < '3.14'" },
+    { name = "nanoid", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-haystack", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-langchain", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-openai", marker = "python_full_version < '3.14'" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-instrumentation-crewai", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
+    { name = "pksuid", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "python-liquid", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "retry", marker = "python_full_version < '3.14'" },
+    { name = "termcolor", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/52/359afd09f4054ab1c7dc4b349c6b65d4f32321ad758028c6f085cefa781a/langwatch-0.10.2.tar.gz", hash = "sha256:455b211d1e0b44fecb0a0240b7a5781349ecf52ce9d3fba33e23118a33b1e02b", size = 1365949, upload-time = "2026-02-05T06:54:48.456Z" }
 wheels = [
@@ -10383,7 +10383,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-scavio"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "src/bundles/scavio" }
 dependencies = [
     { name = "httpx" },
@@ -10925,7 +10925,7 @@ name = "lxml-html-clean"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
+    { name = "lxml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
 wheels = [
@@ -11000,13 +11000,13 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dotenv" },
+    { name = "click", marker = "sys_platform == 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/8fdd991142ad3e037179a494b153f463024e5a211ef3ad948b955c26b4de/magika-0.6.2.tar.gz", hash = "sha256:37eb6ae8020f6e68f231bc06052c0a0cbe8e6fa27492db345e8dc867dbceb067", size = 3036634, upload-time = "2025-05-02T14:54:18.88Z" }
 wheels = [
@@ -11035,13 +11035,13 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dotenv" },
+    { name = "click", marker = "sys_platform != 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -11204,15 +11204,15 @@ name = "matplotlib"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy" },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "cycler", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -11302,8 +11302,8 @@ wheels = [
 
 [package.optional-dependencies]
 cli = [
-    { name = "python-dotenv" },
-    { name = "typer" },
+    { name = "python-dotenv", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 
 [[package]]
@@ -11370,12 +11370,12 @@ name = "milvus-lite"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu", version = "1.9.0.post1", source = { registry = "https://pypi.org/simple" } },
-    { name = "grpcio" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pyarrow" },
-    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin')" },
+    { name = "faiss-cpu", version = "1.9.0.post1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "grpcio", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/d0/3edb31f832287557c8a8bb0515aec2c73265512040dcd4fc43d747722d11/milvus_lite-3.1.1.tar.gz", hash = "sha256:0cbf8386a2e99b6464a5eda14cf8e31934b0e287e36c831e293aee614d9efc2e", size = 647172, upload-time = "2026-07-27T05:03:56.834Z" }
 wheels = [
@@ -11387,7 +11387,7 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
@@ -11433,7 +11433,7 @@ name = "mlx"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal" },
+    { name = "mlx-metal", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/38/a034159df4d21ef7b5721225a2c46092e20a2c627724f57be3e89fa7dbce/mlx-0.32.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:c6feb17e32160b70c7634aab925cf3f8c5c7bebbf99f227c48450478e1008af2", size = 562899, upload-time = "2026-07-07T17:55:25.157Z" },
@@ -11458,14 +11458,14 @@ name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "mlx" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "sentencepiece" },
-    { name = "transformers" },
+    { name = "jinja2", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "mlx", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "pyyaml", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "sentencepiece", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "transformers", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -11487,19 +11487,19 @@ name = "mlx-vlm"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "mlx" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "opencv-python" },
-    { name = "pillow" },
-    { name = "requests" },
-    { name = "soundfile" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "uvicorn" },
+    { name = "datasets", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "fastapi", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "mlx", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "mlx-lm", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
+    { name = "opencv-python", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "pillow", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "requests", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "soundfile", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "transformers", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "uvicorn", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/cc/04a100878abc21aac431221cc6fb79bb69f29e9e61a84284f866340dadfd/mlx_vlm-0.3.12.tar.gz", hash = "sha256:b9ee7528ec2765cc02d3115b39a70f0dc1c51345473530981e6386a91f26f379", size = 495607, upload-time = "2026-02-16T23:39:27.649Z" }
 wheels = [
@@ -12144,32 +12144,32 @@ name = "nicegui"
 version = "3.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "aiohttp" },
-    { name = "certifi" },
-    { name = "docutils" },
-    { name = "fastapi" },
-    { name = "h11" },
-    { name = "httpx" },
-    { name = "idna" },
-    { name = "ifaddr" },
-    { name = "itsdangerous" },
-    { name = "jinja2" },
-    { name = "lxml" },
-    { name = "lxml-html-clean" },
-    { name = "markdown2" },
-    { name = "orjson" },
-    { name = "pydantic-core" },
-    { name = "pygments" },
-    { name = "python-dotenv" },
-    { name = "python-engineio" },
-    { name = "python-multipart" },
-    { name = "python-socketio", extra = ["asyncio-client"] },
-    { name = "starlette" },
-    { name = "tinycss2" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "watchfiles" },
+    { name = "aiofiles", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "certifi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "docutils", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "fastapi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "h11", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "idna", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ifaddr", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "itsdangerous", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "lxml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "lxml-html-clean", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "markdown2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "orjson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pydantic-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pygments", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-engineio", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-multipart", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-socketio", extra = ["asyncio-client"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "starlette", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "tinycss2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "uvicorn", extra = ["standard"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "watchfiles", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ee/0100f3cd2b2af218db1cb695b9ea5c88862df56356e3a2d47744b2b58bf5/nicegui-3.15.0.tar.gz", hash = "sha256:9472841e9635bce7cf608f10e515549517284c0d5dddf69c47bf176a44c82623", size = 19701841, upload-time = "2026-07-23T16:00:44.05Z" }
 wheels = [
@@ -12238,7 +12238,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
 wheels = [
@@ -12322,7 +12322,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/c4/27ea7849eb4a7e3b51db446b0414254326dba8c6bdee09b9f2abf963e55d/numexpr-2.14.2.tar.gz", hash = "sha256:e7144e83ea9e581f2273e0304f15836736c4e470e2bd2e378ce617662a1ca278", size = 121744, upload-time = "2026-07-18T10:52:43.185Z" }
@@ -12596,16 +12596,16 @@ name = "nv-ingest-api"
 version = "26.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff" },
-    { name = "ffmpeg-python" },
-    { name = "fsspec" },
-    { name = "glom" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pypdfium2" },
-    { name = "tritonclient" },
-    { name = "universal-pathlib" },
+    { name = "backoff", marker = "python_full_version >= '3.12'" },
+    { name = "ffmpeg-python", marker = "python_full_version >= '3.12'" },
+    { name = "fsspec", marker = "python_full_version >= '3.12'" },
+    { name = "glom", marker = "python_full_version >= '3.12'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.12'" },
+    { name = "pypdfium2", marker = "python_full_version >= '3.12'" },
+    { name = "tritonclient", marker = "python_full_version >= '3.12'" },
+    { name = "universal-pathlib", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/a1/cb847218f856e57930562c4974cc1eaba9f68fa076a2466f88e79df4d9b3/nv_ingest_api-26.3.0.tar.gz", hash = "sha256:0cd7be3e13b0f5343e466da988fba315d0673ba3de3106c619bee48500f78fb3", size = 277120, upload-time = "2026-03-16T18:42:41.591Z" }
 wheels = [
@@ -12617,17 +12617,17 @@ name = "nv-ingest-client"
 version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "build" },
-    { name = "charset-normalizer" },
-    { name = "click" },
-    { name = "fsspec" },
-    { name = "httpx" },
-    { name = "lancedb" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "tqdm" },
+    { name = "build", marker = "python_full_version >= '3.12'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "fsspec", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "lancedb", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/62/386bc4a336b91df9c65afc18d905bb1fe3dd44ef1ce038895a701cba6035/nv_ingest_client-26.1.2.tar.gz", hash = "sha256:7ea4a35d4e7051031c273eb2b15170a0555462b702602e5c4fdce947bd39d446", size = 126061, upload-time = "2026-01-21T14:06:31.836Z" }
 wheels = [
@@ -12648,9 +12648,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -12706,13 +12706,13 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "coloredlogs", marker = "python_full_version < '3.14'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -12749,10 +12749,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.14'" },
+    { name = "protobuf", marker = "python_full_version >= '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
@@ -12859,36 +12859,36 @@ name = "opendsstar"
 version = "1.0.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "diskcache" },
-    { name = "docling" },
-    { name = "huggingface-hub" },
-    { name = "kaleido" },
-    { name = "langchain" },
-    { name = "langchain-community" },
-    { name = "langchain-core" },
-    { name = "langchain-huggingface" },
-    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "langchain-milvus" },
-    { name = "langchain-text-splitters" },
-    { name = "langgraph" },
-    { name = "litellm" },
-    { name = "matplotlib" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "openai" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "plotly" },
-    { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "pymilvus", extra = ["milvus-lite"], marker = "sys_platform != 'win32'" },
-    { name = "pymilvus", extra = ["model"] },
-    { name = "python-dotenv" },
-    { name = "ragworkbench" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "diskcache", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "docling", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "kaleido", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-community", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-huggingface", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-milvus", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-text-splitters", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langgraph", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "matplotlib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "plotly", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyarrow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pymilvus", extra = ["milvus-lite"], marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "pymilvus", extra = ["model"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ragworkbench", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "sentence-transformers" },
-    { name = "smolagents" },
-    { name = "tqdm" },
+    { name = "sentence-transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "smolagents", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/92/28a33b1ed586709e9f75e90029071bd558bc41629ab9051da486d178216a/opendsstar-1.0.26.tar.gz", hash = "sha256:035fdeaf2bc3d9b9126f9f2f9ffe9f8de17b28f43a8539dbe5fcd46a857703e7", size = 200210, upload-time = "2026-05-10T11:46:12.152Z" }
 wheels = [
@@ -12915,13 +12915,13 @@ name = "openinference-instrumentation-haystack"
 version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "openinference-instrumentation", marker = "python_full_version < '3.14'" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-instrumentation", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/a6/8dfddcc7bc17b0151f8539a828b74d5a6f4fe74e4011de54f252d52f29d6/openinference_instrumentation_haystack-0.1.34.tar.gz", hash = "sha256:952ebfb4abe8701374f5131d7b5e156b9fb8601bdbee4bc868eabf383d0f63d7", size = 15835, upload-time = "2026-05-18T18:51:31.822Z" }
 wheels = [
@@ -12950,13 +12950,13 @@ name = "openinference-instrumentation-openai"
 version = "0.1.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "openinference-instrumentation", marker = "python_full_version < '3.14'" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-instrumentation", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/90/c81c7426cb9dca075cef1b5fe16f58c68604b7518f7aaa14d837ec80fde3/openinference_instrumentation_openai-0.1.52.tar.gz", hash = "sha256:5a3dceb742209463e33ab2a4aa82f56bedfa20c25c738de28248509931044ea1", size = 23087, upload-time = "2026-06-11T17:13:35.517Z" }
 wheels = [
@@ -14039,10 +14039,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
 wheels = [
@@ -14104,11 +14104,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "pytz", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -14172,8 +14172,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -14202,7 +14202,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
@@ -14295,7 +14295,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -14389,12 +14389,12 @@ name = "pinecone"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "pinecone-plugin-assistant" },
-    { name = "pinecone-plugin-interface" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.14'" },
+    { name = "pinecone-plugin-assistant", marker = "python_full_version < '3.14'" },
+    { name = "pinecone-plugin-interface", marker = "python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "urllib3", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/38/12731d4af470851b4963eba616605868a8599ef4df51c7b6c928e5f3166d/pinecone-7.3.0.tar.gz", hash = "sha256:307edc155621d487c20dc71b76c3ad5d6f799569ba42064190d03917954f9a7b", size = 235256, upload-time = "2025-06-27T20:03:51.498Z" }
 wheels = [
@@ -14403,8 +14403,8 @@ wheels = [
 
 [package.optional-dependencies]
 asyncio = [
-    { name = "aiohttp" },
-    { name = "aiohttp-retry" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp-retry", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -14412,8 +14412,8 @@ name = "pinecone-plugin-assistant"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
-    { name = "requests" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/01/65c4c3a81732fa379f8e7f78a8c18aa57a1139f5b79d58b93a69f2fc8cb0/pinecone_plugin_assistant-1.8.0.tar.gz", hash = "sha256:8e8682cff30f9bae9243b384021aba71c91f4e6ef1650e9d63ee64aab83cba87", size = 150435, upload-time = "2025-08-31T14:31:18.046Z" }
 wheels = [
@@ -14443,7 +14443,7 @@ name = "pksuid"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pybase62" },
+    { name = "pybase62", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/2f/8df6e1663197459f3de732cee69d050a118023d80e3ce00d172b83b6f09d/pksuid-1.1.2.tar.gz", hash = "sha256:dc08ed7924a8affea5f36af4b6af345b126f521c9165b95e91ca1a2acef99e49", size = 4938, upload-time = "2022-05-07T00:19:10.051Z" }
 wheels = [
@@ -14464,8 +14464,8 @@ name = "playwright"
 version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet" },
-    { name = "pyee" },
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pyee", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
@@ -14482,8 +14482,8 @@ name = "plotly"
 version = "6.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "narwhals" },
-    { name = "packaging" },
+    { name = "narwhals", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
 wheels = [
@@ -15584,8 +15584,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
+    { name = "pydantic", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
@@ -15625,7 +15625,7 @@ name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
 wheels = [
@@ -15716,10 +15716,10 @@ wheels = [
 
 [package.optional-dependencies]
 milvus-lite = [
-    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
+    { name = "milvus-lite", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 model = [
-    { name = "pymilvus-model" },
+    { name = "pymilvus-model", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -15727,12 +15727,12 @@ name = "pymilvus-model"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "protobuf" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "transformers" },
+    { name = "transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/8f/a8212f3d932d566fdec354b49befa09174b239c8b8ad25a33b798cee393b/pymilvus_model-0.3.2.tar.gz", hash = "sha256:10ab49a989396943e08555b971f85182ddb50da47076e699a157c9a5ff542872", size = 36268, upload-time = "2025-03-31T08:47:45.007Z" }
 wheels = [
@@ -15842,7 +15842,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -15860,8 +15860,8 @@ name = "pyobjc-framework-coreml"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/1e/7d2db3e4468eb04cc92264be83113d86eea4f96302742437de695a445d6d/pyobjc_framework_coreml-12.2.1.tar.gz", hash = "sha256:ef3c2b6a160891b44173235603d10174929656b9c206d6f2f443fe2aa903c2cb", size = 49272, upload-time = "2026-06-19T16:20:18.459Z" }
 wheels = [
@@ -15879,8 +15879,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -15898,10 +15898,10 @@ name = "pyobjc-framework-vision"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/1fdffff1b6bf124b260a2169869f4b71a08b9f6603698f7dec990d5ae5f3/pyobjc_framework_vision-12.2.1.tar.gz", hash = "sha256:debfd59dd7d962a6053bf733370148c11a9ec44091b517a0966f48d81c305879", size = 72683, upload-time = "2026-06-19T16:22:01.102Z" }
 wheels = [
@@ -16390,10 +16390,10 @@ name = "python-liquid"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel" },
-    { name = "markupsafe" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
+    { name = "babel", marker = "python_full_version < '3.14'" },
+    { name = "markupsafe", marker = "python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "pytz", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/ee/d4c59a4248a35f00bd88798f3ae468255fb7efee7a638692ffdb87cdd760/python_liquid-2.3.0.tar.gz", hash = "sha256:09841630ad2ecfa75ddf214f33bacaad930d4aadef799309f9e8a84f70e2826f", size = 95554, upload-time = "2026-07-06T06:02:17.114Z" }
 wheels = [
@@ -16507,7 +16507,7 @@ wheels = [
 
 [package.optional-dependencies]
 asyncio-client = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 client = [
     { name = "requests" },
@@ -16828,7 +16828,7 @@ name = "ragstack-ai-knowledge-store"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cassio" },
+    { name = "cassio", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/e1/da324f5b590aef5ae07b8e7e38ee249101b2bfae6882ba1152c06f8228b2/ragstack_ai_knowledge_store-0.2.1.tar.gz", hash = "sha256:20424d42978be228feb887a71d76228638765446d1a37a1f6faef109e448fe06", size = 16964, upload-time = "2024-07-30T10:42:12.03Z" }
 wheels = [
@@ -16840,25 +16840,25 @@ name = "ragworkbench"
 version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bert-score" },
-    { name = "datasets" },
-    { name = "docling-core" },
-    { name = "gdown" },
-    { name = "huggingface-hub" },
-    { name = "litellm" },
-    { name = "nicegui" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "bert-score", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "docling-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "gdown", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "nicegui", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "tenacity" },
-    { name = "types-pyyaml" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-    { name = "unitxt" },
+    { name = "tenacity", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "types-pyyaml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "types-requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "unitxt", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/4d/3c9957b9a1d1e15503bbf4e114699355a58ebbbc69f010b892966c97dbe9/ragworkbench-0.1.3.tar.gz", hash = "sha256:7a81302195337ac17512603f351dae88a6eb3d6a477e62a98dc129073873fd27", size = 163965, upload-time = "2026-03-31T09:47:07.212Z" }
 wheels = [
@@ -17204,7 +17204,7 @@ wheels = [
 
 [package.optional-dependencies]
 socks = [
-    { name = "pysocks" },
+    { name = "pysocks", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -17249,8 +17249,8 @@ name = "retry"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator" },
-    { name = "py" },
+    { name = "decorator", marker = "python_full_version < '3.14'" },
+    { name = "py", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
 wheels = [
@@ -17289,9 +17289,9 @@ name = "rich-toolkit"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "rich", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/3a/a258c2fbc6c6bdf428611388f5698ba5d57ffdf0755e1cab474d9cc47813/rich_toolkit-0.20.3.tar.gz", hash = "sha256:223dd2cfba325ed55e94933b9e53f3aca13e9fdf76622bd564c18109a2273c1b", size = 205355, upload-time = "2026-07-13T14:38:06.837Z" }
 wheels = [
@@ -17782,14 +17782,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
+    { name = "imageio", marker = "python_full_version < '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -17838,16 +17838,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "imageio", marker = "python_full_version >= '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "tifffile", version = "2026.7.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
@@ -17913,10 +17913,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -17974,13 +17974,13 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -18027,7 +18027,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -18089,7 +18089,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -18173,7 +18173,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
@@ -18235,12 +18235,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "beautifulsoup4" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "toonify" },
+    { name = "aiohttp", marker = "python_full_version < '3.12'" },
+    { name = "beautifulsoup4", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
+    { name = "toonify", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/b4/9196574ac53c6c94fb311824e3f6e5e13191620fb9a09b056daf0e77a19d/scrapegraph_py-1.47.0.tar.gz", hash = "sha256:4794820d9dcdba2c6ee22b4ad0975843a10adb65e4831e680f846067e13c5aa9", size = 340039, upload-time = "2026-04-18T13:50:01.084Z" }
 wheels = [
@@ -18265,8 +18265,8 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/4b/8b165cfb0d6b564cc69e4f58270bb54f2457c68d5c0fc648d547e3d0e207/scrapegraph_py-2.1.0.tar.gz", hash = "sha256:c4d1ed4d0c11c5c10e999d310ce1146f62809a91292b3d07d69b40c2a0954d75", size = 4876208, upload-time = "2026-04-21T12:53:48.428Z" }
 wheels = [
@@ -18278,9 +18278,9 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "jeepney" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -18700,10 +18700,10 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions" },
+    { name = "cffi", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [
@@ -19037,9 +19037,9 @@ name = "tavily-python"
 version = "0.7.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "requests" },
-    { name = "tiktoken" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "tiktoken", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/29/c2d5056dbf45a80484df5a1bf0d0ae59c611aa9680372c400a278fbf0c50/tavily_python-0.7.26.tar.gz", hash = "sha256:36202728144fce1ef0cece33800f98e3cdeb5f600e6678c50b1232b866a2f509", size = 29647, upload-time = "2026-06-10T18:38:45.231Z" }
 wheels = [
@@ -19126,7 +19126,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -19144,7 +19144,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -19169,7 +19169,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/2f/e5fe51c8f782241d86fdf7251594b195f0d6c2fcf9d389079de212599246/tifffile-2026.7.14.tar.gz", hash = "sha256:ce2703e5ef22c868f1528d5f5b4ef75eefb019cf628a1c9ec0d17e0afeca8ef5", size = 437660, upload-time = "2026-07-14T23:41:31.737Z" }
@@ -19243,7 +19243,7 @@ name = "tinycss2"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings" },
+    { name = "webencodings", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
@@ -19365,7 +19365,7 @@ name = "toonify"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tiktoken" },
+    { name = "tiktoken", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/53/409a1dd7bcb52c74da019994cb866e875d0bf9020b89c7fcfcdea2866ce3/toonify-1.6.0.tar.gz", hash = "sha256:57bf6fbc9d73e463e8773c491123b233b0c79482235e0c27b908b4e58b54ec77", size = 30106, upload-time = "2026-02-06T16:00:02.622Z" }
 wheels = [
@@ -19384,14 +19384,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or platform_machine != 'arm64'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "fsspec", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "jinja2", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "sympy", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", upload-time = "2026-07-08T12:26:07Z" },
@@ -19423,14 +19423,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (python_full_version >= '3.14' and sys_platform == 'darwin')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "setuptools", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "sympy", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:0555fde6108ca90247ae33d4e1237cbae475c86a223bb2f0f91d9addf1f611bd", upload-time = "2026-07-08T19:27:11Z" },
@@ -19474,11 +19474,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pillow" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2a1ef4b6f4bf5828b48cfad97372c8982db906830884b2868ba5c3df937a7d81", upload-time = "2026-07-08T12:26:40Z" },
@@ -19510,11 +19510,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (python_full_version >= '3.14' and sys_platform == 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'darwin'" },
-    { name = "pillow" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7d81da2804da52c9788f2d5a8d0aaddcea9fce6eb5d7c6e19a32b40b4ed0b75a", upload-time = "2026-07-08T12:26:39Z" },
@@ -19819,11 +19819,11 @@ name = "tritonclient"
 version = "2.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "ml-dtypes", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-rapidjson" },
-    { name = "urllib3" },
+    { name = "python-rapidjson", marker = "python_full_version >= '3.12'" },
+    { name = "urllib3", marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/2f/079ce9218627c66b2a704ff37c25c72504cabbd3e2dad65b2235dae636d1/tritonclient-2.70.0-py3-none-any.whl", hash = "sha256:7ef72e5bc11649c9415057b0933ffb9d16675f0013f1f54759457fb625355de2", size = 111782, upload-time = "2026-06-26T16:19:59.329Z" },
@@ -19888,7 +19888,7 @@ name = "typer-slim"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typer" },
+    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
@@ -20077,10 +20077,10 @@ name = "unitxt"
 version = "1.26.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "diskcache" },
-    { name = "evaluate" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "diskcache", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "evaluate", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/68/cda80f4fdc32aa5f8753d5ffe70d5110b9dc25956b15a8b579c72e033c95/unitxt-1.26.10.tar.gz", hash = "sha256:f588045669c222a02ed703386aad8b02d0d41aa87a0122a06182e7623fad4ec2", size = 28838924, upload-time = "2026-05-27T10:43:42.425Z" }
@@ -20093,8 +20093,8 @@ name = "universal-pathlib"
 version = "0.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fsspec" },
-    { name = "pathlib-abc" },
+    { name = "fsspec", marker = "python_full_version >= '3.12'" },
+    { name = "pathlib-abc", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/6e/d997a70ee8f4c61f9a7e2f4f8af721cf072a3326848fc881b05187e52558/universal_pathlib-0.3.10.tar.gz", hash = "sha256:4487cbc90730a48cfb64f811d99e14b6faed6d738420cd5f93f59f48e6930bfb", size = 261110, upload-time = "2026-02-22T14:40:58.87Z" }
 wheels = [
@@ -20342,9 +20342,9 @@ name = "valkey-glide-sync"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "cffi", marker = "sys_platform != 'win32'" },
+    { name = "protobuf", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/c9/e4acc31ceb91fa2c96d0a3147de9d0d86208579532d25eebfcf09aab9877/valkey_glide_sync-2.5.0.tar.gz", hash = "sha256:75366dccc7d0f92a41ec47ccd49fbac45c48b92d2a8d2f677ae5673dda7f9325", size = 961943, upload-time = "2026-07-14T18:50:45.415Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,7 @@ members = [
     "lfx-openai-compatible",
     "lfx-oracle",
     "lfx-paddle",
+    "lfx-scavio",
     "lfx-toolguard",
     "lfx-valkey",
     "lfx-vllm",
@@ -93,8 +94,8 @@ wheels = [
 
 [package.optional-dependencies]
 http-server = [
-    { name = "sse-starlette", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "starlette", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 
 [[package]]
@@ -102,7 +103,7 @@ name = "a2wsgi"
 version = "1.10.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/cb/822c56fbea97e9eee201a2e434a80437f6750ebcb1ed307ee3a0a7505b14/a2wsgi-1.10.10.tar.gz", hash = "sha256:a5bcffb52081ba39df0d5e9a884fc6f819d92e3a42389343ba77cbf809fe1f45", size = 18799, upload-time = "2025-06-18T09:00:10.843Z" }
 wheels = [
@@ -231,7 +232,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -260,7 +261,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -427,7 +428,7 @@ name = "aiohttp-retry"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
 wheels = [
@@ -466,9 +467,9 @@ name = "aiologic"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
@@ -493,8 +494,8 @@ name = "aiosmtpd"
 version = "1.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "atpublic", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "attrs", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "atpublic" },
+    { name = "attrs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/ca/b2b7cc880403ef24be77383edaadfcf0098f5d7b9ddbf3e2c17ef0a6af0d/aiosmtpd-1.4.6.tar.gz", hash = "sha256:5a811826e1a5a06c25ebc3e6c4a704613eb9a1bcf6b78428fbe865f4f6c9a4b8", size = 152775, upload-time = "2024-05-18T11:37:50.029Z" }
 wheels = [
@@ -602,10 +603,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "apify-shared", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "impit", marker = "python_full_version < '3.11'" },
-    { name = "more-itertools", marker = "python_full_version < '3.11'" },
+    { name = "apify-shared" },
+    { name = "colorama" },
+    { name = "impit" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/e4/1eaee14189886362a7d5629c362fb1bdc5bb36d506c99e97e866eea5a0e9/apify_client-2.5.1.tar.gz", hash = "sha256:ff8457c9cc14cbfe0eefb337a8c0a33f4d81e7760768bdd036e7470a5bc63c24", size = 380576, upload-time = "2026-05-20T09:43:36.461Z" }
 wheels = [
@@ -634,10 +635,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "impit", marker = "python_full_version >= '3.11'" },
-    { name = "more-itertools", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.11'" },
+    { name = "colorama" },
+    { name = "impit" },
+    { name = "more-itertools" },
+    { name = "pydantic", extra = ["email"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/c8/6aaee683e2c94b6545dbf76ac361a7fa0866531a7747a2de15bc2a97162b/apify_client-3.1.0.tar.gz", hash = "sha256:08c2b31f7f74a36ab2abc6235bb118bb4d522a84e65a3f0b75c452c4872aa4fe", size = 128468, upload-time = "2026-07-20T07:07:06.601Z" }
 wheels = [
@@ -822,7 +823,7 @@ name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", version = "4.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "async-timeout", version = "4.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
 wheels = [
@@ -1224,15 +1225,15 @@ name = "bert-score"
 version = "0.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "tqdm" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/93/2c97a85cbb66a8a256a13176e11c9c4508074e2341299fe75ee955c81eff/bert_score-0.3.13.tar.gz", hash = "sha256:8ffe5838eac8cdd988b8b1a896af7f49071188c8c011a1ed160d71a9899a2ba4", size = 48621, upload-time = "2023-02-20T21:07:29.477Z" }
 wheels = [
@@ -1544,14 +1545,14 @@ name = "browsergym-core"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "gymnasium", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "lxml", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "playwright", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pyparsing", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "beautifulsoup4" },
+    { name = "gymnasium" },
+    { name = "lxml" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pillow" },
+    { name = "playwright" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/5b/d2285220dbcd74f18ab91fa823792fc0f1672bba569cf8f576c5eb5a79a5/browsergym_core-0.13.0.tar.gz", hash = "sha256:cd9caaaaf5738e84134b4c562a2118cb26cd9caf38a8cba50b9226db0f839d8f", size = 178581, upload-time = "2024-11-07T20:35:08.908Z" }
 wheels = [
@@ -1918,9 +1919,9 @@ name = "choreographer"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "logistro", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "platformdirs", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "simplejson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "logistro" },
+    { name = "platformdirs" },
+    { name = "simplejson" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
 wheels = [
@@ -2203,7 +2204,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -2292,7 +2293,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -2779,7 +2780,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cffi", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
@@ -2847,8 +2848,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cffi", marker = "(python_full_version < '3.11' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -2917,57 +2918,57 @@ name = "cuga"
 version = "0.2.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "a2a-sdk", extra = ["http-server"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "aiohttp", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "aiosmtpd", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "asyncpg", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "beautifulsoup4", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "boto3", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "browsergym-core", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "cuga-oak-health", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "docker", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "dynaconf", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastapi", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastembed", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastmcp", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "hvac", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-core", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-docling", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-groq", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-ibm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-litellm", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-mcp-adapters", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-ollama", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-openai", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langchain-text-splitters", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langfuse", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "langgraph", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "litellm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "loguru", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "markdownify", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "mcp", extra = ["cli"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pgvector", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "playwright", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "psutil", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "psycopg", extra = ["binary"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pymilvus", extra = ["milvus-lite"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "python-dotenv", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pyyaml", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "sqlite-vec", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tavily-python", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
-    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typer-slim", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "a2a-sdk", extra = ["http-server"] },
+    { name = "aiohttp" },
+    { name = "aiosmtpd" },
+    { name = "asyncpg" },
+    { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "browsergym-core" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "cuga-oak-health", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "docker" },
+    { name = "dynaconf" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "fastembed" },
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "hvac" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langchain-docling" },
+    { name = "langchain-groq" },
+    { name = "langchain-ibm" },
+    { name = "langchain-litellm", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-ollama" },
+    { name = "langchain-openai" },
+    { name = "langchain-text-splitters" },
+    { name = "langfuse" },
+    { name = "langgraph" },
+    { name = "litellm" },
+    { name = "loguru" },
+    { name = "markdownify" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pgvector" },
+    { name = "playwright" },
+    { name = "psutil" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pymilvus", extra = ["milvus-lite"] },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "sqlite-vec" },
+    { name = "tavily-python" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "typer" },
+    { name = "typer-slim" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/93/a64555661bc99c1ae06347df5ff63bbfc593f98a391e2ff905cb8f6553a3/cuga-0.2.28.tar.gz", hash = "sha256:aa28ab4dce691783ff0e2a3a6f0eff3dcb978080269d08cad9581f0bdd49e377", size = 3140162, upload-time = "2026-05-10T13:25:22.039Z" }
 wheels = [
@@ -2979,9 +2980,9 @@ name = "cuga-oak-health"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pydantic", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/b94a6ee122d09e7a0aa12ddb964a2a3c769f98149f68ae8654a55e4f64c3/cuga_oak_health-1.3.0.tar.gz", hash = "sha256:53800bcfc30a89d7046dfcc8225f746f81077fd9816b0cd88f215506775b37b9", size = 79358, upload-time = "2026-03-22T15:30:43.666Z" }
 wheels = [
@@ -2999,8 +3000,8 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "aiologic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
 wheels = [
@@ -3774,12 +3775,12 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx", marker = "python_full_version == '3.12.*'" },
-    { name = "pydantic", marker = "python_full_version == '3.12.*'" },
-    { name = "pydantic-core", marker = "python_full_version == '3.12.*'" },
-    { name = "requests", marker = "python_full_version == '3.12.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
-    { name = "websockets", marker = "python_full_version == '3.12.*'" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/83/fd165b38a69a4a40746926a908ea92e456a0e0dd5b6038836c9cc94a3487/elevenlabs-1.58.1.tar.gz", hash = "sha256:e9f723a528c1bbd80605e639e858f7a58f204860faa9417305a4083508c7c0fb", size = 185830, upload-time = "2025-05-07T13:54:37.814Z" }
 wheels = [
@@ -3808,12 +3809,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx", marker = "python_full_version != '3.12.*'" },
-    { name = "pydantic", marker = "python_full_version != '3.12.*'" },
-    { name = "pydantic-core", marker = "python_full_version != '3.12.*'" },
-    { name = "requests", marker = "python_full_version != '3.12.*'" },
-    { name = "typing-extensions", marker = "python_full_version != '3.12.*'" },
-    { name = "websockets", marker = "python_full_version != '3.12.*'" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/5f/01197145be5be258abdce254010eb300868b85fbf6cf1c6c1538a68caef4/elevenlabs-1.59.0.tar.gz", hash = "sha256:16e735bd594e86d415dd445d249c8cc28b09996cfd627fbc10102c0a84698859", size = 200549, upload-time = "2025-05-15T12:19:28.868Z" }
 wheels = [
@@ -3856,17 +3857,17 @@ name = "evaluate"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "dill", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "fsspec", extra = ["http"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "multiprocess", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "xxhash", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "datasets" },
+    { name = "dill" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/d0/0c17a8e6e8dc7245f22dea860557c32bae50fc4d287ae030cb0e8ab8720f/evaluate-0.4.6.tar.gz", hash = "sha256:e07036ca12b3c24331f83ab787f21cc2dbf3631813a1631e63e40897c69a3f21", size = 65716, upload-time = "2025-09-18T13:06:30.581Z" }
 wheels = [
@@ -3955,7 +3956,7 @@ name = "face"
 version = "26.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boltons", marker = "python_full_version >= '3.12'" },
+    { name = "boltons" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/fd/f84f0600bd72953d5a322f0dedbd4f900e2cedab718e6b6a093ae2d16aae/face-26.0.1.tar.gz", hash = "sha256:8183d94bc248baaea855a9f8445f97a22a9988908e60abddccc6e251da77c4c6", size = 51754, upload-time = "2026-06-17T23:14:39.938Z" }
 wheels = [
@@ -3985,9 +3986,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/85/ee4bafafa70bc99904a61f06e7f5e36d06ab6b37335e687085786f9a248d/faiss_cpu-1.9.0.post1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e18602465f5a96c3c973ab440f9263a0881034fb54810be20bc8cdb8b069456d", size = 7672124, upload-time = "2024-11-20T02:20:02.33Z" },
@@ -4022,8 +4023,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -4119,15 +4120,15 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastar", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "jinja2", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pydantic-extra-types", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pydantic-settings", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "python-multipart", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -4135,10 +4136,10 @@ name = "fastapi-cli"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "rich-toolkit" },
+    { name = "tomli", marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/eb/3b534c6f8e157f9ddbf2a153512307c886cad0b258739c200dd8ff8c4452/fastapi_cli-0.0.32.tar.gz", hash = "sha256:38024d2345275e1b37ce8848727a580d84901b570e96b3256d9d36a9a5039424", size = 26636, upload-time = "2026-07-16T12:16:58.678Z" }
 wheels = [
@@ -4147,8 +4148,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -4156,15 +4157,15 @@ name = "fastapi-cloud-cli"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "detect-installer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "fastar", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pydantic", extra = ["email"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "rich-toolkit", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "rignore", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "sentry-sdk", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "detect-installer" },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/f2/36bfe990baa656de89a2b98a77a15dcd018474f7245c8e4a10cada0553c5/fastapi_cloud_cli-0.22.2.tar.gz", hash = "sha256:7ec78c1fed58f578af5eb1fb54ec4b456eba4dc1eaca1c3a93cf499a7cbc7ab3", size = 94480, upload-time = "2026-07-14T09:27:01.349Z" }
 wheels = [
@@ -4400,17 +4401,17 @@ name = "fastembed"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "loguru", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "mmh3", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "py-rust-stemmers", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tokenizers", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tqdm", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
@@ -4598,7 +4599,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future", marker = "python_full_version >= '3.12'" },
+    { name = "future" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -4934,10 +4935,10 @@ name = "gassist"
 version = "0.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "flask", marker = "sys_platform == 'win32'" },
-    { name = "flask-cors", marker = "sys_platform == 'win32'" },
-    { name = "tqdm", marker = "sys_platform == 'win32'" },
+    { name = "colorama" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/2e/f79632d7300874f7f0e60b61a6ab22455a245e1556116a1729542a77b0da/gassist-0.0.1-py3-none-any.whl", hash = "sha256:bb0fac74b453153a6c74b2db40a14fdde7879cbc10ec692ed170e576c8e2b6aa", size = 23819, upload-time = "2025-05-09T18:22:23.609Z" },
@@ -4948,11 +4949,11 @@ name = "gdown"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "filelock", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "requests", extra = ["socks"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
 wheels = [
@@ -5141,9 +5142,9 @@ name = "glom"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.12'" },
-    { name = "boltons", marker = "python_full_version >= '3.12'" },
-    { name = "face", marker = "python_full_version >= '3.12'" },
+    { name = "attrs" },
+    { name = "boltons" },
+    { name = "face" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/74/8387f95565ba7c30cd152a585b275ebb9a834d1d32782425c5d2fe0a102c/glom-25.12.0.tar.gz", hash = "sha256:1ae7da88be3693df40ad27bdf57a765a55c075c86c971bcddd67927403eb0069", size = 196128, upload-time = "2025-12-29T06:29:07.274Z" }
 wheels = [
@@ -5700,11 +5701,11 @@ name = "gymnasium"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "farama-notifications", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
 wheels = [
@@ -5915,7 +5916,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -5936,7 +5937,7 @@ name = "hvac"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
 wheels = [
@@ -6122,16 +6123,16 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cachetools", marker = "python_full_version < '3.11'" },
-    { name = "certifi", marker = "python_full_version < '3.11'" },
-    { name = "httpx", marker = "python_full_version < '3.11'" },
-    { name = "ibm-cos-sdk", marker = "python_full_version < '3.11'" },
-    { name = "lomond", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "tabulate", marker = "python_full_version < '3.11'" },
-    { name = "urllib3", marker = "python_full_version < '3.11'" },
+    { name = "cachetools" },
+    { name = "certifi" },
+    { name = "httpx" },
+    { name = "ibm-cos-sdk" },
+    { name = "lomond" },
+    { name = "packaging" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/56/2e3df38a1f13062095d7bde23c87a92f3898982993a15186b1bfecbd206f/ibm_watsonx_ai-1.3.42.tar.gz", hash = "sha256:ee5be59009004245d957ce97d1227355516df95a2640189749487614fef674ff", size = 688651, upload-time = "2025-10-01T13:35:41.527Z" }
 wheels = [
@@ -6160,16 +6161,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cachetools", marker = "python_full_version >= '3.11'" },
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "ibm-cos-sdk", marker = "python_full_version >= '3.11'" },
-    { name = "lomond", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "tabulate", marker = "python_full_version >= '3.11'" },
-    { name = "urllib3", marker = "python_full_version >= '3.11'" },
+    { name = "cachetools" },
+    { name = "certifi" },
+    { name = "httpx" },
+    { name = "ibm-cos-sdk" },
+    { name = "lomond" },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/23/e47882874980299fda04aec031926fc52b6ea1a7e0f4be66d3108decf664/ibm_watsonx_ai-1.6.0.tar.gz", hash = "sha256:707dbfe8c641a0053114037c2e56f85fa20028c50af20d96338c3ac92185e0d7", size = 739403, upload-time = "2026-07-15T11:58:24.115Z" }
 wheels = [
@@ -6181,9 +6182,9 @@ name = "ibm-watsonx-orchestrate-clients"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cloud-sdk-core", marker = "python_full_version >= '3.11'" },
-    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
-    { name = "websocket-client", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-cloud-sdk-core" },
+    { name = "ibm-watsonx-orchestrate-core" },
+    { name = "websocket-client" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/80/778542ed944c64792c26fe453ebd257ddd766c1aefd8827a9fceda4618b9/ibm_watsonx_orchestrate_clients-2.12.0.tar.gz", hash = "sha256:fc2bb4444dca1e73a5f937f79a5a268196e7678d7164eb32e418f70570cbf71a", size = 1889, upload-time = "2026-06-26T23:50:05.922Z" }
 wheels = [
@@ -6195,8 +6196,8 @@ name = "ibm-watsonx-orchestrate-core"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/ed/6f0d7222d14aa9edae04c7148a2640dc2bb1792cf3e03ec7c86956376cbb/ibm_watsonx_orchestrate_core-2.12.0.tar.gz", hash = "sha256:3cd07e9a51bfb55fe672fb3baab4cd7d94c04aa3ce0bc024c5921811788b2bbb", size = 1227, upload-time = "2026-06-26T23:50:06.601Z" }
 wheels = [
@@ -6491,17 +6492,17 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -6530,18 +6531,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -6553,7 +6554,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -7028,10 +7029,10 @@ name = "kaleido"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "choreographer", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "logistro", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "orjson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "choreographer" },
+    { name = "logistro" },
+    { name = "orjson" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
 wheels = [
@@ -7207,7 +7208,7 @@ name = "lance-namespace"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lance-namespace-urllib3-client", marker = "python_full_version >= '3.12'" },
+    { name = "lance-namespace-urllib3-client" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
 wheels = [
@@ -7219,10 +7220,10 @@ name = "lance-namespace-urllib3-client"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
-    { name = "urllib3", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
 wheels = [
@@ -7234,14 +7235,14 @@ name = "lancedb"
 version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation", marker = "python_full_version >= '3.12'" },
-    { name = "lance-namespace", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pyarrow", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
@@ -7313,7 +7314,7 @@ wheels = [
 
 [package.optional-dependencies]
 valkey = [
-    { name = "valkey-glide-sync", marker = "sys_platform != 'win32'" },
+    { name = "valkey-glide-sync" },
 ]
 
 [[package]]
@@ -7620,9 +7621,9 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "langchain-core", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "litellm", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "litellm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/fa/088dd2e3426aa413991afb67aef4c4e79ff3c0e4c25f753842bfaf4ec43f/langchain_litellm-0.5.1.tar.gz", hash = "sha256:1af5743c424456ce12c59cbf08b4774fbc9025124b6de8249713864242db57e1", size = 18869, upload-time = "2026-02-11T00:56:40.631Z" }
 wheels = [
@@ -7648,10 +7649,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "litellm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/24/473283e69791fb35e11126c11e7347ffbf110c2dfcebebe90bd974bc7348/langchain_litellm-0.7.0.tar.gz", hash = "sha256:d3b8d0e6f65132f048fbe9d706e5334d45830e3c49aa033d32c37c6683ad2ceb", size = 345959, upload-time = "2026-06-15T10:00:36.437Z" }
 wheels = [
@@ -7799,14 +7800,14 @@ name = "langchain-pinecone"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "langchain-core", marker = "python_full_version < '3.14'" },
-    { name = "langchain-openai", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pinecone", extra = ["asyncio"], marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "simsimd", marker = "python_full_version < '3.14'" },
+    { name = "pinecone", extra = ["asyncio"] },
+    { name = "pydantic" },
+    { name = "simsimd" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/e9/b52029651f6f8c0c585f26ae665a8ef34cd36a47b2590a2cd3a1a0b11d9d/langchain_pinecone-0.2.13.tar.gz", hash = "sha256:294a6da7e1a81d5805060e37639d3e4fb72cb239d651a34a4d1f81ba096f473a", size = 40655, upload-time = "2025-11-02T19:11:45.842Z" }
 wheels = [
@@ -9098,26 +9099,26 @@ name = "langwatch"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.14'" },
-    { name = "coolname", marker = "python_full_version < '3.14'" },
-    { name = "deprecated", marker = "python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "langchain-core", marker = "python_full_version < '3.14'" },
-    { name = "nanoid", marker = "python_full_version < '3.14'" },
-    { name = "openinference-instrumentation-haystack", marker = "python_full_version < '3.14'" },
-    { name = "openinference-instrumentation-langchain", marker = "python_full_version < '3.14'" },
-    { name = "openinference-instrumentation-openai", marker = "python_full_version < '3.14'" },
-    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-instrumentation-crewai", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
-    { name = "pksuid", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "python-liquid", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "retry", marker = "python_full_version < '3.14'" },
-    { name = "termcolor", marker = "python_full_version < '3.14'" },
+    { name = "attrs" },
+    { name = "coolname" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "nanoid" },
+    { name = "openinference-instrumentation-haystack" },
+    { name = "openinference-instrumentation-langchain" },
+    { name = "openinference-instrumentation-openai" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-crewai" },
+    { name = "opentelemetry-sdk" },
+    { name = "pksuid" },
+    { name = "pydantic" },
+    { name = "python-liquid" },
+    { name = "pyyaml" },
+    { name = "retry" },
+    { name = "termcolor" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/52/359afd09f4054ab1c7dc4b349c6b65d4f32321ad758028c6f085cefa781a/langwatch-0.10.2.tar.gz", hash = "sha256:455b211d1e0b44fecb0a0240b7a5781349ecf52ce9d3fba33e23118a33b1e02b", size = 1365949, upload-time = "2026-02-05T06:54:48.456Z" }
 wheels = [
@@ -10379,6 +10380,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "lfx-scavio"
+version = "0.1.0"
+source = { editable = "src/bundles/scavio" }
+dependencies = [
+    { name = "httpx" },
+    { name = "lfx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "lfx", editable = "src/lfx" },
+]
+
+[[package]]
 name = "lfx-toolguard"
 version = "0.1.0"
 source = { editable = "src/bundles/toolguard" }
@@ -10907,7 +10923,7 @@ name = "lxml-html-clean"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "lxml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
 wheels = [
@@ -10982,13 +10998,13 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "sys_platform == 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
-    { name = "python-dotenv", marker = "sys_platform == 'win32'" },
+    { name = "click" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/8fdd991142ad3e037179a494b153f463024e5a211ef3ad948b955c26b4de/magika-0.6.2.tar.gz", hash = "sha256:37eb6ae8020f6e68f231bc06052c0a0cbe8e6fa27492db345e8dc867dbceb067", size = 3036634, upload-time = "2025-05-02T14:54:18.88Z" }
 wheels = [
@@ -11017,13 +11033,13 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "click", marker = "sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "python-dotenv", marker = "sys_platform != 'win32'" },
+    { name = "click" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.28.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -11186,15 +11202,15 @@ name = "matplotlib"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "cycler", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pillow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -11284,8 +11300,8 @@ wheels = [
 
 [package.optional-dependencies]
 cli = [
-    { name = "python-dotenv", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -11352,12 +11368,12 @@ name = "milvus-lite"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu", version = "1.9.0.post1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "grpcio", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "pyarrow", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "faiss-cpu", version = "1.9.0.post1", source = { registry = "https://pypi.org/simple" } },
+    { name = "grpcio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyarrow" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/d0/3edb31f832287557c8a8bb0515aec2c73265512040dcd4fc43d747722d11/milvus_lite-3.1.1.tar.gz", hash = "sha256:0cbf8386a2e99b6464a5eda14cf8e31934b0e287e36c831e293aee614d9efc2e", size = 647172, upload-time = "2026-07-27T05:03:56.834Z" }
 wheels = [
@@ -11369,7 +11385,7 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
@@ -11415,7 +11431,7 @@ name = "mlx"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "mlx-metal" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/38/a034159df4d21ef7b5721225a2c46092e20a2c627724f57be3e89fa7dbce/mlx-0.32.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:c6feb17e32160b70c7634aab925cf3f8c5c7bebbf99f227c48450478e1008af2", size = 562899, upload-time = "2026-07-07T17:55:25.157Z" },
@@ -11440,14 +11456,14 @@ name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "mlx", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
-    { name = "protobuf", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "pyyaml", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "sentencepiece", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "transformers", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "jinja2" },
+    { name = "mlx" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -11469,19 +11485,19 @@ name = "mlx-vlm"
 version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "fastapi", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "mlx", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "mlx-lm", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
-    { name = "opencv-python", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "pillow", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "requests", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "soundfile", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "tqdm", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "transformers", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "uvicorn", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "datasets" },
+    { name = "fastapi" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "requests" },
+    { name = "soundfile" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/cc/04a100878abc21aac431221cc6fb79bb69f29e9e61a84284f866340dadfd/mlx_vlm-0.3.12.tar.gz", hash = "sha256:b9ee7528ec2765cc02d3115b39a70f0dc1c51345473530981e6386a91f26f379", size = 495607, upload-time = "2026-02-16T23:39:27.649Z" }
 wheels = [
@@ -12126,32 +12142,32 @@ name = "nicegui"
 version = "3.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "certifi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "docutils", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "fastapi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "h11", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "idna", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "ifaddr", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "itsdangerous", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "lxml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "lxml-html-clean", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "markdown2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "orjson", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pydantic-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pygments", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-engineio", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-multipart", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-socketio", extra = ["asyncio-client"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "starlette", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "tinycss2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "uvicorn", extra = ["standard"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "docutils" },
+    { name = "fastapi" },
+    { name = "h11" },
+    { name = "httpx" },
+    { name = "idna" },
+    { name = "ifaddr" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "lxml" },
+    { name = "lxml-html-clean" },
+    { name = "markdown2" },
+    { name = "orjson" },
+    { name = "pydantic-core" },
+    { name = "pygments" },
+    { name = "python-dotenv" },
+    { name = "python-engineio" },
+    { name = "python-multipart" },
+    { name = "python-socketio", extra = ["asyncio-client"] },
+    { name = "starlette" },
+    { name = "tinycss2" },
+    { name = "typing-extensions" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ee/0100f3cd2b2af218db1cb695b9ea5c88862df56356e3a2d47744b2b58bf5/nicegui-3.15.0.tar.gz", hash = "sha256:9472841e9635bce7cf608f10e515549517284c0d5dddf69c47bf176a44c82623", size = 19701841, upload-time = "2026-07-23T16:00:44.05Z" }
 wheels = [
@@ -12220,7 +12236,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
 wheels = [
@@ -12304,7 +12320,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/c4/27ea7849eb4a7e3b51db446b0414254326dba8c6bdee09b9f2abf963e55d/numexpr-2.14.2.tar.gz", hash = "sha256:e7144e83ea9e581f2273e0304f15836736c4e470e2bd2e378ce617662a1ca278", size = 121744, upload-time = "2026-07-18T10:52:43.185Z" }
@@ -12578,16 +12594,16 @@ name = "nv-ingest-api"
 version = "26.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backoff", marker = "python_full_version >= '3.12'" },
-    { name = "ffmpeg-python", marker = "python_full_version >= '3.12'" },
-    { name = "fsspec", marker = "python_full_version >= '3.12'" },
-    { name = "glom", marker = "python_full_version >= '3.12'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.12'" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.12'" },
-    { name = "tritonclient", marker = "python_full_version >= '3.12'" },
-    { name = "universal-pathlib", marker = "python_full_version >= '3.12'" },
+    { name = "backoff" },
+    { name = "ffmpeg-python" },
+    { name = "fsspec" },
+    { name = "glom" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pypdfium2" },
+    { name = "tritonclient" },
+    { name = "universal-pathlib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/a1/cb847218f856e57930562c4974cc1eaba9f68fa076a2466f88e79df4d9b3/nv_ingest_api-26.3.0.tar.gz", hash = "sha256:0cd7be3e13b0f5343e466da988fba315d0673ba3de3106c619bee48500f78fb3", size = 277120, upload-time = "2026-03-16T18:42:41.591Z" }
 wheels = [
@@ -12599,17 +12615,17 @@ name = "nv-ingest-client"
 version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "build", marker = "python_full_version >= '3.12'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.12'" },
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "fsspec", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "lancedb", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "build" },
+    { name = "charset-normalizer" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "lancedb" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/62/386bc4a336b91df9c65afc18d905bb1fe3dd44ef1ce038895a701cba6035/nv_ingest_client-26.1.2.tar.gz", hash = "sha256:7ea4a35d4e7051031c273eb2b15170a0555462b702602e5c4fdce947bd39d446", size = 126061, upload-time = "2026-01-21T14:06:31.836Z" }
 wheels = [
@@ -12630,9 +12646,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "pillow" },
+    { name = "pyobjc-framework-vision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -12688,13 +12704,13 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.14'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -12731,10 +12747,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.14'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
@@ -12841,36 +12857,36 @@ name = "opendsstar"
 version = "1.0.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "diskcache", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "docling", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "kaleido", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-community", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-huggingface", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-milvus", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langchain-text-splitters", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "langgraph", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "matplotlib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "openai", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "plotly", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pyarrow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pymilvus", extra = ["milvus-lite"], marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "pymilvus", extra = ["model"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "ragworkbench", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "datasets" },
+    { name = "diskcache" },
+    { name = "docling" },
+    { name = "huggingface-hub" },
+    { name = "kaleido" },
+    { name = "langchain" },
+    { name = "langchain-community" },
+    { name = "langchain-core" },
+    { name = "langchain-huggingface" },
+    { name = "langchain-litellm", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "langchain-milvus" },
+    { name = "langchain-text-splitters" },
+    { name = "langgraph" },
+    { name = "litellm" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "openai" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "plotly" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "pymilvus", extra = ["milvus-lite"], marker = "sys_platform != 'win32'" },
+    { name = "pymilvus", extra = ["model"] },
+    { name = "python-dotenv" },
+    { name = "ragworkbench" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "sentence-transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "smolagents", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "sentence-transformers" },
+    { name = "smolagents" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/92/28a33b1ed586709e9f75e90029071bd558bc41629ab9051da486d178216a/opendsstar-1.0.26.tar.gz", hash = "sha256:035fdeaf2bc3d9b9126f9f2f9ffe9f8de17b28f43a8539dbe5fcd46a857703e7", size = 200210, upload-time = "2026-05-10T11:46:12.152Z" }
 wheels = [
@@ -12897,13 +12913,13 @@ name = "openinference-instrumentation-haystack"
 version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation", marker = "python_full_version < '3.14'" },
-    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-instrumentation", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "wrapt", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/a6/8dfddcc7bc17b0151f8539a828b74d5a6f4fe74e4011de54f252d52f29d6/openinference_instrumentation_haystack-0.1.34.tar.gz", hash = "sha256:952ebfb4abe8701374f5131d7b5e156b9fb8601bdbee4bc868eabf383d0f63d7", size = 15835, upload-time = "2026-05-18T18:51:31.822Z" }
 wheels = [
@@ -12932,13 +12948,13 @@ name = "openinference-instrumentation-openai"
 version = "0.1.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation", marker = "python_full_version < '3.14'" },
-    { name = "openinference-semantic-conventions", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-instrumentation", marker = "python_full_version < '3.14'" },
-    { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "wrapt", marker = "python_full_version < '3.14'" },
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/90/c81c7426cb9dca075cef1b5fe16f58c68604b7518f7aaa14d837ec80fde3/openinference_instrumentation_openai-0.1.52.tar.gz", hash = "sha256:5a3dceb742209463e33ab2a4aa82f56bedfa20c25c738de28248509931044ea1", size = 23087, upload-time = "2026-06-11T17:13:35.517Z" }
 wheels = [
@@ -14021,10 +14037,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
 wheels = [
@@ -14086,11 +14102,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "pytz", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -14154,8 +14170,8 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "types-pytz", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "types-pytz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -14184,7 +14200,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
@@ -14277,7 +14293,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -14371,12 +14387,12 @@ name = "pinecone"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.14'" },
-    { name = "pinecone-plugin-assistant", marker = "python_full_version < '3.14'" },
-    { name = "pinecone-plugin-interface", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "urllib3", marker = "python_full_version < '3.14'" },
+    { name = "certifi" },
+    { name = "pinecone-plugin-assistant" },
+    { name = "pinecone-plugin-interface" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/38/12731d4af470851b4963eba616605868a8599ef4df51c7b6c928e5f3166d/pinecone-7.3.0.tar.gz", hash = "sha256:307edc155621d487c20dc71b76c3ad5d6f799569ba42064190d03917954f9a7b", size = 235256, upload-time = "2025-06-27T20:03:51.498Z" }
 wheels = [
@@ -14385,8 +14401,8 @@ wheels = [
 
 [package.optional-dependencies]
 asyncio = [
-    { name = "aiohttp", marker = "python_full_version < '3.14'" },
-    { name = "aiohttp-retry", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
 ]
 
 [[package]]
@@ -14394,8 +14410,8 @@ name = "pinecone-plugin-assistant"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "packaging" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/01/65c4c3a81732fa379f8e7f78a8c18aa57a1139f5b79d58b93a69f2fc8cb0/pinecone_plugin_assistant-1.8.0.tar.gz", hash = "sha256:8e8682cff30f9bae9243b384021aba71c91f4e6ef1650e9d63ee64aab83cba87", size = 150435, upload-time = "2025-08-31T14:31:18.046Z" }
 wheels = [
@@ -14425,7 +14441,7 @@ name = "pksuid"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pybase62", marker = "python_full_version < '3.14'" },
+    { name = "pybase62" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/2f/8df6e1663197459f3de732cee69d050a118023d80e3ce00d172b83b6f09d/pksuid-1.1.2.tar.gz", hash = "sha256:dc08ed7924a8affea5f36af4b6af345b126f521c9165b95e91ca1a2acef99e49", size = 4938, upload-time = "2022-05-07T00:19:10.051Z" }
 wheels = [
@@ -14446,8 +14462,8 @@ name = "playwright"
 version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "pyee", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "greenlet" },
+    { name = "pyee" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
@@ -14464,8 +14480,8 @@ name = "plotly"
 version = "6.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "narwhals", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "narwhals" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
 wheels = [
@@ -15566,8 +15582,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
@@ -15607,7 +15623,7 @@ name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
 wheels = [
@@ -15698,10 +15714,10 @@ wheels = [
 
 [package.optional-dependencies]
 milvus-lite = [
-    { name = "milvus-lite", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
 ]
 model = [
-    { name = "pymilvus-model", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pymilvus-model" },
 ]
 
 [[package]]
@@ -15709,12 +15725,12 @@ name = "pymilvus-model"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "protobuf" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/8f/a8212f3d932d566fdec354b49befa09174b239c8b8ad25a33b798cee393b/pymilvus_model-0.3.2.tar.gz", hash = "sha256:10ab49a989396943e08555b971f85182ddb50da47076e699a157c9a5ff542872", size = 36268, upload-time = "2025-03-31T08:47:45.007Z" }
 wheels = [
@@ -15824,7 +15840,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -15842,8 +15858,8 @@ name = "pyobjc-framework-coreml"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/1e/7d2db3e4468eb04cc92264be83113d86eea4f96302742437de695a445d6d/pyobjc_framework_coreml-12.2.1.tar.gz", hash = "sha256:ef3c2b6a160891b44173235603d10174929656b9c206d6f2f443fe2aa903c2cb", size = 49272, upload-time = "2026-06-19T16:20:18.459Z" }
 wheels = [
@@ -15861,8 +15877,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -15880,10 +15896,10 @@ name = "pyobjc-framework-vision"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/1fdffff1b6bf124b260a2169869f4b71a08b9f6603698f7dec990d5ae5f3/pyobjc_framework_vision-12.2.1.tar.gz", hash = "sha256:debfd59dd7d962a6053bf733370148c11a9ec44091b517a0966f48d81c305879", size = 72683, upload-time = "2026-06-19T16:22:01.102Z" }
 wheels = [
@@ -16372,10 +16388,10 @@ name = "python-liquid"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel", marker = "python_full_version < '3.14'" },
-    { name = "markupsafe", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "pytz", marker = "python_full_version < '3.14'" },
+    { name = "babel" },
+    { name = "markupsafe" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/ee/d4c59a4248a35f00bd88798f3ae468255fb7efee7a638692ffdb87cdd760/python_liquid-2.3.0.tar.gz", hash = "sha256:09841630ad2ecfa75ddf214f33bacaad930d4aadef799309f9e8a84f70e2826f", size = 95554, upload-time = "2026-07-06T06:02:17.114Z" }
 wheels = [
@@ -16489,7 +16505,7 @@ wheels = [
 
 [package.optional-dependencies]
 asyncio-client = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "aiohttp" },
 ]
 client = [
     { name = "requests" },
@@ -16810,7 +16826,7 @@ name = "ragstack-ai-knowledge-store"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cassio", marker = "python_full_version < '3.13'" },
+    { name = "cassio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/e1/da324f5b590aef5ae07b8e7e38ee249101b2bfae6882ba1152c06f8228b2/ragstack_ai_knowledge_store-0.2.1.tar.gz", hash = "sha256:20424d42978be228feb887a71d76228638765446d1a37a1f6faef109e448fe06", size = 16964, upload-time = "2024-07-30T10:42:12.03Z" }
 wheels = [
@@ -16822,25 +16838,25 @@ name = "ragworkbench"
 version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bert-score", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "docling-core", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "gdown", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "nicegui", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "bert-score" },
+    { name = "datasets" },
+    { name = "docling-core" },
+    { name = "gdown" },
+    { name = "huggingface-hub" },
+    { name = "litellm" },
+    { name = "nicegui" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "types-pyyaml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "types-requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "unitxt", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "tenacity" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+    { name = "unitxt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/4d/3c9957b9a1d1e15503bbf4e114699355a58ebbbc69f010b892966c97dbe9/ragworkbench-0.1.3.tar.gz", hash = "sha256:7a81302195337ac17512603f351dae88a6eb3d6a477e62a98dc129073873fd27", size = 163965, upload-time = "2026-03-31T09:47:07.212Z" }
 wheels = [
@@ -17186,7 +17202,7 @@ wheels = [
 
 [package.optional-dependencies]
 socks = [
-    { name = "pysocks", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -17231,8 +17247,8 @@ name = "retry"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator", marker = "python_full_version < '3.14'" },
-    { name = "py", marker = "python_full_version < '3.14'" },
+    { name = "decorator" },
+    { name = "py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
 wheels = [
@@ -17271,9 +17287,9 @@ name = "rich-toolkit"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "rich", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/3a/a258c2fbc6c6bdf428611388f5698ba5d57ffdf0755e1cab474d9cc47813/rich_toolkit-0.20.3.tar.gz", hash = "sha256:223dd2cfba325ed55e94933b9e53f3aca13e9fdf76622bd564c18109a2273c1b", size = 205355, upload-time = "2026-07-13T14:38:06.837Z" }
 wheels = [
@@ -17764,14 +17780,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version < '3.11'" },
-    { name = "lazy-loader", marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -17820,16 +17836,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version >= '3.11'" },
-    { name = "lazy-loader", marker = "python_full_version >= '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "tifffile", version = "2026.7.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
@@ -17895,10 +17911,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -17956,13 +17972,13 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -18009,7 +18025,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -18071,7 +18087,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -18155,7 +18171,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
@@ -18217,12 +18233,12 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.12'" },
-    { name = "beautifulsoup4", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "toonify", marker = "python_full_version < '3.12'" },
+    { name = "aiohttp" },
+    { name = "beautifulsoup4" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "toonify" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/b4/9196574ac53c6c94fb311824e3f6e5e13191620fb9a09b056daf0e77a19d/scrapegraph_py-1.47.0.tar.gz", hash = "sha256:4794820d9dcdba2c6ee22b4ad0975843a10adb65e4831e680f846067e13c5aa9", size = 340039, upload-time = "2026-04-18T13:50:01.084Z" }
 wheels = [
@@ -18247,8 +18263,8 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "httpx" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/4b/8b165cfb0d6b564cc69e4f58270bb54f2457c68d5c0fc648d547e3d0e207/scrapegraph_py-2.1.0.tar.gz", hash = "sha256:c4d1ed4d0c11c5c10e999d310ce1146f62809a91292b3d07d69b40c2a0954d75", size = 4876208, upload-time = "2026-04-21T12:53:48.428Z" }
 wheels = [
@@ -18260,9 +18276,9 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -18682,10 +18698,10 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "cffi" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [
@@ -19019,9 +19035,9 @@ name = "tavily-python"
 version = "0.7.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "requests", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
-    { name = "tiktoken", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "httpx" },
+    { name = "requests" },
+    { name = "tiktoken" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/29/c2d5056dbf45a80484df5a1bf0d0ae59c611aa9680372c400a278fbf0c50/tavily_python-0.7.26.tar.gz", hash = "sha256:36202728144fce1ef0cece33800f98e3cdeb5f600e6678c50b1232b866a2f509", size = 29647, upload-time = "2026-06-10T18:38:45.231Z" }
 wheels = [
@@ -19108,7 +19124,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -19126,7 +19142,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -19151,7 +19167,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/2f/e5fe51c8f782241d86fdf7251594b195f0d6c2fcf9d389079de212599246/tifffile-2026.7.14.tar.gz", hash = "sha256:ce2703e5ef22c868f1528d5f5b4ef75eefb019cf628a1c9ec0d17e0afeca8ef5", size = 437660, upload-time = "2026-07-14T23:41:31.737Z" }
@@ -19225,7 +19241,7 @@ name = "tinycss2"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "webencodings", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "webencodings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
@@ -19347,7 +19363,7 @@ name = "toonify"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tiktoken", marker = "python_full_version < '3.12'" },
+    { name = "tiktoken" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/53/409a1dd7bcb52c74da019994cb866e875d0bf9020b89c7fcfcdea2866ce3/toonify-1.6.0.tar.gz", hash = "sha256:57bf6fbc9d73e463e8773c491123b233b0c79482235e0c27b908b4e58b54ec77", size = 30106, upload-time = "2026-02-06T16:00:02.622Z" }
 wheels = [
@@ -19366,14 +19382,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "fsspec", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "jinja2", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "sympy", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or platform_machine != 'arm64'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", upload-time = "2026-07-08T12:26:07Z" },
@@ -19405,14 +19421,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
-    { name = "setuptools", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (python_full_version >= '3.14' and sys_platform == 'darwin')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:0555fde6108ca90247ae33d4e1237cbae475c86a223bb2f0f91d9addf1f611bd", upload-time = "2026-07-08T19:27:11Z" },
@@ -19456,11 +19472,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform == 'darwin'" },
-    { name = "pillow", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'arm64'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine == 'arm64'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pillow" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2a1ef4b6f4bf5828b48cfad97372c8982db906830884b2868ba5c3df937a7d81", upload-time = "2026-07-08T12:26:40Z" },
@@ -19492,11 +19508,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (python_full_version >= '3.14' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'darwin'" },
-    { name = "pillow", marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.14' and platform_machine != 'arm64') or sys_platform != 'darwin'" },
+    { name = "pillow" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7d81da2804da52c9788f2d5a8d0aaddcea9fce6eb5d7c6e19a32b40b4ed0b75a", upload-time = "2026-07-08T12:26:39Z" },
@@ -19801,11 +19817,11 @@ name = "tritonclient"
 version = "2.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-rapidjson", marker = "python_full_version >= '3.12'" },
-    { name = "urllib3", marker = "python_full_version >= '3.12'" },
+    { name = "python-rapidjson" },
+    { name = "urllib3" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/2f/079ce9218627c66b2a704ff37c25c72504cabbd3e2dad65b2235dae636d1/tritonclient-2.70.0-py3-none-any.whl", hash = "sha256:7ef72e5bc11649c9415057b0933ffb9d16675f0013f1f54759457fb625355de2", size = 111782, upload-time = "2026-06-26T16:19:59.329Z" },
@@ -19870,7 +19886,7 @@ name = "typer-slim"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typer", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
@@ -20059,10 +20075,10 @@ name = "unitxt"
 version = "1.26.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "diskcache", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "evaluate", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "datasets" },
+    { name = "diskcache" },
+    { name = "evaluate" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/68/cda80f4fdc32aa5f8753d5ffe70d5110b9dc25956b15a8b579c72e033c95/unitxt-1.26.10.tar.gz", hash = "sha256:f588045669c222a02ed703386aad8b02d0d41aa87a0122a06182e7623fad4ec2", size = 28838924, upload-time = "2026-05-27T10:43:42.425Z" }
@@ -20075,8 +20091,8 @@ name = "universal-pathlib"
 version = "0.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fsspec", marker = "python_full_version >= '3.12'" },
-    { name = "pathlib-abc", marker = "python_full_version >= '3.12'" },
+    { name = "fsspec" },
+    { name = "pathlib-abc" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/6e/d997a70ee8f4c61f9a7e2f4f8af721cf072a3326848fc881b05187e52558/universal_pathlib-0.3.10.tar.gz", hash = "sha256:4487cbc90730a48cfb64f811d99e14b6faed6d738420cd5f93f59f48e6930bfb", size = 261110, upload-time = "2026-02-22T14:40:58.87Z" }
 wheels = [
@@ -20324,9 +20340,9 @@ name = "valkey-glide-sync"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "sys_platform != 'win32'" },
-    { name = "protobuf", marker = "sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'win32'" },
+    { name = "cffi" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/c9/e4acc31ceb91fa2c96d0a3147de9d0d86208579532d25eebfcf09aab9877/valkey_glide_sync-2.5.0.tar.gz", hash = "sha256:75366dccc7d0f92a41ec47ccd49fbac45c48b92d2a8d2f677ae5673dda7f9325", size = 961943, upload-time = "2026-07-14T18:50:45.415Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -7940,6 +7940,7 @@ dependencies = [
     { name = "lfx-openai" },
     { name = "lfx-openai-compatible" },
     { name = "lfx-oracle" },
+    { name = "lfx-scavio" },
     { name = "lfx-toolguard" },
     { name = "lfx-vllm" },
 ]
@@ -8076,6 +8077,7 @@ requires-dist = [
     { name = "lfx-openai-compatible", editable = "src/bundles/openai-compatible" },
     { name = "lfx-oracle", editable = "src/bundles/oracle" },
     { name = "lfx-paddle", marker = "extra == 'bundles'", editable = "src/bundles/paddle" },
+    { name = "lfx-scavio", editable = "src/bundles/scavio" },
     { name = "lfx-toolguard", editable = "src/bundles/toolguard" },
     { name = "lfx-valkey", marker = "extra == 'bundles'", editable = "src/bundles/valkey" },
     { name = "lfx-vllm", editable = "src/bundles/vllm" },


### PR DESCRIPTION
### Summary

Adds **Scavio** as a standalone Extension Bundle (`lfx-scavio`) under `src/bundles/scavio`, following [`src/bundles/PORTING.md`](https://github.com/langflow-ai/langflow/blob/main/src/bundles/PORTING.md). Scavio is a real-time search API for AI agents: one key over search, retail, real estate, travel, jobs, app stores, company filings, software reviews, ad libraries and social, plus a generic "read any URL as HTML / Markdown / text" endpoint.

**39 components, 188 endpoints, 32 platforms.** Scavio has never shipped in-tree, so `component_migrations.json` is untouched and no compatibility shim belongs under `src/lfx/.../components/scavio/`.

Targets `release-1.12.0` per CONTRIBUTING ("open a pull request against the active `release-X.Y.Z` release candidate branch; do not target `main`") — a new bundle is a feature, so it belongs on the next minor.

### What is in the bundle

| Group | Components |
|---|---|
| Search | Google web / AI Mode / Maps / Shopping / News / Trends / Flights / Hotels, Extract |
| Retail | Amazon, Walmart, eBay, Target, Home Depot |
| Real estate, travel, local | Zillow, Redfin, Booking.com, Airbnb, TripAdvisor, Yelp |
| Jobs, companies, software | Indeed, Glassdoor, SEC EDGAR, Companies House, G2, Capterra |
| App stores and ads | App Store, Google Play, Google Ads Transparency, Meta Ad Library |
| Social | YouTube, Reddit, TikTok, TikTok Shop, Instagram, Threads, X, LinkedIn, Kuaishou |

Multi-endpoint components carry an **Endpoint** dropdown with `real_time_refresh`, so `update_build_config` shows only the fields that endpoint accepts and the node never presents a control the API ignores. Every component has a **Table** output (`DataFrame`) and a **Raw JSON** output (the untouched body, credit counters included).

### Repo-side registrations

- `src/frontend/src/icons/Scavio/` + the `Scavio` key in `src/frontend/src/icons/lazyIconImports.ts` (every component sets `icon = "Scavio"`).
- Root `pyproject.toml`, between the `# langflow-extensions:bundle-*` markers: `[tool.uv.sources]`, `[tool.uv.workspace] members`, and a bounded `lfx-scavio>=0.2.0,<1.0.0` in `[project] dependencies`. Happy to drop the last one and keep Scavio a workspace member only, like the other partner bundles — maintainers' call.
- `uv.lock`.

### Notes since the last push

This branch has been rebased onto current `release-1.12.0` and carries four commits. Three are worth calling out:

**1. `uv.lock` is regenerated, not hand-merged.** The previous revision of this PR rewrote the whole lock file (1238 lines changed), which conflicted on every rebase. It is now the 18 lines that add the workspace member, and nothing else.

**2. Two inputs were silently broken.** `Component` already owns a `start` attribute (a method) and a `user_id` attribute, so an input of either name is shadowed: `getattr(self, "start")` returned the bound method and `getattr(self, "user_id")` returned the literal string `"None"`. Both are now exposed under a different input name (`start_offset`, `target_user_id`) and mapped back to their wire names through `Endpoint.wire`, so the API still receives `start` and `user_id`. A regression test asserts no input name intersects `dir(Component)` — worth knowing about for other bundles.

**3. `lfx extension validate` now passes.** The components previously took their output methods from a plain mixin, which the validator's static check cannot see, so all of them reported `build-method-missing`. They now derive from a `ScavioBaseComponent` that lives one directory above `components/scavio`, so the loader does not register it as a palette node.

While fixing that I hit an import-order fragility in `lfx` itself, which I have **not** touched here since it is outside this bundle's scope: importing `lfx.template.field.base` or `lfx.inputs.inputs` before `lfx.custom.custom_component.component` raises `ImportError: cannot import name 'Component' from partially initialized module`. The bundle now routes every `lfx` name through one module so `import lfx_scavio` works from a cold interpreter, but the underlying cycle is still there for anyone else who trips it.

### Credit costs

Each component states what a call costs. Most endpoints are a flat 1, 2 or 5 credits. Three surfaces are priced from the request body rather than the path and say so rather than quoting a flat number:

- **Walmart** search/category — 1 credit on `domain` `com`/`ca`, 2 on `com.mx`
- **Threads** profile / user posts / user replies — 2 credits by `user_id`, 4 by `username`
- **Extract** — 1 credit in `normal`/`advanced`, 2 in `ultra`, billed only on success

### Testing

```bash
uv run pytest src/bundles/scavio/tests -q          # 52 passed
uv run lfx extension validate src/bundles/scavio/src/lfx_scavio   # ok, 41 files
uv run ruff check src/bundles/scavio && uv run ruff format --check src/bundles/scavio
uv lock --check
```

The suite is fully offline (`httpx.Client` is patched) and guards endpoint coverage, per-endpoint credit costs, the body-priced endpoints, the wire quirks, the flat-vs-`data` envelope split, and the shadowed-input class of bug.

Beyond the offline suite, the components were run against the live API to confirm the request and response shapes end to end — eBay, Zillow, SEC EDGAR, Meta Ad Library, Companies House, Threads and Extract all returned rows at the documented cost. The `result_keys` that drive the Table output are set from those observed responses rather than guessed; detail endpoints deliberately carry none and render as a single row.

### Deliberately not exposed

- `POST /api/v1/google` — Google v1 was retired on 2026-08-04 and answers 410. Every Google component targets `/api/v2/google*`.
- `POST /api/v1/youtube/metadata` — a deprecated alias of `/api/v1/youtube/video`, which is exposed.
- Five LinkedIn endpoints whose upstream dataset was withdrawn and which now answer 410 unbilled.

Docs: https://scavio.dev/docs/langflow
