### PR TITLE
fix(security): replace eval() with safe Literal construction in schema

### DIFF
--- a/src/lfx/src/lfx/io/schema.py
+++ b/src/lfx/src/lfx/io/schema.py
@@ -342,8 +342,7 @@ def create_input_schema(inputs: list["InputTypes"]) -> type[BaseModel]:
             and input_model.options
             and len(input_model.options) <= MAX_OPTIONS_FOR_TOOL_ENUM
         ):
-            literal_string = f"Literal{input_model.options}"
-            field_type = eval(literal_string, {"Literal": Literal})  # noqa: S307
+            field_type = Literal[tuple(input_model.options)]
         if hasattr(input_model, "is_list") and input_model.is_list:
             field_type = list[field_type]  # type: ignore[valid-type]
         if input_model.name:
@@ -388,8 +387,7 @@ def create_input_schema_from_dict(inputs: list[dotdict], param_key: str | None =
             and input_model.options
             and len(input_model.options) <= MAX_OPTIONS_FOR_TOOL_ENUM
         ):
-            literal_string = f"Literal{input_model.options}"
-            field_type = eval(literal_string, {"Literal": Literal})  # noqa: S307
+            field_type = Literal[tuple(input_model.options)]
         if hasattr(input_model, "is_list") and input_model.is_list:
             field_type = list[field_type]  # type: ignore[valid-type]
         if input_model.name:

--- a/src/lfx/tests/unit/schema/test_input_schema.py
+++ b/src/lfx/tests/unit/schema/test_input_schema.py
@@ -27,3 +27,55 @@ def test_create_input_schema_resolves_known_serialized_type():
 def test_create_input_schema_rejects_unknown_serialized_type():
     with pytest.raises(TypeError, match="Unsupported serialized field type"):
         create_input_schema_from_dict(_serialized_input("module.UnknownType"))
+
+
+def _serialized_input_with_options(options):
+    return [
+        dotdict(
+            {
+                "name": "mode",
+                "display_name": "Mode",
+                "info": "Select mode",
+                "required": True,
+                "type": "str",
+                "value": None,
+                "options": options,
+                "is_list": False,
+            }
+        )
+    ]
+
+
+def test_create_input_schema_with_options_builds_literal_type():
+    """Dropdown options should produce a Literal type without using eval()."""
+    schema = create_input_schema_from_dict(
+        _serialized_input_with_options(["fast", "balanced", "thorough"])
+    )
+
+    annotation = schema.model_fields["mode"].annotation
+    # Literal types expose their values via __args__
+    assert annotation.__args__ == ("fast", "balanced", "thorough")
+
+
+def test_create_input_schema_with_single_option_builds_literal_type():
+    """A single option should still produce a valid Literal type."""
+    schema = create_input_schema_from_dict(
+        _serialized_input_with_options(["only"])
+    )
+
+    annotation = schema.model_fields["mode"].annotation
+    assert annotation.__args__ == ("only",)
+
+
+def test_create_input_schema_with_many_options_skips_literal():
+    """When options exceed MAX_OPTIONS_FOR_TOOL_ENUM, no Literal is built."""
+    from lfx.io.schema import MAX_OPTIONS_FOR_TOOL_ENUM
+
+    many_options = [f"opt{i}" for i in range(MAX_OPTIONS_FOR_TOOL_ENUM + 1)]
+    schema = create_input_schema_from_dict(
+        _serialized_input_with_options(many_options)
+    )
+
+    annotation = schema.model_fields["mode"].annotation
+    # Should fall back to the base str type, not a Literal
+    assert annotation is str


### PR DESCRIPTION
## Summary

Replace two `eval()` calls (Bandit S307) in `create_input_schema` and `create_input_schema_from_dict` with `Literal[tuple(input_model.options)]`, which is semantically identical but avoids code evaluation from component option lists.

## Problem

`schema.py` used `eval()` to construct `Literal` types from dropdown option lists:

```python
literal_string = f"Literal{input_model.options}"
field_type = eval(literal_string, {"Literal": Literal})  # noqa: S307
```

While the `noqa: S307` comment suppressed the Bandit warning, `eval()` on data that originates from serialized component templates is a CWE-95 (Improper Evaluation of Code with Contextual Keywords). In multi-tenant Langflow deployments where component definitions can be user-uploaded, this creates an unnecessary attack surface.

## Fix

```python
field_type = Literal[tuple(input_model.options)]
```

`Literal[tuple(options)]` produces the exact same type object as `eval(f"Literal{options}")` but without invoking the Python interpreter. The `literal_string` intermediate variable is removed entirely.

## Verification

- Confirmed equivalence: `Literal[tuple(["a", "b", "c"])]` == `eval("Literal['a', 'b', 'c']", {"Literal": Literal})`
- Tested with string options, single option, and integer options

## Tests

Added 3 test cases to `test_input_schema.py`:
- `test_create_input_schema_with_options_builds_literal_type` — multi-option dropdown produces correct `Literal` type
- `test_create_input_schema_with_single_option_builds_literal_type` — single option edge case
- `test_create_input_schema_with_many_options_skips_literal` — over-limit options correctly fall back to base type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dropdown input fields with selectable options.
  * Ensured fields with too many options continue to use a standard text input instead of an oversized selection list.

* **Tests**
  * Added coverage for single-option, multi-option, and large-option-list scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->