### PR TITLE
fix(lfx): compare template keys directionally in the upgrade checker

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts
@@ -92,7 +92,7 @@ describe("checkCodeValidity", () => {
     });
   });
 
-  it("still treats real component input changes as breaking", () => {
+  it("treats a new required input without a usable default as breaking", () => {
     const componentData = {
       type: "LanguageModelComponent",
       node: {
@@ -100,7 +100,6 @@ describe("checkCodeValidity", () => {
         outputs: [],
         template: {
           code: { value: "old component code" },
-          legacy_input: { value: "" },
           _frontend_node_flow_id: { value: "flow-1" },
           is_refresh: true,
         },
@@ -110,13 +109,145 @@ describe("checkCodeValidity", () => {
       LanguageModelComponent: {
         template: {
           code: { value: "current component code" },
-          current_input: { value: "" },
+          api_key: { value: "", required: true },
         },
         outputs: [],
       },
     } as Parameters<typeof checkCodeValidity>[1];
 
     expect(checkCodeValidity(componentData, currentTemplates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: true,
+      userEdited: false,
+    });
+  });
+
+  // Template key sets are compared directionally, not for equality. A field only the
+  // current component has is introduced with its declared default when the node is
+  // rebuilt through /custom_component; a field only the saved node has holds a value
+  // the updated code no longer reads. Mirrors the same cases in
+  // src/lfx/tests/unit/upgrade/test_checker.py.
+  const nodeWithTemplate = (template: Record<string, unknown>) =>
+    ({
+      type: "LanguageModelComponent",
+      node: {
+        edited: false,
+        outputs: [],
+        template,
+      },
+    }) as Parameters<typeof checkCodeValidity>[0];
+
+  const templatesWithTemplate = (template: Record<string, unknown>) =>
+    ({
+      LanguageModelComponent: {
+        template,
+        outputs: [],
+      },
+    }) as Parameters<typeof checkCodeValidity>[1];
+
+  it("does not treat a new optional input as breaking", () => {
+    const data = nodeWithTemplate({
+      code: { value: "old component code" },
+    });
+    const templates = templatesWithTemplate({
+      code: { value: "current component code" },
+      new_flag: { value: false, required: false },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: false,
+      userEdited: false,
+    });
+  });
+
+  it("does not treat a new required input with a usable default as breaking", () => {
+    const data = nodeWithTemplate({
+      code: { value: "old component code" },
+    });
+    const templates = templatesWithTemplate({
+      code: { value: "current component code" },
+      retries: { value: 3, required: true },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: false,
+      userEdited: false,
+    });
+  });
+
+  // 0, false, and [] are usable defaults; only undefined/null/"" mean there is nothing
+  // to fill. Pins the guard against a truthiness rewrite.
+  it("does not treat a new required input with a falsy but usable default as breaking", () => {
+    for (const falsyDefault of [0, false, []]) {
+      const data = nodeWithTemplate({
+        code: { value: "old component code" },
+      });
+      const templates = templatesWithTemplate({
+        code: { value: "current component code" },
+        max_retries: { value: falsyDefault, required: true },
+      });
+
+      expect(checkCodeValidity(data, templates)).toMatchObject({
+        outdated: true,
+        blocked: false,
+        breakingChange: false,
+        userEdited: false,
+      });
+    }
+  });
+
+  // Exercises inputTypesContained: the new field has input_types, but no saved edge can
+  // feed a field the node predates, so there is nothing to narrow.
+  it("does not treat a new handle input as breaking", () => {
+    const data = nodeWithTemplate({
+      code: { value: "old component code" },
+    });
+    const templates = templatesWithTemplate({
+      code: { value: "current component code" },
+      tools: { value: "", input_types: ["Tool"] },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: false,
+      userEdited: false,
+    });
+  });
+
+  it("does not treat a field the component dropped as breaking", () => {
+    const data = nodeWithTemplate({
+      code: { value: "old component code" },
+      legacy_input: { value: "user set" },
+    });
+    const templates = templatesWithTemplate({
+      code: { value: "current component code" },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
+      outdated: true,
+      blocked: false,
+      breakingChange: false,
+      userEdited: false,
+    });
+  });
+
+  it("still enforces input_types containment on fields both sides have", () => {
+    const data = nodeWithTemplate({
+      code: { value: "old component code" },
+      inp: { value: "", input_types: ["Message"] },
+    });
+    const templates = templatesWithTemplate({
+      code: { value: "current component code" },
+      inp: { value: "", input_types: ["Message", "Data"] },
+    });
+
+    expect(checkCodeValidity(data, templates)).toMatchObject({
       outdated: true,
       blocked: false,
       breakingChange: true,

--- a/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
+++ b/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
@@ -83,7 +83,7 @@ const codeHasBreakingChange = (
   if (
     originalTemplate &&
     userTemplate &&
-    !templateKeysEqual(originalTemplate, userTemplate)
+    !templateKeysCompatible(originalTemplate, userTemplate)
   ) {
     return true;
   }
@@ -148,7 +148,7 @@ export const checkCodeValidity = (
 // The codeIsOutdated function will have many checks to make sure the code is outdated
 // the first check is if the current code is defined
 // the second check is if the data.node.outputs are equal to templates[data.type]?.outputs
-// and the data.node.template keys are equal to templates[data.type]?.template keys
+// and the data.node.template keys are compatible with templates[data.type]?.template keys
 // and all original input_types in each field are contained in the data.node.template input_types. If so, it means it won't break the component
 // this is a breaking change so we will need to handle it
 
@@ -203,7 +203,10 @@ const inputTypesContained = (
   for (const key of Object.keys(originalTemplate)) {
     const origField = originalTemplate[key];
     const userField = userTemplate[key];
-    if (!userField) return false;
+    // A field the saved node predates has no saved edges feeding it; the rebuilt
+    // template introduces it with its declared input_types, so there is nothing
+    // to narrow.
+    if (!userField) continue;
     if (origField.input_types) {
       const origTypes = Array.isArray(origField.input_types)
         ? origField.input_types
@@ -219,20 +222,35 @@ const inputTypesContained = (
   return true;
 };
 
-// Helper to check if template keys are equal
-const templateKeysEqual = (
+// Template key sets are compared directionally, not for equality. Must match
+// _template_keys_compatible in src/lfx/src/lfx/upgrade/checker.py:
+// - A field only the saved node has is one the current component dropped. Its stale
+//   value is not read once the node is updated, so it cannot break the node.
+// - A field only the current component has is one the saved node predates — the
+//   evolution the contributing docs recommend as non-breaking. The update rebuilds
+//   the template through /custom_component, which introduces the field with its
+//   declared default, so it only breaks when that default is unusable: a *required*
+//   field with nothing to fill it, which would turn a node that ran into one that
+//   fails asking for input.
+const templateKeysCompatible = (
   originalTemplate: APITemplateType,
   userTemplate: APITemplateType,
 ): boolean => {
   const isStructuralTemplateKey = (key: string) =>
     !key.startsWith("_") && !transientTemplateKeys.has(key);
-  const origKeys = Object.keys(originalTemplate)
-    .filter(isStructuralTemplateKey)
-    .sort();
-  const userKeys = Object.keys(userTemplate)
-    .filter(isStructuralTemplateKey)
-    .sort();
-  return JSON.stringify(origKeys) === JSON.stringify(userKeys);
+  for (const key of Object.keys(originalTemplate)) {
+    if (!isStructuralTemplateKey(key) || key in userTemplate) continue;
+    const origField = originalTemplate[key];
+    if (
+      origField?.required &&
+      (origField.value === undefined ||
+        origField.value === null ||
+        origField.value === "")
+    ) {
+      return false;
+    }
+  }
+  return true;
 };
 
 export default checkCodeValidity;

--- a/src/lfx/src/lfx/upgrade/applier.py
+++ b/src/lfx/src/lfx/upgrade/applier.py
@@ -1,7 +1,8 @@
 """Apply safe upgrades to a flow dict.
 
-Returns a deep copy of the flow with safe-upgradeable node codes replaced
-by the current registry code. Breaking and blocked nodes are left unchanged.
+Returns a deep copy of the flow with safe-upgradeable node codes replaced by the
+current registry code and any template fields the saved flow predates introduced
+with their registry defaults. Breaking and blocked nodes are left unchanged.
 """
 
 from __future__ import annotations
@@ -12,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-from lfx.upgrade.checker import CompatibilityReport, build_registry_lookup
+from lfx.upgrade.checker import CompatibilityReport, build_registry_lookup, new_template_field_keys
 
 
 def apply_safe_upgrades(
@@ -63,10 +64,19 @@ def _apply_to_nodes(nodes: list[dict], safe_ids: set[str], registry: dict[str, d
             component_type = node.get("data", {}).get("type", "")
             entry = registry.get(component_type)
             if entry:
-                registry_code_field = entry.get("template", {}).get("code")
+                registry_template = entry.get("template", {})
+                registry_code_field = registry_template.get("code")
                 new_code = registry_code_field.get("value") if isinstance(registry_code_field, dict) else None
                 if new_code is not None:
-                    node["data"]["node"]["template"]["code"]["value"] = new_code
+                    flow_template = node["data"]["node"]["template"]
+                    flow_template["code"]["value"] = new_code
+                    # The checker calls a node safe when the registry grew fields the saved
+                    # flow predates; the re-stamped code reads those fields, so introduce
+                    # each one exactly as the registry declares it — the state a freshly
+                    # added component would carry. Deep-copied so later edits to the
+                    # upgraded flow cannot reach back into the shared registry lookup.
+                    for key in new_template_field_keys(registry_template, flow_template):
+                        flow_template[key] = copy.deepcopy(registry_template[key])
                     count += 1
         nested = node.get("data", {}).get("node", {}).get("flow", {}).get("data", {}).get("nodes")
         if nested:

--- a/src/lfx/src/lfx/upgrade/checker.py
+++ b/src/lfx/src/lfx/upgrade/checker.py
@@ -94,8 +94,35 @@ def _structural_template_keys(template: Mapping[str, Any]) -> set[str]:
     return {key for key in template if not key.startswith("_") and key not in TRANSIENT_TEMPLATE_KEYS}
 
 
-def _template_keys_equal(original: dict, user: dict) -> bool:
-    return _structural_template_keys(original) == _structural_template_keys(user)
+def new_template_field_keys(registry_template: Mapping[str, Any], flow_template: Mapping[str, Any]) -> set[str]:
+    """Return registry template fields the saved flow predates.
+
+    These are the fields ``apply_safe_upgrades`` introduces (with their registry-declared
+    state) when it re-stamps a safe node's code, so the checker's definition of a safe
+    upgrade and the applier's write stay in lockstep.
+    """
+    return _structural_template_keys(registry_template) - _structural_template_keys(flow_template)
+
+
+def _template_keys_compatible(registry_template: dict, flow_template: dict) -> bool:
+    """Return True unless the registry grew a field a safe upgrade cannot fill.
+
+    Template key sets are compared directionally, not for equality:
+
+    - A field only the *flow* has is one the registry dropped. Its stale value is not read
+      once the code is re-stamped, and ``apply_safe_upgrades`` leaves it in place, so an
+      edge into it keeps its target handle.
+    - A field only the *registry* has is one the saved flow predates — the evolution the
+      contributing docs recommend as non-breaking. ``apply_safe_upgrades`` introduces it
+      exactly as the registry declares it, so it only breaks when that declared state is
+      unusable: a *required* field with nothing to fill it, which would turn a flow that
+      ran into one that fails asking for input.
+    """
+    for key in new_template_field_keys(registry_template, flow_template):
+        field = registry_template.get(key)
+        if isinstance(field, Mapping) and field.get("required") and field.get("value") in (None, ""):
+            return False
+    return True
 
 
 def _input_types_contained(registry_template: dict, flow_template: dict) -> bool:
@@ -113,7 +140,10 @@ def _input_types_contained(registry_template: dict, flow_template: dict) -> bool
             continue
         flow_field = flow_template.get(key)
         if not flow_field:
-            return False
+            # A field the saved flow predates has no saved edges feeding it, and
+            # apply_safe_upgrades introduces it with the registry's declared input_types,
+            # so there is nothing to narrow.
+            continue
         flow_types = flow_field.get("input_types") or []
         # Every type the saved flow relied on must still be accepted by the registry.
         if not all(t in registry_types for t in flow_types):
@@ -167,7 +197,7 @@ def _has_breaking_change(registry_entry: dict, node_info: dict) -> bool:
         return True
     registry_template = registry_entry.get("template") or {}
     flow_template = node_info.get("template") or {}
-    if registry_template and not _template_keys_equal(registry_template, flow_template):
+    if registry_template and not _template_keys_compatible(registry_template, flow_template):
         return True
     return bool(registry_template) and not _input_types_contained(registry_template, flow_template)
 

--- a/src/lfx/tests/unit/upgrade/test_applier.py
+++ b/src/lfx/tests/unit/upgrade/test_applier.py
@@ -9,11 +9,14 @@ REGISTRY_CODE = "class MyComp:\n    pass  # v2"
 NODE_CODE = "class MyComp:\n    pass  # v1"
 
 
-def _registry(code=REGISTRY_CODE):
+def _registry(code=REGISTRY_CODE, template_extra=None):
+    template = {"code": {"value": code}}
+    if template_extra:
+        template.update(template_extra)
     return {
         "Cat": {
             "MyComp": {
-                "template": {"code": {"value": code}},
+                "template": template,
                 "outputs": [{"name": "o", "display_name": "O", "types": ["M"], "method": "m", "allows_loop": False}],
                 "metadata": {},
             }
@@ -21,7 +24,10 @@ def _registry(code=REGISTRY_CODE):
     }
 
 
-def _node(code=NODE_CODE, type_="MyComp"):
+def _node(code=NODE_CODE, type_="MyComp", template_extra=None):
+    template = {"code": {"value": code}}
+    if template_extra:
+        template.update(template_extra)
     return {
         "id": "n1",
         "data": {
@@ -30,7 +36,7 @@ def _node(code=NODE_CODE, type_="MyComp"):
             "node": {
                 "display_name": "My Component",
                 "edited": False,
-                "template": {"code": {"value": code}},
+                "template": template,
                 "outputs": [{"name": "o", "display_name": "O", "types": ["M"], "method": "m", "allows_loop": False}],
             },
         },
@@ -116,6 +122,66 @@ def test_apply_returns_count_of_updated_nodes():
     assert count == 1
 
 
+def test_apply_merges_new_registry_fields_with_defaults():
+    """Fields the saved flow predates are introduced exactly as the registry declares them.
+
+    Counterpart to test_outdated_safe_when_registry_added_optional_field in test_checker.py:
+    the checker calls the node safe because the applier fills the field, so the applier
+    must actually fill it — otherwise the re-stamped code runs without a field it expects.
+    """
+    new_field = {"value": False, "required": False, "type": "bool"}
+    flow = _flow(_node(code=NODE_CODE))
+    registry = _registry(code=REGISTRY_CODE, template_extra={"new_flag": new_field})
+    report = check_flow_compatibility(flow, registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+    updated = apply_safe_upgrades(flow, registry, report)
+    template = updated["nodes"][0]["data"]["node"]["template"]
+    assert template["code"]["value"] == REGISTRY_CODE
+    assert template["new_flag"] == new_field
+
+    # The merged field must be a copy: editing the upgraded flow later must not reach
+    # back into the shared registry lookup.
+    template["new_flag"]["value"] = True
+    assert registry["Cat"]["MyComp"]["template"]["new_flag"]["value"] is False
+
+
+def test_apply_preserves_fields_registry_dropped():
+    """A field only the flow has is left in place; its value is simply no longer read."""
+    flow = _flow(_node(code=NODE_CODE, template_extra={"legacy": {"value": "keep me"}}))
+    registry = _registry(code=REGISTRY_CODE)
+    report = check_flow_compatibility(flow, registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+    updated = apply_safe_upgrades(flow, registry, report)
+    template = updated["nodes"][0]["data"]["node"]["template"]
+    assert template["code"]["value"] == REGISTRY_CODE
+    assert template["legacy"] == {"value": "keep me"}
+
+
+def test_apply_does_not_overwrite_existing_field_values():
+    """Only fields the flow lacks are merged; the user's saved values always win."""
+    flow = _flow(_node(code=NODE_CODE, template_extra={"opt": {"value": "user-set"}}))
+    registry = _registry(code=REGISTRY_CODE, template_extra={"opt": {"value": "default"}})
+    report = check_flow_compatibility(flow, registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+    updated = apply_safe_upgrades(flow, registry, report)
+    assert updated["nodes"][0]["data"]["node"]["template"]["opt"]["value"] == "user-set"
+
+
+def test_apply_then_recheck_reports_ok_after_field_merge():
+    """A safe upgrade over a grown template converges: the re-checked node is ok."""
+    flow = _flow(_node(code=NODE_CODE))
+    registry = _registry(code=REGISTRY_CODE, template_extra={"new_flag": {"value": False}})
+    report = check_flow_compatibility(flow, registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+    updated = apply_safe_upgrades(flow, registry, report)
+    recheck = check_flow_compatibility(updated, registry)
+    assert recheck.nodes[0].status == "ok"
+
+
 def test_apply_updates_nested_flow_safe_node_code():
     """Safe upgrades inside a grouped component's nested flow must be written, not skipped.
 
@@ -140,7 +206,7 @@ def test_apply_updates_nested_flow_safe_node_code():
         },
     }
     flow = _flow(outer)
-    registry = _registry(code=REGISTRY_CODE)
+    registry = _registry(code=REGISTRY_CODE, template_extra={"new_flag": {"value": False}})
     report = check_flow_compatibility(flow, registry)
     assert any(n.node_id == "nested-1" and n.status == "outdated_safe" for n in report.nodes)
 
@@ -148,3 +214,5 @@ def test_apply_updates_nested_flow_safe_node_code():
     assert count == 1
     written = updated["nodes"][0]["data"]["node"]["flow"]["data"]["nodes"][0]
     assert written["data"]["node"]["template"]["code"]["value"] == REGISTRY_CODE
+    # New registry fields must be merged on the nested path too, not only at top level.
+    assert written["data"]["node"]["template"]["new_flag"] == {"value": False}

--- a/src/lfx/tests/unit/upgrade/test_checker.py
+++ b/src/lfx/tests/unit/upgrade/test_checker.py
@@ -117,12 +117,13 @@ def test_outdated_breaking_when_output_removed():
     assert report.nodes[0].status == "outdated_breaking"
 
 
-def test_outdated_breaking_when_template_key_removed():
+def test_outdated_safe_when_registry_dropped_template_field():
+    """A field only the flow has (the registry dropped it) holds a value nothing reads."""
     old_template_extra = {"prompt": {"value": "hello"}}
     node = _node(code=REGISTRY_CODE_V1, template_extra=old_template_extra)
     registry = _registry(code=REGISTRY_CODE_V2)
     report = check_flow_compatibility(_flow(node), registry)
-    assert report.nodes[0].status == "outdated_breaking"
+    assert report.nodes[0].status == "outdated_safe"
 
 
 def test_outdated_breaking_when_input_types_narrowed():
@@ -256,6 +257,76 @@ def test_outdated_safe_when_input_types_widened():
     """The registry accepting an additional input type (widening) is safe, not breaking."""
     node = _node(code=REGISTRY_CODE_V1, template_extra={"inp": {"input_types": ["Message"]}})
     registry = _registry(code=REGISTRY_CODE_V2, template_extra={"inp": {"input_types": ["Message", "Data"]}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+
+# --- template key differences are directional, not an equality check -------------------
+
+
+def test_outdated_safe_when_registry_added_optional_field():
+    """The registry growing an optional field — the docs-recommended evolution — is safe.
+
+    apply_safe_upgrades introduces the field with its registry default, so the re-stamped
+    code never runs without a field it expects.
+    """
+    node = _node(code=REGISTRY_CODE_V1)
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"new_flag": {"value": False, "required": False}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+
+def test_outdated_safe_when_registry_added_required_field_with_default():
+    """A new required field whose registry default is usable leaves the node runnable."""
+    node = _node(code=REGISTRY_CODE_V1)
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"retries": {"value": 3, "required": True}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+
+def test_outdated_safe_when_registry_added_required_field_with_falsy_default():
+    """0, False, and [] are usable defaults; only None and "" mean there is nothing to fill.
+
+    Pins the guard to ``value in (None, "")`` — a truthiness rewrite would wrongly start
+    marking these as breaking.
+    """
+    for falsy_default in (0, False, []):
+        node = _node(code=REGISTRY_CODE_V1)
+        registry = _registry(
+            code=REGISTRY_CODE_V2, template_extra={"max_retries": {"value": falsy_default, "required": True}}
+        )
+        report = check_flow_compatibility(_flow(node), registry)
+        assert report.nodes[0].status == "outdated_safe"
+
+
+def test_outdated_breaking_when_registry_added_required_field_without_default():
+    """A new required field with nothing to fill it turns a flow that ran into one that fails."""
+    for empty_default in ("", None):
+        node = _node(code=REGISTRY_CODE_V1)
+        registry = _registry(
+            code=REGISTRY_CODE_V2, template_extra={"api_key": {"value": empty_default, "required": True}}
+        )
+        report = check_flow_compatibility(_flow(node), registry)
+        assert report.nodes[0].status == "outdated_breaking"
+
+
+def test_outdated_safe_when_registry_added_handle_input_field():
+    """A new field with input_types has no saved edges feeding it, so nothing narrows."""
+    node = _node(code=REGISTRY_CODE_V1)
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"tools": {"input_types": ["Tool"], "value": ""}})
+    report = check_flow_compatibility(_flow(node), registry)
+    assert report.nodes[0].status == "outdated_safe"
+
+
+def test_outdated_safe_when_optional_field_renamed():
+    """A rename is a drop plus an add; with an optional replacement neither direction breaks.
+
+    The saved value of the old field is not carried over — the new field starts at its
+    registry default, the same state the frontend's update endpoint produces when it
+    rebuilds the template.
+    """
+    node = _node(code=REGISTRY_CODE_V1, template_extra={"legacy_input": {"value": "user set"}})
+    registry = _registry(code=REGISTRY_CODE_V2, template_extra={"current_input": {"value": ""}})
     report = check_flow_compatibility(_flow(node), registry)
     assert report.nodes[0].status == "outdated_safe"
 


### PR DESCRIPTION
Addresses the template-keys half of #14454 (repro 2 there; the tool-mode half is #14456 / its 1.11.3 port #14481). Targets `release-1.11.3`; the same change is ported to `release-1.12.0` in a companion PR, and main picks it up through the usual release back-merge.

## What was wrong

`_template_keys_equal` in `src/lfx/src/lfx/upgrade/checker.py` (and its TS port `templateKeysEqual` in `check-code-validity.ts`) required a saved node's structural template key set to exactly equal the registry entry's. Two normal component evolutions therefore came back `outdated_breaking`, and `lfx upgrade --upgrade-flow=safe` gave up:

- **A)** the flow has a field the registry dropped — a value nothing reads once the code is re-stamped;
- **B)** the registry added a field the saved flow predates — the exact evolution [contributing-components.mdx](https://github.com/langflow-ai/langflow/blob/main/docs/docs/Contributing/contributing-components.mdx) recommends as non-breaking ("Don't remove fields and outputs").

Running the issue's `repro_template_keys.py` before / after this change:

```
baseline Agent                                    -> outdated_safe    | outdated_safe
A) flow has a field the registry dropped           -> outdated_breaking | outdated_safe
B) registry has a field the flow predates          -> outdated_breaking | outdated_safe
C) flow has an extra transient key (control)       -> outdated_safe    | outdated_safe
```

## The fix

**Checker (both languages).** Template key sets are compared directionally instead of for equality. A flow-only field is safe: its stale value is unread after re-stamp, and the applier leaves it in place, so an edge into it keeps its target handle. A registry-only field is safe unless its declared state cannot be filled — a `required` field whose default `value` is `None`/`""` would turn a flow that ran into one that fails asking for input, so that one case stays breaking. `_input_types_contained` / `inputTypesContained` now skip fields the saved flow predates: no saved edge can feed a field that didn't exist, so there is nothing to narrow.

**Applier.** Case B is only safe if the re-stamped code doesn't run without a field it expects, so `apply_safe_upgrades` now introduces registry-only structural fields exactly as the registry declares them (deep-copied), the state a freshly added component would carry. The new `new_template_field_keys` helper is shared between checker and applier so the two cannot disagree about what a safe upgrade consists of. Existing flow fields are never overwritten — the user's saved values always win.

**Frontend applier path.** No change needed: the update flow posts the new code to `/api/v1/custom_component`, and `update_frontend_node_with_template_values` starts from the freshly built template (new fields get their defaults, dropped fields disappear, saved values are copied for keys that still exist). Verified before leaving the TS side checker-only.

## Semantics change to be aware of

A field **rename** (drop + add) was previously breaking and is now safe when the replacement field is optional or has a usable default. The saved value of the old field is not carried over — the new field starts at its registry default, which is the same state the frontend's update endpoint already produces when it rebuilds the template. The previously-breaking classification for renames also blocked every plain field addition/removal, which is the false positive this PR removes. One existing test on each side encoded the old behavior and was updated (`test_outdated_breaking_when_template_key_removed` → safe; the rename-shaped frontend case now uses a required-without-default field to keep the breaking path covered).

## Tests

- `src/lfx/tests/unit/upgrade/test_checker.py`: dropped-field safe, optional-added safe, required-with-default safe (incl. falsy `0`/`False`/`[]` defaults pinned against a truthiness rewrite), required-without-default breaking, new handle-input safe, optional rename safe.
- `src/lfx/tests/unit/upgrade/test_applier.py`: new fields merged with registry defaults (deep-copied, registry lookup not aliased), dropped fields preserved, existing values never overwritten, nested grouped-flow merge, apply→recheck converges to `ok`.
- `src/frontend/src/CustomNodes/helpers/__tests__/check-code-validity.test.ts`: same matrix on the TS side.

`src/lfx/tests/unit/upgrade/` — 88 passed on this base. `check-code-validity.test.ts` — 11 passed. Ruff and Biome clean.

## Relation to #14456 / #14481

Independent halves of the same issue: those fix the outputs comparison for tool-mode nodes, this PR fixes the template-keys comparison. They touch different functions in the same two files (plus overlapping test files), so whichever lands second on a given branch may need a trivial rebase.