### PR TITLE
fix(security): contain bundle FileInput paths

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -614,22 +614,33 @@ async def generate_flow_events(
                 session_id=effective_session_id,
                 run_id=str(job_id) if job_id is not None else run_id,
             )
-            if source_flow_id is not None:
-                graph.flow_id = str(flow_id)
-            return graph
+        else:
+            if not flow_name:
+                lookup_flow_id = source_flow_id if source_flow_id is not None else flow_id
+                result = await fresh_session.exec(select(Flow.name).where(Flow.id == lookup_flow_id))
+                flow_name = result.first()
 
-        if not flow_name:
-            result = await fresh_session.exec(select(Flow.name).where(Flow.id == flow_id))
-            flow_name = result.first()
+            # Sanitized public data still contains FileInput references under
+            # the real source-flow namespace. Build under that trusted scope;
+            # after parameter containment completes, switch the graph to the
+            # visitor-virtual execution ID below.
+            graph_build_flow_id = str(source_flow_id) if source_flow_id is not None else flow_id_str
+            graph = await build_graph_from_data(
+                flow_id=graph_build_flow_id,
+                payload=data.model_dump(),
+                user_id=str(current_user.id),
+                flow_name=flow_name,
+                session_id=effective_session_id,
+                run_id=str(job_id) if job_id is not None else run_id,
+            )
 
-        return await build_graph_from_data(
-            flow_id=flow_id_str,
-            payload=data.model_dump(),
-            user_id=str(current_user.id),
-            flow_name=flow_name,
-            session_id=effective_session_id,
-            run_id=str(job_id) if job_id is not None else run_id,
-        )
+        if source_flow_id is not None:
+            # This value comes from the server-resolved public flow, never from
+            # request data. FileInput containment uses it only after flow_id
+            # becomes visitor-virtual.
+            graph.source_flow_id = str(source_flow_id)
+            graph.flow_id = str(flow_id)
+        return graph
 
     def sort_vertices(graph: Graph) -> list[str]:
         try:

--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -13,6 +13,7 @@ from lfx.graph.vertex.base import Vertex
 from lfx.log.logger import logger
 from lfx.schema.legacy_render import project_payload_to_v1
 from lfx.schema.schema import InputValueRequest
+from lfx.utils.file_path_security import LocalFileAccessError
 from sqlmodel import select
 
 from langflow.api.disconnect import DisconnectHandlerStreamingResponse
@@ -571,7 +572,7 @@ async def generate_flow_events(
                 error_message=str(exc),
             )
 
-            if "stream or streaming set to True" in str(exc):
+            if isinstance(exc, LocalFileAccessError) or "stream or streaming set to True" in str(exc):
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             await logger.aexception("Error checking build status: " + str(exc))
             raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/backend/tests/unit/api/test_build_source_flow_provenance.py
+++ b/src/backend/tests/unit/api/test_build_source_flow_provenance.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, HTTPException
 from langflow.api.v1.schemas import FlowDataRequest
 from lfx.events.event_manager import create_default_event_manager
+from lfx.graph.vertex.base import Vertex
+from lfx.utils.file_path_security import LocalFileAccessError
 
 
 @pytest.mark.parametrize("use_sanitized_data", [False, True])
@@ -72,3 +74,50 @@ async def test_generate_flow_events_sets_source_flow_provenance_for_public_graph
     else:
         build_from_db.assert_awaited_once()
         build_from_data.assert_not_awaited()
+
+
+async def test_generate_flow_events_maps_rejected_file_tweaks_to_bad_request(monkeypatch):
+    import langflow.api.build as build_module
+
+    flow_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    vertex = MagicMock(spec=Vertex)
+    vertex.id = "file-node"
+    rejection = "FileInput path is outside the authenticated user's storage scope."
+    vertex.update_raw_params.side_effect = LocalFileAccessError(rejection)
+    graph = MagicMock()
+    graph.vertices = [vertex]
+
+    chat_service = MagicMock()
+    telemetry_service = MagicMock()
+
+    @asynccontextmanager
+    async def fake_session_scope():
+        yield MagicMock()
+
+    monkeypatch.setattr(build_module, "get_chat_service", lambda: chat_service)
+    monkeypatch.setattr(build_module, "get_telemetry_service", lambda: telemetry_service)
+    monkeypatch.setattr(build_module, "session_scope", fake_session_scope)
+    monkeypatch.setattr(build_module, "build_graph_from_db", AsyncMock(return_value=graph))
+    unexpected_log = AsyncMock()
+    monkeypatch.setattr(build_module.logger, "aexception", unexpected_log)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await build_module.generate_flow_events(
+            flow_id=flow_id,
+            background_tasks=BackgroundTasks(),
+            event_manager=create_default_event_manager(asyncio.Queue()),
+            inputs=None,
+            data=None,
+            files=None,
+            stop_component_id=None,
+            start_component_id=None,
+            log_builds=False,
+            current_user=SimpleNamespace(id=user_id),
+            tweaks={"file-node": {"file": "other-flow/secret.txt"}},
+            track_job_status=False,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == rejection
+    unexpected_log.assert_not_awaited()

--- a/src/backend/tests/unit/api/test_build_source_flow_provenance.py
+++ b/src/backend/tests/unit/api/test_build_source_flow_provenance.py
@@ -1,0 +1,74 @@
+"""Tests for server-provenanced public-flow storage scopes."""
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import BackgroundTasks
+from langflow.api.v1.schemas import FlowDataRequest
+from lfx.events.event_manager import create_default_event_manager
+
+
+@pytest.mark.parametrize("use_sanitized_data", [False, True])
+async def test_generate_flow_events_sets_source_flow_provenance_for_public_graph(monkeypatch, use_sanitized_data):
+    import langflow.api.build as build_module
+
+    virtual_flow_id = uuid.uuid4()
+    source_flow_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    graph = MagicMock()
+    graph.source_flow_id = None
+    graph.flow_id = str(source_flow_id)
+    graph.session_id = str(virtual_flow_id)
+    graph.run_id = None
+    graph.vertices = []
+    graph.vertices_to_run = set()
+    graph.sort_vertices.return_value = []
+    graph.set_run_id.side_effect = lambda value: setattr(graph, "run_id", value)
+    graph.end_all_traces = AsyncMock()
+
+    chat_service = MagicMock()
+    chat_service.set_cache = AsyncMock()
+    telemetry_service = MagicMock()
+
+    @asynccontextmanager
+    async def fake_session_scope():
+        yield MagicMock()
+
+    build_from_db = AsyncMock(return_value=graph)
+    build_from_data = AsyncMock(return_value=graph)
+    monkeypatch.setattr(build_module, "get_chat_service", lambda: chat_service)
+    monkeypatch.setattr(build_module, "get_telemetry_service", lambda: telemetry_service)
+    monkeypatch.setattr(build_module, "session_scope", fake_session_scope)
+    monkeypatch.setattr(build_module, "build_graph_from_db", build_from_db)
+    monkeypatch.setattr(build_module, "build_graph_from_data", build_from_data)
+
+    data = FlowDataRequest(nodes=[], edges=[]) if use_sanitized_data else None
+    await build_module.generate_flow_events(
+        flow_id=virtual_flow_id,
+        source_flow_id=source_flow_id,
+        background_tasks=BackgroundTasks(),
+        event_manager=create_default_event_manager(asyncio.Queue()),
+        inputs=None,
+        data=data,
+        files=None,
+        stop_component_id=None,
+        start_component_id=None,
+        log_builds=False,
+        current_user=SimpleNamespace(id=user_id),
+        flow_name="public-flow",
+        track_job_status=False,
+    )
+
+    assert graph.source_flow_id == str(source_flow_id)
+    assert graph.flow_id == str(virtual_flow_id)
+    if use_sanitized_data:
+        build_from_data.assert_awaited_once()
+        assert build_from_data.await_args.kwargs["flow_id"] == str(source_flow_id)
+        build_from_db.assert_not_awaited()
+    else:
+        build_from_db.assert_awaited_once()
+        build_from_data.assert_not_awaited()

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -96,6 +96,9 @@ class Graph:
         self._runs = 0
         self._updates = 0
         self.flow_id = flow_id
+        # Server-set provenance for a public flow whose execution uses a virtual
+        # flow_id. Request data must never populate this storage scope.
+        self.source_flow_id: str | None = None
         self.flow_name = flow_name
         self.description = description
         self.user_id = user_id
@@ -1285,6 +1288,7 @@ class Graph:
             "vertices": self.vertices,
             "edges": self.edges,
             "flow_id": self.flow_id,
+            "source_flow_id": self.source_flow_id,
             "flow_name": self.flow_name,
             "description": self.description,
             "user_id": self.user_id,
@@ -1327,6 +1331,7 @@ class Graph:
                 copy.deepcopy(self.flow_name, memo),
                 copy.deepcopy(self.user_id, memo),
             )
+            new_graph.source_flow_id = copy.deepcopy(self.source_flow_id, memo)
         else:
             # Create a new graph without start and end, but copy flow_id, flow_name, and user_id
             new_graph = type(self)(
@@ -1336,6 +1341,9 @@ class Graph:
                 copy.deepcopy(self.flow_name, memo),
                 copy.deepcopy(self.user_id, memo),
             )
+            # add_nodes_and_edges synchronously builds FileInput parameters, so
+            # trusted public-flow provenance must exist before reconstruction.
+            new_graph.source_flow_id = copy.deepcopy(self.source_flow_id, memo)
             # Deep copy vertices and edges
             new_graph.add_nodes_and_edges(copy.deepcopy(self._vertices, memo), copy.deepcopy(self._edges, memo))
 
@@ -1345,6 +1353,9 @@ class Graph:
         return new_graph
 
     def __setstate__(self, state):
+        # Graphs cached before source-flow provenance was introduced remain
+        # loadable and simply have no additional trusted storage namespace.
+        state.setdefault("source_flow_id", None)
         run_manager = state["run_manager"]
         if isinstance(run_manager, RunnableVerticesManager):
             state["run_manager"] = run_manager
@@ -2712,6 +2723,7 @@ class Graph:
         subgraph._tracing_service_initialized = True
         subgraph._run_id = self._run_id
         subgraph.session_id = self.session_id
+        subgraph.source_flow_id = self.source_flow_id
         subgraph._is_subgraph = True
 
         # Add the filtered nodes and edges

--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -355,7 +355,7 @@ class Vertex:
         self.load_from_db_fields = load_from_db_fields
         self.raw_params = self.params.copy()
 
-    def update_raw_params(self, new_params: Mapping[str, str | list[str]], *, overwrite: bool = False) -> None:
+    def update_raw_params(self, new_params: Mapping[str, Any], *, overwrite: bool = False) -> None:
         """Update the raw parameters of the vertex with the given new parameters.
 
         Args:
@@ -371,11 +371,13 @@ class Vertex:
             return
         if any(isinstance(self.raw_params.get(key), Vertex) for key in new_params):
             return
+        params_to_update = dict(new_params)
         if not overwrite:
-            for key in new_params.copy():  # type: ignore[attr-defined]
+            for key in params_to_update.copy():
                 if key not in self.raw_params:
-                    new_params.pop(key)  # type: ignore[attr-defined]
-        self.raw_params.update(new_params)
+                    params_to_update.pop(key)
+        params_to_update = ParameterHandler(self, storage_service=None).process_runtime_params(params_to_update)
+        self.raw_params.update(params_to_update)
         self.params = self.raw_params.copy()
         self.updated_raw_params = True
 

--- a/src/lfx/src/lfx/graph/vertex/param_handler.py
+++ b/src/lfx/src/lfx/graph/vertex/param_handler.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Mapping
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
@@ -11,6 +13,11 @@ from lfx.log.logger import logger
 from lfx.schema.data import Data
 from lfx.services.deps import get_storage_service
 from lfx.utils.constants import DIRECT_TYPES
+from lfx.utils.file_path_security import (
+    LocalFileAccessError,
+    enforce_local_file_access,
+    is_local_file_access_restricted,
+)
 from lfx.utils.util import unescape_string
 
 if TYPE_CHECKING:
@@ -52,6 +59,7 @@ class ParameterHandler:
         # Lazy initialization of storage service
         self._storage_service = storage_service
         self._storage_service_initialized = False
+        self._canonical_file_fields_cache: dict[str, dict[str, Any]] | None = None
 
     @property
     def storage_service(self):
@@ -61,6 +69,108 @@ class ParameterHandler:
                 self._storage_service = get_storage_service()
             self._storage_service_initialized = True
         return self._storage_service
+
+    @staticmethod
+    def _file_input_names_from_code(code: str) -> set[str]:
+        """Extract literal FileInput names from trusted component source."""
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return set()
+
+        aliases = {"FileInput"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                aliases.update(alias.asname or alias.name for alias in node.names if alias.name == "FileInput")
+
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            is_file_input = (isinstance(node.func, ast.Name) and node.func.id in aliases) or (
+                isinstance(node.func, ast.Attribute) and node.func.attr == "FileInput"
+            )
+            if not is_file_input:
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+                    if isinstance(keyword.value.value, str) and keyword.value.value:
+                        names.add(keyword.value.value)
+                    break
+        return names
+
+    def _canonical_file_fields(self) -> dict[str, dict[str, Any]]:
+        """Return FileInput metadata derived from server-trusted component source."""
+        if self._canonical_file_fields_cache is not None:
+            return self._canonical_file_fields_cache
+
+        canonical_fields: dict[str, dict[str, Any]] = {}
+        code_field = self.template_dict.get("code")
+        submitted_code = code_field.get("value") if isinstance(code_field, dict) else None
+        if not isinstance(submitted_code, str) or not submitted_code:
+            self._canonical_file_fields_cache = canonical_fields
+            return canonical_fields
+
+        # The flow policy may substitute a server-owned source for a matching
+        # submitted hash. Use that same trusted source for input classification;
+        # an exact source comparison below prevents request metadata from
+        # declaring what is or is not a FileInput.
+        from lfx.interface.components import component_cache
+        from lfx.utils.flow_validation import get_trusted_code_for_validation
+
+        trusted_code = get_trusted_code_for_validation(submitted_code) or submitted_code
+        all_types_dict = component_cache.all_types_dict
+        if isinstance(all_types_dict, Mapping):
+            for category_components in all_types_dict.values():
+                if not isinstance(category_components, Mapping):
+                    continue
+                for component_data in category_components.values():
+                    if not isinstance(component_data, Mapping):
+                        continue
+                    template = component_data.get("template")
+                    if not isinstance(template, Mapping):
+                        continue
+                    server_code_field = template.get("code")
+                    server_code = server_code_field.get("value") if isinstance(server_code_field, Mapping) else None
+                    if server_code != trusted_code:
+                        continue
+                    for field_name, field in template.items():
+                        if not isinstance(field_name, str) or not isinstance(field, Mapping):
+                            continue
+                        if field.get("type") == "file" or field.get("_input_type") == "FileInput":
+                            canonical_fields.setdefault(field_name, dict(field))
+
+        # Direct declarations remain detectable while the component registry is
+        # warming, and cover older trusted component versions absent from the
+        # current registry. Registry metadata above still supplies list/required
+        # semantics for inherited or dynamically assembled inputs.
+        for field_name in self._file_input_names_from_code(trusted_code):
+            canonical_fields.setdefault(
+                field_name,
+                {"type": "file", "_input_type": "FileInput", "list": False, "required": False},
+            )
+
+        self._canonical_file_fields_cache = canonical_fields
+        return canonical_fields
+
+    def _effective_file_field(self, field_name: str, field: dict[str, Any]) -> dict[str, Any]:
+        """Overlay server-owned FileInput semantics on request-supplied values."""
+        canonical = self._canonical_file_fields().get(field_name)
+        if canonical is None:
+            return field
+
+        effective = dict(field)
+        for key in ("type", "_input_type", "list", "required", "display_name"):
+            if key in canonical:
+                effective[key] = canonical[key]
+        effective["type"] = "file"
+        effective["_canonical_file_input"] = True
+        effective.setdefault("list", False)
+        return effective
+
+    @staticmethod
+    def _is_file_field(field: Mapping[str, Any]) -> bool:
+        return field.get("type") == "file" or field.get("_input_type") == "FileInput"
 
     def process_edge_parameters(self, edges: list[CycleEdge]) -> dict[str, Any]:
         """Process parameters from edges.
@@ -123,11 +233,13 @@ class ParameterHandler:
         params: dict[str, Any] = {}
         load_from_db_fields: list[str] = []
 
-        for field_name, field in self.template_dict.items():
+        restricted = is_local_file_access_restricted()
+        for field_name, request_field in self.template_dict.items():
+            field = self._effective_file_field(field_name, request_field) if restricted else request_field
             if self.should_skip_field(field_name, field, params):
                 continue
 
-            if field.get("type") == "file":
+            if self._is_file_field(field):
                 params = self.process_file_field(field_name, field, params)
             elif field.get("type") in DIRECT_TYPES and params.get(field_name) is None:
                 params, load_from_db_fields = self._process_direct_type_field(
@@ -157,25 +269,11 @@ class ParameterHandler:
 
         Converts logical paths (flow_id/filename) to component-ready paths.
         """
-        if file_path := field.get("file_path"):
-            try:
-                full_path: str | list[str] = ""
-                if field.get("list"):
-                    full_path = []
-                    if isinstance(file_path, str):
-                        file_path = [file_path]
-                    for p in file_path:
-                        resolved = self.storage_service.resolve_component_path(p)
-                        full_path.append(resolved)
-                else:
-                    full_path = self.storage_service.resolve_component_path(file_path)
-
-            except ValueError as e:
-                if "too many values to unpack" in str(e):
-                    full_path = file_path
-                else:
-                    raise
-            params[field_name] = full_path
+        file_path = field.get("file_path")
+        if not file_path and field.get("_canonical_file_input"):
+            file_path = field.get("value")
+        if file_path:
+            params[field_name] = self.process_file_value(file_path, is_list=bool(field.get("list")))
         elif field.get("required"):
             field_display_name = field.get("display_name")
             logger.warning(
@@ -184,11 +282,112 @@ class ParameterHandler:
                 self.vertex.display_name,
             )
             params[field_name] = None
-        elif field["list"]:
+        elif field.get("list"):
             params[field_name] = []
         else:
             params[field_name] = None
         return params
+
+    def process_runtime_params(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Resolve and contain FileInput values supplied as runtime tweaks."""
+        processed = params.copy()
+        # Runtime tweaks were historically passed through unchanged. Preserve
+        # that behavior when the operator has explicitly disabled containment.
+        if not is_local_file_access_restricted():
+            return processed
+
+        for field_name, value in processed.items():
+            request_field = self.template_dict.get(field_name, {})
+            field = self._effective_file_field(field_name, request_field)
+            empty_value = value is None or (isinstance(value, str | list) and not value)
+            if not self._is_file_field(field) or empty_value:
+                continue
+            file_value = value
+            if isinstance(value, dict):
+                if "file_path" in value:
+                    file_value = value["file_path"]
+                elif set(value) == {"value"}:
+                    file_value = value["value"]
+                else:
+                    msg = "Runtime FileInput tweaks must provide a file path."
+                    raise LocalFileAccessError(msg)
+            processed[field_name] = self.process_file_value(
+                file_value,
+                is_list=bool(field.get("list")) or isinstance(file_value, list),
+            )
+        return processed
+
+    def process_file_value(self, file_path: str | list[str], *, is_list: bool) -> str | list[str]:
+        """Resolve a FileInput value and enforce the configured storage boundary."""
+        try:
+            if is_list:
+                paths = [file_path] if isinstance(file_path, str) else file_path
+                if not isinstance(paths, list) or not all(isinstance(path, str) for path in paths):
+                    msg = "FileInput values must be file path strings."
+                    raise LocalFileAccessError(msg)
+                full_path: str | list[str] = [self.storage_service.resolve_component_path(path) for path in paths]
+            else:
+                if not isinstance(file_path, str):
+                    msg = "FileInput values must be file path strings."
+                    raise LocalFileAccessError(msg)
+                full_path = self.storage_service.resolve_component_path(file_path)
+        except ValueError as e:
+            if "too many values to unpack" in str(e):
+                full_path = file_path
+            else:
+                raise
+        return self._enforce_file_paths(full_path)
+
+    def _file_access_scopes(self) -> list[str]:
+        """Return server-established storage namespaces for the executing graph."""
+        graph = getattr(self.vertex, "graph", None)
+        scopes: list[str] = []
+        for candidate in (
+            getattr(graph, "user_id", None),
+            getattr(graph, "flow_id", None),
+            getattr(graph, "source_flow_id", None),
+        ):
+            if candidate is not None:
+                scope = str(candidate).strip()
+                if scope and scope not in scopes:
+                    scopes.append(scope)
+        return scopes
+
+    def _enforce_file_paths(self, file_paths: str | list[str]) -> str | list[str]:
+        """Apply storage-specific containment before FileInput values reach components."""
+        storage_settings = getattr(getattr(self.storage_service, "settings_service", None), "settings", None)
+        storage_type = str(getattr(storage_settings, "storage_type", "local")).lower()
+        if not is_local_file_access_restricted():
+            return file_paths
+
+        scopes = self._file_access_scopes()
+        if storage_type == "s3":
+            if isinstance(file_paths, list):
+                return [self._enforce_s3_logical_key(path, scopes) for path in file_paths]
+            return self._enforce_s3_logical_key(file_paths, scopes)
+
+        if isinstance(file_paths, list):
+            return [str(enforce_local_file_access(path, scope_ids=scopes)) for path in file_paths]
+        return str(enforce_local_file_access(file_paths, scope_ids=scopes))
+
+    @staticmethod
+    def _enforce_s3_logical_key(file_path: str, scopes: list[str]) -> str:
+        """Reject S3 logical keys that could be interpreted as foreign local paths."""
+        path = str(file_path)
+        segments = path.split("/")
+        logical_path = PurePosixPath(path)
+        if (
+            not path
+            or "\x00" in path
+            or "\\" in path
+            or logical_path.is_absolute()
+            or any(segment in {"", ".", ".."} for segment in segments)
+            or not logical_path.parts
+            or logical_path.parts[0] not in scopes
+        ):
+            msg = "S3 file references must stay within the authenticated user's or executing flow's namespace."
+            raise LocalFileAccessError(msg)
+        return path
 
     def _process_direct_type_field(
         self, field_name: str, field: dict, params: dict[str, Any], load_from_db_fields: list[str]

--- a/src/lfx/src/lfx/utils/file_path_security.py
+++ b/src/lfx/src/lfx/utils/file_path_security.py
@@ -85,7 +85,7 @@ def _reserved_secret_paths(data_dir: Path) -> set[Path]:
 
 
 def component_file_access_scopes(component: object) -> tuple[str, ...]:
-    """Return authenticated user and flow storage scopes without requiring component properties.
+    """Return authenticated user, execution-flow, and trusted source-flow storage scopes.
 
     Components are instantiated without a graph while metadata is built. Reading ``user_id`` or
     ``flow_id`` properties in that state raises, so this helper inspects their backing graph safely.
@@ -94,6 +94,7 @@ def component_file_access_scopes(component: object) -> tuple[str, ...]:
     candidates = (
         getattr(component, "_user_id", None) or getattr(graph, "user_id", None),
         getattr(graph, "flow_id", None),
+        getattr(graph, "source_flow_id", None),
     )
     scopes: list[str] = []
     for candidate in candidates:

--- a/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
+++ b/src/lfx/tests/unit/graph/vertex/test_vertex_base.py
@@ -4,18 +4,23 @@ This module contains tests for verifying the functionality of the ParameterHandl
 which is responsible for processing and managing parameters in vertices.
 """
 
+import copy
 import pickle
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
 from ag_ui.core import StepFinishedEvent, StepStartedEvent
 from lfx.components.input_output import ChatInput
+from lfx.graph import Graph
 from lfx.graph.edge.base import Edge
 from lfx.graph.vertex import base as vertex_base_module
 from lfx.graph.vertex import vertex_types as vertex_types_module
 from lfx.graph.vertex.base import ParameterHandler, Vertex
+from lfx.interface.components import component_cache
+from lfx.services.storage.local import LocalStorageService
 from lfx.services.storage.service import StorageService
+from lfx.utils.file_path_security import LocalFileAccessError
 from lfx.utils.util import unescape_string
 
 
@@ -42,6 +47,42 @@ def test_vertex_getstate_drops_custom_component_runtime_state():
     pickle.dumps(state)
 
 
+def test_graph_source_flow_provenance_survives_pickle_and_legacy_state():
+    """Cached public graphs retain provenance while older cache entries remain readable."""
+    graph = Graph(flow_id="visitor-virtual-flow-id")
+    graph.source_flow_id = "public-source-flow-id"
+
+    restored = pickle.loads(pickle.dumps(graph))  # noqa: S301 - round-tripping trusted in-memory test data
+    assert restored.source_flow_id == "public-source-flow-id"
+
+    legacy_state = graph.__getstate__()
+    legacy_state.pop("source_flow_id")
+    legacy_graph = object.__new__(Graph)
+    legacy_graph.__setstate__(legacy_state)
+    assert legacy_graph.source_flow_id is None
+
+
+def test_graph_deepcopy_sets_source_flow_provenance_before_rebuild(monkeypatch):
+    """Deep-copy reconstruction exposes the trusted source scope before rebuilding FileInputs."""
+    graph = Graph(flow_id="visitor-virtual-flow-id")
+    graph.source_flow_id = "public-source-flow-id"
+    original_add_nodes_and_edges = Graph.add_nodes_and_edges
+    rebuild_observed = False
+
+    def checked_add_nodes_and_edges(copied_graph, nodes, edges):
+        nonlocal rebuild_observed
+        rebuild_observed = True
+        assert copied_graph.source_flow_id == "public-source-flow-id"
+        return original_add_nodes_and_edges(copied_graph, nodes, edges)
+
+    monkeypatch.setattr(Graph, "add_nodes_and_edges", checked_add_nodes_and_edges)
+
+    cloned = copy.deepcopy(graph)
+
+    assert rebuild_observed is True
+    assert cloned.source_flow_id == "public-source-flow-id"
+
+
 @pytest.fixture
 def mock_storage_service() -> Mock:
     """Create a mock storage service for testing."""
@@ -58,6 +99,9 @@ def mock_vertex() -> Mock:
     # Create a mock graph
     mock_graph = Mock()
     mock_graph.get_vertex = Mock(return_value="source_vertex")
+    mock_graph.user_id = "test-user-id"
+    mock_graph.flow_id = "test-flow-id"
+    mock_graph.source_flow_id = None
 
     # Set the graph attribute on the vertex
     vertex.graph = mock_graph
@@ -133,6 +177,443 @@ def test_process_file_field(parameter_handler):
         {},
     )
     assert params["file_field"] == []
+
+
+@pytest.fixture
+def restricted_file_access(tmp_path):
+    """Enable local-file restriction with a temporary upload storage root."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    settings_service = Mock()
+    settings_service.settings.restrict_local_file_access = True
+    settings_service.settings.config_dir = config_dir
+    settings_service.settings.database_url = ""
+    with patch("lfx.utils.file_path_security.get_settings_service", return_value=settings_service):
+        yield config_dir
+
+
+TRUSTED_FILE_COMPONENT_CODE = """
+from lfx.io import FileInput
+
+class TrustedFileComponent:
+    inputs = [FileInput(name="file_field")]
+"""
+
+
+@pytest.fixture
+def trusted_file_component_registry(monkeypatch):
+    """Install minimal server-owned metadata for canonical FileInput classification."""
+    monkeypatch.setattr(
+        component_cache,
+        "all_types_dict",
+        {
+            "trusted_bundle": {
+                "TrustedFileComponent": {
+                    "template": {
+                        "code": {"type": "code", "value": TRUSTED_FILE_COMPONENT_CODE},
+                        "file_field": {
+                            "_input_type": "FileInput",
+                            "type": "file",
+                            "list": False,
+                            "required": False,
+                            "show": True,
+                        },
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(component_cache, "code_by_hash", None)
+
+
+def _relabel_file_input_as_string(vertex, *, include_field: bool = True) -> None:
+    template = {
+        "code": {"type": "code", "value": TRUSTED_FILE_COMPONENT_CODE, "show": True},
+        "text_field": {"type": "str", "value": "original", "show": True},
+    }
+    if include_field:
+        template["file_field"] = {
+            "type": "str",
+            "value": "test-flow-id/../../server-secret.txt",
+            "show": True,
+        }
+    vertex.data["node"]["template"] = template
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_process_file_field_rejects_path_outside_graph_scopes(
+    parameter_handler,
+    mock_storage_service,
+    tmp_path,
+):
+    """FileInput paths cannot escape user/flow storage before a bundle receives them."""
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        parameter_handler.process_file_field(
+            "file_field",
+            {"type": "file", "file_path": "test-flow-id/../../server-secret.txt"},
+            {},
+        )
+
+
+@pytest.mark.usefixtures("restricted_file_access", "trusted_file_component_registry")
+def test_process_field_parameters_rejects_relabelled_canonical_file_input(
+    mock_vertex,
+    mock_storage_service,
+    tmp_path,
+):
+    """Request metadata cannot disguise a trusted bundle FileInput as a string."""
+    _relabel_file_input_as_string(mock_vertex)
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        ParameterHandler(mock_vertex, mock_storage_service).process_field_parameters()
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_process_field_parameters_uses_ast_file_input_fallback_while_registry_is_unavailable(
+    monkeypatch,
+    mock_vertex,
+    mock_storage_service,
+    tmp_path,
+):
+    """Direct trusted FileInput declarations remain protected while metadata warms."""
+    monkeypatch.setattr(component_cache, "all_types_dict", None)
+    monkeypatch.setattr(component_cache, "code_by_hash", {})
+    _relabel_file_input_as_string(mock_vertex)
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        ParameterHandler(mock_vertex, mock_storage_service).process_field_parameters()
+
+
+@pytest.mark.usefixtures("trusted_file_component_registry")
+def test_process_field_parameters_uses_canonical_file_list_semantics(
+    mock_vertex,
+    mock_storage_service,
+    restricted_file_access,
+    tmp_path,
+):
+    """Request list metadata cannot prevent containment from checking every canonical FileInput item."""
+    component_cache.all_types_dict["trusted_bundle"]["TrustedFileComponent"]["template"]["file_field"]["list"] = True
+    _relabel_file_input_as_string(mock_vertex)
+    mock_vertex.data["node"]["template"]["file_field"]["value"] = ["test-flow-id/safe.txt", "/etc/passwd"]
+    mock_vertex.data["node"]["template"]["file_field"]["list"] = False
+    safe_path = restricted_file_access / "test-flow-id" / "safe.txt"
+    safe_path.parent.mkdir()
+    safe_path.write_text("safe", encoding="utf-8")
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.side_effect = [str(safe_path), str(outside_path)]
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        ParameterHandler(mock_vertex, mock_storage_service).process_field_parameters()
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_process_file_field_rejects_legacy_absolute_path_fallback(
+    parameter_handler,
+    mock_storage_service,
+    tmp_path,
+):
+    """The legacy path-parser compatibility fallback cannot bypass containment."""
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.side_effect = ValueError("too many values to unpack")
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        parameter_handler.process_file_field(
+            "file_field",
+            {"type": "file", "file_path": str(outside_path)},
+            {},
+        )
+
+
+@pytest.mark.parametrize("namespace", ["test-user-id", "test-flow-id"])
+def test_process_file_field_allows_uploaded_files_in_graph_scopes(
+    parameter_handler,
+    mock_storage_service,
+    restricted_file_access,
+    namespace,
+):
+    """Regular and temporary uploads remain usable from user and flow namespaces."""
+    uploaded_path = restricted_file_access / namespace / "uploaded.txt"
+    uploaded_path.parent.mkdir()
+    uploaded_path.write_text("uploaded", encoding="utf-8")
+    mock_storage_service.resolve_component_path.return_value = str(uploaded_path)
+
+    params = parameter_handler.process_file_field(
+        "file_field",
+        {"type": "file", "file_path": f"{namespace}/uploaded.txt", "temp_file": True},
+        {},
+    )
+
+    assert params["file_field"] == str(uploaded_path.resolve())
+
+
+def test_process_file_field_checks_every_list_item(
+    parameter_handler,
+    mock_storage_service,
+    restricted_file_access,
+    tmp_path,
+):
+    """List-valued FileInputs reject the whole input when any path escapes."""
+    uploaded_path = restricted_file_access / "test-flow-id" / "uploaded.txt"
+    uploaded_path.parent.mkdir()
+    uploaded_path.write_text("uploaded", encoding="utf-8")
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.side_effect = [str(uploaded_path), str(outside_path)]
+
+    with pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"):
+        parameter_handler.process_file_field(
+            "file_field",
+            {
+                "type": "file",
+                "file_path": ["test-flow-id/uploaded.txt", "test-flow-id/../../server-secret.txt"],
+                "list": True,
+            },
+            {},
+        )
+
+
+def test_process_file_field_preserves_unrestricted_local_path_compatibility(
+    parameter_handler,
+    mock_storage_service,
+    tmp_path,
+):
+    """Single-tenant installs retain arbitrary local FileInput support by default."""
+    settings_service = Mock()
+    settings_service.settings.restrict_local_file_access = False
+    outside_path = tmp_path / "local-file.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with patch("lfx.utils.file_path_security.get_settings_service", return_value=settings_service):
+        params = parameter_handler.process_file_field(
+            "file_field",
+            {"type": "file", "file_path": str(outside_path)},
+            {},
+        )
+
+    assert params["file_field"] == str(outside_path)
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_process_file_field_preserves_s3_references(
+    parameter_handler,
+    mock_storage_service,
+):
+    """Non-local storage keys remain logical references for storage-aware consumers."""
+    mock_storage_service.settings_service = Mock()
+    mock_storage_service.settings_service.settings.storage_type = "s3"
+    mock_storage_service.resolve_component_path.return_value = "test-flow-id/uploaded.txt"
+
+    params = parameter_handler.process_file_field(
+        "file_field",
+        {"type": "file", "file_path": "test-flow-id/uploaded.txt"},
+        {},
+    )
+
+    assert params["file_field"] == "test-flow-id/uploaded.txt"
+
+
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        "/etc/passwd",
+        "test-flow-id/../../etc/passwd",
+        "test-flow-id\\..\\..\\windows\\win.ini",
+        "test-flow-id/secret\x00.txt",
+        "other-flow-id/uploaded.txt",
+    ],
+)
+@pytest.mark.usefixtures("restricted_file_access")
+def test_process_file_field_rejects_unsafe_s3_keys_before_bundle_file_open(
+    parameter_handler,
+    mock_storage_service,
+    malicious_path,
+):
+    """JigsawStack-style Path.open consumers never receive an unsafe S3 logical key."""
+    mock_storage_service.settings_service = Mock()
+    mock_storage_service.settings_service.settings.storage_type = "s3"
+    mock_storage_service.resolve_component_path.side_effect = lambda path: path
+
+    with pytest.raises(LocalFileAccessError, match="must stay within"):
+        parameter_handler.process_file_field(
+            "file_field",
+            {"type": "file", "file_path": malicious_path},
+            {},
+        )
+
+
+def test_process_file_field_allows_server_provenanced_public_flow_namespace(
+    parameter_handler,
+    mock_storage_service,
+    restricted_file_access,
+):
+    """Public flows retain source-flow attachments after switching to a virtual flow ID."""
+    source_flow_id = "public-source-flow-id"
+    parameter_handler.vertex.graph.flow_id = "visitor-virtual-flow-id"
+    parameter_handler.vertex.graph.source_flow_id = source_flow_id
+    uploaded_path = restricted_file_access / source_flow_id / "uploaded.txt"
+    uploaded_path.parent.mkdir()
+    uploaded_path.write_text("uploaded", encoding="utf-8")
+    mock_storage_service.resolve_component_path.return_value = str(uploaded_path)
+
+    params = parameter_handler.process_file_field(
+        "file_field",
+        {"type": "file", "file_path": f"{source_flow_id}/uploaded.txt"},
+        {},
+    )
+
+    assert params["file_field"] == str(uploaded_path.resolve())
+
+
+def _runtime_file_vertex(*, source_flow_id: str | None = None) -> Vertex:
+    vertex = object.__new__(Vertex)
+    vertex.data = {
+        "node": {
+            "template": {
+                "file_field": {"type": "file", "file_path": "test-flow-id/original.txt", "show": True},
+                "text_field": {"type": "str", "value": "original", "show": True},
+            }
+        }
+    }
+    vertex.graph = Mock(
+        user_id="test-user-id",
+        flow_id="visitor-virtual-flow-id" if source_flow_id else "test-flow-id",
+        source_flow_id=source_flow_id,
+    )
+    vertex.raw_params = {"file_field": "original-file", "text_field": "original"}
+    vertex.params = vertex.raw_params.copy()
+    vertex.updated_raw_params = False
+    return vertex
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_update_raw_params_rejects_run_flow_file_tweak_escape(mock_storage_service, tmp_path):
+    """Run Flow node tweaks cannot bypass FileInput resolution and containment."""
+    vertex = _runtime_file_vertex()
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with (
+        patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service),
+        pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"),
+    ):
+        vertex.update_raw_params({"file_field": "test-flow-id/../../server-secret.txt"}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == "original-file"
+
+
+@pytest.mark.usefixtures("restricted_file_access", "trusted_file_component_registry")
+def test_update_raw_params_rejects_relabelled_canonical_file_input(
+    mock_storage_service,
+    tmp_path,
+):
+    """Run Flow tweaks cannot bypass containment by relabeling trusted FileInput metadata."""
+    vertex = _runtime_file_vertex()
+    _relabel_file_input_as_string(vertex)
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with (
+        patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service),
+        pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"),
+    ):
+        vertex.update_raw_params({"file_field": "/etc/passwd"}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == "original-file"
+
+
+@pytest.mark.usefixtures("restricted_file_access", "trusted_file_component_registry")
+def test_update_raw_params_rejects_canonical_file_input_omitted_from_request_template(
+    mock_storage_service,
+    tmp_path,
+):
+    """Canonical field identity survives removal of its request-side metadata."""
+    vertex = _runtime_file_vertex()
+    _relabel_file_input_as_string(vertex, include_field=False)
+    outside_path = tmp_path / "server-secret.txt"
+    mock_storage_service.resolve_component_path.return_value = str(outside_path)
+
+    with (
+        patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service),
+        pytest.raises(LocalFileAccessError, match="outside the authenticated user's storage scope"),
+    ):
+        vertex.update_raw_params({"file_field": "/etc/passwd"}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == "original-file"
+
+
+def test_update_raw_params_preserves_unrestricted_absolute_path_with_real_local_storage(tmp_path):
+    """Disabling containment retains the legacy pass-through behavior for runtime tweaks."""
+    vertex = _runtime_file_vertex()
+    settings_service = Mock()
+    settings_service.settings.config_dir = tmp_path / "config"
+    settings_service.settings.restrict_local_file_access = False
+    storage_service = LocalStorageService(Mock(), settings_service)
+    absolute_path = str(tmp_path / "example.txt")
+
+    with (
+        patch("lfx.utils.file_path_security.get_settings_service", return_value=settings_service),
+        patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=storage_service),
+    ):
+        vertex.update_raw_params({"file_field": absolute_path}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == absolute_path
+
+
+@pytest.mark.usefixtures("restricted_file_access")
+def test_update_raw_params_rejects_s3_file_tweak_before_jigsawstack_file_open(mock_storage_service):
+    """Bundle consumers cannot receive absolute paths from Run Flow S3 tweaks."""
+    vertex = _runtime_file_vertex()
+    mock_storage_service.settings_service = Mock()
+    mock_storage_service.settings_service.settings.storage_type = "s3"
+    mock_storage_service.resolve_component_path.side_effect = lambda path: path
+
+    with (
+        patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service),
+        pytest.raises(LocalFileAccessError, match="must stay within"),
+    ):
+        vertex.update_raw_params({"file_field": "/etc/passwd"}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == "original-file"
+
+
+def test_update_raw_params_resolves_v2_public_flow_file_input(
+    mock_storage_service,
+    restricted_file_access,
+):
+    """V2/public execution inputs resolve against trusted source-flow provenance."""
+    source_flow_id = "public-source-flow-id"
+    vertex = _runtime_file_vertex(source_flow_id=source_flow_id)
+    uploaded_path = restricted_file_access / source_flow_id / "uploaded.txt"
+    uploaded_path.parent.mkdir()
+    uploaded_path.write_text("uploaded", encoding="utf-8")
+    mock_storage_service.resolve_component_path.return_value = str(uploaded_path)
+
+    with patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service):
+        vertex.update_raw_params({"file_field": f"{source_flow_id}/uploaded.txt"}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == str(uploaded_path.resolve())
+    assert vertex.params["file_field"] == str(uploaded_path.resolve())
+    assert vertex.updated_raw_params is True
+
+
+def test_update_raw_params_resolves_wrapped_v2_file_tweak(mock_storage_service, restricted_file_access):
+    """Template-shaped V2 FileInput tweaks use the same resolver as scalar tweaks."""
+    vertex = _runtime_file_vertex()
+    uploaded_path = restricted_file_access / "test-flow-id" / "uploaded.txt"
+    uploaded_path.parent.mkdir()
+    uploaded_path.write_text("uploaded", encoding="utf-8")
+    mock_storage_service.resolve_component_path.return_value = str(uploaded_path)
+
+    with patch("lfx.graph.vertex.param_handler.get_storage_service", return_value=mock_storage_service):
+        vertex.update_raw_params({"file_field": {"file_path": "test-flow-id/uploaded.txt"}}, overwrite=True)
+
+    assert vertex.raw_params["file_field"] == str(uploaded_path.resolve())
 
 
 def test_should_skip_field(parameter_handler):

--- a/src/lfx/tests/unit/utils/test_file_path_security.py
+++ b/src/lfx/tests/unit/utils/test_file_path_security.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from lfx.utils.file_path_security import (
     LocalFileAccessError,
+    component_file_access_scopes,
     enforce_local_file_access,
     is_local_file_access_restricted,
 )
@@ -30,6 +31,21 @@ def test_disabled_is_noop(tmp_path):
         assert is_local_file_access_restricted() is False
         # An obviously-outside path is returned unchanged.
         assert enforce_local_file_access("/etc/passwd") == Path("/etc/passwd")
+
+
+def test_component_scopes_include_trusted_public_source_flow():
+    """Bundle consumers can re-check public attachments after flow_id becomes visitor-virtual."""
+    component = MagicMock()
+    component._user_id = None
+    component._vertex.graph.user_id = "public-owner-id"
+    component._vertex.graph.flow_id = "visitor-virtual-flow-id"
+    component._vertex.graph.source_flow_id = "public-source-flow-id"
+
+    assert component_file_access_scopes(component) == (
+        "public-owner-id",
+        "visitor-virtual-flow-id",
+        "public-source-flow-id",
+    )
 
 
 def test_path_inside_storage_allowed(tmp_path):


### PR DESCRIPTION
## Summary

- derive FileInput identity from server-trusted component templates before processing request metadata
- contain initial and runtime FileInput paths within authenticated user, execution-flow, or trusted public source-flow scopes
- validate S3 logical keys and preserve trusted provenance across graph caching, copies, and subgraphs

## Validation

- `src/lfx/tests/unit/graph/vertex/test_vertex_base.py` + `test_file_path_security.py`: 69 passed
- public-flow provenance + V2 public workflow tests: 19 passed
- Ruff, Ruff format, pre-commit, and `git diff --check`: passed

Related to LE-2132 / PVR0835651.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened file access controls for local and cloud storage, including path validation and flow-specific access boundaries.
  * Prevented unauthorized access through malformed paths, traversal attempts, or untrusted runtime file settings.

* **Improvements**
  * Improved handling of public flows while preserving their source-flow context.
  * Runtime parameter updates now support more value types and avoid modifying submitted data.
  * Improved compatibility for saved and copied graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->