### PR TITLE
fix(tests): handle the Setup Provider state in the right-click-dropdown spec

### DIFF
--- a/src/frontend/tests/core/features/right-click-dropdown.spec.ts
+++ b/src/frontend/tests/core/features/right-click-dropdown.spec.ts
@@ -128,13 +128,30 @@ test(
 
     await adjustScreenView(page);
 
-    // Open the model providers modal from the node's model field. With no
-    // provider configured the field opens the modal directly, so the footer
-    // button of the model list may never render.
-    await page.getByTestId("model_model").first().click();
-    const manageProviders = page.getByTestId("manage-model-providers");
-    if (await manageProviders.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await manageProviders.click();
+    // Open the model providers modal from the node's model field. On a
+    // backend with no configured provider, ModelInput renders a "Setup
+    // Provider" call-to-action that does not carry the model_model test id
+    // and opens the provider manager directly (#14478). With a provider
+    // configured, the model_model dropdown mounts instead and the modal
+    // opens through its "Manage providers" footer button.
+    const modelTrigger = page.getByTestId("model_model").first();
+    const setupProviderTrigger = page
+      .locator(".react-flow__node")
+      .getByText("Setup Provider", { exact: true })
+      .first();
+    await expect(modelTrigger.or(setupProviderTrigger).first()).toBeVisible({
+      timeout: 30000,
+    });
+    if (await setupProviderTrigger.isVisible()) {
+      await setupProviderTrigger.click();
+    } else {
+      await modelTrigger.click();
+      const manageProviders = page.getByTestId("manage-model-providers");
+      if (
+        await manageProviders.isVisible({ timeout: 3000 }).catch(() => false)
+      ) {
+        await manageProviders.click();
+      }
     }
 
     const searchProviders = page.getByTestId("provider-search-input");


### PR DESCRIPTION
## Summary

The Playwright test `right-click-dropdown.spec.ts › right-clicking inside a modal opened from a node leaves the node alone` fails deterministically on CI workers where no model provider is configured (example: [run 31409892411](https://github.com/langflow-ai/langflow/actions/runs/31409892411), shard 42/70, both attempts, all retries).

With no provider configured, the Agent node's model field renders the **Setup Provider** call-to-action instead of the model dropdown — the CTA does not carry the `model_model` test id, so the spec's inlined `getByTestId("model_model").first().click()` times out. This is the exact failure mode fixed for the shared `selectGptModel` helper in #14478 (da44904677), but this spec inlines its own click instead of using the helper.

## Fix

Mirror the #14478 approach at the spec level: wait for either the `model_model` trigger or the Setup Provider CTA to mount, then

- click the CTA when present — it opens the provider manager modal directly (`ModelTrigger.tsx` wires it to `onOpenManageProviders`), which is all this test needs (it only right-clicks the provider search input); or
- fall back to the existing `model_model` → *Manage providers* footer path when a provider is already configured.

The shared helper wasn't reused because `setupProviderIfNeeded` goes on to fill an API key, save, and enable a model — this test only needs the modal open, and must work without any `OPENAI_API_KEY`.

## Test plan

- [x] Reproduced the CI failure locally: fresh sqlite DB, no `OPENAI_API_KEY` → unfixed spec fails with `TimeoutError … waiting for getByTestId('model_model')` at line 134, matching CI
- [x] Fixed spec passes in the same no-provider environment (26.7s)
- [x] Provider-configured path is untouched (existing `model_model` → `manage-model-providers` branch preserved verbatim)
- [x] `npx biome check` clean; pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated right-click menu test coverage to support workflows with or without configured providers.
  * Improved validation of provider setup and management actions before opening the provider dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->