### PR TITLE
fix(security): reject ambiguous URL authorities

### DIFF
--- a/src/lfx/src/lfx/utils/ssrf_protection.py
+++ b/src/lfx/src/lfx/utils/ssrf_protection.py
@@ -368,6 +368,17 @@ def _validate_hostname_resolution(hostname: str) -> None:
         raise SSRFProtectionError(msg)
 
 
+def _validate_raw_url_authority(url: str) -> None:
+    """Reject authority forms that urllib.parse and HTTP clients interpret differently."""
+    # Requests/urllib3 treats a backslash in the authority as a path separator,
+    # while urllib.parse can treat the suffix as the hostname. Reject only the
+    # ambiguous authority form; Requests safely quotes backslashes after it.
+    raw_authority = re.split(r"[/#?]", url.partition("://")[2], maxsplit=1)[0]
+    if "\\" in raw_authority:
+        msg = "URL contains a backslash, which is not permitted"
+        raise SSRFProtectionError(msg)
+
+
 def validate_url_for_ssrf(url: str, *, warn_only: bool = False) -> None:
     """Validate a URL to prevent SSRF attacks.
 
@@ -398,6 +409,8 @@ def validate_url_for_ssrf(url: str, *, warn_only: bool = False) -> None:
         raise ValueError(msg) from e
 
     try:
+        _validate_raw_url_authority(url)
+
         # Validate scheme (raises SSRFProtectionError for any non-http/https scheme)
         _validate_url_scheme(parsed.scheme)
 
@@ -491,6 +504,7 @@ def _connector_url_has_loopback_exemption(url: str) -> bool:
     if not is_ssrf_protection_enabled():
         return False
 
+    _validate_raw_url_authority(url)
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https") or not parsed.hostname:
         msg = (
@@ -787,6 +801,8 @@ def validate_and_resolve_url(url: str) -> tuple[str, list[str]]:
         raise ValueError(msg) from e
 
     try:
+        _validate_raw_url_authority(url)
+
         # ============================================================================
         # Step 3: Validate URL scheme (raises SSRFProtectionError for any non-http/https scheme)
         # ============================================================================

--- a/src/lfx/tests/unit/utils/test_ssrf_httpx.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_httpx.py
@@ -119,6 +119,29 @@ class TestSSRFSafeHTTPX:
             ssrf_safe_httpx_get("http://169.254.169.254/latest/meta-data/", timeout=5)
         mock_get.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1\\@1.1.1.1/",
+            "http://1.1.1.1\\@127.0.0.1/",
+        ],
+    )
+    def test_ambiguous_authority_is_blocked_before_transport(self, url):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+                    "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+                },
+                clear=True,
+            ),
+            patch("httpx.Client.get") as mock_get,
+            pytest.raises(SSRFProtectionError, match="backslash"),
+        ):
+            ssrf_safe_httpx_get(url, timeout=5)
+        mock_get.assert_not_called()
+
     def test_sync_dns_pinning_prevents_rebinding_attack(self):
         call_count = 0
         connected_to_ip = None

--- a/src/lfx/tests/unit/utils/test_ssrf_protection.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_protection.py
@@ -12,6 +12,7 @@ from lfx.utils.ssrf_protection import (
     is_ip_blocked,
     is_ssrf_protection_enabled,
     resolve_hostname,
+    validate_and_resolve_url,
     validate_connector_url_for_ssrf,
     validate_database_url_for_ssrf,
     validate_git_repository_url,
@@ -305,6 +306,16 @@ class TestURLValidation:
             validate_url_for_ssrf("http://example.com", warn_only=False)
             validate_url_for_ssrf("https://example.com", warn_only=False)
             validate_url_for_ssrf("https://api.example.com/v1", warn_only=False)
+
+    def test_dns_pinning_validator_blocks_ambiguous_authority(self):
+        """The DNS-pinning validator applies the same raw-authority validation."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname") as mock_resolve,
+            pytest.raises(SSRFProtectionError, match="backslash"),
+        ):
+            validate_and_resolve_url("http://127.0.0.1\\@1.1.1.1/")
+        mock_resolve.assert_not_called()
 
     def test_direct_ip_blocking(self):
         """Test blocking of direct IP addresses."""

--- a/src/lfx/tests/unit/utils/test_ssrf_requests.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_requests.py
@@ -43,6 +43,33 @@ class TestSSRFSafeGet:
             ssrf_safe_get("http://127.0.0.1:8080/secret", timeout=5)
         mock_get.assert_not_called()
 
+    def test_backslash_authority_parser_confusion_is_blocked(self):
+        """A URL interpreted differently by stdlib and Requests is blocked before transport."""
+        with (
+            patch.dict(os.environ, {"LANGFLOW_SSRF_PROTECTION_ENABLED": "true"}),
+            patch("requests.get") as mock_get,
+            pytest.raises(SSRFProtectionError, match="backslash"),
+        ):
+            ssrf_safe_get("http://127.0.0.1\\@1.1.1.1/", timeout=5)
+        mock_get.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://feed.example.com/folder\\item",
+            "http://feed.example.com/rss?filter=folder\\item",
+        ],
+    )
+    def test_backslash_outside_authority_is_allowed(self, url):
+        """Backslashes outside the authority retain Requests' existing quoting behavior."""
+        with (
+            patch.dict(os.environ, {"LANGFLOW_SSRF_PROTECTION_ENABLED": "true"}),
+            patch("socket.getaddrinfo", side_effect=_resolve_public),
+            patch("requests.get", return_value=_response()) as mock_get,
+        ):
+            ssrf_safe_get(url, timeout=5)
+        mock_get.assert_called_once()
+
     def test_cloud_metadata_endpoint_is_blocked(self):
         """The cloud metadata endpoint is blocked before any request is made."""
         with (


### PR DESCRIPTION
## Summary
- reject ambiguous raw URL authorities before standard, DNS-pinning, or connector-exemption validation reaches an HTTP client
- preserve existing path and query quoting behavior
- cover Requests, pinned HTTPX transport, and direct DNS-pinning validation with no-network regressions

Refs LE-2140 / PVR0838739.

## Test plan
- offline SSRF utility suites: 149 passed, 2 live-DNS tests deselected
- Ruff check and format
- pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SSRF protection by rejecting URLs with ambiguous backslashes in their authority.
  - Prevents requests from being misinterpreted by different URL parsers or HTTP clients.
  - Ensures potentially unsafe URLs are blocked before DNS resolution or network requests.
  - Backslashes in URL paths and query parameters remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->