### PR TITLE
fix: validate production preflight secret key

### DIFF
--- a/src/backend/base/langflow/cli/preflight.py
+++ b/src/backend/base/langflow/cli/preflight.py
@@ -256,13 +256,27 @@ async def probe_storage(settings_service: SettingsService) -> CheckResult:
 
 
 async def probe_secret_key(settings_service: SettingsService) -> CheckResult:
-    """Require an operator-supplied encryption secret key (not auto-generated).
+    """Require a usable operator-supplied encryption secret key (not auto-generated).
 
     Reads provenance from the environment because the materialized settings
     value is indistinguishable between env-supplied, file-loaded, and
     per-boot auto-generated keys.
     """
-    if os.environ.get("LANGFLOW_SECRET_KEY", "").strip():
+    secret_key = os.environ.get("LANGFLOW_SECRET_KEY", "")
+    if secret_key.strip():
+        from cryptography.fernet import Fernet
+
+        from langflow.services.auth.utils import ensure_fernet_key
+
+        try:
+            Fernet(ensure_fernet_key(secret_key))
+        except ValueError as exc:
+            return CheckResult(
+                "fail",
+                f"operator-supplied but unusable ({_short_exc(exc)})",
+                "Set LANGFLOW_SECRET_KEY to a URL-safe base64-encoded 32-byte key, such as the output of "
+                "Fernet.generate_key(), and use the same value in every replica.",
+            )
         return CheckResult("ok", "operator-supplied (LANGFLOW_SECRET_KEY)")
 
     config_dir = settings_service.settings.config_dir
@@ -277,7 +291,8 @@ async def probe_secret_key(settings_service: SettingsService) -> CheckResult:
     return CheckResult(
         "fail",
         "secret key is auto-generated per boot",
-        "Set LANGFLOW_SECRET_KEY to a stable, operator-provided value (32+ characters).",
+        "Set LANGFLOW_SECRET_KEY to a URL-safe base64-encoded 32-byte key, such as the output of "
+        "Fernet.generate_key(), and use the same value in every replica.",
     )
 
 

--- a/src/backend/tests/unit/test_cli_preflight.py
+++ b/src/backend/tests/unit/test_cli_preflight.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 
 import pytest
+from cryptography.fernet import Fernet
 from langflow.cli import preflight
 from langflow.cli.preflight import (
     PREFLIGHT_COMPLETED_ENV,
@@ -82,11 +83,33 @@ def test_deployment_profile_rejects_invalid():
 # ---------------------------------------------------------------------------
 
 
-async def test_secret_key_env_supplied(monkeypatch):
-    monkeypatch.setenv("LANGFLOW_SECRET_KEY", "x" * 40)
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        pytest.param("a" * 31, id="short-derived-key"),
+        pytest.param(Fernet.generate_key().decode(), id="fernet-key"),
+    ],
+)
+async def test_secret_key_env_supplied_and_usable(monkeypatch, secret_key):
+    monkeypatch.setenv("LANGFLOW_SECRET_KEY", secret_key)
     result = await probe_secret_key(_StubService())
     assert result.status == "ok"
     assert "operator-supplied" in result.detail
+
+
+@pytest.mark.parametrize(
+    "secret_key",
+    [
+        pytest.param("a" * 32, id="invalid-32-characters"),
+        pytest.param("x" * 40, id="invalid-40-characters"),
+    ],
+)
+async def test_secret_key_env_supplied_but_unusable_fails(monkeypatch, secret_key):
+    monkeypatch.setenv("LANGFLOW_SECRET_KEY", secret_key)
+    result = await probe_secret_key(_StubService())
+    assert result.status == "fail"
+    assert "Fernet key must be 32 url-safe base64-encoded bytes" in result.detail
+    assert "Fernet.generate_key()" in result.remediation
 
 
 async def test_secret_key_file_only_fails(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- validate operator-supplied LANGFLOW_SECRET_KEY with the same ensure_fernet_key and Fernet construction used at runtime
- fail the required production preflight when that key cannot encrypt credentials, with actionable Fernet key remediation
- preserve the supported short-secret derivation path and accept generated Fernet keys

## Release branch investigation

- release-1.11.3 contains the same runtime key derivation, so unusable 32+ character values fail encryption there too
- release-1.11.3 does not contain the deployment profile or production preflight; the false-green check was introduced by #14393 on release-1.12.0
- this PR therefore targets release-1.12.0 and does not change compatibility-sensitive key derivation

## Testing

- 44 passed: src/backend/tests/unit/test_cli_preflight.py
- 6 passed: focused secret-key cases
- ruff check on both changed files
- ruff format --check on both changed files
- repository pre-commit hooks, including detect-secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Secret keys supplied through the environment are now validated for usability before startup.
  - Invalid keys produce a clear preflight error with guidance to provide a URL-safe, base64-encoded 32-byte key.
  - Valid derived and Fernet-compatible keys continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->