### PR TITLE
fix(security): block SQL connection target query overrides

### DIFF
--- a/src/lfx/src/lfx/utils/ssrf_protection.py
+++ b/src/lfx/src/lfx/utils/ssrf_protection.py
@@ -22,7 +22,7 @@ import functools
 import ipaddress
 import re
 import socket
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse
 
 from lfx.logging import logger
 from lfx.services.deps import get_settings_service
@@ -565,6 +565,103 @@ def validate_and_resolve_connector_url(url: str) -> tuple[str, list[str]]:
 # (e.g. sqlite:////etc/passwd, or ATTACH to read/write arbitrary server files).
 _LOCAL_FILE_DB_DIALECTS = frozenset({"sqlite", "duckdb", "access", "shell"})
 
+# SQLAlchemy merges URL query parameters into DBAPI connection arguments after
+# parsing the authority. These keys can replace the validated network target or
+# select a local transport, so tenant-controlled URLs must not supply them.
+_DATABASE_CONNECTION_TARGET_QUERY_KEYS = frozenset(
+    {
+        "addr",
+        "address",
+        "data source",
+        "dsn",
+        "failover_partner",
+        "filedsn",
+        "host",
+        "hostaddr",
+        "network address",
+        "odbc_connect",
+        "port",
+        "server",
+        "unix_socket",
+    }
+)
+
+_DATABASE_LOCAL_FILE_QUERY_KEYS = frozenset(
+    {
+        "clientcertificate",
+        "clientkey",
+        "dsn",
+        "filedsn",
+        "odbc_connect",
+        "querylogfile",
+        "savefile",
+        "servercertificate",
+        "statslogfile",
+    }
+)
+
+# ODBC drivers accept extensible connection-string attributes. Once either SSRF
+# or local-file policy is active, pass through only documented non-target,
+# non-file options; unknown attributes may be aliases defined by another driver.
+_SAFE_ODBC_QUERY_KEYS = frozenset(
+    {
+        "ansi",
+        "ansinpw",
+        "app",
+        "application name",
+        "applicationintent",
+        "authentication",
+        "autocommit",
+        "autotranslate",
+        "charset",
+        "clientcertificate",
+        "columnencryption",
+        "concatnullyieldsnull",
+        "connectretrycount",
+        "connectretryinterval",
+        "database",
+        "description",
+        "driver",
+        "encrypt",
+        "failoverpartnerspn",
+        "getdataextensions",
+        "hostnameincertificate",
+        "ipaddresspreference",
+        "keepalive",
+        "keepaliveinterval",
+        "keystoreauthentication",
+        "keystoreprincipalid",
+        "keystoresecret",
+        "language",
+        "longasmax",
+        "mars_connection",
+        "multisubnetfailover",
+        "net",
+        "network",
+        "odbc_autotranslate",
+        "pwd",
+        "querylog_on",
+        "querylogtime",
+        "quotedid",
+        "readonly",
+        "regional",
+        "replication",
+        "retryexec",
+        "serverspn",
+        "sslmode",
+        "statslog_on",
+        "timeout",
+        "transparentnetworkipresolution",
+        "trusted_connection",
+        "trustservercertificate",
+        "uid",
+        "unicode_results",
+        "usefmtonly",
+        "user",
+        "wsid",
+    }
+)
+
 
 def validate_database_url_for_ssrf(url: str, *, validate_network_host: bool = True) -> None:
     """Validate a SQLAlchemy database URL against SSRF and local-file access.
@@ -601,8 +698,8 @@ def validate_database_url_for_ssrf(url: str, *, validate_network_host: bool = Tr
         msg = f"Invalid database URL format: {e}"
         raise ValueError(msg) from e
 
-    # SQLAlchemy schemes look like "postgresql+psycopg2"; reduce to the dialect.
-    dialect = (parsed.scheme or "").lower().split("+", 1)[0]
+    # SQLAlchemy schemes look like "postgresql+psycopg2"; separate dialect and driver.
+    dialect, _separator, driver = (parsed.scheme or "").lower().partition("+")
     if dialect in _LOCAL_FILE_DB_DIALECTS:
         if file_restricted:
             msg = (
@@ -613,15 +710,53 @@ def validate_database_url_for_ssrf(url: str, *, validate_network_host: bool = Tr
         # Not restricted: local-file DBs are allowed (single-tenant default).
         return
 
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    query_keys = {key.casefold() for key, _value in query_items}
+
+    # SQLAlchemy's ODBC connector serializes arbitrary query keys directly into
+    # the connection string, and ODBC drivers may define their own aliases.
+    is_odbc = "odbc" in driver or dialect.endswith("odbc") or (dialect == "mssql" and not driver)
+
+    local_file_options = sorted(
+        {
+            key.casefold()
+            for key, value in query_items
+            if key.casefold() in _DATABASE_LOCAL_FILE_QUERY_KEYS
+            and (key.casefold() != "clientcertificate" or value.casefold().startswith("file:"))
+        }
+    )
+    if file_restricted and local_file_options:
+        keys = ", ".join(local_file_options)
+        msg = f"Database URL query key(s) {keys} can access the local filesystem and are not permitted."
+        raise SSRFProtectionError(msg)
+
+    if ssrf_on:
+        hostname = parsed.hostname
+        if not hostname:
+            # A network dialect with no host cannot be validated -> fail closed.
+            msg = "Database URL must contain a network host."
+            raise SSRFProtectionError(msg)
+
+        target_overrides = sorted(query_keys & _DATABASE_CONNECTION_TARGET_QUERY_KEYS)
+        if target_overrides:
+            keys = ", ".join(target_overrides)
+            msg = f"Database URL query key(s) {keys} cannot override the validated connection target."
+            raise SSRFProtectionError(msg)
+
+    if is_odbc and (ssrf_on or file_restricted):
+        allowed_odbc_keys = set(_SAFE_ODBC_QUERY_KEYS)
+        if not ssrf_on:
+            allowed_odbc_keys.update(_DATABASE_CONNECTION_TARGET_QUERY_KEYS)
+        if not file_restricted:
+            allowed_odbc_keys.update(_DATABASE_LOCAL_FILE_QUERY_KEYS)
+        unsupported_keys = query_keys - allowed_odbc_keys
+        if unsupported_keys:
+            msg = "Database URL contains an unsupported ODBC query key."
+            raise SSRFProtectionError(msg)
+
     # Network dialect: host SSRF validation only applies when SSRF protection is enabled.
     if not ssrf_on:
         return
-
-    hostname = parsed.hostname
-    if not hostname:
-        # A network dialect with no host cannot be validated -> fail closed.
-        msg = "Database URL must contain a network host."
-        raise SSRFProtectionError(msg)
 
     # Reuse the same allowlist + blocked-range checks as HTTP SSRF validation.
     if _validate_direct_ip_address(hostname):

--- a/src/lfx/tests/unit/utils/test_ssrf_protection.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_protection.py
@@ -3,6 +3,7 @@
 import os
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlencode
 
 import pytest
 from lfx.utils.ssrf_protection import (
@@ -38,6 +39,14 @@ def mock_ssrf_settings(*, enabled=False, allowed_hosts=None, restrict_files=Fals
         patch("lfx.utils.file_path_security.get_settings_service", return_value=mock_settings),
     ):
         yield
+
+
+def _sqlalchemy_odbc_connect_string(uri: str) -> str:
+    """Return SQLAlchemy's serialized PyODBC connection string when available."""
+    sqlalchemy = pytest.importorskip("sqlalchemy")
+    pyodbc = pytest.importorskip("sqlalchemy.dialects.mssql.pyodbc")
+    connect_args, _connect_kwargs = pyodbc.MSDialect_pyodbc().create_connect_args(sqlalchemy.engine.make_url(uri))
+    return connect_args[0]
 
 
 class TestSSRFProtectionConfiguration:
@@ -509,6 +518,159 @@ class TestDatabaseURLValidation:
         ):
             mock_resolve.return_value = ["93.184.216.34"]  # public IP
             validate_database_url_for_ssrf("postgresql://db.example.com:5432/app")
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "host=127.0.0.1",
+            "h%6fst=127.0.0.1",
+            "host=1.1.1.1&host=127.0.0.1",
+            "hostaddr=127.0.0.1",
+            "port=15432",
+            "unix_socket=%2Fvar%2Frun%2Fdatabase.sock",
+            "odbc_connect=SERVER%3D127.0.0.1",
+            "dsn=127.0.0.1%3A15432%2Fapp",
+        ],
+    )
+    def test_connection_target_query_overrides_blocked(self, query):
+        """DBAPI query options cannot replace the network target that passed validation."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+            pytest.raises(SSRFProtectionError, match="connection target"),
+        ):
+            validate_database_url_for_ssrf(f"postgresql://db.example.com:5432/app?{query}")
+
+    def test_non_target_query_options_allowed(self):
+        """Connection options that cannot redirect the target remain supported."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+        ):
+            validate_database_url_for_ssrf("postgresql://db.example.com:5432/app?sslmode=require")
+
+    @pytest.mark.parametrize("target_key", ["SERVER", "Address", "Addr", "Network+Address", "Data+Source"])
+    def test_odbc_connection_target_query_aliases_blocked(self, target_key):
+        """ODBC aliases cannot supersede the server from the validated authority."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+            pytest.raises(SSRFProtectionError, match="connection target"),
+        ):
+            validate_database_url_for_ssrf(
+                f"mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&{target_key}=127.0.0.1"
+            )
+
+    @pytest.mark.parametrize(
+        ("scheme", "query_key"),
+        [
+            ("mssql+pyodbc", "trace%3Bextra"),
+            ("mssql+aioodbc", "trace%3Dextra"),
+            ("mssql", "trace%0Aextra"),
+            ("mysql+pyodbc", "trace%00extra"),
+        ],
+    )
+    def test_odbc_connection_string_delimiters_and_controls_blocked(self, scheme, query_key):
+        """Unsafe ODBC key characters are rejected before SQLAlchemy serializes them."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+            pytest.raises(SSRFProtectionError, match="unsupported ODBC query key"),
+        ):
+            validate_database_url_for_ssrf(f"{scheme}://db.example.com/app?driver=ODBC+Driver+18&{query_key}=enabled")
+
+    def test_odbc_delimiter_key_matches_sqlalchemy_serialization(self):
+        """Regression mirrors how SQLAlchemy turns an arbitrary key into a new ODBC attribute."""
+        uri = "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&trace%3BServer=alternate.example.com=enabled"
+
+        assert ";Server=alternate.example.com=" in _sqlalchemy_odbc_connect_string(uri)
+
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+            pytest.raises(SSRFProtectionError, match="unsupported ODBC query key"),
+        ):
+            validate_database_url_for_ssrf(uri)
+
+    def test_unknown_odbc_driver_attribute_blocked(self):
+        """Driver-defined attributes are denied unless explicitly classified as safe."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            pytest.raises(SSRFProtectionError, match="unsupported ODBC query key"),
+        ):
+            validate_database_url_for_ssrf(
+                "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&VendorOption=enabled"
+            )
+
+    def test_unknown_odbc_driver_attribute_allowed_when_protections_disabled(self):
+        """The explicit OSS opt-out preserves vendor-specific ODBC attributes."""
+        with mock_ssrf_settings(enabled=False, restrict_files=False):
+            validate_database_url_for_ssrf(
+                "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&VendorOption=enabled"
+            )
+
+    def test_odbc_filedsn_target_override_blocked(self):
+        """FILEDSN is serialized as a target source and cannot bypass authority validation."""
+        uri = "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&FILEDSN=%2Ftmp%2Fconnection.dsn"
+        assert ";FILEDSN=/tmp/connection.dsn" in _sqlalchemy_odbc_connect_string(uri)
+
+        with (
+            mock_ssrf_settings(enabled=True, restrict_files=False),
+            pytest.raises(SSRFProtectionError, match="connection target"),
+        ):
+            validate_database_url_for_ssrf(uri)
+
+    def test_odbc_failover_partner_target_override_blocked(self):
+        """Failover_Partner cannot supply an alternate server target."""
+        uri = "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18&Failover_Partner=alternate.example.com"
+        assert ";Failover_Partner=alternate.example.com" in _sqlalchemy_odbc_connect_string(uri)
+
+        with (
+            mock_ssrf_settings(enabled=True, restrict_files=False),
+            pytest.raises(SSRFProtectionError, match="connection target"),
+        ):
+            validate_database_url_for_ssrf(uri)
+
+    @pytest.mark.parametrize(
+        ("query_key", "query_value"),
+        [
+            ("SAVEFILE", "/tmp/connection.dsn"),
+            ("ClientCertificate", "file:/tmp/client.pem"),
+            ("ClientKey", "file:/tmp/client.key"),
+            ("QueryLogFile", "/tmp/query.log"),
+            ("ServerCertificate", "/tmp/server.pem"),
+            ("StatsLogFile", "/tmp/stats.log"),
+        ],
+    )
+    def test_odbc_local_file_options_blocked_when_restricted(self, query_key, query_value):
+        """ODBC client-file options are blocked even when network SSRF validation is disabled."""
+        query = urlencode({"driver": "ODBC Driver 18", query_key: query_value})
+        uri = f"mssql+pyodbc://db.example.com/app?{query}"
+        assert f";{query_key}={query_value}" in _sqlalchemy_odbc_connect_string(uri)
+
+        with (
+            mock_ssrf_settings(enabled=False, restrict_files=True),
+            pytest.raises(SSRFProtectionError, match="local filesystem"),
+        ):
+            validate_database_url_for_ssrf(uri)
+
+    @pytest.mark.parametrize("certificate", ["sha1:0123456789abcdef", "subject:Langflow Client"])
+    def test_odbc_certificate_store_selectors_allowed_when_local_files_restricted(self, certificate):
+        """Non-file ClientCertificate forms do not access the local filesystem."""
+        query = urlencode({"driver": "ODBC Driver 18", "ClientCertificate": certificate})
+        with mock_ssrf_settings(enabled=False, restrict_files=True):
+            validate_database_url_for_ssrf(f"mssql+pyodbc://db.example.com/app?{query}")
+
+    def test_safe_odbc_query_options_allowed(self):
+        """Common ODBC options with safe key names remain supported."""
+        with (
+            mock_ssrf_settings(enabled=True),
+            patch("lfx.utils.ssrf_protection.resolve_hostname", return_value=["93.184.216.34"]),
+        ):
+            validate_database_url_for_ssrf(
+                "mssql+pyodbc://db.example.com/app?driver=ODBC+Driver+18"
+                "&TrustServerCertificate=yes&Application+Name=Langflow"
+            )
 
     def test_missing_host_blocked(self):
         """A non-file dialect with no host cannot be validated -> blocked (fail closed)."""


### PR DESCRIPTION
## Summary
- reject DB connection query keys that can replace the validated network target or access restricted client files
- use a strict safe-query allowlist for extensible ODBC attributes only when a protection policy is active
- preserve OSS opt-out behavior, documented non-target options, and non-file certificate-store selectors
- cover real SQLAlchemy serialization, unknown driver attributes, and disabled-policy compatibility

Refs LE-2137 / PVR0836214.

## Test plan
- offline SSRF utility suite: 155 passed, 2 live-DNS tests deselected
- database URL validation class: 44 passed
- Ruff check and format
- pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened database connection validation to prevent query parameters from bypassing network and local-file protections.
  * Improved handling of ODBC connection options, including aliases, unknown attributes, unsafe characters, and certificate settings.
  * Rejected database URLs missing a host when network protection is enabled.

* **Tests**
  * Added comprehensive coverage for database URL security validation and supported connection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->