### PR TITLE
fix(security): replace eval() with safe Literal construction in schema.py

### DIFF
--- a/src/lfx/src/lfx/io/schema.py
+++ b/src/lfx/src/lfx/io/schema.py
@@ -342,8 +342,7 @@ def create_input_schema(inputs: list["InputTypes"]) -> type[BaseModel]:
             and input_model.options
             and len(input_model.options) <= MAX_OPTIONS_FOR_TOOL_ENUM
         ):
-            literal_string = f"Literal{input_model.options}"
-            field_type = eval(literal_string, {"Literal": Literal})  # noqa: S307
+            field_type = Literal[tuple(input_model.options)]
         if hasattr(input_model, "is_list") and input_model.is_list:
             field_type = list[field_type]  # type: ignore[valid-type]
         if input_model.name:
@@ -388,8 +387,7 @@ def create_input_schema_from_dict(inputs: list[dotdict], param_key: str | None =
             and input_model.options
             and len(input_model.options) <= MAX_OPTIONS_FOR_TOOL_ENUM
         ):
-            literal_string = f"Literal{input_model.options}"
-            field_type = eval(literal_string, {"Literal": Literal})  # noqa: S307
+            field_type = Literal[tuple(input_model.options)]
         if hasattr(input_model, "is_list") and input_model.is_list:
             field_type = list[field_type]  # type: ignore[valid-type]
         if input_model.name:

--- a/src/lfx/tests/unit/schema/test_input_schema.py
+++ b/src/lfx/tests/unit/schema/test_input_schema.py
@@ -1,5 +1,8 @@
+from typing import Literal, get_args, get_origin
+
 import pytest
-from lfx.io.schema import create_input_schema_from_dict
+from lfx.inputs.inputs import DropdownInput
+from lfx.io.schema import MAX_OPTIONS_FOR_TOOL_ENUM, create_input_schema, create_input_schema_from_dict
 from lfx.schema.dotdict import dotdict
 
 
@@ -46,23 +49,61 @@ def _serialized_input_with_options(field_type, options):
     ]
 
 
-def test_create_input_schema_builds_literal_from_options():
-    """Options should produce a Literal type without using eval()."""
-    from typing import Literal, get_args
-
+def test_create_input_schema_from_dict_builds_literal_from_options():
+    """Serialized dropdown options should produce a Literal type without eval()."""
     schema = create_input_schema_from_dict(_serialized_input_with_options("str", ["a", "b", "c"]))
 
     annotation = schema.model_fields["value"].annotation
     assert get_origin(annotation) is Literal
-    assert set(get_args(annotation)) == {"a", "b", "c"}
+    assert get_args(annotation) == ("a", "b", "c")
 
 
-def test_create_input_schema_literal_single_option():
+def test_create_input_schema_from_dict_literal_single_option():
     """A single option should still produce a valid Literal type."""
-    from typing import Literal, get_args
-
     schema = create_input_schema_from_dict(_serialized_input_with_options("str", ["only"]))
 
     annotation = schema.model_fields["value"].annotation
     assert get_origin(annotation) is Literal
     assert get_args(annotation) == ("only",)
+
+
+def _dropdown_input(options):
+    return DropdownInput(name="mode", display_name="Mode", info="Select mode", required=True, options=options)
+
+
+def test_create_input_schema_builds_literal_from_options():
+    """DropdownInput options should produce a Literal type without eval()."""
+    schema = create_input_schema([_dropdown_input(["fast", "balanced", "thorough"])])
+
+    annotation = schema.model_fields["mode"].annotation
+    assert get_origin(annotation) is Literal
+    assert get_args(annotation) == ("fast", "balanced", "thorough")
+
+
+def test_create_input_schema_literal_single_option():
+    """A single option should still produce a valid Literal type."""
+    schema = create_input_schema([_dropdown_input(["only"])])
+
+    annotation = schema.model_fields["mode"].annotation
+    assert get_origin(annotation) is Literal
+    assert get_args(annotation) == ("only",)
+
+
+def test_literal_skipped_when_options_exceed_limit():
+    """Over-limit option lists fall back to the base type instead of Literal."""
+    many = [f"opt{i}" for i in range(MAX_OPTIONS_FOR_TOOL_ENUM + 1)]
+
+    from_dict_schema = create_input_schema_from_dict(_serialized_input_with_options("str", many))
+    assert from_dict_schema.model_fields["value"].annotation is str
+
+    schema = create_input_schema([_dropdown_input(many)])
+    assert schema.model_fields["mode"].annotation is str
+
+
+def test_literal_skipped_when_options_empty():
+    """An empty option list falls back to the base type instead of Literal."""
+    from_dict_schema = create_input_schema_from_dict(_serialized_input_with_options("str", []))
+    assert from_dict_schema.model_fields["value"].annotation is str
+
+    schema = create_input_schema([_dropdown_input([])])
+    assert schema.model_fields["mode"].annotation is str

--- a/src/lfx/tests/unit/schema/test_input_schema.py
+++ b/src/lfx/tests/unit/schema/test_input_schema.py
@@ -27,3 +27,42 @@ def test_create_input_schema_resolves_known_serialized_type():
 def test_create_input_schema_rejects_unknown_serialized_type():
     with pytest.raises(TypeError, match="Unsupported serialized field type"):
         create_input_schema_from_dict(_serialized_input("module.UnknownType"))
+
+
+def _serialized_input_with_options(field_type, options):
+    return [
+        dotdict(
+            {
+                "name": "value",
+                "display_name": "Value",
+                "info": "",
+                "required": True,
+                "type": field_type,
+                "value": None,
+                "options": options,
+                "is_list": False,
+            }
+        )
+    ]
+
+
+def test_create_input_schema_builds_literal_from_options():
+    """Options should produce a Literal type without using eval()."""
+    from typing import Literal, get_args
+
+    schema = create_input_schema_from_dict(_serialized_input_with_options("str", ["a", "b", "c"]))
+
+    annotation = schema.model_fields["value"].annotation
+    assert get_origin(annotation) is Literal
+    assert set(get_args(annotation)) == {"a", "b", "c"}
+
+
+def test_create_input_schema_literal_single_option():
+    """A single option should still produce a valid Literal type."""
+    from typing import Literal, get_args
+
+    schema = create_input_schema_from_dict(_serialized_input_with_options("str", ["only"]))
+
+    annotation = schema.model_fields["value"].annotation
+    assert get_origin(annotation) is Literal
+    assert get_args(annotation) == ("only",)


### PR DESCRIPTION
## Summary

Replace two `eval()` calls (Bandit S307) in `create_input_schema()` and `create_input_schema_from_dict()` with `Literal[tuple(options)]`, which is semantically identical but avoids arbitrary code execution.

## Problem

Both functions construct `Literal[...]` types from dropdown options using:

```python
literal_string = fLiteral{input_model.options}
field_type = eval(literal_string, {Literal: Literal})  # noqa: S307
```

The `eval()` call processes a string built from `input_model.options`, which originates from serialized component templates. In multi-tenant Langflow deployments where components can be user-uploaded, this is a potential code injection vector (CWE-95 â€” Improper Evaluation of Code with Contextual Keywords).

## Fix

```python
field_type = Literal[tuple(input_model.options)]
```

`Literal[tuple(options)]` is the canonical way to construct a `Literal` type programmatically from a runtime list. It produces an identical type object without evaluating any string as code.

## Verification

- Existing `test_input_schema.py` tests pass
- Added two new tests:
  - `test_create_input_schema_builds_literal_from_options` â€” verifies multi-option Literal construction
  - `test_create_input_schema_literal_single_option` â€” verifies single-option edge case

## Files Changed

- `src/lfx/src/lfx/io/schema.py` â€” replaced 2 `eval()` calls (6 lines removed, 2 added)
- `src/lfx/tests/unit/schema/test_input_schema.py` â€” added 2 tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input schema generation for fields with selectable options.
  * Preserved expected behavior when options are empty or exceed configured limits.

* **Tests**
  * Added coverage confirming that single and multiple serialized options produce the correct input annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->