### PR TITLE
fix: strip query strings from URL attributes before spans are exported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ real_services_tests: ## run tests that need real service instances (needs LANGFL
 lfx_tests: ## run lfx package unit tests
 	@echo 'Running LFX Package Tests...'
 	@cd src/lfx && \
-	uv sync --dev && \
+	uv sync --dev --extra otel && \
 	uv run pytest tests/unit -v --cov=src/lfx --cov-report=xml --cov-report=html --cov-report=term-missing $(args)
 
 integration_tests:

--- a/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
+++ b/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
@@ -1,0 +1,112 @@
+"""The operator's APM must never receive a credential that travelled in a URL.
+
+``lfx serve`` accepts its API key as a query parameter (``APIKeyQuery``), and the FastAPI
+server span records ``url.query`` verbatim. That scope is on the export allowlist, so before
+this the key went to whatever OTLP backend the operator configured.
+
+Runs in a subprocess because the tracer provider is process-global.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from lfx.observability import APPLICATION_INSTRUMENTATION_SCOPES
+
+SECRET = "lfx-serve-api-key-NOT-REAL"  # noqa: S105  # pragma: allowlist secret
+
+# The server span is already allowlisted, and ``lfx serve`` accepts its API key as a query
+# parameter, so this is a live path today rather than a hypothetical one.
+SERVER_SPAN_PROBE = f"""
+import asyncio, json
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lfx.observability import ApplicationOnlySpanProcessor, instrument_fastapi_app
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+app = FastAPI()
+
+
+@app.get("/flows/run")
+async def run():
+    return {{"ok": True}}
+
+
+instrument_fastapi_app(app)
+SECRET = {SECRET!r}
+
+
+async def main():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://probe") as client:
+        await client.get(f"/flows/run?x-api-key={{SECRET}}&flow=abc")
+    provider.force_flush()
+    spans = [
+        {{"name": s.name, "attrs": dict(s.attributes)}}
+        for s in exporter.get_finished_spans()
+        if s.attributes and "url.path" in s.attributes
+    ]
+    print("PROBE_RESULT " + json.dumps({{"spans": spans}}))
+
+
+asyncio.run(main())
+"""
+
+
+def run_probe(source: str) -> dict:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe_path = Path(tmp) / "probe.py"
+        probe_path.write_text(source, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    assert completed.returncode == 0, completed.stderr
+    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
+    return json.loads(line.removeprefix("PROBE_RESULT "))
+
+
+def test_the_serve_api_key_never_reaches_the_apm():
+    """Regression for a live leak: the key is accepted as a query param and the span kept it."""
+    result = run_probe(SERVER_SPAN_PROBE)
+
+    assert result["spans"], "expected a server span carrying url.path"
+    blob = json.dumps(result["spans"])
+    assert SECRET not in blob, f"serve API key reached the APM: {blob}"
+
+
+def test_redaction_keeps_the_route_an_operator_needs():
+    """Blanking everything would be safe and useless; path and method must survive."""
+    result = run_probe(SERVER_SPAN_PROBE)
+    attrs = result["spans"][0]["attrs"]
+
+    assert attrs["url.path"] == "/flows/run"
+    assert attrs["url.query"] == ""
+    assert attrs["http.request.method"] == "GET"
+
+
+def test_outbound_http_scopes_stay_out_of_the_allowlist():
+    """Redacting URLs does not make the LLM transports safe to export; that boundary stands."""
+    for scope in (
+        "opentelemetry.instrumentation.httpx",
+        "opentelemetry.instrumentation.requests",
+        "opentelemetry.instrumentation.urllib3",
+    ):
+        assert scope not in APPLICATION_INSTRUMENTATION_SCOPES

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -23,6 +23,7 @@ import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
 
 from lfx.log.logger import logger
 from lfx.observability_fastapi import patch_otel_fastapi_route_details
@@ -183,6 +184,7 @@ if _OTEL_AVAILABLE:
         def on_end(self, span) -> None:
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
             if scope in APPLICATION_INSTRUMENTATION_SCOPES:
+                _redact_url_attributes(span)
                 super().on_end(span)
                 return
             if scope not in self._dropped_scopes:
@@ -493,6 +495,52 @@ class ApplicationTelemetry:
             self.tracer_provider.shutdown()
         if self.logger_provider is not None:
             self.logger_provider.shutdown()
+
+
+# URL attributes an HTTP instrumentor may set. Every one of them can carry a full URL, and a
+# full URL can carry a credential: providers put API keys in the query string (Gemini's
+# ?key=, several others), and a URL may also carry userinfo before the host.
+_URL_SPAN_ATTRIBUTES = ("http.url", "url.full", "http.target", "url.query")
+
+
+def _redact_url_attributes(span) -> None:
+    """Strip query strings and userinfo from a span's URL attributes, in place.
+
+    A live leak, not a hypothetical, and on a scope that is already allowlisted: the FastAPI
+    server span records ``url.query`` verbatim, and ``lfx serve`` accepts its API key as a
+    query parameter (``APIKeyQuery``). A probe against the real instrumented app exports
+    ``url.query = "x-api-key=<the key>"``, so any deployment whose callers pass the key that
+    way has been sending it to the operator's APM.
+
+    Done at the export boundary rather than through an instrumentor hook because this is the
+    same place that already decides what leaves: one chokepoint, and it covers instrumentors
+    the runtime does not install itself.
+
+    Scheme, host, port, path and every non-URL attribute survive, so "POST api.openai.com
+    /v1/chat/completions took 3s" still reads exactly as an operator needs it to.
+    """
+    attributes = span.attributes
+    if not attributes or not any(key in attributes for key in _URL_SPAN_ATTRIBUTES):
+        return
+    redacted = dict(attributes)
+    for key in _URL_SPAN_ATTRIBUTES:
+        if key not in redacted:
+            continue
+        if key == "url.query":
+            # The whole point of this attribute is the query string, so there is nothing to keep.
+            redacted[key] = ""
+            continue
+        parts = urlsplit(str(redacted[key]))
+        netloc = parts.hostname or ""
+        if parts.port:
+            netloc = f"{netloc}:{parts.port}"
+        redacted[key] = urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    # Imported here, not at module scope: opentelemetry is an optional lfx extra and this
+    # module must stay importable without it.
+    from opentelemetry.attributes import BoundedAttributes
+
+    # ReadableSpan exposes no setter; the SDK's own processors reach for this attribute too.
+    span._attributes = BoundedAttributes(attributes=redacted)  # noqa: SLF001
 
 
 def bootstrap_application_telemetry(*, prometheus_enabled: bool = False) -> ApplicationTelemetry:

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -522,25 +522,62 @@ def _redact_url_attributes(span) -> None:
     attributes = span.attributes
     if not attributes or not any(key in attributes for key in _URL_SPAN_ATTRIBUTES):
         return
+
+    original_attributes = span._attributes  # noqa: SLF001
     redacted = dict(attributes)
+
     for key in _URL_SPAN_ATTRIBUTES:
-        if key not in redacted:
+        if key not in attributes:
             continue
         if key == "url.query":
             # The whole point of this attribute is the query string, so there is nothing to keep.
             redacted[key] = ""
-            continue
-        parts = urlsplit(str(redacted[key]))
-        netloc = parts.hostname or ""
-        if parts.port:
-            netloc = f"{netloc}:{parts.port}"
-        redacted[key] = urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+        else:
+            value = attributes[key]
+            if not isinstance(value, str) or (
+                original_attributes.max_value_len is not None and len(value) >= original_attributes.max_value_len
+            ):
+                # A sequence is not a valid semantic URL value. A value at the SDK's length cap
+                # may have lost its query or userinfo delimiter, so neither can be redacted safely.
+                redacted[key] = ""
+                continue
+            try:
+                parts = urlsplit(value)
+                # Accessing port validates the authority. Keep using the raw netloc below so
+                # bracketed IPv6 and port zero retain their exact valid representation.
+                _ = parts.port
+            except ValueError:
+                # Telemetry must never break request handling. A malformed authority is not useful
+                # operational data, so fail closed rather than exporting it or raising from Span.end().
+                redacted[key] = ""
+            else:
+                # Strip userinfo from the raw authority instead of rebuilding it from hostname/port:
+                # the raw form preserves IPv6 brackets and port zero.
+                netloc = parts.netloc.rsplit("@", maxsplit=1)[-1]
+                missing_authority = not netloc and (
+                    key in ("http.url", "url.full") or parts.scheme.lower() in ("http", "https", "ws", "wss")
+                )
+                if missing_authority:
+                    # Absolute URL attributes and hierarchical HTTP-style values require an
+                    # authority. Otherwise credential-looking bytes may be hiding in the path.
+                    redacted[key] = ""
+                else:
+                    redacted[key] = urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
     # Imported here, not at module scope: opentelemetry is an optional lfx extra and this
     # module must stay importable without it.
     from opentelemetry.attributes import BoundedAttributes
 
-    # ReadableSpan exposes no setter; the SDK's own processors reach for this attribute too.
-    span._attributes = BoundedAttributes(attributes=redacted)  # noqa: SLF001
+    # Span.end() freezes the SDK's BoundedAttributes before processors run, and ReadableSpan
+    # exposes no public setter. Rebuild the immutable mapping with its original limits and
+    # carry the prior drop count forward so exporters receive the same span metadata.
+    redacted_attributes = BoundedAttributes(
+        maxlen=original_attributes.maxlen,
+        attributes=redacted,
+        max_value_len=original_attributes.max_value_len,
+    )
+    redacted_attributes.dropped = original_attributes.dropped
+    span._attributes = redacted_attributes  # noqa: SLF001
 
 
 def bootstrap_application_telemetry(*, prometheus_enabled: bool = False) -> ApplicationTelemetry:

--- a/src/lfx/tests/unit/test_observability.py
+++ b/src/lfx/tests/unit/test_observability.py
@@ -19,6 +19,7 @@ import pytest
 
 _HAS_OTEL = importlib.util.find_spec("opentelemetry") is not None
 requires_otel = pytest.mark.skipif(not _HAS_OTEL, reason="requires the lfx[otel] extra")
+_TEST_USERINFO = "user:password"  # pragma: allowlist secret
 
 
 def _run(probe: str, env_overrides: dict[str, str]) -> subprocess.CompletedProcess:
@@ -198,6 +199,85 @@ def test_span_filter_drops_llm_scopes():
 
     exported = {span.name for span in exporter.get_finished_spans()}
     assert exported == {"flow.execute"}
+
+
+def _export_application_span(attributes, *, span_limits=None):
+    from lfx.observability import APPLICATION_TRACER_NAME, ApplicationOnlySpanProcessor
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(span_limits=span_limits)
+    provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+    try:
+        span = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("url.redaction")
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+        span.end()
+        provider.force_flush()
+        exported = exporter.get_finished_spans()
+    finally:
+        provider.shutdown()
+
+    assert len(exported) == 1
+    return exported[0]
+
+
+@requires_otel
+@pytest.mark.parametrize(
+    ("attribute", "value", "expected"),
+    [
+        ("url.query", "x-api-key=secret", ""),
+        ("http.target", "/flows/run?x-api-key=secret#fragment", "/flows/run"),
+        (
+            "url.full",
+            f"https://{_TEST_USERINFO}@example.com:443/flows/run?x-api-key=secret#fragment",
+            "https://example.com:443/flows/run",
+        ),
+        (
+            "http.url",
+            f"http://{_TEST_USERINFO}@[2001:db8::1]:0/flows/run?x-api-key=secret#fragment",
+            "http://[2001:db8::1]:0/flows/run",
+        ),
+        (
+            "http.url",
+            f"http://{_TEST_USERINFO}@example.com:notaport/flows/run?x-api-key=secret#fragment",
+            "",
+        ),
+        ("url.full", "http://[broken/flows/run?x-api-key=secret", ""),
+        ("url.full", f"http:{_TEST_USERINFO}@example.com/flows/run?x-api-key=secret", ""),
+        ("http.url", f"http:///{_TEST_USERINFO}@example.com/flows/run?x-api-key=secret", ""),
+        ("http.target", f"http:{_TEST_USERINFO}@example.com/flows/run?x-api-key=secret", ""),
+        ("url.full", (f"https://{_TEST_USERINFO}@example.com/flows/run?x-api-key=secret",), ""),
+    ],
+)
+def test_span_filter_redacts_url_attributes_without_losing_operational_details(attribute, value, expected):
+    span_attributes = {attribute: value, "http.request.method": "GET"}
+    if attribute != "url.query":
+        span_attributes["url.query"] = "another-secret=x"
+    exported = _export_application_span(span_attributes)
+
+    assert exported.attributes[attribute] == expected
+    if attribute != "url.query":
+        assert exported.attributes["url.query"] == ""
+    assert exported.attributes["http.request.method"] == "GET"
+    assert "secret" not in str(exported.attributes)
+    assert "password" not in str(exported.attributes)
+
+
+@requires_otel
+def test_span_filter_preserves_attribute_limits_and_drop_count():
+    from opentelemetry.sdk.trace import SpanLimits
+
+    exported = _export_application_span(
+        {"discarded": "value", "url.full": "https://secret@example.com/flows/run?secret=x"},
+        span_limits=SpanLimits(max_span_attributes=1, max_span_attribute_length=14),
+    )
+
+    assert exported.attributes["url.full"] == ""
+    assert exported.dropped_attributes == 1
+    assert exported._attributes.maxlen == 1
+    assert exported._attributes.max_value_len == 14
 
 
 @requires_otel


### PR DESCRIPTION
## The problem

`lfx serve` accepts its API key as a query parameter (`APIKeyQuery`), and the FastAPI server span records `url.query` verbatim. That scope is on the export allowlist, so a deployment whose callers pass the key that way has been sending it to whatever OTLP backend the operator configured.

A probe against the real instrumented app, before this change:

```
url.query = "x-api-key=<the key>&flow=abc"
```

## The fix

The export boundary strips the query string and any userinfo from URL attributes on the way out. Scheme, host, port and path survive, so `GET /flows/run` reads exactly as it did.

It happens at the boundary rather than in an instrumentor hook because that is the one place already deciding what leaves the process, so it also covers instrumentation the runtime does not install itself.

## What this does not do

It allowlists no new scope. Redacting a URL does not make the LLM vendor transports (`httpx`, `requests`, `urllib3`) safe to export, and that boundary is untouched — the 16 tests in `test_application_span_filter.py` that guard it still pass unchanged.

## Verification

| Mutation | Result |
| --- | --- |
| Remove the redaction call | leak test red, with the key visible in `url.query` |

Three tests, subprocess-isolated because the tracer provider is process-global. They drive the real instrumented FastAPI app rather than constructing a span by hand, so the assertion covers the instrumentation's actual attribute names.

Split out of #14420 so it can be reviewed and merged on its own; that PR keeps the database spans and the sampler pinning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensitive URL query parameters and user information are now removed from exported application telemetry.
  * URL scheme, host, port, and path remain available for troubleshooting.
  * URL query attributes are cleared before export.

* **Bug Fixes**
  * Improved protection against API keys and other secrets appearing in telemetry data.
  * Preserved HTTP method and route details needed for operational diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->