### PR TITLE
fix(mcp): compose interpreter hardening fail-closed with unset package allowlist

### DIFF
--- a/src/lfx/src/lfx/base/mcp/source_policy.py
+++ b/src/lfx/src/lfx/base/mcp/source_policy.py
@@ -733,6 +733,14 @@ def validate_mcp_stdio_source_policy(
         else interpreter_hardening
     )
 
+    if use_interpreter_hardening and configured_packages is None:
+        # Interpreter hardening is documented as restricting tenants to
+        # operator-approved packages, but an unset package list leaves the
+        # uvx/npx lane open to ANY registry package -- arbitrary code
+        # execution with the hardening switch on. Compose fail-closed:
+        # deny all packages unless the operator explicitly lists them.
+        configured_packages = frozenset()
+
     _validate_interpreter_invocation(base_command, combined_args, hardened=use_interpreter_hardening)
     if base_command == "uvx":
         _validate_uvx_args(combined_args)

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -309,12 +309,26 @@ def test_interpreter_hardening_preserves_authenticated_agentic_module():
     )
 
 
-def test_interpreter_hardening_denies_all_packages_when_allowlist_unset():
+def test_interpreter_hardening_denies_all_packages_when_allowlist_unset(monkeypatch):
     # Hardening on + no explicit package list must compose fail-closed:
     # uvx with an arbitrary registry package is arbitrary code execution.
-    with pytest.raises(ValueError, match=r"not allowed"):
+    # Patch the setting read so the unset case is deterministic regardless of
+    # LANGFLOW_MCP_SERVER_ALLOWED_PACKAGES in the environment.
+    monkeypatch.setattr("lfx.base.mcp.source_policy._configured_allowed_packages", lambda: None)
+    with pytest.raises(ValueError, match=r"Package 'mcp-proxy' is not allowed for MCP uvx"):
         validate_mcp_stdio_source_policy(
             "uvx",
+            ["mcp-proxy"],
+            interpreter_hardening=True,
+            allowed_packages=None,
+        )
+
+
+def test_interpreter_hardening_denies_npx_when_allowlist_unset(monkeypatch):
+    monkeypatch.setattr("lfx.base.mcp.source_policy._configured_allowed_packages", lambda: None)
+    with pytest.raises(ValueError, match=r"Package 'mcp-proxy' is not allowed for MCP npx"):
+        validate_mcp_stdio_source_policy(
+            "npx",
             ["mcp-proxy"],
             interpreter_hardening=True,
             allowed_packages=None,
@@ -328,9 +342,16 @@ def test_interpreter_hardening_permits_explicitly_listed_package():
         interpreter_hardening=True,
         allowed_packages=frozenset({"mcp-proxy"}),
     )
+    validate_mcp_stdio_source_policy(
+        "npx",
+        ["mcp-proxy"],
+        interpreter_hardening=True,
+        allowed_packages=frozenset({"mcp-proxy"}),
+    )
 
 
-def test_lenient_mode_keeps_legacy_open_package_runner():
+def test_lenient_mode_keeps_legacy_open_package_runner(monkeypatch):
+    monkeypatch.setattr("lfx.base.mcp.source_policy._configured_allowed_packages", lambda: None)
     validate_mcp_stdio_source_policy(
         "uvx",
         ["mcp-proxy"],

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -309,6 +309,36 @@ def test_interpreter_hardening_preserves_authenticated_agentic_module():
     )
 
 
+def test_interpreter_hardening_denies_all_packages_when_allowlist_unset():
+    # Hardening on + no explicit package list must compose fail-closed:
+    # uvx with an arbitrary registry package is arbitrary code execution.
+    with pytest.raises(ValueError, match=r"not allowed"):
+        validate_mcp_stdio_source_policy(
+            "uvx",
+            ["mcp-proxy"],
+            interpreter_hardening=True,
+            allowed_packages=None,
+        )
+
+
+def test_interpreter_hardening_permits_explicitly_listed_package():
+    validate_mcp_stdio_source_policy(
+        "uvx",
+        ["mcp-proxy"],
+        interpreter_hardening=True,
+        allowed_packages=frozenset({"mcp-proxy"}),
+    )
+
+
+def test_lenient_mode_keeps_legacy_open_package_runner():
+    validate_mcp_stdio_source_policy(
+        "uvx",
+        ["mcp-proxy"],
+        interpreter_hardening=False,
+        allowed_packages=None,
+    )
+
+
 def test_windows_forward_slash_executable_path_preserves_source_policy():
     with pytest.raises(ValueError, match=r"not allowed"):
         validate_mcp_stdio_config(


### PR DESCRIPTION
## Summary

`mcp_server_interpreter_hardening` is documented as blocking "tenant-controlled Python, Node.js, and shell MCP entrypoints" so that tenants are restricted to operator-approved packages. But the package-runner lane composes fail-**open**: when `LANGFLOW_MCP_SERVER_ALLOWED_PACKAGES` is unset (the default), `_validate_allowed_package` returns early on `None`, so `uvx <any-pypi-package>` / `npx <any-npm-package>` pass validation **with the hardening switch on** — arbitrary code execution for any tenant who can embed an MCP stdio config, exactly what hardened mode exists to prevent.

An operator who enables interpreter hardening (and docker hardening) but doesn't know about the third switch has a hardening posture that looks closed but isn't.

## Fix

In `validate_mcp_stdio_source_policy`, when interpreter hardening is active and no package allowlist is configured, treat the allowlist as empty — deny all `uvx`/`npx` packages. Operators opt packages back in explicitly via the existing `LANGFLOW_MCP_SERVER_ALLOWED_PACKAGES` setting. Lenient (legacy single-tenant) mode is unchanged.

## Test plan

- [x] `test_interpreter_hardening_denies_all_packages_when_allowlist_unset` — hardening on + unset allowlist rejects `uvx mcp-proxy` (mutation-verified: fails without the fix)
- [x] `test_interpreter_hardening_permits_explicitly_listed_package` — operator allowlist still opens the lane
- [x] `test_lenient_mode_keeps_legacy_open_package_runner` — legacy default behavior preserved
- [x] Full `test_stdio_source_policy.py` suite: 121/121 pass

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interpreter hardening now blocks unapproved `uvx` and `npx` packages when no package allowlist is configured.
  * Explicitly approved packages continue to run as expected.
  * Non-hardened mode retains its existing unrestricted package behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->