### PR TITLE
fix(security): skip symlinks in GitExtractor

### DIFF
--- a/src/backend/tests/unit/components/git/test_gitextractor_ssrf.py
+++ b/src/backend/tests/unit/components/git/test_gitextractor_ssrf.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.base import ComponentTestBaseWithoutClient
+
 
 @pytest.fixture
 def ssrf_on():
@@ -56,44 +58,60 @@ async def test_gitloader_blocks_dangerous_clone_url():
         assert mock_loader.call_count == 0
 
 
-@pytest.fixture
-def gitextractor_repo_with_symlink(tmp_path, monkeypatch):
-    """Provide a checked-out tree whose symlink points outside the repository."""
-    from lfx.components.git.gitextractor import GitExtractorComponent
+class TestGitExtractorComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        from lfx.components.git.gitextractor import GitExtractorComponent
 
-    repository = tmp_path / "repository"
-    repository.mkdir()
-    (repository / "README.md").write_text("repository content\n", encoding="utf-8")
+        return GitExtractorComponent
 
-    outside_file = tmp_path / "outside.txt"
-    outside_file.write_text("SAFE_CANARY\n" * 3, encoding="utf-8")
-    (repository / "linked.txt").symlink_to(outside_file)
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"repository_url": "https://example.com/repository.git"}
 
-    @asynccontextmanager
-    async def fake_temp_git_repo(_self):
-        yield str(repository)
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
 
-    monkeypatch.setattr(GitExtractorComponent, "temp_git_repo", fake_temp_git_repo)
-    return GitExtractorComponent(repository_url="https://example.com/repository.git")
+    @pytest.fixture
+    def gitextractor_repo_with_symlink(self, component_class, default_kwargs, tmp_path, monkeypatch):
+        """Provide a checked-out tree whose symlinks point outside the repository."""
+        repository = tmp_path / "repository"
+        repository.mkdir()
+        (repository / "README.md").write_bytes(b"repository content\n")
 
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("SAFE_CANARY\n" * 3, encoding="utf-8")
+        (repository / "linked.txt").symlink_to(outside_file)
 
-async def test_gitextractor_files_content_skips_symlinks(gitextractor_repo_with_symlink):
-    result = await gitextractor_repo_with_symlink.get_files_content()
+        outside_directory = tmp_path / "outside-directory"
+        outside_directory.mkdir()
+        (repository / "linked-directory").symlink_to(outside_directory, target_is_directory=True)
 
-    assert [item.data["path"] for item in result] == ["README.md"]
-    assert "SAFE_CANARY" not in result[0].data["content"]
+        @asynccontextmanager
+        async def fake_temp_git_repo(_self):
+            yield str(repository)
 
+        monkeypatch.setattr(component_class, "temp_git_repo", fake_temp_git_repo)
+        return component_class(**default_kwargs)
 
-async def test_gitextractor_text_content_skips_symlinks(gitextractor_repo_with_symlink):
-    result = await gitextractor_repo_with_symlink.get_text_based_file_contents()
+    async def test_files_content_skips_symlinks(self, gitextractor_repo_with_symlink):
+        result = await gitextractor_repo_with_symlink.get_files_content()
 
-    assert "README.md" in result.text
-    assert "linked.txt" not in result.text
-    assert "SAFE_CANARY" not in result.text
+        assert [item.data["path"] for item in result] == ["README.md"]
+        assert "SAFE_CANARY" not in result[0].data["content"]
 
+    async def test_text_content_skips_symlinks(self, gitextractor_repo_with_symlink):
+        result = await gitextractor_repo_with_symlink.get_text_based_file_contents()
 
-async def test_gitextractor_statistics_skips_symlinks(gitextractor_repo_with_symlink):
-    result = await gitextractor_repo_with_symlink.get_statistics()
+        assert "README.md" in result.text
+        assert "linked.txt" not in result.text
+        assert "SAFE_CANARY" not in result.text
 
-    assert result[0].data["total_files"] == 1
-    assert result[0].data["total_lines"] == 1
+    async def test_statistics_skips_symlinks(self, gitextractor_repo_with_symlink):
+        result = await gitextractor_repo_with_symlink.get_statistics()
+
+        assert result[0].data["total_files"] == 1
+        assert result[0].data["total_lines"] == 1
+        assert result[0].data["total_size_bytes"] == len(b"repository content\n")
+        assert result[0].data["directories"] == 0

--- a/src/backend/tests/unit/components/git/test_gitextractor_ssrf.py
+++ b/src/backend/tests/unit/components/git/test_gitextractor_ssrf.py
@@ -1,10 +1,11 @@
-"""SSRF / RCE regression tests for the Git components' clone URL handling.
+"""Security regression tests for the Git components.
 
 A tenant-controlled repository URL handed to ``git clone`` enables RCE via the ``ext::``
 remote helper, arbitrary local-file disclosure via ``file://`` / bare paths, and SSRF to
 internal hosts. These tests confirm the dangerous URL never reaches ``git.Repo.clone_from``.
 """
 
+from contextlib import asynccontextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -53,3 +54,46 @@ async def test_gitloader_blocks_dangerous_clone_url():
         with pytest.raises((SSRFProtectionError, ValueError)):
             await component.build_gitloader()
         assert mock_loader.call_count == 0
+
+
+@pytest.fixture
+def gitextractor_repo_with_symlink(tmp_path, monkeypatch):
+    """Provide a checked-out tree whose symlink points outside the repository."""
+    from lfx.components.git.gitextractor import GitExtractorComponent
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "README.md").write_text("repository content\n", encoding="utf-8")
+
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("SAFE_CANARY\n" * 3, encoding="utf-8")
+    (repository / "linked.txt").symlink_to(outside_file)
+
+    @asynccontextmanager
+    async def fake_temp_git_repo(_self):
+        yield str(repository)
+
+    monkeypatch.setattr(GitExtractorComponent, "temp_git_repo", fake_temp_git_repo)
+    return GitExtractorComponent(repository_url="https://example.com/repository.git")
+
+
+async def test_gitextractor_files_content_skips_symlinks(gitextractor_repo_with_symlink):
+    result = await gitextractor_repo_with_symlink.get_files_content()
+
+    assert [item.data["path"] for item in result] == ["README.md"]
+    assert "SAFE_CANARY" not in result[0].data["content"]
+
+
+async def test_gitextractor_text_content_skips_symlinks(gitextractor_repo_with_symlink):
+    result = await gitextractor_repo_with_symlink.get_text_based_file_contents()
+
+    assert "README.md" in result.text
+    assert "linked.txt" not in result.text
+    assert "SAFE_CANARY" not in result.text
+
+
+async def test_gitextractor_statistics_skips_symlinks(gitextractor_repo_with_symlink):
+    result = await gitextractor_repo_with_symlink.get_statistics()
+
+    assert result[0].data["total_files"] == 1
+    assert result[0].data["total_lines"] == 1

--- a/src/bundles/lfx-bundles/src/lfx_bundles/git/gitextractor.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/git/gitextractor.py
@@ -89,10 +89,12 @@ class GitExtractorComponent(Component):
                 directories = 0
 
                 for root, dirs, files in os.walk(temp_dir):
-                    total_files += len(files)
                     directories += len(dirs)
                     for file in files:
                         file_path = Path(root) / file
+                        if file_path.is_symlink():
+                            continue
+                        total_files += 1
                         total_size += file_path.stat().st_size
                         try:
                             async with aiofiles.open(file_path, encoding="utf-8") as f:
@@ -145,6 +147,8 @@ class GitExtractorComponent(Component):
                 for root, _, files in os.walk(temp_dir):
                     for file in files:
                         file_path = Path(root) / file
+                        if file_path.is_symlink():
+                            continue
                         relative_path = file_path.relative_to(temp_dir)
                         file_size = file_path.stat().st_size
                         try:
@@ -172,6 +176,8 @@ class GitExtractorComponent(Component):
                 for root, _, files in os.walk(temp_dir):
                     for file in files:
                         file_path = Path(root) / file
+                        if file_path.is_symlink():
+                            continue
                         relative_path = file_path.relative_to(temp_dir)
                         content_list.extend(["=" * 50, f"File: /{relative_path}", "=" * 50])
 

--- a/src/bundles/lfx-bundles/src/lfx_bundles/git/gitextractor.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/git/gitextractor.py
@@ -89,6 +89,7 @@ class GitExtractorComponent(Component):
                 directories = 0
 
                 for root, dirs, files in os.walk(temp_dir):
+                    dirs[:] = [directory for directory in dirs if not (Path(root) / directory).is_symlink()]
                     directories += len(dirs)
                     for file in files:
                         file_path = Path(root) / file


### PR DESCRIPTION
## Summary

- skip checked-out symlinks before every GitExtractor file `stat` or read
- keep file statistics and returned content limited to regular repository files
- add safe out-of-tree canary regressions for all three affected outputs

## Validation

- `9 passed` — `src/backend/tests/unit/components/git/test_gitextractor_ssrf.py`
- Ruff format and lint passed for changed files

Internal tracking: LE-2138 / PVR0836215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository scanning to safely skip symbolic links during statistics, file-content extraction, and text-content extraction.
  * Prevented files linked from outside the repository from appearing in extracted content or repository metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->