### PR TITLE
ci: harden workflow/composite inputs before shell use

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -25,13 +25,15 @@ runs:
     - name: Get Playwright version
       uses: actions/github-script@v7
       id: version
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       with:
         script: |
           const fs = require('fs');
           const path = require('path');
 
-          // Get working directory
-          const workingDirectory = "${{ inputs.working-directory }}";
+          // Get working directory (via env — avoid interpolating inputs into script source)
+          const workingDirectory = process.env.WORKING_DIRECTORY || './';
           console.debug("Specified working directory:", workingDirectory);
           if (workingDirectory) process.chdir(workingDirectory);
           console.debug("Actual working directory:", process.cwd());
@@ -67,7 +69,9 @@ runs:
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.working-directory }}
-      run: npx playwright install ${{ inputs.browsers }} --with-deps
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
+      run: npx playwright install $PLAYWRIGHT_BROWSERS --with-deps
 
     - name: Install just Playwright's dependencies
       shell: bash

--- a/.github/workflows/a11y-scan.yml
+++ b/.github/workflows/a11y-scan.yml
@@ -37,22 +37,27 @@ jobs:
       - name: Resolve Ref To Scan
         id: resolve_ref
         shell: bash
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_VALUE: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ -n "${{ inputs.ref }}" ]; then
-            REF="${{ inputs.ref }}"
-          elif [ "${{ github.event_name }}" = "schedule" ]; then
-            REF=$(git ls-remote --heads https://github.com/${{ github.repository }} 'refs/heads/release-*' \
+          if [ -n "$INPUT_REF" ]; then
+            REF="$INPUT_REF"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
+            REF=$(git ls-remote --heads "https://github.com/$REPOSITORY" 'refs/heads/release-*' \
               | awk '{print $2}' \
               | sed 's|refs/heads/||' \
               | grep -E '^release-[0-9]+\.[0-9]+\.[0-9]+$' \
               | sort -V \
               | tail -n 1)
             if [ -z "$REF" ]; then
-              echo "No release-* branch found in ${{ github.repository }}"
+              echo "No release-* branch found in $REPOSITORY"
               exit 1
             fi
           else
-            REF="${{ github.ref }}"
+            REF="$GITHUB_REF_VALUE"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "Scanning ref: $REF"

--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -31,6 +31,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.13"
+  LFX_VERSION: ${{ github.event.inputs.version }}
 
 permissions:
   contents: write
@@ -67,21 +68,21 @@ jobs:
           version=$(echo $version | sed 's/^v//')
           echo "current_version=$version" >> $GITHUB_OUTPUT
 
-          if [ "$version" != "${{ github.event.inputs.version }}" ]; then
-            echo "❌ Version mismatch: package has $version but input is ${{ github.event.inputs.version }}"
+          if [ "$version" != "$LFX_VERSION" ]; then
+            echo "❌ Version mismatch: package has $version but input is $LFX_VERSION"
             echo "Please update the version in pyproject.toml first"
             echo "should_release=false" >> $GITHUB_OUTPUT
             exit 1
           fi
 
           # Check if version already exists on PyPI
-          if curl -s "https://pypi.org/pypi/lfx/json" | jq -r '.releases | keys[]' | grep -q "^${{ github.event.inputs.version }}$"; then
-            echo "❌ Version ${{ github.event.inputs.version }} already exists on PyPI"
+          if curl -s "https://pypi.org/pypi/lfx/json" | jq -r '.releases | keys[]' | grep -q "^${LFX_VERSION}$"; then
+            echo "❌ Version $LFX_VERSION already exists on PyPI"
             echo "should_release=false" >> $GITHUB_OUTPUT
             exit 1
           fi
 
-          echo "✅ Version ${{ github.event.inputs.version }} is valid and not yet released"
+          echo "✅ Version $LFX_VERSION is valid and not yet released"
           echo "should_release=true" >> $GITHUB_OUTPUT
 
   run-tests:
@@ -157,8 +158,8 @@ jobs:
           version=$(echo $version | sed 's/^v//')
 
           # Verify version matches input
-          if [ "$version" != "${{ github.event.inputs.version }}" ]; then
-            echo "Version $version does not match input ${{ github.event.inputs.version }}. Exiting the workflow."
+          if [ "$version" != "$LFX_VERSION" ]; then
+            echo "Version $version does not match input $LFX_VERSION. Exiting the workflow."
             exit 1
           fi
 
@@ -291,31 +292,34 @@ jobs:
 
       - name: Generate release notes
         id: notes
+        env:
+          CURRENT_VERSION: ${{ needs.validate-version.outputs.current_version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           cat > release_notes.md << EOF
-          # LFX ${{ github.event.inputs.version }}
+          # LFX $LFX_VERSION
 
           ## 🚀 Installation
 
           ### PyPI
           \`\`\`bash
-          pip install lfx==${{ github.event.inputs.version }}
+          pip install lfx==$LFX_VERSION
           # or
-          uv pip install lfx==${{ github.event.inputs.version }}
+          uv pip install lfx==$LFX_VERSION
           # or run without installing
-          uvx lfx@${{ github.event.inputs.version }} --help
+          uvx lfx@$LFX_VERSION --help
           \`\`\`
 
           ### Docker
           \`\`\`bash
           # Standard image
-          docker pull langflowai/lfx:${{ github.event.inputs.version }}
+          docker pull langflowai/lfx:$LFX_VERSION
 
           # Alpine image (smaller)
-          docker pull langflowai/lfx:${{ github.event.inputs.version }}-alpine
+          docker pull langflowai/lfx:$LFX_VERSION-alpine
 
           # Run a flow
-          docker run --rm -v \$(pwd):/app/data langflowai/lfx:${{ github.event.inputs.version }} lfx run flow.json --input-value "Hello"
+          docker run --rm -v \$(pwd):/app/data langflowai/lfx:$LFX_VERSION lfx run flow.json --input-value "Hello"
           \`\`\`
 
           ## 📦 What's New
@@ -330,7 +334,7 @@ jobs:
 
           ---
 
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/v${{ needs.validate-version.outputs.current_version }}...lfx-v${{ github.event.inputs.version }}
+          **Full Changelog**: https://github.com/$REPOSITORY/compare/v$CURRENT_VERSION...lfx-v$LFX_VERSION
           EOF
 
       - name: Create Release
@@ -362,17 +366,17 @@ jobs:
         if: needs.release-lfx.result == 'success'
         run: |
           # Test installation using uv
-          uv pip install lfx==${{ github.event.inputs.version }}
+          uv pip install "lfx==$LFX_VERSION"
           uv run lfx --help
 
       - name: Test Docker image
         if: needs.build-docker.result == 'success'
         run: |
           # Test standard image
-          docker run --rm langflowai/lfx:${{ github.event.inputs.version }} lfx --help
+          docker run --rm "langflowai/lfx:$LFX_VERSION" lfx --help
 
           # Test alpine image
-          docker run --rm langflowai/lfx:${{ github.event.inputs.version }}-alpine lfx --help
+          docker run --rm "langflowai/lfx:$LFX_VERSION-alpine" lfx --help
 
           # Test with a simple flow
           cat > test_flow.json << 'EOF'
@@ -382,7 +386,7 @@ jobs:
           }
           EOF
 
-          docker run --rm -v $(pwd):/app/data langflowai/lfx:${{ github.event.inputs.version }} \
+          docker run --rm -v "$(pwd):/app/data" "langflowai/lfx:$LFX_VERSION" \
             lfx run /app/data/test_flow.json --input-value "test" || true
 
   notify:
@@ -393,14 +397,16 @@ jobs:
     steps:
       - name: Notify success
         if: needs.create-release.result == 'success'
+        env:
+          REPOSITORY: ${{ github.repository }}
         run: |
-          echo "✅ LFX ${{ github.event.inputs.version }} released successfully!"
-          echo "PyPI: https://pypi.org/project/lfx/${{ github.event.inputs.version }}/"
+          echo "✅ LFX $LFX_VERSION released successfully!"
+          echo "PyPI: https://pypi.org/project/lfx/$LFX_VERSION/"
           echo "Docker Hub: https://hub.docker.com/r/langflowai/lfx/tags"
-          echo "GitHub Release: https://github.com/${{ github.repository }}/releases/tag/lfx-v${{ github.event.inputs.version }}"
+          echo "GitHub Release: https://github.com/$REPOSITORY/releases/tag/lfx-v$LFX_VERSION"
 
       - name: Notify failure
         if: needs.create-release.result != 'success'
         run: |
-          echo "❌ LFX ${{ github.event.inputs.version }} release failed!"
+          echo "❌ LFX $LFX_VERSION release failed!"
           exit 1


### PR DESCRIPTION
## Summary
- CI hygiene for free-string inputs interpolated into `run:` shells.
- Bind under `env:` / use shell vars in:
  - `.github/workflows/release-lfx.yml` (`github.event.inputs.version`)
  - `.github/workflows/a11y-scan.yml` (`inputs.ref`)
  - `.github/actions/install-playwright` (`browsers`, `working-directory`)
- Privileged release path + reusable composite — defense-in-depth, not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Optional `workflow_dispatch` on a11y-scan with a stable ref
- [ ] Playwright install composite still installs default browser set

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow handling for version, browser, and repository settings.
  * Standardized release validation, testing, release notes, and notifications around the selected release version.
  * Preserved existing reference-selection behavior for accessibility scans across manual and scheduled runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->