### PR TITLE
fix(authz): support scoped project visibility

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1441,7 +1441,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_projects.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 2049,
+        "line_number": 2105,
         "is_secret": false
       }
     ],
@@ -7301,5 +7301,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T20:54:59Z"
+  "generated_at": "2026-08-05T22:27:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1441,7 +1441,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_projects.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 2035,
+        "line_number": 2049,
         "is_secret": false
       }
     ],
@@ -7301,5 +7301,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T19:38:40Z"
+  "generated_at": "2026-08-05T19:55:17Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3030,7 +3030,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "06e10503631d5b1680e4a08e3a5e0ab109812c48",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -3038,7 +3038,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "de70a102ac9fe37a0714c25453e50afb4f078359",
         "is_verified": false,
-        "line_number": 1721,
+        "line_number": 1722,
         "is_secret": false
       },
       {
@@ -3046,27 +3046,19 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "16bce207c70bb100ece74b75c4c4a79e262cfd5c",
         "is_verified": false,
-        "line_number": 1723
+        "line_number": 1724
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "42174448e882bf43f51c70d0ed3f57d377bb74bb",
         "is_verified": false,
-        "line_number": 1724
+        "line_number": 1725
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "da5b4695b6132090955c121e932d6f9b833c0b1d",
-        "is_verified": false,
-        "line_number": 1785,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "d4f39052ccfaf9ef5b8fd360ed75d23cf12fa2c4",
         "is_verified": false,
         "line_number": 1786,
         "is_secret": false
@@ -3074,7 +3066,7 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "bfc0c1d4d70399476ea81e40a48418ed9962832d",
+        "hashed_secret": "d4f39052ccfaf9ef5b8fd360ed75d23cf12fa2c4",
         "is_verified": false,
         "line_number": 1787,
         "is_secret": false
@@ -3082,9 +3074,17 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "bfc0c1d4d70399476ea81e40a48418ed9962832d",
+        "is_verified": false,
+        "line_number": 1788,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "2a24f50d36559883d2bc391e4e99f9a7afd56ef9",
         "is_verified": false,
-        "line_number": 1809,
+        "line_number": 1810,
         "is_secret": false
       },
       {
@@ -3092,7 +3092,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fd0543de99a00bd6e67f3e522a18ed417089b6b4",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -3100,7 +3100,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fa4b98297401af5e6ab7a402330a12715e891325",
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1958,
         "is_secret": false
       },
       {
@@ -3108,7 +3108,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9c46c22e7a8ff423706b990fc02c85e0d324f134",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -3116,7 +3116,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "91cde4236a3754b4b57733682edfc50571d954c6",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1973,
         "is_secret": false
       },
       {
@@ -3124,7 +3124,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9625c6b66710b648d27ee284940849a6b5abf3f0",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1976,
         "is_secret": false
       },
       {
@@ -3132,7 +3132,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "370c53187d8e550db85edabdcb86547dab96e300",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -3140,7 +3140,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc57a2140542893b4c9396b6a7186b26351c6fe5",
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1990,
         "is_secret": false
       },
       {
@@ -3148,7 +3148,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "d922d16c3bbc818b6fab4e8d2662fa361309fa9d",
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2205,
         "is_secret": false
       },
       {
@@ -3156,7 +3156,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "8ea601e5cac549eef50d2743f915e4af54135789",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2206,
         "is_secret": false
       },
       {
@@ -3164,7 +3164,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e498ebe977c948f4d1b7eddd6bb77be398ed4d7c",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -3172,7 +3172,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "02e680473cb1ee7473e2cdb5b0b6c48cd8aae081",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2213,
         "is_secret": false
       },
       {
@@ -3180,7 +3180,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc50b2aac5d886516a06afb79b4931f4ee66422d",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -3428,7 +3428,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8e77e1ff96d9be727f25fc393a48f767935660db",
         "is_verified": false,
-        "line_number": 1221,
+        "line_number": 1222,
         "is_secret": false
       },
       {
@@ -3436,7 +3436,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4a7c565d4c4430e3bb8fa6c560125d5eb37e7c3d",
         "is_verified": false,
-        "line_number": 1448,
+        "line_number": 1449,
         "is_secret": false
       },
       {
@@ -3444,7 +3444,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29538b53771fff5bad78e3a48a3a8f88c2f141d2",
         "is_verified": false,
-        "line_number": 1528,
+        "line_number": 1529,
         "is_secret": false
       },
       {
@@ -3452,7 +3452,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8d24e5afd2e9b40d21e4300c893a486aab979795",
         "is_verified": false,
-        "line_number": 1529,
+        "line_number": 1530,
         "is_secret": false
       },
       {
@@ -3460,7 +3460,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ed05045c1666dd556d9a09f9eb6889f42a81aa5a",
         "is_verified": false,
-        "line_number": 1625,
+        "line_number": 1626,
         "is_secret": false
       },
       {
@@ -3468,7 +3468,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f616a4d4abc959d505a5b83f1b3fa1a6bce6b2e",
         "is_verified": false,
-        "line_number": 1627,
+        "line_number": 1628,
         "is_secret": false
       },
       {
@@ -3476,7 +3476,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1bbb8fd38e8fef4280c7218b961ae2ceeb83bbc9",
         "is_verified": false,
-        "line_number": 1628,
+        "line_number": 1629,
         "is_secret": false
       },
       {
@@ -3484,7 +3484,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "0b8eacdde75bb24c6f29adf660f50ca4d9846358",
         "is_verified": false,
-        "line_number": 1630,
+        "line_number": 1631,
         "is_secret": false
       },
       {
@@ -3492,7 +3492,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8cde7462c1ce55676dc45124068d844ad3b86dcf",
         "is_verified": false,
-        "line_number": 1651,
+        "line_number": 1652,
         "is_secret": false
       },
       {
@@ -3500,7 +3500,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "afbf9aed8c22c3faf4d92dccadabe324d49bc5a8",
         "is_verified": false,
-        "line_number": 1882,
+        "line_number": 1883,
         "is_secret": false
       },
       {
@@ -3508,7 +3508,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "651f66f27bbfaed040c836e22515162e20c4fa0d",
         "is_verified": false,
-        "line_number": 1896,
+        "line_number": 1897,
         "is_secret": false
       },
       {
@@ -3516,7 +3516,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e38ef0e653c39ce1a4dde13da87333c43ced6cab",
         "is_verified": false,
-        "line_number": 1981,
+        "line_number": 1982,
         "is_secret": false
       },
       {
@@ -3524,7 +3524,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "a3e4ec7cb1a57129b074bdd0b9403a008a7f0019",
         "is_verified": false,
-        "line_number": 1999,
+        "line_number": 2000,
         "is_secret": false
       }
     ],
@@ -3742,7 +3742,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "d35e35ce246c917e0d30a073363f12eb6b412d5e",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -3750,27 +3750,19 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6848bf99f0e8cbaa9e3afe15724b0592761c9895",
         "is_verified": false,
-        "line_number": 1723
+        "line_number": 1724
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "71e1d05cafdbe483092571dc8fa209cb4fb602d2",
         "is_verified": false,
-        "line_number": 1724
+        "line_number": 1725
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bd2d890bd01b9843827f1583db8f9ee99564f270",
-        "is_verified": false,
-        "line_number": 1785,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "b245ddc4e5dfcb57cba8d08000e59c5dc0809ceb",
         "is_verified": false,
         "line_number": 1786,
         "is_secret": false
@@ -3778,7 +3770,7 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "443fd1115c9bd30afaac31a42fc192b86476f288",
+        "hashed_secret": "b245ddc4e5dfcb57cba8d08000e59c5dc0809ceb",
         "is_verified": false,
         "line_number": 1787,
         "is_secret": false
@@ -3786,9 +3778,17 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "443fd1115c9bd30afaac31a42fc192b86476f288",
+        "is_verified": false,
+        "line_number": 1788,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "5c324bbf8f0a15d640a2ca93b4bb0183d106edd8",
         "is_verified": false,
-        "line_number": 1809,
+        "line_number": 1810,
         "is_secret": false
       },
       {
@@ -3796,7 +3796,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "49d8b438094e36554d1d2ec73dbc4adbdca1a891",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -3804,7 +3804,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bdd17febdd742a928650952ec63b0ab0d7eeddac",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -3812,7 +3812,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "15e4f8d5f1d2759b1e83f9082a8ce8e194eb5600",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1973,
         "is_secret": false
       },
       {
@@ -3820,7 +3820,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "c8700cb4716f270e7c37191104366e7b1cadc9de",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1976,
         "is_secret": false
       },
       {
@@ -3828,7 +3828,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "60b0610326aa371e079775047f4e66c77aabb0a2",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -3836,7 +3836,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "0147f29ee8d8343d8d70f94b71b0053b268461e3",
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1990,
         "is_secret": false
       },
       {
@@ -3844,7 +3844,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "3c89182cf4fc330080cfb2352105827a904d5691",
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2205,
         "is_secret": false
       },
       {
@@ -3852,7 +3852,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "998c11b06dfd04593f289507da2b499cf4bca6e8",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2206,
         "is_secret": false
       },
       {
@@ -3860,7 +3860,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "ccaa726ee57e4ccdab0a28886273feee26d647ec",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -3868,7 +3868,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "2e329e7c25daa340c17b719f5371248f691de123",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2213,
         "is_secret": false
       },
       {
@@ -3876,7 +3876,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6e09157ed6a7516c860d26d0747fb229badf190a",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -4046,7 +4046,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7f49bb36f7d78041a9c8e79fdead35277249f701",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -4054,7 +4054,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "88362d0d044cf4144e78f646e101110e3f44a9e5",
         "is_verified": false,
-        "line_number": 1721,
+        "line_number": 1722,
         "is_secret": false
       },
       {
@@ -4062,21 +4062,21 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "f924297673a9a6a8f9362349954b1e5273549e28",
         "is_verified": false,
-        "line_number": 1723
+        "line_number": 1724
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "649624ecf03baa824fd2f66c653ef47a10159656",
         "is_verified": false,
-        "line_number": 1724
+        "line_number": 1725
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "89400786d11d1ee5d936d6cd1890e99e4e3aa54b",
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1788,
         "is_secret": false
       },
       {
@@ -4084,7 +4084,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "b1df0ac48f734b370fc58c591ef0772266f88bb4",
         "is_verified": false,
-        "line_number": 1809,
+        "line_number": 1810,
         "is_secret": false
       },
       {
@@ -4092,7 +4092,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "541b6268f8abceae80c498212280ee7136eba255",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -4100,7 +4100,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "ff959bbe348ba1b8176852cd2e3d6ba8dbf4062d",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -4108,7 +4108,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "73f311b6a3b5bb2b45eccad848db62d85ae37b58",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -4116,7 +4116,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7294ab5b6d4cf3ea2deab49cecb0a7baacd16447",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -4124,7 +4124,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "8dfdd0969287ef24a795d71e17f53f148d37d766",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -4270,7 +4270,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "d46f0990d79bb487d60ff3a855f6916f3e4e6a1a",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -4278,7 +4278,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c0428438c20615c80570a0bd88158db6a5cc6003",
         "is_verified": false,
-        "line_number": 1785,
+        "line_number": 1786,
         "is_secret": false
       },
       {
@@ -4286,7 +4286,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c22e6661861b4203426d47e3a1a50363c09c812e",
         "is_verified": false,
-        "line_number": 1786,
+        "line_number": 1787,
         "is_secret": false
       },
       {
@@ -4294,7 +4294,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b360f8c2eb4e5aeab3a63c711ffe95b4fa24afde",
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1788,
         "is_secret": false
       },
       {
@@ -4302,7 +4302,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b6416594e1de4cfc0351c6562ab936519130f5b2",
         "is_verified": false,
-        "line_number": 1796,
+        "line_number": 1797,
         "is_secret": false
       },
       {
@@ -4310,7 +4310,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b7cd1a2885e8998336c89a87d4df110a6b66e2f2",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -4318,7 +4318,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "5e8bcadfaab440649c70e43a015503e9109a7bfa",
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1958,
         "is_secret": false
       },
       {
@@ -4326,7 +4326,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "44ed46c9ee10a3a7308c6d1a5df4cb082c57b9e0",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -4334,7 +4334,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "20e6aa34a3dd984dd602c294ee85714b53a0a872",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1973,
         "is_secret": false
       },
       {
@@ -4342,7 +4342,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b5426a913c9da60eff621ee15e0b195bf6aaa8da",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1976,
         "is_secret": false
       },
       {
@@ -4350,7 +4350,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "415c03a82cd5f390ad3e28dd82c88e36fb540548",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -4358,7 +4358,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "9e7ba6c71dc246eee615e88e31861a563e33b42d",
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1990,
         "is_secret": false
       },
       {
@@ -4366,7 +4366,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "18a887dd97555ab726e7f4d4d999dedd236763eb",
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2205,
         "is_secret": false
       },
       {
@@ -4374,7 +4374,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "e4777a4b7b9c6fd1911762e35405c0b6b80ae735",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2206,
         "is_secret": false
       },
       {
@@ -4382,7 +4382,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "8847d054d32b57b7a5633fed58444d7237209e24",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -4390,7 +4390,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "369cb27892790b429dacabb4ee12cdfd63d6c250",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2213,
         "is_secret": false
       },
       {
@@ -4398,7 +4398,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b9743a370a7e12046cbb762dda96137a0327fc28",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -4623,7 +4623,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "29022bd1c2181fbd36940c13cc3fa70041b48ab6",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -4631,27 +4631,19 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9fc16a99501e66da0391bf67c7a16b236b23bed9",
         "is_verified": false,
-        "line_number": 1723
+        "line_number": 1724
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "6e40094f370649da3568ca1c747fb5a17575c2be",
         "is_verified": false,
-        "line_number": 1724
+        "line_number": 1725
       },
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "924dffdc29e36152ac5c5ad72472d4012c453619",
-        "is_verified": false,
-        "line_number": 1785,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "3cf10d8f342037e71cf0fa4f902939cce046db88",
         "is_verified": false,
         "line_number": 1786,
         "is_secret": false
@@ -4659,7 +4651,7 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "83107836c3fbb4f7126e1c62127d867f2115c66e",
+        "hashed_secret": "3cf10d8f342037e71cf0fa4f902939cce046db88",
         "is_verified": false,
         "line_number": 1787,
         "is_secret": false
@@ -4667,9 +4659,17 @@
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "83107836c3fbb4f7126e1c62127d867f2115c66e",
+        "is_verified": false,
+        "line_number": 1788,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "e5de519e1707a85ae531c311d440ee66c9d92013",
         "is_verified": false,
-        "line_number": 1809,
+        "line_number": 1810,
         "is_secret": false
       },
       {
@@ -4677,7 +4677,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "5e210e2b1f3abec2110bc9be8e64d7f330fa1077",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -4685,7 +4685,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f0b397ea447a3fa2ad71bf2275fef3c57c19ced",
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1958,
         "is_secret": false
       },
       {
@@ -4693,7 +4693,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9a36a9b7c6bfc059b4f02372fff29d59a7d28956",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -4701,7 +4701,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "d041f1238574c9fda80f329a69df103dd0362201",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1973,
         "is_secret": false
       },
       {
@@ -4709,7 +4709,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "cb9c85cb748ddd0400375630f5ec0206759ddb89",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1976,
         "is_secret": false
       },
       {
@@ -4717,7 +4717,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f426df5e9101c108190dccfd037a953d0d402f2",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -4725,7 +4725,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "01817544892d96dedca2ad884fa493fea87ba133",
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1990,
         "is_secret": false
       },
       {
@@ -4733,7 +4733,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "187a0dc92fd69a86bd0e675941e7f1898e3b55e1",
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2205,
         "is_secret": false
       },
       {
@@ -4741,7 +4741,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "685a15b5a75fafecd74ad06561f50711e97d7275",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2206,
         "is_secret": false
       },
       {
@@ -4749,7 +4749,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "47a5deeb29d9b4f9d88464d050560a7f7b294ddd",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -4757,7 +4757,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "32c3af10cab241e0b425cebc42831cbaa236f1c6",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2213,
         "is_secret": false
       },
       {
@@ -4765,7 +4765,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "4cb21cbeac2b9488b0fde6c6291caf37245c54c2",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -4911,7 +4911,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "00e66990421091c8a0f9084a1997c317ffe34000",
         "is_verified": false,
-        "line_number": 1718,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -4919,7 +4919,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d370647062f8a9ebf57183122e6aacd46c2a7bda",
         "is_verified": false,
-        "line_number": 1785,
+        "line_number": 1786,
         "is_secret": false
       },
       {
@@ -4927,7 +4927,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7d2d5daebdd522b7de7fab94e153cbea4620c369",
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1788,
         "is_secret": false
       },
       {
@@ -4935,7 +4935,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "74a3dd23222f2bc1888171506f585281009f79a4",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1821,
         "is_secret": false
       },
       {
@@ -4943,7 +4943,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "c10e8dbe79654ae8ed496c4c50f5e188b7924a4e",
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1958,
         "is_secret": false
       },
       {
@@ -4951,7 +4951,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7223cfc50b72fe9b091b46275f561526aba9e705",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -4959,7 +4959,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "4aa9a3231780af9a37413cb7034ecdf72d43cfec",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1973,
         "is_secret": false
       },
       {
@@ -4967,7 +4967,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "68af7627d36cc6b923f5928a198165857f1ba5f1",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1976,
         "is_secret": false
       },
       {
@@ -4975,7 +4975,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7acd3659ef48c980ce4aef1d0f2f218ff25efc89",
         "is_verified": false,
-        "line_number": 1980,
+        "line_number": 1981,
         "is_secret": false
       },
       {
@@ -4983,7 +4983,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7443c6e0ef4c013461140fb1aa2a7a60b40a0b89",
         "is_verified": false,
-        "line_number": 1989,
+        "line_number": 1990,
         "is_secret": false
       },
       {
@@ -4991,7 +4991,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "3c274d81d83ceba5bfaaaf2ac4f6b0aedcf431a0",
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2205,
         "is_secret": false
       },
       {
@@ -4999,7 +4999,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "583ddc85a613ceef2e54f9d2251113f3acef73a3",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2206,
         "is_secret": false
       },
       {
@@ -5007,7 +5007,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8494b7db80f8bfedeef8cc5697bed5339cd1a4ee",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2212,
         "is_secret": false
       },
       {
@@ -5015,7 +5015,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d45af2467cb991008a273eb0c4590fa9a96fc497",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2213,
         "is_secret": false
       },
       {
@@ -5023,7 +5023,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8da5daf1ef780fe5e37ae02bee48cbdb023c7101",
         "is_verified": false,
-        "line_number": 2222,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -7301,5 +7301,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T19:55:17Z"
+  "generated_at": "2026-08-05T20:54:59Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1441,7 +1441,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_projects.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 1997,
+        "line_number": 2035,
         "is_secret": false
       }
     ],
@@ -7301,5 +7301,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T16:25:25Z"
+  "generated_at": "2026-08-05T19:38:40Z"
 }

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -84,6 +84,7 @@ from langflow.services.database.models.deployment.crud import (
     count_deployments_by_provider,
     delete_deployment_by_id,
     get_deployment_by_resource_key,
+    has_visible_deployment_for_provider,
 )
 from langflow.services.database.models.deployment.crud import (
     create_deployment_from_model as create_deployment_db,
@@ -792,25 +793,42 @@ async def list_deployments(
         )
     )
 
-    # OSS / no-plugin path keeps the strict owner gate (byte-for-byte the prior
-    # behavior). Relax it only when the prefilter actually lists ids to surface:
-    # an empty list means "no extra visibility", so there's nothing a cross-user
-    # reader could see under a provider they don't own — keep the strict 404 there
-    # rather than degrade it to an empty 200. A non-empty list resolves the
-    # provider account by id alone so a shared deployment under another user's
-    # provider account can be listed; the (owner ⊕ visible) union below still
-    # governs which rows actually surface.
-    if visibility_scope is not None and visibility_scope.has_cross_user_access:
+    # OSS / no-plugin path keeps the strict owner gate. A structured prefilter
+    # may relax it only after the same SQL visibility predicate used by the page
+    # proves that this specific provider owns at least one row visible to the
+    # caller. A coarse workspace/project/global grant alone is not enough:
+    # loading arbitrary foreign provider UUIDs would expose an existence oracle.
+    use_shared_provider_lookup = bool(
+        visibility_scope is not None
+        and visibility_scope.has_cross_user_access
+        and await has_visible_deployment_for_provider(
+            session,
+            user_id=current_user.id,
+            deployment_provider_account_id=provider_id,
+            visibility_scope=visibility_scope,
+        )
+    )
+    if use_shared_provider_lookup:
         provider_account = await get_shared_listing_provider_account_or_404(provider_id=provider_id, db=session)
     else:
         provider_account = await get_owned_provider_account_or_404(
             provider_id=provider_id, user_id=current_user.id, db=session
         )
-    await ensure_deployment_permission(
-        current_user,
-        DeploymentAction.READ,
-        project_id=project_id,
-    )
+    try:
+        await ensure_deployment_permission(
+            current_user,
+            DeploymentAction.READ,
+            project_id=project_id,
+        )
+    except HTTPException as exc:
+        if use_shared_provider_lookup:
+            # The relaxed provider-account lookup above loads by UUID alone so
+            # shared deployments can be listed. Once that path is active, mask
+            # a policy deny exactly like a missing account; otherwise callers
+            # could distinguish an existing foreign provider UUID (403) from a
+            # nonexistent UUID (404).
+            raise deny_to_404(exc, detail="Deployment provider account not found.") from exc
+        raise
     deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
     if load_from_provider:

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -173,7 +173,9 @@ async def read_flows(
         default_folder = (await session.exec(select(Folder).where(Folder.name == DEFAULT_FOLDER_NAME))).first()
         default_folder_id = default_folder.id if default_folder else None
 
-        starter_folder = (await session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME))).first()
+        starter_folder = (
+            await session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME, Folder.user_id.is_(None)))
+        ).first()
         starter_folder_id = starter_folder.id if starter_folder else None
 
         if not starter_folder and not default_folder:
@@ -1060,7 +1062,11 @@ async def read_basic_examples(
         cached_flow_reads = _starter_flows_cache.get("starter_flows")
         if cached_flow_reads is CACHE_MISS:
             try:
-                starter_folder = (await session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME))).first()
+                starter_folder = (
+                    await session.exec(
+                        select(Folder).where(Folder.name == STARTER_FOLDER_NAME, Folder.user_id.is_(None))
+                    )
+                ).first()
 
                 if not starter_folder:
                     return compress_response([])

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -256,19 +256,21 @@ async def read_projects(
         else:
             stmt = select(Folder).where(or_(owned_clause, Folder.user_id == None))  # noqa: E711
         projects = (await session.exec(stmt)).all()
-        projects = [project for project in projects if project.name != STARTER_FOLDER_NAME]
+        projects = [
+            project for project in projects if not (project.name == STARTER_FOLDER_NAME and project.user_id is None)
+        ]
         # When no DB prefilter is available (OSS pass-through), drop projects the
         # user can't read in memory. ``domain_extractor`` groups requests by
-        # workspace so each batch is evaluated against the right policy tuple
-        # (projects are the resource itself, so the domain falls back to
-        # workspace or ``*``). When the prefilter is active the SQL union is
-        # already authoritative — skip the per-row enforce to avoid an N+1.
+        # concrete project so each batch is evaluated against the same policy
+        # tuple as the single-resource guard. When the prefilter is active the
+        # SQL union is already authoritative — skip the per-row enforce to
+        # avoid an N+1.
         if visibility_scope is None:
             projects = await filter_visible_resources(
                 current_user,
                 resource_type="project",
                 candidates=list(projects),
-                domain_extractor=lambda project: _resolve_authz_domain(project.workspace_id, None),
+                domain_extractor=lambda project: _resolve_authz_domain(project.workspace_id, project.id),
                 owner_extractor=lambda project: project.user_id,
                 act=ProjectAction.READ,
             )
@@ -509,6 +511,17 @@ async def update_project(
     except HTTPException as exc:
         raise deny_to_404(exc, detail="Project not found") from exc
 
+    if (
+        project.name is not None
+        and project.name != existing_project.name
+        and existing_project.name == STARTER_FOLDER_NAME
+        and existing_project.user_id is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"The system-managed '{STARTER_FOLDER_NAME}' project cannot be renamed.",
+        )
+
     # Flow rollup uses the project owner — a non-owner editing a shared
     # project must touch the owner's flows, not the actor's same-folder
     # flows (which would be empty for a non-owner anyway).
@@ -742,10 +755,12 @@ async def delete_project(
     except HTTPException as exc:
         raise deny_to_404(exc, detail="Project not found") from exc
 
-    # Prevent deletion of the Langflow Assistant folder
-    if project.name == ASSISTANT_FOLDER_NAME:
-        msg = f"Cannot delete the '{ASSISTANT_FOLDER_NAME}' folder, that contains pre-built flows."
-        await logger.adebug("Cannot delete the '%s' folder, that contains pre-built flows.", ASSISTANT_FOLDER_NAME)
+    # Prevent deletion of projects managed by Langflow. The ownerless Starter
+    # Project is also a stable authorization boundary for bundled examples.
+    is_system_starter = project.name == STARTER_FOLDER_NAME and project.user_id is None
+    if project.name == ASSISTANT_FOLDER_NAME or is_system_starter:
+        msg = f"Cannot delete the '{project.name}' folder, which contains pre-built flows."
+        await logger.adebug("Cannot delete the '%s' folder, which contains pre-built flows.", project.name)
         raise HTTPException(
             status_code=403,
             detail=msg,

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -60,11 +60,13 @@ from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NA
 from langflow.services.database.models.folder.model import (
     Folder,
     FolderCreate,
+    FolderListRead,
     FolderRead,
     FolderReadWithFlows,
     FolderUpdate,
 )
 from langflow.services.database.models.folder.pagination_model import FolderWithPaginatedFlows
+from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_service, get_settings_service
 from langflow.services.schema import ServiceType
 
@@ -220,7 +222,7 @@ async def create_project(
     return folder_read
 
 
-@router.get("/", response_model=list[FolderRead], status_code=200)
+@router.get("/", response_model=list[FolderListRead], status_code=200)
 async def read_projects(
     *,
     session: DbSession,
@@ -272,8 +274,22 @@ async def read_projects(
             )
         sorted_projects = sorted(projects, key=lambda x: x.name != DEFAULT_FOLDER_NAME)
 
-        # Convert to FolderRead while session is still active to avoid detached instance errors
-        return [FolderRead.model_validate(project, from_attributes=True) for project in sorted_projects]
+        owner_ids = {project.user_id for project in sorted_projects if project.user_id is not None}
+        owners_by_id: dict[str, str] = {}
+        if owner_ids:
+            owner_rows = (await session.exec(select(User.id, User.username).where(User.id.in_(owner_ids)))).all()
+            owners_by_id = {str(owner_id): username for owner_id, username in owner_rows}
+
+        # Convert while the session is active so owner-qualified project lists
+        # do not trigger lazy loads after the request-scoped session closes.
+        return [
+            FolderListRead(
+                **FolderRead.model_validate(project, from_attributes=True).model_dump(),
+                owner_username=owners_by_id.get(str(project.user_id)) if project.user_id is not None else None,
+                is_owner=str(project.user_id) == str(current_user.id),
+            )
+            for project in sorted_projects
+        ]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -8,7 +8,7 @@ from fastapi_pagination.ext.sqlmodel import apaginate
 from lfx.log.logger import logger
 from lfx.services.mcp_composer.service import MCPComposerService
 from lfx.utils.util_strings import escape_like_pattern
-from sqlalchemy import literal, or_, update
+from sqlalchemy import literal, null, or_, update
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -283,10 +283,13 @@ async def read_projects(
         # Convert while the session is active so owner-qualified project lists
         # do not trigger lazy loads after the request-scoped session closes.
         return [
-            FolderListRead(
-                **FolderRead.model_validate(project, from_attributes=True).model_dump(),
-                owner_username=owners_by_id.get(str(project.user_id)) if project.user_id is not None else None,
-                is_owner=str(project.user_id) == str(current_user.id),
+            FolderListRead.model_validate(
+                project,
+                from_attributes=True,
+                update={
+                    "owner_username": owners_by_id.get(str(project.user_id)) if project.user_id is not None else None,
+                    "is_owner": str(project.user_id) == str(current_user.id),
+                },
             )
             for project in sorted_projects
         ]
@@ -381,7 +384,7 @@ async def read_project(
                     stmt,
                     id_column=Flow.id,
                     owner_clause=Flow.user_id == current_user.id,
-                    workspace_expression=literal(project.workspace_id),
+                    workspace_expression=null() if project.workspace_id is None else literal(project.workspace_id),
                     project_column=Flow.folder_id,
                     visibility=visibility_scope,
                 )

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -845,7 +845,7 @@ async def delete_starter_projects(session, folder_id) -> None:
 
 
 async def folder_exists(session, folder_name):
-    stmt = select(Folder).where(Folder.name == folder_name)
+    stmt = select(Folder).where(Folder.name == folder_name, Folder.user_id.is_(None))
     folder = (await session.exec(stmt)).first()
     return folder is not None
 
@@ -858,7 +858,7 @@ async def get_or_create_starter_folder(session):
         await session.flush()
         await session.refresh(db_folder)
         return db_folder
-    stmt = select(Folder).where(Folder.name == STARTER_FOLDER_NAME)
+    stmt = select(Folder).where(Folder.name == STARTER_FOLDER_NAME, Folder.user_id.is_(None))
     return (await session.exec(stmt)).first()
 
 

--- a/src/backend/base/langflow/services/authorization/guards.py
+++ b/src/backend/base/langflow/services/authorization/guards.py
@@ -321,7 +321,11 @@ _RESOURCE_SPECS: dict[str, _ResourceSpec] = {
         owner_kw="project_user_id",
         id_kw="project_id",
         workspace_kw="workspace_id",
-        scope_kw=None,
+        # Existing-project checks use the concrete project domain so plugins
+        # can distinguish reserved projects from their parent workspace.
+        # CREATE has no project id and still resolves to the workspace/global
+        # domain as before.
+        scope_kw="project_id",
     ),
     "knowledge_base": _ResourceSpec(
         resource_type="knowledge_base",

--- a/src/backend/base/langflow/services/authorization/listing.py
+++ b/src/backend/base/langflow/services/authorization/listing.py
@@ -259,7 +259,20 @@ def restrict_to_owned_or_visible_scope(
 ) -> StatementT:
     """Apply owner, concrete-ID, workspace, and project visibility before pagination."""
     if visibility.all_resources:
-        return stmt
+        if project_column is None or not visibility.excluded_global_project_ids:
+            return stmt
+        # Global role access can exclude reserved projects without enumerating
+        # every visible resource. Ownership and concrete grants remain additive,
+        # so users retain their own resources and directly shared resources in
+        # an otherwise excluded project. Folderless resources remain global.
+        global_clauses: list[ColumnElement[bool]] = [
+            owner_clause,
+            col(project_column).is_(None),
+            col(project_column).not_in(visibility.excluded_global_project_ids),
+        ]
+        if visibility.resource_ids:
+            global_clauses.append(col(id_column).in_(visibility.resource_ids))
+        return stmt.where(or_(*global_clauses))
 
     clauses: list[ColumnElement[bool]] = [owner_clause]
     if visibility.resource_ids:
@@ -332,10 +345,13 @@ def resource_visible_in_scope(
     project_id: UUID | None = None,
 ) -> bool:
     """Evaluate a compact visibility scope for an already-loaded resource."""
+    globally_visible = visibility.all_resources and (
+        project_id is None or project_id not in visibility.excluded_global_project_ids
+    )
     workspace_project_allowed = project_id is None or project_id not in visibility.excluded_workspace_project_ids
     unassigned_project_allowed = project_id is not None and project_id not in visibility.excluded_workspace_project_ids
     return bool(
-        visibility.all_resources
+        globally_visible
         or resource_id in visibility.resource_ids
         or (workspace_project_allowed and workspace_id is not None and workspace_id in visibility.workspace_ids)
         or (unassigned_project_allowed and workspace_id is None and visibility.include_unassigned_workspace)

--- a/src/backend/base/langflow/services/authorization/listing.py
+++ b/src/backend/base/langflow/services/authorization/listing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from lfx.services.authorization.base import ResourceVisibilityScope
-from sqlalchemy import Select, false
+from sqlalchemy import Select, and_, false
 from sqlmodel import col, or_
 
 from langflow.services.authorization.actions import FlowAction
@@ -267,8 +267,35 @@ def restrict_to_owned_or_visible_scope(
     resolved_workspace = workspace_expression
     if resolved_workspace is None and workspace_column is not None:
         resolved_workspace = col(workspace_column)
+    workspace_project_allowed: ColumnElement[bool] | None = None
+    if project_column is not None and visibility.excluded_workspace_project_ids:
+        # A workspace-only resource has no project to exclude. Keep it visible
+        # for an explicit workspace grant while excluding resources attached to
+        # reserved projects. The explicit ``IS NULL`` branch also keeps SQL's
+        # three-valued NULL semantics aligned with ``resource_visible_in_scope``.
+        workspace_project_allowed = or_(
+            col(project_column).is_(None),
+            col(project_column).not_in(visibility.excluded_workspace_project_ids),
+        )
     if resolved_workspace is not None and visibility.workspace_ids:
-        clauses.append(resolved_workspace.in_(visibility.workspace_ids))
+        workspace_clause = resolved_workspace.in_(visibility.workspace_ids)
+        if workspace_project_allowed is not None:
+            workspace_clause = and_(workspace_clause, workspace_project_allowed)
+        clauses.append(workspace_clause)
+    if resolved_workspace is not None and project_column is not None and visibility.include_unassigned_workspace:
+        # The logical unassigned workspace contains projects whose stored
+        # workspace is NULL; it does not contain folderless/workspace-less
+        # resources. Requiring a concrete project keeps list filtering aligned
+        # with direct authorization, which resolves this scope through the
+        # resource's project relation.
+        unassigned_project_allowed = col(project_column).is_not(None)
+        if visibility.excluded_workspace_project_ids:
+            unassigned_project_allowed = and_(
+                unassigned_project_allowed,
+                col(project_column).not_in(visibility.excluded_workspace_project_ids),
+            )
+        workspace_clause = and_(resolved_workspace.is_(None), unassigned_project_allowed)
+        clauses.append(workspace_clause)
     if project_column is not None and visibility.project_ids:
         clauses.append(col(project_column).in_(visibility.project_ids))
     return stmt.where(or_(*clauses))
@@ -305,9 +332,12 @@ def resource_visible_in_scope(
     project_id: UUID | None = None,
 ) -> bool:
     """Evaluate a compact visibility scope for an already-loaded resource."""
+    workspace_project_allowed = project_id is None or project_id not in visibility.excluded_workspace_project_ids
+    unassigned_project_allowed = project_id is not None and project_id not in visibility.excluded_workspace_project_ids
     return bool(
         visibility.all_resources
         or resource_id in visibility.resource_ids
-        or (workspace_id is not None and workspace_id in visibility.workspace_ids)
+        or (workspace_project_allowed and workspace_id is not None and workspace_id in visibility.workspace_ids)
+        or (unassigned_project_allowed and workspace_id is None and visibility.include_unassigned_workspace)
         or (project_id is not None and project_id in visibility.project_ids)
     )

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -397,11 +397,21 @@ async def _scope_to_owner_or_allowed(
             visible_ids=allowed_ids or (),
         )
 
+    from langflow.services.database.models.folder.model import Folder
+
+    # ``Deployment.workspace_id`` was introduced as denormalized plumbing and
+    # is absent on legacy rows (and on rows created through the current CRUD
+    # helper). Resolve the workspace from the authoritative project relation so
+    # Default-workspace access cannot absorb deployments whose project belongs
+    # to an explicit workspace.
+    project_workspace = (
+        select(Folder.workspace_id).where(Folder.id == Deployment.project_id).correlate(Deployment).scalar_subquery()
+    )
     return await apply_owned_or_visible_scope_prefilter(
         stmt,
         id_column=Deployment.id,
         owner_clause=Deployment.user_id == user_id,
-        workspace_column=Deployment.workspace_id,
+        workspace_expression=project_workspace,
         project_column=Deployment.project_id,
         visibility=visibility_scope,
     )

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -407,6 +407,31 @@ async def _scope_to_owner_or_allowed(
     )
 
 
+async def has_visible_deployment_for_provider(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    deployment_provider_account_id: UUID,
+    visibility_scope: ResourceVisibilityScope,
+) -> bool:
+    """Return whether this provider owns a deployment visible to the caller.
+
+    Cross-user deployment listing must resolve a foreign provider account to
+    select its adapter, but loading an arbitrary account by UUID creates an
+    existence oracle. Bind that relaxed lookup to the same owner/visibility
+    predicate used by the page and count queries, scoped to the requested
+    provider, before any provider metadata is loaded.
+    """
+    stmt = select(Deployment.id).where(Deployment.deployment_provider_account_id == deployment_provider_account_id)
+    stmt = await _scope_to_owner_or_allowed(
+        stmt,
+        user_id=user_id,
+        allowed_ids=None,
+        visibility_scope=visibility_scope,
+    )
+    return (await db.exec(stmt.limit(1))).first() is not None
+
+
 async def list_deployments_page(
     db: AsyncSession,
     *,

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -51,6 +51,11 @@ class FolderRead(FolderBase):
     parent_id: UUID | None = Field()
 
 
+class FolderListRead(FolderRead):
+    owner_username: str | None = None
+    is_owner: bool
+
+
 class FolderReadWithFlows(FolderBase):
     id: UUID
     parent_id: UUID | None = Field()

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -488,7 +488,7 @@ class DatabaseService(Service):
                 .join(models.Folder)
                 .where(
                     models.Flow.user_id == None,  # noqa: E711
-                    models.Folder.name != STARTER_FOLDER_NAME,
+                    sa.or_(models.Folder.name != STARTER_FOLDER_NAME, models.Folder.user_id.is_not(None)),
                 )
             )
             orphaned_flows = (await session.exec(stmt)).all()

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -872,7 +872,6 @@ class TestListDeploymentsMetadataSync:
 
 
 class TestListDeploymentsSharedPrefilter:
-    @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
     @patch(f"{ROUTES_MODULE}.ensure_deployment_permission", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
@@ -912,7 +911,6 @@ class TestListDeploymentsSharedPrefilter:
         mock_get_shared_pa.assert_awaited_once()
         mock_resolve_adapter.assert_not_called()
 
-    @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
@@ -950,7 +948,6 @@ class TestListDeploymentsSharedPrefilter:
         mock_get_owned_pa.assert_awaited_once()
         mock_get_shared_pa.assert_not_awaited()
 
-    @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.list_deployments_synced", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -873,15 +873,95 @@ class TestListDeploymentsMetadataSync:
 
 class TestListDeploymentsSharedPrefilter:
     @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
+    @patch(f"{ROUTES_MODULE}.ensure_deployment_permission", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
+    async def test_cross_user_provider_permission_deny_is_masked_as_not_found(
+        self,
+        mock_prefilter,
+        mock_get_owned_pa,
+        mock_get_shared_pa,
+        mock_has_visible_deployment,
+        mock_ensure_permission,
+        mock_resolve_adapter,
+    ):
+        """A relaxed provider lookup must not reveal whether a foreign UUID exists."""
+        from langflow.api.v1.deployments import list_deployments
+
+        provider_account = _fake_provider_account()
+        mock_prefilter.return_value = ResourceVisibilityScope(include_unassigned_workspace=True)
+        mock_has_visible_deployment.return_value = True
+        mock_get_shared_pa.return_value = provider_account
+        mock_ensure_permission.side_effect = HTTPException(status_code=403, detail="Not authorized")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_deployments(
+                provider_id=provider_account.id,
+                session=MagicMock(),
+                current_user=_fake_user(),
+                params=SimpleNamespace(page=1, size=20),
+                deployment_type=None,
+            )
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Deployment provider account not found."
+        mock_get_owned_pa.assert_not_awaited()
+        mock_get_shared_pa.assert_awaited_once()
+        mock_resolve_adapter.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
+    async def test_unrelated_foreign_provider_never_reaches_unscoped_lookup(
+        self,
+        mock_prefilter,
+        mock_get_owned_pa,
+        mock_get_shared_pa,
+        mock_has_visible_deployment,
+    ):
+        """A coarse scope cannot reveal a provider with no deployment visible in that scope."""
+        from langflow.api.v1.deployments import list_deployments
+
+        provider_id = uuid4()
+        mock_prefilter.return_value = ResourceVisibilityScope(workspace_ids=(uuid4(),))
+        mock_has_visible_deployment.return_value = False
+        mock_get_owned_pa.side_effect = HTTPException(
+            status_code=404,
+            detail="Deployment provider account not found.",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_deployments(
+                provider_id=provider_id,
+                session=MagicMock(),
+                current_user=_fake_user(),
+                params=SimpleNamespace(page=1, size=20),
+                deployment_type=None,
+            )
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Deployment provider account not found."
+        mock_has_visible_deployment.assert_awaited_once()
+        mock_get_owned_pa.assert_awaited_once()
+        mock_get_shared_pa.assert_not_awaited()
+
+    @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.list_deployments_synced", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
     async def test_concrete_prefilter_relaxes_provider_gate_and_threads_visibility_scope(
         self,
         mock_prefilter,
+        mock_has_visible_deployment,
         mock_get_owned_pa,
         mock_get_shared_pa,
         mock_get_mapper,
@@ -906,6 +986,7 @@ class TestListDeploymentsSharedPrefilter:
 
         scope = ResourceVisibilityScope(resource_ids=(shared_id,))
         mock_prefilter.return_value = scope
+        mock_has_visible_deployment.return_value = True
         mock_get_shared_pa.return_value = pa
         mock_resolve_adapter.return_value = AsyncMock()
         mapper = MagicMock()
@@ -4070,10 +4151,12 @@ class TestListDeploymentsScopedKeyPrefilter:
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_shared_listing_provider_account_or_404", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.has_visible_deployment_for_provider", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.visible_scope_prefilter", new_callable=AsyncMock)
     async def test_concrete_prefilter_threads_visibility_scope_without_owner_union_assumption(
         self,
         mock_prefilter,
+        mock_has_visible_deployment,
         mock_get_owned_pa,
         mock_get_shared_pa,
         mock_get_mapper,
@@ -4093,6 +4176,7 @@ class TestListDeploymentsScopedKeyPrefilter:
         visibility_scope = ResourceVisibilityScope(resource_ids=(visible_only,))
         pa = _fake_provider_account()
         mock_prefilter.return_value = visibility_scope
+        mock_has_visible_deployment.return_value = True
         mock_get_shared_pa.return_value = pa
         mock_resolve_adapter.return_value = AsyncMock()
         mapper = MagicMock()

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi import status
+from fastapi import BackgroundTasks, HTTPException, status
 from httpx import AsyncClient
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.services.database.models.deployment.model import Deployment
@@ -180,14 +180,14 @@ async def test_read_projects_qualifies_visible_same_named_projects_by_owner():
         "langflow.api.v1.projects.filter_visible_resources",
         new_callable=AsyncMock,
         side_effect=return_candidates,
-    ):
+    ) as filter_visible:
         result = await read_projects(
             session=session,
             current_user=SimpleNamespace(id=actor_id),
         )
 
     projects_by_id = {project.id: project for project in result}
-    assert set(projects_by_id) == {shared_project.id, ownerless_project.id, own_project.id}
+    assert set(projects_by_id) == {shared_project.id, internal_project.id, ownerless_project.id, own_project.id}
     assert (
         projects_by_id[shared_project.id].name,
         projects_by_id[shared_project.id].owner_username,
@@ -199,11 +199,18 @@ async def test_read_projects_qualifies_visible_same_named_projects_by_owner():
         projects_by_id[ownerless_project.id].is_owner,
     ) == ("Ownerless Project", None, False)
     assert (
+        projects_by_id[internal_project.id].name,
+        projects_by_id[internal_project.id].owner_username,
+        projects_by_id[internal_project.id].is_owner,
+    ) == (STARTER_FOLDER_NAME, "other-user", False)
+    assert (
         projects_by_id[own_project.id].name,
         projects_by_id[own_project.id].owner_username,
         projects_by_id[own_project.id].is_owner,
     ) == ("Starter Project", "current-user", True)
     assert session.exec.await_count == 2
+    domain_extractor = filter_visible.await_args.kwargs["domain_extractor"]
+    assert domain_extractor(shared_project) == f"project:{shared_project.id}"
 
 
 async def test_read_project(client: AsyncClient, logged_in_headers, basic_case):
@@ -261,6 +268,32 @@ async def test_update_project(client: AsyncClient, logged_in_headers, basic_case
     assert "parent_id" in result, "The dictionary must contain a key called 'parent_id'"
 
 
+async def test_update_project_cannot_rename_system_starter(monkeypatch):
+    from langflow.api.v1 import projects as projects_module
+    from langflow.services.database.models.folder.model import FolderUpdate
+
+    project_id = uuid4()
+    system_starter = Folder(id=project_id, name=STARTER_FOLDER_NAME, user_id=None)
+    monkeypatch.setattr(
+        projects_module,
+        "authorized_or_owner_scoped",
+        AsyncMock(return_value=system_starter),
+    )
+    monkeypatch.setattr(projects_module, "ensure_project_permission", AsyncMock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await projects_module.update_project(
+            session=AsyncMock(),
+            project_id=project_id,
+            project=FolderUpdate(name="Renamed starter"),
+            current_user=SimpleNamespace(id=uuid4()),
+            background_tasks=BackgroundTasks(),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert "cannot be renamed" in exc_info.value.detail
+
+
 async def test_update_project_rejects_unowned_parent_id(
     client: AsyncClient, logged_in_headers, basic_case, active_user
 ):
@@ -303,6 +336,29 @@ async def test_delete_project_then_404(client: AsyncClient, logged_in_headers, b
 
     get_resp = await client.get(f"api/v1/projects/{proj_id}", headers=logged_in_headers)
     assert get_resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_delete_project_cannot_delete_system_starter(monkeypatch):
+    from langflow.api.v1 import projects as projects_module
+
+    project_id = uuid4()
+    system_starter = Folder(id=project_id, name=STARTER_FOLDER_NAME, user_id=None)
+    monkeypatch.setattr(
+        projects_module,
+        "authorized_or_owner_scoped",
+        AsyncMock(return_value=system_starter),
+    )
+    monkeypatch.setattr(projects_module, "ensure_project_permission", AsyncMock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await projects_module.delete_project(
+            session=AsyncMock(),
+            project_id=project_id,
+            current_user=SimpleNamespace(id=uuid4()),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert STARTER_FOLDER_NAME in exc_info.value.detail
 
 
 async def test_delete_project_recovers_from_concurrent_write_lock(

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -163,10 +163,11 @@ async def test_read_projects_qualifies_visible_same_named_projects_by_owner():
     other_user_id = uuid4()
     own_project = Folder(id=uuid4(), name="Starter Project", user_id=actor_id)
     shared_project = Folder(id=uuid4(), name="Starter Project", user_id=other_user_id)
+    ownerless_project = Folder(id=uuid4(), name="Ownerless Project", user_id=None)
     internal_project = Folder(id=uuid4(), name=STARTER_FOLDER_NAME, user_id=other_user_id)
 
     projects_result = MagicMock()
-    projects_result.all.return_value = [shared_project, internal_project, own_project]
+    projects_result.all.return_value = [shared_project, internal_project, ownerless_project, own_project]
     owners_result = MagicMock()
     owners_result.all.return_value = [(actor_id, "current-user"), (other_user_id, "other-user")]
     session = AsyncMock()
@@ -185,10 +186,23 @@ async def test_read_projects_qualifies_visible_same_named_projects_by_owner():
             current_user=SimpleNamespace(id=actor_id),
         )
 
-    assert [(project.name, project.owner_username, project.is_owner) for project in result] == [
-        ("Starter Project", "other-user", False),
-        ("Starter Project", "current-user", True),
-    ]
+    projects_by_id = {project.id: project for project in result}
+    assert set(projects_by_id) == {shared_project.id, ownerless_project.id, own_project.id}
+    assert (
+        projects_by_id[shared_project.id].name,
+        projects_by_id[shared_project.id].owner_username,
+        projects_by_id[shared_project.id].is_owner,
+    ) == ("Starter Project", "other-user", False)
+    assert (
+        projects_by_id[ownerless_project.id].name,
+        projects_by_id[ownerless_project.id].owner_username,
+        projects_by_id[ownerless_project.id].is_owner,
+    ) == ("Ownerless Project", None, False)
+    assert (
+        projects_by_id[own_project.id].name,
+        projects_by_id[own_project.id].owner_username,
+        projects_by_id[own_project.id].is_owner,
+    ) == ("Starter Project", "current-user", True)
     assert session.exec.await_count == 2
 
 

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -152,6 +152,44 @@ async def test_read_projects(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_200_OK
     assert isinstance(result, list), "The result must be a list"
     assert len(result) > 0, "The list must not be empty"
+    assert all(project["owner_username"] for project in result)
+    assert all(project["is_owner"] is True for project in result)
+
+
+async def test_read_projects_qualifies_visible_same_named_projects_by_owner():
+    from langflow.api.v1.projects import read_projects
+
+    actor_id = uuid4()
+    other_user_id = uuid4()
+    own_project = Folder(id=uuid4(), name="Starter Project", user_id=actor_id)
+    shared_project = Folder(id=uuid4(), name="Starter Project", user_id=other_user_id)
+    internal_project = Folder(id=uuid4(), name=STARTER_FOLDER_NAME, user_id=other_user_id)
+
+    projects_result = MagicMock()
+    projects_result.all.return_value = [shared_project, internal_project, own_project]
+    owners_result = MagicMock()
+    owners_result.all.return_value = [(actor_id, "current-user"), (other_user_id, "other-user")]
+    session = AsyncMock()
+    session.exec.side_effect = [projects_result, owners_result]
+
+    async def return_candidates(*_args, **kwargs):
+        return kwargs["candidates"]
+
+    with patch(
+        "langflow.api.v1.projects.filter_visible_resources",
+        new_callable=AsyncMock,
+        side_effect=return_candidates,
+    ):
+        result = await read_projects(
+            session=session,
+            current_user=SimpleNamespace(id=actor_id),
+        )
+
+    assert [(project.name, project.owner_username, project.is_owner) for project in result] == [
+        ("Starter Project", "other-user", False),
+        ("Starter Project", "current-user", True),
+    ]
+    assert session.exec.await_count == 2
 
 
 async def test_read_project(client: AsyncClient, logged_in_headers, basic_case):

--- a/src/backend/tests/unit/initial_setup/test_setup_functions.py
+++ b/src/backend/tests/unit/initial_setup/test_setup_functions.py
@@ -3,8 +3,10 @@ from copy import deepcopy
 from uuid import uuid4
 
 import pytest
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.initial_setup.setup import (
     get_or_create_default_folder,
+    get_or_create_starter_folder,
     session_scope,
     update_projects_components_with_latest_component_versions,
 )
@@ -25,6 +27,20 @@ async def test_get_or_create_default_folder_creation() -> None:
         folder = await get_or_create_default_folder(session, test_user_id)
         assert folder.name == DEFAULT_FOLDER_NAME, "The project name should match the default."
         assert hasattr(folder, "id"), "The project should have an 'id' attribute after creation."
+
+
+async def test_get_or_create_starter_folder_ignores_user_owned_name_collision(async_session) -> None:
+    """A user project named like the reserved project must not become the system Starter Project."""
+    user_folder = Folder(user_id=uuid4(), name=STARTER_FOLDER_NAME, description="User project")
+    async_session.add(user_folder)
+    await async_session.flush()
+
+    starter_folder = await get_or_create_starter_folder(async_session)
+
+    assert starter_folder.user_id is None
+    assert starter_folder.id != user_folder.id
+    matching_folders = (await async_session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME))).all()
+    assert {folder.id for folder in matching_folders} == {user_folder.id, starter_folder.id}
 
 
 @pytest.mark.usefixtures("client")

--- a/src/backend/tests/unit/services/authorization/test_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_guards.py
@@ -640,8 +640,10 @@ async def test_ensure_project_permission_create_uses_wildcard_obj(monkeypatch, f
     install_audit_recorder(monkeypatch)
 
     await authz_guards.ensure_project_permission(fake_user, ProjectAction.CREATE)
+    assert service.calls[0]["domain"] == "*"
     assert service.calls[0]["obj"] == "project:*"
     assert service.calls[0]["act"] == "create"
+    assert service.calls[0]["context"]["workspace_id"] is None
 
 
 # ----------------------------------------------------------------------------- #

--- a/src/backend/tests/unit/services/authorization/test_guards.py
+++ b/src/backend/tests/unit/services/authorization/test_guards.py
@@ -597,17 +597,19 @@ async def test_ensure_project_permission_accepts_enum(monkeypatch, fake_user):
 
 
 @pytest.mark.anyio
-async def test_ensure_project_permission_uses_workspace_domain(monkeypatch, fake_user):
+async def test_ensure_project_permission_uses_project_domain(monkeypatch, fake_user):
     install_settings(monkeypatch, authz_enabled=True)
     service = _StubAuthorizationService(allow=True)
     install_authz(monkeypatch, service)
     install_audit_recorder(monkeypatch)
 
+    project_id = uuid4()
     workspace_id = uuid4()
     await authz_guards.ensure_project_permission(
-        fake_user, ProjectAction.WRITE, project_id=uuid4(), project_user_id=uuid4(), workspace_id=workspace_id
+        fake_user, ProjectAction.WRITE, project_id=project_id, project_user_id=uuid4(), workspace_id=workspace_id
     )
-    assert service.calls[0]["domain"] == f"workspace:{workspace_id}"
+    assert service.calls[0]["domain"] == f"project:{project_id}"
+    assert service.calls[0]["context"]["project_id"] == project_id
     assert service.calls[0]["context"]["workspace_id"] == workspace_id
 
 
@@ -644,6 +646,21 @@ async def test_ensure_project_permission_create_uses_wildcard_obj(monkeypatch, f
     assert service.calls[0]["obj"] == "project:*"
     assert service.calls[0]["act"] == "create"
     assert service.calls[0]["context"]["workspace_id"] is None
+
+
+@pytest.mark.anyio
+async def test_ensure_project_permission_create_uses_workspace_domain(monkeypatch, fake_user):
+    install_settings(monkeypatch, authz_enabled=True)
+    service = _StubAuthorizationService(allow=True)
+    install_authz(monkeypatch, service)
+    install_audit_recorder(monkeypatch)
+
+    workspace_id = uuid4()
+    await authz_guards.ensure_project_permission(fake_user, ProjectAction.CREATE, workspace_id=workspace_id)
+
+    assert service.calls[0]["domain"] == f"workspace:{workspace_id}"
+    assert service.calls[0]["obj"] == "project:*"
+    assert service.calls[0]["context"]["project_id"] is None
 
 
 # ----------------------------------------------------------------------------- #

--- a/src/backend/tests/unit/services/authorization/test_listing_null_owner_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_listing_null_owner_prefilter.py
@@ -28,6 +28,7 @@ import contextlib
 import gzip
 import json
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 from langflow.services.database.models.flow.model import Flow
@@ -35,6 +36,8 @@ from langflow.services.database.models.folder.model import Folder
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_auth_service, get_settings_service, session_scope
 from lfx.services.authorization.base import BaseAuthorizationService, ResourceVisibilityScope
+from sqlalchemy.dialects.postgresql.asyncpg import PGDialect_asyncpg
+from sqlalchemy.sql.sqltypes import NullType
 from sqlmodel import select
 
 if TYPE_CHECKING:
@@ -376,6 +379,51 @@ async def test_shared_project_flow_listing_uses_project_workspace_for_both_respo
             )
             assert spoofed_visible not in hidden_ids
             assert canonical_visible in visible_ids
+
+
+async def test_shared_unassigned_project_pagination_compiles_safely_for_asyncpg(client):
+    from langflow.api.v1 import projects as projects_module
+
+    settings = get_settings_service()
+    username = f"owner_{uuid4().hex}"
+    await _make_user(username)
+    other_id = await _make_user(f"other_{uuid4().hex}")
+    headers = await _login(client, username)
+    project_id = await _make_folder(
+        f"unassigned_project_{uuid4().hex}",
+        user_id=other_id,
+        workspace_id=None,
+    )
+    await _make_flow(
+        f"visible_{uuid4().hex}",
+        user_id=other_id,
+        folder_id=project_id,
+        workspace_id=None,
+    )
+    scope = ResourceVisibilityScope(include_unassigned_workspace=True)
+    compiled_statements = []
+    original_apaginate = projects_module.apaginate
+
+    async def capture_statement(*args, **kwargs):
+        statement = args[1]
+        compiled_statements.append(statement.compile(dialect=PGDialect_asyncpg()))
+        return await original_apaginate(*args, **kwargs)
+
+    with (
+        _install_prefilter_authz(settings, {}, scope_by_type={"flow": scope}),
+        patch.object(projects_module, "apaginate", new=capture_statement),
+    ):
+        response = await client.get(
+            f"api/v1/projects/{project_id}",
+            headers=headers,
+            params={"page": 1, "size": 50},
+        )
+
+    assert response.status_code == 200, response.text
+    assert len(compiled_statements) == 1
+    compiled = compiled_statements[0]
+    assert "NULL IS NULL" in str(compiled)
+    assert not any(isinstance(bind.type, NullType) for bind in compiled.binds.values())
 
 
 async def test_shared_project_get_does_not_delete_flows_hidden_from_response(client):

--- a/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
@@ -147,7 +147,6 @@ def test_unassigned_workspace_scope_uses_a_compact_null_predicate():
     )
 
 
-@pytest.mark.anyio
 async def test_workspace_scope_sql_matches_in_memory_for_project_nulls_and_exclusions(async_session):
     owner_id = uuid4()
     ordinary_project_id = uuid4()

--- a/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
@@ -6,10 +6,12 @@ from uuid import uuid4
 
 import pytest
 from langflow.services.authorization.listing import (
+    resource_visible_in_scope,
     restrict_to_owned_or_visible_scope,
     visible_scope_prefilter,
 )
 from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.folder.model import Folder
 from lfx.services.authorization.base import ResourceVisibilityScope
 from sqlmodel import select
 
@@ -102,7 +104,128 @@ def test_global_scope_does_not_emit_an_unbounded_id_list():
     assert "flow.user_id =" not in sql
 
 
+def test_unassigned_workspace_scope_uses_a_compact_null_predicate():
+    excluded_project_id = uuid4()
+    scope = ResourceVisibilityScope(
+        include_unassigned_workspace=True,
+        excluded_workspace_project_ids=(excluded_project_id,),
+    )
+    constrained = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == uuid4(),
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=scope,
+    )
+
+    sql = str(constrained)
+    assert "flow.workspace_id IS NULL" in sql
+    assert "flow.folder_id IS NOT NULL" in sql
+    assert "flow.folder_id NOT IN" in sql
+    assert not resource_visible_in_scope(
+        resource_id=uuid4(),
+        workspace_id=None,
+        visibility=scope,
+    )
+    assert resource_visible_in_scope(
+        resource_id=uuid4(),
+        workspace_id=None,
+        project_id=uuid4(),
+        visibility=scope,
+    )
+    assert not resource_visible_in_scope(
+        resource_id=uuid4(),
+        workspace_id=uuid4(),
+        visibility=scope,
+    )
+    assert not resource_visible_in_scope(
+        resource_id=uuid4(),
+        workspace_id=None,
+        project_id=excluded_project_id,
+        visibility=scope,
+    )
+
+
+@pytest.mark.anyio
+async def test_workspace_scope_sql_matches_in_memory_for_project_nulls_and_exclusions(async_session):
+    owner_id = uuid4()
+    ordinary_project_id = uuid4()
+    excluded_project_id = uuid4()
+    explicit_workspace_id = uuid4()
+    ordinary_default_flow = Flow(name="ordinary default", folder_id=ordinary_project_id, workspace_id=None)
+    excluded_default_flow = Flow(name="excluded default", folder_id=excluded_project_id, workspace_id=None)
+    folderless_default_flow = Flow(name="folderless default", folder_id=None, workspace_id=None)
+    explicit_workspace_flow = Flow(name="workspace only", folder_id=None, workspace_id=explicit_workspace_id)
+    excluded_explicit_flow = Flow(
+        name="excluded explicit",
+        folder_id=excluded_project_id,
+        workspace_id=explicit_workspace_id,
+    )
+    async_session.add_all(
+        [
+            Folder(id=ordinary_project_id, name="Ordinary project"),
+            Folder(id=excluded_project_id, name="Reserved project", workspace_id=explicit_workspace_id),
+            ordinary_default_flow,
+            excluded_default_flow,
+            folderless_default_flow,
+            explicit_workspace_flow,
+            excluded_explicit_flow,
+        ]
+    )
+    await async_session.commit()
+
+    default_scope = ResourceVisibilityScope(
+        include_unassigned_workspace=True,
+        excluded_workspace_project_ids=(excluded_project_id,),
+    )
+    default_stmt = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == owner_id,
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=default_scope,
+    )
+    default_rows = list((await async_session.exec(default_stmt)).all())
+    assert [row.id for row in default_rows] == [ordinary_default_flow.id]
+
+    explicit_scope = ResourceVisibilityScope(
+        workspace_ids=(explicit_workspace_id,),
+        excluded_workspace_project_ids=(excluded_project_id,),
+    )
+    explicit_stmt = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == owner_id,
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=explicit_scope,
+    )
+    explicit_rows = list((await async_session.exec(explicit_stmt)).all())
+    assert [row.id for row in explicit_rows] == [explicit_workspace_flow.id]
+
+    cases = [
+        (ordinary_default_flow, default_scope, True),
+        (excluded_default_flow, default_scope, False),
+        (folderless_default_flow, default_scope, False),
+        (explicit_workspace_flow, explicit_scope, True),
+        (excluded_explicit_flow, explicit_scope, False),
+    ]
+    for flow, scope, expected in cases:
+        assert (
+            resource_visible_in_scope(
+                resource_id=flow.id,
+                workspace_id=flow.workspace_id,
+                project_id=flow.folder_id,
+                visibility=scope,
+            )
+            is expected
+        )
+
+
 def test_scope_reports_cross_user_access_without_resource_enumeration():
     assert ResourceVisibilityScope().has_cross_user_access is False
     assert ResourceVisibilityScope(all_resources=True).has_cross_user_access is True
     assert ResourceVisibilityScope(workspace_ids=(uuid4(),)).has_cross_user_access is True
+    assert ResourceVisibilityScope(include_unassigned_workspace=True).has_cross_user_access is True

--- a/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
+++ b/src/backend/tests/unit/services/authorization/test_visibility_scope_prefilter.py
@@ -104,6 +104,72 @@ def test_global_scope_does_not_emit_an_unbounded_id_list():
     assert "flow.user_id =" not in sql
 
 
+async def test_global_scope_excludes_reserved_projects_but_keeps_owner_share_and_folderless(async_session):
+    owner_id = uuid4()
+    other_owner_id = uuid4()
+    ordinary_project_id = uuid4()
+    excluded_project_id = uuid4()
+    ordinary_flow = Flow(name="ordinary", user_id=other_owner_id, folder_id=ordinary_project_id)
+    excluded_flow = Flow(name="excluded", user_id=other_owner_id, folder_id=excluded_project_id)
+    owned_excluded_flow = Flow(name="owned excluded", user_id=owner_id, folder_id=excluded_project_id)
+    shared_excluded_flow = Flow(name="shared excluded", user_id=other_owner_id, folder_id=excluded_project_id)
+    folderless_flow = Flow(name="folderless", user_id=other_owner_id, folder_id=None)
+    async_session.add_all(
+        [
+            Folder(id=ordinary_project_id, name="Ordinary project"),
+            Folder(id=excluded_project_id, name="Reserved project"),
+            ordinary_flow,
+            excluded_flow,
+            owned_excluded_flow,
+            shared_excluded_flow,
+            folderless_flow,
+        ]
+    )
+    await async_session.commit()
+
+    scope = ResourceVisibilityScope(
+        all_resources=True,
+        resource_ids=(shared_excluded_flow.id,),
+        excluded_global_project_ids=(excluded_project_id,),
+    )
+    stmt = restrict_to_owned_or_visible_scope(
+        select(Flow),
+        id_column=Flow.id,
+        owner_clause=Flow.user_id == owner_id,
+        workspace_column=Flow.workspace_id,
+        project_column=Flow.folder_id,
+        visibility=scope,
+    )
+    rows = list((await async_session.exec(stmt)).all())
+
+    assert {row.id for row in rows} == {
+        ordinary_flow.id,
+        owned_excluded_flow.id,
+        shared_excluded_flow.id,
+        folderless_flow.id,
+    }
+    assert resource_visible_in_scope(
+        resource_id=ordinary_flow.id,
+        project_id=ordinary_project_id,
+        visibility=scope,
+    )
+    assert not resource_visible_in_scope(
+        resource_id=excluded_flow.id,
+        project_id=excluded_project_id,
+        visibility=scope,
+    )
+    assert resource_visible_in_scope(
+        resource_id=shared_excluded_flow.id,
+        project_id=excluded_project_id,
+        visibility=scope,
+    )
+    assert resource_visible_in_scope(
+        resource_id=folderless_flow.id,
+        project_id=None,
+        visibility=scope,
+    )
+
+
 def test_unassigned_workspace_scope_uses_a_compact_null_predicate():
     excluded_project_id = uuid4()
     scope = ResourceVisibilityScope(

--- a/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import pytest
 from langflow.services.database.models.deployment.crud import (
     count_deployments_by_provider,
+    has_visible_deployment_for_provider,
     list_deployments_page,
 )
 from langflow.services.database.models.deployment.model import Deployment
@@ -194,6 +195,32 @@ async def test_get_provider_account_by_id_unscoped_loads_foreign_account(async_s
     # A non-existent id returns None (the helper raises no error; the route maps
     # None → 404).
     assert await get_provider_account_by_id_unscoped(async_session, provider_id=uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_provider_visibility_proof_is_bound_to_provider_and_scope(async_session: AsyncSession):
+    """An unscoped provider fetch is permitted only for a visible row under that provider."""
+    owner, provider, _owned, foreign_visible, _foreign_hidden = await _seed(async_session)
+    actor_id = uuid4()
+
+    assert await has_visible_deployment_for_provider(
+        async_session,
+        user_id=actor_id,
+        deployment_provider_account_id=provider.id,
+        visibility_scope=ResourceVisibilityScope(resource_ids=(foreign_visible.id,)),
+    )
+    assert not await has_visible_deployment_for_provider(
+        async_session,
+        user_id=actor_id,
+        deployment_provider_account_id=provider.id,
+        visibility_scope=ResourceVisibilityScope(project_ids=(uuid4(),)),
+    )
+    assert not await has_visible_deployment_for_provider(
+        async_session,
+        user_id=owner.id,
+        deployment_provider_account_id=uuid4(),
+        visibility_scope=ResourceVisibilityScope(all_resources=True),
+    )
 
 
 async def test_count_deployments_by_provider_reflects_allowed_ids(async_session: AsyncSession):

--- a/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
@@ -197,7 +197,6 @@ async def test_get_provider_account_by_id_unscoped_loads_foreign_account(async_s
     assert await get_provider_account_by_id_unscoped(async_session, provider_id=uuid4()) is None
 
 
-@pytest.mark.asyncio
 async def test_provider_visibility_proof_is_bound_to_provider_and_scope(async_session: AsyncSession):
     """An unscoped provider fetch is permitted only for a visible row under that provider."""
     owner, provider, _owned, foreign_visible, _foreign_hidden = await _seed(async_session)

--- a/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_authz_prefilter.py
@@ -286,3 +286,68 @@ async def test_structured_scope_keeps_page_and_total_consistent(async_session: A
 
     assert {deployment.id for deployment, _count, _matched in rows} == expected
     assert total == len(expected)
+
+
+async def test_default_workspace_scope_uses_authoritative_project_workspace(async_session: AsyncSession):
+    """Legacy NULL deployment workspace ids must not pull explicit-project rows into Default."""
+    actor = User(username=f"actor-{uuid4()}", password=f"hashed-{uuid4()}", is_active=True)
+    owner = User(username=f"owner-{uuid4()}", password=f"hashed-{uuid4()}", is_active=True)
+    default_project = Folder(name=f"default-{uuid4()}", user_id=owner.id, workspace_id=None)
+    explicit_workspace_id = uuid4()
+    explicit_project = Folder(name=f"explicit-{uuid4()}", user_id=owner.id, workspace_id=explicit_workspace_id)
+    provider = DeploymentProviderAccount(
+        user_id=owner.id,
+        name=f"provider-{uuid4()}",
+        provider_tenant_id=None,
+        provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
+        provider_url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
+        api_key="encrypted-api-key",  # pragma: allowlist secret
+    )
+    async_session.add_all([actor, owner, default_project, explicit_project, provider])
+    await async_session.commit()
+
+    def deployment(project: Folder) -> Deployment:
+        return Deployment(
+            user_id=owner.id,
+            workspace_id=None,
+            project_id=project.id,
+            deployment_provider_account_id=provider.id,
+            resource_key=f"rk-{uuid4()}",
+            display_name=f"dep-{uuid4()}",
+            deployment_type=DeploymentType.AGENT,
+        )
+
+    default_deployment = deployment(default_project)
+    explicit_deployment = deployment(explicit_project)
+    async_session.add_all([default_deployment, explicit_deployment])
+    await async_session.commit()
+
+    scope = ResourceVisibilityScope(include_unassigned_workspace=True)
+    rows = await list_deployments_page(
+        async_session,
+        user_id=actor.id,
+        deployment_provider_account_id=provider.id,
+        offset=0,
+        limit=20,
+        visibility_scope=scope,
+    )
+    total = await count_deployments_by_provider(
+        async_session,
+        user_id=actor.id,
+        deployment_provider_account_id=provider.id,
+        visibility_scope=scope,
+    )
+
+    assert {row.id for row, _count, _matched in rows} == {default_deployment.id}
+    assert explicit_deployment.id not in {row.id for row, _count, _matched in rows}
+    assert total == 1
+
+    explicit_rows = await list_deployments_page(
+        async_session,
+        user_id=actor.id,
+        deployment_provider_account_id=provider.id,
+        offset=0,
+        limit=20,
+        visibility_scope=ResourceVisibilityScope(workspace_ids=(explicit_workspace_id,)),
+    )
+    assert {row.id for row, _count, _matched in explicit_rows} == {explicit_deployment.id}

--- a/src/backend/tests/unit/services/database/test_orphaned_flow_assignment.py
+++ b/src/backend/tests/unit/services/database/test_orphaned_flow_assignment.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
+from langflow.services.database import service as database_service_module
+from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.folder.model import Folder
+from langflow.services.deps import get_db_service, session_scope
+from sqlmodel import select
+
+
+async def test_orphan_assignment_reserves_only_the_ownerless_starter_project(active_user, monkeypatch) -> None:
+    """A user-owned same-name project remains ordinary during orphan adoption."""
+    async with session_scope() as session:
+        system_starter = (
+            await session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME, Folder.user_id.is_(None)))
+        ).first()
+        assert system_starter is not None
+
+        user_starter = Folder(name=STARTER_FOLDER_NAME, user_id=active_user.id)
+        session.add(user_starter)
+        await session.flush()
+
+        system_flow = Flow(name=f"system-{uuid4()}", folder_id=system_starter.id, user_id=None)
+        user_project_flow = Flow(name=f"user-project-{uuid4()}", folder_id=user_starter.id, user_id=None)
+        session.add_all([system_flow, user_project_flow])
+        await session.commit()
+
+    settings = SimpleNamespace(auth_settings=SimpleNamespace(AUTO_LOGIN=True, SUPERUSER="test-superuser"))
+
+    async def get_test_superuser(_session, _username):
+        return SimpleNamespace(id=active_user.id)
+
+    monkeypatch.setattr(database_service_module, "get_settings_service", lambda: settings)
+    monkeypatch.setattr(database_service_module, "get_user_by_username", get_test_superuser)
+
+    await get_db_service().assign_orphaned_flows_to_superuser()
+
+    async with session_scope() as session:
+        reloaded_system_flow = await session.get(Flow, system_flow.id)
+        reloaded_user_project_flow = await session.get(Flow, user_project_flow.id)
+
+    assert reloaded_system_flow is not None
+    assert reloaded_system_flow.user_id is None
+    assert reloaded_user_project_flow is not None
+    assert reloaded_user_project_flow.user_id == active_user.id

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/__tests__/FlowMenu.spec.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/__tests__/FlowMenu.spec.tsx
@@ -31,10 +31,18 @@ jest.mock(
   "@/controllers/API/queries/flows/use-get-refresh-flows-query",
   () => ({ __esModule: true, useGetRefreshFlowsQuery: () => ({}) }),
 );
+let mockFolders = [
+  {
+    id: "f1",
+    name: "Folder",
+    owner_username: "current-user",
+    is_owner: true,
+  },
+];
 jest.mock("@/controllers/API/queries/folders/use-get-folders", () => ({
   __esModule: true,
   useGetFoldersQuery: () => ({
-    data: [{ id: "f1", name: "Folder" }],
+    data: mockFolders,
     isFetched: true,
   }),
 }));
@@ -128,6 +136,14 @@ jest.mock("lucide-react/dynamicIconImports", () => ({}), { virtual: true });
 describe("FlowMenu MenuBar", () => {
   beforeEach(() => {
     mockIsReadOnly = false;
+    mockFolders = [
+      {
+        id: "f1",
+        name: "Folder",
+        owner_username: "current-user",
+        is_owner: true,
+      },
+    ];
   });
 
   it("renders current folder and flow name, enables save", async () => {
@@ -141,6 +157,23 @@ describe("FlowMenu MenuBar", () => {
 
     const saveBtn = screen.getByTestId("save-flow-button");
     expect(saveBtn).not.toBeDisabled();
+  });
+
+  it("qualifies a foreign project in the breadcrumb", () => {
+    mockFolders = [
+      {
+        id: "f1",
+        name: "Starter Project",
+        owner_username: "other-user",
+        is_owner: false,
+      },
+    ];
+
+    render(<MenuBar />);
+
+    expect(
+      screen.getByRole("button", { name: "Starter Project — other-user" }),
+    ).toBeInTheDocument();
   });
 
   it("renders flow settings trigger as a named keyboard button", () => {

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -22,6 +22,7 @@ import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useShortcutsStore } from "@/stores/shortcuts";
+import { getProjectDisplayName } from "@/utils/project-display-name";
 import { swatchColors } from "@/utils/styleUtils";
 import { cn, getNumberFromString } from "@/utils/utils";
 
@@ -127,7 +128,9 @@ export const MenuBar = memo((): JSX.Element => {
                     );
                   }}
                 >
-                  <span className="truncate">{currentFolder?.name}</span>
+                  <span className="truncate">
+                    {getProjectDisplayName(currentFolder)}
+                  </span>
                 </Button>
               </div>
             )}

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -129,7 +129,7 @@ export const MenuBar = memo((): JSX.Element => {
                   }}
                 >
                   <span className="truncate">
-                    {getProjectDisplayName(currentFolder)}
+                    {getProjectDisplayName(currentFolder, t)}
                   </span>
                 </Button>
               </div>

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-create-error.test.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-create-error.test.tsx
@@ -27,8 +27,15 @@ jest.mock("@tanstack/react-query", () => ({
 jest.mock("react-i18next", () => ({
   initReactI18next: { type: "3rdParty", init: jest.fn() },
   useTranslation: () => ({
-    t: (key: string) =>
-      key === "sidebar.projectCreateError" ? "Unable to create project." : key,
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === "sidebar.projectCreateError") {
+        return "Unable to create project.";
+      }
+      if (key === "project.ownedBy") {
+        return `${options?.name} — ${options?.owner}`;
+      }
+      return key;
+    },
   }),
 }));
 
@@ -251,6 +258,8 @@ describe("project creation errors", () => {
 
     render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
 
+    expect(screen.getByTestId("sidebar-nav-own-id")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-nav-foreign-id")).toBeInTheDocument();
     const ownLabel = screen.getByText("Starter Project");
     const foreignLabel = screen.getByText("Starter Project — other-user");
     fireEvent.doubleClick(foreignLabel);

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-create-error.test.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-create-error.test.tsx
@@ -2,7 +2,21 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import SideBarFoldersButtonsComponent from "..";
 
 const mockMutateAddFolder = jest.fn();
+const mockMutateUpdateFolder = jest.fn();
 const mockSetErrorData = jest.fn();
+const mockCan = jest.fn(
+  (_projectId: string | undefined | null, _action: string) => true,
+);
+let mockFolders: Array<{
+  id: string;
+  name: string;
+  description: string;
+  parent_id: string;
+  flows: never[];
+  components: never[];
+  owner_username: string;
+  is_owner: boolean;
+}> = [];
 
 jest.mock("@tanstack/react-query", () => ({
   ...jest.requireActual("@tanstack/react-query"),
@@ -27,6 +41,19 @@ jest.mock("@/components/ui/sidebar", () => {
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   );
+  const SidebarMenuButton = ({
+    children,
+    isActive: _isActive,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isActive?: boolean;
+    size?: string;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
   return {
     Sidebar: Wrapper,
     SidebarContent: Wrapper,
@@ -35,7 +62,7 @@ jest.mock("@/components/ui/sidebar", () => {
     SidebarGroupContent: Wrapper,
     SidebarHeader: Wrapper,
     SidebarMenu: Wrapper,
-    SidebarMenuButton: Wrapper,
+    SidebarMenuButton,
     SidebarMenuItem: Wrapper,
   };
 });
@@ -44,6 +71,7 @@ jest.mock("@/contexts/permissionsContext", () => ({
   PermissionsProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+  usePermissions: () => ({ can: mockCan }),
 }));
 
 jest.mock("@/controllers/API/queries/auth", () => ({
@@ -51,7 +79,7 @@ jest.mock("@/controllers/API/queries/auth", () => ({
 }));
 
 jest.mock("@/controllers/API/queries/folders", () => ({
-  usePatchFolders: () => ({ mutate: jest.fn() }),
+  usePatchFolders: () => ({ mutate: mockMutateUpdateFolder }),
   usePostFolders: () => ({
     mutate: mockMutateAddFolder,
     isPending: false,
@@ -107,13 +135,13 @@ jest.mock("@/stores/flowsManagerStore", () => ({
 jest.mock("@/stores/foldersStore", () => ({
   useFolderStore: (
     selector: (state: {
-      folders: never[];
+      folders: typeof mockFolders;
       folderIdDragging: null;
       myCollectionId: string;
     }) => unknown,
   ) =>
     selector({
-      folders: [],
+      folders: mockFolders,
       folderIdDragging: null,
       myCollectionId: "root",
     }),
@@ -135,7 +163,27 @@ jest.mock("../components/header-buttons", () => ({
   ),
 }));
 jest.mock("../components/input-edit-folder-name", () => ({
-  InputEditFolderName: () => null,
+  InputEditFolderName: ({
+    item,
+    foldersNames,
+    handleEditFolderName,
+    handleEditNameFolder,
+  }: {
+    item: { id: string };
+    foldersNames: Record<string, string>;
+    handleEditFolderName: (
+      event: React.ChangeEvent<HTMLInputElement>,
+      folderId: string,
+    ) => void;
+    handleEditNameFolder: (item: { id: string }) => void;
+  }) => (
+    <input
+      data-testid={`input-project-${item.id}`}
+      value={foldersNames[item.id] ?? ""}
+      onChange={(event) => handleEditFolderName(event, item.id)}
+      onBlur={() => handleEditNameFolder(item)}
+    />
+  ),
 }));
 jest.mock("../components/mcp-server-notice", () => ({
   MCPServerNotice: () => null,
@@ -150,6 +198,8 @@ jest.mock("../../sidebarFolderSkeleton", () => ({
 describe("project creation errors", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCan.mockReturnValue(true);
+    mockFolders = [];
   });
 
   it("surfaces a backend permission denial in the alert UI", () => {
@@ -168,5 +218,65 @@ describe("project creation errors", () => {
       title: "Unable to create project.",
       list: ["Not enough permissions"],
     });
+  });
+
+  it("qualifies foreign duplicate names and only renames writable projects by id", () => {
+    mockFolders = [
+      {
+        id: "own-id",
+        name: "Starter Project",
+        description: "",
+        parent_id: "",
+        flows: [],
+        components: [],
+        owner_username: "current-user",
+        is_owner: true,
+      },
+      {
+        id: "foreign-id",
+        name: "Starter Project",
+        description: "",
+        parent_id: "",
+        flows: [],
+        components: [],
+        owner_username: "other-user",
+        is_owner: false,
+      },
+    ];
+
+    mockCan.mockImplementation(
+      (projectId: string | undefined | null, action: string) =>
+        action !== "write" || projectId !== "foreign-id",
+    );
+
+    render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
+
+    const ownLabel = screen.getByText("Starter Project");
+    const foreignLabel = screen.getByText("Starter Project — other-user");
+    fireEvent.doubleClick(foreignLabel);
+
+    expect(
+      screen.queryByTestId("input-project-foreign-id"),
+    ).not.toBeInTheDocument();
+    expect(mockMutateUpdateFolder).not.toHaveBeenCalled();
+
+    fireEvent.doubleClick(ownLabel);
+
+    const ownInput = screen.getByTestId("input-project-own-id");
+    expect(
+      screen.queryByTestId("input-project-foreign-id"),
+    ).not.toBeInTheDocument();
+    expect(ownInput).toHaveValue("Starter Project");
+
+    fireEvent.change(ownInput, { target: { value: "Renamed Project" } });
+    fireEvent.blur(ownInput);
+
+    expect(mockMutateUpdateFolder).toHaveBeenCalledWith(
+      {
+        data: expect.objectContaining({ name: "Renamed Project" }),
+        folderId: "own-id",
+      },
+      expect.any(Object),
+    );
   });
 });

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/input-edit-folder-name.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/input-edit-folder-name.tsx
@@ -13,10 +13,10 @@ export const InputEditFolderName = ({
 }: {
   handleEditFolderName: (
     e: React.ChangeEvent<HTMLInputElement>,
-    folderName: string,
+    folderId: string,
   ) => void;
   item: FolderType;
-  refInput: React.RefObject<HTMLInputElement>;
+  refInput: React.RefObject<HTMLInputElement | null>;
   handleKeyDownFn: (
     e: React.KeyboardEvent<HTMLInputElement>,
     folder: FolderType,
@@ -27,7 +27,7 @@ export const InputEditFolderName = ({
     folderName: string,
   ) => void;
   handleEditNameFolder: (item: FolderType) => void;
-  editFolderName: { name: string; edit: boolean };
+  editFolderName: { id: string; edit: boolean };
   foldersNames: Record<string, string>;
 }) => {
   return (
@@ -35,7 +35,7 @@ export const InputEditFolderName = ({
       <Input
         className="h-6 flex-1 text-xs focus:border-0"
         onChange={(e) => {
-          handleEditFolderName(e, item.name);
+          handleEditFolderName(e, item.id!);
         }}
         maxLength={38}
         ref={refInput}
@@ -46,7 +46,7 @@ export const InputEditFolderName = ({
         autoFocus={true}
         onBlur={(e) => {
           // fixes autofocus problem where cursor isn't present
-          if (e.relatedTarget?.id === `options-trigger-${item.name}`) {
+          if (e.relatedTarget?.id === `options-trigger-${item.id}`) {
             refInput.current?.focus();
             return;
           }
@@ -58,8 +58,8 @@ export const InputEditFolderName = ({
           }
           refInput.current?.blur();
         }}
-        value={foldersNames[item.name]}
-        id={`input-project-${item.name}`}
+        value={foldersNames[item.id!]}
+        id={`input-project-${item.id}`}
         data-testid={`input-project`}
       />
     </>

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import IconComponent from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
-import { convertTestName } from "@/components/common/storeCardComponent/utils/convert-test-name";
 import {
   Select,
   SelectContent,
@@ -33,7 +32,7 @@ export const SelectOptions = ({
   const canRename = can(item.id, "write");
   const canDownload = can(item.id, "read");
   const canDelete = can(item.id, "delete");
-  const displayName = getProjectDisplayName(item);
+  const displayName = getProjectDisplayName(item, t);
   return (
     <div>
       <Select
@@ -57,7 +56,7 @@ export const SelectOptions = ({
             variant="plain"
             className="h-6 w-6 min-h-[24px] min-w-[24px]"
             id={`options-trigger-${item.id}`}
-            data-testid={`more-options-button_${convertTestName(item?.name ?? "")}_${item.id}`}
+            data-testid={`more-options-button_${item.id}`}
             aria-label={t("folder.optionsFor", { name: displayName })}
           >
             <IconComponent

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { usePermissions } from "@/contexts/permissionsContext";
 import type { FolderType } from "@/pages/MainPage/entities";
+import { getProjectDisplayName } from "@/utils/project-display-name";
 import { cn } from "@/utils/utils";
 import { handleSelectChange } from "../helpers/handle-select-change";
 import { FolderSelectItem } from "./folder-select-item";
@@ -32,6 +33,7 @@ export const SelectOptions = ({
   const canRename = can(item.id, "write");
   const canDownload = can(item.id, "read");
   const canDelete = can(item.id, "delete");
+  const displayName = getProjectDisplayName(item);
   return (
     <div>
       <Select
@@ -54,11 +56,11 @@ export const SelectOptions = ({
           <SelectTrigger
             variant="plain"
             className="h-6 w-6 min-h-[24px] min-w-[24px]"
-            id={`options-trigger-${item.name}`}
+            id={`options-trigger-${item.id}`}
             data-testid={
               "more-options-button" + `_${convertTestName(item?.name ?? "")}`
             }
-            aria-label={t("folder.optionsFor", { name: item.name })}
+            aria-label={t("folder.optionsFor", { name: displayName })}
           >
             <IconComponent
               name={"MoreHorizontal"}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -57,9 +57,7 @@ export const SelectOptions = ({
             variant="plain"
             className="h-6 w-6 min-h-[24px] min-w-[24px]"
             id={`options-trigger-${item.id}`}
-            data-testid={
-              "more-options-button" + `_${convertTestName(item?.name ?? "")}`
-            }
+            data-testid={`more-options-button_${convertTestName(item?.name ?? "")}_${item.id}`}
             aria-label={t("folder.optionsFor", { name: displayName })}
           >
             <IconComponent

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -453,7 +453,7 @@ const SideBarFoldersButtonsComponent = ({
                                   onDragLeave={dragLeave}
                                   onDrop={(e) => onDrop(e, item.id!)}
                                   key={item.id}
-                                  data-testid={`sidebar-nav-${item.name}`}
+                                  data-testid={`sidebar-nav-${item.name}-${item.id}`}
                                   id={`sidebar-nav-${item.id}`}
                                   isActive={checkPathName(item.id!)}
                                   onClick={() => handleChangeFolder!(item.id!)}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -1,5 +1,5 @@
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
@@ -14,7 +14,10 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { PermissionsProvider } from "@/contexts/permissionsContext";
+import {
+  PermissionsProvider,
+  usePermissions,
+} from "@/contexts/permissionsContext";
 import { useUpdateUser } from "@/controllers/API/queries/auth";
 import {
   usePatchFolders,
@@ -38,6 +41,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import useAuthStore from "@/stores/authStore";
 import type { FlowType } from "@/types/flow";
 import { extractApiErrorMessages } from "@/utils/apiError";
+import { getProjectDisplayName } from "@/utils/project-display-name";
 import type { FolderType } from "../../../../../pages/MainPage/entities";
 import useAlertStore from "../../../../../stores/alertStore";
 import useFlowsManagerStore from "../../../../../stores/flowsManagerStore";
@@ -58,6 +62,17 @@ type SideBarFoldersButtonsComponentProps = {
 };
 
 type UploadedFlowFile = FlowType | { flows: FlowType[] };
+
+const ProjectRenamePermission = ({
+  projectId,
+  children,
+}: {
+  projectId: string;
+  children: (canRename: boolean) => ReactNode;
+}) => {
+  const { can } = usePermissions();
+  return children(can(projectId, "write"));
+};
 
 const SideBarFoldersButtonsComponent = ({
   handleChangeFolder,
@@ -96,9 +111,9 @@ const SideBarFoldersButtonsComponent = ({
 
   const { dragOver, dragEnter, dragLeave, onDrop } = useFileDrop(folderId);
   const uploadFlow = useUploadFlow();
-  const [foldersNames, setFoldersNames] = useState({});
+  const [foldersNames, setFoldersNames] = useState<Record<string, string>>({});
   const [editFolders, setEditFolderName] = useState(
-    folders.map((obj) => ({ name: obj.name, edit: false })) ?? [],
+    folders.map((obj) => ({ id: obj.id!, edit: false })) ?? [],
   );
 
   const isFetchingFolders = !!useIsFetching({
@@ -234,40 +249,38 @@ const SideBarFoldersButtonsComponent = ({
     );
   }
 
-  function handleEditFolderName(e, name): void {
+  function handleEditFolderName(e, folderId): void {
     const {
       target: { value },
     } = e;
     setFoldersNames((old) => ({
       ...old,
-      [name]: value,
+      [folderId]: value,
     }));
   }
 
   useEffect(() => {
     if (folders && folders.length > 0) {
-      setEditFolderName(
-        folders.map((obj) => ({ name: obj.name, edit: false })),
-      );
+      setEditFolderName(folders.map((obj) => ({ id: obj.id!, edit: false })));
     }
   }, [folders]);
 
   const handleEditNameFolder = async (item) => {
     const newEditFolders = editFolders.map((obj) => {
-      if (obj.name === item.name) {
-        return { name: item.name, edit: false };
+      if (obj.id === item.id) {
+        return { id: item.id, edit: false };
       }
-      return { name: obj.name, edit: false };
+      return { id: obj.id, edit: false };
     });
     setEditFolderName(newEditFolders);
-    if (foldersNames[item.name].trim() !== "") {
+    if (foldersNames[item.id].trim() !== "") {
       setFoldersNames((old) => ({
         ...old,
-        [item.name]: foldersNames[item.name],
+        [item.id]: foldersNames[item.id],
       }));
       const body = {
         ...item,
-        name: foldersNames[item.name],
+        name: foldersNames[item.id],
         flows: item.flows?.length > 0 ? item.flows : [],
         components: item.components?.length > 0 ? item.components : [],
       };
@@ -289,7 +302,7 @@ const SideBarFoldersButtonsComponent = ({
             setFoldersNames({});
             setEditFolderName(
               folders.map((obj) => ({
-                name: obj.name,
+                id: obj.id!,
                 edit: false,
               })),
             );
@@ -299,7 +312,7 @@ const SideBarFoldersButtonsComponent = ({
     } else {
       setFoldersNames((old) => ({
         ...old,
-        [item.name]: item.name,
+        [item.id]: item.name,
       }));
     }
   };
@@ -312,26 +325,26 @@ const SideBarFoldersButtonsComponent = ({
   };
 
   const handleSelectFolderToRename = (item) => {
-    if (!foldersNames[item.name]) {
-      setFoldersNames({ [item.name]: item.name });
+    if (!foldersNames[item.id]) {
+      setFoldersNames({ [item.id]: item.name });
     }
 
-    if (editFolders.find((obj) => obj.name === item.name)?.name) {
+    if (editFolders.some((obj) => obj.id === item.id)) {
       const newEditFolders = editFolders.map((obj) => {
-        if (obj.name === item.name) {
-          return { name: item.name, edit: true };
+        if (obj.id === item.id) {
+          return { id: item.id, edit: true };
         }
-        return { name: obj.name, edit: false };
+        return { id: obj.id, edit: false };
       });
       setEditFolderName(newEditFolders);
       takeSnapshot();
       return;
     }
 
-    setEditFolderName((old) => [...old, { name: item.name, edit: true }]);
+    setEditFolderName((old) => [...old, { id: item.id, edit: true }]);
     setFoldersNames((oldFolder) => ({
       ...oldFolder,
-      [item.name]: item.name,
+      [item.id]: item.name,
     }));
     takeSnapshot();
   };
@@ -339,16 +352,16 @@ const SideBarFoldersButtonsComponent = ({
   const handleKeyDownFn = (e, item) => {
     if (e.key === "Escape") {
       const newEditFolders = editFolders.map((obj) => {
-        if (obj.name === item.name) {
-          return { name: item.name, edit: false };
+        if (obj.id === item.id) {
+          return { id: item.id, edit: false };
         }
-        return { name: obj.name, edit: false };
+        return { id: obj.id, edit: false };
       });
       setEditFolderName(newEditFolders);
       setFoldersNames({});
       setEditFolderName(
         folders.map((obj) => ({
-          name: obj.name,
+          id: obj.id!,
           edit: false,
         })),
       );
@@ -419,69 +432,71 @@ const SideBarFoldersButtonsComponent = ({
                       {t("sidebar.emptyMessage")}
                     </div>
                   ) : (
-                    folders.map((item, index) => {
+                    folders.map((item) => {
                       const editFolderName = editFolders?.filter(
-                        (folder) => folder.name === item.name,
+                        (folder) => folder.id === item.id,
                       )[0];
                       return (
                         <SidebarMenuItem
-                          key={index}
+                          key={item.id}
                           className="group/menu-button"
                           onMouseEnter={() => setHoveredFolderId(item.id!)}
                           onMouseLeave={() => setHoveredFolderId(null)}
                         >
                           <div className="relative flex w-full">
-                            <SidebarMenuButton
-                              size="md"
-                              onDragOver={(e) => dragOver(e, item.id!)}
-                              onDragEnter={(e) => dragEnter(e, item.id!)}
-                              onDragLeave={dragLeave}
-                              onDrop={(e) => onDrop(e, item.id!)}
-                              key={item.id}
-                              data-testid={`sidebar-nav-${item.name}`}
-                              id={`sidebar-nav-${item.name}`}
-                              isActive={checkPathName(item.id!)}
-                              onClick={() => handleChangeFolder!(item.id!)}
-                              className={cn(
-                                "flex-grow pr-8",
-                                hoveredFolderId === item.id && "bg-accent",
-                                checkHoveringFolder(item.id!),
-                              )}
-                            >
-                              <div
-                                onDoubleClick={(event) => {
-                                  handleDoubleClick(event, item);
-                                }}
-                                className="flex w-full items-center justify-between gap-2"
-                              >
-                                <div className="flex flex-1 items-center gap-2">
-                                  {editFolderName?.edit && !isUpdatingFolder ? (
-                                    <InputEditFolderName
-                                      handleEditFolderName={
-                                        handleEditFolderName
-                                      }
-                                      item={item}
-                                      refInput={refInput}
-                                      handleKeyDownFn={handleKeyDownFn}
-                                      handleEditNameFolder={
-                                        handleEditNameFolder
-                                      }
-                                      editFolderName={editFolderName}
-                                      foldersNames={foldersNames}
-                                      handleKeyDown={handleKeyDown}
-                                    />
-                                  ) : (
-                                    <span className="block w-0 grow truncate text-sm opacity-100">
-                                      {item.name}
-                                    </span>
+                            <ProjectRenamePermission projectId={item.id!}>
+                              {(canRename) => (
+                                <SidebarMenuButton
+                                  size="md"
+                                  onDragOver={(e) => dragOver(e, item.id!)}
+                                  onDragEnter={(e) => dragEnter(e, item.id!)}
+                                  onDragLeave={dragLeave}
+                                  onDrop={(e) => onDrop(e, item.id!)}
+                                  key={item.id}
+                                  data-testid={`sidebar-nav-${item.name}`}
+                                  id={`sidebar-nav-${item.id}`}
+                                  isActive={checkPathName(item.id!)}
+                                  onClick={() => handleChangeFolder!(item.id!)}
+                                  onDoubleClick={(event) => {
+                                    if (canRename) {
+                                      handleDoubleClick(event, item);
+                                    }
+                                  }}
+                                  className={cn(
+                                    "flex-grow pr-8",
+                                    hoveredFolderId === item.id && "bg-accent",
+                                    checkHoveringFolder(item.id!),
                                   )}
-                                </div>
-                              </div>
-                            </SidebarMenuButton>
-                            <div
-                              className="absolute right-2 top-[0.45rem] flex items-center hover:text-foreground"
-                              onClick={(e) => e.stopPropagation()}
-                            >
+                                >
+                                  <div className="flex w-full items-center justify-between gap-2">
+                                    <div className="flex flex-1 items-center gap-2">
+                                      {editFolderName?.edit &&
+                                      !isUpdatingFolder ? (
+                                        <InputEditFolderName
+                                          handleEditFolderName={
+                                            handleEditFolderName
+                                          }
+                                          item={item}
+                                          refInput={refInput}
+                                          handleKeyDownFn={handleKeyDownFn}
+                                          handleEditNameFolder={
+                                            handleEditNameFolder
+                                          }
+                                          editFolderName={editFolderName}
+                                          foldersNames={foldersNames}
+                                          handleKeyDown={handleKeyDown}
+                                        />
+                                      ) : (
+                                        <span className="block w-0 grow truncate text-sm opacity-100">
+                                          {getProjectDisplayName(item)}
+                                        </span>
+                                      )}
+                                    </div>
+                                  </div>
+                                </SidebarMenuButton>
+                              )}
+                            </ProjectRenamePermission>
+                            <div className="absolute right-2 top-[0.45rem] flex items-center hover:text-foreground">
                               <SelectOptions
                                 item={item}
                                 handleDeleteFolder={handleDeleteFolder}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -440,6 +440,7 @@ const SideBarFoldersButtonsComponent = ({
                         <SidebarMenuItem
                           key={item.id}
                           className="group/menu-button"
+                          data-project-id={item.id}
                           onMouseEnter={() => setHoveredFolderId(item.id!)}
                           onMouseLeave={() => setHoveredFolderId(null)}
                         >
@@ -453,7 +454,7 @@ const SideBarFoldersButtonsComponent = ({
                                   onDragLeave={dragLeave}
                                   onDrop={(e) => onDrop(e, item.id!)}
                                   key={item.id}
-                                  data-testid={`sidebar-nav-${item.name}-${item.id}`}
+                                  data-testid={`sidebar-nav-${item.id}`}
                                   id={`sidebar-nav-${item.id}`}
                                   isActive={checkPathName(item.id!)}
                                   onClick={() => handleChangeFolder!(item.id!)}
@@ -488,7 +489,7 @@ const SideBarFoldersButtonsComponent = ({
                                         />
                                       ) : (
                                         <span className="block w-0 grow truncate text-sm opacity-100">
-                                          {getProjectDisplayName(item)}
+                                          {getProjectDisplayName(item, t)}
                                         </span>
                                       )}
                                     </div>

--- a/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
@@ -1,15 +1,16 @@
-import type { FolderType } from "@/pages/MainPage/entities";
+import type { ProjectListType } from "@/pages/MainPage/entities";
 import useAuthStore from "@/stores/authStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import type { useQueryFunctionType } from "@/types/api";
+import { getDefaultProjectId } from "@/utils/project-display-name";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export const useGetFoldersQuery: useQueryFunctionType<
   undefined,
-  FolderType[]
+  ProjectListType[]
 > = (options) => {
   const { query } = UseRequestProcessor();
 
@@ -18,13 +19,11 @@ export const useGetFoldersQuery: useQueryFunctionType<
   const defaultFolderName = useUtilityStore((state) => state.defaultFolderName);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  const getFoldersFn = async (): Promise<FolderType[]> => {
-    const res = await api.get(`${getURL("PROJECTS")}/`);
+  const getFoldersFn = async (): Promise<ProjectListType[]> => {
+    const res = await api.get<ProjectListType[]>(`${getURL("PROJECTS")}/`);
     const data = res.data;
 
-    // Find default folder by name, or fall back to first folder if not found
-    const myCollectionId =
-      data?.find((f) => f.name === defaultFolderName)?.id ?? data?.[0]?.id;
+    const myCollectionId = getDefaultProjectId(data, defaultFolderName);
     setMyCollectionId(myCollectionId);
     setFolders(data);
 

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "Das Projekt wurde erfolgreich gelöscht.",
   "project.errorDeleting": "Fehler beim Löschen des Projekts.",
   "project.newName": "Neues Projekt",
+  "project.ownedBy": "{{name}} — {{owner}}",
   "project.starterName": "Einsteigerprojekt",
   "settings.addNewKey": "Neu hinzufügen",
   "settings.apiKeys.columnCreated": "Erstellungsdatum",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -716,6 +716,7 @@
   "project.deletedSuccessfully": "Project deleted successfully.",
   "project.errorDeleting": "Error deleting project.",
   "project.newName": "New Project",
+  "project.ownedBy": "{{name}} — {{owner}}",
   "project.starterName": "Starter Project",
   "fileManager.selectFiles": "Select files",
   "fileManager.selectFile": "Select file",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "El proyecto se ha eliminado correctamente.",
   "project.errorDeleting": "Error al eliminar el proyecto.",
   "project.newName": "Nuevo proyecto",
+  "project.ownedBy": "{{name}} — {{owner}}",
   "project.starterName": "Proyecto de inicio",
   "settings.addNewKey": "Añadir nuevo",
   "settings.apiKeys.columnCreated": "Creado",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "Le projet a été supprimé avec succès.",
   "project.errorDeleting": "Erreur lors de la suppression du projet.",
   "project.newName": "Nouveau projet",
+  "project.ownedBy": "{{name}} — {{owner}}",
   "project.starterName": "Projet de démarrage",
   "settings.addNewKey": "Ajouter un nouvel élément",
   "settings.apiKeys.columnCreated": "Date de création",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "プロジェクトが正常に削除されました。",
   "project.errorDeleting": "プロジェクトの削除に失敗しました。",
   "project.newName": "新規プロジェクト",
+  "project.ownedBy": "{{owner}} の {{name}}",
   "project.starterName": "入門プロジェクト",
   "settings.addNewKey": "新規の追加",
   "settings.apiKeys.columnCreated": "作成済み",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "O projeto foi excluído com sucesso.",
   "project.errorDeleting": "Erro ao excluir o projeto.",
   "project.newName": "Novo projeto",
+  "project.ownedBy": "{{name}} — {{owner}}",
   "project.starterName": "Projeto Inicial",
   "settings.addNewKey": "Incluir novo",
   "settings.apiKeys.columnCreated": "Criado em",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1706,6 +1706,7 @@
   "project.deletedSuccessfully": "项目已成功删除。",
   "project.errorDeleting": "删除项目时发生错误。",
   "project.newName": "新建项目",
+  "project.ownedBy": "{{owner}} 的 {{name}}",
   "project.starterName": "入门项目",
   "settings.addNewKey": "添加新项",
   "settings.apiKeys.columnCreated": "创建时间",

--- a/src/frontend/src/pages/MainPage/entities/index.tsx
+++ b/src/frontend/src/pages/MainPage/entities/index.tsx
@@ -7,6 +7,14 @@ export type FolderType = {
   parent_id: string;
   flows: FlowType[];
   components: string[];
+  owner_username?: string | null;
+  is_owner?: boolean;
+};
+
+export type ProjectListType = FolderType & {
+  id: string;
+  owner_username: string | null;
+  is_owner: boolean;
 };
 
 export type PaginatedFolderType = {

--- a/src/frontend/src/pages/MainPage/pages/homePage/__tests__/project-owner-label.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/__tests__/project-owner-label.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import HomePage from "..";
+
+const mockFolders = [
+  {
+    id: "foreign-id",
+    name: "Starter Project",
+    description: "",
+    parent_id: "",
+    flows: [],
+    components: [],
+    owner_username: "other-user",
+    is_owner: false,
+  },
+  {
+    id: "own-id",
+    name: "Starter Project",
+    description: "",
+    parent_id: "",
+    flows: [],
+    components: [],
+    owner_username: "current-user",
+    is_owner: true,
+  },
+];
+const mockFlows = [];
+const mockNavigate = jest.fn();
+let mockFolderId: string | undefined = "foreign-id";
+const mockFolderQuery = {
+  data: {
+    folder: mockFolders[0],
+    flows: { items: [], page: 1, size: 12, total: 1, pages: 1 },
+  },
+  isLoading: false,
+};
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ state: undefined }),
+  useParams: () => ({ folderId: mockFolderId }),
+}));
+jest.mock("@/components/common/paginatorComponent", () => () => null);
+jest.mock("@/components/core/cardsWrapComponent", () => ({ children }) => (
+  <>{children}</>
+));
+jest.mock(
+  "@/components/core/flowBuilderWelcome/hooks/use-start-new-flow",
+  () => ({ useStartNewFlow: () => jest.fn() }),
+);
+jest.mock("@/constants/constants", () => ({ IS_MAC: false }));
+jest.mock("@/contexts/permissionsContext", () => ({
+  PermissionsProvider: ({ children }) => <>{children}</>,
+}));
+jest.mock("@/controllers/API/queries/folders/use-get-folder", () => ({
+  useGetFolderQuery: () => mockFolderQuery,
+}));
+jest.mock("@/customization/components/custom-banner", () => ({
+  CustomBanner: () => null,
+}));
+jest.mock("@/customization/components/custom-McpServerTab", () => ({
+  CustomMcpServerTab: ({ folderName }) => (
+    <div data-testid="mcp-project-name">{folderName}</div>
+  ),
+}));
+jest.mock("@/customization/feature-flags", () => ({
+  ENABLE_DATASTAX_LANGFLOW: false,
+  ENABLE_MCP: true,
+}));
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => mockNavigate,
+}));
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector) => selector({ flows: mockFlows }),
+}));
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: (selector) =>
+    selector({ myCollectionId: "own-id", folders: mockFolders }),
+}));
+jest.mock("@/pages/MainPage/components/header", () => ({ folderName }) => (
+  <div data-testid="header-project-name">{folderName}</div>
+));
+jest.mock("@/pages/MainPage/components/list", () => () => null);
+jest.mock("@/pages/MainPage/components/listSkeleton", () => () => null);
+jest.mock("@/pages/MainPage/components/modalsComponent", () => () => null);
+jest.mock("@/pages/MainPage/hooks/use-on-file-drop", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/deployments-page",
+  () => () => null,
+);
+jest.mock("@/pages/MainPage/pages/emptyFolder", () => () => null);
+
+describe("HomePage project names", () => {
+  beforeEach(() => {
+    mockFolderId = "foreign-id";
+  });
+
+  it("qualifies the visible header while preserving the canonical MCP name", async () => {
+    render(<HomePage type="mcp" />);
+
+    expect(screen.getByTestId("header-project-name")).toHaveTextContent(
+      "Starter Project — other-user",
+    );
+    expect(await screen.findByTestId("mcp-project-name")).toHaveTextContent(
+      "Starter Project",
+    );
+  });
+
+  it("uses the caller-owned collection name when the default route has no folder id", () => {
+    mockFolderId = undefined;
+
+    render(<HomePage type="flows" />);
+
+    expect(screen.getByTestId("header-project-name")).toHaveTextContent(
+      "Starter Project",
+    );
+    expect(screen.getByTestId("header-project-name")).not.toHaveTextContent(
+      "other-user",
+    );
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/homePage/__tests__/project-owner-label.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/__tests__/project-owner-label.test.tsx
@@ -35,7 +35,10 @@ const mockFolderQuery = {
 };
 
 jest.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) =>
+      key === "project.ownedBy" ? `${options?.name} — ${options?.owner}` : key,
+  }),
 }));
 jest.mock("react-router-dom", () => ({
   useLocation: () => ({ state: undefined }),

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
+import { getProjectDisplayName } from "@/utils/project-display-name";
 import HeaderComponent from "../../components/header";
 import ListComponent from "../../components/list";
 import ListSkeleton from "../../components/listSkeleton";
@@ -48,10 +49,13 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   );
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
   const folders = useFolderStore((state) => state.folders);
-  const folderName =
-    folders.find((folder) => folder.id === folderId)?.name ??
-    folders[0]?.name ??
-    "";
+  const currentFolderId = folderId ?? myCollectionId;
+  const currentFolder =
+    folders.find((folder) => folder.id === currentFolderId) ?? folders[0];
+  const folderName = currentFolder?.name ?? "";
+  const folderDisplayName = currentFolder
+    ? getProjectDisplayName(currentFolder)
+    : "";
   const flows = useFlowsManagerStore((state) => state.flows);
   // The primary "New Flow" handler — creates an empty flow, primes the
   // welcome overlay store, and navigates to the canvas. Replaces the old
@@ -308,7 +312,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
             >
               <div className="flex h-full flex-col justify-start">
                 <HeaderComponent
-                  folderName={folderName}
+                  folderName={folderDisplayName}
                   flowType={flowType}
                   setFlowType={setFlowType}
                   view={view}

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -54,7 +54,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
     folders.find((folder) => folder.id === currentFolderId) ?? folders[0];
   const folderName = currentFolder?.name ?? "";
   const folderDisplayName = currentFolder
-    ? getProjectDisplayName(currentFolder)
+    ? getProjectDisplayName(currentFolder, t)
     : "";
   const flows = useFlowsManagerStore((state) => state.flows);
   // The primary "New Flow" handler — creates an empty flow, primes the

--- a/src/frontend/src/types/zustand/folders/index.ts
+++ b/src/frontend/src/types/zustand/folders/index.ts
@@ -1,8 +1,8 @@
 import type { FolderType } from "../../../pages/MainPage/entities";
 
 export type FoldersStoreType = {
-  myCollectionId: string | null;
-  setMyCollectionId: (value: string) => void;
+  myCollectionId: string | null | undefined;
+  setMyCollectionId: (value: string | undefined) => void;
   folderToEdit: FolderType | null;
   setFolderToEdit: (folder: FolderType | null) => void;
   folderDragging: boolean;

--- a/src/frontend/src/utils/__tests__/project-display-name.test.ts
+++ b/src/frontend/src/utils/__tests__/project-display-name.test.ts
@@ -18,31 +18,40 @@ const project = (
   ...overrides,
 });
 
+const t = (key: string, options?: Record<string, unknown>) => {
+  if (key === "project.ownedBy") {
+    return `${options?.name} — ${options?.owner}`;
+  }
+  return key;
+};
+
 describe("getProjectDisplayName", () => {
   it("keeps an owned project's canonical name", () => {
-    expect(getProjectDisplayName(project())).toBe("Starter Project");
+    expect(getProjectDisplayName(project(), t)).toBe("Starter Project");
   });
 
   it("qualifies a foreign project with its owner's username", () => {
     expect(
       getProjectDisplayName(
         project({ is_owner: false, owner_username: "other-user" }),
+        t,
       ),
     ).toBe("Starter Project — other-user");
   });
 
-  it("falls back to the project id when owner metadata is missing", () => {
+  it("keeps the canonical name when owner metadata is missing", () => {
     expect(
       getProjectDisplayName(
         project({ is_owner: false, owner_username: null, id: "foreign-id" }),
+        t,
       ),
-    ).toBe("Starter Project — foreign-id");
+    ).toBe("Starter Project");
   });
 });
 
 describe("getDefaultProjectId", () => {
-  it("returns an empty id when no projects are visible", () => {
-    expect(getDefaultProjectId([], "Starter Project")).toBe("");
+  it("returns undefined when no projects are visible", () => {
+    expect(getDefaultProjectId([], "Starter Project")).toBeUndefined();
   });
 
   it("selects the caller-owned default when a foreign duplicate comes first", () => {
@@ -72,6 +81,17 @@ describe("getDefaultProjectId", () => {
 
     expect(getDefaultProjectId(projects, "Starter Project")).toBe(
       "own-project",
+    );
+  });
+
+  it("preserves name-based default selection when ownership metadata is absent", () => {
+    const projects = [
+      project({ id: "first-project", name: "My Project", is_owner: undefined }),
+      project({ id: "default-project", is_owner: undefined }),
+    ];
+
+    expect(getDefaultProjectId(projects, "Starter Project")).toBe(
+      "default-project",
     );
   });
 });

--- a/src/frontend/src/utils/__tests__/project-display-name.test.ts
+++ b/src/frontend/src/utils/__tests__/project-display-name.test.ts
@@ -1,0 +1,73 @@
+import type { ProjectListType } from "@/pages/MainPage/entities";
+import {
+  getDefaultProjectId,
+  getProjectDisplayName,
+} from "../project-display-name";
+
+const project = (
+  overrides: Partial<ProjectListType> = {},
+): ProjectListType => ({
+  id: "project-id",
+  name: "Starter Project",
+  description: "",
+  parent_id: "",
+  flows: [],
+  components: [],
+  owner_username: "current-user",
+  is_owner: true,
+  ...overrides,
+});
+
+describe("getProjectDisplayName", () => {
+  it("keeps an owned project's canonical name", () => {
+    expect(getProjectDisplayName(project())).toBe("Starter Project");
+  });
+
+  it("qualifies a foreign project with its owner's username", () => {
+    expect(
+      getProjectDisplayName(
+        project({ is_owner: false, owner_username: "other-user" }),
+      ),
+    ).toBe("Starter Project — other-user");
+  });
+
+  it("falls back to the project id when owner metadata is missing", () => {
+    expect(
+      getProjectDisplayName(
+        project({ is_owner: false, owner_username: null, id: "foreign-id" }),
+      ),
+    ).toBe("Starter Project — foreign-id");
+  });
+});
+
+describe("getDefaultProjectId", () => {
+  it("selects the caller-owned default when a foreign duplicate comes first", () => {
+    const projects = [
+      project({
+        id: "foreign-default",
+        is_owner: false,
+        owner_username: "other-user",
+      }),
+      project({ id: "own-default" }),
+    ];
+
+    expect(getDefaultProjectId(projects, "Starter Project")).toBe(
+      "own-default",
+    );
+  });
+
+  it("falls back to another owned project before a visible foreign project", () => {
+    const projects = [
+      project({
+        id: "foreign-default",
+        is_owner: false,
+        owner_username: "other-user",
+      }),
+      project({ id: "own-project", name: "My Project" }),
+    ];
+
+    expect(getDefaultProjectId(projects, "Starter Project")).toBe(
+      "own-project",
+    );
+  });
+});

--- a/src/frontend/src/utils/__tests__/project-display-name.test.ts
+++ b/src/frontend/src/utils/__tests__/project-display-name.test.ts
@@ -41,6 +41,10 @@ describe("getProjectDisplayName", () => {
 });
 
 describe("getDefaultProjectId", () => {
+  it("returns an empty id when no projects are visible", () => {
+    expect(getDefaultProjectId([], "Starter Project")).toBe("");
+  });
+
   it("selects the caller-owned default when a foreign duplicate comes first", () => {
     const projects = [
       project({

--- a/src/frontend/src/utils/project-display-name.ts
+++ b/src/frontend/src/utils/project-display-name.ts
@@ -1,26 +1,34 @@
 import type { FolderType, ProjectListType } from "@/pages/MainPage/entities";
 
+type ProjectNameTranslator = (
+  key: "project.ownedBy",
+  options: { name: string; owner: string },
+) => string;
+
 export const getProjectDisplayName = (
   project: Pick<FolderType, "id" | "name" | "owner_username" | "is_owner">,
+  t: ProjectNameTranslator,
 ): string => {
-  if (project.is_owner !== false) {
+  if (project.is_owner !== false || !project.owner_username) {
     return project.name;
   }
 
-  return `${project.name} — ${project.owner_username ?? project.id ?? "unknown owner"}`;
+  return t("project.ownedBy", {
+    name: project.name,
+    owner: project.owner_username,
+  });
 };
 
 export const getDefaultProjectId = (
   projects: ProjectListType[],
   defaultProjectName: string,
-): string => {
+): string | undefined => {
   return (
-    (
-      projects.find(
-        (project) => project.is_owner && project.name === defaultProjectName,
-      ) ??
-      projects.find((project) => project.is_owner) ??
-      projects[0]
-    )?.id ?? ""
-  );
+    projects.find(
+      (project) => project.is_owner && project.name === defaultProjectName,
+    ) ??
+    projects.find((project) => project.is_owner) ??
+    projects.find((project) => project.name === defaultProjectName) ??
+    projects[0]
+  )?.id;
 };

--- a/src/frontend/src/utils/project-display-name.ts
+++ b/src/frontend/src/utils/project-display-name.ts
@@ -1,0 +1,26 @@
+import type { FolderType, ProjectListType } from "@/pages/MainPage/entities";
+
+export const getProjectDisplayName = (
+  project: Pick<FolderType, "id" | "name" | "owner_username" | "is_owner">,
+): string => {
+  if (project.is_owner !== false) {
+    return project.name;
+  }
+
+  return `${project.name} — ${project.owner_username ?? project.id ?? "unknown owner"}`;
+};
+
+export const getDefaultProjectId = (
+  projects: ProjectListType[],
+  defaultProjectName: string,
+): string => {
+  return (
+    (
+      projects.find(
+        (project) => project.is_owner && project.name === defaultProjectName,
+      ) ??
+      projects.find((project) => project.is_owner) ??
+      projects[0]
+    )?.id ?? ""
+  );
+};

--- a/src/frontend/tests/core/features/folder-deletion-integrity.spec.ts
+++ b/src/frontend/tests/core/features/folder-deletion-integrity.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
 import { TEXTS } from "../../utils/constants/texts";
+import {
+  getSidebarProjectButton,
+  getSidebarProjectOptionsButton,
+  getSidebarProjectRows,
+} from "../../utils/project-sidebar";
 
 /**
  * Tests for folder deletion integrity
@@ -63,17 +68,18 @@ test(
     });
 
     // Verify the folder exists in the sidebar
-    const folderBeforeDelete = page.getByTestId(
-      "sidebar-nav-test-folder-to-delete",
+    const folderBeforeDelete = getSidebarProjectButton(
+      page,
+      "test-folder-to-delete",
     );
     await expect(folderBeforeDelete).toBeVisible({ timeout: 5000 });
 
     // Delete the folder
     await folderBeforeDelete.hover();
-    await page
-      .getByTestId("more-options-button_test-folder-to-delete")
-      .waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("more-options-button_test-folder-to-delete").click();
+    await getSidebarProjectOptionsButton(page, "test-folder-to-delete").waitFor(
+      { state: "visible", timeout: 5000 },
+    );
+    await getSidebarProjectOptionsButton(page, "test-folder-to-delete").click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
 
@@ -83,9 +89,7 @@ test(
     });
 
     // Verify the folder is removed from the sidebar immediately (no stale data)
-    await expect(
-      page.getByTestId("sidebar-nav-test-folder-to-delete"),
-    ).not.toBeVisible({ timeout: 5000 });
+    await expect(folderBeforeDelete).not.toBeVisible({ timeout: 5000 });
 
     // Verify the page is still functional by checking for the add project button
     await expect(page.getByTestId("add-project-button")).toBeVisible({
@@ -168,20 +172,21 @@ test(
     });
 
     // Verify both folders exist
-    await expect(page.getByTestId("sidebar-nav-folder-alpha")).toBeVisible({
+    await expect(getSidebarProjectButton(page, "folder-alpha")).toBeVisible({
       timeout: 5000,
     });
-    await expect(page.getByTestId("sidebar-nav-folder-beta")).toBeVisible({
+    await expect(getSidebarProjectButton(page, "folder-beta")).toBeVisible({
       timeout: 5000,
     });
 
     // Delete the first folder
-    const folderAlpha = page.getByTestId("sidebar-nav-folder-alpha");
+    const folderAlpha = getSidebarProjectButton(page, "folder-alpha");
     await folderAlpha.hover();
-    await page
-      .getByTestId("more-options-button_folder-alpha")
-      .waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("more-options-button_folder-alpha").click();
+    await getSidebarProjectOptionsButton(page, "folder-alpha").waitFor({
+      state: "visible",
+      timeout: 5000,
+    });
+    await getSidebarProjectOptionsButton(page, "folder-alpha").click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
 
@@ -191,12 +196,12 @@ test(
     });
 
     // Verify folder-alpha is removed
-    await expect(page.getByTestId("sidebar-nav-folder-alpha")).not.toBeVisible({
+    await expect(folderAlpha).not.toBeVisible({
       timeout: 5000,
     });
 
     // Verify folder-beta still exists and is accessible
-    const folderBeta = page.getByTestId("sidebar-nav-folder-beta");
+    const folderBeta = getSidebarProjectButton(page, "folder-beta");
     await expect(folderBeta).toBeVisible({ timeout: 5000 });
 
     // Click on folder-beta to ensure the app is functional
@@ -209,10 +214,11 @@ test(
 
     // Clean up - delete the remaining folder
     await folderBeta.hover();
-    await page
-      .getByTestId("more-options-button_folder-beta")
-      .waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("more-options-button_folder-beta").click();
+    await getSidebarProjectOptionsButton(page, "folder-beta").waitFor({
+      state: "visible",
+      timeout: 5000,
+    });
+    await getSidebarProjectOptionsButton(page, "folder-beta").click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
 
@@ -271,12 +277,13 @@ test(
     });
 
     // Delete the folder
-    const folderOne = page.getByTestId("sidebar-nav-folder-one");
+    const folderOne = getSidebarProjectButton(page, "folder-one");
     await folderOne.hover();
-    await page
-      .getByTestId("more-options-button_folder-one")
-      .waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("more-options-button_folder-one").click();
+    await getSidebarProjectOptionsButton(page, "folder-one").waitFor({
+      state: "visible",
+      timeout: 5000,
+    });
+    await getSidebarProjectOptionsButton(page, "folder-one").click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
 
@@ -285,7 +292,7 @@ test(
     });
 
     // Verify folder is deleted
-    await expect(page.getByTestId("sidebar-nav-folder-one")).not.toBeVisible({
+    await expect(folderOne).not.toBeVisible({
       timeout: 5000,
     });
 
@@ -315,15 +322,16 @@ test(
       timeout: 30000,
     });
 
-    const folderTwo = page.getByTestId("sidebar-nav-folder-two");
+    const folderTwo = getSidebarProjectButton(page, "folder-two");
     await expect(folderTwo).toBeVisible({ timeout: 5000 });
 
     // Clean up
     await folderTwo.hover();
-    await page
-      .getByTestId("more-options-button_folder-two")
-      .waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("more-options-button_folder-two").click();
+    await getSidebarProjectOptionsButton(page, "folder-two").waitFor({
+      state: "visible",
+      timeout: 5000,
+    });
+    await getSidebarProjectOptionsButton(page, "folder-two").click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
 
@@ -340,50 +348,23 @@ test(
     await awaitBootstrapTest(page, { skipModal: true });
 
     // Get all folders in the sidebar and delete them one by one
-    const projectSidebar = page.locator("[data-testid='project-sidebar']");
-
     // Delete all folders until none are left
-    let folderCount = await projectSidebar
-      .locator('[data-testid^="sidebar-nav-"]')
-      .filter({ hasNotText: "add_note" })
-      .count();
+    let folderCount = await getSidebarProjectRows(page).count();
 
     while (folderCount > 0) {
       // Get the first folder
-      const firstFolder = projectSidebar
-        .locator('[data-testid^="sidebar-nav-"]')
-        .filter({ hasNotText: "add_note" })
-        .first();
-      const folderTestId = await firstFolder.getAttribute("data-testid");
-
-      if (!folderTestId) {
-        break;
-      }
-
-      // Extract folder name from testid (e.g., "sidebar-nav-Starter Project" -> "starter-project")
-      const folderName = folderTestId.replace("sidebar-nav-", "");
-      const kebabName = folderName.toLowerCase().replace(/\s+/g, "-");
+      const firstFolder = getSidebarProjectRows(page).first();
 
       // Hover and click more options
-      await firstFolder.hover();
+      await firstFolder.getByTestId(/^sidebar-nav-/).hover();
 
-      // Try to find and click the more options button
-      const moreOptionsButton = page.getByTestId(
-        `more-options-button_${kebabName}`,
+      const moreOptionsButton = firstFolder.getByTestId(
+        /^more-options-button_/,
       );
 
       // Wait for the button to appear after hover
-      try {
-        await moreOptionsButton.waitFor({ state: "visible", timeout: 5000 });
-        await moreOptionsButton.click();
-      } catch {
-        // Try with the original name format
-        const altMoreOptions = page
-          .locator(`[data-testid^="more-options-button_"]`)
-          .first();
-        await altMoreOptions.waitFor({ state: "visible", timeout: 5000 });
-        await altMoreOptions.click();
-      }
+      await moreOptionsButton.waitFor({ state: "visible", timeout: 5000 });
+      await moreOptionsButton.click();
 
       await page.getByTestId("btn-delete-project").click();
       await page.getByText(TEXTS.delete).last().click();
@@ -397,10 +378,7 @@ test(
       await page.waitForTimeout(500);
 
       // Recount folders
-      folderCount = await projectSidebar
-        .locator('[data-testid^="sidebar-nav-"]')
-        .filter({ hasNotText: "add_note" })
-        .count();
+      folderCount = await getSidebarProjectRows(page).count();
     }
 
     // Now create a new flow using the empty state button on main page
@@ -446,12 +424,12 @@ test(
     await page.getByTestId("icon-ChevronLeft").first().click();
 
     // Verify that a default folder ("Starter Project") was created
-    await expect(page.getByTestId("sidebar-nav-Starter Project")).toBeVisible({
+    await expect(getSidebarProjectButton(page, "Starter Project")).toBeVisible({
       timeout: 10000,
     });
 
     // Verify we can click on the folder and see the flow
-    await page.getByTestId("sidebar-nav-Starter Project").click();
+    await getSidebarProjectButton(page, "Starter Project").click();
 
     // The folder should contain our newly created flow. Templates render an
     // extra example list-card alongside the user's flow when the folder is

--- a/src/frontend/tests/core/features/folders.spec.ts
+++ b/src/frontend/tests/core/features/folders.spec.ts
@@ -2,6 +2,10 @@ import { readFileSync } from "fs";
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { TEXTS } from "../../utils/constants/texts";
+import {
+  getSidebarProjectButton,
+  getSidebarProjectOptionsButton,
+} from "../../utils/project-sidebar";
 import { renameFlow } from "../../utils/rename-flow";
 
 test(
@@ -53,13 +57,13 @@ test(
       timeout: 30000,
     });
 
-    await page.getByTestId("sidebar-nav-new project test name").last().hover();
+    await getSidebarProjectButton(page, "new project test name").last().hover();
 
-    await page
-      .getByTestId("more-options-button_new-project-test-name")
-      .waitFor({ state: "visible", timeout: 5000 });
+    await getSidebarProjectOptionsButton(page, "new project test name").waitFor(
+      { state: "visible", timeout: 5000 },
+    );
 
-    await page.getByTestId("more-options-button_new-project-test-name").click();
+    await getSidebarProjectOptionsButton(page, "new project test name").click();
 
     await page.getByTestId("btn-delete-project").click();
     await page.getByText(TEXTS.delete).last().click();
@@ -80,7 +84,8 @@ test("add a flow into a folder by drag and drop", async ({ page }) => {
 
   // Wait for the target element to be available before evaluation
 
-  await page.waitForSelector('[data-testid="sidebar-nav-Starter Project"]', {
+  await getSidebarProjectButton(page, "Starter Project").waitFor({
+    state: "visible",
     timeout: 100000,
   });
   // Create the DataTransfer and File
@@ -95,7 +100,7 @@ test("add a flow into a folder by drag and drop", async ({ page }) => {
   }, jsonContent);
 
   // Now dispatch
-  await page.getByTestId("sidebar-nav-Starter Project").dispatchEvent("drop", {
+  await getSidebarProjectButton(page, "Starter Project").dispatchEvent("drop", {
     dataTransfer,
   });
   // wait for the file to be uploaded failed with waitforselector
@@ -108,7 +113,7 @@ test("add a flow into a folder by drag and drop", async ({ page }) => {
     expect(true).toBeTruthy();
   }
 
-  await page.getByTestId("sidebar-nav-Starter Project").click();
+  await getSidebarProjectButton(page, "Starter Project").click();
 
   await page.waitForSelector("text=Getting Started:", {
     timeout: 100000,
@@ -168,11 +173,11 @@ test("change flow folder", async ({ page }) => {
   await page.getByTestId("input-project").fill(destinationProjectName);
   await page.keyboard.press("Enter");
   await expect(
-    page.getByTestId(`sidebar-nav-${destinationProjectName}`),
+    getSidebarProjectButton(page, destinationProjectName),
   ).toBeVisible({ timeout: 10000 });
 
   // Go back to the source project where the flow currently lives.
-  await page.getByTestId("sidebar-nav-Starter Project").click();
+  await getSidebarProjectButton(page, "Starter Project").click();
   await expect(
     page.getByTestId("list-card").filter({ hasText: uniqueFlowName }),
   ).toHaveCount(1, { timeout: 10000 });
@@ -184,19 +189,19 @@ test("change flow folder", async ({ page }) => {
     .getByTestId("list-card")
     .filter({ hasText: uniqueFlowName })
     .first()
-    .dragTo(page.getByTestId(`sidebar-nav-${destinationProjectName}`));
+    .dragTo(getSidebarProjectButton(page, destinationProjectName));
 
   // Click the destination folder and verify the moved flow is visible
   // WITHOUT a manual page refresh. This is the behavior that regresses
   // when the patch-flow cache invalidation is incomplete.
-  await page.getByTestId(`sidebar-nav-${destinationProjectName}`).click();
+  await getSidebarProjectButton(page, destinationProjectName).click();
 
   await expect(
     page.getByTestId("list-card").filter({ hasText: uniqueFlowName }),
   ).toHaveCount(1, { timeout: 10000 });
 
   // And the flow must NOT remain in the source project.
-  await page.getByTestId("sidebar-nav-Starter Project").click();
+  await getSidebarProjectButton(page, "Starter Project").click();
   await expect(
     page.getByTestId("list-card").filter({ hasText: uniqueFlowName }),
   ).toHaveCount(0, { timeout: 10000 });

--- a/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from "@playwright/test";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { cleanOldFolders } from "../../utils/clean-old-folders";
 import { TEXTS } from "../../utils/constants/texts";
-import { convertTestName } from "../../utils/convert-test-name";
 import { navigateSettingsPages } from "../../utils/go-to-settings";
+import {
+  getSidebarProjectButton,
+  getSidebarProjectOptionsButton,
+} from "../../utils/project-sidebar";
 
 test(
   "user must be able to see starter projects for mcp servers",
@@ -49,20 +52,17 @@ test(
 
     //rename a folder
 
-    const getFirstFolderName = convertTestName(
-      (await page
-        .getByText(TEXTS.labelNewProject)
-        .first()
-        .textContent()) as string,
-    );
+    const getFirstFolderName = (await page
+      .getByText(TEXTS.labelNewProject)
+      .first()
+      .textContent()) as string;
 
     await page
       .getByText(TEXTS.labelNewProject)
       .first()
       .hover()
       .then(async () => {
-        await page
-          .getByTestId(`more-options-button_${getFirstFolderName}`)
+        await getSidebarProjectOptionsButton(page, getFirstFolderName)
           .last()
           .click();
         await page.getByText("Rename", { exact: true }).last().click();
@@ -84,12 +84,10 @@ test(
     //delete a folder
 
     await page.getByTestId("icon-ChevronLeft").first().click();
-    await page
-      .getByTestId("sidebar-nav-renamed_project")
+    await getSidebarProjectButton(page, "renamed_project")
       .hover()
       .then(async () => {
-        await page
-          .getByTestId("more-options-button_renamed_project")
+        await getSidebarProjectOptionsButton(page, "renamed_project")
           .last()
           .click();
         await page.getByText(TEXTS.delete, { exact: true }).last().click();

--- a/src/frontend/tests/extended/regression/general-bugs-move-flow-from-folder.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-move-flow-from-folder.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { TEXTS } from "../../utils/constants/texts";
+import { getSidebarProjectButton } from "../../utils/project-sidebar";
 import { renameFlow } from "../../utils/rename-flow";
 
 test(
@@ -48,7 +49,7 @@ test(
     // Confirm we landed on the new (empty) project and the empty-state
     // UI rendered — this guarantees `useGetFolder` has actually fired
     // and cached `total: 0` for the destination.
-    await expect(page.getByTestId("sidebar-nav-New Project")).toBeVisible({
+    await expect(getSidebarProjectButton(page, "New Project")).toBeVisible({
       timeout: 10000,
     });
     await page.waitForTimeout(1000);
@@ -56,7 +57,7 @@ test(
     // Step 2: go back to the source project. The destination's query
     // becomes inactive but stays in the cache with the stale empty
     // payload.
-    await page.getByTestId("sidebar-nav-Starter Project").click();
+    await getSidebarProjectButton(page, "Starter Project").click();
     await expect(page.getByText(flowName).first()).toBeVisible({
       timeout: 10000,
     });
@@ -68,7 +69,7 @@ test(
       .getByTestId("list-card")
       .filter({ hasText: flowName })
       .first()
-      .dragTo(page.getByTestId("sidebar-nav-New Project"));
+      .dragTo(getSidebarProjectButton(page, "New Project"));
 
     // Give the PATCH request time to complete but NOT enough time for a
     // full page refresh to matter. If the fix works, the query cache
@@ -80,7 +81,7 @@ test(
     // short polling timeout — a long `waitForSelector` would mask the
     // bug by giving React Query's implicit `refetchOnMount` enough
     // runway to recover behind the scenes.
-    await page.getByTestId("sidebar-nav-New Project").click();
+    await getSidebarProjectButton(page, "New Project").click();
 
     await expect(
       page.getByTestId("list-card").filter({ hasText: flowName }).first(),

--- a/src/frontend/tests/utils/clean-old-folders.ts
+++ b/src/frontend/tests/utils/clean-old-folders.ts
@@ -1,22 +1,21 @@
 import type { Page } from "@playwright/test";
 import { TEXTS } from "../utils/constants/texts";
-import { convertTestName } from "./convert-test-name";
+import { getSidebarProjectOptionsButton } from "./project-sidebar";
 export const cleanOldFolders = async (page: Page) => {
   let numberOfFolders = await page.getByText(TEXTS.labelNewProject).count();
 
   while (numberOfFolders > 0) {
-    const getFirstFolderName = convertTestName(
-      (await page
-        .getByText(TEXTS.labelNewProject)
-        .first()
-        .textContent()) as string,
-    );
+    const getFirstFolderName = (await page
+      .getByText(TEXTS.labelNewProject)
+      .first()
+      .textContent()) as string;
 
     await page.getByText(TEXTS.labelNewProject).first().hover();
 
-    const moreOptionsBtn = page
-      .getByTestId(`more-options-button_${getFirstFolderName}`)
-      .last();
+    const moreOptionsBtn = getSidebarProjectOptionsButton(
+      page,
+      getFirstFolderName,
+    ).last();
     await moreOptionsBtn.waitFor({ state: "visible", timeout: 5000 });
     await moreOptionsBtn.click();
     await page.getByText(TEXTS.delete, { exact: true }).last().click();

--- a/src/frontend/tests/utils/project-sidebar.ts
+++ b/src/frontend/tests/utils/project-sidebar.ts
@@ -1,0 +1,24 @@
+import type { Locator, Page } from "@playwright/test";
+
+export const getSidebarProjectRows = (page: Page): Locator =>
+  page.getByTestId("project-sidebar").locator("[data-project-id]");
+
+export const getSidebarProjectRow = (
+  page: Page,
+  projectName: string,
+): Locator =>
+  getSidebarProjectRows(page).filter({
+    has: page.getByText(projectName, { exact: true }),
+  });
+
+export const getSidebarProjectButton = (
+  page: Page,
+  projectName: string,
+): Locator =>
+  getSidebarProjectRow(page, projectName).getByTestId(/^sidebar-nav-/);
+
+export const getSidebarProjectOptionsButton = (
+  page: Page,
+  projectName: string,
+): Locator =>
+  getSidebarProjectRow(page, projectName).getByTestId(/^more-options-button_/);

--- a/src/lfx/src/lfx/services/authorization/base.py
+++ b/src/lfx/src/lfx/services/authorization/base.py
@@ -169,6 +169,8 @@ class ResourceVisibilityScope:
     ``excluded_workspace_project_ids`` removes reserved projects from both
     explicit and logical workspace grants without affecting workspace-only
     resources in an explicit workspace.
+    ``excluded_global_project_ids`` removes reserved projects from a global
+    wildcard while preserving owner and concrete resource grants.
     """
 
     all_resources: bool = False
@@ -177,6 +179,7 @@ class ResourceVisibilityScope:
     project_ids: tuple[UUID, ...] = ()
     include_unassigned_workspace: bool = False
     excluded_workspace_project_ids: tuple[UUID, ...] = ()
+    excluded_global_project_ids: tuple[UUID, ...] = ()
 
     @property
     def has_cross_user_access(self) -> bool:

--- a/src/lfx/src/lfx/services/authorization/base.py
+++ b/src/lfx/src/lfx/services/authorization/base.py
@@ -161,18 +161,33 @@ class ResourceVisibilityScope:
     ``resource_ids`` represents concrete grants such as user/team shares.
     ``workspace_ids`` and ``project_ids`` represent wildcard role grants at
     those domains without expanding them to every resource UUID. A global
-    wildcard is represented by ``all_resources``.
+    wildcard is represented by ``all_resources``. Plugins that define a
+    logical, project-backed workspace for rows whose workspace column is null
+    can use ``include_unassigned_workspace`` without materializing every
+    project id. Consumers apply that flag only when a concrete project relation
+    exists; folderless resources remain outside the logical workspace.
+    ``excluded_workspace_project_ids`` removes reserved projects from both
+    explicit and logical workspace grants without affecting workspace-only
+    resources in an explicit workspace.
     """
 
     all_resources: bool = False
     resource_ids: tuple[UUID, ...] = ()
     workspace_ids: tuple[UUID, ...] = ()
     project_ids: tuple[UUID, ...] = ()
+    include_unassigned_workspace: bool = False
+    excluded_workspace_project_ids: tuple[UUID, ...] = ()
 
     @property
     def has_cross_user_access(self) -> bool:
         """Return whether the scope can widen an owner-only query."""
-        return bool(self.all_resources or self.resource_ids or self.workspace_ids or self.project_ids)
+        return bool(
+            self.all_resources
+            or self.resource_ids
+            or self.workspace_ids
+            or self.project_ids
+            or self.include_unassigned_workspace
+        )
 
 
 class BaseAuthorizationService(Service, abc.ABC):


### PR DESCRIPTION
## Summary

- Return project owner metadata from the project-list endpoint and qualify foreign project labels in the UI while preserving canonical names for mutations.
- Add a compact, project-backed visibility scope for logical workspaces whose stored `workspace_id` is null, with SQL/in-memory parity and reserved-project exclusions.
- Require provider-specific visible deployment evidence before relaxing deployment-provider account lookup, preserving UUID privacy.

## Validation

- `135 passed, 1 skipped` across project, authorization visibility/guard, and deployment prefilter/route regressions.
- `19 passed` across the four focused frontend suites.
- Ruff, Biome, pre-commit, detect-secrets, and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project listings now show owner information and identify projects you own.
  * Project names are clearer when viewing projects owned by others, including duplicate names.
  * Project selection now prioritizes your own matching project.
* **Bug Fixes**
  * Project renaming now targets the correct project and is restricted to projects you can edit.
  * Improved visibility handling for workspace and project resources.
  * Unauthorized shared deployment access is masked to prevent revealing whether a provider exists.
* **Tests**
  * Expanded coverage for project ownership, visibility, naming, and authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
