### PR TITLE
fix(security): enforce admin-only component builds

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -15,6 +15,7 @@ from lfx.schema.schema import InputValueRequest, OutputValue
 from lfx.services.cache.utils import CacheMiss
 from lfx.utils.flow_validation import (
     CustomComponentValidationError,
+    prepare_flow_build_for_user,
     prepare_public_flow_build,
     validate_flow_for_current_settings,
     validate_public_flow_no_code_execution,
@@ -177,6 +178,12 @@ async def retrieve_vertices_order(
         if not data:
             graph = await build_graph_from_db(flow_id=flow_id, session=session, chat_service=chat_service)
         else:
+            sanitized_data = await prepare_flow_build_for_user(
+                data.model_dump(),
+                is_superuser=current_user.is_superuser,
+            )
+            if sanitized_data is not None:
+                data = FlowDataRequest.model_validate(sanitized_data)
             graph = await build_and_cache_graph_from_data(
                 flow_id=flow_id, graph_data=data.model_dump(), chat_service=chat_service
             )
@@ -214,6 +221,8 @@ async def retrieve_vertices_order(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         if isinstance(exc, CustomComponentValidationError):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if isinstance(exc, RuntimeError):
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
         await logger.aexception("Error checking build status")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -308,7 +317,13 @@ async def build_flow(
 
     try:
         if data:
-            validate_flow_for_current_settings(data.model_dump())
+            raw_data = data.model_dump()
+            sanitized_data = await prepare_flow_build_for_user(
+                raw_data,
+                is_superuser=current_user.is_superuser,
+            )
+            if sanitized_data is not None:
+                data = FlowDataRequest.model_validate(sanitized_data)
         elif flow and flow.data:
             validate_flow_for_current_settings(flow.data)
     except CustomComponentValidationError as exc:

--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -221,8 +221,8 @@ async def authorize_flow_action(
         ) from err
 
 
-def _apply_execution_gates(parsed, flow, current_user: UserRead) -> None:
-    """The langflow request gates that run before a flow executes."""
+def _apply_execution_gates(parsed, flow, current_user: UserRead):
+    """Run request gates and return any server-sanitized execution payload."""
     _reject_unsupported_sync_fields(parsed)
     _reject_sync_only_fields(parsed)
     try:
@@ -234,7 +234,7 @@ def _apply_execution_gates(parsed, flow, current_user: UserRead) -> None:
         if exc.status_code == status.HTTP_404_NOT_FOUND:
             raise _flow_not_found_http_exception(str(parsed.flow_id)) from exc
         raise
-    _validate_flow_data_for_execution(parsed, flow)
+    return _validate_flow_data_for_execution(parsed, flow, current_user)
 
 
 async def run_sync_with_mapping(
@@ -246,7 +246,7 @@ async def run_sync_with_mapping(
     background_tasks: BackgroundTasks,
 ) -> WorkflowExecutionResponse:
     """Inline sync run with the langflow timeout/validation error mapping."""
-    _apply_execution_gates(parsed, flow, current_user)
+    parsed = _apply_execution_gates(parsed, flow, current_user)
     job_id = uuid4()
     try:
         return await execute_sync_workflow_with_timeout(
@@ -321,7 +321,7 @@ def build_stream_response(
     side-channel, and vertex-build persistence all survive. Validation gates run
     before the response is constructed so a bad request fails before streaming.
     """
-    _apply_execution_gates(parsed, flow, current_user)
+    parsed = _apply_execution_gates(parsed, flow, current_user)
     adapter = get_stream_adapter(
         stream_protocol,
         StreamAdapterContext(
@@ -346,7 +346,7 @@ async def submit_background_with_mapping(
     stream_protocol: str,
 ) -> WorkflowJobResponse:
     """Queue a durable background run with the langflow service error mapping."""
-    _apply_execution_gates(parsed, flow, current_user)
+    parsed = _apply_execution_gates(parsed, flow, current_user)
     try:
         return await execute_workflow_background(
             parsed=parsed,

--- a/src/backend/base/langflow/api/v2/workflow_validation.py
+++ b/src/backend/base/langflow/api/v2/workflow_validation.py
@@ -8,8 +8,14 @@ route handlers can surface a structured error without running the graph.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from fastapi import HTTPException, status
-from lfx.utils.flow_validation import CustomComponentValidationError, validate_flow_for_current_settings
+from lfx.utils.flow_validation import (
+    CustomComponentValidationError,
+    prepare_flow_build_for_user_from_cache,
+    validate_flow_for_current_settings,
+)
 from lfx.workflow.converters import ParsedWorkflowRun
 
 from langflow.services.authorization.fetch import deny_to_404
@@ -85,17 +91,27 @@ def _enforce_flow_data_override_owner(parsed: ParsedWorkflowRun, flow: FlowRead,
     )
 
 
-def _validate_flow_data_for_execution(parsed: ParsedWorkflowRun, flow: FlowRead) -> None:
-    """Apply the same server-side component policy gate used by v1/public runs."""
+def _validate_flow_data_for_execution(
+    parsed: ParsedWorkflowRun,
+    flow: FlowRead,
+    current_user: UserRead,
+) -> ParsedWorkflowRun:
+    """Apply component policies and return sanitized caller-supplied graph data."""
     try:
         if parsed.data is not None:
-            validate_flow_for_current_settings(parsed.data)
+            sanitized_data = prepare_flow_build_for_user_from_cache(
+                parsed.data,
+                is_superuser=current_user.is_superuser,
+            )
+            if sanitized_data is not None:
+                return replace(parsed, data=sanitized_data)
         elif flow.data:
             validate_flow_for_current_settings(flow.data)
     except CustomComponentValidationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    return parsed
 
 
 def _validate_output_ids(output_ids: list[str] | None, terminal_node_ids: list[str]) -> None:

--- a/src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py
+++ b/src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -62,7 +63,12 @@ def patch_build_flow(monkeypatch):
     """Install fakes for session_scope, _read_flow, ensure_flow_permission, start_flow_build."""
     from langflow.api.v1 import chat as chat_module
 
-    state: dict[str, Any] = {"session_exec": [], "read_flow": None, "ensure_raises": None}
+    state: dict[str, Any] = {
+        "session_exec": [],
+        "read_flow": None,
+        "ensure_raises": None,
+        "start_kwargs": None,
+    }
 
     @asynccontextmanager
     async def fake_session_scope():
@@ -75,7 +81,8 @@ def patch_build_flow(monkeypatch):
         if state["ensure_raises"] is not None:
             raise state["ensure_raises"]
 
-    async def fake_start_build(**_kwargs):
+    async def fake_start_build(**kwargs):
+        state["start_kwargs"] = kwargs
         return "fake-job-id"
 
     monkeypatch.setattr(chat_module, "session_scope", fake_session_scope)
@@ -171,7 +178,10 @@ async def test_build_flow_owner_can_override_flow_data(patch_build_flow, monkeyp
     from langflow.api.v1 import chat as chat_module
     from langflow.api.v1.schemas import FlowDataRequest
 
-    monkeypatch.setattr(chat_module, "validate_flow_for_current_settings", lambda _data: None)
+    async def allow_inline(_data, *, is_superuser):
+        assert is_superuser is False
+
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", allow_inline)
 
     owner = _make_user()
     flow = _make_flow(owner_id=owner.id, public=False)
@@ -186,6 +196,152 @@ async def test_build_flow_owner_can_override_flow_data(patch_build_flow, monkeyp
         data=override,
     )
     assert result == {"job_id": "fake-job-id"}
+
+
+@pytest.mark.asyncio
+async def test_build_flow_admin_only_blocks_non_superuser_inline_custom_code(patch_build_flow, monkeypatch):
+    """Admin-only policy is applied before owner-supplied inline graph data reaches the build worker."""
+    from langflow.api.v1 import chat as chat_module
+    from langflow.api.v1.schemas import FlowDataRequest
+    from lfx.utils.flow_validation import CustomComponentValidationError
+
+    owner = _make_user()
+    flow = _make_flow(owner_id=owner.id, public=False)
+    patch_build_flow["read_flow"] = flow
+    override = FlowDataRequest(nodes=[{"id": "custom"}], edges=[])
+
+    async def reject_custom_code(_data, *, is_superuser):
+        assert is_superuser is False
+        message = "custom components are restricted to administrators"
+        raise CustomComponentValidationError(message)
+
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", reject_custom_code)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_module.build_flow(
+            flow_id=flow.id,
+            background_tasks=None,
+            current_user=owner,
+            queue_service=_make_queue_service(),
+            data=override,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "restricted to administrators" in excinfo.value.detail
+    assert patch_build_flow["start_kwargs"] is None
+
+
+@pytest.mark.asyncio
+async def test_build_flow_admin_only_passes_sanitized_template_to_worker(patch_build_flow, monkeypatch):
+    """A known template remains usable, but the worker receives the server-trusted payload."""
+    from langflow.api.v1 import chat as chat_module
+    from langflow.api.v1.schemas import FlowDataRequest
+
+    owner = _make_user()
+    flow = _make_flow(owner_id=owner.id, public=False)
+    patch_build_flow["read_flow"] = flow
+    override = FlowDataRequest(nodes=[{"id": "known", "data": {"source": "request"}}], edges=[])
+    sanitized = {"nodes": [{"id": "known", "data": {"source": "server"}}], "edges": [], "viewport": None}
+
+    async def sanitize(_data, *, is_superuser):
+        assert is_superuser is False
+        return sanitized
+
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", sanitize)
+
+    result = await chat_module.build_flow(
+        flow_id=flow.id,
+        background_tasks=None,
+        current_user=owner,
+        queue_service=_make_queue_service(),
+        data=override,
+    )
+
+    assert result == {"job_id": "fake-job-id"}
+    assert patch_build_flow["start_kwargs"]["data"].model_dump() == sanitized
+    assert override.nodes[0]["data"]["source"] == "request"
+
+
+@pytest.mark.asyncio
+async def test_build_flow_admin_only_keeps_superuser_inline_custom_code(patch_build_flow, monkeypatch):
+    """The operator's admin-only setting preserves the documented superuser exception."""
+    from langflow.api.v1 import chat as chat_module
+    from langflow.api.v1.schemas import FlowDataRequest
+
+    owner = _make_user(is_superuser=True)
+    flow = _make_flow(owner_id=owner.id, public=False)
+    patch_build_flow["read_flow"] = flow
+    override = FlowDataRequest(nodes=[{"id": "custom"}], edges=[])
+    seen: dict[str, Any] = {}
+
+    async def preserve_superuser_data(data, *, is_superuser):
+        assert is_superuser is True
+        seen["validated"] = data
+
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", preserve_superuser_data)
+
+    result = await chat_module.build_flow(
+        flow_id=flow.id,
+        background_tasks=None,
+        current_user=owner,
+        queue_service=_make_queue_service(),
+        data=override,
+    )
+
+    assert result == {"job_id": "fake-job-id"}
+    assert seen["validated"] == override.model_dump()
+    assert patch_build_flow["start_kwargs"]["data"] is override
+
+
+@pytest.mark.asyncio
+async def test_legacy_vertices_route_passes_only_sanitized_inline_data(monkeypatch):
+    """The still-routed legacy graph cache cannot bypass the inline-data policy."""
+    from langflow.api.v1 import chat as chat_module
+    from langflow.api.v1.schemas import FlowDataRequest
+
+    owner = _make_user()
+    flow = _make_flow(owner_id=owner.id)
+    original = FlowDataRequest(nodes=[{"id": "known", "data": {"source": "request"}}], edges=[])
+    sanitized = {"nodes": [{"id": "known", "data": {"source": "server"}}], "edges": [], "viewport": None}
+    seen: dict[str, Any] = {}
+
+    async def ensure_allowed(*_args, **_kwargs):
+        return None
+
+    async def sanitize(_data, *, is_superuser):
+        assert is_superuser is False
+        return sanitized
+
+    graph = MagicMock()
+    graph.prepare.return_value = graph
+    graph.vertices = []
+    graph.vertices_to_run = set()
+    graph.first_layer = []
+    graph.run_id = None
+    graph.set_run_id.side_effect = lambda value: setattr(graph, "run_id", value)
+
+    async def build_from_data(*, graph_data, **_kwargs):
+        seen["graph_data"] = graph_data
+        return graph
+
+    chat_service = SimpleNamespace(set_cache=AsyncMock())
+    monkeypatch.setattr(chat_module, "ensure_flow_permission", ensure_allowed)
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", sanitize)
+    monkeypatch.setattr(chat_module, "build_and_cache_graph_from_data", build_from_data)
+    monkeypatch.setattr(chat_module, "get_chat_service", lambda: chat_service)
+    monkeypatch.setattr(chat_module, "get_telemetry_service", MagicMock)
+    monkeypatch.setattr(chat_module, "get_top_level_vertices", lambda *_args: [])
+
+    await chat_module.retrieve_vertices_order(
+        flow_id=flow.id,
+        background_tasks=SimpleNamespace(add_task=lambda *_args, **_kwargs: None),
+        data=original,
+        session=_FakeSession([[flow]]),
+        current_user=owner,
+    )
+
+    assert seen["graph_data"] == sanitized
+    assert original.nodes[0]["data"]["source"] == "request"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v2/test_workflow_admin_only_build.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_admin_only_build.py
@@ -1,0 +1,84 @@
+"""Regressions for admin-only policy on V2 inline workflow execution."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from lfx.workflow.converters import ParsedWorkflowRun
+
+
+def _execution_context(*, mode: str):
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    flow = SimpleNamespace(id=uuid4(), user_id=user.id, data=None)
+    parsed = ParsedWorkflowRun(
+        flow_id=str(flow.id),
+        mode=mode,
+        data={"nodes": [{"id": "known", "data": {"source": "request"}}], "edges": []},
+    )
+    return parsed, flow, user
+
+
+def test_v2_stream_passes_sanitized_inline_data_to_execution(monkeypatch):
+    """Live streaming must not retain the caller's code bytes after validation."""
+    from langflow.api.v2 import workflow as workflow_module
+    from langflow.api.v2 import workflow_validation
+
+    parsed, flow, user = _execution_context(mode="stream")
+    sanitized = {"nodes": [{"id": "known", "data": {"source": "server"}}], "edges": []}
+    execute = MagicMock(return_value=object())
+
+    def sanitize(_data, *, is_superuser):
+        assert is_superuser is False
+        return sanitized
+
+    monkeypatch.setattr(
+        workflow_validation,
+        "prepare_flow_build_for_user_from_cache",
+        sanitize,
+    )
+    monkeypatch.setattr(workflow_module, "get_stream_adapter", MagicMock(return_value=object()))
+    monkeypatch.setattr(workflow_module, "_execute_streaming_workflow", execute)
+
+    workflow_module.build_stream_response(
+        parsed,
+        flow,
+        user,
+        stream_protocol="langflow",
+        background_tasks=MagicMock(),
+    )
+
+    assert execute.call_args.kwargs["parsed"].data == sanitized
+    assert parsed.data["nodes"][0]["data"]["source"] == "request"
+
+
+@pytest.mark.asyncio
+async def test_v2_background_persists_only_sanitized_inline_data(monkeypatch):
+    """Durable background requests must queue the trusted server payload."""
+    from langflow.api.v2 import workflow as workflow_module
+    from langflow.api.v2 import workflow_validation
+
+    parsed, flow, user = _execution_context(mode="background")
+    sanitized = {"nodes": [{"id": "known", "data": {"source": "server"}}], "edges": []}
+    execute = AsyncMock(return_value=object())
+
+    def sanitize(_data, *, is_superuser):
+        assert is_superuser is False
+        return sanitized
+
+    monkeypatch.setattr(
+        workflow_validation,
+        "prepare_flow_build_for_user_from_cache",
+        sanitize,
+    )
+    monkeypatch.setattr(workflow_module, "execute_workflow_background", execute)
+
+    await workflow_module.submit_background_with_mapping(
+        parsed,
+        flow,
+        user,
+        stream_protocol="langflow",
+    )
+
+    assert execute.call_args.kwargs["parsed"].data == sanitized
+    assert parsed.data["nodes"][0]["data"]["source"] == "request"

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -285,20 +285,39 @@ def _get_invalid_components(
     blocked: list[str] = []
     outdated: list[str] = []
 
-    for node in nodes:
-        node_data = node.get("data", {})
-        node_info = node_data.get("node", {})
+    for index, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            blocked.append(f"malformed component (index {index})")
+            continue
+
+        node_data = node.get("data")
+        node_id = node.get("id", f"index {index}")
+        if not isinstance(node_data, dict):
+            blocked.append(f"malformed component ({node_id})")
+            continue
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, dict):
+            blocked.append(f"malformed component ({node_id})")
+            continue
 
         component_type = node_data.get("type")
 
         node_template = node_info.get("template", {})
+        if not isinstance(node_template, dict):
+            blocked.append(f"malformed component ({node_id})")
+            continue
         node_code_field = node_template.get("code", {})
         node_code = node_code_field.get("value") if isinstance(node_code_field, dict) else None
 
         if node_code:
             display_name = node_info.get("display_name") or component_type or "unknown"
-            node_id = node_data.get("id") or node.get("id", "unknown")
+            node_id = node_data.get("id") or node_id
             label = f"{display_name} ({node_id})"
+
+            if not isinstance(node_code, str):
+                blocked.append(label)
+                continue
 
             # A node carrying executable code must resolve to a known component
             # type so its code hash can be checked against the trusted set. If the
@@ -311,7 +330,7 @@ def _get_invalid_components(
             # allow_custom_components gate while its stored code still executed at
             # build time (instantiate_class runs the node's stored code, which
             # does not consult the type).
-            expected_hashes = type_to_current_hash.get(component_type) if component_type else None
+            expected_hashes = type_to_current_hash.get(component_type) if isinstance(component_type, str) else None
             if expected_hashes is None:
                 blocked.append(label)
             else:
@@ -322,7 +341,13 @@ def _get_invalid_components(
         flow_data = node_info.get("flow", {})
         if isinstance(flow_data, dict):
             nested_data = flow_data.get("data", {})
+            if not isinstance(nested_data, dict):
+                blocked.append(f"malformed nested flow ({node_id})")
+                continue
             nested_nodes = nested_data.get("nodes", [])
+            if not isinstance(nested_nodes, list):
+                blocked.append(f"malformed nested flow ({node_id})")
+                continue
             if nested_nodes:
                 nested_blocked, nested_outdated = _get_invalid_components(
                     nested_nodes,
@@ -330,6 +355,8 @@ def _get_invalid_components(
                 )
                 blocked.extend(nested_blocked)
                 outdated.extend(nested_outdated)
+        elif flow_data is not None:
+            blocked.append(f"malformed nested flow ({node_id})")
 
     return blocked, outdated
 
@@ -342,22 +369,45 @@ def _find_code_execution_components(nodes: list[dict]) -> list[str]:
     """
     found: list[str] = []
 
-    for node in nodes:
-        node_data = node.get("data", {})
-        node_info = node_data.get("node", {})
-        display_name = node_info.get("display_name") if isinstance(node_info, dict) else None
+    for index, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            msg = f"Flow validation failed: malformed component at index {index}."
+            raise CustomComponentValidationError(msg)
+
+        node_data = node.get("data")
+        node_id = node.get("id", f"index {index}")
+        if not isinstance(node_data, dict):
+            msg = f"Flow validation failed: malformed component ({node_id})."
+            raise CustomComponentValidationError(msg)
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, dict):
+            msg = f"Flow validation failed: malformed component ({node_id})."
+            raise CustomComponentValidationError(msg)
+
+        display_name = node_info.get("display_name")
 
         component_type = node_data.get("type")
         if is_code_execution_component(component_type, display_name):
             display_name = display_name or component_type
-            node_id = node_data.get("id") or node.get("id", "unknown")
+            node_id = node_data.get("id") or node_id
             found.append(f"{display_name} ({node_id})")
 
         flow_data = node_info.get("flow", {})
         if isinstance(flow_data, dict):
-            nested_nodes = flow_data.get("data", {}).get("nodes", [])
+            nested_data = flow_data.get("data", {})
+            if not isinstance(nested_data, dict):
+                msg = f"Flow validation failed: malformed nested flow ({node_id})."
+                raise CustomComponentValidationError(msg)
+            nested_nodes = nested_data.get("nodes", [])
+            if not isinstance(nested_nodes, list):
+                msg = f"Flow validation failed: malformed nested flow ({node_id})."
+                raise CustomComponentValidationError(msg)
             if nested_nodes:
                 found.extend(_find_code_execution_components(nested_nodes))
+        elif flow_data is not None:
+            msg = f"Flow validation failed: malformed nested flow ({node_id})."
+            raise CustomComponentValidationError(msg)
 
     return found
 
@@ -372,6 +422,9 @@ def check_code_execution_components_and_raise(flow_data: dict | None) -> None:
         return
 
     nodes = flow_data.get("nodes", [])
+    if not isinstance(nodes, list):
+        msg = "Flow validation failed: nodes must be a list."
+        raise CustomComponentValidationError(msg)
     if not nodes:
         return
 
@@ -413,6 +466,51 @@ def get_trusted_code_for_validation(code: str) -> str | None:
         return None
 
     return code_by_hash.get(_compute_code_hash(code))
+
+
+def _substitute_trusted_code_by_hash(nodes: list[dict]) -> list[str]:
+    """Replace code-bearing nodes with the matching server-trusted source.
+
+    The caller must first validate each node's declared type and code hash with
+    :func:`check_flow_and_raise`. This second pass ensures the build executes
+    the server's copy for that exact hash instead of request bytes, and fails
+    closed if the trusted-source lookup is incomplete. Nested flow payloads are
+    handled recursively.
+    """
+    blocked: list[str] = []
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+
+        node_data = node.get("data")
+        if not isinstance(node_data, dict):
+            continue
+
+        node_info = node_data.get("node")
+        if not isinstance(node_info, dict):
+            continue
+
+        template = node_info.get("template")
+        code_field = template.get("code") if isinstance(template, dict) else None
+        code = code_field.get("value") if isinstance(code_field, dict) else None
+        if isinstance(code, str) and code:
+            trusted = get_trusted_code_for_validation(code)
+            if trusted is None:
+                display_name = node_info.get("display_name") or node_data.get("type") or "unknown"
+                node_id = node_data.get("id") or node.get("id", "unknown")
+                blocked.append(f"{display_name} ({node_id})")
+            else:
+                code_field["value"] = trusted
+
+        nested_flow = node_info.get("flow")
+        if isinstance(nested_flow, dict):
+            nested_data = nested_flow.get("data")
+            nested_nodes = nested_data.get("nodes") if isinstance(nested_data, dict) else None
+            if isinstance(nested_nodes, list) and nested_nodes:
+                blocked.extend(_substitute_trusted_code_by_hash(nested_nodes))
+
+    return blocked
 
 
 def resolve_trusted_code_for_build(code: str) -> str:
@@ -458,9 +556,11 @@ def check_flow_and_raise(
         return
 
     nodes = flow_data.get("nodes", [])
+    if not isinstance(nodes, list):
+        msg = "Flow validation failed: nodes must be a list."
+        raise CustomComponentValidationError(msg)
     if not nodes:
         return
-
     if type_to_current_hash is None:
         logger.error(
             "Flow validation requested but component hash lookups are not yet loaded. "
@@ -861,8 +961,13 @@ def validate_public_flow_no_code_execution(target: Mapping[str, Any] | Any | Non
         raise PublicFlowValidationError(message)
 
 
-async def ensure_component_hash_lookups_loaded() -> dict[str, str] | None:
-    """Ensure component hash lookups are available for CLI/runtime validation."""
+async def ensure_component_hash_lookups_loaded(*, force: bool = False) -> dict[str, set[str]] | None:
+    """Ensure component hash lookups are available for runtime validation.
+
+    Normally the lookup is required only when custom components are disabled.
+    ``force=True`` also loads it for caller-specific policy, such as the
+    admin-only gate for a non-superuser build request.
+    """
     from lfx.interface.components import component_cache, get_and_cache_all_types_dict
     from lfx.services.deps import get_settings_service
 
@@ -870,11 +975,126 @@ async def ensure_component_hash_lookups_loaded() -> dict[str, str] | None:
     if settings_service is None:
         raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
 
-    if not settings_service.settings.allow_custom_components and component_cache.type_to_current_hash is None:
+    lookups_required = force or not settings_service.settings.allow_custom_components
+    if lookups_required and component_cache.type_to_current_hash is None:
         try:
-            await get_and_cache_all_types_dict(settings_service)
+            if component_cache.all_types_dict is None:
+                await get_and_cache_all_types_dict(settings_service)
+            if component_cache.type_to_current_hash is None:
+                get_component_hash_lookups_for_validation()
         except Exception as exc:
             logger.warning("Failed to populate component template hash lookups", exc_info=exc)
             raise
 
     return component_cache.type_to_current_hash
+
+
+def _sanitize_admin_only_flow_build(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    type_to_current_hash: dict[str, set[str]] | None,
+) -> dict[str, Any] | None:
+    """Return trusted build data after component hashes have been loaded.
+
+    Admin-only mode permits regular users to refresh and run known server
+    component templates, but not to submit new or modified component code.
+    Validate every code-bearing node against the server registry, then replace
+    the request bytes with the trusted source for the matching hash before the
+    graph is handed to the build worker.
+    """
+    import copy
+
+    normalized_flow_data = _extract_flow_data(target)
+    if normalized_flow_data is None:
+        if target is not None:
+            msg = (
+                "Flow validation failed: could not extract graph data from the provided target. "
+                "Ensure the flow payload or Graph object contains valid graph data."
+            )
+            raise CustomComponentValidationError(msg)
+        return None
+
+    check_flow_and_raise(
+        normalized_flow_data,
+        allow_custom_components=False,
+        type_to_current_hash=type_to_current_hash,
+    )
+
+    sanitized = copy.deepcopy(normalized_flow_data)
+    nodes = sanitized.get("nodes", [])
+    blocked = _substitute_trusted_code_by_hash(nodes) if isinstance(nodes, list) else []
+    if blocked:
+        blocked_names = ", ".join(blocked)
+        logger.warning(f"Flow build blocked: trusted component source unavailable: {blocked_names}")
+        message = f"Flow build blocked: no trusted server component matches: {blocked_names}"
+        raise CustomComponentValidationError(message)
+
+    return sanitized
+
+
+def _admin_only_build_required(settings: Any, *, is_superuser: bool) -> bool:
+    return getattr(settings, "custom_component_admin_only", False) is True and not is_superuser
+
+
+async def prepare_admin_only_flow_build(target: Mapping[str, Any] | Any | None) -> dict[str, Any] | None:
+    """Backward-compatible admin-only sanitizer for callers that already selected this policy."""
+    return _sanitize_admin_only_flow_build(
+        target,
+        type_to_current_hash=await ensure_component_hash_lookups_loaded(force=True),
+    )
+
+
+async def prepare_flow_build_for_user(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    is_superuser: bool,
+) -> dict[str, Any] | None:
+    """Apply cumulative build policies and sanitize inline data when required.
+
+    This async form can populate a cold component registry and is used by V1
+    endpoints before caller-supplied graph data reaches a graph constructor or
+    worker. ``None`` means the original payload is safe to preserve unchanged.
+    """
+    from lfx.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    if settings_service is None:
+        raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
+
+    admin_only = _admin_only_build_required(settings_service.settings, is_superuser=is_superuser)
+    type_to_current_hash = await ensure_component_hash_lookups_loaded(force=True) if admin_only else None
+
+    # Policies are cumulative: the admin-only hash gate must not disable the
+    # code-interpreter or global custom-component restrictions.
+    validate_flow_for_current_settings(target)
+    if not admin_only:
+        return None
+
+    return _sanitize_admin_only_flow_build(target, type_to_current_hash=type_to_current_hash)
+
+
+def prepare_flow_build_for_user_from_cache(
+    target: Mapping[str, Any] | Any | None,
+    *,
+    is_superuser: bool,
+) -> dict[str, Any] | None:
+    """Synchronous policy gate for execution seams that construct responses.
+
+    The V2 streaming host must validate before returning ``StreamingResponse``
+    and cannot await registry loading at that seam. Startup normally warms the
+    registry; if it is unavailable, the hash gate fails closed.
+    """
+    from lfx.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    if settings_service is None:
+        raise RuntimeError(SETTINGS_SERVICE_REQUIRED_MESSAGE)
+
+    validate_flow_for_current_settings(target)
+    if not _admin_only_build_required(settings_service.settings, is_superuser=is_superuser):
+        return None
+
+    return _sanitize_admin_only_flow_build(
+        target,
+        type_to_current_hash=get_component_hash_lookups_for_validation(),
+    )

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -61,6 +61,7 @@ async def test_ensure_component_hash_lookups_loaded_surfaces_loader_failures(mon
         settings=SimpleNamespace(allow_custom_components=False),
     )
     monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(component_cache, "all_types_dict", None)
     monkeypatch.setattr(component_cache, "type_to_current_hash", None)
 
     with (

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -73,6 +73,237 @@ async def test_ensure_component_hash_lookups_loaded_surfaces_loader_failures(mon
         await ensure_component_hash_lookups_loaded()
 
 
+@pytest.mark.asyncio
+async def test_ensure_component_hash_lookups_loaded_force_loads_in_permissive_mode(monkeypatch):
+    """Caller-specific policy can require hashes even when custom components are globally enabled."""
+    from lfx.interface.components import component_cache
+    from lfx.utils import flow_validation as fv
+
+    trusted_code = "# trusted component"
+    trusted_hash = fv._compute_code_hash(trusted_code)
+    all_types_dict = {
+        "inputs": {
+            "ChatInput": {
+                "metadata": {"code_hash": trusted_hash},
+                "template": {"code": {"value": trusted_code}},
+            }
+        }
+    }
+    settings_service = SimpleNamespace(settings=SimpleNamespace(allow_custom_components=True))
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(component_cache, "all_types_dict", None)
+    monkeypatch.setattr(component_cache, "type_to_current_hash", None)
+    monkeypatch.setattr(component_cache, "all_known_hashes", None)
+    monkeypatch.setattr(component_cache, "code_by_hash", None)
+
+    async def load_components(_settings_service):
+        component_cache.all_types_dict = all_types_dict
+        return all_types_dict
+
+    monkeypatch.setattr("lfx.interface.components.get_and_cache_all_types_dict", load_components)
+
+    lookups = await ensure_component_hash_lookups_loaded(force=True)
+
+    assert lookups == {"ChatInput": {trusted_hash}}
+    assert component_cache.code_by_hash == {trusted_hash: trusted_code}
+
+
+@pytest.mark.asyncio
+async def test_prepare_admin_only_flow_build_blocks_modified_known_component(monkeypatch):
+    """A regular user cannot relabel modified code as a built-in component in admin-only mode."""
+    from lfx.utils import flow_validation as fv
+
+    trusted_code = "# trusted ChatInput code"
+    trusted_hash = fv._compute_code_hash(trusted_code)
+    monkeypatch.setattr(
+        fv,
+        "ensure_component_hash_lookups_loaded",
+        AsyncMock(return_value={"ChatInput": {trusted_hash}}),
+    )
+
+    flow = {"nodes": [_node("custom", "ChatInput", "# modified code")], "edges": []}
+    with pytest.raises(CustomComponentValidationError, match="outdated components"):
+        await fv.prepare_admin_only_flow_build(flow)
+
+
+@pytest.mark.asyncio
+async def test_prepare_admin_only_flow_build_substitutes_server_source(monkeypatch):
+    """Even a matching request hash is replaced with the server's source before build."""
+    from lfx.utils import flow_validation as fv
+
+    submitted_code = "# request bytes with a matching truncated hash"
+    trusted_code = "# server-trusted component source"
+    monkeypatch.setattr(fv, "_compute_code_hash", lambda _code: "same-hash")
+    monkeypatch.setattr(
+        fv,
+        "ensure_component_hash_lookups_loaded",
+        AsyncMock(return_value={"ChatInput": {"same-hash"}}),
+    )
+    monkeypatch.setattr(fv, "get_trusted_code_for_validation", lambda _code: trusted_code)
+
+    flow = {"nodes": [_node("known", "ChatInput", submitted_code)], "edges": []}
+    sanitized = await fv.prepare_admin_only_flow_build(flow)
+
+    assert sanitized is not None
+    assert sanitized["nodes"][0]["data"]["node"]["template"]["code"]["value"] == trusted_code
+    assert flow["nodes"][0]["data"]["node"]["template"]["code"]["value"] == submitted_code
+
+
+@pytest.mark.asyncio
+async def test_prepare_admin_only_flow_build_fails_closed_without_trusted_source(monkeypatch):
+    """A matching hash is insufficient when the server cannot recover trusted source bytes."""
+    from lfx.utils import flow_validation as fv
+
+    code = "# known hash"
+    code_hash = fv._compute_code_hash(code)
+    monkeypatch.setattr(
+        fv,
+        "ensure_component_hash_lookups_loaded",
+        AsyncMock(return_value={"ChatInput": {code_hash}}),
+    )
+    monkeypatch.setattr(fv, "get_trusted_code_for_validation", lambda _code: None)
+
+    flow = {"nodes": [_node("known", "ChatInput", code)], "edges": []}
+    with pytest.raises(CustomComponentValidationError, match="no trusted server component"):
+        await fv.prepare_admin_only_flow_build(flow)
+
+
+@pytest.mark.asyncio
+async def test_prepare_flow_build_for_user_keeps_code_interpreter_policy_cumulative(monkeypatch):
+    """Admin-only sanitization must not disable the separate code-interpreter gate."""
+    from lfx.utils import flow_validation as fv
+
+    code = "print('builtin component')"
+    code_hash = fv._compute_code_hash(code)
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=True,
+            custom_component_admin_only=True,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(
+        fv,
+        "ensure_component_hash_lookups_loaded",
+        AsyncMock(return_value={"PythonREPLComponent": {code_hash}}),
+    )
+
+    with pytest.raises(CustomComponentValidationError, match="code-execution components are not allowed"):
+        await fv.prepare_flow_build_for_user(_code_interpreter_raw_graph(), is_superuser=False)
+
+
+def _malformed_inline_graphs() -> list[dict]:
+    return [
+        {"nodes": [["not-a-node"]], "edges": []},
+        {"nodes": {}, "edges": []},
+        {"nodes": None, "edges": []},
+        {
+            "nodes": [
+                {
+                    "id": "wrapper",
+                    "data": {
+                        "type": "GroupNode",
+                        "node": {"flow": {"data": "not-flow-data"}},
+                    },
+                }
+            ],
+            "edges": [],
+        },
+        {
+            "nodes": [
+                {
+                    "id": "wrapper",
+                    "data": {
+                        "type": "GroupNode",
+                        "node": {"flow": {"data": {"nodes": {}}}},
+                    },
+                }
+            ],
+            "edges": [],
+        },
+        {
+            "nodes": [
+                {
+                    "id": "bad-template",
+                    "data": {
+                        "type": "ChatInput",
+                        "node": {"template": "not-a-template"},
+                    },
+                }
+            ],
+            "edges": [],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow", _malformed_inline_graphs())
+async def test_prepare_flow_build_for_user_maps_malformed_shapes_to_policy_error(monkeypatch, flow):
+    """The cumulative async gate fails closed for malformed top-level and nested request shapes."""
+    from lfx.utils import flow_validation as fv
+
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=True,
+            custom_component_admin_only=True,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(fv, "ensure_component_hash_lookups_loaded", AsyncMock(return_value={}))
+
+    with pytest.raises(CustomComponentValidationError):
+        await fv.prepare_flow_build_for_user(flow, is_superuser=False)
+
+
+@pytest.mark.parametrize("flow", _malformed_inline_graphs())
+def test_prepare_flow_build_for_user_from_cache_maps_malformed_shapes_to_policy_error(monkeypatch, flow):
+    """The synchronous V2 gate maps malformed payloads to the normal policy error type."""
+    from lfx.utils import flow_validation as fv
+
+    settings_service = SimpleNamespace(
+        settings=SimpleNamespace(
+            allow_custom_components=True,
+            block_code_interpreter_components=True,
+            custom_component_admin_only=True,
+        )
+    )
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(fv, "get_component_hash_lookups_for_validation", dict)
+
+    with pytest.raises(CustomComponentValidationError):
+        fv.prepare_flow_build_for_user_from_cache(flow, is_superuser=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "nodes",
+    [
+        [["not-a-node"]],
+        [{"id": "bad", "data": "not-node-data"}],
+        [
+            {
+                "id": "wrapper",
+                "data": {
+                    "id": "wrapper",
+                    "type": "GroupNode",
+                    "node": {"flow": {"data": {"nodes": [["not-a-nested-node"]]}}},
+                },
+            }
+        ],
+    ],
+)
+async def test_prepare_admin_only_flow_build_maps_malformed_nodes_to_policy_error(monkeypatch, nodes):
+    """Malformed top-level and nested shapes fail closed without leaking TypeError/AttributeError."""
+    from lfx.utils import flow_validation as fv
+
+    monkeypatch.setattr(fv, "ensure_component_hash_lookups_loaded", AsyncMock(return_value={}))
+
+    with pytest.raises(CustomComponentValidationError, match="custom components are not allowed"):
+        await fv.prepare_admin_only_flow_build({"nodes": nodes, "edges": []})
+
+
 def test_validate_flow_for_current_settings_requires_settings_service(monkeypatch):
     """Unified validation should also require the settings service."""
     monkeypatch.setattr("lfx.services.deps.get_settings_service", lambda: None)


### PR DESCRIPTION
## Summary

- apply the admin-only custom-component policy at every inline V1 and V2 build entrypoint, including legacy, streaming, and background execution paths
- validate submitted component code against the server registry and substitute the server-trusted source before execution
- keep global code-interpreter/custom-component restrictions cumulative and map malformed graph shapes to the normal policy error path

## Validation

- `src/lfx/tests/unit/utils/test_flow_validation.py`: 95 passed
- V1/V2 focused route tests: 14 passed
- Ruff format/check and pre-commit: passed
- Independent security/code review: approved with no findings

Related: LE-2131 / PVR0835650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved workflow validation and sanitization for submitted and inline flow data.
  * Restricted builds now use trusted component code and reject altered, unverifiable, or malformed components.
  * Added stronger protections for nested flows and admin-only components.

* **Bug Fixes**
  * Authorization failures now return appropriate not-found responses.
  * Vertex-order retrieval errors now return service-unavailable responses.
  * Malformed workflow structures now produce clear validation errors instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->