### PR TITLE
fix(tests): require exact MCP server name match

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -581,7 +581,7 @@ test(
     });
 
     // Find and edit the server
-    await expect(page.getByText(testName)).toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).toBeVisible({
       timeout: 10000,
     });
 


### PR DESCRIPTION
## Summary

- requires an exact text match when the HTTP/SSE persistence test locates the saved MCP server name
- avoids Playwright strict-mode collisions with the screen-reader-only `<name> error: ...` detail
- changes no production code or accessibility behavior

## Why

The unscoped substring locator matches both the standalone visible server name and the longer `sr-only` error detail. That makes the test deterministically fail in strict mode when the saved test server reports an expected connection error.

Observed on [#14437 shard 61](https://github.com/langflow-ai/langflow/actions/runs/31411775519/job/93532146560); #14437 does not touch frontend or MCP behavior, so this repair belongs on the shared release branch.

## Validation

- Biome check: passed
- Playwright discovery/type loading: all 6 tests in `mcp-server.spec.ts` listed successfully
- exact HTTP/SSE persistence browser test with retries disabled: **1 passed**
- independent frontend and TypeScript reviews: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test accuracy by requiring an exact match when locating an MCP server before editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->