### PR TITLE
fix(tests): click Save in the provider modal before waiting for the key-saved toast (shard-65)

### DIFF
--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -348,6 +348,7 @@ const ProviderConfigurationForm = ({
             <Button
               onClick={onSave}
               size="sm"
+              data-testid="provider-save-button"
               loading={isLoading || isFetchingModels}
               disabled={!canSave || isLoading || isFetchingModels}
             >

--- a/src/frontend/tests/utils/select-anthropic-model.ts
+++ b/src/frontend/tests/utils/select-anthropic-model.ts
@@ -49,10 +49,14 @@ export const selectAnthropicModel = async (page: Page) => {
       const checkExistingKey = await page.getByTestId("input-end-icon").count();
       if (checkExistingKey === 0) {
         await page
-          .getByPlaceholder("Add API key")
+          .getByTestId("provider-variable-input-ANTHROPIC_API_KEY") // pragma: allowlist secret
           .fill(process.env.ANTHROPIC_API_KEY!);
-        await page.waitForSelector("text=Anthropic Api Key Saved", {
-          timeout: 30000,
+        // The provider modal saves only on the explicit Save click (live key
+        // validation + persist); the success toast fires after the post-save
+        // model refetch settles, so the toggle below is ready once it shows.
+        await page.getByTestId("provider-save-button").click();
+        await page.waitForSelector("text=Anthropic Configuration Saved", {
+          timeout: 60000,
         });
         await page.getByTestId(`llm-toggle-${ANTHROPIC_MODEL_NAME}`).click();
         await page.getByText(TEXTS.close).last().click();

--- a/src/frontend/tests/utils/select-assistant-openai-model.ts
+++ b/src/frontend/tests/utils/select-assistant-openai-model.ts
@@ -41,10 +41,14 @@ const enablePreferredOpenAiModel = async (page: Page) => {
   const checkExistingKey = await page.getByTestId("input-end-icon").count();
   if (checkExistingKey === 0) {
     await page
-      .getByPlaceholder("Add API key")
+      .getByTestId("provider-variable-input-OPENAI_API_KEY")
       .fill(process.env.OPENAI_API_KEY!);
-    await page.waitForSelector("text=OpenAI Api Key Saved", {
-      timeout: 30000,
+    // The provider modal saves only on the explicit Save click (live key
+    // validation + persist); the success toast fires after the post-save
+    // model refetch settles, so the toggles below are ready once it shows.
+    await page.getByTestId("provider-save-button").click();
+    await page.waitForSelector("text=OpenAI Configuration Saved", {
+      timeout: 60000,
     });
   }
 

--- a/src/frontend/tests/utils/select-gpt-model.ts
+++ b/src/frontend/tests/utils/select-gpt-model.ts
@@ -69,8 +69,15 @@ const configureOpenAiInProviderModal = async (page: Page) => {
   const checkExistingKey = await page.getByTestId("input-end-icon").count();
   if (checkExistingKey === 0 && (await apiKeyInput.count()) > 0) {
     await apiKeyInput.fill(process.env.OPENAI_API_KEY!);
-    await page.waitForSelector("text=OpenAI Api Key Saved", {
-      timeout: 30000,
+    // The provider modal stopped autosaving on input when it gained the
+    // explicit Save flow (#11446): the key is validated with a live provider
+    // call and persisted only after the Save button is clicked. The success
+    // toast ("<Provider> Configuration Saved") is deferred until the post-save
+    // model refetch settles, so once it shows the model toggles below are
+    // ready to interact with.
+    await page.getByTestId("provider-save-button").click();
+    await page.waitForSelector(`text=${OPENAI_PROVIDER} Configuration Saved`, {
+      timeout: 60000,
     });
   }
 


### PR DESCRIPTION
## Summary

Finishes the shard-65 fix started in #14478. That PR correctly routed the fresh-DB "Setup Provider" CTA into `configureOpenAiInProviderModal` — but doing so exposed a second, older bug in the same helper, so `Playwright Tests - Shard 65/70` kept failing on internal release-1.12.0 PRs (e.g. [#14410](https://github.com/langflow-ai/langflow/pull/14410), failing at the `OpenAI Api Key Saved` wait in `utils/select-gpt-model.ts`).

### Root cause

The provider-modal test helpers still assume the modal's **old autosave-on-input** behavior: fill the API key input, then wait for an `<Provider> Api Key Saved` toast. Since #11446 the modal only validates + persists on the explicit **Save** button click, and the success toast is `<Provider> Configuration Saved` (i18n `modelProviders.configurationSaved`) — the old toast text no longer exists anywhere in the app. So the helper filled the key, never saved it, and stalled 30s waiting for a toast that can never fire, leaving the provider unconfigured and the flow run failing.

The pre-#14478 runs never hit this branch (the backend auto-filled the model and the key came from the env fallback), which is why the dead code survived; whether a given post-#14478 run passed came down to worker scheduling (another worker's test configuring the provider first).

### Changes

- `tests/utils/select-gpt-model.ts`, `tests/utils/select-anthropic-model.ts`, `tests/utils/select-assistant-openai-model.ts`: after filling the key, click the Save button and wait for the real deferred `<Provider> Configuration Saved` toast — it only fires after the post-save model refetch settles, so the model toggles the helpers use next are guaranteed ready.
- Replace the dead `getByPlaceholder("Add API key")` locators in the Anthropic/assistant helpers (current placeholders are `sk-...` / `sk-ant-...`) with the `provider-variable-input-*` test ids.
- `ProviderConfigurationForm.tsx`: add `data-testid="provider-save-button"` to the Save button (its siblings `provider-disconnect-button` / `provider-deactivate-button` already have test ids).

## Test plan

- [x] Local red/green against a fresh temp DB with the backend pointed at a mock OpenAI upstream via `OPENAI_BASE_URL` (so both live validations — `POST /api/v1/models/validate-provider` and the variable-create key check — execute for real):
  - **old code**: `chatInputOutputUser-shard-1.spec.ts` reproduces CI's exact stall (`waiting for locator('text=OpenAI Api Key Saved')`)
  - **this fix**: the same spec passes end to end (Setup Provider CTA → modal → fill → Save → validation → toast → toggle → model selected → flow build → output inspection)
- [x] `biome check` clean on all four files
- [ ] CI `Playwright Tests - Shard 65/70` green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider configuration saving and confirmation handling for Anthropic and OpenAI API keys.
  * Updated configuration flows to explicitly save changes and wait for the correct success confirmation.
  * Increased confirmation wait time to improve reliability during provider setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->