### PR TITLE
fix(security): protect OpenAI model discovery requests

### DIFF
--- a/src/backend/tests/unit/api/v1/test_openai_models_ssrf.py
+++ b/src/backend/tests/unit/api/v1/test_openai_models_ssrf.py
@@ -1,0 +1,184 @@
+"""SSRF regressions for OpenAI-compatible live model discovery."""
+
+import os
+import socket
+from contextlib import contextmanager
+from unittest import mock
+
+import httpcore
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+
+PUBLIC_BASE_URL = "http://models.example:8080/v1"
+PUBLIC_IP = "93.184.216.34"
+INTERNAL_MODEL = "instance-credential-secret"
+
+
+def _requests_response(model_name: str):
+    response = mock.MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"data": [{"id": model_name}]}
+    return response
+
+
+def _http_response(*, status_code: int = 200, body: bytes = b"", location: str | None = None):
+    reason = "OK" if status_code == 200 else "Found"
+    headers = [
+        f"HTTP/1.1 {status_code} {reason}\r\n".encode(),
+        f"Content-Length: {len(body)}\r\n".encode(),
+    ]
+    if location is not None:
+        headers.append(f"Location: {location}\r\n".encode())
+    headers.extend([b"Content-Type: application/json\r\n", b"\r\n", body])
+    return httpcore.MockStream(headers)
+
+
+def _public_dns(host, *_args, **_kwargs):
+    assert host == "models.example"
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (PUBLIC_IP, 0))]
+
+
+def _model_names(response) -> list[str]:
+    return [
+        model["model_name"]
+        for provider in response.json()
+        if provider["provider"] == "OpenAI"
+        for model in provider["models"]
+    ]
+
+
+@contextmanager
+def _patched_model_route(base_url: str):
+    async def configured_openai(*_args, **_kwargs):
+        return {"enabled_providers": ["OpenAI"], "provider_status": {"OpenAI": True}}
+
+    async def no_enabled_models(*_args, **_kwargs):
+        return {"enabled_models": {}, "enabled_models_by_type": {}}
+
+    async def no_default_model(*_args, **_kwargs):
+        return {}
+
+    async def no_explicit_models(*_args, **_kwargs):
+        return set()
+
+    def provider_variable(_user_id, key):
+        if key == "OPENAI_BASE_URL":
+            return base_url
+        if key == "OPENAI_API_KEY":
+            return "sk-test"  # pragma: allowlist secret
+        return None
+
+    with (
+        mock.patch("langflow.api.v1.models.get_enabled_providers", side_effect=configured_openai),
+        mock.patch("langflow.api.v1.models.get_enabled_models", side_effect=no_enabled_models),
+        mock.patch("langflow.api.v1.models.get_default_model", side_effect=no_default_model),
+        mock.patch("langflow.api.v1.models._get_enabled_models", side_effect=no_explicit_models),
+        mock.patch(
+            "lfx.base.models.model_utils.get_provider_variable_value",
+            side_effect=provider_variable,
+        ),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_models_endpoint_blocks_direct_openai_metadata_target(client: AsyncClient, logged_in_headers):
+    """A configured base URL cannot turn model discovery into a metadata read."""
+    policy = {
+        "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+        "LANGFLOW_SSRF_ALLOWED_HOSTS": "",
+    }
+    with (
+        mock.patch.dict(os.environ, policy),
+        _patched_model_route("http://169.254.169.254/latest/meta-data"),
+        mock.patch("requests.get", return_value=_requests_response(INTERNAL_MODEL)) as requests_get,
+    ):
+        response = await client.get(
+            "api/v1/models",
+            params={"provider": "OpenAI", "model_type": "llm"},
+            headers=logged_in_headers,
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert INTERNAL_MODEL not in _model_names(response)
+    requests_get.assert_not_called()
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_models_endpoint_blocks_redirect_to_openai_metadata_target(client: AsyncClient, logged_in_headers):
+    """Every redirect hop is checked before a connection or credential reflection."""
+    connected_hosts: list[str] = []
+
+    def connect_to_public(_self, host, port, **_kwargs):
+        connected_hosts.append(host)
+        assert port == 8080
+        return _http_response(
+            status_code=302,
+            location="http://169.254.169.254/latest/meta-data/models",
+        )
+
+    policy = {
+        "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+        "LANGFLOW_SSRF_ALLOWED_HOSTS": "",
+    }
+    with (
+        mock.patch.dict(os.environ, policy),
+        _patched_model_route(PUBLIC_BASE_URL),
+        mock.patch("socket.getaddrinfo", side_effect=_public_dns),
+        mock.patch.object(httpcore.SyncBackend, "connect_tcp", connect_to_public),
+        # Before the fix, requests follows the redirect and exposes this final body.
+        mock.patch("requests.get", return_value=_requests_response(INTERNAL_MODEL)) as requests_get,
+    ):
+        response = await client.get(
+            "api/v1/models",
+            params={"provider": "OpenAI", "model_type": "llm"},
+            headers=logged_in_headers,
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert INTERNAL_MODEL not in _model_names(response)
+    requests_get.assert_not_called()
+    assert connected_hosts == [PUBLIC_IP]
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_models_endpoint_pins_public_openai_host_and_returns_models(client: AsyncClient, logged_in_headers):
+    """A legitimate custom endpoint remains usable without a second DNS lookup."""
+    connected_hosts: list[str] = []
+    model_name = "self-hosted-model"
+    body = f'{{"data":[{{"id":"{model_name}"}}]}}'.encode()
+
+    def connect_to_public(_self, host, port, **_kwargs):
+        connected_hosts.append(host)
+        assert port == 8080
+        return _http_response(body=body)
+
+    policy = {
+        "LANGFLOW_SSRF_PROTECTION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED": "true",
+        "LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK": "false",
+        "LANGFLOW_SSRF_ALLOWED_HOSTS": "",
+    }
+    with (
+        mock.patch.dict(os.environ, policy),
+        _patched_model_route(PUBLIC_BASE_URL),
+        mock.patch("socket.getaddrinfo", side_effect=_public_dns) as getaddrinfo,
+        mock.patch.object(httpcore.SyncBackend, "connect_tcp", connect_to_public),
+        mock.patch("requests.get", return_value=_requests_response(model_name)) as requests_get,
+    ):
+        response = await client.get(
+            "api/v1/models",
+            params={"provider": "OpenAI", "model_type": "llm"},
+            headers=logged_in_headers,
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _model_names(response) == [model_name]
+    requests_get.assert_not_called()
+    assert getaddrinfo.call_count == 1
+    assert connected_hosts == [PUBLIC_IP]

--- a/src/backend/tests/unit/test_openai_base_url_support.py
+++ b/src/backend/tests/unit/test_openai_base_url_support.py
@@ -19,6 +19,7 @@ fetch — external servers CI cannot reproduce.
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 from lfx.base.models.model_metadata import (
     CONDITIONAL_LIVE_MODEL_PROVIDERS,
     LIVE_MODEL_PROVIDERS,
@@ -161,13 +162,14 @@ class TestLiveOpenAICompatibleModels:
                 if key == "OPENAI_BASE_URL"
                 else "sk-test",  # pragma: allowlist secret
             ),
-            patch("requests.get", return_value=response) as http_get,
+            patch("lfx.base.models.model_utils.ssrf_safe_httpx_get", return_value=response) as http_get,
         ):
             models = fetch_live_openai_compatible_models(USER_ID, "llm")
 
         assert [m["name"] for m in models] == ["gpt-oss:20b", "llama3.2:latest"]
         assert all(m["tool_calling"] for m in models)
         assert http_get.call_args.args[0] == f"{CUSTOM_BASE_URL}/models"
+        assert http_get.call_args.kwargs["follow_redirects"] is True
 
     def test_should_list_embeddings_from_the_custom_server(self):
         response = MagicMock()
@@ -180,7 +182,7 @@ class TestLiveOpenAICompatibleModels:
                 if key == "OPENAI_BASE_URL"
                 else "sk-test",  # pragma: allowlist secret
             ),
-            patch("requests.get", return_value=response),
+            patch("lfx.base.models.model_utils.ssrf_safe_httpx_get", return_value=response),
         ):
             models = fetch_live_openai_compatible_models(USER_ID, "embeddings")
 
@@ -189,10 +191,25 @@ class TestLiveOpenAICompatibleModels:
         assert all(not model["tool_calling"] for model in models)
 
     def test_should_reject_unknown_model_type_without_fetching(self):
-        with patch("requests.get") as http_get:
+        with patch("lfx.base.models.model_utils.ssrf_safe_httpx_get") as http_get:
             assert fetch_live_openai_compatible_models(USER_ID, "image") == []
 
         http_get.assert_not_called()
+
+    def test_should_return_empty_for_malformed_custom_base_url(self):
+        with (
+            patch(
+                "lfx.base.models.model_utils.get_provider_variable_value",
+                side_effect=lambda _uid, key: "http://models.example:notaport/v1"
+                if key == "OPENAI_BASE_URL"
+                else "sk-test",  # pragma: allowlist secret
+            ),
+            patch(
+                "lfx.base.models.model_utils.ssrf_safe_httpx_get",
+                side_effect=httpx.InvalidURL("Invalid port: 'notaport'"),
+            ),
+        ):
+            assert fetch_live_openai_compatible_models(USER_ID, "llm") == []
 
 
 class TestConditionalLiveReplacement:
@@ -269,7 +286,7 @@ class TestMalformedModelsPayload:
                 if key == "OPENAI_BASE_URL"
                 else "sk-x",  # pragma: allowlist secret
             ),
-            patch("requests.get", return_value=FakeResp()),
+            patch("lfx.base.models.model_utils.ssrf_safe_httpx_get", return_value=FakeResp()),
         ):
             return fetch_live_openai_compatible_models(USER_ID, "llm")
 

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -26,6 +26,7 @@ from lfx.log.logger import logger
 from lfx.services.deps import get_variable_service, session_scope
 from lfx.utils.async_helpers import run_until_complete
 from lfx.utils.secrets import unwrap_secret_value
+from lfx.utils.ssrf_httpx import ssrf_safe_httpx_get
 from lfx.utils.ssrf_protection import SSRFProtectionError, validate_connector_url_for_ssrf
 from lfx.utils.util import transform_localhost_url
 
@@ -544,14 +545,15 @@ def fetch_live_openai_compatible_models(user_id: UUID | str | None, model_type: 
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
     try:
-        response = requests.get(
+        response = ssrf_safe_httpx_get(
             f"{base_url.rstrip('/')}/models",
             headers=headers,
             timeout=OPENAI_COMPATIBLE_FETCH_TIMEOUT,
+            follow_redirects=True,
         )
         response.raise_for_status()
         payload = response.json()
-    except (requests.RequestException, ValueError) as exc:
+    except (httpx.HTTPError, httpx.InvalidURL, ValueError) as exc:
         logger.debug(f"Could not fetch live OpenAI-compatible models from {base_url}: {exc}")
         return []
 

--- a/src/lfx/src/lfx/utils/ssrf_httpx.py
+++ b/src/lfx/src/lfx/utils/ssrf_httpx.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urljoin
 
 import httpx
 
@@ -18,6 +19,10 @@ from lfx.utils.ssrf_transport import (
     create_ssrf_protected_client,
     create_ssrf_protected_sync_client,
 )
+
+# HTTP redirect responses carrying a Location header (RFC 9110).
+REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+DEFAULT_MAX_REDIRECTS = 20
 
 
 def validate_url_for_ssrf_or_raise(url: str) -> None:
@@ -106,12 +111,97 @@ async def ssrf_safe_async_post(url: str, **request_kwargs: Any) -> httpx.Respons
         return await client.post(url=validated_url, **request_kwargs)
 
 
-def ssrf_safe_httpx_get(url: str, **request_kwargs: Any) -> httpx.Response:
-    """Perform a synchronous GET with connector SSRF validation and DNS pinning."""
-    _raise_if_following_redirects(request_kwargs)
-    validated_url, validated_ips = validate_and_resolve_connector_url(url)
-    with _sync_client_for_url(validated_url, validated_ips) as client:
-        return client.get(url=validated_url, **request_kwargs)
+def _same_origin(first_url: str, second_url: str) -> bool:
+    first = httpx.URL(first_url)
+    second = httpx.URL(second_url)
+    return (first.scheme, first.raw_host, first.port) == (second.scheme, second.raw_host, second.port)
+
+
+def _is_safe_https_upgrade(previous_url: str, next_url: str) -> bool:
+    """Match httpx's authorization-preserving HTTP-to-HTTPS redirect exception."""
+    previous = httpx.URL(previous_url)
+    next_ = httpx.URL(next_url)
+    return (
+        previous.scheme == "http"
+        and previous.raw_host == next_.raw_host
+        and previous.port is None
+        and next_.scheme == "https"
+        and next_.port is None
+    )
+
+
+def _headers_for_redirect(headers: Any, previous_url: str, next_url: str) -> httpx.Headers | None:
+    if headers is None:
+        return None
+
+    redirect_headers = httpx.Headers(headers)
+    if _same_origin(previous_url, next_url):
+        return redirect_headers
+
+    # Match httpx's safe HTTP-to-HTTPS authorization exception, while never
+    # replaying caller-supplied cookies or proxy credentials across origins.
+    if not _is_safe_https_upgrade(previous_url, next_url):
+        redirect_headers.pop("Authorization", None)
+    redirect_headers.pop("Cookie", None)
+    redirect_headers.pop("Proxy-Authorization", None)
+    return redirect_headers
+
+
+def _request_kwargs_for_redirect(request_kwargs: dict[str, Any], previous_url: str, next_url: str) -> dict[str, Any]:
+    if _same_origin(previous_url, next_url):
+        return request_kwargs
+
+    redirect_kwargs = request_kwargs.copy()
+    redirect_kwargs.pop("cookies", None)
+    if not _is_safe_https_upgrade(previous_url, next_url):
+        redirect_kwargs.pop("auth", None)
+    return redirect_kwargs
+
+
+def ssrf_safe_httpx_get(
+    url: str,
+    *,
+    follow_redirects: bool = False,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    **request_kwargs: Any,
+) -> httpx.Response:
+    """Perform a synchronous GET with connector SSRF validation and DNS pinning.
+
+    When redirects are requested, they are followed manually so each target is
+    independently validated and connected through a transport pinned to the IPs
+    returned by that validation. Credentials are not forwarded across origins,
+    except authorization on a same-host, standard-port HTTP-to-HTTPS upgrade.
+    """
+    current_url = url
+    supplied_headers = request_kwargs.pop("headers", None)
+    current_headers = httpx.Headers(supplied_headers) if supplied_headers is not None else None
+    current_params = request_kwargs.pop("params", None)
+    current_request_kwargs = request_kwargs
+
+    for _ in range(max_redirects + 1):
+        validated_url, validated_ips = validate_and_resolve_connector_url(current_url)
+        with _sync_client_for_url(validated_url, validated_ips) as client:
+            response = client.get(
+                url=validated_url,
+                headers=current_headers,
+                params=current_params,
+                follow_redirects=False,
+                **current_request_kwargs,
+            )
+
+        location = response.headers.get("location")
+        if not follow_redirects or response.status_code not in REDIRECT_STATUS_CODES or not location:
+            return response
+
+        next_url = urljoin(validated_url, location)
+        current_headers = _headers_for_redirect(current_headers, validated_url, next_url)
+        current_request_kwargs = _request_kwargs_for_redirect(current_request_kwargs, validated_url, next_url)
+        current_url = next_url
+        # Redirect locations carry their own query string; initial params apply once.
+        current_params = None
+
+    msg = f"Exceeded the maximum of {max_redirects} redirects while requesting {url}"
+    raise SSRFProtectionError(msg)
 
 
 def ssrf_safe_httpx_post(url: str, **request_kwargs: Any) -> httpx.Response:

--- a/src/lfx/tests/unit/utils/test_ssrf_httpx.py
+++ b/src/lfx/tests/unit/utils/test_ssrf_httpx.py
@@ -3,6 +3,7 @@ import socket
 from unittest.mock import AsyncMock, patch
 
 import httpcore
+import httpx
 import pytest
 from lfx.utils.ssrf_httpx import (
     ssrf_protected_httpx_client_kwargs_for_url,
@@ -154,3 +155,122 @@ class TestSSRFSafeHTTPX:
         assert response.status_code == 200
         assert call_count == 1
         assert connected_to_ip == "8.8.8.8"
+
+    def test_sync_redirects_are_revalidated_and_strip_cross_origin_credentials(self):
+        first_url = "https://models.example/v1/models"
+        second_url = "https://catalog.example/models"
+        auth = httpx.BasicAuth("user", "secret")
+        responses = [
+            httpx.Response(302, headers={"location": second_url}, request=httpx.Request("GET", first_url)),
+            httpx.Response(200, json={"data": []}, request=httpx.Request("GET", second_url)),
+        ]
+
+        with (
+            patch(
+                "lfx.utils.ssrf_httpx.validate_and_resolve_connector_url",
+                side_effect=lambda url: (url, []),
+            ) as validate_url,
+            patch("httpx.Client.get", side_effect=responses) as get,
+        ):
+            response = ssrf_safe_httpx_get(
+                first_url,
+                headers=[
+                    (b"Authorization", b"Bearer secret"),
+                    (b"Cookie", b"session=header-secret"),
+                    (b"Proxy-Authorization", b"Basic proxy-secret"),
+                    (b"User-Agent", b"langflow-test"),
+                ],
+                auth=auth,
+                cookies={"session": "kwarg-secret"},
+                timeout=5,
+                follow_redirects=True,
+            )
+
+        assert response.status_code == 200
+        assert [call.args[0] for call in validate_url.call_args_list] == [first_url, second_url]
+        first_headers = get.call_args_list[0].kwargs["headers"]
+        assert first_headers["Authorization"] == "Bearer secret"
+        assert first_headers["Cookie"] == "session=header-secret"
+        assert first_headers["Proxy-Authorization"] == "Basic proxy-secret"
+        assert get.call_args_list[0].kwargs["auth"] is auth
+        assert get.call_args_list[0].kwargs["cookies"] == {"session": "kwarg-secret"}
+
+        second_headers = get.call_args_list[1].kwargs["headers"]
+        assert dict(second_headers) == {"user-agent": "langflow-test"}
+        assert "auth" not in get.call_args_list[1].kwargs
+        assert "cookies" not in get.call_args_list[1].kwargs
+        assert all(call.kwargs["follow_redirects"] is False for call in get.call_args_list)
+
+    def test_sync_https_upgrade_preserves_auth_but_not_cookie_or_proxy_credentials(self):
+        first_url = "http://models.example:80/v1/models"
+        second_url = "https://models.example:443/v1/models"
+        auth = httpx.BasicAuth("user", "secret")
+        responses = [
+            httpx.Response(308, headers={"location": second_url}, request=httpx.Request("GET", first_url)),
+            httpx.Response(200, json={"data": []}, request=httpx.Request("GET", second_url)),
+        ]
+
+        with (
+            patch(
+                "lfx.utils.ssrf_httpx.validate_and_resolve_connector_url",
+                side_effect=lambda url: (url, []),
+            ),
+            patch("httpx.Client.get", side_effect=responses) as get,
+        ):
+            response = ssrf_safe_httpx_get(
+                first_url,
+                headers=[
+                    (b"Authorization", b"Bearer secret"),
+                    (b"Cookie", b"session=header-secret"),
+                    (b"Proxy-Authorization", b"Basic proxy-secret"),
+                ],
+                auth=auth,
+                cookies={"session": "kwarg-secret"},
+                follow_redirects=True,
+            )
+
+        assert response.status_code == 200
+        second_call = get.call_args_list[1]
+        assert second_call.kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert "Cookie" not in second_call.kwargs["headers"]
+        assert "Proxy-Authorization" not in second_call.kwargs["headers"]
+        assert second_call.kwargs["auth"] is auth
+        assert "cookies" not in second_call.kwargs
+
+    def test_sync_public_redirect_uses_each_hops_validated_pinned_ip(self):
+        first_url = "http://first.example:8080/models"
+        second_url = "http://second.example:8081/models"
+        public_ips = {"first.example": "8.8.8.8", "second.example": "1.1.1.1"}
+        resolved_hosts: list[str] = []
+        connections: list[tuple[str, int]] = []
+
+        def mock_getaddrinfo(host, _port, *_args, **_kwargs):
+            resolved_hosts.append(host)
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (public_ips[host], 0))]
+
+        def mock_connect_tcp(_self, host, port, **_kwargs):
+            connections.append((host, port))
+            if host == public_ips["first.example"]:
+                body = b""
+                status_line = b"HTTP/1.1 302 Found\r\n"
+                location = f"Location: {second_url}\r\n".encode()
+            else:
+                body = b'{"data":[]}'
+                status_line = b"HTTP/1.1 200 OK\r\n"
+                location = b""
+            response_chunks = [status_line, f"Content-Length: {len(body)}\r\n".encode()]
+            if location:
+                response_chunks.append(location)
+            response_chunks.extend([b"Content-Type: application/json\r\n", b"\r\n", body])
+            return httpcore.MockStream(response_chunks)
+
+        with (
+            patch.dict(os.environ, {"LANGFLOW_SSRF_PROTECTION_ENABLED": "true"}),
+            patch("socket.getaddrinfo", side_effect=mock_getaddrinfo),
+            patch.object(httpcore.SyncBackend, "connect_tcp", mock_connect_tcp),
+        ):
+            response = ssrf_safe_httpx_get(first_url, timeout=5, follow_redirects=True)
+
+        assert response.status_code == 200
+        assert resolved_hosts == ["first.example", "second.example"]
+        assert connections == [("8.8.8.8", 8080), ("1.1.1.1", 8081)]


### PR DESCRIPTION
## Summary

- route OpenAI-compatible model discovery through the SSRF-safe, DNS-pinned HTTP transport
- revalidate every redirect target and strip credentials when a redirect crosses origins
- fail closed for metadata/private targets and malformed configured base URLs while preserving live-model discovery behavior

## Validation

- `src/lfx/tests/unit/utils/test_ssrf_httpx.py`: 12 passed
- `src/backend/tests/unit/test_openai_base_url_support.py src/backend/tests/unit/api/v1/test_openai_models_ssrf.py`: 25 passed
- Ruff format/check: passed
- Independent security/code review: approved with no findings

Related: LE-2133 / PVR0835659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for OpenAI-compatible model discovery by blocking requests to internal metadata endpoints, including through redirects.
  * Added safe redirect handling with destination validation, DNS protection, and sensitive-header sanitization.
  * Preserved valid authentication during secure HTTP-to-HTTPS upgrades.
  * Invalid custom model-service URLs now fail gracefully without raising errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->