### PR TITLE
fix(security): close MCP stdio path-form allowlist bypass; fail hardening flags to last-known-good

### DIFF
--- a/src/lfx/src/lfx/base/mcp/security.py
+++ b/src/lfx/src/lfx/base/mcp/security.py
@@ -267,29 +267,52 @@ def extract_base_command(command: str) -> str:
     return base_command
 
 
+# Last-known-good hardening states. The settings service can be unavailable at
+# early import (legit default-off), but a runtime failure AFTER a successful
+# read must not silently revert an operator's enabled hardening to permissive.
+_hardening_last_known: dict[str, bool] = {"docker": False, "interpreter": False}
+
+
+def _read_hardening_flag(key: str, reader) -> bool:
+    """Read a hardening flag, failing to its last-known-good value on error.
+
+    A successful read always updates the cache (so an operator intentionally
+    disabling hardening is honored); only a failed read falls back to the
+    cached state (default False for the early-import case).
+    """
+    try:
+        value = bool(reader())
+    except Exception:  # noqa: BLE001 - settings may be unavailable; use last-known-good
+        return _hardening_last_known[key]
+    _hardening_last_known[key] = value
+    return value
+
+
 def _docker_hardening_enabled() -> bool:
     """Whether the opt-in MCP docker-arg hardening policy is active.
 
-    Reads ``LANGFLOW_MCP_SERVER_DOCKER_HARDENING`` (default False). Fails safe to False if the
-    settings service is unavailable -- the hardening is an opt-in multi-tenant control, not a
-    default, so an unreadable setting must not start rejecting previously-valid docker configs.
+    Reads ``LANGFLOW_MCP_SERVER_DOCKER_HARDENING`` (default False). Falls back to the
+    last-known-good value if the settings service is unavailable -- an unreadable
+    setting must not silently disable hardening an operator already turned on.
     """
-    try:
+
+    def _read() -> bool:
         from lfx.services.deps import get_settings_service
 
         return bool(get_settings_service().settings.mcp_server_docker_hardening)
-    except Exception:  # noqa: BLE001 - settings may be unavailable (e.g. early import); default off
-        return False
+
+    return _read_hardening_flag("docker", _read)
 
 
 def _interpreter_hardening_enabled() -> bool:
     """Whether direct Python/Node MCP entrypoints are restricted for multi-tenant use."""
-    try:
+
+    def _read() -> bool:
         from lfx.services.deps import get_settings_service
 
         return bool(get_settings_service().settings.mcp_server_interpreter_hardening)
-    except Exception:  # noqa: BLE001 - settings may be unavailable; preserve the legacy default
-        return False
+
+    return _read_hardening_flag("interpreter", _read)
 
 
 def _normalize_package_name(package_spec: str) -> str:
@@ -509,6 +532,16 @@ def validate_mcp_stdio_config(
 
     # Command allowlist.
     if command:
+        # In hardened (multi-tenant) mode the command must be a bare executable name
+        # resolved via PATH. A path-form command ('/tmp/x/node', './node') reduces to a
+        # lookalike basename ('node') that passes the allowlist while executing an
+        # attacker-chosen binary; legacy single-tenant mode keeps trusting operator paths.
+        if _is_file_path(command) and (interpreter_hardening or docker_hardening):
+            msg = (
+                f"Command '{command}' is a file path; hardened mode requires a bare command name "
+                "resolved via PATH so the allowlist cannot be bypassed by a lookalike binary."
+            )
+            raise MCPStdioSecurityError(msg)
         base_command = extract_base_command(command)
         if base_command not in ALLOWED_MCP_COMMANDS:
             allowed_list = ", ".join(sorted(ALLOWED_MCP_COMMANDS))
@@ -554,6 +587,13 @@ def validate_mcp_stdio_config(
             wrapped_args = args[2:] if wrapped_command else []
 
             if wrapped_command:
+                # Same path-bypass guard for the wrapped command (sh -c '/tmp/x/node ...').
+                if _is_file_path(wrapped_command) and (interpreter_hardening or docker_hardening):
+                    msg = (
+                        f"Shell-wrapped command '{wrapped_command}' is a file path; hardened mode "
+                        "requires a bare command name resolved via PATH."
+                    )
+                    raise MCPStdioSecurityError(msg)
                 wrapped_base = extract_base_command(wrapped_command)
                 allowed_wrapped = ALLOWED_MCP_COMMANDS - SHELL_WRAPPERS
                 if wrapped_base not in allowed_wrapped:
@@ -572,6 +612,12 @@ def validate_mcp_stdio_config(
                 if wrapped_tokens:
                     nested_command = wrapped_tokens[0]
                     nested_args = wrapped_tokens[1:] + wrapped_args
+                    if _is_file_path(nested_command) and (interpreter_hardening or docker_hardening):
+                        msg = (
+                            f"Shell-wrapped command '{nested_command}' is a file path; hardened mode "
+                            "requires a bare command name resolved via PATH."
+                        )
+                        raise MCPStdioSecurityError(msg)
                     nested_base = extract_base_command(nested_command)
                     _validate_interpreter_invocation(nested_base, nested_args, hardened=interpreter_hardening)
                     if nested_base == "docker":

--- a/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
+++ b/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
@@ -230,6 +230,73 @@ def test_extract_base_command_handles_paths_and_args():
     assert extract_base_command(r"C:\Program Files\nodejs\node.exe") == "node"
 
 
+def test_path_form_command_rejected_in_hardened_mode():
+    """A lookalike path ('/tmp/x/node') must not pass the basename allowlist when hardened."""
+    for command in ("/tmp/evil/node", "./node", "../bin/node", r"C:\Temp\node.exe"):
+        with pytest.raises(MCPStdioSecurityError, match="file path"):
+            validate_mcp_stdio_config(command, [], {}, interpreter_hardening=True)
+        with pytest.raises(MCPStdioSecurityError, match="file path"):
+            validate_mcp_stdio_config(command, [], {}, docker_hardening=True, interpreter_hardening=False)
+
+
+def test_path_form_command_allowed_in_legacy_mode():
+    """Legacy single-tenant mode keeps trusting operator-supplied paths."""
+    validate_mcp_stdio_config(
+        "/usr/local/bin/uvx", ["mcp-server-fetch"], {}, docker_hardening=False, interpreter_hardening=False
+    )
+
+
+def test_shell_wrapped_path_command_rejected_in_hardened_mode():
+    """Shell-exec wrapping a path ('sh -c /tmp/x/node') hits the same guard as a top-level path."""
+    with pytest.raises(MCPStdioSecurityError, match="file path"):
+        validate_mcp_stdio_config(
+            "sh",
+            ["-c", "/tmp/evil/node server.js"],
+            {},
+            interpreter_hardening=True,
+        )
+
+
+def test_hardening_flag_falls_back_to_last_known_good(monkeypatch):
+    """A settings failure after a successful True read must not silently disable hardening."""
+    from lfx.base.mcp import security
+
+    monkeypatch.setitem(security._hardening_last_known, "docker", value=False)
+    calls = {"n": 0}
+
+    class _Settings:
+        @property
+        def mcp_server_docker_hardening(self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return True
+            msg = "settings service exploded"
+            raise RuntimeError(msg)
+
+    class _Svc:
+        settings = _Settings()
+
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", _Svc, raising=False)
+    assert security._docker_hardening_enabled() is True  # successful read caches True
+    assert security._docker_hardening_enabled() is True  # failure falls back to cached True
+
+
+def test_hardening_flag_honors_intentional_disable(monkeypatch):
+    """A successful False read clears the cache so later failures do not resurrect hardening."""
+    from lfx.base.mcp import security
+
+    monkeypatch.setitem(security._hardening_last_known, "interpreter", value=True)
+
+    class _Settings:
+        mcp_server_interpreter_hardening = False
+
+    class _Svc:
+        settings = _Settings()
+
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", _Svc, raising=False)
+    assert security._interpreter_hardening_enabled() is False  # successful False read wins
+
+
 def test_allowlist_excludes_dangerous_binaries():
     for bad in ("curl", "wget", "nc", "rm", "perl", "ruby"):
         assert bad not in ALLOWED_MCP_COMMANDS

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -310,7 +310,11 @@ def test_interpreter_hardening_preserves_authenticated_agentic_module():
 
 
 def test_windows_forward_slash_executable_path_preserves_source_policy():
-    with pytest.raises(ValueError, match=r"not allowed"):
+    # Hardened mode now rejects file-path commands at the dedicated gate
+    # ("is a file path ...") before the allowlist check ("not allowed").
+    # Either message proves the rejection; accept both so the test asserts
+    # behavior (rejection) rather than a specific wording.
+    with pytest.raises(ValueError, match=r"not allowed|is a file path"):
         validate_mcp_stdio_config(
             "C:/Program Files/uv/uvx.exe",
             ["--index-url", "https://packages.example.invalid/simple", "mcp-proxy"],


### PR DESCRIPTION
## Summary

Two multi-tenant gaps in the MCP stdio security policy (`lfx/base/mcp/security.py`), both verified against `main`:

**1. Path-form commands bypass the basename allowlist (RCE class)**

`extract_base_command()` reduces a full path to its basename, so a tenant-supplied config with `command = "/tmp/evil/node"` (or `./node`, `C:\Temp\node.exe`) passes the `ALLOWED_MCP_COMMANDS` check as `node` while executing an attacker-chosen binary. The allowlist gate runs for **every** stdio config, but it only ever sees the basename.

When either hardening mode is enabled (the multi-tenant posture), path-form commands are now rejected in favor of bare executable names resolved via `PATH` — including commands nested inside shell wrappers (`sh -c '/tmp/evil/node ...'` hits the same guard). Legacy single-tenant behavior (operator-supplied absolute paths) is unchanged.

**2. Hardening flags fail open on settings errors**

`_docker_hardening_enabled()` and `_interpreter_hardening_enabled()` returned `False` on **any** exception, so a settings-service failure *after* an operator enabled hardening silently reverted the policy to permissive. Both readers now fall back to the last-known-good value: a successful `False` read still honors intentional disablement, and the early-import default remains off.

## Test plan

- [x] 168 unit tests pass (`src/lfx/tests/unit/mcp/test_mcp_stdio_security.py`), including 5 new:
  - path-form commands rejected when interpreter **or** docker hardening is on
  - path-form commands still allowed in legacy mode
  - shell-wrapped path commands rejected in hardened mode
  - settings failure after a `True` read keeps hardening on (last-known-good)
  - intentional disable is honored (a successful `False` read clears the cache)
- [x] `ruff check` and `ruff format` clean on both files

🤖 Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened Docker and interpreter modes now reject executable paths, including shell-wrapped paths; commands must use bare executable names resolved through `PATH`.
  * Legacy mode continues to allow explicitly provided executable paths.
* **Reliability**
  * Previously successful hardening settings remain in effect when settings access temporarily fails.
  * Explicitly disabling a hardening setting is honored immediately.
* **Tests**
  * Added coverage for command validation and hardening-setting fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->