### PR TITLE
fix(mcp): disable HTTP client redirects after one-shot SSRF check

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_ssl.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_ssl.py
@@ -27,6 +27,11 @@ class TestSSLClientFactory:
         # httpx stores verify in the transport
         assert hasattr(client, "_transport")
 
+    def test_create_client_does_not_follow_redirects(self):
+        """MCP HTTP client must not follow redirects after one-shot SSRF check."""
+        client = create_mcp_http_client_with_ssl_option(verify_ssl=True)
+        assert client.follow_redirects is False
+
     def test_create_client_with_ssl_verification_disabled(self):
         """Test creating HTTP client with SSL verification disabled."""
         client = create_mcp_http_client_with_ssl_option(verify_ssl=False)

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -156,6 +156,10 @@ def create_mcp_http_client_with_ssl_option(
     This is a custom factory that extends the standard MCP client factory
     to support disabling SSL verification for self-signed certificates.
 
+    Redirects are disabled: connector URLs are SSRF-checked once before
+    connect, and following 3xx without re-validation could reach private
+    or link-local hosts. Matches A2A agent client hardening.
+
     Args:
         headers: Optional headers to include with all requests.
         timeout: Request timeout as httpx.Timeout object.
@@ -166,7 +170,7 @@ def create_mcp_http_client_with_ssl_option(
         Configured httpx.AsyncClient instance.
     """
     kwargs: dict[str, Any] = {
-        "follow_redirects": True,
+        "follow_redirects": False,
         "verify": verify_ssl,
     }
 

--- a/src/lfx/tests/unit/mcp/test_mcp_http_client_redirects.py
+++ b/src/lfx/tests/unit/mcp/test_mcp_http_client_redirects.py
@@ -1,0 +1,13 @@
+"""MCP HTTP client must not follow redirects after one-shot SSRF validation."""
+
+from lfx.base.mcp.util import create_mcp_http_client_with_ssl_option
+
+
+def test_mcp_http_client_does_not_follow_redirects():
+    client = create_mcp_http_client_with_ssl_option(verify_ssl=True)
+    assert client.follow_redirects is False
+
+
+def test_mcp_http_client_no_redirects_when_ssl_disabled():
+    client = create_mcp_http_client_with_ssl_option(verify_ssl=False)
+    assert client.follow_redirects is False


### PR DESCRIPTION
## Summary

`create_mcp_http_client_with_ssl_option` built httpx clients with `follow_redirects=True` after connector URLs were SSRF-validated once. A public MCP endpoint that 302s to a private/link-local host could bypass that guard.

This sets `follow_redirects=False`, matching A2A agent client hardening and other Langflow SSRF-safe HTTP helpers. Framed as defense-in-depth hardening (sibling of #14432 / #14442), not a public advisory.

## Test plan

- [x] `uv run pytest tests/unit/mcp/test_mcp_http_client_redirects.py` (2 passed)
- [x] Assert `create_mcp_http_client_with_ssl_option().follow_redirects is False`
- [ ] Confirm Streamable HTTP / SSE MCP connectors still connect to non-redirecting endpoints


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP HTTP clients no longer automatically follow redirects.
  * Redirect targets are not revalidated after the initial security check, improving protection against unsafe redirect behavior.

* **Tests**
  * Added coverage confirming redirect handling remains disabled with SSL verification both enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->