### PR TITLE
fix(security): join repeated X-Forwarded-For lines before taking the last hop

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -83,6 +83,7 @@ from langflow.services.database.models.api_key.model import ApiKeyCreate
 from langflow.services.database.models.user.crud import get_user_by_username
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_service
+from langflow.services.rate_limit.service import get_last_forwarded_for_hop
 
 # Constants
 ALL_INTERFACES_HOST = "0.0.0.0"  # noqa: S104
@@ -792,6 +793,9 @@ def get_client_ip(request: Request) -> str:
     (``rate_limit_trust_proxy``) do we consult ``X-Forwarded-For``, and then we
     take the rightmost entry — the last hop added by the trusted proxy, which a
     client cannot forge — mirroring ``langflow.services.rate_limit.service.get_client_ip``.
+    Every occurrence of the header is joined first, so a proxy that appends its
+    own line rather than extending the client's cannot leave the attacker's line
+    as the one we read.
 
     Args:
         request: FastAPI Request object
@@ -802,11 +806,9 @@ def get_client_ip(request: Request) -> str:
     # Only consult X-Forwarded-For when an operator has explicitly declared a
     # trusted proxy; otherwise the header is attacker-controlled.
     if get_settings_service().settings.rate_limit_trust_proxy:
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            # Rightmost entry = last hop added by the trusted proxy (unspoofable);
-            # the leftmost entry is client-supplied and must never be trusted.
-            return forwarded_for.split(",")[-1].strip()
+        last_hop = get_last_forwarded_for_hop(request)
+        if last_hop:
+            return last_hop
 
     # Default: trust only the real TCP peer.
     if request.client:

--- a/src/backend/base/langflow/services/rate_limit/service.py
+++ b/src/backend/base/langflow/services/rate_limit/service.py
@@ -104,6 +104,27 @@ def check_rate_limit(
         raise RateLimitExceeded(limit_wrapper)
 
 
+def get_last_forwarded_for_hop(request: Request) -> str | None:
+    """Return the rightmost ``X-Forwarded-For`` entry, or None when the header is absent.
+
+    The header may legitimately arrive as several separate lines: some proxies
+    (HAProxy's ``option forwardfor``, for one) append their own line instead of
+    extending the client's. ``Headers.get`` returns only the first line, so
+    reading it alone would yield the rightmost entry of the *client-supplied*
+    line and hand an attacker control of a value the caller assumes is
+    unspoofable. Join every line in order, per RFC 9110 field-order semantics,
+    before taking the last hop.
+
+    Callers must gate this on an explicit trusted-proxy opt-in; the header is
+    attacker-controlled otherwise.
+    """
+    # X-Forwarded-For format: "client, proxy1, proxy2", possibly split across lines.
+    chain = [ip.strip() for line in request.headers.getlist("x-forwarded-for") for ip in line.split(",")]
+    entries = [ip for ip in chain if ip]
+    # Rightmost entry = last hop added by the trusted proxy; the leftmost is client-supplied.
+    return entries[-1] if entries else None
+
+
 def get_client_ip(request: Request) -> str:
     """Extract client IP address from request, using rightmost X-Forwarded-For entry.
 
@@ -118,12 +139,9 @@ def get_client_ip(request: Request) -> str:
         str: Client IP address
     """
     # Check X-Forwarded-For header first (for proxied requests)
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        # X-Forwarded-For format: "client, proxy1, proxy2"
-        # Take the rightmost IP (last proxy before us)
-        ips = [ip.strip() for ip in forwarded_for.split(",")]
-        return ips[-1]
+    last_hop = get_last_forwarded_for_hop(request)
+    if last_hop:
+        return last_hop
 
     # Fall back to direct client IP
     if request.client:

--- a/src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_install_xff_trust.py
@@ -12,11 +12,18 @@ from types import SimpleNamespace
 
 from langflow.api.v1 import mcp_projects
 from langflow.api.v1.mcp_projects import get_client_ip, is_local_ip
+from starlette.datastructures import Headers
 
 
 def _request(headers: dict | None = None, host: str | None = "203.0.113.7"):
     client = SimpleNamespace(host=host) if host is not None else None
-    return SimpleNamespace(headers=headers or {}, client=client)
+    return SimpleNamespace(headers=Headers(headers or {}), client=client)
+
+
+def _request_raw(raw_headers: list[tuple[bytes, bytes]], host: str | None = "203.0.113.7"):
+    """Build a request whose headers may repeat, which ``Headers(dict)`` cannot express."""
+    client = SimpleNamespace(host=host) if host is not None else None
+    return SimpleNamespace(headers=Headers(raw=raw_headers), client=client)
 
 
 def _set_trust_proxy(monkeypatch, *, value: bool) -> None:
@@ -48,6 +55,49 @@ def test_trusted_proxy_uses_rightmost_xff(monkeypatch):
     _set_trust_proxy(monkeypatch, value=True)
     # The client spoofs 127.0.0.1 as the leftmost entry; the trusted proxy appends the real last hop.
     req = _request(headers={"X-Forwarded-For": "127.0.0.1, 203.0.113.7"}, host="10.0.0.2")
+    ip = get_client_ip(req)
+    assert ip == "203.0.113.7"
+    assert is_local_ip(ip) is False
+
+
+def test_trusted_proxy_joins_repeated_xff_lines(monkeypatch):
+    """A proxy that appends its own header line must not leave the client's line as the one we read.
+
+    HAProxy's ``option forwardfor`` adds a second ``X-Forwarded-For`` line rather than extending the
+    client's. ``Headers.get`` returns only the first line, so reading it alone would take the
+    rightmost entry of the attacker-supplied line — handing the attacker the value the locality gate
+    assumes is unspoofable.
+    """
+    _set_trust_proxy(monkeypatch, value=True)
+    req = _request_raw(
+        [
+            (b"host", b"target:7860"),
+            (b"x-forwarded-for", b"127.0.0.1"),  # attacker's own line, sent first
+            (b"x-forwarded-for", b"203.0.113.7"),  # line appended by the trusted proxy
+        ],
+        host="10.0.0.5",  # TCP peer is the proxy
+    )
+    ip = get_client_ip(req)
+    assert ip == "203.0.113.7"
+    assert is_local_ip(ip) is False
+
+
+def test_repeated_xff_lines_ignored_without_trusted_proxy(monkeypatch):
+    """Without the trusted-proxy opt-in, repeated lines are ignored entirely."""
+    _set_trust_proxy(monkeypatch, value=False)
+    req = _request_raw(
+        [(b"x-forwarded-for", b"127.0.0.1"), (b"x-forwarded-for", b"127.0.0.1")],
+        host="203.0.113.7",
+    )
+    ip = get_client_ip(req)
+    assert ip == "203.0.113.7"
+    assert is_local_ip(ip) is False
+
+
+def test_empty_xff_falls_back_to_peer(monkeypatch):
+    """A blank header must not resolve to an empty client IP."""
+    _set_trust_proxy(monkeypatch, value=True)
+    req = _request(headers={"X-Forwarded-For": "  "}, host="203.0.113.7")
     ip = get_client_ip(req)
     assert ip == "203.0.113.7"
     assert is_local_ip(ip) is False

--- a/src/backend/tests/unit/test_login_rate_limiting.py
+++ b/src/backend/tests/unit/test_login_rate_limiting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
+from starlette.datastructures import Headers
 
 
 @pytest.fixture
@@ -103,7 +104,7 @@ class TestIPExtraction:
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {"X-Forwarded-For": "203.0.113.1"}
+        request.headers = Headers({"X-Forwarded-For": "203.0.113.1"})
         request.client = Mock(host="127.0.0.1")
 
         ip = get_client_ip(request)
@@ -115,7 +116,7 @@ class TestIPExtraction:
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {"X-Forwarded-For": "203.0.113.1, 198.51.100.1, 192.0.2.1"}
+        request.headers = Headers({"X-Forwarded-For": "203.0.113.1, 198.51.100.1, 192.0.2.1"})
         request.client = Mock(host="127.0.0.1")
 
         ip = get_client_ip(request)
@@ -128,7 +129,7 @@ class TestIPExtraction:
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {"X-Forwarded-For": "  203.0.113.1  ,  198.51.100.1  "}
+        request.headers = Headers({"X-Forwarded-For": "  203.0.113.1  ,  198.51.100.1  "})
         request.client = Mock(host="127.0.0.1")
 
         ip = get_client_ip(request)
@@ -136,12 +137,46 @@ class TestIPExtraction:
         # Should use rightmost IP, stripped of whitespace
         assert ip == "198.51.100.1"
 
+    def test_get_client_ip_joins_repeated_x_forwarded_for_lines(self):
+        """Repeated X-Forwarded-For lines must be joined before taking the rightmost entry.
+
+        Some proxies append their own header line instead of extending the client's. Reading only
+        the first line would key the rate limiter on an attacker-chosen value, letting a caller pin
+        or rotate their own bucket.
+        """
+        from langflow.services.rate_limit.service import get_client_ip
+
+        request = Mock()
+        request.headers = Headers(
+            raw=[
+                (b"x-forwarded-for", b"203.0.113.1"),  # client-supplied line
+                (b"x-forwarded-for", b"192.0.2.1"),  # line appended by the trusted proxy
+            ]
+        )
+        request.client = Mock(host="10.0.0.5")
+
+        ip = get_client_ip(request)
+
+        assert ip == "192.0.2.1"
+
+    def test_get_client_ip_ignores_blank_x_forwarded_for(self):
+        """A blank header must fall back to the peer rather than returning an empty key."""
+        from langflow.services.rate_limit.service import get_client_ip
+
+        request = Mock()
+        request.headers = Headers({"X-Forwarded-For": " , "})
+        request.client = Mock(host="192.168.1.100")
+
+        ip = get_client_ip(request)
+
+        assert ip == "192.168.1.100"
+
     def test_get_client_ip_from_direct_connection(self):
         """Test IP extraction from direct client connection (no proxy)."""
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {}
+        request.headers = Headers({})
         request.client = Mock(host="192.168.1.100")
 
         ip = get_client_ip(request)
@@ -153,7 +188,7 @@ class TestIPExtraction:
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {}
+        request.headers = Headers({})
         request.client = None
 
         ip = get_client_ip(request)
@@ -165,7 +200,7 @@ class TestIPExtraction:
         from langflow.services.rate_limit.service import get_client_ip
 
         request = Mock()
-        request.headers = {"X-Forwarded-For": "203.0.113.1"}
+        request.headers = Headers({"X-Forwarded-For": "203.0.113.1"})
         request.client = Mock(host="127.0.0.1")
 
         ip = get_client_ip(request)


### PR DESCRIPTION
## Context

While confirming **GHSA-4f6c-2vvp-gw82** / **GHSA-qvvj-g573-9638** (MCP installer trusting client-supplied `X-Forwarded-For`) against `release-1.11.3`, I found the reported bypass is **already fixed** — `1641b28f33` (#13530, 2026-07-13) is contained in v1.11.0/v1.11.1/v1.11.2, and release-1.10.3 has it via the separate backport `94859df33a` (#14071). The advisory PoC no longer reproduces.

This PR fixes a **residual variant of the same bypass** that is still reachable on `release-1.11.3`.

## The bug

Both client-IP resolvers read the forwarded chain with `Headers.get("X-Forwarded-For")`:

- `langflow.api.v1.mcp_projects.get_client_ip`
- `langflow.services.rate_limit.service.get_client_ip`

Starlette's `Headers.get` returns only the **first matching header line**; it does not join repeated occurrences the way uvicorn does. Proxies that append their own `X-Forwarded-For` line rather than extending the client's — HAProxy's `option forwardfor` does this by default — therefore leave the *caller's* line as the one we parse. The "rightmost entry is the trusted proxy's last hop, which a client cannot forge" invariant then resolves to an attacker-chosen value.

Concretely, with `rate_limit_trust_proxy=True`:

```
X-Forwarded-For: 127.0.0.1        <- attacker's line, sent first
X-Forwarded-For: 203.0.113.7      <- line appended by the trusted proxy
```

`Headers.get` returns `"127.0.0.1"`, its rightmost entry is `127.0.0.1`, and `is_local_ip` passes — so a remote caller clears the local-only gate on `POST /api/v1/mcp/project/{project_id}/install`, which writes MCP client config (`~/.cursor/mcp.json` and friends) to the host filesystem. That is the impact GHSA-4f6c-2vvp-gw82 describes, reached through a differently-shaped header.

The same parsing feeds rate-limit bucket keys for login, public build, and public workflow endpoints, so a caller can also pin or rotate their own bucket.

nginx's `$proxy_add_x_forwarded_for` produces a single joined line and was never affected.

## Scope

**Default deployments are not affected.** `rate_limit_trust_proxy` defaults to `False`, and neither resolver reads the header in that mode; `forwarded_allow_ips=""` additionally stops uvicorn's `ProxyHeadersMiddleware` from rewriting `request.client`. Exposure requires the operator to have opted into a trusted proxy, which is why this is materially lower severity than the original advisory.

## The fix

One shared `get_last_forwarded_for_hop` helper that joins every occurrence of the header in order before taking the last hop, and drops empty entries so a blank header falls back to the TCP peer instead of resolving to an empty client IP. Both call sites use it; the trusted-proxy gate in `mcp_projects` is unchanged.

## Test plan

- [x] Four new regression tests (repeated-line chain under trusted proxy, repeated lines ignored without the opt-in, blank-header fallback, and the rate-limit-key equivalent) **fail against the pre-fix source and pass with the fix** — verified by stashing only the source change and re-running.
- [x] The 11 pre-existing IP-extraction tests pass unchanged both before and after, so no behavior regression for single-line chains.
- [x] `src/backend/tests/unit/api/v1/test_mcp_projects.py` — 55 passed.
- [x] `test_mcp_install_xff_trust.py` + `test_login_rate_limiting.py` + `test_rate_limit_bypass_prevention.py` — 28 passed.
- [x] `ruff check` / `ruff format` clean; pre-commit hooks pass.

The header mocks in `test_login_rate_limiting.py` were plain dicts, which cannot express a repeated header and have no `.getlist`; they are now real `starlette.datastructures.Headers`, matching what the production code actually receives.

## Not addressed here

Behind a **same-host** reverse proxy with `rate_limit_trust_proxy=False`, `request.client.host` is `127.0.0.1` for every remote user, so the local-only gate is satisfied with no spoofing at all. A TCP-peer check cannot express "this caller is on the server machine" in a proxied deployment. If `install_mcp_config` is meant to be a real trust boundary rather than a convenience guard, it needs a different control (an explicit setting, or a local-only bind/socket). That is a design change rather than a patch, so it is deliberately out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client IP detection when requests pass through trusted proxies.
  * Correctly handles repeated or comma-separated forwarding headers, selecting the appropriate originating address.
  * Preserves direct connection fallback when forwarded address information is missing or blank.
  * Improves reliability of login rate limiting and locality checks in proxy-based deployments.

* **Tests**
  * Added coverage for repeated, blank, and untrusted forwarded-header scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->