### PR TITLE
fix: allow project-scoped flow creation

### DIFF
--- a/src/backend/base/langflow/api/v1/authz_route_dependencies.py
+++ b/src/backend/base/langflow/api/v1/authz_route_dependencies.py
@@ -89,7 +89,12 @@ async def require_flow_create_permission(
     session: DbSession,
 ) -> tuple[UUID | None, UUID]:
     """Authorize CREATE at the destination workspace/folder before inserting a flow."""
-    destination = await _canonicalize_flow_destination(session, flow, current_user.id)
+    destination = await _canonicalize_flow_destination(
+        session,
+        flow,
+        current_user.id,
+        widen_for_authz=True,
+    )
     await ensure_flow_permission(
         current_user,
         FlowAction.CREATE,

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -146,7 +146,13 @@ async def create_flow(
         # into the row we persist so stale caller scope fields cannot retarget
         # the write after the guard has run.
         flow.workspace_id, flow.folder_id = _create
-        return await _new_flow(session=session, flow=flow, user_id=current_user.id, storage_service=storage_service)
+        return await _new_flow(
+            session=session,
+            flow=flow,
+            user_id=current_user.id,
+            storage_service=storage_service,
+            widen_for_authz=True,
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -383,6 +389,7 @@ async def update_flow(
             db_flow.user_id,
             requested_folder_id,
             fallback_folder_id=db_flow.folder_id,
+            authorized_existing_folder_id=db_flow.folder_id,
         )
         flow.workspace_id = target_workspace_id
         if requested_folder_id is not None:
@@ -435,6 +442,7 @@ async def update_flow(
                 db_flow_for_attempt.user_id,
                 flow.folder_id,
                 fallback_folder_id=db_flow_for_attempt.folder_id,
+                authorized_existing_folder_id=db_flow_for_attempt.folder_id,
             )
             if (
                 attempt_target_workspace_id != db_flow_for_attempt.workspace_id
@@ -531,6 +539,7 @@ async def upsert_flow(
                 requested_folder_id,
                 fallback_folder_id=existing_flow.folder_id,
                 reject_invalid=True,
+                authorized_existing_folder_id=existing_flow.folder_id,
             )
             flow.workspace_id = target_workspace_id
             if requested_folder_id is not None:
@@ -585,6 +594,7 @@ async def upsert_flow(
                     requested_folder_id,
                     fallback_folder_id=existing_flow_for_attempt.folder_id,
                     reject_invalid=requested_folder_id is not None,
+                    authorized_existing_folder_id=existing_flow_for_attempt.folder_id,
                 )
                 flow.workspace_id = attempt_target_workspace_id
                 if requested_folder_id is not None:
@@ -836,6 +846,7 @@ async def upload_file(
             flow,
             current_user.id,
             fallback_folder_id=fallback_folder_id,
+            authorized_existing_folder_id=existing_flow.folder_id if existing_flow is not None else None,
         )
         await ensure_flow_permission(
             current_user,

--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -22,6 +22,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.api.utils import build_content_disposition, normalize_flow_for_export, remove_api_keys
+from langflow.services.authorization.fetch import authorized_or_owner_scoped
 from langflow.services.database.models.base import orjson_dumps
 from langflow.services.database.models.deployment.orm_guards import ensure_flow_move_allowed
 from langflow.services.database.models.flow.guards import (
@@ -257,11 +258,15 @@ async def _validate_and_assign_folder(
     session: AsyncSession,
     db_flow: Flow,
     user_id: UUID,
+    *,
+    widen_for_authz: bool = False,
+    authorized_existing_folder_id: UUID | None = None,
 ) -> None:
-    """Ensure *db_flow* has a valid ``folder_id`` belonging to *user_id*.
+    """Ensure *db_flow* has a valid permission-guarded destination project.
 
-    Falls back to the default folder when the current ``folder_id`` is
-    ``None`` or references a non-existent / other-user's folder.
+    The OSS path falls back to the user's default project when the current
+    ``folder_id`` is missing or not owned. Cross-user authorization plugins may
+    preserve a foreign-owned project that the route already authorized.
     """
     old_folder_id = db_flow.folder_id
     # no_autoflush prevents the guard query (ensure_flow_move_allowed)
@@ -273,6 +278,8 @@ async def _validate_and_assign_folder(
             db_flow,
             user_id,
             reject_invalid=db_flow.folder_id is not None,
+            widen_for_authz=widen_for_authz,
+            authorized_existing_folder_id=authorized_existing_folder_id,
         )
         await ensure_flow_move_allowed(
             session,
@@ -282,6 +289,34 @@ async def _validate_and_assign_folder(
         )
 
 
+async def _get_flow_destination_folder(
+    session: AsyncSession,
+    user_id: UUID,
+    folder_id: UUID,
+    *,
+    widen_for_authz: bool = False,
+    authorized_existing_folder_id: UUID | None = None,
+) -> Folder | None:
+    """Load a non-system project using authorization-aware owner scoping."""
+    if folder_id == authorized_existing_folder_id:
+        # The exact current folder came from an already-authorized flow row.
+        # Preserve it for in-place edits without widening a requested move.
+        folder = (await session.exec(select(Folder).where(Folder.id == folder_id))).first()
+    elif widen_for_authz:
+        folder = await authorized_or_owner_scoped(
+            session,
+            Folder,
+            id_column=Folder.id,
+            resource_id=folder_id,
+            owner_column=Folder.user_id,
+            owner_id=user_id,
+        )
+    else:
+        folder = (await session.exec(select(Folder).where(Folder.id == folder_id, Folder.user_id == user_id))).first()
+    # Ownerless folders are system-managed and are never valid write targets.
+    return folder if folder is not None and folder.user_id is not None else None
+
+
 async def _resolve_flow_destination(
     session: AsyncSession,
     user_id: UUID,
@@ -289,17 +324,28 @@ async def _resolve_flow_destination(
     *,
     fallback_folder_id: UUID | None = None,
     reject_invalid: bool = False,
+    widen_for_authz: bool = False,
+    authorized_existing_folder_id: UUID | None = None,
 ) -> tuple[UUID | None, UUID]:
     """Resolve the folder/workspace tuple that a flow write will actually use.
 
-    Folder membership is canonical. A missing or stale caller folder keeps the
-    established API behavior of falling back to the user's default folder, but
-    callers must authorize this resolved tuple before writing.
+    Folder membership is canonical. When ``widen_for_authz`` is set, an enabled
+    authorization plugin that supports cross-user fetch may resolve a project
+    owned by another user so the caller's permission check can decide access.
+    The default path remains owner-scoped. A missing or stale caller folder keeps
+    the established API behavior of falling back to the user's default folder,
+    but callers must authorize this resolved tuple before writing.
     """
     folder_id = requested_folder_id if requested_folder_id is not None else fallback_folder_id
     folder = None
     if folder_id is not None:
-        folder = (await session.exec(select(Folder).where(Folder.id == folder_id, Folder.user_id == user_id))).first()
+        folder = await _get_flow_destination_folder(
+            session,
+            user_id,
+            folder_id,
+            widen_for_authz=widen_for_authz,
+            authorized_existing_folder_id=authorized_existing_folder_id,
+        )
         if folder is None and requested_folder_id is not None and reject_invalid:
             raise HTTPException(status_code=400, detail="Folder not found")
     if folder is None:
@@ -319,6 +365,8 @@ async def _canonicalize_flow_destination(
     *,
     fallback_folder_id: UUID | None = None,
     reject_invalid: bool = False,
+    widen_for_authz: bool = False,
+    authorized_existing_folder_id: UUID | None = None,
 ) -> tuple[UUID | None, UUID]:
     """Apply the canonical destination tuple to a flow payload or row."""
     workspace_id, folder_id = await _resolve_flow_destination(
@@ -327,6 +375,8 @@ async def _canonicalize_flow_destination(
         flow.folder_id,
         fallback_folder_id=fallback_folder_id,
         reject_invalid=reject_invalid,
+        widen_for_authz=widen_for_authz,
+        authorized_existing_folder_id=authorized_existing_folder_id,
     )
     flow.folder_id = folder_id
     flow.workspace_id = workspace_id
@@ -342,6 +392,7 @@ async def _new_flow(
     flow_id: UUID | None = None,
     fail_on_endpoint_conflict: bool = False,
     validate_folder: bool = False,
+    widen_for_authz: bool = False,
 ):
     """Create or upsert a flow.
 
@@ -352,15 +403,19 @@ async def _new_flow(
         storage_service: Service for filesystem operations.
         flow_id: Allows PUT upsert to create flows with a specific ID for syncing between instances.
         fail_on_endpoint_conflict: PUT should fail predictably on conflicts rather than silently renaming.
-        validate_folder: Validates folder_id exists and belongs to user when upserting from external sources.
+        validate_folder: Validates folder_id under the active authorization fetch mode for external upserts.
+        widen_for_authz: Preserve a cross-user destination that the route already authorized.
     """
     try:
         await _verify_fs_path(flow.fs_path, user_id, storage_service)
 
         if validate_folder and flow.folder_id is not None:
-            folder = (
-                await session.exec(select(Folder).where(Folder.id == flow.folder_id, Folder.user_id == user_id))
-            ).first()
+            folder = await _get_flow_destination_folder(
+                session,
+                user_id,
+                flow.folder_id,
+                widen_for_authz=widen_for_authz,
+            )
             if not folder:
                 raise HTTPException(status_code=400, detail="Folder not found")
 
@@ -384,7 +439,7 @@ async def _new_flow(
             db_flow.id = effective_id
 
         db_flow.updated_at = datetime.now(timezone.utc)
-        await _validate_and_assign_folder(session, db_flow, user_id)
+        await _validate_and_assign_folder(session, db_flow, user_id, widen_for_authz=widen_for_authz)
 
         session.add(db_flow)
         await session.flush()
@@ -456,6 +511,7 @@ async def _update_existing_flow(
     actor_user_id = current_user.id
     owner_user_id: UUID = existing_flow.user_id
     is_owner_edit = owner_user_id == actor_user_id
+    existing_folder_id = existing_flow.folder_id
 
     # Non-owner edits cannot relocate the flow into folders or storage they
     # own, nor transfer ownership. Reject early so the failure is explicit
@@ -501,9 +557,12 @@ async def _update_existing_flow(
     # Validate folder_id if provided — scoped to the owner so a non-owner
     # cannot land the flow in their own default folder via this code path.
     if flow.folder_id is not None:
-        folder = (
-            await session.exec(select(Folder).where(Folder.id == flow.folder_id, Folder.user_id == owner_user_id))
-        ).first()
+        folder = await _get_flow_destination_folder(
+            session,
+            owner_user_id,
+            flow.folder_id,
+            authorized_existing_folder_id=existing_folder_id,
+        )
         if not folder:
             raise HTTPException(status_code=400, detail="Folder not found")
 
@@ -565,7 +624,12 @@ async def _update_existing_flow(
         update_data = remove_api_keys(update_data)
 
     _apply_update_data(existing_flow, update_data)
-    await _validate_and_assign_folder(session, existing_flow, owner_user_id)
+    await _validate_and_assign_folder(
+        session,
+        existing_flow,
+        owner_user_id,
+        authorized_existing_folder_id=existing_folder_id,
+    )
 
     webhook_component = get_webhook_component_in_flow(existing_flow.data or {})
     existing_flow.webhook = webhook_component is not None
@@ -602,6 +666,7 @@ async def _patch_flow(
 
     owner_user_id: UUID = db_flow.user_id
     is_owner_edit = owner_user_id == user_id
+    existing_folder_id = db_flow.folder_id
 
     # PATCH follows the same rule: None-valued fields are omitted unless
     # explicitly reintroduced below (for example endpoint_name clear).
@@ -674,7 +739,12 @@ async def _patch_flow(
 
     # Folder validation must be scoped to the owner — otherwise a non-owner
     # edit would land in the actor's default folder (see ``_validate_and_assign_folder``).
-    await _validate_and_assign_folder(session, db_flow, owner_user_id)
+    await _validate_and_assign_folder(
+        session,
+        db_flow,
+        owner_user_id,
+        authorized_existing_folder_id=existing_folder_id,
+    )
 
     session.add(db_flow)
     await session.flush()

--- a/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
+++ b/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
@@ -19,13 +19,20 @@ Everything runs against the OSS package only — no EE Casbin enforcer required.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 from langflow.api.v1.knowledge_bases import KBStorageHelper
 from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.folder.model import Folder
 from langflow.services.database.models.user.model import User
-from langflow.services.deps import get_auth_service, get_settings_service, session_scope
+from langflow.services.deps import (
+    get_auth_service,
+    get_authorization_service,
+    get_settings_service,
+    session_scope,
+)
 
 from ._policy_double import (
     assign_role,
@@ -64,6 +71,18 @@ async def _make_flow(owner_id: UUID, name: str, *, workspace_id: UUID | None = N
         flow_id = flow.id
         await session.commit()
     return flow_id
+
+
+async def _make_project(owner_id: UUID, name: str, *, workspace_id: UUID | None = None) -> UUID:
+    """Insert a project owned by ``owner_id`` and return its id."""
+    async with session_scope() as session:
+        project = Folder(name=name, user_id=owner_id, workspace_id=workspace_id)
+        session.add(project)
+        await session.flush()
+        assert project.id is not None
+        project_id = project.id
+        await session.commit()
+    return project_id
 
 
 async def _seed_roles() -> dict[str, UUID]:
@@ -248,6 +267,139 @@ async def test_read_only_share_allows_get_but_denies_write_and_execute(client):
         # not grant build either -> deny -> 404
         build = await client.post(f"api/v1/build/{flow_id}/flow", headers=bob_headers, json={})
         assert build.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Flow create destinations: plugin grants may target a foreign-owned project,
+# while the OSS pass-through must keep its existing owner-scoped fallback.
+# --------------------------------------------------------------------------- #
+
+
+async def test_project_scoped_developer_can_create_flow_in_foreign_project(client):
+    """A plugin-authorized non-owner must retain the project destination it was granted."""
+    role_ids = await _seed_roles()
+    project_owner_id = await _make_user(f"project_owner_{uuid4().hex}")
+    workspace_id = uuid4()
+    project_id = await _make_project(
+        project_owner_id,
+        f"shared_project_{uuid4().hex}",
+        workspace_id=workspace_id,
+    )
+    developer_id, headers = await _role_user(
+        client,
+        "developer",
+        role_ids,
+        domain_type="project",
+        domain_id=project_id,
+    )
+
+    with install_policy_authz(get_settings_service()):
+        response = await client.post(
+            "api/v1/flows/",
+            headers=headers,
+            json={
+                "name": f"shared_project_flow_{uuid4().hex}",
+                "folder_id": str(project_id),
+                "data": {"nodes": [], "edges": []},
+            },
+        )
+        assert response.status_code == 201, response.text
+        created = response.json()
+        edit = await client.patch(
+            f"api/v1/flows/{created['id']}",
+            headers=headers,
+            json={"name": f"edited_shared_project_flow_{uuid4().hex}"},
+        )
+        upload = await client.post(
+            "api/v1/flows/upload/",
+            headers=headers,
+            files={
+                "file": (
+                    "shared-project-flow.json",
+                    json.dumps(
+                        {
+                            "id": created["id"],
+                            "name": f"uploaded_shared_project_flow_{uuid4().hex}",
+                        }
+                    ),
+                    "application/json",
+                )
+            },
+        )
+
+    assert created["user_id"] == str(developer_id)
+    assert created["folder_id"] == str(project_id)
+    assert created["workspace_id"] == str(workspace_id)
+    assert edit.status_code == 200, edit.text
+    assert edit.json()["folder_id"] == str(project_id)
+    assert edit.json()["workspace_id"] == str(workspace_id)
+    assert upload.status_code == 201, upload.text
+    assert upload.json()[0]["id"] == created["id"]
+    assert upload.json()[0]["folder_id"] == str(project_id)
+    assert upload.json()[0]["workspace_id"] == str(workspace_id)
+
+
+async def test_oss_create_flow_keeps_foreign_project_owner_scoped(client):
+    """The OSS service must not widen a foreign project merely because authz is enabled."""
+    project_owner_id = await _make_user(f"project_owner_{uuid4().hex}")
+    foreign_project_id = await _make_project(project_owner_id, f"foreign_project_{uuid4().hex}")
+    creator_username = f"creator_{uuid4().hex}"
+    creator_id = await _make_user(creator_username)
+    headers = await _login(client, creator_username)
+
+    settings = get_settings_service()
+    authz = get_authorization_service()
+    assert await authz.supports_cross_user_fetch() is False
+    saved_authz_enabled = settings.auth_settings.AUTHZ_ENABLED
+    settings.auth_settings.AUTHZ_ENABLED = True
+    try:
+        response = await client.post(
+            "api/v1/flows/",
+            headers=headers,
+            json={
+                "name": f"oss_owner_scoped_flow_{uuid4().hex}",
+                "folder_id": str(foreign_project_id),
+                "data": {"nodes": [], "edges": []},
+            },
+        )
+    finally:
+        settings.auth_settings.AUTHZ_ENABLED = saved_authz_enabled
+
+    assert response.status_code == 201, response.text
+    created = response.json()
+    assert created["folder_id"] != str(foreign_project_id)
+    async with session_scope() as session:
+        destination = await session.get(Folder, UUID(created["folder_id"]))
+    assert destination is not None
+    assert destination.user_id == creator_id
+
+
+async def test_cross_user_destination_resolution_does_not_widen_flow_moves(client):
+    """Cross-user destination fetch is limited to CREATE and cannot bypass move authorization."""
+    project_owner_id = await _make_user(f"move_project_owner_{uuid4().hex}")
+    foreign_project_id = await _make_project(project_owner_id, f"move_target_{uuid4().hex}")
+    creator_username = f"move_creator_{uuid4().hex}"
+    await _make_user(creator_username)
+    headers = await _login(client, creator_username)
+
+    create = await client.post(
+        "api/v1/flows/",
+        headers=headers,
+        json={"name": f"move_source_{uuid4().hex}", "data": {"nodes": [], "edges": []}},
+    )
+    assert create.status_code == 201, create.text
+    original_folder_id = create.json()["folder_id"]
+
+    with install_policy_authz(get_settings_service()):
+        move = await client.patch(
+            f"api/v1/flows/{create.json()['id']}",
+            headers=headers,
+            json={"folder_id": str(foreign_project_id)},
+        )
+
+    assert move.status_code == 200, move.text
+    assert move.json()["folder_id"] == original_folder_id
+    assert move.json()["folder_id"] != str(foreign_project_id)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- resolve POST flow destinations through the authorization-aware fetch path when an enabled plugin supports cross-user access
- preserve the exact authorized project through persistence, autosave, PUT updates, and stable-ID uploads
- keep OSS behavior owner-scoped and prevent existing-flow moves from widening to unrelated foreign projects
- add regression coverage for project-scoped creation, lifecycle updates, OSS fallback, and move safety

## Problem

Project-scoped developers and admins had a valid `flow:create` grant, but `POST /api/v1/flows/` resolved the requested project with an owner-only folder query. For non-owners, the destination silently fell back to the caller's default project, so the subsequent create permission check ran in the wrong domain and returned 403.

## Validation

- 59 focused flow-folder and authorization tests passed
- Ruff lint and format checks passed
- `git diff --check` passed
- pre-commit hooks passed, including secret scanning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization when creating, editing, uploading, and moving flows between folders or projects.
  * Authorized users can now work with flows in shared projects while ownership restrictions remain enforced.
  * Preserved existing folder context during flow updates and prevented unauthorized destination changes.

* **Tests**
  * Added coverage for cross-project flow creation, editing, uploading, and destination authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->