### PR TITLE
test(frontend): stabilize grouped node readiness

### DIFF
--- a/src/frontend/tests/core/unit/groupFalseError.spec.ts
+++ b/src/frontend/tests/core/unit/groupFalseError.spec.ts
@@ -1,6 +1,7 @@
 import type { APIClassType, APIObjectType } from "../../../src/types/api";
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
 
 /**
  * LE-2045: grouping succeeds but raises "Error while updating the Component".
@@ -110,8 +111,18 @@ test(
     expect(created.status()).toBe(201);
     const flowId = (await created.json()).id;
 
+    const flowLoadPromise = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname.endsWith(`/api/v1/flows/${flowId}`) &&
+        response.request().method() === "GET" &&
+        response.status() === 200,
+      { timeout: TIMEOUTS.standard },
+    );
     await page.goto(`/flow/${flowId}`);
-    await expect(page.getByTestId("div-generic-node")).toHaveCount(1);
+    await flowLoadPromise;
+    await expect(page.getByTestId("div-generic-node")).toHaveCount(1, {
+      timeout: TIMEOUTS.standard,
+    });
     await page.waitForTimeout(4000);
 
     await page.getByTestId("notification_button").click();


### PR DESCRIPTION
## Summary

- wait for the exact flow GET response before asserting that the grouped node mounted
- use the shared 30-second page-load timeout for both flow loading and canvas readiness

## Why

Frontend shard 53 repeatedly timed out after Playwright's default 5 seconds while waiting for `div-generic-node`. The failing trace showed the flow GET did not begin until roughly 15.5 seconds after navigation under shard contention, then returned successfully and rendered the node. The same signature also occurred on unrelated PRs, so this stabilizes the regression test without changing application behavior.

Failing job: https://github.com/langflow-ai/langflow/actions/runs/30952988293/job/92139921491

## Testing

- `biome check tests/core/unit/groupFalseError.spec.ts`
- `playwright test tests/core/unit/groupFalseError.spec.ts --list --retries=0 --workers=2`
- `playwright test tests/core/unit/groupFalseError.spec.ts --workers=1 --retries=0` (1 passed)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by waiting for flow data to load before validating results.
  * Standardized timeout handling to reduce intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->