### PR TITLE
fix(storage): validate local list flow ids

### DIFF
--- a/src/backend/base/langflow/services/storage/local.py
+++ b/src/backend/base/langflow/services/storage/local.py
@@ -40,6 +40,48 @@ class LocalStorageService(StorageService):
         super().__init__(session_service, settings_service)
         # Base class already sets self.data_dir as anyio.Path from settings_service.settings.config_dir
 
+    async def _validated_flow_dir(self, flow_id: str) -> anyio.Path:
+        """Return a flow directory inside ``data_dir`` or raise if traversal is attempted."""
+        if (
+            not isinstance(flow_id, str)
+            or not flow_id
+            or "/" in flow_id
+            or "\\" in flow_id
+            or ".." in flow_id
+            or "\x00" in flow_id
+        ):
+            await logger.aerror("Invalid flow_id contains path separators or traversal sequences")
+            msg = "Invalid flow_id: contains path separators"
+            raise ValueError(msg)
+
+        folder_path = self.data_dir / flow_id
+
+        try:
+            resolved_data_dir = await self.data_dir.resolve()
+            resolved_folder = await folder_path.resolve()
+            if not resolved_folder.is_relative_to(resolved_data_dir):
+                await logger.aerror(
+                    f"Path traversal attempt detected for flow_id='{flow_id}'. "
+                    "Flow directory would escape data directory boundary."
+                )
+                msg = "Invalid flow_id: path traversal detected"
+                raise ValueError(msg)
+        except ValueError:
+            raise
+        except AttributeError:
+            resolved_data_dir_str = str(await self.data_dir.resolve())
+            resolved_folder_str = str(await folder_path.resolve())
+            if not resolved_folder_str.startswith(resolved_data_dir_str):
+                await logger.aerror(f"Path traversal attempt detected for flow_id='{flow_id}' (fallback check)")
+                msg = "Invalid flow_id: path traversal detected"
+                raise ValueError(msg) from None
+        except Exception as e:
+            await logger.aerror(f"Error validating flow directory for flow_id='{flow_id}': {type(e).__name__}")
+            msg = "Invalid flow_id"
+            raise ValueError(msg) from e
+
+        return folder_path
+
     async def _validated_path(self, flow_id: str, file_name: str) -> anyio.Path:
         """Return a path inside the flow directory or raise if traversal is attempted.
 
@@ -56,19 +98,7 @@ class LocalStorageService(StorageService):
             msg = "Invalid file name: contains path separators"
             raise ValueError(msg)
 
-        if (
-            not isinstance(flow_id, str)
-            or not flow_id
-            or "/" in flow_id
-            or "\\" in flow_id
-            or ".." in flow_id
-            or "\x00" in flow_id
-        ):
-            await logger.aerror("Invalid flow_id contains path separators or traversal sequences")
-            msg = "Invalid flow_id: contains path separators"
-            raise ValueError(msg)
-
-        folder_path = self.data_dir / flow_id
+        folder_path = await self._validated_flow_dir(flow_id)
         file_path = folder_path / file_name
 
         try:
@@ -244,7 +274,7 @@ class LocalStorageService(StorageService):
         if not isinstance(flow_id, str):
             flow_id = str(flow_id)
 
-        folder_path = self.data_dir / flow_id
+        folder_path = await self._validated_flow_dir(flow_id)
         if not await folder_path.exists() or not await folder_path.is_dir():
             await logger.awarning(f"Flow {flow_id} directory does not exist.")
             return []

--- a/src/backend/tests/unit/services/storage/test_local_storage_service.py
+++ b/src/backend/tests/unit/services/storage/test_local_storage_service.py
@@ -398,11 +398,32 @@ class TestLocalStorageServicePathTraversal:
         with pytest.raises(ValueError, match="Invalid"):
             await local_storage_service.get_file(malicious_flow_id, "passwd")
 
+    @pytest.mark.parametrize(
+        "malicious_flow_id",
+        [
+            "/etc",
+            "..",
+            "../other",
+            "..\\other",
+            "flow/sub",
+            "flow\\sub",
+            "with\x00null",
+            "",
+        ],
+    )
+    async def test_list_files_rejects_malicious_flow_id(self, local_storage_service, malicious_flow_id):
+        with pytest.raises(ValueError, match="Invalid"):
+            await local_storage_service.list_files(malicious_flow_id)
+
     async def test_get_file_rejects_absolute_flow_id_collapse(self, local_storage_service):
         # Direct regression for the public-build arbitrary-file-read: ensure the
         # /etc/<file> shape is rejected even when the file would exist on disk.
         with pytest.raises(ValueError, match="Invalid"):
             await local_storage_service.get_file("/etc", "hosts")
+
+    async def test_list_files_rejects_absolute_flow_id_collapse(self, local_storage_service):
+        with pytest.raises(ValueError, match="Invalid"):
+            await local_storage_service.list_files("/etc")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Validate local storage flow ids before listing files, matching the containment checks already used by read/write/delete/size operations.

## Why

`LocalStorageService.list_files()` built `self.data_dir / flow_id` directly, while the other local storage entry points used path validation. This left one storage method with a weaker boundary and could allow malformed flow ids such as absolute paths or traversal segments to escape the configured data directory if called with untrusted input.

## Changes

- Add `_validated_flow_dir()` for shared flow-id validation and containment checks
- Reuse it from `_validated_path()`
- Apply it to `list_files()`
- Add regression coverage for malicious flow ids in `list_files()`

## Testing

- `python -m py_compile src/backend/base/langflow/services/storage/local.py src/backend/tests/unit/services/storage/test_local_storage_service.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for stored flow files by rejecting invalid or potentially unsafe flow identifiers.
  * Prevented directory traversal, absolute-path access, path separators, null bytes, and empty identifiers from accessing local storage.
  * Added validation when listing stored files to ensure access remains within the configured data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->