### PR TITLE
feat: add enterprise lifespan hook registry and run-event store

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -5,6 +5,7 @@ import re
 import sys
 import tempfile
 import warnings
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager, suppress
 from http import HTTPStatus
 from pathlib import Path
@@ -68,6 +69,26 @@ warnings.filterwarnings("ignore", category=ResourceWarning, message=".*MemoryObj
 _tasks: list[asyncio.Task] = []
 
 MAX_PORT = 65535
+
+# Enterprise lifespan hook registry. Enterprise plugins append async callables
+# at app-construction time (plugin registration runs before the lifespan
+# starts); the lifespan awaits "startup" hooks after all services are
+# initialized, right before it yields, and "shutdown" hooks first on teardown.
+# Hooks are best-effort: a failing hook is logged and never blocks OSS startup
+# or shutdown.
+_enterprise_lifespan_hooks: dict[str, list[Callable[[], Awaitable[None]]]] = {
+    "startup": [],
+    "shutdown": [],
+}
+
+
+async def _run_enterprise_lifespan_hooks(phase: str) -> None:
+    for hook in list(_enterprise_lifespan_hooks.get(phase, [])):
+        try:
+            await hook()
+        except Exception as e:  # noqa: BLE001
+            hook_name = getattr(hook, "__qualname__", repr(hook))
+            await logger.awarning(f"Enterprise lifespan {phase} hook {hook_name} failed: {e}")
 
 
 async def log_exception_to_telemetry(exc: Exception, context: str) -> None:
@@ -577,6 +598,10 @@ def get_lifespan(*, fix_migration=False, version=None):
             except Exception as e:  # noqa: BLE001
                 await logger.awarning(f"DB pool metrics failed to register: {e}")
 
+            # Enterprise startup hooks run last: every service they may touch
+            # is initialized by this point.
+            await _run_enterprise_lifespan_hooks("startup")
+
             yield
         except asyncio.CancelledError:
             await logger.adebug("Lifespan received cancellation signal")
@@ -614,6 +639,12 @@ def get_lifespan(*, fix_migration=False, version=None):
             # CRITICAL: Cleanup MCP sessions FIRST, before any other shutdown logic.
             # This ensures MCP subprocesses are killed even if shutdown is interrupted.
             await cleanup_mcp_sessions()
+
+            # Enterprise shutdown hooks run before service teardown so they can
+            # still flush through live services. Also reached when startup
+            # failed before the hooks ran — enterprise stop() paths must (and
+            # do) tolerate never having started.
+            await _run_enterprise_lifespan_hooks("shutdown")
 
             # After the MCP cleanup above, deliberately: stopping the sampler awaits a
             # cancellation, and parking there first would both delay that guarantee and give

--- a/src/backend/base/langflow/services/telemetry/run_event_store.py
+++ b/src/backend/base/langflow/services/telemetry/run_event_store.py
@@ -1,0 +1,44 @@
+"""In-process store of completed-run events for enterprise metering.
+
+TelemetryService.log_package_run appends every RunPayload here before the
+do-not-track gate: metering consumers must see every run even when outbound
+telemetry is disabled. Nothing in OSS reads the store — enterprise builds
+drain it periodically via pop_all() — and events never leave the process
+unless such a consumer is installed. The store is bounded so a deployment
+without a consumer holds at most _MAX_EVENTS payloads.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from langflow.services.telemetry.schema import RunPayload
+
+_MAX_EVENTS = 10_000
+
+_lock = threading.Lock()
+_events: list[RunPayload] = []
+
+
+def append_run_event(payload: RunPayload) -> None:
+    """Append a run event, discarding the oldest events beyond the bound."""
+    with _lock:
+        _events.append(payload)
+        if len(_events) > _MAX_EVENTS:
+            del _events[: len(_events) - _MAX_EVENTS]
+
+
+def pop_all() -> list[RunPayload]:
+    """Atomically drain and return all pending events."""
+    with _lock:
+        drained = list(_events)
+        _events.clear()
+        return drained
+
+
+def peek_all() -> list[RunPayload]:
+    """Return a snapshot of pending events without draining."""
+    with _lock:
+        return list(_events)

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -13,6 +13,7 @@ from lfx.log.logger import logger
 
 from langflow.services.base import Service
 from langflow.services.telemetry.opentelemetry import OpenTelemetry
+from langflow.services.telemetry.run_event_store import append_run_event
 from langflow.services.telemetry.schema import (
     MAX_TELEMETRY_URL_SIZE,
     ComponentIndexPayload,
@@ -109,6 +110,10 @@ class TelemetryService(Service):
             await logger.aerror(f"Unexpected error occurred: {err}.")
 
     async def log_package_run(self, payload: RunPayload) -> None:
+        # Recorded before the do-not-track gate in _queue_event: enterprise
+        # metering must see every run even when outbound telemetry is off.
+        # The store is process-local and bounded; see run_event_store.
+        append_run_event(payload)
         await self._queue_event((self.send_telemetry_data, payload, "run"))
 
     async def log_package_deployment(self, payload: DeploymentPayload) -> None:

--- a/src/backend/tests/unit/services/telemetry/test_run_event_store.py
+++ b/src/backend/tests/unit/services/telemetry/test_run_event_store.py
@@ -1,0 +1,57 @@
+"""Unit tests for the run event store (enterprise metering seam).
+
+Testing library and framework: pytest
+"""
+
+import pytest
+from langflow.services.telemetry import run_event_store
+from langflow.services.telemetry.run_event_store import append_run_event, peek_all, pop_all
+from langflow.services.telemetry.schema import RunPayload
+
+
+@pytest.fixture(autouse=True)
+def _drain_store():
+    """Isolate each test from events other tests (or fixtures) appended."""
+    pop_all()
+    yield
+    pop_all()
+
+
+def _payload(run_id: str) -> RunPayload:
+    return RunPayload(run_seconds=1, run_success=True, run_id=run_id)
+
+
+def test_append_and_pop_roundtrip():
+    p = _payload("r1")
+    append_run_event(p)
+    assert pop_all() == [p]
+
+
+def test_pop_all_drains():
+    append_run_event(_payload("r1"))
+    append_run_event(_payload("r2"))
+    assert len(pop_all()) == 2
+    assert pop_all() == []
+
+
+def test_pop_all_preserves_order():
+    first, second = _payload("r1"), _payload("r2")
+    append_run_event(first)
+    append_run_event(second)
+    assert pop_all() == [first, second]
+
+
+def test_peek_all_is_nondestructive():
+    p = _payload("r1")
+    append_run_event(p)
+    assert peek_all() == [p]
+    assert peek_all() == [p]
+    assert pop_all() == [p]
+
+
+def test_bound_discards_oldest(monkeypatch):
+    monkeypatch.setattr(run_event_store, "_MAX_EVENTS", 3)
+    for i in range(5):
+        append_run_event(_payload(f"r{i}"))
+    kept = pop_all()
+    assert [p.run_id for p in kept] == ["r2", "r3", "r4"]

--- a/src/backend/tests/unit/test_enterprise_lifespan_hooks.py
+++ b/src/backend/tests/unit/test_enterprise_lifespan_hooks.py
@@ -1,0 +1,54 @@
+"""Unit tests for the enterprise lifespan hook registry in langflow.main.
+
+Testing library and framework: pytest
+"""
+
+import pytest
+from langflow.main import _enterprise_lifespan_hooks, _run_enterprise_lifespan_hooks
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Restore the module-global registry after each test."""
+    saved = {phase: list(hooks) for phase, hooks in _enterprise_lifespan_hooks.items()}
+    yield
+    for phase, hooks in saved.items():
+        _enterprise_lifespan_hooks[phase][:] = hooks
+
+
+async def test_hooks_run_in_registration_order():
+    calls: list[str] = []
+
+    async def first():
+        calls.append("first")
+
+    async def second():
+        calls.append("second")
+
+    _enterprise_lifespan_hooks["startup"].extend([first, second])
+    await _run_enterprise_lifespan_hooks("startup")
+    assert calls == ["first", "second"]
+
+
+async def test_failing_hook_does_not_block_later_hooks():
+    calls: list[str] = []
+
+    async def broken():
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    async def survivor():
+        calls.append("survivor")
+
+    _enterprise_lifespan_hooks["shutdown"].extend([broken, survivor])
+    # Must not raise: hooks are best-effort by contract.
+    await _run_enterprise_lifespan_hooks("shutdown")
+    assert calls == ["survivor"]
+
+
+async def test_unknown_phase_is_a_noop():
+    await _run_enterprise_lifespan_hooks("no-such-phase")
+
+
+async def test_registry_has_expected_phases():
+    assert set(_enterprise_lifespan_hooks) == {"startup", "shutdown"}


### PR DESCRIPTION
## Summary

- add `langflow.main._enterprise_lifespan_hooks`, a registry of async startup/shutdown callables for enterprise plugins. Plugins append hooks at app-construction time (plugin registration runs before the lifespan starts); the lifespan awaits startup hooks after all services are initialized — right before it yields — and shutdown hooks first on teardown, before service teardown. Hooks are best-effort: a failing hook is logged via `_run_enterprise_lifespan_hooks` and never blocks OSS startup or shutdown. The OSS app passes `lifespan=` to FastAPI, so `@app.on_event()` / router startup hooks registered by plugins are silently bypassed — this registry is the supported seam.
- add `langflow.services.telemetry.run_event_store`, a bounded (10k), thread-safe, process-local store of completed-run payloads. `TelemetryService.log_package_run` appends every `RunPayload` **before** the do-not-track gate: enterprise usage metering must see every run even when outbound telemetry is disabled. OSS itself never reads the store, and events never leave the process unless an enterprise consumer drains `pop_all()`.

Both seams follow the existing pattern of enterprise extension points living in OSS (service replacement via `lfx.services` entry points, `langflow.plugins` route hooks).

## Testing

- 9 passed: `src/backend/tests/unit/services/telemetry/test_run_event_store.py`, `src/backend/tests/unit/test_enterprise_lifespan_hooks.py`
- `ruff check` and `ruff format --check` on all touched files
- downstream integration validated against the enterprise consumer (drain bridge + lifespan hook registration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enterprise startup and shutdown hooks.
  * Added local buffering of completed run events with FIFO ordering and bounded storage.
  * Added atomic event draining and non-destructive event inspection.

* **Bug Fixes**
  * Run events are now recorded locally before telemetry filtering, ensuring they remain available when external telemetry is disabled.

* **Tests**
  * Added coverage for event storage behavior and lifecycle hook execution, ordering, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->