### PR TITLE
fix(tests): account for the pre-run transaction release in commit counts

### DIFF
--- a/src/backend/tests/unit/agentic/mcp/test_run_assistant_tool.py
+++ b/src/backend/tests/unit/agentic/mcp/test_run_assistant_tool.py
@@ -426,7 +426,9 @@ class TestRunAssistantAndPersist:
         assert exc_info.value.status_code == 400
         assert "BlockedComponent" in exc_info.value.detail
         assert flow.data is original_data
-        session.commit.assert_not_awaited()
+        # One, not none: the pre-run transaction release added by #14448 commits before the
+        # agent runs. That nothing was persisted is what the two assertions above cover.
+        assert session.commit.await_count == 1
         save_flow.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -472,7 +474,10 @@ class TestRunAssistantAndPersist:
 
         assert exc_info.value.status_code == 400
         session.delete.assert_awaited_once_with(created_flow)
-        assert session.commit.await_count == 2
+        # Three, not two: creating the provisional flow, then the transaction release added by
+        # #14448 so the agent run does not hold a pooled connection, then deleting the flow the
+        # catalog rejected.
+        assert session.commit.await_count == 3
         save_flow.assert_not_awaited()
 
 
@@ -758,7 +763,8 @@ class TestRunAssistantPersistsAuthoritativeWorkingFlow:
 
         assert result["flow_changed"] is True
         assert flow.data == {"nodes": [], "edges": []}
-        session.commit.assert_awaited_once()
+        # Two: the pre-run transaction release added by #14448, then the persist itself.
+        assert session.commit.await_count == 2
 
     @pytest.mark.asyncio
     async def test_should_fall_back_to_event_replay_when_working_flow_is_empty(self):


### PR DESCRIPTION
## What

#14448 added a `release_db_transaction(session)` call before the assistant agent loop, so the caller's read transaction isn't held across a run that can take minutes. That call commits, and three assertions in the assistant runner tests still counted the commits from before it:

- the catalog-rejection path expected 2 commits, now 3 (create provisional flow, release, delete rejected flow)
- the blocked-canvas path expected none, now 1 (the release; nothing is persisted, which the neighbouring `flow.data` and `save_flow` assertions already cover)
- the persist path expected exactly 1, now 2 (release, then the persist)

All three are stale expectations, not a double commit. Each site gets a short note saying which commit is which, so the next person moving the transaction boundary can tell what the numbers mean.

## Why now

`test_should_delete_provisional_flow_when_catalog_rejects_new_canvas` is currently failing on `release-1.12.0`, so it fails on every PR into that branch and blocks the merge queue. It doesn't show up on the base branch itself because pushes there only run Mend, not the unit suite.

The other two fail the same way but hadn't surfaced in CI yet, since the first failure in a group cancels its siblings.

## Verification

Against `release-1.12.0` with no other changes, the three fail:

```
FAILED ...::test_should_reject_catalog_blocked_canvas_changes_before_persisting - Expected commit to not have been awaited. Awaited 1 times.
FAILED ...::test_should_delete_provisional_flow_when_catalog_rejects_new_canvas - assert 3 == 2
FAILED ...::test_should_persist_empty_working_flow_after_removing_last_blocked_component - Expected commit to have been awaited once. Awaited 2 times.
3 failed, 15 passed
```

With this change, `src/backend/tests/unit/agentic/mcp/` is `46 passed`.

@erichare tagging you since this is the test side of #14448 - worth a sanity check that 3 commits on the rejection path is what you intended and not one too many.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated persistence test expectations to reflect transaction commits that occur before assistant tool execution.
  * Improved test coverage for catalog-rejection and empty-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->