### PR TITLE
fix: mend scans should now scan all codebase deps

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -40,18 +40,21 @@ jobs:
           java-version: "21"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.12.3"
 
       - name: Export Python deps for Mend
         run: |
-          uv export --no-hashes --format requirements-txt -o requirements-mend.txt
+          uv export --quiet --locked --all-packages --all-extras --all-groups --no-emit-workspace \
+            --no-hashes --format requirements.txt -o requirements-mend.txt
+          uv pip compile --quiet --python-version 3.13 --generate-hashes \
+            --constraint requirements-mend.txt scripts/gp/requirements.txt -o requirements-gp-mend.txt
 
       - name: Download Mend Unified Agent
         run: |

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -39,6 +39,20 @@ jobs:
           distribution: "semeru"
           java-version: "21"
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Export Python deps for Mend
+        run: |
+          uv export --no-hashes --format requirements-txt -o requirements-mend.txt
+
       - name: Download Mend Unified Agent
         run: |
           curl --fail --show-error --retry 3 --location -o wss-unified-agent.jar https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
@@ -53,4 +67,4 @@ jobs:
           WS_PRODUCTNAME: ${{ secrets.WS_PRODUCTNAME }}
           WS_PROJECTNAME: ${{ secrets.WS_PROJECTNAME }}
         run: |
-          java -jar wss-unified-agent.jar -d src -logLevel info
+          java -jar wss-unified-agent.jar -d . -c wss-generated.config -logLevel info

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   mend-scan:
@@ -42,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -52,9 +53,14 @@ jobs:
       - name: Export Python deps for Mend
         run: |
           uv export --quiet --locked --all-packages --all-extras --all-groups --no-emit-workspace \
-            --no-hashes --format requirements.txt -o requirements-mend.txt
-          uv pip compile --quiet --python-version 3.13 --generate-hashes \
-            --constraint requirements-mend.txt scripts/gp/requirements.txt -o requirements-gp-mend.txt
+            --no-annotate --no-header --no-hashes --format requirements.txt -o requirements-workspace-mend.txt
+          uv pip compile --quiet --python-version ${{ env.PYTHON_VERSION }} \
+            --python-platform x86_64-unknown-linux-gnu --index https://download.pytorch.org/whl/cpu \
+            --index-strategy unsafe-first-match --emit-index-url --generate-hashes --no-annotate --no-header \
+            requirements-workspace-mend.txt -o requirements-mend.txt
+          uv pip compile --quiet --python-version ${{ env.PYTHON_VERSION }} \
+            --index-strategy unsafe-first-match --generate-hashes --constraint requirements-mend.txt \
+            scripts/gp/requirements.txt -o requirements-gp-mend.txt
 
       - name: Download Mend Unified Agent
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,4 @@ whitesource/
 
 # Mend
 requirements-mend.txt
+requirements-gp-mend.txt

--- a/.gitignore
+++ b/.gitignore
@@ -307,4 +307,5 @@ whitesource/
 
 # Mend
 requirements-mend.txt
+requirements-workspace-mend.txt
 requirements-gp-mend.txt

--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,6 @@ whitesource/
 
 #ai folders
 .bob/
+
+# Mend
+requirements-mend.txt

--- a/wss-generated.config
+++ b/wss-generated.config
@@ -1,15 +1,18 @@
 ## Mend Unified Agent configuration
 ## https://docs.mend.io/bundle/unified_agent/page/unified_agent_configuration_parameters.html
 
-# Scan from repo root so requirements-mend.txt (exported uv lockfile) is reachable
-includes=requirements-mend.txt,src/**
+# Resolve package-manager manifests without uploading flat source/binary matches
+fileSystemScan=false
 
-# Exclude non-code directories and generated artifacts
-excludes=**/docs/**,**/coverage/**,**/htmlcov/**,**/playwright-report/**,**/blob-report/**,**/test-results/**,**/node_modules/**,**/.venv/**,**/dist/**,**/__pycache__/**,**/scripts/**
+# Exclude generated artifacts while preserving dependency-bearing directories
+excludes=**/coverage/**,**/htmlcov/**,**/playwright-report/**,**/blob-report/**,**/test-results/**,**/node_modules/**,**/.venv/**,**/dist/**,**/__pycache__/**
+
+# NPM resolver -- include build, test, and development dependencies
+npm.includeDevDependencies=true
 
 # Python resolver — use pip3 binary
 python.path=python3
 python.pipPath=pip3
 python.ignoreSourceFiles=true
-python.requirementsFileIncludes=requirements-mend.txt
+python.requirementsFileIncludes=requirements-mend.txt,requirements-gp-mend.txt
 python.installVirtualenv=true

--- a/wss-generated.config
+++ b/wss-generated.config
@@ -1,0 +1,15 @@
+## Mend Unified Agent configuration
+## https://docs.mend.io/bundle/unified_agent/page/unified_agent_configuration_parameters.html
+
+# Scan from repo root so requirements-mend.txt (exported uv lockfile) is reachable
+includes=requirements-mend.txt,src/**
+
+# Exclude non-code directories and generated artifacts
+excludes=**/docs/**,**/coverage/**,**/htmlcov/**,**/playwright-report/**,**/blob-report/**,**/test-results/**,**/node_modules/**,**/.venv/**,**/dist/**,**/__pycache__/**,**/scripts/**
+
+# Python resolver — use pip3 binary
+python.path=python3
+python.pipPath=pip3
+python.ignoreSourceFiles=true
+python.requirementsFileIncludes=requirements-mend.txt
+python.installVirtualenv=true

--- a/wss-generated.config
+++ b/wss-generated.config
@@ -3,6 +3,7 @@
 
 # Resolve package-manager manifests without uploading flat source/binary matches
 fileSystemScan=false
+failErrorLevel=ALL
 
 # Exclude generated artifacts while preserving dependency-bearing directories
 excludes=**/coverage/**,**/htmlcov/**,**/playwright-report/**,**/blob-report/**,**/test-results/**,**/node_modules/**,**/.venv/**,**/dist/**,**/__pycache__/**


### PR DESCRIPTION
mend scans should now scan all codebase deps
this should include pythong, java and node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Mend security scanning to use Python 3.13 and resolve project dependencies before scanning.
  * Expanded scanning to cover the repository with clearer inclusion and exclusion rules.
  * Added configuration for Python dependency analysis and excluded generated, documentation, and development files.
  * Prevented generated dependency export files from being tracked in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->