### PR TITLE
feat: add shared database-backed policy bundle

### DIFF
--- a/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
+++ b/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
@@ -2,7 +2,7 @@
 
 Phase: EXPAND
 Revision ID: f7a9c2d4e6b8
-Revises: d4a7c9e1b2f6
+Revises: 8d9e0f1a2b3c
 Create Date: 2026-08-05 00:00:00.000000
 
 The legacy provider singleton and catalog rule tables remain in place for N-1
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 revision: str = "f7a9c2d4e6b8"  # pragma: allowlist secret
-down_revision: str | None = "d4a7c9e1b2f6"  # pragma: allowlist secret
+down_revision: str | None = "8d9e0f1a2b3c"  # pragma: allowlist secret
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
+++ b/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
@@ -5,9 +5,12 @@ Revision ID: f7a9c2d4e6b8
 Revises: 8d9e0f1a2b3c
 Create Date: 2026-08-05 00:00:00.000000
 
-The legacy provider singleton and catalog rule tables remain in place for N-1
-services and downgrade compatibility. The initial active revision is a complete
-snapshot of their currently enforced global policy.
+The legacy provider singleton and catalog rule tables remain in place for
+already-running legacy services during the mixed-version window and for a
+qualified rollback image that recognizes the preceding migration head. The
+initial active revision is a complete snapshot of their currently enforced
+global policy. A previously shipped image that does not recognize the preceding
+head still requires a pre-upgrade database restore.
 """
 
 from __future__ import annotations

--- a/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
+++ b/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
@@ -272,6 +272,9 @@ def _sync_legacy_policy(conn: sa.Connection) -> None:
         .one_or_none()
     )
     if active is None:
+        if conn.execute(sa.select(sa.literal(1)).select_from(revision_table).limit(1)).first() is not None:
+            msg = "Shared policy bundle has immutable revision history but no active singleton"
+            raise RuntimeError(msg)
         return
     active_revision = active["revision"]
     bundle = (
@@ -280,7 +283,8 @@ def _sync_legacy_policy(conn: sa.Connection) -> None:
         .one_or_none()
     )
     if bundle is None:
-        return
+        msg = "Active policy bundle points to a missing immutable revision"
+        raise RuntimeError(msg)
 
     provider_table = _legacy_provider_table()
     conn.execute(
@@ -328,8 +332,22 @@ def _sync_legacy_policy(conn: sa.Connection) -> None:
 def downgrade() -> None:
     """Copy the active bundle to legacy stores before removing new tables."""
     conn = op.get_bind()
-    if not migration.table_exists(REVISION_TABLE, conn) or not migration.table_exists(ACTIVE_TABLE, conn):
+    revision_exists = migration.table_exists(REVISION_TABLE, conn)
+    active_exists = migration.table_exists(ACTIVE_TABLE, conn)
+    if revision_exists != active_exists:
+        existing_table = _revision_table() if revision_exists else _active_table()
+        if conn.execute(sa.select(sa.literal(1)).select_from(existing_table).limit(1)).first() is not None:
+            msg = "Shared policy bundle schema is partially initialized with durable data"
+            raise RuntimeError(msg)
+        if active_exists:
+            op.drop_table(ACTIVE_TABLE)
+        if revision_exists:
+            op.drop_table(REVISION_TABLE)
         return
+
+    if not revision_exists:
+        return
+
     _sync_legacy_policy(conn)
     op.drop_table(ACTIVE_TABLE)
     op.drop_table(REVISION_TABLE)

--- a/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
+++ b/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
@@ -1,0 +1,332 @@
+"""Add immutable shared provider and catalog policy bundles.
+
+Phase: EXPAND
+Revision ID: f7a9c2d4e6b8
+Revises: d4a7c9e1b2f6
+Create Date: 2026-08-05 00:00:00.000000
+
+The legacy provider singleton and catalog rule tables remain in place for N-1
+services and downgrade compatibility. The initial active revision is a complete
+snapshot of their currently enforced global policy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "f7a9c2d4e6b8"  # pragma: allowlist secret
+down_revision: str | None = "d4a7c9e1b2f6"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+REVISION_TABLE = "policy_bundle_revision"
+ACTIVE_TABLE = "policy_bundle_active"
+SINGLETON_ID = 1
+REASON_MAX_LENGTH = 1024
+SOURCE_MAX_LENGTH = 32
+_REVISION_COLUMNS = frozenset(
+    {
+        "revision",
+        "initialized",
+        "approved_provider_ids",
+        "blocked_component_keys",
+        "blocked_template_keys",
+        "content_hash",
+        "source",
+        "created_by",
+        "created_at",
+        "reason",
+        "rollback_of_revision",
+    }
+)
+_ACTIVE_COLUMNS = frozenset({"id", "revision", "initialized", "updated_at"})
+
+
+def _canonical_hash(
+    approved_provider_ids: list[str],
+    blocked_component_keys: list[str],
+    blocked_template_keys: list[str],
+) -> str:
+    payload = {
+        "approved_provider_ids": sorted(set(approved_provider_ids)),
+        "blocked_component_keys": sorted(set(blocked_component_keys)),
+        "blocked_template_keys": sorted(set(blocked_template_keys)),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _revision_table() -> sa.TableClause:
+    return sa.table(
+        REVISION_TABLE,
+        sa.column("revision", sa.Integer()),
+        sa.column("initialized", sa.Boolean()),
+        sa.column("approved_provider_ids", sa.JSON()),
+        sa.column("blocked_component_keys", sa.JSON()),
+        sa.column("blocked_template_keys", sa.JSON()),
+        sa.column("content_hash", sa.String(64)),
+        sa.column("source", sa.String(SOURCE_MAX_LENGTH)),
+        sa.column("created_by", sa.Uuid()),
+        sa.column("reason", sa.String(REASON_MAX_LENGTH)),
+        sa.column("rollback_of_revision", sa.Integer()),
+    )
+
+
+def _active_table() -> sa.TableClause:
+    return sa.table(
+        ACTIVE_TABLE,
+        sa.column("id", sa.Integer()),
+        sa.column("revision", sa.Integer()),
+        sa.column("initialized", sa.Boolean()),
+    )
+
+
+def _legacy_provider_table() -> sa.TableClause:
+    return sa.table(
+        "model_provider_policy",
+        sa.column("id", sa.Integer()),
+        sa.column("approved_provider_ids", sa.JSON()),
+        sa.column("version", sa.Integer()),
+    )
+
+
+def _legacy_catalog_table() -> sa.TableClause:
+    return sa.table(
+        "catalog_policy_rule",
+        sa.column("id", sa.Uuid()),
+        sa.column("resource_kind", sa.String()),
+        sa.column("resource_key", sa.String()),
+        sa.column("mode", sa.String()),
+        sa.column("scope", sa.String()),
+        sa.column("domain_id", sa.Uuid()),
+        sa.column("created_by", sa.Uuid()),
+    )
+
+
+def _validate_columns(conn: sa.Connection, table_name: str, required: frozenset[str]) -> None:
+    columns = {column["name"] for column in sa.inspect(conn).get_columns(table_name)}
+    missing = required - columns
+    if missing:
+        detail = ", ".join(sorted(missing))
+        msg = f"Existing {table_name!r} table is missing required columns: {detail}"
+        raise RuntimeError(msg)
+
+
+def _legacy_snapshot(conn: sa.Connection) -> tuple[int, bool, list[str], list[str], list[str]]:
+    provider_table = _legacy_provider_table()
+    provider = (
+        conn.execute(
+            sa.select(provider_table.c.approved_provider_ids, provider_table.c.version).where(
+                provider_table.c.id == SINGLETON_ID
+            )
+        )
+        .mappings()
+        .one_or_none()
+    )
+    if provider is None:
+        msg = "Model-provider policy singleton is missing; apply the prerequisite migration"
+        raise RuntimeError(msg)
+
+    catalog_table = _legacy_catalog_table()
+    rows = conn.execute(
+        sa.select(catalog_table.c.resource_kind, catalog_table.c.resource_key).where(
+            catalog_table.c.mode == "block",
+            catalog_table.c.scope == "global",
+            catalog_table.c.domain_id.is_(None),
+            catalog_table.c.resource_kind.in_(("component", "template")),
+        )
+    ).all()
+    components = sorted({row.resource_key for row in rows if row.resource_kind == "component"})
+    templates = sorted({row.resource_key for row in rows if row.resource_kind == "template"})
+    provider_ids = sorted(set(provider["approved_provider_ids"] or []))
+    provider_version = int(provider["version"])
+    initialized = bool(provider_version > 0 or provider_ids or components or templates)
+    return max(1, provider_version), initialized, provider_ids, components, templates
+
+
+def _seed_active_bundle(conn: sa.Connection) -> None:
+    revision_table = _revision_table()
+    active_table = _active_table()
+    active = conn.execute(sa.select(active_table.c.revision).where(active_table.c.id == SINGLETON_ID)).first()
+    if active is not None:
+        exists = conn.execute(
+            sa.select(revision_table.c.revision).where(revision_table.c.revision == active.revision)
+        ).first()
+        if exists is None:
+            msg = "Active policy bundle points to a missing immutable revision"
+            raise RuntimeError(msg)
+        return
+
+    if conn.execute(sa.select(revision_table.c.revision).limit(1)).first() is not None:
+        msg = "Policy bundle history exists without an active singleton pointer"
+        raise RuntimeError(msg)
+
+    initial_revision, initialized, provider_ids, components, templates = _legacy_snapshot(conn)
+    conn.execute(
+        revision_table.insert().values(
+            revision=initial_revision,
+            initialized=initialized,
+            approved_provider_ids=provider_ids,
+            blocked_component_keys=components,
+            blocked_template_keys=templates,
+            content_hash=_canonical_hash(provider_ids, components, templates),
+            source="migration",
+            created_by=None,
+            reason="Migrated existing provider and catalog policy",
+            rollback_of_revision=None,
+        )
+    )
+    conn.execute(
+        active_table.insert().values(
+            id=SINGLETON_ID,
+            revision=initial_revision,
+            initialized=initialized,
+        )
+    )
+
+
+def _create_revision_table() -> None:
+    op.create_table(
+        REVISION_TABLE,
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("initialized", sa.Boolean(), nullable=False),
+        sa.Column("approved_provider_ids", sa.JSON(), nullable=False),
+        sa.Column("blocked_component_keys", sa.JSON(), nullable=False),
+        sa.Column("blocked_template_keys", sa.JSON(), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("source", sa.String(length=SOURCE_MAX_LENGTH), nullable=False),
+        sa.Column("created_by", sa.Uuid(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("reason", sa.String(length=REASON_MAX_LENGTH), nullable=True),
+        sa.Column("rollback_of_revision", sa.Integer(), nullable=True),
+        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_revision_positive"),
+        sa.CheckConstraint("length(content_hash) = 64", name="ck_policy_bundle_revision_hash_length"),
+        sa.ForeignKeyConstraint(
+            ["rollback_of_revision"],
+            [f"{REVISION_TABLE}.revision"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("revision"),
+    )
+
+
+def _create_active_table() -> None:
+    op.create_table(
+        ACTIVE_TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("initialized", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(f"id = {SINGLETON_ID}", name="ck_policy_bundle_active_singleton"),
+        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_active_revision_positive"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def upgrade() -> None:
+    """Create and seed the additive shared policy bundle store."""
+    conn = op.get_bind()
+    revision_exists = migration.table_exists(REVISION_TABLE, conn)
+    active_exists = migration.table_exists(ACTIVE_TABLE, conn)
+    if revision_exists:
+        _validate_columns(conn, REVISION_TABLE, _REVISION_COLUMNS)
+    if active_exists:
+        _validate_columns(conn, ACTIVE_TABLE, _ACTIVE_COLUMNS)
+
+    if revision_exists != active_exists:
+        existing_table = _revision_table() if revision_exists else _active_table()
+        existing_key = existing_table.c.revision if revision_exists else existing_table.c.id
+        if conn.execute(sa.select(existing_key).limit(1)).first() is not None:
+            msg = "Shared policy bundle schema is partially initialized with durable data"
+            raise RuntimeError(msg)
+
+    if not revision_exists:
+        _create_revision_table()
+    if not active_exists:
+        _create_active_table()
+
+    _seed_active_bundle(conn)
+
+
+def _sync_legacy_policy(conn: sa.Connection) -> None:
+    revision_table = _revision_table()
+    active_table = _active_table()
+    active = (
+        conn.execute(
+            sa.select(active_table.c.revision, active_table.c.initialized).where(active_table.c.id == SINGLETON_ID)
+        )
+        .mappings()
+        .one_or_none()
+    )
+    if active is None:
+        return
+    active_revision = active["revision"]
+    bundle = (
+        conn.execute(sa.select(revision_table).where(revision_table.c.revision == active_revision))
+        .mappings()
+        .one_or_none()
+    )
+    if bundle is None:
+        return
+
+    provider_table = _legacy_provider_table()
+    conn.execute(
+        provider_table.update()
+        .where(provider_table.c.id == SINGLETON_ID)
+        .values(
+            approved_provider_ids=bundle["approved_provider_ids"],
+            # The legacy version is the only pristine/bootstrap sentinel.
+            # Preserve it across downgrade so a later re-upgrade can still
+            # perform the one-time Enterprise environment bootstrap.
+            version=active_revision if active["initialized"] else 0,
+        )
+    )
+
+    catalog_table = _legacy_catalog_table()
+    conn.execute(
+        catalog_table.delete().where(
+            catalog_table.c.mode == "block",
+            catalog_table.c.scope == "global",
+            catalog_table.c.domain_id.is_(None),
+            catalog_table.c.resource_kind.in_(("component", "template")),
+        )
+    )
+    for resource_kind, keys in (
+        ("component", bundle["blocked_component_keys"]),
+        ("template", bundle["blocked_template_keys"]),
+    ):
+        for key in keys:
+            conn.execute(
+                catalog_table.insert().values(
+                    id=uuid4(),
+                    resource_kind=resource_kind,
+                    resource_key=key,
+                    mode="block",
+                    scope="global",
+                    domain_id=None,
+                    # Bundle history deliberately retains actor UUIDs after a
+                    # user is deleted, while this legacy table has a user FK.
+                    # Never let a dangling historical actor block rollback.
+                    created_by=None,
+                )
+            )
+
+
+def downgrade() -> None:
+    """Copy the active bundle to legacy stores before removing new tables."""
+    conn = op.get_bind()
+    if not migration.table_exists(REVISION_TABLE, conn) or not migration.table_exists(ACTIVE_TABLE, conn):
+        return
+    _sync_legacy_policy(conn)
+    op.drop_table(ACTIVE_TABLE)
+    op.drop_table(REVISION_TABLE)

--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -33,6 +33,7 @@ from langflow.api.v1 import (
     models_router,
     monitor_router,
     openai_responses_router,
+    policy_bundle_router,
     projects_router,
     starter_projects_router,
     store_router,
@@ -96,6 +97,7 @@ router_v1.include_router(openai_responses_router)
 router_v1.include_router(models_router)
 router_v1.include_router(model_options_router)
 router_v1.include_router(model_provider_policy_router)
+router_v1.include_router(policy_bundle_router)
 router_v1.include_router(authz_shares_router)
 router_v1.include_router(authz_audit_router)
 router_v1.include_router(authz_roles_router)

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -25,6 +25,7 @@ from langflow.api.v1.model_provider_policy import router as model_provider_polic
 from langflow.api.v1.models import router as models_router
 from langflow.api.v1.monitor import router as monitor_router
 from langflow.api.v1.openai_responses import router as openai_responses_router
+from langflow.api.v1.policy_bundle import router as policy_bundle_router
 from langflow.api.v1.projects import router as projects_router
 from langflow.api.v1.starter_projects import router as starter_projects_router
 from langflow.api.v1.store import router as store_router
@@ -62,6 +63,7 @@ __all__ = [
     "models_router",
     "monitor_router",
     "openai_responses_router",
+    "policy_bundle_router",
     "projects_router",
     "starter_projects_router",
     "store_router",

--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -13,6 +13,7 @@ from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import audit_decision
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_catalog_policy_service
+from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
 
 router = APIRouter(prefix="/catalog-policy", tags=["Catalog Policy"])
 
@@ -37,6 +38,25 @@ def _raise_if_externally_managed(service: BaseCatalogPolicyService) -> None:
             status_code=status.HTTP_409_CONFLICT,
             detail="Catalog policy is externally managed and cannot be changed through this API.",
         )
+    if not service.supports_policy_bundle_updates:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Configured catalog policy service does not support shared policy bundle updates; "
+                "upgrade the plugin before changing database-backed policy"
+            ),
+        )
+
+
+def _revision_conflict(exc: PolicyBundleRevisionConflictError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": "Policy bundle revision conflict",
+            "expected_revision": exc.expected_revision,
+            "active_revision": exc.active_revision,
+        },
+    )
 
 
 async def _audit_update(
@@ -89,10 +109,13 @@ async def replace_component_policy(
     """Replace the complete global component block set."""
     service = get_catalog_policy_service()
     _raise_if_externally_managed(service)
-    update = await service.replace_blocked_component_keys(
-        payload.blocked,
-        actor_user_id=admin.id,
-    )
+    try:
+        update = await service.replace_blocked_component_keys(
+            payload.blocked,
+            actor_user_id=admin.id,
+        )
+    except PolicyBundleRevisionConflictError as exc:
+        raise _revision_conflict(exc) from exc
     await _audit_update(
         user_id=admin.id,
         resource_kind="component",
@@ -120,10 +143,13 @@ async def replace_template_policy(
     """Replace the complete global template block set."""
     service = get_catalog_policy_service()
     _raise_if_externally_managed(service)
-    update = await service.replace_blocked_template_keys(
-        payload.blocked,
-        actor_user_id=admin.id,
-    )
+    try:
+        update = await service.replace_blocked_template_keys(
+            payload.blocked,
+            actor_user_id=admin.id,
+        )
+    except PolicyBundleRevisionConflictError as exc:
+        raise _revision_conflict(exc) from exc
     await _audit_update(
         user_id=admin.id,
         resource_kind="template",

--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicySnapshot
 
+from langflow.api.v1.policy_bundle_errors import policy_bundle_revision_conflict
 from langflow.api.v1.schemas.catalog_policy import CatalogPolicyBlockedSet, CatalogPolicyRead
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import audit_decision
@@ -46,17 +47,6 @@ def _raise_if_externally_managed(service: BaseCatalogPolicyService) -> None:
                 "upgrade the plugin before changing database-backed policy"
             ),
         )
-
-
-def _revision_conflict(exc: PolicyBundleRevisionConflictError) -> HTTPException:
-    return HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={
-            "message": "Policy bundle revision conflict",
-            "expected_revision": exc.expected_revision,
-            "active_revision": exc.active_revision,
-        },
-    )
 
 
 async def _audit_update(
@@ -115,7 +105,7 @@ async def replace_component_policy(
             actor_user_id=admin.id,
         )
     except PolicyBundleRevisionConflictError as exc:
-        raise _revision_conflict(exc) from exc
+        raise policy_bundle_revision_conflict(exc) from exc
     await _audit_update(
         user_id=admin.id,
         resource_kind="component",
@@ -149,7 +139,7 @@ async def replace_template_policy(
             actor_user_id=admin.id,
         )
     except PolicyBundleRevisionConflictError as exc:
-        raise _revision_conflict(exc) from exc
+        raise policy_bundle_revision_conflict(exc) from exc
     await _audit_update(
         user_id=admin.id,
         resource_kind="template",

--- a/src/backend/base/langflow/api/v1/model_provider_policy.py
+++ b/src/backend/base/langflow/api/v1/model_provider_policy.py
@@ -10,6 +10,7 @@ from lfx.services.deps import get_model_provider_policy_service
 from pydantic import BaseModel, Field, StringConstraints, field_validator
 
 from langflow.api.utils import DbSession, DbSessionReadOnly
+from langflow.api.v1.policy_bundle_errors import policy_bundle_revision_conflict
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import AUDIT_ALLOW, audit_decision
 from langflow.services.database.models.user.model import User
@@ -145,14 +146,7 @@ async def replace_model_provider_policy(
     except PolicyBundleApplicationNotSupportedError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     except PolicyBundleRevisionConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": "Policy bundle revision conflict",
-                "expected_revision": exc.expected_revision,
-                "active_revision": exc.active_revision,
-            },
-        ) from exc
+        raise policy_bundle_revision_conflict(exc) from exc
 
     try:
         await audit_decision(

--- a/src/backend/base/langflow/api/v1/model_provider_policy.py
+++ b/src/backend/base/langflow/api/v1/model_provider_policy.py
@@ -19,6 +19,10 @@ from langflow.services.model_provider_policy import (
     get_model_provider_policy_state,
     replace_model_provider_policy_state,
 )
+from langflow.services.policy_bundle import (
+    PolicyBundleApplicationNotSupportedError,
+    PolicyBundleRevisionConflictError,
+)
 
 router = APIRouter(prefix="/model-provider-policy", tags=["Model Provider Policy"])
 
@@ -130,9 +134,25 @@ async def replace_model_provider_policy(
         raise _externally_managed()
 
     try:
-        state = await replace_model_provider_policy_state(session, payload.approved_provider_ids)
+        state = await replace_model_provider_policy_state(
+            session,
+            payload.approved_provider_ids,
+            actor_user_id=admin.id,
+            reason="Replace approved model providers",
+        )
     except ModelProviderPolicyNotInitializedError as exc:
         raise _policy_unavailable() from exc
+    except PolicyBundleApplicationNotSupportedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except PolicyBundleRevisionConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Policy bundle revision conflict",
+                "expected_revision": exc.expected_revision,
+                "active_revision": exc.active_revision,
+            },
+        ) from exc
 
     try:
         await audit_decision(

--- a/src/backend/base/langflow/api/v1/policy_bundle.py
+++ b/src/backend/base/langflow/api/v1/policy_bundle.py
@@ -13,6 +13,8 @@ from lfx.services.policy_bundle import PolicyBundleSnapshot
 from pydantic import BaseModel, Field, StringConstraints, field_validator
 
 from langflow.api.utils import DbSession, DbSessionReadOnly
+from langflow.api.v1.policy_bundle_errors import policy_bundle_revision_conflict
+from langflow.api.v1.schemas.catalog_policy import CatalogPolicyKeyList, normalize_catalog_policy_keys
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import AUDIT_ALLOW, audit_decision
 from langflow.services.database.models.policy_bundle import POLICY_BUNDLE_REASON_MAX_LENGTH
@@ -34,24 +36,13 @@ router = APIRouter(prefix="/policy-bundle", tags=["Policy Bundle"])
 ProviderId = Annotated[str, StringConstraints(pattern=r"^[a-z0-9][a-z0-9._-]*$", max_length=255)]
 
 
-def _normalize_keys(values: list[str]) -> list[str]:
-    normalized: set[str] = set()
-    for raw_value in values:
-        value = raw_value.strip()
-        if not value:
-            msg = "Policy bundle catalog keys must not be empty"
-            raise ValueError(msg)
-        normalized.add(value)
-    return sorted(normalized)
-
-
 class PolicyBundleWrite(BaseModel):
     """Complete replacement guarded by the caller's observed revision."""
 
     expected_revision: int = Field(ge=1)
     approved_provider_ids: Annotated[list[ProviderId], Field(max_length=1000)]
-    blocked_component_keys: list[str]
-    blocked_template_keys: list[str]
+    blocked_component_keys: CatalogPolicyKeyList
+    blocked_template_keys: CatalogPolicyKeyList
     reason: str | None = Field(default=None, max_length=POLICY_BUNDLE_REASON_MAX_LENGTH)
 
     @field_validator("approved_provider_ids", mode="before")
@@ -72,7 +63,7 @@ class PolicyBundleWrite(BaseModel):
     @field_validator("blocked_component_keys", "blocked_template_keys")
     @classmethod
     def normalize_catalog_keys(cls, values: list[str]) -> list[str]:
-        return _normalize_keys(values)
+        return normalize_catalog_policy_keys(values)
 
 
 class PolicyBundleRollbackWrite(BaseModel):
@@ -128,17 +119,6 @@ def _unavailable() -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Policy bundle is not initialized. Apply the latest database migrations and restart Langflow.",
-    )
-
-
-def _conflict(exc: PolicyBundleRevisionConflictError) -> HTTPException:
-    return HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={
-            "message": "Policy bundle revision conflict",
-            "expected_revision": exc.expected_revision,
-            "active_revision": exc.active_revision,
-        },
     )
 
 
@@ -204,7 +184,7 @@ async def replace_policy_bundle(
     except PolicyBundleNotInitializedError as exc:
         raise _unavailable() from exc
     except PolicyBundleRevisionConflictError as exc:
-        raise _conflict(exc) from exc
+        raise policy_bundle_revision_conflict(exc) from exc
 
     try:
         await _audit_bundle(snapshot, user_id=admin.id, action="policy_bundle:replace")
@@ -251,7 +231,7 @@ async def rollback_policy_bundle(
     except PolicyBundleNotInitializedError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except PolicyBundleRevisionConflictError as exc:
-        raise _conflict(exc) from exc
+        raise policy_bundle_revision_conflict(exc) from exc
 
     try:
         await _audit_bundle(snapshot, user_id=admin.id, action="policy_bundle:rollback")

--- a/src/backend/base/langflow/api/v1/policy_bundle.py
+++ b/src/backend/base/langflow/api/v1/policy_bundle.py
@@ -1,0 +1,269 @@
+"""Superuser administration for atomic provider-and-catalog policy bundles."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from lfx.base.models.provider_registry import resolve_provider_id
+from lfx.services.deps import get_catalog_policy_service, get_model_provider_policy_service
+from lfx.services.policy_bundle import PolicyBundleSnapshot
+from pydantic import BaseModel, Field, StringConstraints, field_validator
+
+from langflow.api.utils import DbSession, DbSessionReadOnly
+from langflow.services.auth.utils import get_current_active_superuser
+from langflow.services.authorization.audit import AUDIT_ALLOW, audit_decision
+from langflow.services.database.models.policy_bundle import POLICY_BUNDLE_REASON_MAX_LENGTH
+from langflow.services.database.models.user.model import User
+from langflow.services.policy_bundle import (
+    PolicyBundleApplicationNotSupportedError,
+    PolicyBundleNotInitializedError,
+    PolicyBundleRevisionConflictError,
+    apply_policy_bundle_state,
+    ensure_policy_bundle_application_supported,
+    get_policy_bundle_state,
+    list_policy_bundle_history,
+    replace_policy_bundle_state,
+    rollback_policy_bundle_state,
+)
+
+router = APIRouter(prefix="/policy-bundle", tags=["Policy Bundle"])
+
+ProviderId = Annotated[str, StringConstraints(pattern=r"^[a-z0-9][a-z0-9._-]*$", max_length=255)]
+
+
+def _normalize_keys(values: list[str]) -> list[str]:
+    normalized: set[str] = set()
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            msg = "Policy bundle catalog keys must not be empty"
+            raise ValueError(msg)
+        normalized.add(value)
+    return sorted(normalized)
+
+
+class PolicyBundleWrite(BaseModel):
+    """Complete replacement guarded by the caller's observed revision."""
+
+    expected_revision: int = Field(ge=1)
+    approved_provider_ids: Annotated[list[ProviderId], Field(max_length=1000)]
+    blocked_component_keys: list[str]
+    blocked_template_keys: list[str]
+    reason: str | None = Field(default=None, max_length=POLICY_BUNDLE_REASON_MAX_LENGTH)
+
+    @field_validator("approved_provider_ids", mode="before")
+    @classmethod
+    def canonicalize_provider_ids(cls, provider_ids):
+        if not isinstance(provider_ids, list):
+            return provider_ids
+        return [
+            resolve_provider_id(provider_id) if isinstance(provider_id, str) else provider_id
+            for provider_id in provider_ids
+        ]
+
+    @field_validator("approved_provider_ids")
+    @classmethod
+    def deduplicate_provider_ids(cls, provider_ids: list[str]) -> list[str]:
+        return sorted(set(provider_ids))
+
+    @field_validator("blocked_component_keys", "blocked_template_keys")
+    @classmethod
+    def normalize_catalog_keys(cls, values: list[str]) -> list[str]:
+        return _normalize_keys(values)
+
+
+class PolicyBundleRollbackWrite(BaseModel):
+    expected_revision: int = Field(ge=1)
+    reason: str | None = Field(default=None, max_length=POLICY_BUNDLE_REASON_MAX_LENGTH)
+
+
+class PolicyBundleRead(BaseModel):
+    revision: int
+    initialized: bool
+    source: str
+    approved_provider_ids: list[str]
+    blocked_component_keys: list[str]
+    blocked_template_keys: list[str]
+    content_hash: str
+    created_at: datetime | None
+    created_by: UUID | None
+    reason: str | None
+    rollback_of_revision: int | None
+    managed_externally: bool = False
+
+
+class PolicyBundleHistoryRead(BaseModel):
+    items: list[PolicyBundleRead]
+    next_before_revision: int | None
+
+
+def _managed_externally() -> bool:
+    return (
+        get_model_provider_policy_service().external_approved_provider_ids is not None
+        or get_catalog_policy_service().external_policy_snapshot is not None
+    )
+
+
+def _response(snapshot: PolicyBundleSnapshot, *, managed_externally: bool = False) -> PolicyBundleRead:
+    return PolicyBundleRead(
+        revision=snapshot.revision,
+        initialized=snapshot.initialized,
+        source=snapshot.source,
+        approved_provider_ids=sorted(snapshot.approved_provider_ids),
+        blocked_component_keys=sorted(snapshot.blocked_component_keys),
+        blocked_template_keys=sorted(snapshot.blocked_template_keys),
+        content_hash=snapshot.content_hash,
+        created_at=snapshot.created_at,
+        created_by=snapshot.created_by,
+        reason=snapshot.reason,
+        rollback_of_revision=snapshot.rollback_of_revision,
+        managed_externally=managed_externally,
+    )
+
+
+def _unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Policy bundle is not initialized. Apply the latest database migrations and restart Langflow.",
+    )
+
+
+def _conflict(exc: PolicyBundleRevisionConflictError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": "Policy bundle revision conflict",
+            "expected_revision": exc.expected_revision,
+            "active_revision": exc.active_revision,
+        },
+    )
+
+
+def _raise_if_externally_managed() -> None:
+    if _managed_externally():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Policy bundle is externally managed and cannot be changed through this API.",
+        )
+    try:
+        ensure_policy_bundle_application_supported()
+    except PolicyBundleApplicationNotSupportedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+async def _audit_bundle(snapshot: PolicyBundleSnapshot, *, user_id: UUID, action: str) -> None:
+    await audit_decision(
+        user_id=user_id,
+        action=action,
+        obj=f"policy_bundle:{snapshot.revision}",
+        result=AUDIT_ALLOW,
+        details={
+            "revision": snapshot.revision,
+            "content_hash": snapshot.content_hash,
+            "source": snapshot.source,
+            "rollback_of_revision": snapshot.rollback_of_revision,
+            "reason": snapshot.reason,
+        },
+    )
+
+
+@router.get("", response_model=PolicyBundleRead)
+@router.get("/", response_model=PolicyBundleRead, include_in_schema=False)
+async def read_policy_bundle(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+    session: DbSessionReadOnly,
+) -> PolicyBundleRead:
+    try:
+        snapshot = await get_policy_bundle_state(session)
+    except PolicyBundleNotInitializedError as exc:
+        raise _unavailable() from exc
+    return _response(snapshot, managed_externally=_managed_externally())
+
+
+@router.put("", response_model=PolicyBundleRead)
+@router.put("/", response_model=PolicyBundleRead, include_in_schema=False)
+async def replace_policy_bundle(
+    payload: PolicyBundleWrite,
+    admin: Annotated[User, Depends(get_current_active_superuser)],
+    session: DbSession,
+) -> PolicyBundleRead:
+    _raise_if_externally_managed()
+    try:
+        snapshot = await replace_policy_bundle_state(
+            session,
+            expected_revision=payload.expected_revision,
+            approved_provider_ids=payload.approved_provider_ids,
+            blocked_component_keys=payload.blocked_component_keys,
+            blocked_template_keys=payload.blocked_template_keys,
+            actor_user_id=admin.id,
+            reason=payload.reason,
+        )
+    except PolicyBundleNotInitializedError as exc:
+        raise _unavailable() from exc
+    except PolicyBundleRevisionConflictError as exc:
+        raise _conflict(exc) from exc
+
+    try:
+        await _audit_bundle(snapshot, user_id=admin.id, action="policy_bundle:replace")
+    finally:
+        apply_policy_bundle_state(snapshot)
+    return _response(snapshot)
+
+
+@router.get("/history", response_model=PolicyBundleHistoryRead)
+async def read_policy_bundle_history(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+    session: DbSessionReadOnly,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    before_revision: Annotated[int | None, Query(ge=1)] = None,
+) -> PolicyBundleHistoryRead:
+    items = await list_policy_bundle_history(
+        session,
+        limit=limit,
+        before_revision=before_revision,
+    )
+    next_before_revision = items[-1].revision if len(items) == limit else None
+    return PolicyBundleHistoryRead(
+        items=[_response(item) for item in items],
+        next_before_revision=next_before_revision,
+    )
+
+
+@router.post("/rollback/{revision}", response_model=PolicyBundleRead)
+async def rollback_policy_bundle(
+    revision: int,
+    payload: PolicyBundleRollbackWrite,
+    admin: Annotated[User, Depends(get_current_active_superuser)],
+    session: DbSession,
+) -> PolicyBundleRead:
+    _raise_if_externally_managed()
+    try:
+        snapshot = await rollback_policy_bundle_state(
+            session,
+            expected_revision=payload.expected_revision,
+            target_revision=revision,
+            actor_user_id=admin.id,
+            reason=payload.reason,
+        )
+    except PolicyBundleNotInitializedError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except PolicyBundleRevisionConflictError as exc:
+        raise _conflict(exc) from exc
+
+    try:
+        await _audit_bundle(snapshot, user_id=admin.id, action="policy_bundle:rollback")
+    finally:
+        apply_policy_bundle_state(snapshot)
+    return _response(snapshot)
+
+
+__all__ = [
+    "PolicyBundleHistoryRead",
+    "PolicyBundleRead",
+    "PolicyBundleRollbackWrite",
+    "PolicyBundleWrite",
+    "router",
+]

--- a/src/backend/base/langflow/api/v1/policy_bundle_errors.py
+++ b/src/backend/base/langflow/api/v1/policy_bundle_errors.py
@@ -1,0 +1,20 @@
+"""Shared HTTP error mapping for policy-bundle-backed administration APIs."""
+
+from fastapi import HTTPException, status
+
+from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
+
+
+def policy_bundle_revision_conflict(exc: PolicyBundleRevisionConflictError) -> HTTPException:
+    """Preserve the structured optimistic-concurrency response across policy APIs."""
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": "Policy bundle revision conflict",
+            "expected_revision": exc.expected_revision,
+            "active_revision": exc.active_revision,
+        },
+    )
+
+
+__all__ = ["policy_bundle_revision_conflict"]

--- a/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
@@ -2,13 +2,33 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, Field, StringConstraints, field_validator
+
+CATALOG_POLICY_KEY_MAX_LENGTH = 255
+CATALOG_POLICY_KEYS_MAX_LENGTH = 1000
+
+CatalogPolicyKey = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=CATALOG_POLICY_KEY_MAX_LENGTH,
+    ),
+]
+CatalogPolicyKeyList = Annotated[list[CatalogPolicyKey], Field(max_length=CATALOG_POLICY_KEYS_MAX_LENGTH)]
+
+
+def normalize_catalog_policy_keys(value: list[str]) -> list[str]:
+    """Deduplicate validated catalog keys and sort them deterministically."""
+    return sorted(set(value))
 
 
 class CatalogPolicyBlockedSet(BaseModel):
     """A normalized whole-set catalog block policy."""
 
-    blocked: list[str] = Field(
+    blocked: CatalogPolicyKeyList = Field(
         ...,
         description="Complete set of blocked catalog keys for this resource kind.",
     )
@@ -16,18 +36,25 @@ class CatalogPolicyBlockedSet(BaseModel):
     @field_validator("blocked")
     @classmethod
     def normalize_blocked_keys(cls, value: list[str]) -> list[str]:
-        """Trim, reject empty values, deduplicate, and sort deterministically."""
-        normalized: set[str] = set()
-        for raw_key in value:
-            key = raw_key.strip()
-            if not key:
-                msg = "Blocked catalog keys must not be empty"
-                raise ValueError(msg)
-            normalized.add(key)
-        return sorted(normalized)
+        """Deduplicate and sort the already-trimmed, validated keys."""
+        return normalize_catalog_policy_keys(value)
 
 
-class CatalogPolicyRead(CatalogPolicyBlockedSet):
+class CatalogPolicyRead(BaseModel):
     """Current catalog block policy and its ownership source."""
 
+    # Response/history schemas intentionally remain unconstrained so a policy
+    # written by an older release can still be read and repaired.
+    blocked: list[str]
     managed_externally: bool
+
+
+__all__ = [
+    "CATALOG_POLICY_KEYS_MAX_LENGTH",
+    "CATALOG_POLICY_KEY_MAX_LENGTH",
+    "CatalogPolicyBlockedSet",
+    "CatalogPolicyKey",
+    "CatalogPolicyKeyList",
+    "CatalogPolicyRead",
+    "normalize_catalog_policy_keys",
+]

--- a/src/backend/base/langflow/services/catalog_policy/factory.py
+++ b/src/backend/base/langflow/services/catalog_policy/factory.py
@@ -28,4 +28,6 @@ class CatalogPolicyServiceFactory(ServiceFactory):
 
     def create(self, database_service: DatabaseService) -> BaseCatalogPolicyService:
         """Build a catalog-policy service using the injected database service."""
-        return self.service_class(database_service)
+        from lfx.services.deps import get_policy_bundle_service
+
+        return self.service_class(database_service, get_policy_bundle_service())

--- a/src/backend/base/langflow/services/catalog_policy/service.py
+++ b/src/backend/base/langflow/services/catalog_policy/service.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicySnapshot, CatalogPolicyUpdate
 from lfx.services.deps import session_scope, session_scope_readonly
+from lfx.services.policy_bundle import BasePolicyBundleService, PolicyBundleSnapshot
 from lfx.services.schema import ServiceType
 from sqlmodel import col, select
 
@@ -15,6 +16,11 @@ from langflow.services.database.models.catalog_policy import (
     CatalogPolicyRule,
     CatalogPolicyScope,
     CatalogResourceKind,
+)
+from langflow.services.policy_bundle import (
+    apply_policy_bundle_state,
+    get_policy_bundle_state,
+    replace_policy_bundle_state,
 )
 
 if TYPE_CHECKING:
@@ -39,19 +45,18 @@ def _normalize_keys(keys: Collection[str]) -> frozenset[str]:
 
 
 class LangflowCatalogPolicyService(BaseCatalogPolicyService):
-    """Durable global catalog policy backed by an immutable local snapshot.
+    """Catalog projection of the process-wide immutable policy bundle."""
 
-    Each Langflow process owns its snapshot. Startup hydration and successful
-    writes update that process; coordinating snapshots across multiple workers
-    requires an external invalidation mechanism and is outside this service.
-    Before hydration, the empty snapshot deliberately allows every resource.
-    """
-
-    def __init__(self, database_service: DatabaseService) -> None:
+    def __init__(
+        self,
+        database_service: DatabaseService | None,
+        policy_bundle_service: BasePolicyBundleService | None = None,
+    ) -> None:
         super().__init__()
         self.database_service = database_service
-        self._snapshot = CatalogPolicySnapshot()
-        self._hydrated = False
+        self._policy_bundle_service = policy_bundle_service
+        self._legacy_snapshot = CatalogPolicySnapshot()
+        self._legacy_hydrated = False
         self._write_lock = asyncio.Lock()
         # Direct service-class registration does not call set_ready(), unlike
         # factory creation. The fail-open snapshot is usable immediately.
@@ -65,12 +70,38 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
     @property
     def snapshot(self) -> CatalogPolicySnapshot:
         """Return the current immutable process-local snapshot."""
-        return self._snapshot
+        if self._policy_bundle_service is None:
+            return self._legacy_snapshot
+        bundle = self._policy_bundle_service.snapshot
+        return CatalogPolicySnapshot(
+            blocked_component_keys=bundle.blocked_component_keys,
+            blocked_template_keys=bundle.blocked_template_keys,
+        )
+
+    @property
+    def policy_bundle_snapshot(self) -> PolicyBundleSnapshot:
+        if self._policy_bundle_service is None:
+            return PolicyBundleSnapshot(
+                blocked_component_keys=self._legacy_snapshot.blocked_component_keys,
+                blocked_template_keys=self._legacy_snapshot.blocked_template_keys,
+            )
+        return self._policy_bundle_service.snapshot
+
+    @property
+    def supports_policy_bundle_updates(self) -> bool:
+        return self._policy_bundle_service is not None
+
+    def apply_policy_bundle(self, snapshot: PolicyBundleSnapshot) -> bool:
+        if self._policy_bundle_service is None:
+            return False
+        return self._policy_bundle_service.publish(snapshot)
 
     @property
     def hydrated(self) -> bool:
         """Return whether durable policy has been loaded successfully."""
-        return self._hydrated
+        if self._policy_bundle_service is None:
+            return self._legacy_hydrated
+        return self._policy_bundle_service.hydrated
 
     async def hydrate(self) -> CatalogPolicySnapshot:
         """Load global block rules and atomically publish a complete snapshot.
@@ -79,11 +110,17 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
         the failure and continue with its fail-open decision surface.
         """
         async with self._write_lock:
+            if self._policy_bundle_service is None:
+                async with session_scope_readonly() as session:
+                    snapshot, _rows = await self._read_policy(session)
+                self._legacy_snapshot = snapshot
+                self._legacy_hydrated = True
+                return snapshot
+
             async with session_scope_readonly() as session:
-                snapshot, _rows = await self._read_policy(session)
-            self._snapshot = snapshot
-            self._hydrated = True
-            return snapshot
+                bundle = await get_policy_bundle_state(session)
+            apply_policy_bundle_state(bundle)
+            return self.snapshot
 
     async def replace_blocked_component_keys(
         self,
@@ -121,47 +158,90 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
         desired = _normalize_keys(keys)
 
         async with self._write_lock:
+            if self._policy_bundle_service is None:
+                return await self._replace_legacy_blocked_keys(
+                    resource_kind,
+                    desired,
+                    actor_user_id=actor_user_id,
+                )
+
             async with session_scope() as session:
-                current_snapshot, rows = await self._read_policy(session)
-                current_rows = {row.resource_key: row for row in rows if row.resource_kind == resource_kind.value}
-                current = frozenset(current_rows)
-                added = desired - current
-                removed = current - desired
-
-                for key in removed:
-                    await session.delete(current_rows[key])
-                for key in added:
-                    session.add(
-                        CatalogPolicyRule(
-                            resource_kind=resource_kind.value,
-                            resource_key=key,
-                            mode=CatalogPolicyMode.BLOCK.value,
-                            scope=CatalogPolicyScope.GLOBAL.value,
-                            domain_id=None,
-                            created_by=actor_user_id,
-                        )
-                    )
-
-            if resource_kind == CatalogResourceKind.COMPONENT:
-                committed_snapshot = CatalogPolicySnapshot(
-                    blocked_component_keys=desired,
-                    blocked_template_keys=current_snapshot.blocked_template_keys,
-                )
-            else:
-                committed_snapshot = CatalogPolicySnapshot(
-                    blocked_component_keys=current_snapshot.blocked_component_keys,
-                    blocked_template_keys=desired,
+                current = await get_policy_bundle_state(session)
+                if resource_kind == CatalogResourceKind.COMPONENT:
+                    current_keys = current.blocked_component_keys
+                    components = desired
+                    templates = current.blocked_template_keys
+                else:
+                    current_keys = current.blocked_template_keys
+                    components = current.blocked_component_keys
+                    templates = desired
+                committed = await replace_policy_bundle_state(
+                    session,
+                    expected_revision=current.revision,
+                    approved_provider_ids=current.approved_provider_ids,
+                    blocked_component_keys=components,
+                    blocked_template_keys=templates,
+                    actor_user_id=actor_user_id,
+                    reason=f"Replace blocked {resource_kind.value} catalog keys",
                 )
 
-            # A single reference swap publishes both frozensets together, and
-            # occurs only after the durable transaction has committed.
-            self._snapshot = committed_snapshot
-            self._hydrated = True
+            apply_policy_bundle_state(committed)
             return CatalogPolicyUpdate(
-                snapshot=committed_snapshot,
-                added=frozenset(added),
-                removed=frozenset(removed),
+                snapshot=CatalogPolicySnapshot(
+                    blocked_component_keys=committed.blocked_component_keys,
+                    blocked_template_keys=committed.blocked_template_keys,
+                ),
+                added=desired - current_keys,
+                removed=current_keys - desired,
             )
+
+    async def _replace_legacy_blocked_keys(
+        self,
+        resource_kind: CatalogResourceKind,
+        desired: frozenset[str],
+        *,
+        actor_user_id: UUID | None,
+    ) -> CatalogPolicyUpdate:
+        """Preserve the pre-bundle service seam for direct/plugin construction."""
+        async with session_scope() as session:
+            current_snapshot, rows = await self._read_policy(session)
+            current_rows = {row.resource_key: row for row in rows if row.resource_kind == resource_kind.value}
+            current = frozenset(current_rows)
+            added = desired - current
+            removed = current - desired
+
+            for key in removed:
+                await session.delete(current_rows[key])
+            for key in added:
+                session.add(
+                    CatalogPolicyRule(
+                        resource_kind=resource_kind.value,
+                        resource_key=key,
+                        mode=CatalogPolicyMode.BLOCK.value,
+                        scope=CatalogPolicyScope.GLOBAL.value,
+                        domain_id=None,
+                        created_by=actor_user_id,
+                    )
+                )
+
+        if resource_kind == CatalogResourceKind.COMPONENT:
+            committed_snapshot = CatalogPolicySnapshot(
+                blocked_component_keys=desired,
+                blocked_template_keys=current_snapshot.blocked_template_keys,
+            )
+        else:
+            committed_snapshot = CatalogPolicySnapshot(
+                blocked_component_keys=current_snapshot.blocked_component_keys,
+                blocked_template_keys=desired,
+            )
+
+        self._legacy_snapshot = committed_snapshot
+        self._legacy_hydrated = True
+        return CatalogPolicyUpdate(
+            snapshot=committed_snapshot,
+            added=frozenset(added),
+            removed=frozenset(removed),
+        )
 
     @staticmethod
     async def _read_policy(

--- a/src/backend/base/langflow/services/catalog_policy/service.py
+++ b/src/backend/base/langflow/services/catalog_policy/service.py
@@ -18,6 +18,7 @@ from langflow.services.database.models.catalog_policy import (
     CatalogResourceKind,
 )
 from langflow.services.policy_bundle import (
+    PolicyBundleRevisionConflictError,
     apply_policy_bundle_state,
     get_policy_bundle_state,
     replace_policy_bundle_state,
@@ -30,6 +31,9 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
     from langflow.services.database.service import DatabaseService
+
+
+_CATALOG_POLICY_CAS_ATTEMPTS = 3
 
 
 def _normalize_keys(keys: Collection[str]) -> frozenset[str]:
@@ -57,6 +61,7 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
         self._policy_bundle_service = policy_bundle_service
         self._legacy_snapshot = CatalogPolicySnapshot()
         self._legacy_hydrated = False
+        self._projected_snapshot: tuple[PolicyBundleSnapshot, CatalogPolicySnapshot] | None = None
         self._write_lock = asyncio.Lock()
         # Direct service-class registration does not call set_ready(), unlike
         # factory creation. The fail-open snapshot is usable immediately.
@@ -73,10 +78,17 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
         if self._policy_bundle_service is None:
             return self._legacy_snapshot
         bundle = self._policy_bundle_service.snapshot
-        return CatalogPolicySnapshot(
-            blocked_component_keys=bundle.blocked_component_keys,
-            blocked_template_keys=bundle.blocked_template_keys,
-        )
+        projected = self._projected_snapshot
+        if projected is None or projected[0] is not bundle:
+            projected = (
+                bundle,
+                CatalogPolicySnapshot(
+                    blocked_component_keys=bundle.blocked_component_keys,
+                    blocked_template_keys=bundle.blocked_template_keys,
+                ),
+            )
+            self._projected_snapshot = projected
+        return projected[1]
 
     @property
     def policy_bundle_snapshot(self) -> PolicyBundleSnapshot:
@@ -165,25 +177,32 @@ class LangflowCatalogPolicyService(BaseCatalogPolicyService):
                     actor_user_id=actor_user_id,
                 )
 
-            async with session_scope() as session:
-                current = await get_policy_bundle_state(session)
-                if resource_kind == CatalogResourceKind.COMPONENT:
-                    current_keys = current.blocked_component_keys
-                    components = desired
-                    templates = current.blocked_template_keys
-                else:
-                    current_keys = current.blocked_template_keys
-                    components = current.blocked_component_keys
-                    templates = desired
-                committed = await replace_policy_bundle_state(
-                    session,
-                    expected_revision=current.revision,
-                    approved_provider_ids=current.approved_provider_ids,
-                    blocked_component_keys=components,
-                    blocked_template_keys=templates,
-                    actor_user_id=actor_user_id,
-                    reason=f"Replace blocked {resource_kind.value} catalog keys",
-                )
+            for attempt in range(_CATALOG_POLICY_CAS_ATTEMPTS):
+                async with session_scope() as session:
+                    current = await get_policy_bundle_state(session)
+                    if resource_kind == CatalogResourceKind.COMPONENT:
+                        current_keys = current.blocked_component_keys
+                        components = desired
+                        templates = current.blocked_template_keys
+                    else:
+                        current_keys = current.blocked_template_keys
+                        components = current.blocked_component_keys
+                        templates = desired
+                    try:
+                        committed = await replace_policy_bundle_state(
+                            session,
+                            expected_revision=current.revision,
+                            approved_provider_ids=current.approved_provider_ids,
+                            blocked_component_keys=components,
+                            blocked_template_keys=templates,
+                            actor_user_id=actor_user_id,
+                            reason=f"Replace blocked {resource_kind.value} catalog keys",
+                        )
+                    except PolicyBundleRevisionConflictError:
+                        if attempt == _CATALOG_POLICY_CAS_ATTEMPTS - 1:
+                            raise
+                        continue
+                    break
 
             apply_policy_bundle_state(committed)
             return CatalogPolicyUpdate(

--- a/src/backend/base/langflow/services/database/models/__init__.py
+++ b/src/backend/base/langflow/services/database/models/__init__.py
@@ -35,6 +35,7 @@ from .mcp_server import MCPServer
 from .memory_base import MemoryBase, MemoryBaseSession, MemoryBaseWorkflowRun, MessageIngestionRecord
 from .message import MessageTable
 from .model_provider_policy import ModelProviderPolicy
+from .policy_bundle import PolicyBundleActive, PolicyBundleRevision
 from .traces.model import SpanTable, TraceTable
 from .transactions import TransactionTable
 from .user import User
@@ -78,6 +79,8 @@ __all__ = [
     "MessageIngestionRecord",
     "MessageTable",
     "ModelProviderPolicy",
+    "PolicyBundleActive",
+    "PolicyBundleRevision",
     "SSOConfig",
     "SSOConfigCreate",
     "SSOConfigRead",

--- a/src/backend/base/langflow/services/database/models/policy_bundle/__init__.py
+++ b/src/backend/base/langflow/services/database/models/policy_bundle/__init__.py
@@ -1,0 +1,15 @@
+from .model import (
+    POLICY_BUNDLE_REASON_MAX_LENGTH,
+    POLICY_BUNDLE_SINGLETON_ID,
+    POLICY_BUNDLE_SOURCE_MAX_LENGTH,
+    PolicyBundleActive,
+    PolicyBundleRevision,
+)
+
+__all__ = [
+    "POLICY_BUNDLE_REASON_MAX_LENGTH",
+    "POLICY_BUNDLE_SINGLETON_ID",
+    "POLICY_BUNDLE_SOURCE_MAX_LENGTH",
+    "PolicyBundleActive",
+    "PolicyBundleRevision",
+]

--- a/src/backend/base/langflow/services/database/models/policy_bundle/model.py
+++ b/src/backend/base/langflow/services/database/models/policy_bundle/model.py
@@ -1,0 +1,93 @@
+"""Immutable deployment policy bundle history and active revision pointer."""
+
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+
+from langflow.schema.serialize import UUIDstr
+
+POLICY_BUNDLE_SINGLETON_ID = 1
+POLICY_BUNDLE_REASON_MAX_LENGTH = 1024
+POLICY_BUNDLE_SOURCE_MAX_LENGTH = 32
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class PolicyBundleRevision(SQLModel, table=True):  # type: ignore[call-arg]
+    """One immutable, complete deployment-governance policy revision."""
+
+    __tablename__ = "policy_bundle_revision"
+    __table_args__ = (
+        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_revision_positive"),
+        sa.CheckConstraint("length(content_hash) = 64", name="ck_policy_bundle_revision_hash_length"),
+    )
+
+    revision: int = Field(primary_key=True, ge=1)
+    initialized: bool = Field(default=True, sa_column=sa.Column(sa.Boolean(), nullable=False))
+    approved_provider_ids: list[str] = Field(default_factory=list, sa_column=sa.Column(sa.JSON, nullable=False))
+    blocked_component_keys: list[str] = Field(default_factory=list, sa_column=sa.Column(sa.JSON, nullable=False))
+    blocked_template_keys: list[str] = Field(default_factory=list, sa_column=sa.Column(sa.JSON, nullable=False))
+    content_hash: str = Field(sa_column=sa.Column(sa.String(64), nullable=False))
+    source: str = Field(
+        default="api",
+        max_length=POLICY_BUNDLE_SOURCE_MAX_LENGTH,
+        sa_column=sa.Column(sa.String(POLICY_BUNDLE_SOURCE_MAX_LENGTH), nullable=False),
+    )
+    created_by: UUIDstr | None = Field(
+        default=None,
+        # Immutable history keeps actor attribution even if the user row is
+        # later deleted; authentication validates the actor before insertion.
+        sa_column=sa.Column(sa.Uuid(), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=_utc_now,
+        sa_column=sa.Column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    reason: str | None = Field(
+        default=None,
+        max_length=POLICY_BUNDLE_REASON_MAX_LENGTH,
+        sa_column=sa.Column(sa.String(POLICY_BUNDLE_REASON_MAX_LENGTH), nullable=True),
+    )
+    rollback_of_revision: int | None = Field(
+        default=None,
+        sa_column=sa.Column(
+            sa.Integer(),
+            sa.ForeignKey("policy_bundle_revision.revision", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+class PolicyBundleActive(SQLModel, table=True):  # type: ignore[call-arg]
+    """Singleton pointer used to allocate and activate revisions with CAS."""
+
+    __tablename__ = "policy_bundle_active"
+    __table_args__ = (
+        sa.CheckConstraint(
+            f"id = {POLICY_BUNDLE_SINGLETON_ID}",
+            name="ck_policy_bundle_active_singleton",
+        ),
+        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_active_revision_positive"),
+    )
+
+    id: int = Field(default=POLICY_BUNDLE_SINGLETON_ID, primary_key=True)
+    # Deliberately no FK: writers CAS this pointer before inserting the new
+    # immutable revision in the same transaction. No reader can observe the
+    # uncommitted pointer, and a failed insert rolls the CAS back atomically.
+    revision: int = Field(nullable=False, ge=1)
+    initialized: bool = Field(
+        default=False,
+        sa_column=sa.Column(sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    updated_at: datetime = Field(
+        default_factory=_utc_now,
+        sa_column=sa.Column(
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -684,6 +684,46 @@ class DatabaseService(Service):
                 should_initialize_alembic = True
         await asyncio.to_thread(self._run_migrations, should_initialize_alembic, fix)
 
+    def _current_alembic_revisions(self) -> set[str]:
+        """Read current revisions from the configured database, never alembic.ini."""
+        engine = sa.create_engine(_normalize_sync_postgres_url(self.database_url))
+        try:
+            with engine.connect() as connection:
+                return set(connection.execute(sa.text("SELECT version_num FROM alembic_version")).scalars())
+        finally:
+            engine.dispose()
+
+    def _run_migration_downgrade(self, *, expected_current_revision: str, target_revision: str) -> None:
+        """Downgrade the configured database only from one explicitly expected revision."""
+        buffer_context = self._open_alembic_log_buffer()
+        with _postgres_migration_lock(self.database_url), buffer_context as buffer:
+            current_revisions = self._current_alembic_revisions()
+            if current_revisions != {expected_current_revision}:
+                found = ", ".join(sorted(current_revisions)) or "none"
+                msg = (
+                    "Refusing migration downgrade: expected current revision "
+                    f"{expected_current_revision}, found {found}"
+                )
+                raise RuntimeError(msg)
+
+            alembic_cfg = Config(stdout=buffer)
+            alembic_cfg.set_main_option("script_location", str(self.script_location))
+            alembic_cfg.set_main_option("sqlalchemy.url", self.database_url.replace("%", "%%"))
+            command.downgrade(alembic_cfg, target_revision)
+
+    async def run_migration_downgrade(
+        self,
+        *,
+        expected_current_revision: str,
+        target_revision: str,
+    ) -> None:
+        """Safely downgrade the configured database in a worker thread."""
+        await asyncio.to_thread(
+            self._run_migration_downgrade,
+            expected_current_revision=expected_current_revision,
+            target_revision=target_revision,
+        )
+
     @staticmethod
     def try_downgrade_upgrade_until_success(alembic_cfg, retries=5) -> None:
         # Try -1 then head, if it fails, try -2 then head, etc.

--- a/src/backend/base/langflow/services/deps.py
+++ b/src/backend/base/langflow/services/deps.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 from lfx.services.auth.base import BaseAuthService  # noqa: TC002
 from lfx.services.authorization.base import BaseAuthorizationService  # noqa: TC002
 from lfx.services.catalog_policy.base import BaseCatalogPolicyService  # noqa: TC002
+from lfx.services.policy_bundle.base import BasePolicyBundleService  # noqa: TC002
 from lfx.services.settings.service import SettingsService  # noqa: TC002
 
 from langflow.services.job_queue.service import JobQueueService  # noqa: TC001
@@ -304,6 +305,13 @@ def get_catalog_policy_service() -> BaseCatalogPolicyService:
     from lfx.services.deps import get_catalog_policy_service as get_lfx_catalog_policy_service
 
     return get_lfx_catalog_policy_service()
+
+
+def get_policy_bundle_service() -> BasePolicyBundleService:
+    """Retrieve the shared process-local policy bundle coordinator."""
+    from lfx.services.deps import get_policy_bundle_service as get_lfx_policy_bundle_service
+
+    return get_lfx_policy_bundle_service()
 
 
 def get_job_service():

--- a/src/backend/base/langflow/services/factory.py
+++ b/src/backend/base/langflow/services/factory.py
@@ -78,7 +78,7 @@ def import_all_services_into_a_dict():
 
             # Shared services live in lfx so both the standalone runtime and
             # the Langflow application use the same contract and instance.
-            if service_name in {"mcp_composer", "model_provider_policy"}:
+            if service_name in {"mcp_composer", "model_provider_policy", "policy_bundle"}:
                 module_name = f"lfx.services.{service_name}.service"
             else:
                 module_name = f"langflow.services.{service_name}.service"
@@ -99,10 +99,12 @@ def import_all_services_into_a_dict():
     from lfx.services.auth.base import BaseAuthService
     from lfx.services.authorization.base import BaseAuthorizationService
     from lfx.services.catalog_policy.base import BaseCatalogPolicyService
+    from lfx.services.policy_bundle.base import BasePolicyBundleService
     from lfx.services.settings.service import SettingsService
 
     services["BaseAuthService"] = BaseAuthService
     services["BaseAuthorizationService"] = BaseAuthorizationService
     services["BaseCatalogPolicyService"] = BaseCatalogPolicyService
+    services["BasePolicyBundleService"] = BasePolicyBundleService
     services["SettingsService"] = SettingsService
     return services

--- a/src/backend/base/langflow/services/model_provider_policy.py
+++ b/src/backend/base/langflow/services/model_provider_policy.py
@@ -2,22 +2,32 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from lfx.services.deps import get_model_provider_policy_service
 from lfx.services.model_provider_policy import ModelProviderPolicyService
 from sqlalchemy import update
+from sqlalchemy.exc import DBAPIError
 from sqlmodel import select
 
 from langflow.services.database.models.model_provider_policy import (
     MODEL_PROVIDER_POLICY_SINGLETON_ID,
     ModelProviderPolicy,
 )
+from langflow.services.policy_bundle import (
+    PolicyBundleNotInitializedError,
+    apply_policy_bundle_state,
+    ensure_policy_bundle_application_supported,
+    get_policy_bundle_state,
+    replace_policy_bundle_state,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from uuid import UUID
 
+    from lfx.services.policy_bundle import PolicyBundleSnapshot
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 
@@ -27,10 +37,10 @@ class PersistedModelProviderPolicy:
 
     approved_provider_ids: frozenset[str]
     version: int
+    bundle_snapshot: PolicyBundleSnapshot | None = field(default=None, compare=False, repr=False)
 
 
-class ModelProviderPolicyNotInitializedError(RuntimeError):
-    """The singleton row required to evaluate the install-wide policy is missing."""
+ModelProviderPolicyNotInitializedError = PolicyBundleNotInitializedError
 
 
 def _policy_statement():
@@ -60,6 +70,27 @@ async def get_model_provider_policy_state(session: AsyncSession) -> PersistedMod
     would silently remove a configured deployment ceiling, so surface a
     dedicated initialization error instead.
     """
+    # Keep the provider-only read seam usable against an N-1 database while a
+    # rolling deployment is applying the additive policy-bundle migration.
+    # Lightweight test/plugin sessions also intentionally expose only exec().
+    if not callable(getattr(session, "get", None)):
+        return await _get_legacy_model_provider_policy_state(session)
+
+    try:
+        row = await get_policy_bundle_state(session)
+    except DBAPIError as exc:
+        if not _is_missing_policy_bundle_table(exc):
+            raise
+        await session.rollback()
+        return await _get_legacy_model_provider_policy_state(session)
+    return PersistedModelProviderPolicy(
+        approved_provider_ids=frozenset(row.approved_provider_ids),
+        version=row.revision,
+        bundle_snapshot=row,
+    )
+
+
+async def _get_legacy_model_provider_policy_state(session: AsyncSession) -> PersistedModelProviderPolicy:
     row = (await session.exec(_policy_statement())).one_or_none()
     if row is None:
         msg = "Model-provider policy singleton is missing; apply the latest database migrations"
@@ -70,9 +101,19 @@ async def get_model_provider_policy_state(session: AsyncSession) -> PersistedMod
     )
 
 
+def _is_missing_policy_bundle_table(exc: DBAPIError) -> bool:
+    message = str(getattr(exc, "orig", exc)).casefold()
+    return "policy_bundle_active" in message and (
+        "does not exist" in message or "no such table" in message or "undefined table" in message
+    )
+
+
 async def replace_model_provider_policy_state(
     session: AsyncSession,
     provider_ids: Collection[str],
+    *,
+    actor_user_id: UUID | None = None,
+    reason: str | None = None,
 ) -> PersistedModelProviderPolicy:
     """Serialize and commit a complete replacement of the singleton policy.
 
@@ -82,11 +123,40 @@ async def replace_model_provider_policy_state(
     writer cannot interleave. Concurrent replacements therefore commit complete
     sets with distinct versions.
     """
+    if not callable(getattr(session, "get", None)):
+        return await _replace_legacy_model_provider_policy_state(session, provider_ids)
+
+    current = await get_model_provider_policy_state(session)
+    if current.bundle_snapshot is None:
+        return await _replace_legacy_model_provider_policy_state(session, provider_ids)
+
+    bundle = current.bundle_snapshot
+    ensure_policy_bundle_application_supported()
+    state = await replace_policy_bundle_state(
+        session,
+        expected_revision=bundle.revision,
+        approved_provider_ids=provider_ids,
+        blocked_component_keys=bundle.blocked_component_keys,
+        blocked_template_keys=bundle.blocked_template_keys,
+        actor_user_id=actor_user_id,
+        reason=reason,
+    )
+    return PersistedModelProviderPolicy(
+        approved_provider_ids=state.approved_provider_ids,
+        version=state.revision,
+        bundle_snapshot=state,
+    )
+
+
+async def _replace_legacy_model_provider_policy_state(
+    session: AsyncSession,
+    provider_ids: Collection[str],
+) -> PersistedModelProviderPolicy:
     result = await session.exec(_replace_policy_statement(provider_ids))
     if result.rowcount != 1:
         msg = "Model-provider policy singleton is missing; apply the latest database migrations"
         raise ModelProviderPolicyNotInitializedError(msg)
-    state = await get_model_provider_policy_state(session)
+    state = await _get_legacy_model_provider_policy_state(session)
     await session.commit()
     return state
 
@@ -98,6 +168,12 @@ def apply_model_provider_policy_state(
 ) -> bool:
     """Publish committed state locally, returning whether this worker changed."""
     service = get_model_provider_policy_service()
+    # A mixed-ownership deployment may keep provider policy external while the
+    # catalog facets remain database-owned. Publish the complete bundle first;
+    # apply_policy_bundle_state deliberately leaves an external provider alone.
+    if state.bundle_snapshot is not None:
+        return apply_policy_bundle_state(state.bundle_snapshot)
+
     # Explicitly external services own both their state and invalidation. This
     # check is intentionally based on ``is not None`` because an empty external
     # ceiling still establishes external ownership. Check ownership before the

--- a/src/backend/base/langflow/services/policy_bundle.py
+++ b/src/backend/base/langflow/services/policy_bundle.py
@@ -1,0 +1,455 @@
+"""Atomic persistence and runtime publication for deployment policy bundles."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from lfx.base.models.provider_registry import resolve_provider_id
+from lfx.services.model_provider_policy import ModelProviderPolicyService
+from lfx.services.policy_bundle import PolicyBundleSnapshot, policy_bundle_content_hash
+from sqlalchemy import update
+from sqlmodel import col, select
+
+from langflow.services.database.models.catalog_policy import (
+    CatalogPolicyMode,
+    CatalogPolicyRule,
+    CatalogPolicyScope,
+    CatalogResourceKind,
+)
+from langflow.services.database.models.model_provider_policy import (
+    MODEL_PROVIDER_POLICY_SINGLETON_ID,
+    ModelProviderPolicy,
+)
+from langflow.services.database.models.policy_bundle import (
+    POLICY_BUNDLE_REASON_MAX_LENGTH,
+    POLICY_BUNDLE_SINGLETON_ID,
+    POLICY_BUNDLE_SOURCE_MAX_LENGTH,
+    PolicyBundleActive,
+    PolicyBundleRevision,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from uuid import UUID
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+_STABLE_PROVIDER_ID_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,254}", flags=re.ASCII)
+_POLICY_SOURCE_RE = re.compile(r"[a-z][a-z0-9_-]{0,31}", flags=re.ASCII)
+
+
+class PolicyBundleNotInitializedError(RuntimeError):
+    """The active bundle singleton or its immutable revision is unavailable."""
+
+
+class PolicyBundleRevisionConflictError(RuntimeError):
+    """A writer used a stale expected revision."""
+
+    def __init__(self, *, expected_revision: int, active_revision: int) -> None:
+        self.expected_revision = expected_revision
+        self.active_revision = active_revision
+        super().__init__(
+            f"Policy bundle revision conflict: expected {expected_revision}, active revision is {active_revision}"
+        )
+
+
+class PolicyBundleApplicationNotSupportedError(RuntimeError):
+    """Raised when a database-owned catalog plugin cannot apply shared bundles."""
+
+
+def ensure_policy_bundle_application_supported() -> None:
+    """Reject writes that the active database-owned catalog plugin cannot enforce."""
+    from lfx.services.deps import get_catalog_policy_service
+
+    catalog_service = get_catalog_policy_service()
+    if catalog_service.external_policy_snapshot is None and not catalog_service.supports_policy_bundle_updates:
+        msg = (
+            "Configured catalog policy service does not support shared policy bundle updates; "
+            "upgrade the plugin before changing database-backed policy"
+        )
+        raise PolicyBundleApplicationNotSupportedError(msg)
+
+
+def _normalize_provider_ids(provider_ids: Collection[str]) -> frozenset[str]:
+    normalized: set[str] = set()
+    for provider_id in provider_ids:
+        canonical = resolve_provider_id(provider_id.strip())
+        if _STABLE_PROVIDER_ID_RE.fullmatch(canonical) is None:
+            msg = "Model provider IDs must use stable lowercase identifier syntax"
+            raise ValueError(msg)
+        normalized.add(canonical)
+    return frozenset(normalized)
+
+
+def _normalize_catalog_keys(keys: Collection[str]) -> frozenset[str]:
+    normalized: set[str] = set()
+    for raw_key in keys:
+        key = raw_key.strip()
+        if not key:
+            msg = "Catalog policy keys must not be empty"
+            raise ValueError(msg)
+        normalized.add(key)
+    return frozenset(normalized)
+
+
+def _normalize_reason(reason: str | None) -> str | None:
+    if reason is None:
+        return None
+    normalized = reason.strip()
+    if not normalized:
+        return None
+    if len(normalized) > POLICY_BUNDLE_REASON_MAX_LENGTH:
+        msg = f"Policy bundle reason must not exceed {POLICY_BUNDLE_REASON_MAX_LENGTH} characters"
+        raise ValueError(msg)
+    return normalized
+
+
+def _normalize_source(source: str) -> str:
+    normalized = source.strip().lower()
+    if len(normalized) > POLICY_BUNDLE_SOURCE_MAX_LENGTH or _POLICY_SOURCE_RE.fullmatch(normalized) is None:
+        msg = "Policy bundle source must use lowercase identifier syntax"
+        raise ValueError(msg)
+    return normalized
+
+
+def _snapshot_from_row(row: PolicyBundleRevision, *, initialized: bool | None = None) -> PolicyBundleSnapshot:
+    return PolicyBundleSnapshot(
+        revision=row.revision,
+        initialized=row.initialized if initialized is None else initialized,
+        source=row.source,
+        approved_provider_ids=frozenset(row.approved_provider_ids),
+        blocked_component_keys=frozenset(row.blocked_component_keys),
+        blocked_template_keys=frozenset(row.blocked_template_keys),
+        content_hash=row.content_hash,
+        created_at=row.created_at,
+        created_by=row.created_by,
+        reason=row.reason,
+        rollback_of_revision=row.rollback_of_revision,
+    )
+
+
+async def get_policy_bundle_state(
+    session: AsyncSession,
+    *,
+    revision: int | None = None,
+) -> PolicyBundleSnapshot:
+    """Read the active or requested immutable bundle revision."""
+    target_revision = revision
+    initialized: bool | None = None
+    if target_revision is None:
+        active = await session.get(
+            PolicyBundleActive,
+            POLICY_BUNDLE_SINGLETON_ID,
+            populate_existing=True,
+        )
+        if active is None:
+            msg = "Active policy bundle is missing; apply the latest database migrations"
+            raise PolicyBundleNotInitializedError(msg)
+        target_revision = active.revision
+        initialized = active.initialized
+
+    statement = (
+        select(PolicyBundleRevision)
+        .where(PolicyBundleRevision.revision == target_revision)
+        .execution_options(populate_existing=True)
+    )
+    row = (await session.exec(statement)).one_or_none()
+    if row is None:
+        msg = f"Policy bundle revision {target_revision} is missing"
+        raise PolicyBundleNotInitializedError(msg)
+    return _snapshot_from_row(row, initialized=initialized)
+
+
+async def list_policy_bundle_history(
+    session: AsyncSession,
+    *,
+    limit: int = 50,
+    before_revision: int | None = None,
+) -> list[PolicyBundleSnapshot]:
+    """Return newest-first immutable bundle history."""
+    statement = select(PolicyBundleRevision)
+    if before_revision is not None:
+        statement = statement.where(PolicyBundleRevision.revision < before_revision)
+    statement = statement.order_by(col(PolicyBundleRevision.revision).desc()).limit(limit)
+    return [_snapshot_from_row(row) for row in (await session.exec(statement)).all()]
+
+
+async def _active_revision(session: AsyncSession) -> int:
+    active = await session.get(
+        PolicyBundleActive,
+        POLICY_BUNDLE_SINGLETON_ID,
+        populate_existing=True,
+    )
+    if active is None:
+        msg = "Active policy bundle is missing; apply the latest database migrations"
+        raise PolicyBundleNotInitializedError(msg)
+    return active.revision
+
+
+async def _sync_legacy_policy(
+    session: AsyncSession,
+    snapshot: PolicyBundleSnapshot,
+    *,
+    actor_user_id: UUID | None,
+) -> None:
+    """Dual-write the N-1 stores without deleting reserved catalog rules."""
+    provider_table = ModelProviderPolicy.__table__
+    result = await session.exec(
+        update(provider_table)
+        .where(provider_table.c.id == MODEL_PROVIDER_POLICY_SINGLETON_ID)
+        .values(
+            approved_provider_ids=sorted(snapshot.approved_provider_ids),
+            version=snapshot.revision,
+        )
+    )
+    if result.rowcount != 1:
+        msg = "Model-provider policy singleton is missing; apply the latest database migrations"
+        raise PolicyBundleNotInitializedError(msg)
+
+    statement = select(CatalogPolicyRule).where(
+        CatalogPolicyRule.mode == CatalogPolicyMode.BLOCK.value,
+        CatalogPolicyRule.scope == CatalogPolicyScope.GLOBAL.value,
+        col(CatalogPolicyRule.domain_id).is_(None),
+        CatalogPolicyRule.resource_kind.in_((CatalogResourceKind.COMPONENT.value, CatalogResourceKind.TEMPLATE.value)),
+    )
+    rows = list((await session.exec(statement)).all())
+    rows_by_kind = {
+        CatalogResourceKind.COMPONENT: {
+            row.resource_key: row for row in rows if row.resource_kind == CatalogResourceKind.COMPONENT.value
+        },
+        CatalogResourceKind.TEMPLATE: {
+            row.resource_key: row for row in rows if row.resource_kind == CatalogResourceKind.TEMPLATE.value
+        },
+    }
+    desired_by_kind = {
+        CatalogResourceKind.COMPONENT: snapshot.blocked_component_keys,
+        CatalogResourceKind.TEMPLATE: snapshot.blocked_template_keys,
+    }
+    for resource_kind, current_rows in rows_by_kind.items():
+        desired = desired_by_kind[resource_kind]
+        for key in set(current_rows) - desired:
+            await session.delete(current_rows[key])
+        for key in desired - set(current_rows):
+            session.add(
+                CatalogPolicyRule(
+                    resource_kind=resource_kind.value,
+                    resource_key=key,
+                    mode=CatalogPolicyMode.BLOCK.value,
+                    scope=CatalogPolicyScope.GLOBAL.value,
+                    domain_id=None,
+                    created_by=actor_user_id,
+                )
+            )
+
+
+async def replace_policy_bundle_state(
+    session: AsyncSession,
+    *,
+    expected_revision: int,
+    approved_provider_ids: Collection[str],
+    blocked_component_keys: Collection[str],
+    blocked_template_keys: Collection[str],
+    actor_user_id: UUID | None,
+    reason: str | None = None,
+    rollback_of_revision: int | None = None,
+    source: str = "api",
+    require_uninitialized: bool = False,
+) -> PolicyBundleSnapshot:
+    """Create and activate one complete immutable revision in one transaction."""
+    providers = _normalize_provider_ids(approved_provider_ids)
+    components = _normalize_catalog_keys(blocked_component_keys)
+    templates = _normalize_catalog_keys(blocked_template_keys)
+    normalized_reason = _normalize_reason(reason)
+    normalized_source = _normalize_source(source)
+    new_revision = expected_revision + 1
+
+    active_table = PolicyBundleActive.__table__
+    conditions = [
+        active_table.c.id == POLICY_BUNDLE_SINGLETON_ID,
+        active_table.c.revision == expected_revision,
+    ]
+    if require_uninitialized:
+        conditions.append(active_table.c.initialized.is_(False))
+    result = await session.exec(
+        update(active_table)
+        .where(
+            *conditions,
+        )
+        .values(revision=new_revision, initialized=True, updated_at=sa.func.now())
+    )
+    if result.rowcount != 1:
+        active_revision = await _active_revision(session)
+        await session.rollback()
+        raise PolicyBundleRevisionConflictError(
+            expected_revision=expected_revision,
+            active_revision=active_revision,
+        )
+
+    created_at = datetime.now(timezone.utc)
+    snapshot = PolicyBundleSnapshot(
+        revision=new_revision,
+        initialized=True,
+        source=normalized_source,
+        approved_provider_ids=providers,
+        blocked_component_keys=components,
+        blocked_template_keys=templates,
+        content_hash=policy_bundle_content_hash(
+            approved_provider_ids=providers,
+            blocked_component_keys=components,
+            blocked_template_keys=templates,
+        ),
+        created_at=created_at,
+        created_by=actor_user_id,
+        reason=normalized_reason,
+        rollback_of_revision=rollback_of_revision,
+    )
+    session.add(
+        PolicyBundleRevision(
+            revision=snapshot.revision,
+            initialized=snapshot.initialized,
+            approved_provider_ids=sorted(snapshot.approved_provider_ids),
+            blocked_component_keys=sorted(snapshot.blocked_component_keys),
+            blocked_template_keys=sorted(snapshot.blocked_template_keys),
+            content_hash=snapshot.content_hash,
+            source=normalized_source,
+            created_at=created_at,
+            created_by=actor_user_id,
+            reason=normalized_reason,
+            rollback_of_revision=rollback_of_revision,
+        )
+    )
+    await _sync_legacy_policy(session, snapshot, actor_user_id=actor_user_id)
+    await session.commit()
+    return snapshot
+
+
+async def rollback_policy_bundle_state(
+    session: AsyncSession,
+    *,
+    expected_revision: int,
+    target_revision: int,
+    actor_user_id: UUID | None,
+    reason: str | None = None,
+) -> PolicyBundleSnapshot:
+    """Reactivate old content as a new monotonically increasing revision."""
+    target = await get_policy_bundle_state(session, revision=target_revision)
+    return await replace_policy_bundle_state(
+        session,
+        expected_revision=expected_revision,
+        approved_provider_ids=target.approved_provider_ids,
+        blocked_component_keys=target.blocked_component_keys,
+        blocked_template_keys=target.blocked_template_keys,
+        actor_user_id=actor_user_id,
+        reason=reason or f"Rollback to policy bundle revision {target_revision}",
+        rollback_of_revision=target_revision,
+        source="rollback",
+    )
+
+
+async def bootstrap_policy_bundle_if_pristine(
+    session: AsyncSession,
+    *,
+    approved_provider_ids: Collection[str],
+    blocked_component_keys: Collection[str],
+    blocked_template_keys: Collection[str],
+    reason: str | None = None,
+) -> tuple[PolicyBundleSnapshot, bool]:
+    """Initialize a migration-created pristine bundle exactly once.
+
+    Concurrent replicas race through the same CAS. The loser returns the
+    winner's durable revision so the caller can verify configuration equality.
+    """
+    current = await get_policy_bundle_state(session)
+    if current.initialized:
+        return current, False
+    try:
+        snapshot = await replace_policy_bundle_state(
+            session,
+            expected_revision=current.revision,
+            approved_provider_ids=approved_provider_ids,
+            blocked_component_keys=blocked_component_keys,
+            blocked_template_keys=blocked_template_keys,
+            actor_user_id=None,
+            reason=reason or "Bootstrap policy bundle from deployment environment",
+            source="environment",
+            require_uninitialized=True,
+        )
+    except PolicyBundleRevisionConflictError:
+        return await get_policy_bundle_state(session), False
+    return snapshot, True
+
+
+def apply_policy_bundle_state(snapshot: PolicyBundleSnapshot) -> bool:
+    """Publish a committed bundle locally with one catalog-owned reference swap."""
+    from lfx.services.deps import (
+        get_catalog_policy_service,
+        get_model_provider_policy_service,
+        get_policy_bundle_service,
+    )
+
+    catalog_service = get_catalog_policy_service()
+    if catalog_service.external_policy_snapshot is None and not catalog_service.supports_policy_bundle_updates:
+        msg = (
+            "Configured catalog policy service does not support shared policy bundle updates; "
+            "upgrade the plugin before applying database-backed policy"
+        )
+        raise PolicyBundleApplicationNotSupportedError(msg)
+
+    policy_bundle_service = get_policy_bundle_service()
+    bundle_changed = policy_bundle_service.publish(snapshot)
+    authoritative_snapshot = policy_bundle_service.snapshot
+
+    catalog_changed = False
+    if catalog_service.external_policy_snapshot is None:
+        # Built-ins share policy_bundle_service, making this an idempotent
+        # same-revision publication. The explicit hook keeps independently
+        # implemented database-owned plugins synchronized as well.
+        catalog_changed = catalog_service.apply_policy_bundle(authoritative_snapshot)
+
+    provider_service = get_model_provider_policy_service()
+    if provider_service.external_approved_provider_ids is not None:
+        return bundle_changed or catalog_changed
+
+    if isinstance(provider_service, ModelProviderPolicyService):
+        if provider_service.policy_bundle_service is None:
+            provider_changed = provider_service.set_approved_provider_ids(
+                authoritative_snapshot.approved_provider_ids,
+                version=authoritative_snapshot.revision,
+            )
+        else:
+            provider_changed = bundle_changed
+            if provider_changed:
+                provider_service.invalidate()
+        return bundle_changed or catalog_changed or provider_changed
+
+    # DB-owned policy plugins may derive provider decisions from the catalog
+    # service's shared bundle snapshot. Invalidate contextual decision caches.
+    if bundle_changed or catalog_changed:
+        provider_service.invalidate()
+    return bundle_changed or catalog_changed
+
+
+async def hydrate_policy_bundle(session: AsyncSession) -> PolicyBundleSnapshot:
+    """Load and publish the active complete policy revision."""
+    snapshot = await get_policy_bundle_state(session)
+    apply_policy_bundle_state(snapshot)
+    return snapshot
+
+
+__all__ = [
+    "PolicyBundleApplicationNotSupportedError",
+    "PolicyBundleNotInitializedError",
+    "PolicyBundleRevisionConflictError",
+    "apply_policy_bundle_state",
+    "bootstrap_policy_bundle_if_pristine",
+    "ensure_policy_bundle_application_supported",
+    "get_policy_bundle_state",
+    "hydrate_policy_bundle",
+    "list_policy_bundle_history",
+    "policy_bundle_content_hash",
+    "replace_policy_bundle_state",
+    "rollback_policy_bundle_state",
+]

--- a/src/backend/base/langflow/services/schema.py
+++ b/src/backend/base/langflow/services/schema.py
@@ -8,6 +8,7 @@ class ServiceType(str, Enum):
     AUTHORIZATION_SERVICE = "authorization_service"
     CATALOG_POLICY_SERVICE = "catalog_policy_service"
     MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
+    POLICY_BUNDLE_SERVICE = "policy_bundle_service"
     CACHE_SERVICE = "cache_service"
     SHARED_COMPONENT_CACHE_SERVICE = "shared_component_cache_service"
     SETTINGS_SERVICE = "settings_service"

--- a/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
+++ b/src/backend/base/langflow/services/task/model_provider_policy_refresh.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 
 from lfx.log.logger import logger
-from lfx.services.deps import get_model_provider_policy_service
+from lfx.services.deps import get_catalog_policy_service, get_model_provider_policy_service, get_policy_bundle_service
 from lfx.services.model_provider_policy import ModelProviderPolicyService
 
 from langflow.services.deps import get_settings_service, session_scope
@@ -31,7 +31,7 @@ class ModelProviderPolicyRefreshWorker:
         self._task: asyncio.Task | None = None
 
     async def start(self) -> None:
-        """Start refreshes only for the built-in OSS policy implementation."""
+        """Start refreshes only for the built-in database-owned policy implementation."""
         if self._task is not None and not self._task.done():
             await logger.awarning("Model-provider policy refresh worker is already running")
             return
@@ -42,9 +42,13 @@ class ModelProviderPolicyRefreshWorker:
                 self._task.result()
             self._task = None
         service = get_model_provider_policy_service()
-        if service.external_approved_provider_ids is not None or not isinstance(service, ModelProviderPolicyService):
-            await logger.adebug("Model-provider policy refresh worker not started: external policy service active")
-            return
+        if service.external_approved_provider_ids is not None:
+            catalog_service = get_catalog_policy_service()
+            if catalog_service.external_policy_snapshot is not None:
+                await logger.adebug(
+                    "Policy-bundle refresh worker not started: provider and catalog policies are externally managed"
+                )
+                return
 
         self._active_interval = (
             self._interval_override
@@ -102,6 +106,12 @@ class ModelProviderPolicyRefreshWorker:
                 # Install deny-all synchronously before any logging await: a
                 # broken async sink must never preserve broader stale policy.
                 changed = service.fail_closed(deny_all_required=deny_all_required)
+            elif service.external_approved_provider_ids is None:
+                bundle_service = get_policy_bundle_service()
+                if deny_all_required or bundle_service.snapshot.approved_provider_ids:
+                    changed = bundle_service.mark_source_unavailable()
+                    if changed:
+                        service.invalidate()
             with contextlib.suppress(Exception):
                 await logger.aerror(f"Model-provider policy refresh failed: {exc}")
             return changed

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -568,6 +568,7 @@ def register_all_service_factories() -> None:
     from lfx.services.executor import factory as executor_factory
     from lfx.services.mcp_composer import factory as mcp_composer_factory
     from lfx.services.model_provider_policy.service import ModelProviderPolicyService
+    from lfx.services.policy_bundle.service import PolicyBundleService
     from lfx.services.settings import factory as settings_factory
 
     from langflow.services.auth import factory as auth_factory
@@ -625,6 +626,11 @@ def register_all_service_factories() -> None:
         ServiceType.AUTHORIZATION_SERVICE, LangflowAuthorizationService, override=True
     )
     service_manager.register_factory(authorization_factory.AuthorizationServiceFactory())
+    service_manager.register_service_class(
+        ServiceType.POLICY_BUNDLE_SERVICE,
+        PolicyBundleService,
+        override=True,
+    )
     service_manager.register_service_class(
         ServiceType.CATALOG_POLICY_SERVICE,
         LangflowCatalogPolicyService,
@@ -726,11 +732,13 @@ async def initialize_services(*, fix_migration: bool = False, skip_superuser_set
 
     # Setup the superuser
     await initialize_database(fix_migration=fix_migration)
-    from langflow.services.model_provider_policy import hydrate_model_provider_policy
+    from langflow.services.policy_bundle import hydrate_policy_bundle
 
     async with session_scope() as session:
-        await hydrate_model_provider_policy(session)
-
+        await hydrate_policy_bundle(session)
+    # Preserve the pre-bundle plugin lifecycle for catalog implementations
+    # that load their own source in hydrate(). Bundle-aware services treat
+    # this as an idempotent read of the already published revision.
     await hydrate_catalog_policy()
     db_service = get_db_service()
     await db_service.initialize_alembic_log_file()

--- a/src/backend/tests/unit/alembic/test_shared_policy_bundle_migration.py
+++ b/src/backend/tests/unit/alembic/test_shared_policy_bundle_migration.py
@@ -1,0 +1,244 @@
+"""SQLite contract tests for the shared policy-bundle migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = Path(__file__).parents[3] / "base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py"
+
+
+def _load_migration():
+    assert _MIGRATION_PATH.exists(), "the shared policy-bundle migration has not been added"
+    spec = importlib.util.spec_from_file_location("shared_policy_bundle_migration", _MIGRATION_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_legacy_policy_tables(connection: sa.Connection) -> tuple[sa.Table, sa.Table]:
+    """Create the two pre-bundle stores as they exist at the migration boundary."""
+    metadata = sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    provider_policy = sa.Table(
+        "model_provider_policy",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("approved_provider_ids", sa.JSON(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+    )
+    catalog_policy = sa.Table(
+        "catalog_policy_rule",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("resource_kind", sa.String(), nullable=False),
+        sa.Column("resource_key", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("domain_id", sa.Uuid(), nullable=True),
+        sa.Column("created_by", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    metadata.create_all(connection)
+    return provider_policy, catalog_policy
+
+
+def _reflect_bundle_tables(connection: sa.Connection) -> tuple[sa.Table, sa.Table]:
+    metadata = sa.MetaData()
+    return (
+        sa.Table("policy_bundle_revision", metadata, autoload_with=connection),
+        sa.Table("policy_bundle_active", metadata, autoload_with=connection),
+    )
+
+
+def test_migration_backfills_one_active_revision_idempotently_and_preserves_legacy_tables(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=ON")
+        provider_policy, catalog_policy = _create_legacy_policy_tables(connection)
+        scoped_domain_id = uuid4()
+        legacy_rows = [
+            {
+                "id": uuid4(),
+                "resource_kind": "component",
+                "resource_key": "OpenAIModel",
+                "mode": "block",
+                "scope": "global",
+            },
+            {
+                "id": uuid4(),
+                "resource_kind": "component",
+                "resource_key": "Case-Sensitive",
+                "mode": "block",
+                "scope": "global",
+            },
+            {
+                "id": uuid4(),
+                "resource_kind": "template",
+                "resource_key": "starter-template",
+                "mode": "block",
+                "scope": "global",
+            },
+            {
+                "id": uuid4(),
+                "resource_kind": "component",
+                "resource_key": "reserved-allow-row",
+                "mode": "allow",
+                "scope": "global",
+            },
+            {
+                "id": uuid4(),
+                "resource_kind": "template",
+                "resource_key": "reserved-scoped-row",
+                "mode": "block",
+                "scope": "workspace",
+                "domain_id": scoped_domain_id,
+            },
+        ]
+        connection.execute(
+            provider_policy.insert(),
+            {"id": 1, "approved_provider_ids": ["openai", "anthropic"], "version": 7},
+        )
+        connection.execute(catalog_policy.insert(), legacy_rows)
+
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(migration, "op", operations)
+
+        migration.upgrade()
+        migration.upgrade()
+
+        inspector = sa.inspect(connection)
+        assert {"policy_bundle_revision", "policy_bundle_active"} <= set(inspector.get_table_names())
+        history, active = _reflect_bundle_tables(connection)
+        history_rows = list(connection.execute(sa.select(history)).mappings())
+        active_rows = list(connection.execute(sa.select(active)).mappings())
+
+        assert len(history_rows) == 1
+        assert len(active_rows) == 1
+        initial = history_rows[0]
+        assert initial["revision"] == 7
+        assert bool(initial["initialized"]) is True
+        assert active_rows[0]["id"] == 1
+        assert active_rows[0]["revision"] == initial["revision"]
+        assert bool(active_rows[0]["initialized"]) is True
+        assert initial["approved_provider_ids"] == ["anthropic", "openai"]
+        assert initial["blocked_component_keys"] == ["Case-Sensitive", "OpenAIModel"]
+        assert initial["blocked_template_keys"] == ["starter-template"]
+        assert re.fullmatch(r"[0-9a-f]{64}", initial["content_hash"])
+        assert initial["source"] == "migration"
+        assert initial["created_by"] is None
+        assert initial["created_at"] is not None
+        assert initial["rollback_of_revision"] is None
+
+        # Reserved allow/scoped rows are outside the initial global-block snapshot,
+        # but migration to the additive bundle must not delete or rewrite them.
+        assert connection.execute(sa.select(sa.func.count()).select_from(provider_policy)).scalar_one() == 1
+        assert connection.execute(sa.select(sa.func.count()).select_from(catalog_policy)).scalar_one() == 5
+        preserved = set(
+            connection.execute(
+                sa.select(
+                    catalog_policy.c.resource_kind,
+                    catalog_policy.c.resource_key,
+                    catalog_policy.c.mode,
+                    catalog_policy.c.scope,
+                )
+            ).tuples()
+        )
+        assert preserved == {
+            (row["resource_kind"], row["resource_key"], row["mode"], row["scope"]) for row in legacy_rows
+        }
+
+        # Immutable history may retain an actor after its user row is deleted.
+        # The legacy catalog table has a user FK, so rollback must not copy a
+        # potentially dangling actor UUID into recreated rules.
+        connection.execute(history.update().values(created_by=str(uuid4())))
+        migration.downgrade()
+        migration.downgrade()
+
+        remaining_tables = set(sa.inspect(connection).get_table_names())
+        assert "policy_bundle_revision" not in remaining_tables
+        assert "policy_bundle_active" not in remaining_tables
+        assert {"model_provider_policy", "catalog_policy_rule"} <= remaining_tables
+        assert connection.execute(sa.select(sa.func.count()).select_from(catalog_policy)).scalar_one() == 5
+        recreated_global_blocks = connection.execute(
+            sa.select(catalog_policy.c.created_by).where(
+                catalog_policy.c.mode == "block",
+                catalog_policy.c.scope == "global",
+                catalog_policy.c.domain_id.is_(None),
+            )
+        ).scalars()
+        assert list(recreated_global_blocks) == [None, None, None]
+
+
+def test_migration_seeds_revision_one_for_a_pristine_legacy_install(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=ON")
+        provider_policy, _catalog_policy = _create_legacy_policy_tables(connection)
+        connection.execute(
+            provider_policy.insert(),
+            {"id": 1, "approved_provider_ids": [], "version": 0},
+        )
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+
+        migration.upgrade()
+
+        history, active = _reflect_bundle_tables(connection)
+        initial = connection.execute(sa.select(history)).mappings().one()
+        assert initial["revision"] == 1
+        assert bool(initial["initialized"]) is False
+        active_row = connection.execute(sa.select(active)).mappings().one()
+        assert active_row["revision"] == 1
+        assert bool(active_row["initialized"]) is False
+        assert initial["source"] == "migration"
+        assert initial["approved_provider_ids"] == []
+        assert initial["blocked_component_keys"] == []
+        assert initial["blocked_template_keys"] == []
+
+        migration.downgrade()
+        legacy = connection.execute(sa.select(provider_policy)).mappings().one()
+        assert legacy["version"] == 0
+
+        migration.upgrade()
+        _history, active = _reflect_bundle_tables(connection)
+        active_row = connection.execute(sa.select(active)).mappings().one()
+        assert active_row["revision"] == 1
+        assert bool(active_row["initialized"]) is False
+
+
+def test_migration_repairs_an_empty_revision_table_left_by_interrupted_sqlite_ddl(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        provider_policy, _catalog_policy = _create_legacy_policy_tables(connection)
+        connection.execute(
+            provider_policy.insert(),
+            {"id": 1, "approved_provider_ids": [], "version": 0},
+        )
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+
+        migration._create_revision_table()
+        assert "policy_bundle_revision" in sa.inspect(connection).get_table_names()
+        assert "policy_bundle_active" not in sa.inspect(connection).get_table_names()
+
+        migration.upgrade()
+
+        history, active = _reflect_bundle_tables(connection)
+        assert connection.execute(sa.select(sa.func.count()).select_from(history)).scalar_one() == 1
+        active_row = connection.execute(sa.select(active)).mappings().one()
+        assert active_row["revision"] == 1
+        assert bool(active_row["initialized"]) is False

--- a/src/backend/tests/unit/alembic/test_shared_policy_bundle_migration.py
+++ b/src/backend/tests/unit/alembic/test_shared_policy_bundle_migration.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -58,6 +59,10 @@ def _reflect_bundle_tables(connection: sa.Connection) -> tuple[sa.Table, sa.Tabl
         sa.Table("policy_bundle_revision", metadata, autoload_with=connection),
         sa.Table("policy_bundle_active", metadata, autoload_with=connection),
     )
+
+
+def _reflect_revision_table(connection: sa.Connection) -> sa.Table:
+    return sa.Table("policy_bundle_revision", sa.MetaData(), autoload_with=connection)
 
 
 def test_migration_backfills_one_active_revision_idempotently_and_preserves_legacy_tables(monkeypatch):
@@ -242,3 +247,159 @@ def test_migration_repairs_an_empty_revision_table_left_by_interrupted_sqlite_dd
         active_row = connection.execute(sa.select(active)).mappings().one()
         assert active_row["revision"] == 1
         assert bool(active_row["initialized"]) is False
+
+
+def test_migration_refuses_a_partial_bundle_schema_with_durable_revision_history(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        provider_policy, _catalog_policy = _create_legacy_policy_tables(connection)
+        connection.execute(
+            provider_policy.insert(),
+            {"id": 1, "approved_provider_ids": [], "version": 0},
+        )
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+
+        migration._create_revision_table()
+        history = _reflect_revision_table(connection)
+        connection.execute(
+            history.insert(),
+            {
+                "revision": 1,
+                "initialized": False,
+                "approved_provider_ids": [],
+                "blocked_component_keys": [],
+                "blocked_template_keys": [],
+                "content_hash": migration._canonical_hash([], [], []),
+                "source": "migration",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="partially initialized with durable data"):
+            migration.upgrade()
+
+        assert "policy_bundle_active" not in sa.inspect(connection).get_table_names()
+
+
+def test_migration_refuses_an_active_pointer_to_a_missing_revision(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        provider_policy, _catalog_policy = _create_legacy_policy_tables(connection)
+        connection.execute(
+            provider_policy.insert(),
+            {"id": 1, "approved_provider_ids": [], "version": 0},
+        )
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+
+        migration._create_revision_table()
+        migration._create_active_table()
+        _history, active = _reflect_bundle_tables(connection)
+        connection.execute(active.insert(), {"id": 1, "revision": 99, "initialized": True})
+
+        with pytest.raises(RuntimeError, match="points to a missing immutable revision"):
+            migration.upgrade()
+
+
+def test_downgrade_refuses_revision_history_without_an_active_pointer(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        _create_legacy_policy_tables(connection)
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        migration._create_revision_table()
+        migration._create_active_table()
+        history, _active = _reflect_bundle_tables(connection)
+        connection.execute(
+            history.insert(),
+            {
+                "revision": 1,
+                "initialized": False,
+                "approved_provider_ids": [],
+                "blocked_component_keys": [],
+                "blocked_template_keys": [],
+                "content_hash": migration._canonical_hash([], [], []),
+                "source": "migration",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="immutable revision history but no active singleton"):
+            migration.downgrade()
+
+        assert {migration.REVISION_TABLE, migration.ACTIVE_TABLE} <= set(sa.inspect(connection).get_table_names())
+
+
+def test_downgrade_refuses_an_active_pointer_to_a_missing_revision(monkeypatch):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        _create_legacy_policy_tables(connection)
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        migration._create_revision_table()
+        migration._create_active_table()
+        _history, active = _reflect_bundle_tables(connection)
+        connection.execute(active.insert(), {"id": 1, "revision": 99, "initialized": True})
+
+        with pytest.raises(RuntimeError, match="points to a missing immutable revision"):
+            migration.downgrade()
+
+        assert {migration.REVISION_TABLE, migration.ACTIVE_TABLE} <= set(sa.inspect(connection).get_table_names())
+
+
+@pytest.mark.parametrize("lone_table", ["revision", "active"])
+def test_downgrade_removes_an_empty_lone_bundle_table(monkeypatch, lone_table):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        if lone_table == "revision":
+            migration._create_revision_table()
+            table_name = migration.REVISION_TABLE
+        else:
+            migration._create_active_table()
+            table_name = migration.ACTIVE_TABLE
+
+        migration.downgrade()
+
+        assert table_name not in sa.inspect(connection).get_table_names()
+
+
+@pytest.mark.parametrize("lone_table", ["revision", "active"])
+def test_downgrade_refuses_to_discard_a_populated_lone_bundle_table(monkeypatch, lone_table):
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        if lone_table == "revision":
+            migration._create_revision_table()
+            history = _reflect_revision_table(connection)
+            connection.execute(
+                history.insert(),
+                {
+                    "revision": 1,
+                    "initialized": False,
+                    "approved_provider_ids": [],
+                    "blocked_component_keys": [],
+                    "blocked_template_keys": [],
+                    "content_hash": migration._canonical_hash([], [], []),
+                    "source": "migration",
+                },
+            )
+            table_name = migration.REVISION_TABLE
+        else:
+            migration._create_active_table()
+            metadata = sa.MetaData()
+            active = sa.Table(migration.ACTIVE_TABLE, metadata, autoload_with=connection)
+            connection.execute(active.insert(), {"id": 1, "revision": 1, "initialized": False})
+            table_name = migration.ACTIVE_TABLE
+
+        with pytest.raises(RuntimeError, match="partially initialized with durable data"):
+            migration.downgrade()
+
+        assert table_name in sa.inspect(connection).get_table_names()

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -14,6 +14,7 @@ from langflow.api.v1 import catalog_policy
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.database.models.api_key.model import ApiKey
 from langflow.services.database.models.catalog_policy import CatalogPolicyRule
+from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
 from lfx.services.catalog_policy import CatalogPolicySnapshot, CatalogPolicyUpdate
 from lfx.services.deps import session_scope_readonly
 from sqlmodel import select
@@ -31,6 +32,10 @@ class _StubCatalogPolicy:
     @property
     def external_policy_snapshot(self):
         return None
+
+    @property
+    def supports_policy_bundle_updates(self):
+        return True
 
     async def replace_blocked_component_keys(self, keys, *, actor_user_id):
         desired = frozenset(keys)
@@ -76,6 +81,22 @@ class _ExternalCatalogPolicy(_StubCatalogPolicy):
     @property
     def external_policy_snapshot(self):
         return self.snapshot
+
+
+class _ConflictingCatalogPolicy(_StubCatalogPolicy):
+    async def replace_blocked_component_keys(self, keys, *, actor_user_id):
+        _ = keys, actor_user_id
+        raise PolicyBundleRevisionConflictError(expected_revision=7, active_revision=8)
+
+    async def replace_blocked_template_keys(self, keys, *, actor_user_id):
+        _ = keys, actor_user_id
+        raise PolicyBundleRevisionConflictError(expected_revision=7, active_revision=8)
+
+
+class _LegacyCatalogPolicy(_StubCatalogPolicy):
+    @property
+    def supports_policy_bundle_updates(self):
+        return False
 
 
 def _client(monkeypatch, *, service=None, superuser=True):
@@ -202,6 +223,20 @@ def test_put_components_normalizes_whole_set_and_audits_each_delta(monkeypatch):
     ]
 
 
+def test_put_rejects_legacy_plugin_without_bundle_update_support(monkeypatch):
+    client, service, _admin, audit = _client(monkeypatch, service=_LegacyCatalogPolicy())
+
+    response = client.put(
+        "/api/v1/catalog-policy/components",
+        json={"blocked": ["NewComponent"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "does not support shared policy bundle updates" in response.json()["detail"]
+    assert service.component_calls == []
+    audit.assert_not_awaited()
+
+
 def test_put_templates_preserves_case_and_accepts_unknown_keys(monkeypatch):
     client, service, admin, audit = _client(monkeypatch)
 
@@ -236,6 +271,26 @@ def test_put_requires_explicit_whole_set_without_writing_or_auditing(monkeypatch
 
     assert response.status_code == 422
     assert service.component_calls == []
+    audit.assert_not_awaited()
+
+
+@pytest.mark.parametrize("resource_kind", ["components", "templates"])
+def test_concurrent_legacy_put_returns_bundle_revision_conflict(monkeypatch, resource_kind):
+    client, _service, _admin, audit = _client(monkeypatch, service=_ConflictingCatalogPolicy())
+
+    response = client.put(
+        f"/api/v1/catalog-policy/{resource_kind}",
+        json={"blocked": ["NewKey"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": {
+            "message": "Policy bundle revision conflict",
+            "expected_revision": 7,
+            "active_revision": 8,
+        }
+    }
     audit.assert_not_awaited()
 
 

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -275,6 +275,29 @@ def test_put_requires_explicit_whole_set_without_writing_or_auditing(monkeypatch
 
 
 @pytest.mark.parametrize("resource_kind", ["components", "templates"])
+@pytest.mark.parametrize(
+    "invalid_keys",
+    [
+        ["x" * 256],
+        [f"catalog-key-{index}" for index in range(1001)],
+    ],
+    ids=["key-too-long", "too-many-keys"],
+)
+def test_put_bounds_catalog_key_sets_without_writing_or_auditing(monkeypatch, resource_kind, invalid_keys):
+    client, service, _admin, audit = _client(monkeypatch)
+
+    response = client.put(
+        f"/api/v1/catalog-policy/{resource_kind}",
+        json={"blocked": invalid_keys},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert service.component_calls == []
+    assert service.template_calls == []
+    audit.assert_not_awaited()
+
+
+@pytest.mark.parametrize("resource_kind", ["components", "templates"])
 def test_concurrent_legacy_put_returns_bundle_revision_conflict(monkeypatch, resource_kind):
     client, _service, _admin, audit = _client(monkeypatch, service=_ConflictingCatalogPolicy())
 

--- a/src/backend/tests/unit/api/v1/test_model_provider_policy.py
+++ b/src/backend/tests/unit/api/v1/test_model_provider_policy.py
@@ -12,6 +12,7 @@ from langflow.api.v1 import model_provider_policy as policy_api
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
 from langflow.services.model_provider_policy import ModelProviderPolicyNotInitializedError
+from langflow.services.policy_bundle import PolicyBundleApplicationNotSupportedError
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly
 from lfx.services.model_provider_policy import BaseModelProviderPolicyService, ModelProviderPolicyService
 from pydantic import ValidationError
@@ -194,6 +195,33 @@ def test_external_policy_rejects_valid_writes_without_side_effects(monkeypatch, 
     audit.assert_not_awaited()
     apply.assert_not_called()
     invalidate.assert_not_called()
+
+
+def test_shared_write_rejects_legacy_catalog_plugin_without_side_effects(monkeypatch):
+    service = ModelProviderPolicyService()
+    replace_state = AsyncMock(
+        side_effect=PolicyBundleApplicationNotSupportedError(
+            "Configured catalog policy service does not support shared policy bundle updates"
+        )
+    )
+    audit = AsyncMock()
+    apply = Mock()
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_service", lambda: service, raising=False)
+    monkeypatch.setattr(policy_api, "replace_model_provider_policy_state", replace_state)
+    monkeypatch.setattr(policy_api, "audit_decision", audit)
+    monkeypatch.setattr(policy_api, "apply_model_provider_policy_state", apply)
+    client = _client_with_superuser(policy_api.router)
+
+    response = client.put(
+        "/model-provider-policy",
+        json={"approved_provider_ids": ["openai"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "does not support shared policy bundle updates" in response.json()["detail"]
+    replace_state.assert_awaited_once()
+    audit.assert_not_awaited()
+    apply.assert_not_called()
 
 
 async def test_replace_policy_commits_before_runtime_invalidation(monkeypatch):

--- a/src/backend/tests/unit/api/v1/test_model_provider_policy.py
+++ b/src/backend/tests/unit/api/v1/test_model_provider_policy.py
@@ -12,7 +12,10 @@ from langflow.api.v1 import model_provider_policy as policy_api
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
 from langflow.services.model_provider_policy import ModelProviderPolicyNotInitializedError
-from langflow.services.policy_bundle import PolicyBundleApplicationNotSupportedError
+from langflow.services.policy_bundle import (
+    PolicyBundleApplicationNotSupportedError,
+    PolicyBundleRevisionConflictError,
+)
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly
 from lfx.services.model_provider_policy import BaseModelProviderPolicyService, ModelProviderPolicyService
 from pydantic import ValidationError
@@ -219,6 +222,41 @@ def test_shared_write_rejects_legacy_catalog_plugin_without_side_effects(monkeyp
 
     assert response.status_code == status.HTTP_409_CONFLICT
     assert "does not support shared policy bundle updates" in response.json()["detail"]
+    replace_state.assert_awaited_once()
+    audit.assert_not_awaited()
+    apply.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["post", "put"])
+def test_shared_write_returns_structured_revision_conflict_without_side_effects(monkeypatch, method):
+    service = ModelProviderPolicyService()
+    replace_state = AsyncMock(
+        side_effect=PolicyBundleRevisionConflictError(
+            expected_revision=7,
+            active_revision=8,
+        )
+    )
+    audit = AsyncMock()
+    apply = Mock()
+    monkeypatch.setattr(policy_api, "get_model_provider_policy_service", lambda: service, raising=False)
+    monkeypatch.setattr(policy_api, "replace_model_provider_policy_state", replace_state)
+    monkeypatch.setattr(policy_api, "audit_decision", audit)
+    monkeypatch.setattr(policy_api, "apply_model_provider_policy_state", apply)
+    client = _client_with_superuser(policy_api.router)
+
+    response = getattr(client, method)(
+        "/model-provider-policy",
+        json={"approved_provider_ids": ["openai"]},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": {
+            "message": "Policy bundle revision conflict",
+            "expected_revision": 7,
+            "active_revision": 8,
+        }
+    }
     replace_state.assert_awaited_once()
     audit.assert_not_awaited()
     apply.assert_not_called()

--- a/src/backend/tests/unit/api/v1/test_policy_bundle.py
+++ b/src/backend/tests/unit/api/v1/test_policy_bundle.py
@@ -1,0 +1,323 @@
+"""Contract tests for superuser administration of the shared policy bundle."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from langflow.api.v1 import policy_bundle as policy_api
+from langflow.services.auth.utils import get_current_active_superuser
+from langflow.services.policy_bundle import (
+    PolicyBundleApplicationNotSupportedError,
+    PolicyBundleRevisionConflictError,
+)
+from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly
+from lfx.services.policy_bundle import PolicyBundleSnapshot
+
+
+async def _unused_session():
+    yield SimpleNamespace()
+
+
+def _client(monkeypatch, *, superuser: bool = True):
+    app = FastAPI()
+    app.include_router(policy_api.router, prefix="/api/v1")
+    admin = SimpleNamespace(id=uuid4(), is_superuser=True)
+
+    if superuser:
+        app.dependency_overrides[get_current_active_superuser] = lambda: admin
+    else:
+
+        def reject_non_superuser():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="The user doesn't have enough privileges",
+            )
+
+        app.dependency_overrides[get_current_active_superuser] = reject_non_superuser
+
+    app.dependency_overrides[injectable_session_scope] = _unused_session
+    app.dependency_overrides[injectable_session_scope_readonly] = _unused_session
+    read_state = AsyncMock()
+    replace_state = AsyncMock()
+    list_history = AsyncMock()
+    rollback_state = AsyncMock()
+    apply_state = Mock()
+    monkeypatch.setattr(policy_api, "get_policy_bundle_state", read_state)
+    monkeypatch.setattr(policy_api, "replace_policy_bundle_state", replace_state)
+    monkeypatch.setattr(policy_api, "list_policy_bundle_history", list_history)
+    monkeypatch.setattr(policy_api, "rollback_policy_bundle_state", rollback_state)
+    monkeypatch.setattr(policy_api, "apply_policy_bundle_state", apply_state)
+    monkeypatch.setattr(policy_api, "_managed_externally", lambda: False)
+    monkeypatch.setattr(policy_api, "ensure_policy_bundle_application_supported", lambda: None)
+    monkeypatch.setattr(policy_api, "audit_decision", AsyncMock())
+    return TestClient(app), admin, read_state, replace_state, list_history, rollback_state, apply_state
+
+
+def _snapshot(*, revision: int, actor_id=None, reason: str | None = None) -> PolicyBundleSnapshot:
+    return PolicyBundleSnapshot(
+        revision=revision,
+        initialized=True,
+        source="api",
+        approved_provider_ids={"openai", "anthropic"},
+        blocked_component_keys={"ZetaComponent", "AlphaComponent"},
+        blocked_template_keys={"template-z", "template-a"},
+        content_hash=f"{revision:064x}",
+        created_at=datetime(2026, 8, 5, 12, 30, tzinfo=timezone.utc),
+        created_by=actor_id,
+        reason=reason,
+        rollback_of_revision=None,
+    )
+
+
+def test_router_exposes_only_the_shared_bundle_administration_contract():
+    routes = [route for route in policy_api.router.routes if isinstance(route, APIRoute)]
+    schema_routes = [route for route in routes if route.include_in_schema]
+
+    assert {(route.path, frozenset(route.methods)) for route in schema_routes} == {
+        ("/policy-bundle", frozenset({"GET"})),
+        ("/policy-bundle", frozenset({"PUT"})),
+        ("/policy-bundle/history", frozenset({"GET"})),
+        ("/policy-bundle/rollback/{revision}", frozenset({"POST"})),
+    }
+    for route in routes:
+        dependency_calls = [dependency.call for dependency in route.dependant.dependencies]
+        assert get_current_active_superuser in dependency_calls
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/v1/policy-bundle"),
+        ("put", "/api/v1/policy-bundle"),
+        ("get", "/api/v1/policy-bundle/history"),
+        ("post", "/api/v1/policy-bundle/rollback/1"),
+    ],
+)
+def test_policy_bundle_routes_reject_non_superusers_without_database_access(monkeypatch, method, path):
+    client, _admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(
+        monkeypatch, superuser=False
+    )
+    payload = {
+        "expected_revision": 1,
+        "approved_provider_ids": [],
+        "blocked_component_keys": [],
+        "blocked_template_keys": [],
+    }
+
+    response = getattr(client, method)(path, **({"json": payload} if method in {"put", "post"} else {}))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    read_state.assert_not_awaited()
+    replace_state.assert_not_awaited()
+    list_history.assert_not_awaited()
+    rollback_state.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
+def test_get_returns_the_complete_active_bundle_with_stable_sorted_lists(monkeypatch):
+    client, admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(monkeypatch)
+    active = _snapshot(revision=4, actor_id=admin.id, reason="approved rollout")
+    read_state.return_value = active
+
+    response = client.get("/api/v1/policy-bundle")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "revision": 4,
+        "initialized": True,
+        "source": "api",
+        "approved_provider_ids": ["anthropic", "openai"],
+        "blocked_component_keys": ["AlphaComponent", "ZetaComponent"],
+        "blocked_template_keys": ["template-a", "template-z"],
+        "content_hash": f"{4:064x}",
+        "created_by": str(admin.id),
+        "created_at": "2026-08-05T12:30:00Z",
+        "reason": "approved rollout",
+        "rollback_of_revision": None,
+        "managed_externally": False,
+    }
+    read_state.assert_awaited_once_with(ANY)
+    replace_state.assert_not_awaited()
+    list_history.assert_not_awaited()
+    rollback_state.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
+def test_put_forwards_one_complete_cas_replacement_and_publishes_committed_snapshot(monkeypatch):
+    client, admin, read_state, replace_state, _list_history, _rollback_state, apply_state = _client(monkeypatch)
+    committed = _snapshot(revision=8, actor_id=admin.id, reason="quarterly policy refresh")
+    replace_state.return_value = committed
+    payload = {
+        "expected_revision": 7,
+        "approved_provider_ids": ["anthropic", "openai"],
+        "blocked_component_keys": ["AlphaComponent", "ZetaComponent"],
+        "blocked_template_keys": ["template-a", "template-z"],
+        "reason": "quarterly policy refresh",
+    }
+
+    response = client.put("/api/v1/policy-bundle", json=payload)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["revision"] == 8
+    assert response.json()["reason"] == "quarterly policy refresh"
+    replace_state.assert_awaited_once_with(
+        ANY,
+        expected_revision=7,
+        approved_provider_ids=["anthropic", "openai"],
+        blocked_component_keys=["AlphaComponent", "ZetaComponent"],
+        blocked_template_keys=["template-a", "template-z"],
+        actor_user_id=admin.id,
+        reason="quarterly policy refresh",
+    )
+    apply_state.assert_called_once_with(committed)
+    read_state.assert_not_awaited()
+
+
+def test_put_maps_stale_expected_revision_to_conflict_without_runtime_publication(monkeypatch):
+    client, _admin, _read_state, replace_state, _list_history, _rollback_state, apply_state = _client(monkeypatch)
+    replace_state.side_effect = PolicyBundleRevisionConflictError(
+        expected_revision=3,
+        active_revision=4,
+    )
+
+    response = client.put(
+        "/api/v1/policy-bundle",
+        json={
+            "expected_revision": 3,
+            "approved_provider_ids": ["openai"],
+            "blocked_component_keys": [],
+            "blocked_template_keys": [],
+        },
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == {
+        "message": "Policy bundle revision conflict",
+        "expected_revision": 3,
+        "active_revision": 4,
+    }
+    apply_state.assert_not_called()
+
+
+def test_put_rejects_legacy_catalog_plugin_before_database_write(monkeypatch):
+    client, _admin, _read_state, replace_state, _list_history, _rollback_state, apply_state = _client(monkeypatch)
+
+    def reject_legacy_plugin():
+        msg = "Configured catalog policy service does not support shared policy bundle updates"
+        raise PolicyBundleApplicationNotSupportedError(msg)
+
+    monkeypatch.setattr(policy_api, "ensure_policy_bundle_application_supported", reject_legacy_plugin)
+    response = client.put(
+        "/api/v1/policy-bundle",
+        json={
+            "expected_revision": 3,
+            "approved_provider_ids": ["openai"],
+            "blocked_component_keys": [],
+            "blocked_template_keys": [],
+        },
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "does not support shared policy bundle updates" in response.json()["detail"]
+    replace_state.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "expected_revision": 1,
+            "approved_provider_ids": [],
+            "blocked_component_keys": [],
+        },
+        {
+            "expected_revision": None,
+            "approved_provider_ids": [],
+            "blocked_component_keys": [],
+            "blocked_template_keys": [],
+        },
+        {
+            "expected_revision": 1,
+            "approved_provider_ids": "openai",
+            "blocked_component_keys": [],
+            "blocked_template_keys": [],
+        },
+        {
+            "expected_revision": 1,
+            "approved_provider_ids": [],
+            "blocked_component_keys": None,
+            "blocked_template_keys": [],
+        },
+    ],
+)
+def test_put_requires_expected_revision_and_all_three_lists(monkeypatch, payload):
+    client, _admin, _read_state, replace_state, _list_history, _rollback_state, apply_state = _client(monkeypatch)
+
+    response = client.put("/api/v1/policy-bundle", json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    replace_state.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
+def test_history_is_newest_first_and_forwards_pagination(monkeypatch):
+    client, admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(monkeypatch)
+    list_history.return_value = [
+        _snapshot(revision=4, actor_id=admin.id, reason="current"),
+        _snapshot(revision=3, actor_id=admin.id, reason="previous"),
+    ]
+
+    response = client.get("/api/v1/policy-bundle/history?limit=2&before_revision=5")
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert [item["revision"] for item in body["items"]] == [4, 3]
+    assert all(item["initialized"] is True for item in body["items"])
+    assert all(item["source"] == "api" for item in body["items"])
+    assert body["next_before_revision"] == 3
+    list_history.assert_awaited_once_with(ANY, limit=2, before_revision=5)
+    read_state.assert_not_awaited()
+    replace_state.assert_not_awaited()
+    rollback_state.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
+def test_rollback_endpoint_creates_and_publishes_a_new_revision(monkeypatch):
+    client, admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(monkeypatch)
+    rolled_back = replace(
+        _snapshot(revision=9, actor_id=admin.id, reason="incident rollback"),
+        source="rollback",
+        rollback_of_revision=3,
+    )
+    rollback_state.return_value = rolled_back
+
+    response = client.post(
+        "/api/v1/policy-bundle/rollback/3",
+        json={"expected_revision": 8, "reason": "incident rollback"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["revision"] == 9
+    assert response.json()["source"] == "rollback"
+    assert response.json()["rollback_of_revision"] == 3
+    rollback_state.assert_awaited_once_with(
+        ANY,
+        expected_revision=8,
+        target_revision=3,
+        actor_user_id=admin.id,
+        reason="incident rollback",
+    )
+    apply_state.assert_called_once_with(rolled_back)
+    read_state.assert_not_awaited()
+    replace_state.assert_not_awaited()
+    list_history.assert_not_awaited()

--- a/src/backend/tests/unit/api/v1/test_policy_bundle.py
+++ b/src/backend/tests/unit/api/v1/test_policy_bundle.py
@@ -270,6 +270,33 @@ def test_put_requires_expected_revision_and_all_three_lists(monkeypatch, payload
     apply_state.assert_not_called()
 
 
+@pytest.mark.parametrize("field_name", ["blocked_component_keys", "blocked_template_keys"])
+@pytest.mark.parametrize(
+    "invalid_keys",
+    [
+        ["x" * 256],
+        [f"catalog-key-{index}" for index in range(1001)],
+    ],
+    ids=["key-too-long", "too-many-keys"],
+)
+def test_put_bounds_each_catalog_key_set_without_writing(monkeypatch, field_name, invalid_keys):
+    client, _admin, _read_state, replace_state, _list_history, _rollback_state, apply_state = _client(monkeypatch)
+    payload = {
+        "expected_revision": 1,
+        "approved_provider_ids": [],
+        "blocked_component_keys": [],
+        "blocked_template_keys": [],
+    }
+    payload[field_name] = invalid_keys
+
+    response = client.put("/api/v1/policy-bundle", json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    replace_state.assert_not_awaited()
+    policy_api.audit_decision.assert_not_awaited()
+    apply_state.assert_not_called()
+
+
 def test_history_is_newest_first_and_forwards_pagination(monkeypatch):
     client, admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(monkeypatch)
     list_history.return_value = [
@@ -318,6 +345,34 @@ def test_rollback_endpoint_creates_and_publishes_a_new_revision(monkeypatch):
         reason="incident rollback",
     )
     apply_state.assert_called_once_with(rolled_back)
+    read_state.assert_not_awaited()
+    replace_state.assert_not_awaited()
+    list_history.assert_not_awaited()
+
+
+def test_rollback_maps_stale_revision_to_conflict_without_audit_or_publication(monkeypatch):
+    client, _admin, read_state, replace_state, list_history, rollback_state, apply_state = _client(monkeypatch)
+    rollback_state.side_effect = PolicyBundleRevisionConflictError(
+        expected_revision=8,
+        active_revision=9,
+    )
+
+    response = client.post(
+        "/api/v1/policy-bundle/rollback/3",
+        json={"expected_revision": 8, "reason": "incident rollback"},
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": {
+            "message": "Policy bundle revision conflict",
+            "expected_revision": 8,
+            "active_revision": 9,
+        }
+    }
+    rollback_state.assert_awaited_once()
+    policy_api.audit_decision.assert_not_awaited()
+    apply_state.assert_not_called()
     read_state.assert_not_awaited()
     replace_state.assert_not_awaited()
     list_history.assert_not_awaited()

--- a/src/backend/tests/unit/services/catalog_policy/test_service.py
+++ b/src/backend/tests/unit/services/catalog_policy/test_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -18,6 +18,7 @@ from langflow.services.database.models.catalog_policy import (
 )
 from langflow.services.schema import ServiceType
 from lfx.services.catalog_policy import BaseCatalogPolicyService
+from lfx.services.policy_bundle import PolicyBundleService, PolicyBundleSnapshot
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -145,6 +146,157 @@ async def test_replace_rejects_empty_keys_before_opening_a_transaction(catalog_d
 
     assert service.snapshot.blocked_template_keys == frozenset()
     assert service.hydrated is False
+
+
+def test_snapshot_projection_is_reused_until_bundle_identity_changes():
+    bundle_service = PolicyBundleService()
+    service = LangflowCatalogPolicyService(None, bundle_service)
+    first_bundle = PolicyBundleSnapshot(
+        revision=1,
+        initialized=True,
+        blocked_component_keys={"PythonREPL"},
+    )
+    bundle_service.publish(first_bundle)
+
+    first_projection = service.snapshot
+
+    assert service.snapshot is first_projection
+    replacement_bundle = PolicyBundleSnapshot(
+        revision=1,
+        initialized=True,
+        blocked_component_keys={"PythonREPL"},
+    )
+    bundle_service.publish(replacement_bundle)
+    replacement_projection = service.snapshot
+    assert replacement_projection is service.snapshot
+    assert replacement_projection is not first_projection
+    assert replacement_projection == first_projection
+
+
+@pytest.mark.asyncio
+async def test_component_replace_retries_conflicts_with_each_newest_complete_bundle(monkeypatch):
+    bundle_service = PolicyBundleService()
+    service = LangflowCatalogPolicyService(None, bundle_service)
+    current_bundles = [
+        PolicyBundleSnapshot(
+            revision=revision,
+            initialized=True,
+            approved_provider_ids={provider},
+            blocked_component_keys={f"old-component-{revision}"},
+            blocked_template_keys={template},
+        )
+        for revision, provider, template in (
+            (1, "openai", "template-one"),
+            (2, "anthropic", "template-two"),
+            (3, "google_generative_ai", "template-three"),
+        )
+    ]
+    committed = PolicyBundleSnapshot(
+        revision=4,
+        initialized=True,
+        approved_provider_ids=current_bundles[-1].approved_provider_ids,
+        blocked_component_keys={"PythonREPL"},
+        blocked_template_keys=current_bundles[-1].blocked_template_keys,
+    )
+
+    @asynccontextmanager
+    async def session_scope():
+        yield object()
+
+    read_bundle = AsyncMock(side_effect=current_bundles)
+    replace_bundle = AsyncMock(
+        side_effect=[
+            catalog_policy_service_module.PolicyBundleRevisionConflictError(
+                expected_revision=1,
+                active_revision=2,
+            ),
+            catalog_policy_service_module.PolicyBundleRevisionConflictError(
+                expected_revision=2,
+                active_revision=3,
+            ),
+            committed,
+        ]
+    )
+    publish_bundle = Mock(side_effect=bundle_service.publish)
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope", session_scope)
+    monkeypatch.setattr(catalog_policy_service_module, "get_policy_bundle_state", read_bundle)
+    monkeypatch.setattr(catalog_policy_service_module, "replace_policy_bundle_state", replace_bundle)
+    monkeypatch.setattr(catalog_policy_service_module, "apply_policy_bundle_state", publish_bundle)
+
+    update = await service.replace_blocked_component_keys(["PythonREPL"], actor_user_id=None)
+
+    assert read_bundle.await_count == 3
+    assert replace_bundle.await_count == 3
+    for replace_call, current in zip(replace_bundle.await_args_list, current_bundles, strict=True):
+        assert replace_call.kwargs["expected_revision"] == current.revision
+        assert replace_call.kwargs["approved_provider_ids"] == current.approved_provider_ids
+        assert replace_call.kwargs["blocked_component_keys"] == frozenset({"PythonREPL"})
+        assert replace_call.kwargs["blocked_template_keys"] == current.blocked_template_keys
+    publish_bundle.assert_called_once_with(committed)
+    assert update.added == frozenset({"PythonREPL"})
+    assert update.removed == current_bundles[-1].blocked_component_keys
+    assert service.snapshot.blocked_component_keys == frozenset({"PythonREPL"})
+
+
+@pytest.mark.asyncio
+async def test_template_replace_propagates_third_conflict_without_publishing(monkeypatch):
+    bundle_service = PolicyBundleService()
+    published = PolicyBundleSnapshot(
+        revision=3,
+        initialized=True,
+        approved_provider_ids={"openai"},
+        blocked_component_keys={"PythonREPL"},
+        blocked_template_keys={"published-template"},
+    )
+    bundle_service.publish(published)
+    service = LangflowCatalogPolicyService(None, bundle_service)
+    current_bundles = [
+        PolicyBundleSnapshot(
+            revision=revision,
+            initialized=True,
+            approved_provider_ids={provider},
+            blocked_component_keys={component},
+            blocked_template_keys={f"old-template-{revision}"},
+        )
+        for revision, provider, component in (
+            (4, "openai", "component-four"),
+            (5, "anthropic", "component-five"),
+            (6, "google_generative_ai", "component-six"),
+        )
+    ]
+
+    @asynccontextmanager
+    async def session_scope():
+        yield object()
+
+    read_bundle = AsyncMock(side_effect=current_bundles)
+    conflicts = [
+        catalog_policy_service_module.PolicyBundleRevisionConflictError(
+            expected_revision=current.revision,
+            active_revision=current.revision + 1,
+        )
+        for current in current_bundles
+    ]
+    replace_bundle = AsyncMock(side_effect=conflicts)
+    publish_bundle = Mock()
+    monkeypatch.setattr(catalog_policy_service_module, "session_scope", session_scope)
+    monkeypatch.setattr(catalog_policy_service_module, "get_policy_bundle_state", read_bundle)
+    monkeypatch.setattr(catalog_policy_service_module, "replace_policy_bundle_state", replace_bundle)
+    monkeypatch.setattr(catalog_policy_service_module, "apply_policy_bundle_state", publish_bundle)
+
+    with pytest.raises(catalog_policy_service_module.PolicyBundleRevisionConflictError) as exc_info:
+        await service.replace_blocked_template_keys(["new-template"], actor_user_id=None)
+
+    assert exc_info.value is conflicts[-1]
+    assert read_bundle.await_count == 3
+    assert replace_bundle.await_count == 3
+    for replace_call, current in zip(replace_bundle.await_args_list, current_bundles, strict=True):
+        assert replace_call.kwargs["expected_revision"] == current.revision
+        assert replace_call.kwargs["approved_provider_ids"] == current.approved_provider_ids
+        assert replace_call.kwargs["blocked_component_keys"] == current.blocked_component_keys
+        assert replace_call.kwargs["blocked_template_keys"] == frozenset({"new-template"})
+    publish_bundle.assert_not_called()
+    assert bundle_service.snapshot is published
 
 
 class _Result:

--- a/src/backend/tests/unit/services/database/test_migration_downgrade.py
+++ b/src/backend/tests/unit/services/database/test_migration_downgrade.py
@@ -10,7 +10,7 @@ from langflow.services.database import service as database_service_module
 from langflow.services.database.service import DatabaseService
 
 CURRENT_REVISION = "f7a9c2d4e6b8"  # pragma: allowlist secret
-TARGET_REVISION = "d4a7c9e1b2f6"  # pragma: allowlist secret
+TARGET_REVISION = "8d9e0f1a2b3c"  # pragma: allowlist secret
 
 
 def _service(monkeypatch, *, current_revisions: set[str]) -> DatabaseService:

--- a/src/backend/tests/unit/services/database/test_migration_downgrade.py
+++ b/src/backend/tests/unit/services/database/test_migration_downgrade.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import re
 from contextlib import nullcontext
 from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+import sqlalchemy as sa
 from langflow.services.database import service as database_service_module
 from langflow.services.database.service import DatabaseService
 
@@ -15,7 +17,7 @@ TARGET_REVISION = "8d9e0f1a2b3c"  # pragma: allowlist secret
 
 def _service(monkeypatch, *, current_revisions: set[str]) -> DatabaseService:
     service = object.__new__(DatabaseService)
-    service.database_url = "sqlite:////configured/production.db"
+    service.database_url = "sqlite+aiosqlite:////configured/production.db"
     service.script_location = Path("/installed/langflow/alembic")
     service._open_alembic_log_buffer = lambda: nullcontext(StringIO())
     monkeypatch.setattr(service, "_current_alembic_revisions", lambda: current_revisions)
@@ -35,15 +37,49 @@ def test_explicit_downgrade_uses_configured_database_and_script_location(monkeyp
     alembic_cfg, target = downgrade.call_args.args
     assert target == TARGET_REVISION
     assert alembic_cfg.get_main_option("script_location") == "/installed/langflow/alembic"
-    assert alembic_cfg.get_main_option("sqlalchemy.url") == "sqlite:////configured/production.db"
+    assert alembic_cfg.get_main_option("sqlalchemy.url") == "sqlite+aiosqlite:////configured/production.db"
 
 
-def test_explicit_downgrade_refuses_an_unexpected_database_revision(monkeypatch):
-    service = _service(monkeypatch, current_revisions={"later_revision"})
+def test_current_alembic_revisions_reads_a_sanitized_file_backed_sqlite_database(tmp_path):
+    database_path = tmp_path / "revisions.db"
+    sync_url = f"sqlite:///{database_path}"
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+            connection.execute(
+                sa.text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+                {"revision": CURRENT_REVISION},
+            )
+    finally:
+        engine.dispose()
+
+    service = object.__new__(DatabaseService)
+    service.database_url = f"sqlite+aiosqlite:///{database_path}"
+
+    assert service._current_alembic_revisions() == {CURRENT_REVISION}
+
+
+@pytest.mark.parametrize(
+    ("current_revisions", "expected_found"),
+    [
+        ({"later_revision"}, "later_revision"),
+        ({CURRENT_REVISION, "other_head"}, f"{CURRENT_REVISION}, other_head"),
+        (set(), "none"),
+    ],
+    ids=["later-revision", "multiple-heads", "no-revision"],
+)
+def test_explicit_downgrade_refuses_an_unexpected_database_revision(
+    monkeypatch,
+    current_revisions,
+    expected_found,
+):
+    service = _service(monkeypatch, current_revisions=current_revisions)
     downgrade = Mock()
     monkeypatch.setattr(database_service_module.command, "downgrade", downgrade)
 
-    with pytest.raises(RuntimeError, match=rf"expected current revision {CURRENT_REVISION}, found later_revision"):
+    expected_message = rf"expected current revision {CURRENT_REVISION}, found {re.escape(expected_found)}"
+    with pytest.raises(RuntimeError, match=expected_message):
         service._run_migration_downgrade(
             expected_current_revision=CURRENT_REVISION,
             target_revision=TARGET_REVISION,

--- a/src/backend/tests/unit/services/database/test_migration_downgrade.py
+++ b/src/backend/tests/unit/services/database/test_migration_downgrade.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from io import StringIO
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from langflow.services.database import service as database_service_module
+from langflow.services.database.service import DatabaseService
+
+CURRENT_REVISION = "f7a9c2d4e6b8"  # pragma: allowlist secret
+TARGET_REVISION = "d4a7c9e1b2f6"  # pragma: allowlist secret
+
+
+def _service(monkeypatch, *, current_revisions: set[str]) -> DatabaseService:
+    service = object.__new__(DatabaseService)
+    service.database_url = "sqlite:////configured/production.db"
+    service.script_location = Path("/installed/langflow/alembic")
+    service._open_alembic_log_buffer = lambda: nullcontext(StringIO())
+    monkeypatch.setattr(service, "_current_alembic_revisions", lambda: current_revisions)
+    return service
+
+
+def test_explicit_downgrade_uses_configured_database_and_script_location(monkeypatch):
+    service = _service(monkeypatch, current_revisions={CURRENT_REVISION})
+    downgrade = Mock()
+    monkeypatch.setattr(database_service_module.command, "downgrade", downgrade)
+
+    service._run_migration_downgrade(
+        expected_current_revision=CURRENT_REVISION,
+        target_revision=TARGET_REVISION,
+    )
+
+    alembic_cfg, target = downgrade.call_args.args
+    assert target == TARGET_REVISION
+    assert alembic_cfg.get_main_option("script_location") == "/installed/langflow/alembic"
+    assert alembic_cfg.get_main_option("sqlalchemy.url") == "sqlite:////configured/production.db"
+
+
+def test_explicit_downgrade_refuses_an_unexpected_database_revision(monkeypatch):
+    service = _service(monkeypatch, current_revisions={"later_revision"})
+    downgrade = Mock()
+    monkeypatch.setattr(database_service_module.command, "downgrade", downgrade)
+
+    with pytest.raises(RuntimeError, match=rf"expected current revision {CURRENT_REVISION}, found later_revision"):
+        service._run_migration_downgrade(
+            expected_current_revision=CURRENT_REVISION,
+            target_revision=TARGET_REVISION,
+        )
+
+    downgrade.assert_not_called()

--- a/src/backend/tests/unit/services/test_model_provider_policy_refresh.py
+++ b/src/backend/tests/unit/services/test_model_provider_policy_refresh.py
@@ -6,7 +6,33 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 from langflow.services.task import model_provider_policy_refresh as refresh_module
-from lfx.services.model_provider_policy import ModelProviderPolicyService
+from lfx.services.model_provider_policy import (
+    BaseModelProviderPolicyService,
+    ModelProviderPolicyContext,
+    ModelProviderPolicyPurpose,
+    ModelProviderPolicyService,
+)
+from lfx.services.policy_bundle import PolicyBundleService, PolicyBundleSnapshot
+
+
+class _DatabaseOwnedPluginPolicyService(BaseModelProviderPolicyService):
+    def __init__(self, policy_bundle_service: PolicyBundleService) -> None:
+        super().__init__()
+        self.policy_bundle_service = policy_bundle_service
+        self.set_ready()
+
+    def get_allowed_provider_ids(
+        self,
+        *,
+        context: ModelProviderPolicyContext,
+        candidate_provider_ids: frozenset[str],
+        purpose: ModelProviderPolicyPurpose,
+    ) -> frozenset[str]:
+        _ = context, purpose
+        if not self.policy_bundle_service.source_available:
+            return frozenset()
+        ceiling = self.policy_bundle_service.snapshot.approved_provider_ids
+        return candidate_provider_ids if not ceiling else candidate_provider_ids & ceiling
 
 
 class _ExternalBuiltinPolicyService(ModelProviderPolicyService):
@@ -165,17 +191,103 @@ async def test_start_uses_configured_interval_and_stop_clears_task(monkeypatch):
     assert worker._task is None
 
 
+async def test_start_refreshes_a_database_owned_provider_plugin(monkeypatch):
+    service = _DatabaseOwnedPluginPolicyService(PolicyBundleService())
+    worker = refresh_module.ModelProviderPolicyRefreshWorker(interval=5)
+    run_started = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def run():
+        run_started.set()
+        await keep_running.wait()
+
+    monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(worker, "_run", run)
+
+    await worker.start()
+    await run_started.wait()
+
+    assert worker._task is not None
+
+    await worker.stop()
+
+
+async def test_refresh_failure_marks_a_restrictive_database_owned_plugin_unavailable(monkeypatch):
+    bundle_service = PolicyBundleService()
+    bundle_service.publish(
+        PolicyBundleSnapshot(
+            revision=3,
+            initialized=True,
+            source="api",
+            approved_provider_ids=frozenset({"openai"}),
+        )
+    )
+    service = _DatabaseOwnedPluginPolicyService(bundle_service)
+    error_message = "policy store unavailable"
+
+    @asynccontextmanager
+    async def failing_session_scope():
+        raise ConnectionError(error_message)
+        yield
+
+    invalidate = Mock(wraps=service.invalidate)
+    monkeypatch.setattr(service, "invalidate", invalidate)
+    monkeypatch.setattr(refresh_module, "session_scope", failing_session_scope)
+    monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(refresh_module, "get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr(refresh_module.logger, "aerror", AsyncMock())
+
+    changed = await refresh_module.ModelProviderPolicyRefreshWorker()._run_once()
+
+    assert changed is True
+    assert bundle_service.source_available is False
+    invalidate.assert_called_once_with()
+
+
 async def test_start_skips_explicitly_external_builtin_subclass(monkeypatch):
     service = _ExternalBuiltinPolicyService()
     worker = refresh_module.ModelProviderPolicyRefreshWorker()
     debug = AsyncMock()
     monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(
+        refresh_module,
+        "get_catalog_policy_service",
+        lambda: SimpleNamespace(external_policy_snapshot=object()),
+    )
     monkeypatch.setattr(refresh_module.logger, "adebug", debug)
 
     await worker.start()
 
     assert worker._task is None
-    debug.assert_awaited_once_with("Model-provider policy refresh worker not started: external policy service active")
+    debug.assert_awaited_once_with(
+        "Policy-bundle refresh worker not started: provider and catalog policies are externally managed"
+    )
+
+
+async def test_start_refreshes_database_catalog_when_provider_policy_is_external(monkeypatch):
+    service = _ExternalBuiltinPolicyService()
+    worker = refresh_module.ModelProviderPolicyRefreshWorker(interval=5)
+    run_started = asyncio.Event()
+    keep_running = asyncio.Event()
+
+    async def run():
+        run_started.set()
+        await keep_running.wait()
+
+    monkeypatch.setattr(refresh_module, "get_model_provider_policy_service", lambda: service)
+    monkeypatch.setattr(
+        refresh_module,
+        "get_catalog_policy_service",
+        lambda: SimpleNamespace(external_policy_snapshot=None),
+    )
+    monkeypatch.setattr(worker, "_run", run)
+
+    await worker.start()
+    await run_started.wait()
+
+    assert worker._task is not None
+
+    await worker.stop()
 
 
 async def test_refresh_failure_does_not_fail_close_explicitly_external_builtin_subclass(monkeypatch):

--- a/src/backend/tests/unit/services/test_model_provider_policy_store.py
+++ b/src/backend/tests/unit/services/test_model_provider_policy_store.py
@@ -9,7 +9,9 @@ import pytest
 from langflow.services import model_provider_policy as policy_store
 from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
 from langflow.services.task import model_provider_policy_refresh as refresh_module
+from lfx.services.catalog_policy import CatalogPolicyService
 from lfx.services.model_provider_policy import BaseModelProviderPolicyService, ModelProviderPolicyService
+from lfx.services.policy_bundle import PolicyBundleService, PolicyBundleSnapshot
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -121,6 +123,39 @@ def test_explicitly_external_builtin_subclass_does_not_receive_database_state(mo
     assert policy_store.apply_model_provider_policy_state(state) is False
     assert service.approved_provider_ids == frozenset({"openai"})
     assert service.policy_version == 2
+
+
+def test_external_provider_does_not_block_database_owned_catalog_bundle_refresh(monkeypatch):
+    class ExternalBuiltinPolicyService(ModelProviderPolicyService):
+        @property
+        def external_approved_provider_ids(self) -> frozenset[str]:
+            return frozenset({"openai"})
+
+    provider_service = ExternalBuiltinPolicyService()
+    provider_service.set_approved_provider_ids({"openai"}, version=2)
+    bundle_service = PolicyBundleService()
+    catalog_service = CatalogPolicyService(bundle_service)
+    snapshot = PolicyBundleSnapshot(
+        revision=3,
+        initialized=True,
+        source="api",
+        approved_provider_ids=frozenset({"anthropic"}),
+        blocked_component_keys=frozenset({"PythonREPL"}),
+    )
+    state = policy_store.PersistedModelProviderPolicy(
+        approved_provider_ids=snapshot.approved_provider_ids,
+        version=snapshot.revision,
+        bundle_snapshot=snapshot,
+    )
+
+    monkeypatch.setattr(policy_store, "get_model_provider_policy_service", lambda: provider_service)
+    monkeypatch.setattr("lfx.services.deps.get_model_provider_policy_service", lambda: provider_service)
+    monkeypatch.setattr("lfx.services.deps.get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr("lfx.services.deps.get_catalog_policy_service", lambda: catalog_service)
+
+    assert policy_store.apply_model_provider_policy_state(state) is True
+    assert bundle_service.snapshot is snapshot
+    assert provider_service.approved_provider_ids == frozenset({"openai"})
 
 
 def test_replacement_is_one_atomic_versioned_update():

--- a/src/backend/tests/unit/services/test_model_provider_policy_store.py
+++ b/src/backend/tests/unit/services/test_model_provider_policy_store.py
@@ -155,6 +155,7 @@ def test_external_provider_does_not_block_database_owned_catalog_bundle_refresh(
 
     assert policy_store.apply_model_provider_policy_state(state) is True
     assert bundle_service.snapshot is snapshot
+    assert catalog_service.is_component_blocked("PythonREPL") is True
     assert provider_service.approved_provider_ids == frozenset({"openai"})
 
 

--- a/src/backend/tests/unit/services/test_policy_bundle_store.py
+++ b/src/backend/tests/unit/services/test_policy_bundle_store.py
@@ -1,0 +1,513 @@
+"""Atomic store and cross-worker runtime tests for shared policy bundles."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+from langflow.services import deps as langflow_service_deps
+from langflow.services import policy_bundle as policy_store
+from langflow.services.database.models.catalog_policy import CatalogPolicyRule, CatalogResourceKind
+from langflow.services.database.models.model_provider_policy import ModelProviderPolicy
+from langflow.services.database.models.policy_bundle import PolicyBundleActive, PolicyBundleRevision
+from langflow.services.database.models.user.model import User
+from langflow.services.task import model_provider_policy_refresh as refresh_module
+from lfx.services import deps as lfx_service_deps
+from lfx.services.catalog_policy import CatalogPolicyService
+from lfx.services.catalog_policy.base import BaseCatalogPolicyService, CatalogPolicySnapshot
+from lfx.services.model_provider_policy import ModelProviderPolicyService
+from lfx.services.policy_bundle import PolicyBundleService, PolicyBundleSnapshot
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+_INITIAL_PROVIDERS = frozenset({"openai"})
+_INITIAL_COMPONENTS = frozenset({"OldComponent"})
+_INITIAL_TEMPLATES = frozenset({"old-template"})
+
+
+def test_policy_bundle_revision_resolves_created_by_for_validation_and_schema():
+    actor_id = uuid4()
+    revision = PolicyBundleRevision.model_validate(
+        {
+            "revision": 1,
+            "initialized": True,
+            "approved_provider_ids": [],
+            "blocked_component_keys": [],
+            "blocked_template_keys": [],
+            "content_hash": "0" * 64,
+            "created_by": str(actor_id),
+        }
+    )
+
+    assert revision.created_by == actor_id
+    assert "created_by" in PolicyBundleRevision.model_json_schema()["properties"]
+    assert all(foreign_key.parent.name != "created_by" for foreign_key in PolicyBundleRevision.__table__.foreign_keys)
+
+
+@pytest.fixture
+async def bundle_session_maker(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'policy-bundle.db'}",
+        connect_args={"timeout": 30},
+    )
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: SQLModel.metadata.create_all(
+                sync_connection,
+                tables=[
+                    User.__table__,
+                    ModelProviderPolicy.__table__,
+                    CatalogPolicyRule.__table__,
+                    PolicyBundleRevision.__table__,
+                    PolicyBundleActive.__table__,
+                ],
+            )
+        )
+
+    initial_hash = policy_store.policy_bundle_content_hash(
+        approved_provider_ids=_INITIAL_PROVIDERS,
+        blocked_component_keys=_INITIAL_COMPONENTS,
+        blocked_template_keys=_INITIAL_TEMPLATES,
+    )
+    async with session_maker() as session:
+        session.add_all(
+            [
+                PolicyBundleRevision(
+                    revision=1,
+                    initialized=True,
+                    approved_provider_ids=sorted(_INITIAL_PROVIDERS),
+                    blocked_component_keys=sorted(_INITIAL_COMPONENTS),
+                    blocked_template_keys=sorted(_INITIAL_TEMPLATES),
+                    content_hash=initial_hash,
+                    source="migration",
+                    reason="initial",
+                ),
+                PolicyBundleActive(revision=1, initialized=True),
+                ModelProviderPolicy(
+                    approved_provider_ids=sorted(_INITIAL_PROVIDERS),
+                    version=1,
+                ),
+                CatalogPolicyRule(
+                    resource_kind=CatalogResourceKind.COMPONENT.value,
+                    resource_key="OldComponent",
+                ),
+                CatalogPolicyRule(
+                    resource_kind=CatalogResourceKind.TEMPLATE.value,
+                    resource_key="old-template",
+                ),
+            ]
+        )
+        await session.commit()
+
+    yield session_maker
+    await engine.dispose()
+
+
+async def _read_active(session_maker) -> PolicyBundleSnapshot:
+    async with session_maker() as session:
+        return await policy_store.get_policy_bundle_state(session)
+
+
+def _bundle_value(snapshot: PolicyBundleSnapshot) -> tuple:
+    """Compare persisted semantics without depending on SQLite timezone reflection."""
+    timestamp = snapshot.created_at.replace(tzinfo=None) if snapshot.created_at is not None else None
+    return (
+        snapshot.revision,
+        snapshot.approved_provider_ids,
+        snapshot.blocked_component_keys,
+        snapshot.blocked_template_keys,
+        snapshot.content_hash,
+        snapshot.created_by,
+        timestamp,
+        snapshot.reason,
+        snapshot.rollback_of_revision,
+    )
+
+
+async def test_concurrent_cas_replacements_commit_one_complete_bundle_without_mixing_facets(
+    bundle_session_maker,
+):
+    actor_id = uuid4()
+    proposals = [
+        {
+            "approved_provider_ids": {"anthropic"},
+            "blocked_component_keys": {"AnthropicModel"},
+            "blocked_template_keys": {"anthropic-template"},
+            "reason": "anthropic policy",
+        },
+        {
+            "approved_provider_ids": {"google.generativeai"},
+            "blocked_component_keys": {"GoogleModel"},
+            "blocked_template_keys": {"google-template"},
+            "reason": "google policy",
+        },
+    ]
+
+    async def replace(proposal):
+        async with bundle_session_maker() as session:
+            return await policy_store.replace_policy_bundle_state(
+                session,
+                expected_revision=1,
+                actor_user_id=actor_id,
+                **proposal,
+            )
+
+    results = await asyncio.gather(*(replace(proposal) for proposal in proposals), return_exceptions=True)
+    committed = [result for result in results if isinstance(result, PolicyBundleSnapshot)]
+    conflicts = [result for result in results if isinstance(result, policy_store.PolicyBundleRevisionConflictError)]
+
+    assert len(committed) == 1
+    assert len(conflicts) == 1
+    assert conflicts[0].expected_revision == 1
+    assert conflicts[0].active_revision == 2
+
+    persisted = await _read_active(bundle_session_maker)
+    complete_states = {
+        (
+            frozenset(proposal["approved_provider_ids"]),
+            frozenset(proposal["blocked_component_keys"]),
+            frozenset(proposal["blocked_template_keys"]),
+        )
+        for proposal in proposals
+    }
+    assert persisted.revision == 2
+    assert persisted.initialized is True
+    assert persisted.source == "api"
+    assert (
+        persisted.approved_provider_ids,
+        persisted.blocked_component_keys,
+        persisted.blocked_template_keys,
+    ) in complete_states
+    assert _bundle_value(persisted) == _bundle_value(committed[0])
+
+    async with bundle_session_maker() as session:
+        history = await policy_store.list_policy_bundle_history(session)
+        legacy_provider = await session.get(ModelProviderPolicy, 1)
+        legacy_rules = list((await session.exec(select(CatalogPolicyRule))).all())
+
+    assert [snapshot.revision for snapshot in history] == [2, 1]
+    assert legacy_provider is not None
+    assert legacy_provider.version == persisted.revision
+    assert frozenset(legacy_provider.approved_provider_ids) == persisted.approved_provider_ids
+    assert {
+        row.resource_key for row in legacy_rules if row.resource_kind == CatalogResourceKind.COMPONENT.value
+    } == persisted.blocked_component_keys
+    assert {
+        row.resource_key for row in legacy_rules if row.resource_kind == CatalogResourceKind.TEMPLATE.value
+    } == persisted.blocked_template_keys
+
+
+async def test_rollback_copies_old_content_into_a_new_immutable_revision(bundle_session_maker):
+    first_actor = uuid4()
+    rollback_actor = uuid4()
+    async with bundle_session_maker() as session:
+        revision_two = await policy_store.replace_policy_bundle_state(
+            session,
+            expected_revision=1,
+            approved_provider_ids={"anthropic"},
+            blocked_component_keys={"SecondComponent"},
+            blocked_template_keys={"second-template"},
+            actor_user_id=first_actor,
+            reason="second",
+        )
+    async with bundle_session_maker() as session:
+        revision_three = await policy_store.replace_policy_bundle_state(
+            session,
+            expected_revision=revision_two.revision,
+            approved_provider_ids={"google.generativeai"},
+            blocked_component_keys={"ThirdComponent"},
+            blocked_template_keys={"third-template"},
+            actor_user_id=first_actor,
+            reason="third",
+        )
+    async with bundle_session_maker() as session:
+        rolled_back = await policy_store.rollback_policy_bundle_state(
+            session,
+            expected_revision=revision_three.revision,
+            target_revision=1,
+            actor_user_id=rollback_actor,
+            reason="incident rollback",
+        )
+
+    assert rolled_back.revision == 4
+    assert rolled_back.initialized is True
+    assert rolled_back.source == "rollback"
+    assert rolled_back.approved_provider_ids == _INITIAL_PROVIDERS
+    assert rolled_back.blocked_component_keys == _INITIAL_COMPONENTS
+    assert rolled_back.blocked_template_keys == _INITIAL_TEMPLATES
+    assert rolled_back.rollback_of_revision == 1
+    assert rolled_back.created_by == rollback_actor
+    assert rolled_back.reason == "incident rollback"
+
+    async with bundle_session_maker() as session:
+        history = await policy_store.list_policy_bundle_history(session)
+
+    assert [snapshot.revision for snapshot in history] == [4, 3, 2, 1]
+    by_revision = {snapshot.revision: snapshot for snapshot in history}
+    assert by_revision[1].reason == "initial"
+    assert _bundle_value(by_revision[2]) == _bundle_value(revision_two)
+    assert _bundle_value(by_revision[3]) == _bundle_value(revision_three)
+    assert by_revision[1].content_hash == rolled_back.content_hash
+    assert by_revision[2].rollback_of_revision is None
+    assert by_revision[3].rollback_of_revision is None
+
+
+async def test_stale_expected_revision_leaves_active_state_and_history_unchanged(bundle_session_maker):
+    async with bundle_session_maker() as session:
+        current = await policy_store.replace_policy_bundle_state(
+            session,
+            expected_revision=1,
+            approved_provider_ids={"anthropic"},
+            blocked_component_keys={"CurrentComponent"},
+            blocked_template_keys={"current-template"},
+            actor_user_id=uuid4(),
+        )
+
+    async with bundle_session_maker() as session:
+        with pytest.raises(policy_store.PolicyBundleRevisionConflictError) as exc_info:
+            await policy_store.replace_policy_bundle_state(
+                session,
+                expected_revision=1,
+                approved_provider_ids={"openai"},
+                blocked_component_keys={"StaleComponent"},
+                blocked_template_keys={"stale-template"},
+                actor_user_id=uuid4(),
+            )
+
+    assert exc_info.value.expected_revision == 1
+    assert exc_info.value.active_revision == 2
+    assert _bundle_value(await _read_active(bundle_session_maker)) == _bundle_value(current)
+    async with bundle_session_maker() as session:
+        assert [item.revision for item in await policy_store.list_policy_bundle_history(session)] == [2, 1]
+
+
+async def test_environment_bootstrap_initializes_a_pristine_bundle_exactly_once(bundle_session_maker):
+    empty_hash = policy_store.policy_bundle_content_hash(
+        approved_provider_ids=[],
+        blocked_component_keys=[],
+        blocked_template_keys=[],
+    )
+    async with bundle_session_maker() as session:
+        active = await session.get(PolicyBundleActive, 1)
+        initial = await session.get(PolicyBundleRevision, 1)
+        legacy_provider = await session.get(ModelProviderPolicy, 1)
+        assert active is not None
+        assert initial is not None
+        assert legacy_provider is not None
+        active.initialized = False
+        initial.initialized = False
+        initial.approved_provider_ids = []
+        initial.blocked_component_keys = []
+        initial.blocked_template_keys = []
+        initial.content_hash = empty_hash
+        legacy_provider.approved_provider_ids = []
+        legacy_provider.version = 0
+        for rule in list((await session.exec(select(CatalogPolicyRule))).all()):
+            await session.delete(rule)
+        await session.commit()
+
+    async with bundle_session_maker() as session:
+        bootstrapped, created = await policy_store.bootstrap_policy_bundle_if_pristine(
+            session,
+            approved_provider_ids={"anthropic"},
+            blocked_component_keys={"EnvironmentComponent"},
+            blocked_template_keys={"environment-template"},
+            reason="deployment bootstrap",
+        )
+    async with bundle_session_maker() as session:
+        repeated, repeated_created = await policy_store.bootstrap_policy_bundle_if_pristine(
+            session,
+            approved_provider_ids={"openai"},
+            blocked_component_keys={"MustNotReplace"},
+            blocked_template_keys={"must-not-replace"},
+        )
+
+    assert created is True
+    assert bootstrapped.revision == 2
+    assert bootstrapped.initialized is True
+    assert bootstrapped.source == "environment"
+    assert bootstrapped.approved_provider_ids == frozenset({"anthropic"})
+    assert repeated_created is False
+    assert _bundle_value(repeated) == _bundle_value(bootstrapped)
+    async with bundle_session_maker() as session:
+        history = await policy_store.list_policy_bundle_history(session)
+        pristine = await policy_store.get_policy_bundle_state(session, revision=1)
+    assert [(item.revision, item.initialized) for item in history] == [(2, True), (1, False)]
+    assert pristine.initialized is False
+
+
+def test_runtime_publishes_one_immutable_snapshot_for_provider_and_catalog_facets(monkeypatch):
+    bundle_service = PolicyBundleService()
+    catalog_service = CatalogPolicyService(bundle_service)
+    provider_service = ModelProviderPolicyService(bundle_service)
+    old_snapshot = bundle_service.snapshot
+    new_snapshot = PolicyBundleSnapshot(
+        revision=9,
+        initialized=True,
+        source="api",
+        approved_provider_ids={"anthropic"},
+        blocked_component_keys={"OpenAIModel"},
+        blocked_template_keys={"starter-template"},
+        content_hash="9" * 64,
+        reason="one atomic publication",
+    )
+    monkeypatch.setattr(langflow_service_deps, "get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr(langflow_service_deps, "get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr(lfx_service_deps, "get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_model_provider_policy_service", lambda: provider_service)
+
+    assert policy_store.apply_policy_bundle_state(new_snapshot) is True
+
+    assert bundle_service.snapshot is new_snapshot
+    assert catalog_service.policy_bundle_snapshot is new_snapshot
+    assert provider_service.approved_provider_ids == new_snapshot.approved_provider_ids
+    assert provider_service.policy_version == new_snapshot.revision
+    assert catalog_service.snapshot.blocked_component_keys == new_snapshot.blocked_component_keys
+    assert catalog_service.snapshot.blocked_template_keys == new_snapshot.blocked_template_keys
+    assert old_snapshot == PolicyBundleSnapshot()
+
+
+def test_runtime_applies_bundle_to_database_owned_catalog_plugin_with_independent_state(monkeypatch):
+    class IndependentCatalogPolicy(BaseCatalogPolicyService):
+        def __init__(self) -> None:
+            super().__init__()
+            self._snapshot = CatalogPolicySnapshot()
+            self.applied: list[PolicyBundleSnapshot] = []
+            self.set_ready()
+
+        @property
+        def snapshot(self) -> CatalogPolicySnapshot:
+            return self._snapshot
+
+        @property
+        def supports_policy_bundle_updates(self) -> bool:
+            return True
+
+        def apply_policy_bundle(self, snapshot: PolicyBundleSnapshot) -> bool:
+            self.applied.append(snapshot)
+            self._snapshot = CatalogPolicySnapshot(
+                blocked_component_keys=snapshot.blocked_component_keys,
+                blocked_template_keys=snapshot.blocked_template_keys,
+            )
+            return True
+
+    bundle_service = PolicyBundleService()
+    catalog_service = IndependentCatalogPolicy()
+    provider_service = ModelProviderPolicyService(bundle_service)
+    snapshot = PolicyBundleSnapshot(
+        revision=4,
+        initialized=True,
+        source="api",
+        approved_provider_ids={"openai"},
+        blocked_component_keys={"PythonREPL"},
+        blocked_template_keys={"Starter"},
+        content_hash="4" * 64,
+    )
+    monkeypatch.setattr(lfx_service_deps, "get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr(lfx_service_deps, "get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_model_provider_policy_service", lambda: provider_service)
+
+    assert policy_store.apply_policy_bundle_state(snapshot) is True
+    assert catalog_service.applied == [snapshot]
+    assert catalog_service.snapshot.blocked_component_keys == frozenset({"PythonREPL"})
+    assert catalog_service.snapshot.blocked_template_keys == frozenset({"Starter"})
+
+    stale = PolicyBundleSnapshot(
+        revision=3,
+        initialized=True,
+        source="poll",
+        approved_provider_ids={"anthropic"},
+        blocked_component_keys={"OpenAIModel"},
+        blocked_template_keys={"OldStarter"},
+        content_hash="3" * 64,
+    )
+    assert policy_store.apply_policy_bundle_state(stale) is True
+    assert bundle_service.snapshot is snapshot
+    assert catalog_service.applied == [snapshot, snapshot]
+    assert catalog_service.snapshot.blocked_component_keys == frozenset({"PythonREPL"})
+    assert catalog_service.snapshot.blocked_template_keys == frozenset({"Starter"})
+    assert provider_service.approved_provider_ids == frozenset({"openai"})
+    assert provider_service.policy_version == 4
+
+
+def test_runtime_rejects_database_owned_catalog_plugin_without_bundle_update_support(monkeypatch):
+    class LegacyCatalogPolicy(BaseCatalogPolicyService):
+        def __init__(self) -> None:
+            super().__init__()
+            self.set_ready()
+
+        @property
+        def snapshot(self) -> CatalogPolicySnapshot:
+            return CatalogPolicySnapshot()
+
+    bundle_service = PolicyBundleService()
+    catalog_service = LegacyCatalogPolicy()
+    provider_service = ModelProviderPolicyService(bundle_service)
+    snapshot = PolicyBundleSnapshot(revision=2, initialized=True, content_hash="2" * 64)
+    monkeypatch.setattr(lfx_service_deps, "get_policy_bundle_service", lambda: bundle_service)
+    monkeypatch.setattr(lfx_service_deps, "get_catalog_policy_service", lambda: catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_model_provider_policy_service", lambda: provider_service)
+
+    with pytest.raises(policy_store.PolicyBundleApplicationNotSupportedError, match="upgrade the plugin"):
+        policy_store.apply_policy_bundle_state(snapshot)
+
+    assert bundle_service.snapshot == PolicyBundleSnapshot()
+    assert provider_service.policy_version == 0
+
+
+async def test_second_worker_poll_refreshes_all_facets_from_one_committed_revision(
+    monkeypatch,
+    bundle_session_maker,
+):
+    async with bundle_session_maker() as session:
+        committed = await policy_store.replace_policy_bundle_state(
+            session,
+            expected_revision=1,
+            approved_provider_ids={"anthropic"},
+            blocked_component_keys={"OpenAIModel"},
+            blocked_template_keys={"starter-template"},
+            actor_user_id=uuid4(),
+            reason="cross-worker",
+        )
+
+    second_bundle_service = PolicyBundleService()
+    second_catalog_service = CatalogPolicyService(second_bundle_service)
+    second_provider_service = ModelProviderPolicyService(second_bundle_service)
+
+    @asynccontextmanager
+    async def session_scope():
+        async with bundle_session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(refresh_module, "session_scope", session_scope)
+    monkeypatch.setattr(
+        refresh_module,
+        "get_model_provider_policy_service",
+        lambda: second_provider_service,
+    )
+    monkeypatch.setattr(
+        refresh_module,
+        "get_policy_bundle_service",
+        lambda: second_bundle_service,
+        raising=False,
+    )
+    monkeypatch.setattr(langflow_service_deps, "get_policy_bundle_service", lambda: second_bundle_service)
+    monkeypatch.setattr(langflow_service_deps, "get_catalog_policy_service", lambda: second_catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_policy_bundle_service", lambda: second_bundle_service)
+    monkeypatch.setattr(lfx_service_deps, "get_catalog_policy_service", lambda: second_catalog_service)
+    monkeypatch.setattr(lfx_service_deps, "get_model_provider_policy_service", lambda: second_provider_service)
+
+    changed = await refresh_module.ModelProviderPolicyRefreshWorker()._run_once()
+
+    assert changed is True
+    assert _bundle_value(second_bundle_service.snapshot) == _bundle_value(committed)
+    assert second_catalog_service.policy_bundle_snapshot is second_bundle_service.snapshot
+    assert second_provider_service.approved_provider_ids == committed.approved_provider_ids
+    assert second_provider_service.policy_version == committed.revision
+    assert second_catalog_service.snapshot.blocked_component_keys == committed.blocked_component_keys
+    assert second_catalog_service.snapshot.blocked_template_keys == committed.blocked_template_keys

--- a/src/lfx/src/lfx/services/catalog_policy/__init__.py
+++ b/src/lfx/src/lfx/services/catalog_policy/__init__.py
@@ -2,10 +2,12 @@
 
 from lfx.services.catalog_policy.base import BaseCatalogPolicyService, CatalogPolicySnapshot, CatalogPolicyUpdate
 from lfx.services.catalog_policy.service import CatalogPolicyService
+from lfx.services.policy_bundle import PolicyBundleSnapshot
 
 __all__ = [
     "BaseCatalogPolicyService",
     "CatalogPolicyService",
     "CatalogPolicySnapshot",
     "CatalogPolicyUpdate",
+    "PolicyBundleSnapshot",
 ]

--- a/src/lfx/src/lfx/services/catalog_policy/base.py
+++ b/src/lfx/src/lfx/services/catalog_policy/base.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from lfx.services.base import Service
+from lfx.services.policy_bundle import PolicyBundleSnapshot
 from lfx.services.schema import ServiceType
 
 if TYPE_CHECKING:
@@ -85,6 +86,29 @@ class BaseCatalogPolicyService(Service, abc.ABC):
     @abc.abstractmethod
     def snapshot(self) -> CatalogPolicySnapshot:
         """Return the current immutable process-local snapshot."""
+
+    @property
+    def policy_bundle_snapshot(self) -> PolicyBundleSnapshot:
+        """Return a compatibility bundle view for catalog-only implementations."""
+        snapshot = self.snapshot
+        return PolicyBundleSnapshot(
+            blocked_component_keys=snapshot.blocked_component_keys,
+            blocked_template_keys=snapshot.blocked_template_keys,
+        )
+
+    @property
+    def supports_policy_bundle_updates(self) -> bool:
+        """Return whether committed shared bundles can be applied atomically.
+
+        Legacy plugins default to ``False`` so Langflow never reports a
+        successful database write that the active enforcement plugin ignored.
+        """
+        return False
+
+    def apply_policy_bundle(self, snapshot: PolicyBundleSnapshot) -> bool:
+        """Publish a durable bundle when the implementation supports live updates."""
+        _ = snapshot
+        return False
 
     @property
     def enabled(self) -> bool:

--- a/src/lfx/src/lfx/services/catalog_policy/service.py
+++ b/src/lfx/src/lfx/services/catalog_policy/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from lfx.log.logger import logger
 from lfx.services import register_service
 from lfx.services.catalog_policy.base import BaseCatalogPolicyService, CatalogPolicySnapshot
+from lfx.services.policy_bundle import BasePolicyBundleService, PolicyBundleService, PolicyBundleSnapshot
 from lfx.services.schema import ServiceType
 
 
@@ -12,9 +13,9 @@ from lfx.services.schema import ServiceType
 class CatalogPolicyService(BaseCatalogPolicyService):
     """Standalone default with an immutable empty, allow-all snapshot."""
 
-    def __init__(self) -> None:
+    def __init__(self, policy_bundle_service: BasePolicyBundleService | None = None) -> None:
         super().__init__()
-        self._snapshot = CatalogPolicySnapshot()
+        self._policy_bundle_service = policy_bundle_service or PolicyBundleService()
         self.set_ready()
         logger.debug("Catalog policy service initialized (allow all)")
 
@@ -26,4 +27,19 @@ class CatalogPolicyService(BaseCatalogPolicyService):
     @property
     def snapshot(self) -> CatalogPolicySnapshot:
         """Return the immutable allow-all snapshot."""
-        return self._snapshot
+        bundle = self._policy_bundle_service.snapshot
+        return CatalogPolicySnapshot(
+            blocked_component_keys=bundle.blocked_component_keys,
+            blocked_template_keys=bundle.blocked_template_keys,
+        )
+
+    @property
+    def policy_bundle_snapshot(self) -> PolicyBundleSnapshot:
+        return self._policy_bundle_service.snapshot
+
+    @property
+    def supports_policy_bundle_updates(self) -> bool:
+        return True
+
+    def apply_policy_bundle(self, snapshot: PolicyBundleSnapshot) -> bool:
+        return self._policy_bundle_service.publish(snapshot)

--- a/src/lfx/src/lfx/services/deps.py
+++ b/src/lfx/src/lfx/services/deps.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         TransactionServiceProtocol,
         VariableServiceProtocol,
     )
+    from lfx.services.policy_bundle.base import BasePolicyBundleService
 
 
 def get_service(service_type: ServiceType, default=None):
@@ -77,6 +78,17 @@ def get_model_provider_policy_service():
     service = get_service(ServiceType.MODEL_PROVIDER_POLICY_SERVICE)
     if not isinstance(service, BaseModelProviderPolicyService) or not service.ready:
         msg = "A valid, ready model_provider_policy_service is required"
+        raise TypeError(msg)
+    return service
+
+
+def get_policy_bundle_service() -> BasePolicyBundleService:
+    """Return the ready process-local shared policy bundle coordinator."""
+    from lfx.services.policy_bundle import BasePolicyBundleService, PolicyBundleService  # noqa: F401
+
+    service = get_service(ServiceType.POLICY_BUNDLE_SERVICE)
+    if not isinstance(service, BasePolicyBundleService) or not service.ready:
+        msg = "A valid, ready policy_bundle_service is required"
         raise TypeError(msg)
     return service
 

--- a/src/lfx/src/lfx/services/manager.py
+++ b/src/lfx/src/lfx/services/manager.py
@@ -516,6 +516,12 @@ class ServiceManager:
                     "refusing to start with the OSS allow-all fallback"
                 )
                 raise RuntimeError(msg)
+            if service_type == ServiceType.POLICY_BUNDLE_SERVICE:
+                msg = (
+                    "Configured policy bundle service could not be loaded; "
+                    "refusing to start with the built-in process-local fallback"
+                )
+                raise RuntimeError(msg)
             return
 
         if service_type == ServiceType.MODEL_PROVIDER_POLICY_SERVICE:

--- a/src/lfx/src/lfx/services/manager.py
+++ b/src/lfx/src/lfx/services/manager.py
@@ -433,6 +433,12 @@ class ServiceManager:
             expected_bases[ServiceType.MODEL_PROVIDER_POLICY_SERVICE] = BaseModelProviderPolicyService
         except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
             logger.debug(f"BaseModelProviderPolicyService unavailable; entry-point validation skipped: {exc}")
+        try:
+            from lfx.services.policy_bundle.base import BasePolicyBundleService
+
+            expected_bases[ServiceType.POLICY_BUNDLE_SERVICE] = BasePolicyBundleService
+        except Exception as exc:  # noqa: BLE001 — optional import, validation just skipped
+            logger.debug(f"BasePolicyBundleService unavailable; entry-point validation skipped: {exc}")
 
         for ep in eps:
             try:
@@ -527,6 +533,12 @@ class ServiceManager:
                     "keeping the built-in fail-open service"
                 )
                 return
+        if service_type == ServiceType.POLICY_BUNDLE_SERVICE:
+            from lfx.services.policy_bundle.base import BasePolicyBundleService
+
+            if not isinstance(service_class, type) or not issubclass(service_class, BasePolicyBundleService):
+                msg = "Configured policy bundle service must subclass BasePolicyBundleService"
+                raise RuntimeError(msg)
 
         self.register_service_class(service_type, service_class, override=True)
         logger.debug(f"Registered service from config: {service_key} -> {service_path}")

--- a/src/lfx/src/lfx/services/model_provider_policy/service.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/service.py
@@ -13,14 +13,16 @@ if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
 
     from lfx.services.model_provider_policy.base import ModelProviderPolicyContext, ModelProviderPolicyPurpose
+    from lfx.services.policy_bundle import BasePolicyBundleService
 
 
 @register_service(ServiceType.MODEL_PROVIDER_POLICY_SERVICE)
 class ModelProviderPolicyService(BaseModelProviderPolicyService):
     """OSS default that preserves the historical allow-all behavior."""
 
-    def __init__(self) -> None:
+    def __init__(self, policy_bundle_service: BasePolicyBundleService | None = None) -> None:
         super().__init__()
+        self._policy_bundle_service = policy_bundle_service
         self._approved_provider_ids: frozenset[str] = frozenset()
         self._policy_version: int | None = None
         self._policy_source_available = True
@@ -39,9 +41,9 @@ class ModelProviderPolicyService(BaseModelProviderPolicyService):
         purpose: ModelProviderPolicyPurpose,  # noqa: ARG002
     ) -> Collection[str]:
         with self._snapshot_cache_lock:
-            if not self._policy_source_available:
+            if not self.policy_source_available:
                 return frozenset()
-            approved_provider_ids = self._approved_provider_ids
+            approved_provider_ids = self.approved_provider_ids
         if not approved_provider_ids:
             return candidate_provider_ids
         return candidate_provider_ids & approved_provider_ids
@@ -49,17 +51,28 @@ class ModelProviderPolicyService(BaseModelProviderPolicyService):
     @property
     def approved_provider_ids(self) -> frozenset[str]:
         """Return the install-wide deployment ceiling; empty means unrestricted."""
+        if self._policy_bundle_service is not None:
+            return self._policy_bundle_service.snapshot.approved_provider_ids
         return self._approved_provider_ids
 
     @property
     def policy_version(self) -> int | None:
         """Return the durable policy version last applied in this process."""
+        if self._policy_bundle_service is not None:
+            return self._policy_bundle_service.snapshot.revision
         return self._policy_version
 
     @property
     def policy_source_available(self) -> bool:
         """Return whether the durable ceiling was available on the last refresh."""
+        if self._policy_bundle_service is not None:
+            return self._policy_bundle_service.source_available
         return self._policy_source_available
+
+    @property
+    def policy_bundle_service(self) -> BasePolicyBundleService | None:
+        """Return the shared bundle coordinator used by this service, if any."""
+        return self._policy_bundle_service
 
     def fail_closed(self, *, deny_all_required: bool = False) -> bool:
         """Deny providers after a refresh failure only when a ceiling is active.
@@ -72,8 +85,15 @@ class ModelProviderPolicyService(BaseModelProviderPolicyService):
         application or durable-source corruption makes the ceiling impossible
         to evaluate safely.
         """
+        if self._policy_bundle_service is not None:
+            if not self.approved_provider_ids and not deny_all_required:
+                return False
+            changed = self._policy_bundle_service.mark_source_unavailable()
+            if changed:
+                self.invalidate()
+            return changed
         with self._snapshot_cache_lock:
-            if not self._approved_provider_ids and not deny_all_required:
+            if not self.approved_provider_ids and not deny_all_required:
                 return False
             if not self._policy_source_available:
                 return False
@@ -87,6 +107,16 @@ class ModelProviderPolicyService(BaseModelProviderPolicyService):
         from lfx.base.models.provider_registry import resolve_provider_id
 
         approved_provider_ids = frozenset(resolve_provider_id(provider_id) for provider_id in provider_ids)
+        if self._policy_bundle_service is not None:
+            current = self._policy_bundle_service.snapshot
+            target_revision = current.revision if version is None else version
+            if approved_provider_ids == current.approved_provider_ids and target_revision == current.revision:
+                changed = self._policy_bundle_service.publish(current)
+                if changed:
+                    self.invalidate()
+                return changed
+            msg = "Provider-only mutation is not allowed when a shared policy bundle is configured"
+            raise RuntimeError(msg)
         with self._snapshot_cache_lock:
             if version is not None and self._policy_version is not None and version < self._policy_version:
                 return False

--- a/src/lfx/src/lfx/services/policy_bundle/__init__.py
+++ b/src/lfx/src/lfx/services/policy_bundle/__init__.py
@@ -1,0 +1,9 @@
+from lfx.services.policy_bundle.base import BasePolicyBundleService, PolicyBundleSnapshot, policy_bundle_content_hash
+from lfx.services.policy_bundle.service import PolicyBundleService
+
+__all__ = [
+    "BasePolicyBundleService",
+    "PolicyBundleService",
+    "PolicyBundleSnapshot",
+    "policy_bundle_content_hash",
+]

--- a/src/lfx/src/lfx/services/policy_bundle/base.py
+++ b/src/lfx/src/lfx/services/policy_bundle/base.py
@@ -1,0 +1,87 @@
+"""Stable process-local contract for shared deployment policy bundles."""
+
+from __future__ import annotations
+
+import abc
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lfx.services.base import Service
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from datetime import datetime
+    from uuid import UUID
+
+
+def policy_bundle_content_hash(
+    *,
+    approved_provider_ids: Collection[str],
+    blocked_component_keys: Collection[str],
+    blocked_template_keys: Collection[str],
+) -> str:
+    """Return the SHA-256 of the canonical complete decision payload."""
+    payload = {
+        "approved_provider_ids": sorted(set(approved_provider_ids)),
+        "blocked_component_keys": sorted(set(blocked_component_keys)),
+        "blocked_template_keys": sorted(set(blocked_template_keys)),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyBundleSnapshot:
+    """One immutable provider-and-catalog policy revision."""
+
+    revision: int = 0
+    initialized: bool = False
+    source: str = "default"
+    approved_provider_ids: frozenset[str] = frozenset()
+    blocked_component_keys: frozenset[str] = frozenset()
+    blocked_template_keys: frozenset[str] = frozenset()
+    content_hash: str = ""
+    created_at: datetime | None = None
+    created_by: UUID | None = None
+    reason: str | None = None
+    rollback_of_revision: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.revision < 0:
+            msg = "Policy bundle revision must not be negative"
+            raise ValueError(msg)
+        object.__setattr__(self, "approved_provider_ids", frozenset(self.approved_provider_ids))
+        object.__setattr__(self, "blocked_component_keys", frozenset(self.blocked_component_keys))
+        object.__setattr__(self, "blocked_template_keys", frozenset(self.blocked_template_keys))
+
+
+class BasePolicyBundleService(Service, abc.ABC):
+    """Publish one immutable policy reference shared by all decision planes."""
+
+    name = ServiceType.POLICY_BUNDLE_SERVICE.value
+
+    @property
+    @abc.abstractmethod
+    def snapshot(self) -> PolicyBundleSnapshot:
+        """Return the currently published complete policy revision."""
+
+    @property
+    @abc.abstractmethod
+    def hydrated(self) -> bool:
+        """Return whether a durable revision has been published."""
+
+    @property
+    @abc.abstractmethod
+    def source_available(self) -> bool:
+        """Return whether the last durable refresh succeeded."""
+
+    @abc.abstractmethod
+    def publish(self, snapshot: PolicyBundleSnapshot) -> bool:
+        """Atomically publish a non-stale complete revision."""
+
+    @abc.abstractmethod
+    def mark_source_unavailable(self) -> bool:
+        """Record a failed refresh without discarding last-known-good content."""

--- a/src/lfx/src/lfx/services/policy_bundle/service.py
+++ b/src/lfx/src/lfx/services/policy_bundle/service.py
@@ -1,0 +1,92 @@
+"""Default in-process coordinator for deployment policy bundles."""
+
+from __future__ import annotations
+
+import threading
+
+from lfx.log.logger import logger
+from lfx.services import register_service
+from lfx.services.policy_bundle.base import BasePolicyBundleService, PolicyBundleSnapshot
+from lfx.services.schema import ServiceType
+
+
+@register_service(ServiceType.POLICY_BUNDLE_SERVICE)
+class PolicyBundleService(BasePolicyBundleService):
+    """Thread-safe owner of one immutable provider-and-catalog snapshot."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._snapshot = PolicyBundleSnapshot()
+        self._hydrated = False
+        self._source_available = True
+        self._lock = threading.RLock()
+        self.set_ready()
+        logger.debug("Policy bundle service initialized")
+
+    @property
+    def name(self) -> str:
+        return ServiceType.POLICY_BUNDLE_SERVICE.value
+
+    @property
+    def snapshot(self) -> PolicyBundleSnapshot:
+        return self._snapshot
+
+    @property
+    def hydrated(self) -> bool:
+        return self._hydrated
+
+    @property
+    def source_available(self) -> bool:
+        return self._source_available
+
+    def publish(self, snapshot: PolicyBundleSnapshot) -> bool:
+        with self._lock:
+            current = self._snapshot
+            if snapshot.revision < current.revision:
+                return False
+            if snapshot.revision == current.revision:
+                current_identity = (
+                    current.initialized,
+                    current.source,
+                    current.approved_provider_ids,
+                    current.blocked_component_keys,
+                    current.blocked_template_keys,
+                    current.content_hash,
+                    current.reason,
+                    current.rollback_of_revision,
+                )
+                snapshot_identity = (
+                    snapshot.initialized,
+                    snapshot.source,
+                    snapshot.approved_provider_ids,
+                    snapshot.blocked_component_keys,
+                    snapshot.blocked_template_keys,
+                    snapshot.content_hash,
+                    snapshot.reason,
+                    snapshot.rollback_of_revision,
+                )
+                if snapshot_identity != current_identity:
+                    msg = f"Policy bundle revision {snapshot.revision} has conflicting content"
+                    raise ValueError(msg)
+                changed = not self._source_available or not self._hydrated
+                self._snapshot = snapshot
+                self._source_available = True
+                self._hydrated = snapshot.revision > 0
+                return changed
+            self._snapshot = snapshot
+            self._hydrated = True
+            self._source_available = True
+            return True
+
+    def mark_source_unavailable(self) -> bool:
+        with self._lock:
+            if not self._source_available:
+                return False
+            self._source_available = False
+            return True
+
+    async def teardown(self) -> None:
+        with self._lock:
+            self._snapshot = PolicyBundleSnapshot()
+            self._hydrated = False
+            self._source_available = True

--- a/src/lfx/src/lfx/services/schema.py
+++ b/src/lfx/src/lfx/services/schema.py
@@ -10,6 +10,7 @@ class ServiceType(str, Enum):
     AUTHORIZATION_SERVICE = "authorization_service"
     CATALOG_POLICY_SERVICE = "catalog_policy_service"
     MODEL_PROVIDER_POLICY_SERVICE = "model_provider_policy_service"
+    POLICY_BUNDLE_SERVICE = "policy_bundle_service"
     DATABASE_SERVICE = "database_service"
     STORAGE_SERVICE = "storage_service"
     SETTINGS_SERVICE = "settings_service"

--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -17,6 +17,7 @@ from lfx.services.model_provider_policy import (
     reset_current_model_provider_policy_context,
     set_current_model_provider_policy_context,
 )
+from lfx.services.policy_bundle import PolicyBundleService, PolicyBundleSnapshot, policy_bundle_content_hash
 
 _DENIED_RUNTIME_CATALOG_CALLS: list[None] = []
 
@@ -110,6 +111,30 @@ def test_empty_approved_provider_ceiling_preserves_allow_all_default():
 
     assert snapshot.allowed_provider_ids == frozenset({"openai", "anthropic"})
     assert not service.approved_provider_ids
+
+
+def test_shared_bundle_rejects_provider_only_mutation_without_poisoning_revision_or_hash():
+    bundle_service = PolicyBundleService()
+    initial = PolicyBundleSnapshot(
+        revision=3,
+        initialized=True,
+        source="api",
+        approved_provider_ids=frozenset({"openai"}),
+        blocked_component_keys=frozenset({"PythonREPL"}),
+        blocked_template_keys=frozenset({"Starter"}),
+        content_hash=policy_bundle_content_hash(
+            approved_provider_ids={"openai"},
+            blocked_component_keys={"PythonREPL"},
+            blocked_template_keys={"Starter"},
+        ),
+    )
+    bundle_service.publish(initial)
+    service = ModelProviderPolicyService(bundle_service)
+
+    with pytest.raises(RuntimeError, match="Provider-only mutation is not allowed"):
+        service.set_approved_provider_ids({"anthropic"}, version=4)
+
+    assert bundle_service.snapshot is initial
 
 
 def test_default_service_rejects_a_stale_persisted_policy_version():

--- a/src/lfx/tests/unit/services/test_service_manager.py
+++ b/src/lfx/tests/unit/services/test_service_manager.py
@@ -176,6 +176,17 @@ model_provider_policy_service = "{service_path}"
         with pytest.raises(RuntimeError, match=error):
             service_manager.discover_plugins(temp_config_dir)
 
+    def test_missing_explicit_policy_bundle_fails_startup(self, service_manager, temp_config_dir):
+        (temp_config_dir / "lfx.toml").write_text(
+            """
+[services]
+policy_bundle_service = "nonexistent.module:MissingPolicyBundleService"
+"""
+        )
+
+        with pytest.raises(RuntimeError, match="Configured policy bundle service could not be loaded"):
+            service_manager.discover_plugins(temp_config_dir)
+
     def test_discover_multiple_services_from_config(self, service_manager, temp_config_dir):
         """Test discovering multiple real services from config."""
         config_file = temp_config_dir / "lfx.toml"


### PR DESCRIPTION
## Summary

- Add one immutable, revisioned database policy bundle for the model-provider allowlist, component blocklist, and starter-template blocklist.
- Add superuser read, CAS replacement, history, and rollback APIs, plus a shared runtime coordinator and cross-replica refresh path.
- Add an additive migration that seeds from the legacy provider/catalog stores, dual-writes compatibility views, and provides an exact-head guarded downgrade seam.
- Reject stale writes and catalog plugins that cannot apply the shared bundle instead of silently leaving enforcement out of sync.

## Deployment notes

- A committed database revision converges across current-version replicas through the refresh worker; a cluster restart is not required.
- During a mixed old/new rolling deployment, freeze every provider/catalog policy write at ingress. Compatibility is one-way: new writers update legacy tables, but old writers do not update the new bundle.
- The previously shipped N-1 image cannot resolve the new base migration head and therefore requires a pre-upgrade database restore. The release-owned in-place downgrade copies the active bundle back to legacy stores only for a separately qualified rollback image based on the new OSS base.

## Validation

- Backend policy/API/migration suite: **106 passed, 6 skipped**
- Isolated LFX provider/catalog suite: **48 passed**
- Enterprise compatibility contract and service-resolution checks: passed against this commit
- Ruff format/check, `git diff --check`, Alembic expand-contract validation, and secret detection: passed
- Independent Python, security, and final code reviews: no unresolved findings
