### PR TITLE
fix(tests): handle the Setup Provider state in selectGptModel (deterministic shard-65 failure)

### DIFF
--- a/src/frontend/tests/utils/select-gpt-model.ts
+++ b/src/frontend/tests/utils/select-gpt-model.ts
@@ -59,10 +59,7 @@ const clickModelDropdownFooter = async (page: Page, testId: string) => {
   await button.dispatchEvent("click");
 };
 
-const enablePreferredOpenAiModel = async (page: Page) => {
-  await clickModelDropdownFooter(page, "manage-model-providers");
-  await page.waitForSelector("text=Model providers", { timeout: 30000 });
-
+const configureOpenAiInProviderModal = async (page: Page) => {
   await page.getByTestId("provider-item-OpenAI").click();
   await page.waitForTimeout(500);
 
@@ -95,6 +92,12 @@ const enablePreferredOpenAiModel = async (page: Page) => {
   return modelName;
 };
 
+const enablePreferredOpenAiModel = async (page: Page) => {
+  await clickModelDropdownFooter(page, "manage-model-providers");
+  await page.waitForSelector("text=Model providers", { timeout: 30000 });
+  return configureOpenAiInProviderModal(page);
+};
+
 const languageModelNodes = (page: Page) =>
   page.locator(".react-flow__node", {
     has: page.locator(
@@ -107,7 +110,42 @@ const languageModelNodes = (page: Page) =>
     ),
   });
 
+// On a backend with no configured provider, ModelInput renders a "Setup
+// Provider" call-to-action instead of the model dropdown, so the
+// `model_model` trigger doesn't exist and the selection loop below would
+// silently skip every node — leaving the model empty and the run failing
+// with "A model selection is required". Configure OpenAI through the
+// provider manager (the CTA opens the same modal) so the dropdown mounts.
+const setupProviderIfNeeded = async (page: Page) => {
+  const modelNodes = languageModelNodes(page);
+  if ((await modelNodes.count()) === 0) return;
+  if (
+    (await modelNodes
+      .filter({ has: page.getByTestId("model_model") })
+      .count()) > 0
+  ) {
+    return;
+  }
+
+  const setupTrigger = modelNodes
+    .getByText("Setup Provider", { exact: true })
+    .first();
+  if ((await setupTrigger.count()) === 0) return;
+
+  await setupTrigger.click();
+  await page.waitForSelector("text=Model providers", { timeout: 30000 });
+  await configureOpenAiInProviderModal(page);
+
+  // Closing the modal refetches providers/enabled models; the dropdown
+  // replaces the CTA once the refresh settles.
+  await expect(page.getByTestId("model_model").first()).toBeVisible({
+    timeout: 30000,
+  });
+};
+
 export const selectGptModel = async (page: Page) => {
+  await setupProviderIfNeeded(page);
+
   const nodes = languageModelNodes(page).filter({
     has: page.getByTestId("model_model"),
   });


### PR DESCRIPTION
Fixes the deterministic Playwright failure on `release-1.12.0` — `Playwright Tests - Shard 65/70` / `tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts › user must be able to see output inspection` — seen on every internal PR since the 1.11.3 back-merge (#14410, #14437, #14450, #14473).

## What breaks

On a fresh CI backend (no provider configured, `enabled_models` all false), `ModelInput` renders the **"Setup Provider"** call-to-action instead of the model dropdown. That trigger carries no `model_model` test id, so `selectGptModel`'s node filter

```ts
languageModelNodes(page).filter({ has: page.getByTestId("model_model") })
```

matches zero nodes and the helper silently does nothing: no dropdown, no provider setup, no API key saved, and the Basic Prompting template's `model` value stays empty. The trace from the failing run shows the flow posted to `/api/v2/workflows` with `model.value: []`, and the build fails in 0.3s with **"Flow build failed — A model selection is required"**, so `text=built successfully` never appears (8/8 attempts across both workflow retries).

## Why it started now

This gap was always there but was masked: `update_build_config` used to substitute `options[0]` for an empty model value, and langchain-openai fell back to the CI `OPENAI_API_KEY` env var — so the flow ran without the test ever selecting a model. #14465 (merged to `release-1.11.3` on Aug 7, brought here by the Aug 8 back-merge `1dfe36d0a3`) deliberately keeps an explicitly-empty model empty and fails the run with "A model selection is required" instead of silently billing an arbitrary provider. That intended behavior change exposed the helper's blind spot.

`release-1.11.3` doesn't hit this only because its shard layout runs the spec after another test has already configured OpenAI in the shared per-attempt DB. On `release-1.12.0`, shard 65 runs it against a pristine DB. (Fork PRs skip the spec entirely via `skipIfMissing.openAiKey()`, which is why e.g. #14456's shard 65 shows green.)

## Fix

Teach the shared `selectGptModel` helper to handle the fresh-install state: when language-model nodes exist but none render the `model_model` trigger, click the node's "Setup Provider" CTA (which opens the same Model-providers modal as the dropdown footer), configure the OpenAI key and enable a preferred model, then wait for the dropdown to mount before running the normal selection loop. The modal-interaction body of `enablePreferredOpenAiModel` is extracted into `configureOpenAiInProviderModal` and shared by both paths.

The guard only activates when zero `model_model` triggers exist — a state that previously guaranteed failure — so the 35 spec files using `initialGPTsetup`/`selectGptModel` are unaffected when a provider is already configured.

## Test plan

- [x] Reproduced the failure locally on `release-1.12.0` with a fresh temp DB and the stock helper: same signature as CI (model never selected, run fails, `text=built successfully` times out).
- [x] With this change on a fresh temp DB, the helper detects the CTA state, opens the Model-providers modal, and proceeds through the shared configuration path (local run used a placeholder key, so it stops at the live key-validation step; the modal interaction itself is the same code CI already exercises via `enablePreferredOpenAiModel`).
- [ ] Shard 65/70 green on this PR's CI run (CI has a real `OPENAI_API_KEY`, exercising the full path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPT model selection when OpenAI has not yet been configured.
  * Added automatic provider setup handling before selecting a preferred OpenAI model.
  * Improved reliability by waiting for provider information to refresh before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->