### PR TITLE
fix: keep explicitly cleared model selection empty instead of filling cross-provider options[0]

### DIFF
--- a/src/lfx/src/lfx/base/models/unified_models/build_config.py
+++ b/src/lfx/src/lfx/base/models/unified_models/build_config.py
@@ -310,8 +310,13 @@ def update_model_options_in_build_config(
     # of whatever field triggered the update — e.g. api_key text).  Using
     # field_value here would incorrectly reset the model selection whenever a
     # non-model field (like api_key) is cleared or set to a global variable.
+    # An explicit model-field update carrying an empty value must NOT be
+    # auto-filled: ``options`` spans every enabled provider, so ``options[0]``
+    # would silently substitute a model from whichever provider iterates
+    # first — one the node was never configured for.
+    explicit_model_clear = field_name == model_field_name and not field_value
     current_model_value = build_config.get(model_field_name, {}).get("value")
-    if not current_model_value:
+    if not current_model_value and not explicit_model_clear:
         options = cached.get("options", [])
         if options:
             # Determine model type based on cache_key_prefix
@@ -490,8 +495,18 @@ def handle_model_input_update(
             option_names = {opt["name"] for opt in options}
             value_is_valid = bool(field_value) and field_value[0]["name"] in option_names
 
-            # If the value is invalid, reset to the first option if available, otherwise empty.
-            build_config[model_field_name]["value"] = field_value if value_is_valid else [options[0]] if options else ""
+            if value_is_valid:
+                build_config[model_field_name]["value"] = field_value
+            elif not field_value:
+                # Explicitly cleared: stay empty. ``options`` is one flat list
+                # across every enabled provider, so ``options[0]`` would pick a
+                # model from an arbitrary provider the node never selected.
+                build_config[model_field_name]["value"] = []
+            else:
+                # A non-empty invalid value resets to the first option so the
+                # user can pick a valid one (e.g. the Agent filters flow that
+                # drops a tool-incompatible model for a compatible default).
+                build_config[model_field_name]["value"] = [options[0]] if options else ""
             field_value = build_config[model_field_name]["value"]
 
     # Step 2: Reset provider-specific visibility without changing values.

--- a/src/lfx/tests/unit/base/models/test_build_config_empty_model_clear.py
+++ b/src/lfx/tests/unit/base/models/test_build_config_empty_model_clear.py
@@ -1,0 +1,176 @@
+"""An explicitly cleared model selection must stay empty.
+
+Bug: when ``update_build_config`` receives ``field_name="model"`` with an
+empty ``field_value``, the lifecycle filled the value with ``options[0]``.
+``options`` is one flat list across every enabled provider, so the injected
+model belongs to whichever provider happens to iterate first — a provider
+the node was never configured for. Because ``POST /api/v2/workflows``
+carries the live-canvas ``data`` override, the substituted model is what
+actually executes, silently, billed to the wrong provider account.
+
+The auto-default (user's ``__default_language_model__`` variable, falling
+back to ``options[0]``) remains intentional for the initial-load event
+(``field_name=None``, e.g. a freshly dropped node) and for non-model field
+triggers. Only an explicit model-field update with an empty value must be
+left empty.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from lfx.base.models.unified_models.build_config import (
+    handle_model_input_update,
+    update_model_options_in_build_config,
+)
+
+
+def _component(user_id: str = "u-1") -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, cache={}, inputs=[])
+
+
+def _multi_provider_options() -> list[dict]:
+    """Options spanning several providers, mirroring get_language_model_options."""
+    return [
+        {"name": "claude-sonnet-4-5", "provider": "Anthropic", "icon": "Anthropic", "metadata": {}},
+        {"name": "gemini-2.5-flash", "provider": "Google Generative AI", "icon": "GoogleGenerativeAI", "metadata": {}},
+        {"name": "gpt-4o-mini", "provider": "OpenAI", "icon": "OpenAI", "metadata": {}},
+    ]
+
+
+def _get_options(user_id=None):  # noqa: ARG001
+    return _multi_provider_options()
+
+
+class TestExplicitModelClearStaysEmpty:
+    def test_empty_model_update_is_not_filled_from_another_provider(self):
+        """The deterministic repro: field_name="model", field_value=[] must stay empty."""
+        build_config = {"model": {"value": [], "options": []}}
+
+        result = handle_model_input_update(
+            component=_component(),
+            build_config=build_config,
+            field_value=[],
+            field_name="model",
+            get_options_func=_get_options,
+        )
+
+        assert not result["model"]["value"], (
+            f"an explicitly cleared model selection must stay empty, got {result['model']['value']!r}"
+        )
+
+    def test_empty_model_update_clears_stale_build_config_value(self):
+        """An explicit clear wins over a stale non-empty value in build_config."""
+        build_config = {
+            "model": {
+                "value": [{"name": "gpt-4o-mini", "provider": "OpenAI", "metadata": {}}],
+                "options": [],
+            }
+        }
+
+        result = handle_model_input_update(
+            component=_component(),
+            build_config=build_config,
+            field_value=[],
+            field_name="model",
+            get_options_func=_get_options,
+        )
+
+        assert not result["model"]["value"]
+
+    def test_empty_model_update_with_no_options_stays_empty(self):
+        """Clear with zero configured providers keeps today's empty result."""
+        build_config = {"model": {"value": [], "options": []}}
+
+        result = handle_model_input_update(
+            component=_component(),
+            build_config=build_config,
+            field_value=[],
+            field_name="model",
+            get_options_func=lambda user_id=None: [],  # noqa: ARG005
+        )
+
+        assert not result["model"]["value"]
+
+    def test_valid_selection_is_preserved(self):
+        """A valid explicit selection still round-trips untouched."""
+        selection = [{"name": "gpt-4o-mini", "provider": "OpenAI", "metadata": {}}]
+        build_config = {"model": {"value": selection, "options": []}}
+
+        result = handle_model_input_update(
+            component=_component(),
+            build_config=build_config,
+            field_value=selection,
+            field_name="model",
+            get_options_func=_get_options,
+        )
+
+        assert result["model"]["value"][0]["name"] == "gpt-4o-mini"
+        assert result["model"]["value"][0]["provider"] == "OpenAI"
+
+
+class TestAutoDefaultStillFiresForOtherTriggers:
+    def test_initial_load_still_auto_fills_default(self):
+        """field_name=None (new node dropped on canvas) keeps the default fill."""
+        build_config = {"model": {"value": [], "options": []}}
+
+        result = update_model_options_in_build_config(
+            component=_component(),
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=_get_options,
+            field_name=None,
+            field_value=None,
+        )
+
+        value = result["model"]["value"]
+        assert isinstance(value, list)
+        assert value, "initial load must still auto-select a default model"
+
+    def test_non_model_field_trigger_still_auto_fills_default(self):
+        """A non-model trigger (e.g. api_key entry) keeps the default fill."""
+        build_config = {"model": {"value": [], "options": []}}
+
+        result = update_model_options_in_build_config(
+            component=_component(),
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=_get_options,
+            field_name="api_key",
+            field_value="sk-test",
+        )
+
+        value = result["model"]["value"]
+        assert isinstance(value, list)
+        assert value
+
+    def test_model_refresh_with_existing_selection_is_preserved(self):
+        """Refresh (field_name="model") with a real selection never rewrites it."""
+        selection = [{"name": "gemini-2.5-flash", "provider": "Google Generative AI", "metadata": {}}]
+        build_config = {"model": {"value": selection, "options": []}}
+
+        result = update_model_options_in_build_config(
+            component=_component(),
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=_get_options,
+            field_name="model",
+            field_value=selection,
+        )
+
+        assert result["model"]["value"][0]["name"] == "gemini-2.5-flash"
+
+    def test_model_clear_does_not_auto_fill_in_options_refresh(self):
+        """The options-refresh helper itself must honor an explicit clear."""
+        build_config = {"model": {"value": [], "options": []}}
+
+        result = update_model_options_in_build_config(
+            component=_component(),
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=_get_options,
+            field_name="model",
+            field_value=[],
+        )
+
+        assert not result["model"]["value"]


### PR DESCRIPTION
## Summary

A flow run can execute a model from a different provider than the node selects. When `update_build_config` receives `field_name="model"` with an **empty** `field_value`, both fill sites in the ModelInput lifecycle (`src/lfx/src/lfx/base/models/unified_models/build_config.py`) replaced the empty selection with `options[0]`. Since `get_language_model_options` returns one flat list across every enabled provider, `options[0]` is simply the first default-enabled model of the first enabled provider — frequently not the provider the node is configured for.

Because `POST /api/v2/workflows` carries the live-canvas `data` override (which by its own schema takes priority over the saved flow data), whatever the editor filled in is what actually runs — silently, billed to a provider the user never selected. The persisted flow can still hold the correct selection at that moment.

### Deterministic repro (against `POST /api/v1/custom_component/update`, the endpoint the editor uses)

With Anthropic + Google + OpenAI configured, a `LanguageModelComponent` node, field `model`:

| `field_value` sent | returned `model.value` |
|---|---|
| `[{name: gpt-4o-mini, provider: OpenAI}]` | preserved |
| `[{name: definitely-not-a-model, provider: Nope}]` | preserved (sticky-default injection) |
| `[]` | **replaced with `[{name: claude-…, provider: Anthropic}]`** ← bug |

The substitution is usually silent because for most providers `options[0]` is a working chat model; it only fails loudly on OpenAI-Compatible endpoints whose live `/v1/models` list starts with completions-only ids (404 `This is not a chat model…`).

## Fix

An explicit model-field update carrying an empty value now **stays empty**, in both fill sites:

1. `update_model_options_in_build_config` — the auto-default block no longer fires when the triggering event is `field_name == model_field_name` with an empty `field_value`.
2. `handle_model_input_update` — the `value_missing` reset branch keeps an explicitly cleared value empty instead of substituting `[options[0]]`.

At run time an empty selection then raises the existing, loud `"A model selection is required"` from `get_llm` instead of silently executing an arbitrary model.

### Behavior intentionally unchanged (pinned by new tests)

- Initial-load default fill (`field_name=None`, freshly dropped node → user's `__default_language_model__`, else first option).
- Default fill on non-model triggers (e.g. entering an `api_key`).
- Sticky-default injection for saved-but-locally-disabled selections (`not_enabled_locally`).
- Agent `filters` flow: a **non-empty** filter-incompatible value still resets to a compatible default.

## Test plan

- [x] New unit tests in `src/lfx/tests/unit/base/models/test_build_config_empty_model_clear.py` — 3 of them fail before the fix (empty value came back as `claude-… / Anthropic`), all pass after; 5 pin the preserved behaviors above.
- [x] `src/lfx tests/unit/base/models/` + `tests/unit/components/models_and_agents/` — 480 passed, 2 skipped.
- [x] `src/backend/tests/unit/test_unified_models.py` — 66 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicitly cleared model selections now remain empty when model options or related settings are refreshed.
  - Valid model selections are preserved during updates.
  - Invalid non-empty selections continue to reset to the first available option.
  - Automatic defaults still apply during initial setup when no model selection has been cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->