### PR TITLE
fix: stop pre-selecting an unconfigured model

### DIFF
--- a/src/backend/tests/unit/test_model_input_default_selection.py
+++ b/src/backend/tests/unit/test_model_input_default_selection.py
@@ -1,0 +1,85 @@
+"""The user's explicit default model is the only source of an auto-selection.
+
+Companion to ``src/lfx/tests/unit/base/models/test_build_config_no_unconfigured_default.py``
+for LE-2168. These cases need the langflow ``DatabaseVariableService``, which the isolated
+lfx test environment deliberately does not install.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langflow.services.variable.service import DatabaseVariableService
+from lfx.base.models.unified_models.build_config import update_model_options_in_build_config
+
+BUILD_CONFIG_MODULE = "lfx.base.models.unified_models.build_config"
+
+
+def _component(user_id: str = "3f1a0c9e-5b7d-4f2a-9c3e-1d2b3a4c5d6e") -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, cache={}, inputs=[])
+
+
+def _get_options(user_id=None):  # noqa: ARG001
+    return [
+        {"name": "claude-sonnet-4-5", "provider": "Anthropic", "icon": "Anthropic", "metadata": {}},
+        {"name": "gemini-2.5-flash", "provider": "Google Generative AI", "icon": "GoogleGenerativeAI", "metadata": {}},
+        {"name": "gpt-4o-mini", "provider": "OpenAI", "icon": "OpenAI", "metadata": {}},
+    ]
+
+
+@asynccontextmanager
+async def _fake_session_scope():
+    yield MagicMock()
+
+
+def _patched_default_variable(payload: dict | None):
+    """Patch the variable service so ``__default_language_model__`` resolves to *payload*."""
+    variable_service = MagicMock(spec=DatabaseVariableService)
+    if payload is None:
+        variable_service.get_variable_object = AsyncMock(side_effect=ValueError("not found"))
+    else:
+        variable_service.get_variable_object = AsyncMock(return_value=SimpleNamespace(value=json.dumps(payload)))
+    return patch.multiple(
+        BUILD_CONFIG_MODULE,
+        get_variable_service=MagicMock(return_value=variable_service),
+        session_scope=_fake_session_scope,
+    )
+
+
+def _update_on_initial_load(build_config: dict):
+    return update_model_options_in_build_config(
+        component=_component(),
+        build_config=build_config,
+        cache_key_prefix="language_model_options",
+        get_options_func=_get_options,
+        field_name=None,
+        field_value=None,
+    )
+
+
+def test_initial_load_uses_the_users_default_model():
+    """An explicitly chosen default is a real configuration and still auto-fills."""
+    with _patched_default_variable({"model_name": "gpt-4o-mini", "provider": "OpenAI"}):
+        result = _update_on_initial_load({"model": {"value": [], "options": []}})
+
+    assert result["model"]["value"][0]["name"] == "gpt-4o-mini"
+    assert result["model"]["value"][0]["provider"] == "OpenAI"
+
+
+def test_initial_load_ignores_default_that_is_not_available():
+    """A stale preference pointing at a disabled provider must not fall back to options[0]."""
+    with _patched_default_variable({"model_name": "grok-4", "provider": "xAI"}):
+        result = _update_on_initial_load({"model": {"value": [], "options": []}})
+
+    assert not result["model"]["value"]
+
+
+def test_initial_load_stays_empty_when_no_default_is_stored():
+    """Without a stored preference the field stays empty even though options exist."""
+    with _patched_default_variable(None):
+        result = _update_on_initial_load({"model": {"value": [], "options": []}})
+
+    assert not result["model"]["value"]

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -171,8 +171,8 @@ def test_update_model_options_with_custom_field_name():
     assert result["embedding_model"]["options"][0]["name"] == "text-embedding-ada-002"
     assert result["embedding_model"]["options"][1]["provider"] == "Cohere"
 
-    # Verify default value was set
-    assert result["embedding_model"]["value"] == [result["embedding_model"]["options"][0]]
+    # A bare initial load must not guess a provider for the user (LE-2168)
+    assert not result["embedding_model"]["value"]
 
 
 def test_update_model_options_static_options_with_custom_field_name():
@@ -311,7 +311,7 @@ def test_update_model_options_does_not_duplicate_saved_value_already_in_options(
 @pytest.mark.parametrize(
     ("current_value", "expected_value"),
     [
-        ([], [{"name": "gpt-4o-mini", "provider": "OpenAI", "metadata": {"model_class": "ChatOpenAI"}}]),
+        ([], []),
         ("gpt-4o-mini", "gpt-4o-mini"),
         (
             [{"provider": "OpenAI", "metadata": {"model_class": "ChatOpenAI"}}],

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.revalidate-after-autoselect.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.revalidate-after-autoselect.test.tsx
@@ -192,25 +192,20 @@ describe("ModelInputComponent — revalidation after an auto-select", () => {
     jest.clearAllMocks();
   });
 
-  it("should_replace_an_auto_selected_model_once_its_provider_is_disconnected", async () => {
+  it("should_replace_a_selected_model_once_its_provider_is_disconnected", async () => {
     mockAnthropicConnected();
     const handleOnNewValue = jest.fn();
 
+    // Selection is given up front: an empty field is no longer auto-filled (LE-2168).
     const { rerender } = renderWithQueryClient(
       <ModelInputComponent
         {...baseProps}
+        value={[ANTHROPIC_MODEL]}
         handleOnNewValue={handleOnNewValue}
       />,
     );
 
-    await waitFor(() => {
-      expect(handleOnNewValue).toHaveBeenCalled();
-    });
-    expect(handleOnNewValue.mock.calls[0][0].value[0].name).toBe(
-      "claude-opus-5",
-    );
-
-    handleOnNewValue.mockClear();
+    expect(handleOnNewValue).not.toHaveBeenCalled();
     mockAnthropicDisconnectedOpenAiConnected();
 
     const queryClient = new QueryClient({

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
@@ -735,7 +735,7 @@ describe("ModelInputComponent", () => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
 
-    it("should auto-select first model when value is empty and options exist", () => {
+    it("should not auto-select a model when value is empty (LE-2168)", () => {
       const handleOnNewValue = jest.fn();
 
       renderWithQueryClient(
@@ -746,8 +746,9 @@ describe("ModelInputComponent", () => {
         />,
       );
 
-      // Should have called handleOnNewValue with first option
-      expect(handleOnNewValue).toHaveBeenCalled();
+      // A provider is enabled as soon as a credential exists, including keys
+      // harvested from the environment, so an empty field must stay empty.
+      expect(handleOnNewValue).not.toHaveBeenCalled();
     });
   });
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
@@ -19,14 +19,11 @@ export interface DeriveSelectedModelParams {
    * not-enabled-locally trigger.
    */
   providerStatusIsReliable: boolean;
-  /** Current value of the component's `hasProcessedEmptyRef` (read-only here). */
-  hasProcessedEmpty: boolean;
 }
 
 /**
  * Derives the currently selected model shown in the trigger. Pure: extracted
- * verbatim from ModelInputComponent's `selectedModel` memo (LE-1736 W23). Shares
- * `hasProcessedEmpty` with useAutoSelectModel (W24), passed in by value.
+ * verbatim from ModelInputComponent's `selectedModel` memo (LE-1736 W23).
  */
 export function deriveSelectedModel({
   isConnectionMode,
@@ -36,7 +33,6 @@ export function deriveSelectedModel({
   flatOptions,
   providers,
   providerStatusIsReliable,
-  hasProcessedEmpty,
 }: DeriveSelectedModelParams): SelectedModel | null {
   if (isConnectionMode) {
     return {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
@@ -49,9 +49,8 @@ export function deriveSelectedModel({
   const saved = recoverModelOption(savedValue);
   const currentName = saved?.name;
   if (!currentName) {
-    if (flatOptions.length > 0 && !hasProcessedEmpty) {
-      return flatOptions[0];
-    }
+    // Showing flatOptions[0] here would advertise a provider the field is not
+    // actually set to, which is how the pre-selection surfaced (LE-2168).
     return null;
   }
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { useAutoSelectModel } from "../useAutoSelectModel";
+
+/**
+ * LE-2168: a fresh Language Model / Agent node pre-selected `flatOptions[0]`.
+ * Providers count as enabled as soon as a credential exists — Langflow harvests
+ * GOOGLE_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY from the environment and
+ * never validates them — so an empty field advertised a provider the user never
+ * set up (Gemini when only Google was present, Claude when Anthropic sorted first).
+ */
+
+const ANTHROPIC = {
+  name: "claude-opus-5",
+  provider: "Anthropic",
+  icon: "Anthropic",
+  metadata: {},
+};
+const OPENAI = {
+  name: "gpt-4o-mini",
+  provider: "OpenAI",
+  icon: "OpenAI",
+  metadata: {},
+};
+
+const PROVIDERS = [
+  { provider: "Anthropic", is_configured: true, is_enabled: true },
+  { provider: "OpenAI", is_configured: true, is_enabled: true },
+] as never;
+
+const renderAutoSelect = (
+  overrides: Partial<Parameters<typeof useAutoSelectModel>[0]> = {},
+) => {
+  const handleOnNewValue = jest.fn();
+  const hasProcessedEmptyRef: MutableRefObject<boolean> = { current: false };
+
+  renderHook(() =>
+    useAutoSelectModel({
+      flatOptions: [ANTHROPIC, OPENAI],
+      value: [],
+      handleOnNewValue,
+      isConnectionMode: false,
+      providers: PROVIDERS,
+      modelStatusIsReliable: true,
+      hasProcessedEmptyRef,
+      ...overrides,
+    }),
+  );
+
+  return handleOnNewValue;
+};
+
+describe("useAutoSelectModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should_not_select_a_model_when_the_field_is_empty", () => {
+    expect(renderAutoSelect()).not.toHaveBeenCalled();
+  });
+
+  it("should_not_select_a_model_when_the_value_is_undefined", () => {
+    expect(renderAutoSelect({ value: undefined })).not.toHaveBeenCalled();
+  });
+
+  it("should_keep_a_valid_selection_untouched", () => {
+    expect(renderAutoSelect({ value: [OPENAI] })).not.toHaveBeenCalled();
+  });
+
+  it("should_replace_a_selection_whose_provider_no_longer_offers_it", () => {
+    const handleOnNewValue = renderAutoSelect({
+      value: [{ ...ANTHROPIC, name: "claude-retired" }],
+    });
+
+    expect(handleOnNewValue).toHaveBeenCalledTimes(1);
+    expect(handleOnNewValue.mock.calls[0][0].value[0].name).toBe(
+      "claude-opus-5",
+    );
+  });
+
+  it("should_not_act_while_provider_status_is_still_loading", () => {
+    const handleOnNewValue = renderAutoSelect({
+      value: [{ ...ANTHROPIC, name: "claude-retired" }],
+      modelStatusIsReliable: false,
+    });
+
+    expect(handleOnNewValue).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from "@testing-library/react";
-import type { MutableRefObject } from "react";
 import { useAutoSelectModel } from "../useAutoSelectModel";
 
 /**
@@ -32,7 +31,6 @@ const renderAutoSelect = (
   overrides: Partial<Parameters<typeof useAutoSelectModel>[0]> = {},
 ) => {
   const handleOnNewValue = jest.fn();
-  const hasProcessedEmptyRef: MutableRefObject<boolean> = { current: false };
 
   renderHook(() =>
     useAutoSelectModel({
@@ -42,7 +40,6 @@ const renderAutoSelect = (
       isConnectionMode: false,
       providers: PROVIDERS,
       modelStatusIsReliable: true,
-      hasProcessedEmptyRef,
       ...overrides,
     }),
   );

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useEffect } from "react";
+import { useEffect } from "react";
 import type { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
 import type { ModelProviderWithStatus } from "@/controllers/API/queries/models/use-get-model-providers";
 import { matchesModelIdentity } from "../helpers/model-option-identity";
@@ -16,15 +16,13 @@ export interface UseAutoSelectModelParams {
    * fetch must not be read as "the saved model is gone".
    */
   modelStatusIsReliable: boolean;
-  hasProcessedEmptyRef: MutableRefObject<boolean>;
 }
 
 /**
- * Auto-selects the first available model when the value is empty or the saved
- * value went stale — its provider is known but no longer offers the model,
- * whether it was disconnected or the model deactivated. Extracted from
- * ModelInputComponent (LE-1736 W24); the once-guard ref is shared with
- * deriveSelectedModel (W23) and owned by the component.
+ * Replaces a saved value that went stale — its provider is known but no longer
+ * offers the model, whether it was disconnected or the model deactivated. An
+ * empty value is left empty (LE-2168). Extracted from ModelInputComponent
+ * (LE-1736 W24).
  */
 export function useAutoSelectModel({
   flatOptions,
@@ -33,7 +31,6 @@ export function useAutoSelectModel({
   isConnectionMode,
   providers,
   modelStatusIsReliable,
-  hasProcessedEmptyRef,
 }: UseAutoSelectModelParams): void {
   useEffect(() => {
     if (
@@ -60,8 +57,6 @@ export function useAutoSelectModel({
       }
     }
 
-    if (hasProcessedEmptyRef.current && !isSavedValueStale) return;
-
     // Only a stale selection is replaced: an unvalidated env-harvested credential
     // already marks a provider enabled, so filling an empty field pre-selected one (LE-2168).
     if (!isSavedValueStale) return;
@@ -77,7 +72,6 @@ export function useAutoSelectModel({
       },
     ];
     handleOnNewValue({ value: newValue });
-    hasProcessedEmptyRef.current = true;
   }, [
     flatOptions,
     value,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
@@ -60,16 +60,11 @@ export function useAutoSelectModel({
       }
     }
 
-    // The ref debounces the empty-value auto-select only; a value that goes
-    // stale mid-session (provider disconnected) must still be replaced.
     if (hasProcessedEmptyRef.current && !isSavedValueStale) return;
 
-    // Sticky-default: if the component has a saved value, keep it as-is. The
-    // backend injects any selection that isn't in the user's enabled list
-    // back into `options` tagged with `not_enabled_locally`, so the saved
-    // value remains visible and runnable. Only auto-select the first option
-    // when there's no saved value at all OR when the saved value is stale.
-    if (!isEmpty && !isSavedValueStale) return;
+    // Only a stale selection is replaced: an unvalidated env-harvested credential
+    // already marks a provider enabled, so filling an empty field pre-selected one (LE-2168).
+    if (!isSavedValueStale) return;
 
     const firstOption = flatOptions[0];
     const newValue = [

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -92,7 +92,6 @@ export default function ModelInputComponent({
   );
 
   const { refreshAllModelInputs } = useRefreshModelInputs();
-  const hasProcessedEmptyRef = useRef(false);
 
   const _postTemplateValue = usePostTemplateValue({
     parameterId: "model",
@@ -198,7 +197,6 @@ export default function ModelInputComponent({
         flatOptions,
         providers: providersData,
         providerStatusIsReliable,
-        hasProcessedEmpty: hasProcessedEmptyRef.current,
       }),
     [
       value,
@@ -217,7 +215,6 @@ export default function ModelInputComponent({
     isConnectionMode,
     providers: providersData,
     modelStatusIsReliable,
-    hasProcessedEmptyRef,
   });
 
   /**

--- a/src/frontend/tests/a11y/helpers/knowledge-bases.fixtures.ts
+++ b/src/frontend/tests/a11y/helpers/knowledge-bases.fixtures.ts
@@ -286,6 +286,23 @@ export async function openAddSourcesModal(page: LangflowPage) {
   });
 }
 
+/**
+ * Picks an embedding model in the create modal. The field is required and is no
+ * longer pre-filled: an empty model input stays empty so a provider enabled by an
+ * env-harvested credential is never chosen on the user's behalf (LE-2168).
+ */
+export async function selectEmbeddingModel(page: LangflowPage) {
+  const combobox = page.getByRole("combobox", { name: /embedding model/i });
+  await expect(combobox).toBeVisible({ timeout: TIMEOUTS.standard });
+  await combobox.click();
+  const option = page.getByTestId("OpenAI-text-embedding-3-small-option");
+  await expect(option).toBeVisible({ timeout: TIMEOUTS.standard });
+  await option.click();
+  await expect(combobox).toContainText("text-embedding-3-small", {
+    timeout: TIMEOUTS.standard,
+  });
+}
+
 export async function attachFiles(page: LangflowPage, paths: string[]) {
   await page.getByTestId("kb-source-name-input").fill("review_kb");
   await page.locator("#file-input").setInputFiles(paths);

--- a/src/frontend/tests/a11y/knowledge-bases.a11y.spec.ts
+++ b/src/frontend/tests/a11y/knowledge-bases.a11y.spec.ts
@@ -27,6 +27,7 @@ import {
   SEEDED_RUN,
   SEEDED_RUN_DETAIL,
   SEEDED_STATUS_KNOWLEDGE_BASES,
+  selectEmbeddingModel,
   settleNetwork,
 } from "./helpers/knowledge-bases.fixtures";
 
@@ -382,6 +383,7 @@ test.describe("knowledge bases route accessibility", () => {
 
     await page.getByTestId("kb-source-name-input").fill("review_kb");
     await page.locator("#file-input").setInputFiles(SAMPLE_FILE_PATH);
+    await selectEmbeddingModel(page);
 
     await page.getByRole("button", { name: /next step/i }).click();
     await expect(
@@ -391,6 +393,33 @@ test.describe("knowledge bases route accessibility", () => {
     await settleNetwork(page);
     await page.runA11yScan("kb-upload-step-review");
   });
+
+  test(
+    "blocks step 2 until an embedding model is picked",
+    RELEASE,
+    async ({ page }) => {
+      await openCreateModal(page);
+      await page.getByTestId("kb-source-name-input").fill("review_kb");
+
+      // The field starts empty on purpose (LE-2168), so the required-field error
+      // is the first thing a user meets on "Next step".
+      await page.getByRole("button", { name: /next step/i }).click();
+      const error = page.getByText(/embedding model is required/i);
+      await expect(error).toBeVisible({ timeout: TIMEOUTS.standard });
+      await expect(error).toHaveAttribute("role", "alert");
+      await expect(
+        page.getByRole("heading", { name: /review & build/i }),
+      ).toBeHidden();
+      await page.runA11yScan("kb-upload-embedding-required");
+
+      await selectEmbeddingModel(page);
+      await expect(error).toBeHidden({ timeout: TIMEOUTS.standard });
+      await page.getByRole("button", { name: /next step/i }).click();
+      await expect(
+        page.getByRole("heading", { name: /review & build/i }),
+      ).toBeVisible({ timeout: TIMEOUTS.standard });
+    },
+  );
 
   test("scans the no-search-results table", RELEASE, async ({ page }) => {
     await mockKnowledgeBases(page, SEEDED_KNOWLEDGE_BASES);
@@ -558,6 +587,7 @@ test.describe("knowledge bases route accessibility", () => {
     await openCreateModal(page);
 
     await page.getByTestId("kb-source-name-input").fill("review_kb");
+    await selectEmbeddingModel(page);
     await page.getByRole("button", { name: /next step/i }).click();
     await expect(
       page.getByRole("heading", { name: /review & build/i }),
@@ -575,6 +605,7 @@ test.describe("knowledge bases route accessibility", () => {
     });
 
     await attachFiles(page, [SAMPLE_FILE_PATH]);
+    await selectEmbeddingModel(page);
     await page.getByRole("button", { name: /next step/i }).click();
     await expect(page.getByText(/generating preview/i)).toBeVisible({
       timeout: TIMEOUTS.standard,
@@ -597,6 +628,7 @@ test.describe("knowledge bases route accessibility", () => {
     );
 
     await attachFiles(page, [SAMPLE_FILE_PATH]);
+    await selectEmbeddingModel(page);
     await page.getByRole("button", { name: /next step/i }).click();
     await expect(page.getByText(/could not generate preview/i)).toBeVisible({
       timeout: TIMEOUTS.standard,
@@ -634,6 +666,7 @@ test.describe("knowledge bases route accessibility", () => {
       );
       await openCreateModal(page);
       await attachFiles(page, [SAMPLE_FILE_PATH, SAMPLE_FILE_PATH_2]);
+      await selectEmbeddingModel(page);
 
       await page.getByRole("button", { name: /next step/i }).click();
       await expect(

--- a/src/lfx/src/lfx/base/models/unified_models/build_config.py
+++ b/src/lfx/src/lfx/base/models/unified_models/build_config.py
@@ -314,6 +314,7 @@ def update_model_options_in_build_config(
     # The frontend surfaces a "configure" wrench next to the trigger when it
     # sees this flag so the user can enable the provider without silently
     # losing their selection.
+    replaced_unusable_selection = False
     if (
         isinstance(current_value, list)
         and current_value
@@ -330,6 +331,7 @@ def update_model_options_in_build_config(
         if not saved_provider_allowed:
             logger.debug("Dropping saved model from policy-hidden provider %s", saved_provider)
             build_config[model_field_name]["value"] = None
+            replaced_unusable_selection = True
         elif not already_present:
             # When the ModelInput declares filters (e.g. Agent passes
             # ``filters={"tool_calling": True}``) and the saved selection
@@ -350,6 +352,7 @@ def update_model_options_in_build_config(
                     filters,
                 )
                 build_config[model_field_name]["value"] = None
+                replaced_unusable_selection = True
             else:
                 injected = {**saved, "metadata": {**(saved.get("metadata") or {}), "not_enabled_locally": True}}
                 build_config[model_field_name]["options"] = [*options_list, injected]
@@ -432,11 +435,14 @@ def update_model_options_in_build_config(
                         default_model = opt
                         break
 
-            # If user's default not found, fallback to first option
-            if not default_model and options:
+            # A bare initial load is not a configuration act, and an unvalidated credential
+            # harvested from the environment already marks a provider enabled, so falling
+            # back to ``options[0]`` there pre-selects a provider the user never set up
+            # (LE-2168). A user-triggered update or a just-replaced selection still fills.
+            user_triggered = field_name is not None
+            if not default_model and options and (user_triggered or replaced_unusable_selection):
                 default_model = options[0]
 
-            # Set the value
             if default_model:
                 build_config[model_field_name]["value"] = [default_model]
 

--- a/src/lfx/tests/unit/base/models/test_build_config_empty_model_clear.py
+++ b/src/lfx/tests/unit/base/models/test_build_config_empty_model_clear.py
@@ -8,11 +8,14 @@ the node was never configured for. Because ``POST /api/v2/workflows``
 carries the live-canvas ``data`` override, the substituted model is what
 actually executes, silently, billed to the wrong provider account.
 
-The auto-default (user's ``__default_language_model__`` variable, falling
-back to ``options[0]``) remains intentional for the initial-load event
-(``field_name=None``, e.g. a freshly dropped node) and for non-model field
-triggers. Only an explicit model-field update with an empty value must be
-left empty.
+LE-2168 narrowed it again: a bare initial load (``field_name=None``, a freshly
+dropped node or a reopened flow) no longer falls back to ``options[0]`` either,
+because an unvalidated credential harvested from the environment is enough to
+mark a provider enabled, so the fallback pre-selected a provider the user never
+set up. Only the user's stored ``__default_language_model__`` fills there. A
+user-triggered update such as entering an api_key still fills, and so does the
+replacement of a selection that filters or provider policy just took away.
+See ``test_build_config_no_unconfigured_default.py``.
 """
 
 from __future__ import annotations
@@ -109,9 +112,9 @@ class TestExplicitModelClearStaysEmpty:
         assert result["model"]["value"][0]["provider"] == "OpenAI"
 
 
-class TestAutoDefaultStillFiresForOtherTriggers:
-    def test_initial_load_still_auto_fills_default(self):
-        """field_name=None (new node dropped on canvas) keeps the default fill."""
+class TestAutoDefaultNoLongerGuessesAProvider:
+    def test_initial_load_does_not_auto_fill_without_explicit_default(self):
+        """field_name=None (new node dropped on canvas) must not guess a provider (LE-2168)."""
         build_config = {"model": {"value": [], "options": []}}
 
         result = update_model_options_in_build_config(
@@ -123,12 +126,10 @@ class TestAutoDefaultStillFiresForOtherTriggers:
             field_value=None,
         )
 
-        value = result["model"]["value"]
-        assert isinstance(value, list)
-        assert value, "initial load must still auto-select a default model"
+        assert not result["model"]["value"]
 
-    def test_non_model_field_trigger_still_auto_fills_default(self):
-        """A non-model trigger (e.g. api_key entry) keeps the default fill."""
+    def test_non_model_field_trigger_still_auto_fills(self):
+        """A non-model trigger (e.g. api_key entry) is an explicit act and keeps the fill."""
         build_config = {"model": {"value": [], "options": []}}
 
         result = update_model_options_in_build_config(
@@ -140,9 +141,7 @@ class TestAutoDefaultStillFiresForOtherTriggers:
             field_value="sk-test",
         )
 
-        value = result["model"]["value"]
-        assert isinstance(value, list)
-        assert value
+        assert result["model"]["value"]
 
     def test_model_refresh_with_existing_selection_is_preserved(self):
         """Refresh (field_name="model") with a real selection never rewrites it."""

--- a/src/lfx/tests/unit/base/models/test_build_config_no_unconfigured_default.py
+++ b/src/lfx/tests/unit/base/models/test_build_config_no_unconfigured_default.py
@@ -1,0 +1,85 @@
+"""A model must not be auto-selected from a provider the user never configured.
+
+Bug (LE-2168): on a fresh install, dropping a Language Model / Agent node filled the
+model field with ``options[0]`` — the first default model of the first enabled provider
+in alphabetical order. Providers are marked enabled purely because a credential exists
+(``skip_validation=True``), and Langflow harvests ``GOOGLE_API_KEY`` / ``OPENAI_API_KEY``
+/ ``ANTHROPIC_API_KEY`` from the environment into global variables. So a key the user
+never entered anywhere silently produced a pre-selected model — Gemini when only Google
+was present, Claude when Anthropic sorted first.
+
+The user's explicit ``__default_language_model__`` preference remains the one source of
+an auto-selection; without it the field stays empty so the user picks. The preference
+lives in the database variable service, which only exists in the full langflow install —
+those cases are covered in ``src/backend/tests/unit/test_model_input_default_selection.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from lfx.base.models.unified_models.build_config import update_model_options_in_build_config
+
+
+def _component(user_id: str = "3f1a0c9e-5b7d-4f2a-9c3e-1d2b3a4c5d6e") -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, cache={}, inputs=[])
+
+
+def _multi_provider_options() -> list[dict]:
+    """Options spanning several providers, mirroring get_language_model_options."""
+    return [
+        {"name": "claude-sonnet-4-5", "provider": "Anthropic", "icon": "Anthropic", "metadata": {}},
+        {"name": "gemini-2.5-flash", "provider": "Google Generative AI", "icon": "GoogleGenerativeAI", "metadata": {}},
+        {"name": "gpt-4o-mini", "provider": "OpenAI", "icon": "OpenAI", "metadata": {}},
+    ]
+
+
+def _get_options(user_id=None):  # noqa: ARG001
+    return _multi_provider_options()
+
+
+def _update(build_config: dict, field_name: str | None, field_value):
+    return update_model_options_in_build_config(
+        component=_component(),
+        build_config=build_config,
+        cache_key_prefix="language_model_options",
+        get_options_func=_get_options,
+        field_name=field_name,
+        field_value=field_value,
+    )
+
+
+class TestNoAutoSelectionWithoutExplicitDefault:
+    def test_initial_load_leaves_model_empty_without_user_default(self):
+        """The deterministic repro: a freshly dropped node must not pick a model itself."""
+        result = _update({"model": {"value": [], "options": []}}, field_name=None, field_value=None)
+
+        assert not result["model"]["value"], f"no provider was explicitly configured, got {result['model']['value']!r}"
+
+    def test_api_key_entry_still_selects_a_model(self):
+        """Typing a key is an explicit configuration act, so the convenience fill stays.
+
+        Note this still picks ``options[0]`` across all enabled providers rather than the
+        provider whose key was just entered — a narrower defect left untouched here.
+        """
+        result = _update({"model": {"value": [], "options": []}}, field_name="api_key", field_value="sk-test")
+
+        assert result["model"]["value"]
+
+    def test_options_are_still_populated_when_nothing_is_selected(self):
+        """Bounding the auto-selection must not hide the dropdown contents."""
+        result = _update({"model": {"value": [], "options": []}}, field_name=None, field_value=None)
+
+        assert [opt["name"] for opt in result["model"]["options"]] == [
+            "claude-sonnet-4-5",
+            "gemini-2.5-flash",
+            "gpt-4o-mini",
+        ]
+
+    def test_existing_selection_is_never_overwritten(self):
+        """A model already on the node survives the refresh untouched."""
+        selection = [{"name": "gemini-2.5-flash", "provider": "Google Generative AI", "metadata": {}}]
+
+        result = _update({"model": {"value": selection, "options": []}}, field_name=None, field_value=None)
+
+        assert result["model"]["value"][0]["name"] == "gemini-2.5-flash"


### PR DESCRIPTION
On a fresh install, dropping a **Language Model** or **Agent** node filled the model field by itself. The reporter saw `Gemini 3.1` with no Google key configured; on a box where Anthropic sorts first it is `claude-opus-5`. Either way the node advertises a provider the user never set up.

Three behaviours compound:

1. Langflow harvests `GOOGLE_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the environment into global variables (`VARIABLES_TO_GET_FROM_ENVIRONMENT`).
2. A provider counts as enabled purely because a credential exists — `_validate_and_get_enabled_providers` defaults to `skip_validation=True`. A syntactically invalid key still yields `is_configured=True, is_enabled=True`.
3. With the field empty, both the frontend and the backend fell back to `options[0]`: the first default model of the first enabled provider in alphabetical order.

## Changes

**Frontend** — this is what produces the value the user sees. `GET /api/v1/all` returns `model.value = ""`; the pre-fill happens client-side, before the `POST /api/v1/custom_component/update` that persists it.

- `hooks/useAutoSelectModel.ts` — only a *stale* selection is replaced now (provider disconnected, model deactivated). An empty field is left empty.
- `helpers/derive-selected-model.ts` — with no saved value the trigger renders the placeholder instead of `flatOptions[0]`, which advertised a provider the field was not set to.

**Backend** — same principle, defence in depth for API-driven flows.

- `unified_models/build_config.py` — a bare initial load (`field_name=None`) no longer falls back to `options[0]`. A user-triggered update (entering an api_key) and the replacement of a selection dropped by `filters` or provider policy still fill.

## What is deliberately preserved

- The user's stored `__default_language_model__` preference still auto-selects.
- Entering an API key still selects a model — an explicit configuration act.
- Replacing a model whose provider was disconnected, the behaviour added by #14362 / #14386, is untouched and covered by a new test.
- Saved flows keep their selection; nothing is rewritten on load.

## Existing tests that were inverted

Four assertions encoded the behaviour this ticket calls a bug and were updated, not deleted:

| File | Test |
|---|---|
| `test_build_config_empty_model_clear.py` | `test_initial_load_still_auto_fills_default` |
| `test_unified_models.py` | `test_update_model_options_with_custom_field_name` + one parametrised case |
| `ModelInputComponent.test.tsx` | `should auto-select first model when value is empty` |

`ModelInputComponent.revalidate-after-autoselect.test.tsx` only had its **setup** rewritten — it used the empty auto-select to arrange the value; it now passes the selection in directly. The behaviour it covers is unchanged.

## Verification

Reproduced and validated in the running app (`make backend` + `make frontend`), and on a clean `langflow==1.11.3rc1` install:

- Clean environment, no credentials → no model pre-selected (the bug is not reproducible as written in the ticket).
- Add a single fake `GOOGLE_API_KEY=AIzaSyFAKE-…` → `is_configured=True, is_enabled=True` and the Simple Agent template comes up with `gemini-3.5-flash-lite` selected.
- After the fix, a freshly added Language Model node shows **Select a model**; the dropdown still lists every model and a manual pick persists.

Tests:

```
uv run pytest src/lfx/tests/unit/base/models src/lfx/tests/unit/inputs   # 359 passed
uv run pytest src/backend/tests/unit/test_unified_models.py \
              src/backend/tests/unit/test_model_input_default_selection.py   # 77 passed
npx jest src/components/core/parameterRenderComponent   # 344 passed
npx jest src/hooks src/CustomNodes                      # 318 passed
```

The full backend suite and the Playwright E2E suite were not run.

## Follow-ups not addressed here

- The root cause remains: `skip_validation=True` marks a provider configured on credential existence alone. This PR stops the auto-selection, not the false "configured" state.
- The api_key trigger still fills from the cross-provider `options[0]`, so it can select a model from a provider other than the one whose key was just entered.
- `hasProcessedEmpty` is now an unused parameter of `deriveSelectedModel`; removing it changes the signature and its callers.

Jira: LE-2168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selection no longer automatically chooses the first available option when no saved default exists.
  * Empty model fields now remain empty until an explicit selection or qualifying update is made.
  * Existing valid selections are preserved, while unavailable selections continue to be replaced appropriately.
  * Model options remain available even when no selection is made.

* **Tests**
  * Added coverage for saved defaults, unavailable models, provider status changes, empty values, and API-key updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->