### PR TITLE
fix(lfx): stop reporting tool-mode nodes as breaking

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
@@ -123,4 +123,117 @@ describe("checkCodeValidity", () => {
       userEdited: false,
     });
   });
+
+  // Switching a component to tool mode replaces its outputs with a single
+  // component_as_tool entry, which no component declares, so comparing the two output
+  // sets always reported a breaking change.
+  const toolModeNode = (template: Record<string, unknown>) =>
+    ({
+      type: "URLComponent",
+      node: {
+        edited: false,
+        outputs: [
+          {
+            name: "component_as_tool",
+            display_name: "Toolset",
+            types: ["Tool"],
+            method: "to_toolkit",
+          },
+        ],
+        template,
+      },
+    }) as Parameters<typeof checkCodeValidity>[0];
+
+  const urlTemplates = (template: Record<string, unknown>) =>
+    ({
+      URLComponent: {
+        template,
+        outputs: [
+          {
+            name: "page_results",
+            display_name: "Table",
+            types: ["Table"],
+            method: "fetch_content",
+          },
+        ],
+      },
+    }) as Parameters<typeof checkCodeValidity>[1];
+
+  it("does not treat a tool-mode node as breaking while the component supports tool mode", () => {
+    const data = toolModeNode({
+      code: { value: "old component code" },
+      urls: { value: "", tool_mode: true },
+      tools_metadata: {},
+    });
+    const templates = urlTemplates({
+      code: { value: "current component code" },
+      urls: { value: "", tool_mode: true },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: false,
+      userEdited: false,
+    });
+  });
+
+  // Without a tool_mode input the component is not known to still produce the toolset
+  // output, so the node stays breaking. Treating "no inputs at all" as tool-capable would
+  // call an unfixable node safe: MockDataGenerator has no inputs and produces no toolset
+  // output at runtime.
+  it("treats a tool-mode node as breaking when the component declares no tool input", () => {
+    const data = toolModeNode({
+      code: { value: "old component code" },
+      tools_metadata: {},
+    });
+    const templates = urlTemplates({
+      code: { value: "current component code" },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: true,
+      userEdited: false,
+    });
+  });
+
+  it("treats a tool-mode node as breaking once the component drops tool mode", () => {
+    const data = toolModeNode({
+      code: { value: "old component code" },
+      urls: { value: "", tool_mode: true },
+      tools_metadata: {},
+    });
+    const templates = urlTemplates({
+      code: { value: "current component code" },
+      urls: { value: "" },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: true,
+      userEdited: false,
+    });
+  });
+
+  it("still applies the remaining checks to a tool-mode node", () => {
+    const data = toolModeNode({
+      code: { value: "old component code" },
+      urls: { value: "", tool_mode: true, input_types: ["Message"] },
+      tools_metadata: {},
+    });
+    const templates = urlTemplates({
+      code: { value: "current component code" },
+      urls: { value: "", tool_mode: true, input_types: ["Data"] },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: true,
+      userEdited: false,
+    });
+  });
 });

--- a/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
@@ -218,6 +218,29 @@ describe("checkCodeValidity", () => {
     });
   });
 
+  // Tool mode synthesizes exactly one output, so a duplicated name is a malformed node and
+  // must keep going through the authored-output comparison.
+  it("treats a node with a duplicated tool output as breaking", () => {
+    const data = toolModeNode({
+      code: { value: "old component code" },
+      urls: { value: "", tool_mode: true },
+      tools_metadata: {},
+    });
+    const outputs = data.node!.outputs!;
+    data.node!.outputs = [outputs[0], { ...outputs[0] }];
+    const templates = urlTemplates({
+      code: { value: "current component code" },
+      urls: { value: "", tool_mode: true },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: true,
+      userEdited: false,
+    });
+  });
+
   it("still applies the remaining checks to a tool-mode node", () => {
     const data = toolModeNode({
       code: { value: "old component code" },

--- a/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
+++ b/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
@@ -15,6 +15,29 @@ export type CodeValidityType = {
 
 const transientTemplateKeys = new Set(["is_refresh", "tools_metadata"]);
 
+// Synthetic output name a component receives when it is switched to tool mode. Must match
+// TOOL_OUTPUT_NAME in src/lfx/src/lfx/base/tools/constants.py.
+const TOOL_OUTPUT_NAME = "component_as_tool";
+
+// Returns true when the saved node's outputs are the synthesized toolset output. Switching a
+// component to tool mode replaces its authored outputs with this single entry, so they describe a
+// runtime projection rather than anything the original component declares.
+const nodeIsInToolMode = (userOutputs?: OutputFieldType[]): boolean =>
+  !!userOutputs?.length &&
+  userOutputs.every((output) => output.name === TOOL_OUTPUT_NAME);
+
+// Returns true when the original component can still be switched to tool mode: at least one input
+// declares tool_mode. This is the input side of Component._handle_tool_mode, which is what creates
+// the component_as_tool output at build time. The tool_mode flag on *outputs* marks which outputs a
+// toolset exposes rather than the component's capability, so it is not used. checkHasToolMode in
+// src/utils/reactflowUtils.ts answers a different question (whether to offer the toggle at all) and
+// is not reused here.
+const templateSupportsToolMode = (
+  originalTemplate?: APITemplateType,
+): boolean =>
+  !!originalTemplate &&
+  Object.values(originalTemplate).some((field) => Boolean(field?.tool_mode));
+
 // Returns true if the code is outdated (code string changed and not ignored)
 const codeIsOutdated = (
   currentCode: string,
@@ -37,7 +60,16 @@ const codeHasBreakingChange = (
   userTemplate?: APITemplateType,
 ): boolean => {
   // Check outputs
-  if (
+  if (nodeIsInToolMode(userOutputs)) {
+    // A tool-mode node's saved outputs are the toolset projection, so they never match the
+    // original component's declared outputs and comparing the two always reports a breaking
+    // change. What matters for such a node is whether the component still supports tool mode. A
+    // removed or renamed output cannot disconnect its edges, because its only output is the
+    // toolset.
+    if (!templateSupportsToolMode(originalTemplate)) {
+      return true;
+    }
+  } else if (
     originalOutputs &&
     userOutputs &&
     !outputsAreEqual(originalOutputs, userOutputs)

--- a/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
+++ b/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
@@ -21,10 +21,13 @@ const TOOL_OUTPUT_NAME = "component_as_tool";
 
 // Returns true when the saved node's outputs are the synthesized toolset output. Switching a
 // component to tool mode replaces its authored outputs with this single entry, so they describe a
-// runtime projection rather than anything the original component declares.
+// runtime projection rather than anything the original component declares. Requires exactly one
+// output: a malformed node carrying the name more than once is not something tool mode produces, so
+// it keeps going through the authored-output comparison.
 const nodeIsInToolMode = (userOutputs?: OutputFieldType[]): boolean =>
-  !!userOutputs?.length &&
-  userOutputs.every((output) => output.name === TOOL_OUTPUT_NAME);
+  !!userOutputs &&
+  userOutputs.length === 1 &&
+  userOutputs[0].name === TOOL_OUTPUT_NAME;
 
 // Returns true when the original component can still be switched to tool mode: at least one input
 // declares tool_mode. This is the input side of Component._handle_tool_mode, which is what creates

--- a/src/lfx/src/lfx/upgrade/checker.py
+++ b/src/lfx/src/lfx/upgrade/checker.py
@@ -127,8 +127,11 @@ def _node_is_in_tool_mode(flow_outputs: list[dict]) -> bool:
     Switching a component to tool mode replaces its authored outputs with a single
     ``component_as_tool`` entry, so those outputs describe a runtime projection rather than
     anything the registry declares.
+
+    Requires *exactly* one output. A malformed node carrying the name more than once is not
+    something tool mode produces, so it keeps going through the authored-output comparison.
     """
-    return {output.get("name") for output in flow_outputs} == {TOOL_OUTPUT_NAME}
+    return len(flow_outputs) == 1 and flow_outputs[0].get("name") == TOOL_OUTPUT_NAME
 
 
 def _registry_supports_tool_mode(registry_entry: Mapping[str, Any]) -> bool:

--- a/src/lfx/src/lfx/upgrade/checker.py
+++ b/src/lfx/src/lfx/upgrade/checker.py
@@ -9,6 +9,11 @@ from typing import Any, Literal
 COMPONENTS_TO_IGNORE_UPDATE: frozenset[str] = frozenset({"CustomComponent"})
 TRANSIENT_TEMPLATE_KEYS: frozenset[str] = frozenset({"is_refresh", "tools_metadata"})
 
+# Synthetic output name a component receives when it is switched to tool mode. Must match
+# lfx.base.tools.constants.TOOL_OUTPUT_NAME, duplicated as a literal for the same reason
+# lfx.graph.flow_builder.connect does it: to keep this module free of lfx.base imports.
+TOOL_OUTPUT_NAME = "component_as_tool"
+
 NodeStatusLiteral = Literal["ok", "outdated_safe", "outdated_breaking", "blocked"]
 
 
@@ -116,10 +121,46 @@ def _input_types_contained(registry_template: dict, flow_template: dict) -> bool
     return True
 
 
+def _node_is_in_tool_mode(flow_outputs: list[dict]) -> bool:
+    """Return True when the saved node's outputs are the synthesized toolset output.
+
+    Switching a component to tool mode replaces its authored outputs with a single
+    ``component_as_tool`` entry, so those outputs describe a runtime projection rather than
+    anything the registry declares.
+    """
+    return {output.get("name") for output in flow_outputs} == {TOOL_OUTPUT_NAME}
+
+
+def _registry_supports_tool_mode(registry_entry: Mapping[str, Any]) -> bool:
+    """Return True when the current component can still be switched to tool mode.
+
+    Mirrors the input side of ``Component._handle_tool_mode``, which is what actually creates
+    the ``component_as_tool`` output: a component supports tool mode when at least one input
+    declares ``tool_mode``.
+
+    Two signals are deliberately not used. The ``tool_mode`` flag on *outputs* marks which
+    outputs a toolset exposes rather than the component's capability (124 of the 127 bundled
+    components set it, ``ChatInput`` included). And ``add_tool_output``, the other half of the
+    runtime rule, is not serialized into the component index, so components that rely on it
+    alone keep being reported ``outdated_breaking``. Both omissions err the same way: a node is
+    only called safe when re-stamping is known to preserve its toolset output.
+    """
+    template = registry_entry.get("template") or {}
+    return any(isinstance(field_data, Mapping) and field_data.get("tool_mode") for field_data in template.values())
+
+
 def _has_breaking_change(registry_entry: dict, node_info: dict) -> bool:
     registry_outputs = registry_entry.get("outputs") or []
     flow_outputs = node_info.get("outputs") or []
-    if registry_outputs and not _outputs_are_compatible(registry_outputs, flow_outputs):
+    if _node_is_in_tool_mode(flow_outputs):
+        # A tool-mode node's saved outputs are the toolset projection, so they never match the
+        # registry's declared outputs and comparing the two always reports a breaking change.
+        # What matters for such a node is whether the component still supports tool mode. A
+        # removed or renamed output cannot disconnect its edges, because its only output is
+        # the toolset.
+        if not _registry_supports_tool_mode(registry_entry):
+            return True
+    elif registry_outputs and not _outputs_are_compatible(registry_outputs, flow_outputs):
         return True
     registry_template = registry_entry.get("template") or {}
     flow_template = node_info.get("template") or {}

--- a/src/lfx/tests/unit/upgrade/test_checker.py
+++ b/src/lfx/tests/unit/upgrade/test_checker.py
@@ -1,6 +1,7 @@
 """Unit tests for the upgrade compatibility checker."""
 
 from lfx.upgrade.checker import (
+    TOOL_OUTPUT_NAME,
     build_registry_lookup,
     check_flow_compatibility,
 )
@@ -280,3 +281,71 @@ def test_check_accepts_prebuilt_registry():
     lookup = build_registry_lookup(all_types)
     report = check_flow_compatibility(_flow(_node(code=REGISTRY_CODE_V1)), all_types, registry=lookup)
     assert report.nodes[0].status == "outdated_safe"
+
+
+# --- tool-mode nodes carry a synthesized output set ------------------------------------
+
+
+def _tool_outputs():
+    """The outputs a node carries once it is switched to tool mode."""
+    return [
+        {
+            "name": TOOL_OUTPUT_NAME,
+            "display_name": "Toolset",
+            "types": ["Tool"],
+            "method": "to_toolkit",
+            "allows_loop": False,
+        }
+    ]
+
+
+def test_outdated_safe_when_tool_mode_node_outputs_are_the_toolset():
+    """Tool mode replaces a node's outputs, so they never match the registry's declared ones."""
+    node = _node(
+        code=REGISTRY_CODE_V1,
+        outputs=_tool_outputs(),
+        template_extra={"query": {"tool_mode": True}, "tools_metadata": {}},
+    )
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"query": {"tool_mode": True}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+
+def test_outdated_breaking_when_tool_mode_component_declares_no_tool_input():
+    """Without a tool_mode input the component is not known to still produce the toolset output.
+
+    ``Component._handle_tool_mode`` also creates that output for components that set the
+    ``add_tool_output`` class attribute, but it is not serialized into the component index and
+    cannot be detected here. Treating "no inputs at all" as tool-capable would be wrong in the
+    dangerous direction: ``MockDataGenerator`` has no inputs and produces no toolset output at
+    runtime, so a node of it would be called safe and re-stamped while its saved
+    ``component_as_tool`` output still failed to resolve.
+    """
+    node = _node(code=REGISTRY_CODE_V1, outputs=_tool_outputs(), template_extra={"tools_metadata": {}})
+    registry = _registry(code=REGISTRY_CODE_V2)
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_breaking"
+
+
+def test_outdated_breaking_when_tool_mode_node_lost_tool_support():
+    """The component no longer declares a tool-mode input, so the saved node cannot be rebuilt."""
+    node = _node(
+        code=REGISTRY_CODE_V1,
+        outputs=_tool_outputs(),
+        template_extra={"query": {"tool_mode": True}, "tools_metadata": {}},
+    )
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"query": {"tool_mode": False}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_breaking"
+
+
+def test_outdated_breaking_when_tool_mode_node_input_types_narrowed():
+    """The remaining compatibility checks still apply to a tool-mode node."""
+    node = _node(
+        code=REGISTRY_CODE_V1,
+        outputs=_tool_outputs(),
+        template_extra={"query": {"tool_mode": True, "input_types": ["Message"]}, "tools_metadata": {}},
+    )
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"query": {"tool_mode": True, "input_types": ["Data"]}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_breaking"

--- a/src/lfx/tests/unit/upgrade/test_checker.py
+++ b/src/lfx/tests/unit/upgrade/test_checker.py
@@ -339,6 +339,22 @@ def test_outdated_breaking_when_tool_mode_node_lost_tool_support():
     assert report.nodes[0].status == "outdated_breaking"
 
 
+def test_outdated_breaking_when_tool_output_appears_more_than_once():
+    """Tool mode synthesizes exactly one output, so a duplicated name is a malformed node.
+
+    Such a node must keep going through the authored-output comparison instead of being
+    treated as a tool-mode node and skipping it.
+    """
+    node = _node(
+        code=REGISTRY_CODE_V1,
+        outputs=_tool_outputs() + _tool_outputs(),
+        template_extra={"query": {"tool_mode": True}, "tools_metadata": {}},
+    )
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"query": {"tool_mode": True}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_breaking"
+
+
 def test_outdated_breaking_when_tool_mode_node_input_types_narrowed():
     """The remaining compatibility checks still apply to a tool-mode node."""
     node = _node(

--- a/src/lfx/tests/unit/upgrade/test_upgrade_real_flows.py
+++ b/src/lfx/tests/unit/upgrade/test_upgrade_real_flows.py
@@ -185,6 +185,43 @@ def test_original_flow_not_mutated(flow_name, flow_data_map, registry):
 
 
 # ---------------------------------------------------------------------------
+# Tool-mode nodes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flow_name", [f.stem for f in FIXTURE_FLOWS])
+def test_tool_mode_nodes_are_not_breaking_while_the_component_supports_tool_mode(flow_name, flow_data_map, registry):
+    """A node in tool mode must not be breaking merely because its outputs are the toolset.
+
+    Tool mode replaces a node's authored outputs with the single ``component_as_tool`` entry,
+    which no registry entry declares, so comparing the two output sets always fails. Unlike the
+    other checks in this file this one asserts a verdict, but it survives registry evolution
+    because it skips any node whose component has since dropped tool-mode support.
+    """
+    from lfx.upgrade.checker import TOOL_OUTPUT_NAME, _registry_supports_tool_mode, build_registry_lookup
+
+    lookup = build_registry_lookup(registry)
+    flow = flow_data_map[flow_name]
+    report = check_flow_compatibility(flow, registry, registry=lookup)
+    statuses = {n.node_id: n for n in report.nodes}
+
+    for node in flow.get("nodes", []):
+        node_info = node.get("data", {}).get("node", {})
+        output_names = {o.get("name") for o in (node_info.get("outputs") or [])}
+        if output_names != {TOOL_OUTPUT_NAME}:
+            continue
+        entry = lookup.get(node.get("data", {}).get("type", ""))
+        if entry is None or not _registry_supports_tool_mode(entry):
+            continue
+        status = statuses.get(node.get("data", {}).get("id") or node.get("id"))
+        assert status is not None, f"Tool-mode node in {flow_name} was not classified"
+        assert status.status != "outdated_breaking", (
+            f"{status.display_name} ({status.component_type}) in {flow_name} is in tool mode and its "
+            f"component still supports tool mode, so it must not be classified outdated_breaking"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Summary test — print a human-readable report for CI logs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Port of #14456 by @thesaadmirza onto `release-1.11.3`, cherry-picked with the original authorship preserved. Fixes the tool-mode half of #14454.

## Bug

Switching a component to tool mode replaces its authored outputs with a single `component_as_tool` entry. No registry entry declares an output by that name, so the output name-set comparison in `_has_breaking_change` could never pass, and every tool-mode node was classified `outdated_breaking` as soon as its stored code drifted from the shipped code. `lfx upgrade` printed `[BREAKING]` and `--upgrade-flow=safe` aborted on flows that were safe to update. 15 of the 29 bundled starter projects contain at least one tool-mode node (24 nodes total), and tool mode is how an agent gets its tools, so this covers most agent flows.

## Changes

- `src/lfx/src/lfx/upgrade/checker.py`: when a saved node's outputs are exactly the single synthesized toolset output, decide compatibility from whether the component still supports tool mode (at least one template field declares `tool_mode`, mirroring the input side of `Component._handle_tool_mode`) instead of comparing output names. The template-key and `input_types` checks still apply to those nodes.
- `src/frontend/src/CustomNodes/helpers/check-code-validity.ts`: the same change, so the editor's update-components modal and the CLI keep agreeing.
- Tests on both sides, plus an invariant test over the real starter-flow fixtures: a tool-mode node is never `outdated_breaking` while its component still supports tool mode.

## Verified on this branch

Repro from #14454 (Simple Agent starter project with a trivial code edit stamped onto each node), before → after:

```
outdated_breaking  URLComponent      →  outdated_safe
outdated_breaking  UnifiedWebSearch  →  outdated_safe
--upgrade-flow=safe aborts           →  --upgrade-flow=safe applied cleanly
```

Sweeping all 29 bundled starter projects: 22 of the 24 tool-mode nodes now classify `outdated_safe`. The remaining 2 (Chroma, YouTubeTranscripts) are `blocked`, not `outdated_breaking` — their components are not in the bundled component index on this branch (extracted to bundles), which is an unrelated condition this PR does not touch.

## Not included

The template-key half of #14454 (a field added to or removed from a component's template flips the node to `outdated_breaking`) is deliberately not fixed here, for the reason given in #14456: calling the added-field case safe requires `apply_safe_upgrades` to merge newly introduced registry fields with their defaults rather than only rewriting `template.code.value`, which is a larger change than a patch-release branch should carry. That half remains tracked in #14454.

## Test plan

- [x] `src/lfx`: `uv run pytest tests/unit/upgrade/` — 87 passed
- [x] `src/frontend`: `npx jest src/CustomNodes/helpers/__tests__/check-code-validity.test.ts` — 10 passed
- [x] Repro scripts from #14454 re-run on this branch (before/after above)
- [x] `ruff check` / `ruff format --check` / `biome check` clean on changed files

Refs #14454. Credit for the fix goes to @thesaadmirza (#14456); commits are cherry-picked with original authorship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility checks for components operating in tool mode.
  * Tool-mode components remain compatible when tool support and input types are preserved.
  * Changes are correctly flagged when tool support is removed, duplicated, or becomes incompatible.

* **Tests**
  * Added coverage for tool-mode compatibility across unit and starter-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->