### PR TITLE
fix(models): normalize Azure AI Foundry project endpoints to the OpenAI-compatible form

### DIFF
--- a/src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py
+++ b/src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py
@@ -40,6 +40,26 @@ def test_foundry_embedding_kwargs_use_endpoint_when_api_base_blank(unified_model
     assert kwargs["api_key"] == "test-key"  # pragma: allowlist secret
 
 
+def test_foundry_embedding_kwargs_normalize_project_endpoint(unified_models_module):
+    """A stored Foundry *project* endpoint is rewritten to the OpenAI-compatible form."""
+    unified_models_module.get_all_variables_for_provider = MagicMock(
+        return_value={"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/api/projects/my-project"}
+    )
+
+    composed = _compose_embedding_kwargs(
+        "Azure AI Foundry",
+        "text-embedding-3-small",
+        uuid4(),
+        unified_models_module,
+        selected_provider="Azure AI Foundry",
+        api_base="",
+    )
+
+    assert composed is not None
+    _, kwargs = composed
+    assert kwargs["base_url"] == FOUNDRY_ENDPOINT
+
+
 def test_foundry_embedding_kwargs_prefer_explicit_api_base(unified_models_module):
     override = "https://override.example/openai/v1"
     with patch(

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from uuid import UUID
 
 import httpx
@@ -508,8 +508,32 @@ AZURE_AI_FOUNDRY_FETCH_TIMEOUT = 10.0
 AZURE_AI_FOUNDRY_REQUEST_TIMEOUT = AZURE_AI_FOUNDRY_FETCH_TIMEOUT
 
 
+def normalize_azure_ai_foundry_endpoint(endpoint: str) -> str:
+    """Map a pasted Foundry *project* endpoint to the OpenAI-compatible endpoint.
+
+    The Foundry portal most prominently shows the project endpoint
+    (``https://<resource>.services.ai.azure.com/api/projects/<project>``), but this
+    provider needs the OpenAI-compatible form
+    (``https://<resource>.services.ai.azure.com/openai/v1``) — the project form
+    returns HTTP 400 on ``/models``. Rewrite the former to the latter; every other
+    endpoint passes through unchanged.
+    """
+    parsed = urlparse(endpoint)
+    path = parsed.path.lower()
+    if not parsed.netloc or not (path.startswith("/api/projects/") or path.rstrip("/") == "/api/projects"):
+        return endpoint
+    normalized = f"{parsed.scheme}://{parsed.netloc}/openai/v1"
+    logger.info(
+        f"AZURE_AI_FOUNDRY_ENDPOINT {endpoint!r} looks like a Foundry project endpoint; "
+        f"using the OpenAI-compatible endpoint {normalized!r} instead. "
+        f"Update the saved endpoint to that value to silence this message."
+    )
+    return normalized
+
+
 def request_azure_ai_foundry_model_entries(endpoint: str, api_key: str) -> list[dict]:
     """Probe Foundry /models for credential validation (catalog, not deployments)."""
+    endpoint = normalize_azure_ai_foundry_endpoint(endpoint)
     response = requests.get(
         f"{endpoint.rstrip('/')}/models",
         headers={"api-key": api_key},

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -523,10 +523,11 @@ def normalize_azure_ai_foundry_endpoint(endpoint: str) -> str:
     if not parsed.netloc or not (path.startswith("/api/projects/") or path.rstrip("/") == "/api/projects"):
         return endpoint
     normalized = f"{parsed.scheme}://{parsed.netloc}/openai/v1"
+    # Log neither URL: a pasted endpoint can carry user-info or query credentials.
     logger.info(
-        f"AZURE_AI_FOUNDRY_ENDPOINT {endpoint!r} looks like a Foundry project endpoint; "
-        f"using the OpenAI-compatible endpoint {normalized!r} instead. "
-        f"Update the saved endpoint to that value to silence this message."
+        "AZURE_AI_FOUNDRY_ENDPOINT looks like a Foundry project endpoint; "
+        "replacing '/api/projects/...' with '/openai/v1' (the OpenAI-compatible form). "
+        "Update the saved endpoint to silence this message."
     )
     return normalized
 

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -390,7 +390,7 @@ def get_llm(
         if default_headers:
             kwargs["default_headers"] = default_headers
     elif provider == "Azure AI Foundry":
-        from lfx.base.models.model_utils import AZURE_AI_FOUNDRY_REQUEST_TIMEOUT
+        from lfx.base.models.model_utils import AZURE_AI_FOUNDRY_REQUEST_TIMEOUT, normalize_azure_ai_foundry_endpoint
 
         provider_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
         endpoint_value = provider_vars.get("AZURE_AI_FOUNDRY_ENDPOINT") or _env_if_allowed("AZURE_AI_FOUNDRY_ENDPOINT")
@@ -400,7 +400,7 @@ def get_llm(
                 "in Settings → Model Providers or set the environment variable."
             )
             raise ValueError(msg)
-        kwargs["endpoint"] = endpoint_value
+        kwargs["endpoint"] = normalize_azure_ai_foundry_endpoint(endpoint_value)
         connection_url_param = "endpoint"
         # Bound hung/blackholed endpoints the same way live discovery does.
         kwargs["request_timeout"] = AZURE_AI_FOUNDRY_REQUEST_TIMEOUT
@@ -734,6 +734,8 @@ def _compose_embedding_kwargs(
 
     # Apply Foundry endpoint last so a blank component api_base cannot wipe it.
     if provider == "Azure AI Foundry" and "api_base" in param_mapping:
+        from lfx.base.models.model_utils import normalize_azure_ai_foundry_endpoint
+
         foundry_vars = unified_models_module.get_all_variables_for_provider(user_id, provider)
         endpoint_value = (
             api_base_value
@@ -749,7 +751,7 @@ def _compose_embedding_kwargs(
                 raise ValueError(msg)
             return None
         connection_url_param = param_mapping["api_base"]
-        kwargs[connection_url_param] = endpoint_value
+        kwargs[connection_url_param] = normalize_azure_ai_foundry_endpoint(endpoint_value)
 
     _protect_model_connection(
         kwargs,

--- a/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
+++ b/src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py
@@ -119,6 +119,64 @@ def test_request_azure_ai_foundry_model_entries_returns_catalog_data():
     assert entries == [{"id": "gpt-5-mini-2025-08-07"}]
 
 
+@pytest.mark.parametrize(
+    "project_endpoint",
+    [
+        "https://example.services.ai.azure.com/api/projects/my-project",
+        "https://example.services.ai.azure.com/api/projects/my-project/",
+        "https://example.services.ai.azure.com/API/Projects/My-Project",
+        "https://example.services.ai.azure.com/api/projects",
+    ],
+    ids=["plain", "trailing-slash", "mixed-case", "no-project-segment"],
+)
+def test_normalize_azure_ai_foundry_endpoint_rewrites_project_endpoint(project_endpoint):
+    """The Foundry portal's prominent *project* endpoint must map to the OpenAI-compatible form."""
+    from lfx.base.models import model_utils
+
+    normalized = model_utils.normalize_azure_ai_foundry_endpoint(project_endpoint)
+
+    assert normalized == "https://example.services.ai.azure.com/openai/v1"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://example.services.ai.azure.com/openai/v1",
+        "https://example.services.ai.azure.com/openai/v1/",
+        "https://example.services.ai.azure.com",
+        "https://example.openai.azure.com/openai",
+        "not-a-url/api/projects/my-project",
+    ],
+    ids=["openai-v1", "openai-v1-trailing-slash", "bare-resource", "azure-openai", "unparseable"],
+)
+def test_normalize_azure_ai_foundry_endpoint_keeps_other_endpoints(endpoint):
+    from lfx.base.models import model_utils
+
+    assert model_utils.normalize_azure_ai_foundry_endpoint(endpoint) == endpoint
+
+
+def test_request_azure_ai_foundry_model_entries_normalizes_project_endpoint():
+    """A pasted project endpoint must probe the OpenAI-compatible /models, not the 400ing project path."""
+    from lfx.base.models import model_utils
+
+    response = MagicMock()
+    response.json.return_value = {"data": [{"id": "gpt-5-mini-2025-08-07"}]}
+
+    with patch.object(model_utils.requests, "get", return_value=response) as mock_get:
+        entries = model_utils.request_azure_ai_foundry_model_entries(
+            "https://example.services.ai.azure.com/api/projects/my-project",
+            "test-key",  # pragma: allowlist secret
+        )
+
+    mock_get.assert_called_once_with(
+        "https://example.services.ai.azure.com/openai/v1/models",
+        headers={"api-key": "test-key"},
+        timeout=model_utils.AZURE_AI_FOUNDRY_FETCH_TIMEOUT,
+        allow_redirects=False,
+    )
+    assert entries == [{"id": "gpt-5-mini-2025-08-07"}]
+
+
 def test_request_azure_ai_foundry_model_entries_rejects_malformed_payload():
     from lfx.base.models import model_utils
 
@@ -177,6 +235,43 @@ def test_validate_model_provider_key_azure_ai_foundry_success():
             {
                 "AZURE_AI_FOUNDRY_API_KEY": "test-key",  # pragma: allowlist secret
                 "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/openai/v1",
+            },
+        )
+
+    mock_get.assert_called_once_with(
+        "https://example.services.ai.azure.com/openai/v1/models",
+        headers={"api-key": "test-key"},
+        timeout=model_utils.AZURE_AI_FOUNDRY_FETCH_TIMEOUT,
+        allow_redirects=False,
+    )
+
+
+def test_validate_model_provider_key_azure_ai_foundry_accepts_project_endpoint():
+    """Credential validation with a pasted project endpoint probes the OpenAI-compatible /models."""
+    from types import SimpleNamespace
+
+    from lfx.base.models import model_utils
+    from lfx.base.models.unified_models import validate_model_provider_key
+
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"data": []}
+    fake_chat_models = SimpleNamespace(AzureAIOpenAIApiChatModel=object)
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "langchain_azure_ai": SimpleNamespace(chat_models=fake_chat_models),
+                "langchain_azure_ai.chat_models": fake_chat_models,
+            },
+        ),
+        patch("lfx.base.models.unified_models.model_catalog.get_unified_models_detailed", return_value=[]),
+        patch.object(model_utils.requests, "get", return_value=response) as mock_get,
+    ):
+        validate_model_provider_key(
+            "Azure AI Foundry",
+            {
+                "AZURE_AI_FOUNDRY_API_KEY": "test-key",  # pragma: allowlist secret
+                "AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/api/projects/my-project",
             },
         )
 
@@ -271,6 +366,37 @@ def test_get_llm_wires_azure_ai_foundry_endpoint_and_credential():
     assert captured_kwargs["credential"] == "test-key"
     assert captured_kwargs["endpoint"] == "https://example.services.ai.azure.com/openai/v1"
     assert captured_kwargs["request_timeout"] == 10.0
+
+
+def test_get_llm_normalizes_stored_project_endpoint():
+    """A project endpoint stored as the provider variable is normalized at instantiation too."""
+    from lfx.base.models import unified_models as unified_models_module
+    from lfx.base.models.unified_models import instantiation
+    from lfx.base.models.unified_models.instantiation import get_llm
+
+    captured_kwargs: dict = {}
+
+    class FakeFoundryChatModel:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    with (
+        patch.object(
+            unified_models_module,
+            "get_api_key_for_provider",
+            return_value="test-key",
+        ),
+        patch.object(unified_models_module, "get_model_class", return_value=FakeFoundryChatModel),
+        patch.object(
+            unified_models_module,
+            "get_all_variables_for_provider",
+            return_value={"AZURE_AI_FOUNDRY_ENDPOINT": "https://example.services.ai.azure.com/api/projects/my-project"},
+        ),
+        patch.object(instantiation, "validate_url_for_ssrf_or_raise"),
+    ):
+        get_llm(_build_azure_ai_foundry_model_selection(), user_id="user-1", stream=False)
+
+    assert captured_kwargs["endpoint"] == "https://example.services.ai.azure.com/openai/v1"
 
 
 def test_get_llm_azure_ai_foundry_requires_endpoint():


### PR DESCRIPTION
## Problem

The Azure AI Foundry provider expects the OpenAI-compatible endpoint
(`https://<resource>.services.ai.azure.com/openai/v1`), but users commonly paste the
Foundry portal's most prominent **"Project endpoint"**
(`https://<resource>.services.ai.azure.com/api/projects/<project>`) into
`AZURE_AI_FOUNDRY_ENDPOINT`. Credential validation then probes `{endpoint}/models` and
surfaces an opaque **"400 Client Error: BadRequest"** with no hint about what's wrong.

Verified live: the project endpoint form returns HTTP 400 on `/models` with an `api-key`
header, while the `/openai/v1` form returns 200 with the same key.

## Fix

Add `normalize_azure_ai_foundry_endpoint()` in `lfx.base.models.model_utils`:

- When the URL path is `/api/projects/...` (case-insensitive, trailing slash tolerated),
  rewrite to `https://<host>/openai/v1` and log an info message telling the user what
  value to save to silence it.
- Every other endpoint — including well-formed `/openai/v1` forms — passes through
  byte-for-byte unchanged.

The helper is applied at **every** point that consumes the endpoint, not just credential
validation, because env-provisioned endpoints (`AZURE_AI_FOUNDRY_ENDPOINT` set in the
environment) never pass through validation and would otherwise still break at runtime:

- `request_azure_ai_foundry_model_entries` (credential validation probe)
- LLM instantiation (`get_llm` Foundry branch)
- Embeddings instantiation (`_compose_embedding_kwargs` Foundry branch)

## Tests

- `src/lfx/tests/unit/base/models/test_azure_ai_foundry_provider.py` (12 new, mirroring
  the file's existing mock patterns): parametrized rewrite cases (plain / trailing slash /
  mixed case / no project segment), parametrized pass-through cases (openai/v1 forms, bare
  resource host, Azure OpenAI host, unparseable string), plus end-to-end assertions that
  `request_azure_ai_foundry_model_entries`, `validate_model_provider_key`, and `get_llm`
  all hit `.../openai/v1/models` when given the project form.
- `src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py` (1 new): the
  embeddings branch normalizes a stored project endpoint.

## Test plan

- [x] `cd src/lfx && uv sync && uv run pytest tests/unit/base/models/test_azure_ai_foundry_provider.py` — 30 passed
- [x] `uv run pytest src/backend/tests/unit/base/models/test_foundry_embedding_kwargs.py` — 3 passed
- [x] `ruff format` / `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Azure AI Foundry integration by automatically converting project endpoints to the compatible OpenAI endpoint format.
  - Ensured model listing, language model setup, and embedding setup use the correct normalized endpoint.
  - Preserved existing behavior for other endpoint formats and configuration settings.

- **Tests**
  - Added coverage for endpoint conversion, model requests, provider validation, and client setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->