### PR TITLE
chore: bump release versions to 1.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.11.2"
+version = "1.11.3"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base[complete]>=0.11.2",
+    "langflow-base[complete]>=0.11.3",
     # langflow-extensions:bundle-deps-start
     # Release coordination: langflow declares BOUNDED ranges (>=A,<B) for every
     # curated lfx-* package, never exact pins -- exact pins in reusable library

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.11.2"
+version = "0.11.3"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "lfx~=1.11.2",
+    "lfx~=1.11.3",
     "fastapi>=0.139.0,<1.0.0",
     "slowapi>=0.1.9,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
@@ -192,7 +192,7 @@ local = [
 
 # Individual database providers
 couchbase = ["couchbase>=4.2.1"]
-cassandra = ["lfx[cassandra]~=1.11.2"]  # cassio relocated to lfx (lfx-core Cassandra components)
+cassandra = ["lfx[cassandra]~=1.11.3"]  # cassio relocated to lfx (lfx-core Cassandra components)
 clickhouse = ["clickhouse-connect==0.7.19"]
 
 
@@ -263,7 +263,7 @@ opendsstar = [
 ]
 
 # Individual tools
-beautifulsoup = ["lfx~=1.11.2"]  # beautifulsoup4 is now a hard lfx dependency
+beautifulsoup = ["lfx~=1.11.3"]  # beautifulsoup4 is now a hard lfx dependency
 serpapi = ["google-search-results>=2.4.1,<3.0.0"]
 google-api = ["google-api-python-client~=2.161"]
 wikipedia = ["wikipedia==1.4.0"]
@@ -341,7 +341,7 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 # Toolguard Integration
-toolguard = ["lfx[toolguard]~=1.11.2"]  # toolguard relocated to lfx
+toolguard = ["lfx[toolguard]~=1.11.3"]  # toolguard relocated to lfx
 
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.11.2",
+      "version": "1.11.3",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
         "@chakra-ui/number-input": "^2.1.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "1.11.2"
+version = "1.11.3"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [
@@ -57,7 +57,7 @@ dependencies = [
     "cryptography>=48.0.1",
     "pyjwt>=2.10.0,<3.0.0",
     "ag-ui-protocol>=0.1.10",
-    "langflow-sdk>=0.3.2",
+    "langflow-sdk>=0.3.3",
     "markitdown>=0.1.4,<2.0.0",
     "setuptools>=83.0.0,<84.0.0",
     "wheel>=0.46.2,<1.0.0",

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -32569,6 +32569,6 @@
     "num_components": 131,
     "num_modules": 17
   },
-  "sha256": "d595c90de15d7ad88a474c658ce2cd216084ba4e91336eaca50857b161306476",
-  "version": "1.11.2"
+  "sha256": "9e19c76e01ef19fd82c6795f8c51c7c6eb7876bf2e9dfa0c33bb72b577d921e4",
+  "version": "1.11.3"
 }

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-sdk"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python SDK for the Langflow REST API"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -7796,7 +7796,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.11.2"
+version = "1.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "langflow-base", extra = ["complete"] },
@@ -7980,7 +7980,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -8770,7 +8770,7 @@ dev = [
 
 [[package]]
 name = "langflow-sdk"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "src/sdk" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -9044,7 +9044,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "1.11.2"
+version = "1.11.3"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "a2wsgi", marker = "sys_platform != 'win32'" },


### PR DESCRIPTION
## Summary

- bump Langflow, LFX, and frontend package metadata to `1.11.3`
- bump `langflow-base` to `0.11.3`
- bump `langflow-sdk` to `0.3.3` and raise LFX's published SDK floor accordingly
- refresh the frontend lockfile, workspace lockfile, and component-index version/checksum

## Validation

- `uv lock --check`
- `23 passed` in the versioning-focused pytest set
- built and inspected wheels for `langflow==1.11.3`, `langflow-base==0.11.3`, `lfx==1.11.3`, and `langflow-sdk==0.3.3`
- verified wheel dependency metadata for `langflow-base[complete]>=0.11.3`, `lfx~=1.11.3`, and `langflow-sdk>=0.3.3`
- verified all four target versions are currently unused on PyPI
- pre-commit hooks passed

## Release follow-up

The existing lightweight `v1.11.3` tag still points to `d39a7e4f8a`, where `pyproject.toml` reports `1.11.2`. Recreate that tag at the merged version-bump commit before rerunning the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application, backend, frontend, SDK, and component packages to version 1.11.3.
  * Updated package compatibility requirements to align with the latest 1.11.3 and 0.3.3 releases.
  * Refreshed component index metadata and its verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->