### PR TITLE
fix(tests): require exact MCP server name match in remaining locators

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -125,7 +125,7 @@ test(
       timeout: 3000,
     });
 
-    await expect(page.getByText(testName)).toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).toBeVisible({
       timeout: 3000,
     });
 
@@ -196,7 +196,7 @@ test(
       timeout: 3000,
     });
 
-    await expect(page.getByText(testName)).not.toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).not.toBeVisible({
       timeout: 10000,
     });
   },
@@ -421,7 +421,7 @@ test(
     });
 
     // Find and edit the server
-    await expect(page.getByText(testName)).toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).toBeVisible({
       timeout: 3000,
     });
 
@@ -785,7 +785,7 @@ test(
       timeout: 30000,
     });
 
-    await expect(page.getByText(testName)).toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).toBeVisible({
       timeout: 10000,
     });
 
@@ -925,7 +925,7 @@ test(
       timeout: 10000,
     });
 
-    await expect(page.getByText(testName)).not.toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).not.toBeVisible({
       timeout: 10000,
     });
 
@@ -949,7 +949,7 @@ test(
 
     await page.getByTestId("add-mcp-server-button").click();
 
-    await expect(page.getByText(testName)).toBeVisible({
+    await expect(page.getByText(testName, { exact: true })).toBeVisible({
       timeout: 10000,
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #14484, which fixed only one of the strict-mode violations in `mcp-server.spec.ts`.

The WCAG sr-only error span added in #14478 (`statusErrorDetail`, rendering `<name> error: <detail>`) repeats the server name on the MCP Servers settings page whenever a server is in an error state. In CI the test servers use fake commands/URLs and routinely error, so every bare `page.getByText(testName)` on that page resolves to 2 elements and fails Playwright strict mode (e.g. shard 61 in runs 31409892411 and 31407493319, at line 424).

#14484 added `{ exact: true }` to the HTTP/SSE occurrence (line 584) only. This PR applies the same fix to the remaining STDIO occurrence (line 424) and the four other bare uses that assert against the settings page (lines 128, 199, 788, 928, 952). Exact match excludes the sr-only span because its text is the name plus the error detail, never the name alone.

Deliberately left unchanged: the `toHaveCount(3)` assertion at line 333 — it runs against the flow-canvas server dropdown, not the settings page (the sr-only span only renders there), and its count semantics rely on non-exact matching.

Only release-1.12.0 needs this: main and release-1.11.3 do not contain the sr-only span, and the back-merge of release-1.12.0 into main will carry both the span and the spec fixes together.

## Test plan
- [x] `biome check` (repo-pinned 2.1.1) passes on the file with no fixes
- [ ] CI Playwright shard covering `extended/features/mcp-server.spec.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MCP server UI test reliability by requiring exact server-name matches across creation, editing, deletion, and recreation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->