### PR TITLE
feat: add catalog-policy component usage endpoints

### DIFF
--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple
 from uuid import UUID
 
@@ -29,12 +30,18 @@ from langflow.services.deps import get_catalog_policy_service
 from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from lfx.utils.component_aliases import ComponentIdentityIndex
 
 router = APIRouter(prefix="/catalog-policy", tags=["Catalog Policy"])
 
 USAGE_FLOWS_DEFAULT_LIMIT = 100
 USAGE_FLOWS_MAX_LIMIT = 500
+# How long one flow-table scan is reused by the usage endpoints. Governance
+# counts may lag flow writes by up to this window; policy writes never change
+# usage data, so a refetch after saving a policy is served from cache exactly.
+USAGE_SCAN_CACHE_TTL_SECONDS = 30.0
 
 
 def _active_snapshot(service: BaseCatalogPolicyService) -> tuple[CatalogPolicySnapshot, bool]:
@@ -201,6 +208,40 @@ async def _load_flow_component_usage() -> tuple[list[_FlowUsage], int]:
     return usage, len(rows)
 
 
+class _UsageScan(NamedTuple):
+    """An immutable flow-table scan plus the monotonic instant it was taken."""
+
+    usage: tuple[_FlowUsage, ...]
+    flows_scanned: int
+    loaded_at: float
+
+
+_usage_scan_cache: _UsageScan | None = None
+
+
+async def _cached_flow_component_usage() -> tuple[Sequence[_FlowUsage], int]:
+    """Serve the flow scan from a short process-local cache.
+
+    Both usage endpoints share one scan per TTL window, so an admin page that
+    fetches counts on mount and refetches after every policy save costs one
+    flow-table read per window instead of one per request. There is
+    deliberately no lock: concurrent cache misses each scan and the last
+    writer wins, which only duplicates work an uncached implementation would
+    do anyway. The cache is per-process; workers converge within one TTL.
+    """
+    global _usage_scan_cache  # noqa: PLW0603 - module-level TTL cache
+    cached = _usage_scan_cache
+    if cached is not None and time.monotonic() - cached.loaded_at < USAGE_SCAN_CACHE_TTL_SECONDS:
+        return cached.usage, cached.flows_scanned
+    usage, flows_scanned = await _load_flow_component_usage()
+    _usage_scan_cache = _UsageScan(
+        usage=tuple(usage),
+        flows_scanned=flows_scanned,
+        loaded_at=time.monotonic(),
+    )
+    return usage, flows_scanned
+
+
 async def _usage_identity_index() -> ComponentIdentityIndex:
     """Return the collision-aware identity index for the current registry.
 
@@ -228,9 +269,10 @@ async def get_component_usage(
     a legacy alias is counted under the component it resolves to today, the
     same resolution catalog enforcement applies. Keys not present in the
     registry (custom or synthetic components) are counted under their exact
-    stored key. Each flow is counted at most once per component.
+    stored key. Each flow is counted at most once per component. Counts may
+    lag flow writes by up to ``USAGE_SCAN_CACHE_TTL_SECONDS``.
     """
-    usage, flows_scanned = await _load_flow_component_usage()
+    usage, flows_scanned = await _cached_flow_component_usage()
     identity_index = await _usage_identity_index()
 
     counts: dict[str, int] = {}
@@ -261,7 +303,8 @@ async def get_component_usage_flows(
     A flow matches when the queried key and any of the flow's stored keys
     resolve to a shared canonical identity — the same matching rule flow
     writes and runs enforce. Flows are sorted by name, then id, and truncated
-    to ``limit``; ``total`` always reports the full match count.
+    to ``limit``; ``total`` always reports the full match count. Results may
+    lag flow writes by up to ``USAGE_SCAN_CACHE_TTL_SECONDS``.
     """
     component = component.strip()
     if not component:
@@ -269,7 +312,7 @@ async def get_component_usage_flows(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="component must not be blank",
         )
-    usage, _flows_scanned = await _load_flow_component_usage()
+    usage, _flows_scanned = await _cached_flow_component_usage()
     identity_index = await _usage_identity_index()
 
     target_identities = identity_index.resolve(component)

--- a/src/backend/base/langflow/api/v1/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/catalog_policy.py
@@ -2,21 +2,39 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from lfx.services.catalog_policy import BaseCatalogPolicyService, CatalogPolicySnapshot
+from lfx.services.deps import session_scope_readonly
+from lfx.utils.component_aliases import build_component_identity_index
+from lfx.utils.flow_validation import collect_catalog_component_keys
+from sqlmodel import col, select
 
 from langflow.api.v1.policy_bundle_errors import policy_bundle_revision_conflict
-from langflow.api.v1.schemas.catalog_policy import CatalogPolicyBlockedSet, CatalogPolicyRead
+from langflow.api.v1.schemas.catalog_policy import (
+    CATALOG_POLICY_KEY_MAX_LENGTH,
+    CatalogPolicyBlockedSet,
+    CatalogPolicyRead,
+    CatalogPolicyUsageFlowRef,
+    CatalogPolicyUsageFlowsRead,
+    CatalogPolicyUsageRead,
+)
 from langflow.services.auth.utils import get_current_active_superuser
 from langflow.services.authorization.audit import audit_decision
+from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_catalog_policy_service
 from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
 
+if TYPE_CHECKING:
+    from lfx.utils.component_aliases import ComponentIdentityIndex
+
 router = APIRouter(prefix="/catalog-policy", tags=["Catalog Policy"])
+
+USAGE_FLOWS_DEFAULT_LIMIT = 100
+USAGE_FLOWS_MAX_LIMIT = 500
 
 
 def _active_snapshot(service: BaseCatalogPolicyService) -> tuple[CatalogPolicySnapshot, bool]:
@@ -147,6 +165,123 @@ async def replace_template_policy(
         removed=update.removed,
     )
     return _response(update.snapshot.blocked_template_keys, managed_externally=False)
+
+
+class _FlowUsage(NamedTuple):
+    """One flow's identity, display name, and exact stored component keys."""
+
+    flow_id: UUID
+    name: str
+    component_keys: frozenset[str]
+
+
+async def _load_flow_component_usage() -> tuple[list[_FlowUsage], int]:
+    """Return per-flow component keys and the total number of flows scanned.
+
+    Saved components (``is_component``) are excluded — they are palette
+    entries, not flows. Every remaining flow's stored graph is scanned,
+    including nested flows inlined in legacy Run Flow nodes. This reads each
+    flow's full ``data`` payload, so it is reserved for the superuser
+    governance endpoints below rather than any per-request path.
+    """
+    async with session_scope_readonly() as session:
+        rows = (
+            await session.exec(
+                select(Flow.id, Flow.name, Flow.data).where(
+                    col(Flow.is_component).is_not(True),
+                    col(Flow.data).is_not(None),
+                )
+            )
+        ).all()
+    usage = [
+        _FlowUsage(flow_id=flow_id, name=name, component_keys=component_keys)
+        for flow_id, name, data in rows
+        if (component_keys := collect_catalog_component_keys(data))
+    ]
+    return usage, len(rows)
+
+
+async def _usage_identity_index() -> ComponentIdentityIndex:
+    """Return the collision-aware identity index for the current registry.
+
+    Built from the same registry mapping the palette endpoint filters, so
+    usage numbers match what catalog enforcement would actually block.
+    """
+    from langflow.interface.components import get_and_cache_all_types_dict, get_component_identity_index
+    from langflow.services.deps import get_settings_service
+
+    all_types = await get_and_cache_all_types_dict(settings_service=get_settings_service())
+    index = get_component_identity_index(all_types)
+    if index is None:
+        # Only a None mapping can yield None; keep the type checker satisfied.
+        index = build_component_identity_index(all_types)
+    return index
+
+
+@router.get("/usage", response_model=CatalogPolicyUsageRead)
+async def get_component_usage(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+) -> CatalogPolicyUsageRead:
+    """Return how many flows use each component.
+
+    Counts are keyed by canonical registry identity — a flow node saved under
+    a legacy alias is counted under the component it resolves to today, the
+    same resolution catalog enforcement applies. Keys not present in the
+    registry (custom or synthetic components) are counted under their exact
+    stored key. Each flow is counted at most once per component.
+    """
+    usage, flows_scanned = await _load_flow_component_usage()
+    identity_index = await _usage_identity_index()
+
+    counts: dict[str, int] = {}
+    for flow in usage:
+        for identity in identity_index.resolve_many(flow.component_keys):
+            counts[identity] = counts.get(identity, 0) + 1
+    return CatalogPolicyUsageRead(
+        components=dict(sorted(counts.items())),
+        flows_scanned=flows_scanned,
+    )
+
+
+@router.get("/usage/flows", response_model=CatalogPolicyUsageFlowsRead)
+async def get_component_usage_flows(
+    _admin: Annotated[User, Depends(get_current_active_superuser)],
+    component: Annotated[
+        str,
+        Query(
+            min_length=1,
+            max_length=CATALOG_POLICY_KEY_MAX_LENGTH,
+            description="Component key to look up; aliases resolve like catalog enforcement.",
+        ),
+    ],
+    limit: Annotated[int, Query(ge=1, le=USAGE_FLOWS_MAX_LIMIT)] = USAGE_FLOWS_DEFAULT_LIMIT,
+) -> CatalogPolicyUsageFlowsRead:
+    """Return the flows that would be affected by blocking one component key.
+
+    A flow matches when the queried key and any of the flow's stored keys
+    resolve to a shared canonical identity — the same matching rule flow
+    writes and runs enforce. Flows are sorted by name, then id, and truncated
+    to ``limit``; ``total`` always reports the full match count.
+    """
+    component = component.strip()
+    if not component:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="component must not be blank",
+        )
+    usage, _flows_scanned = await _load_flow_component_usage()
+    identity_index = await _usage_identity_index()
+
+    target_identities = identity_index.resolve(component)
+    matches = [
+        flow for flow in usage if not target_identities.isdisjoint(identity_index.resolve_many(flow.component_keys))
+    ]
+    matches.sort(key=lambda flow: (flow.name.casefold(), str(flow.flow_id)))
+    return CatalogPolicyUsageFlowsRead(
+        component=component,
+        total=len(matches),
+        flows=[CatalogPolicyUsageFlowRef(id=flow.flow_id, name=flow.name) for flow in matches[:limit]],
+    )
 
 
 __all__ = ["router"]

--- a/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
+++ b/src/backend/base/langflow/api/v1/schemas/catalog_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
 from pydantic import BaseModel, Field, StringConstraints, field_validator
 
@@ -49,6 +50,34 @@ class CatalogPolicyRead(BaseModel):
     managed_externally: bool
 
 
+class CatalogPolicyUsageRead(BaseModel):
+    """Per-component flow-usage counts for catalog governance."""
+
+    components: dict[str, int] = Field(
+        description=(
+            "Number of flows using each component, keyed by the canonical "
+            "registry identity (or the exact stored key for components not in "
+            "the current registry). A flow is counted once per component."
+        ),
+    )
+    flows_scanned: int = Field(description="Total number of flows examined.")
+
+
+class CatalogPolicyUsageFlowRef(BaseModel):
+    """A flow that uses the queried component."""
+
+    id: UUID
+    name: str
+
+
+class CatalogPolicyUsageFlowsRead(BaseModel):
+    """Flows affected by blocking one component key."""
+
+    component: str
+    total: int = Field(description="Total number of matching flows, before the limit is applied.")
+    flows: list[CatalogPolicyUsageFlowRef]
+
+
 __all__ = [
     "CATALOG_POLICY_KEYS_MAX_LENGTH",
     "CATALOG_POLICY_KEY_MAX_LENGTH",
@@ -56,5 +85,8 @@ __all__ = [
     "CatalogPolicyKey",
     "CatalogPolicyKeyList",
     "CatalogPolicyRead",
+    "CatalogPolicyUsageFlowRef",
+    "CatalogPolicyUsageFlowsRead",
+    "CatalogPolicyUsageRead",
     "normalize_catalog_policy_keys",
 ]

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -17,6 +17,7 @@ from langflow.services.database.models.catalog_policy import CatalogPolicyRule
 from langflow.services.policy_bundle import PolicyBundleRevisionConflictError
 from lfx.services.catalog_policy import CatalogPolicySnapshot, CatalogPolicyUpdate
 from lfx.services.deps import session_scope_readonly
+from lfx.utils.component_aliases import ComponentIdentityIndex
 from sqlmodel import select
 
 
@@ -174,6 +175,8 @@ def test_empty_external_snapshot_still_reports_external_ownership(monkeypatch):
         ("put", "/api/v1/catalog-policy/components"),
         ("get", "/api/v1/catalog-policy/templates"),
         ("put", "/api/v1/catalog-policy/templates"),
+        ("get", "/api/v1/catalog-policy/usage"),
+        ("get", "/api/v1/catalog-policy/usage/flows?component=ChatInput"),
     ],
 )
 def test_all_routes_require_superuser(monkeypatch, method, path):
@@ -390,3 +393,192 @@ def test_external_policy_rejects_valid_puts_without_writing_or_auditing(monkeypa
 def test_managed_marker_is_response_only():
     assert "managed_externally" not in catalog_policy.CatalogPolicyBlockedSet.model_fields
     assert "managed_externally" in catalog_policy.CatalogPolicyRead.model_fields
+
+
+def _usage_index(canonical: set[str], aliases: dict[str, set[str]] | None = None) -> ComponentIdentityIndex:
+    return ComponentIdentityIndex(
+        canonical_keys=frozenset(canonical),
+        aliases={alias: frozenset(targets) for alias, targets in (aliases or {}).items()},
+    )
+
+
+def _usage_client(monkeypatch, *, flows, flows_scanned, index):
+    client, _service, _admin, _audit = _client(monkeypatch)
+    usage = [
+        catalog_policy._FlowUsage(flow_id=flow_id, name=name, component_keys=frozenset(keys))
+        for flow_id, name, keys in flows
+    ]
+    monkeypatch.setattr(
+        catalog_policy,
+        "_load_flow_component_usage",
+        AsyncMock(return_value=(usage, flows_scanned)),
+    )
+    monkeypatch.setattr(catalog_policy, "_usage_identity_index", AsyncMock(return_value=index))
+    return client
+
+
+def test_usage_counts_each_flow_once_per_component(monkeypatch):
+    flow_a, flow_b = uuid4(), uuid4()
+    client = _usage_client(
+        monkeypatch,
+        flows=[
+            (flow_a, "Flow A", {"ChatInput", "Agent"}),
+            (flow_b, "Flow B", {"ChatInput"}),
+        ],
+        flows_scanned=5,
+        index=_usage_index({"ChatInput", "Agent"}),
+    )
+
+    response = client.get("/api/v1/catalog-policy/usage")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "components": {"Agent": 1, "ChatInput": 2},
+        "flows_scanned": 5,
+    }
+
+
+def test_usage_resolves_legacy_aliases_to_canonical_identity(monkeypatch):
+    flow_a, flow_b = uuid4(), uuid4()
+    client = _usage_client(
+        monkeypatch,
+        flows=[
+            # A legacy alias and its canonical key are the same component and
+            # must not double-count; unknown keys survive as themselves.
+            (flow_a, "Legacy", {"Prompt", "Prompt Template", "MyCustomComponent"}),
+            (flow_b, "Modern", {"Prompt Template"}),
+        ],
+        flows_scanned=2,
+        index=_usage_index({"Prompt Template"}, aliases={"Prompt": {"Prompt Template"}}),
+    )
+
+    response = client.get("/api/v1/catalog-policy/usage")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "components": {"MyCustomComponent": 1, "Prompt Template": 2},
+        "flows_scanned": 2,
+    }
+
+
+def test_usage_flows_drilldown_matches_aliases_and_sorts_by_name(monkeypatch):
+    flow_a, flow_b, flow_c = uuid4(), uuid4(), uuid4()
+    client = _usage_client(
+        monkeypatch,
+        flows=[
+            (flow_a, "zeta", {"Prompt"}),
+            (flow_b, "Alpha", {"Prompt Template"}),
+            (flow_c, "beta", {"Unrelated"}),
+        ],
+        flows_scanned=3,
+        index=_usage_index({"Prompt Template", "Unrelated"}, aliases={"Prompt": {"Prompt Template"}}),
+    )
+
+    response = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "Prompt Template"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "component": "Prompt Template",
+        "total": 2,
+        "flows": [
+            {"id": str(flow_b), "name": "Alpha"},
+            {"id": str(flow_a), "name": "zeta"},
+        ],
+    }
+
+    # The alias key drills down to the same affected flows.
+    aliased = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "Prompt"})
+    assert aliased.status_code == 200
+    assert aliased.json()["total"] == 2
+
+
+def test_usage_flows_drilldown_truncates_to_limit_but_reports_total(monkeypatch):
+    flows = [(uuid4(), f"flow-{index:02d}", {"ChatInput"}) for index in range(5)]
+    client = _usage_client(
+        monkeypatch,
+        flows=flows,
+        flows_scanned=5,
+        index=_usage_index({"ChatInput"}),
+    )
+
+    response = client.get(
+        "/api/v1/catalog-policy/usage/flows",
+        params={"component": "ChatInput", "limit": 2},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 5
+    assert [flow["name"] for flow in payload["flows"]] == ["flow-00", "flow-01"]
+
+
+def test_usage_flows_drilldown_unknown_key_matches_exact_only(monkeypatch):
+    flow_a = uuid4()
+    client = _usage_client(
+        monkeypatch,
+        flows=[(flow_a, "Custom", {"MyCustomComponent"})],
+        flows_scanned=1,
+        index=_usage_index({"ChatInput"}),
+    )
+
+    match = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "MyCustomComponent"})
+    miss = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "OtherComponent"})
+
+    assert match.status_code == 200
+    assert match.json()["total"] == 1
+    assert miss.status_code == 200
+    assert miss.json() == {"component": "OtherComponent", "total": 0, "flows": []}
+
+
+def test_usage_flows_drilldown_rejects_blank_component(monkeypatch):
+    client = _usage_client(monkeypatch, flows=[], flows_scanned=0, index=_usage_index(set()))
+
+    missing = client.get("/api/v1/catalog-policy/usage/flows")
+    blank = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "   "})
+
+    assert missing.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert blank.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.anyio
+async def test_usage_scans_persisted_flows_and_excludes_saved_components(client, logged_in_headers_super_user):
+    """End-to-end: flow rows written through the API are visible to usage reads."""
+    custom_key = f"UsageProbeComponent{uuid4().hex}"
+
+    def _graph(*component_types: str) -> dict:
+        return {
+            "nodes": [
+                {"id": f"node-{index}", "data": {"type": component_type, "node": {}}}
+                for index, component_type in enumerate(component_types)
+            ],
+            "edges": [],
+        }
+
+    for payload in (
+        {"name": f"usage-flow-a-{uuid4().hex}", "data": _graph(custom_key, "ChatInput")},
+        {"name": f"usage-flow-b-{uuid4().hex}", "data": _graph(custom_key, custom_key)},
+        {
+            "name": f"usage-saved-component-{uuid4().hex}",
+            "data": _graph(custom_key),
+            "is_component": True,
+        },
+    ):
+        created = await client.post("api/v1/flows/", json=payload, headers=logged_in_headers_super_user)
+        assert created.status_code == status.HTTP_201_CREATED
+
+    usage = await client.get("/api/v1/catalog-policy/usage", headers=logged_in_headers_super_user)
+    assert usage.status_code == 200
+    usage_payload = usage.json()
+    # Saved components are excluded; duplicate nodes count once per flow.
+    assert usage_payload["components"][custom_key] == 2
+    assert usage_payload["flows_scanned"] >= 2
+
+    drilldown = await client.get(
+        "/api/v1/catalog-policy/usage/flows",
+        params={"component": custom_key},
+        headers=logged_in_headers_super_user,
+    )
+    assert drilldown.status_code == 200
+    drilldown_payload = drilldown.json()
+    assert drilldown_payload["total"] == 2
+    assert [flow["name"].split("-")[1] for flow in drilldown_payload["flows"]] == ["flow", "flow"]

--- a/src/backend/tests/unit/api/v1/test_catalog_policy.py
+++ b/src/backend/tests/unit/api/v1/test_catalog_policy.py
@@ -408,18 +408,16 @@ def _usage_client(monkeypatch, *, flows, flows_scanned, index):
         catalog_policy._FlowUsage(flow_id=flow_id, name=name, component_keys=frozenset(keys))
         for flow_id, name, keys in flows
     ]
-    monkeypatch.setattr(
-        catalog_policy,
-        "_load_flow_component_usage",
-        AsyncMock(return_value=(usage, flows_scanned)),
-    )
+    loader = AsyncMock(return_value=(usage, flows_scanned))
+    monkeypatch.setattr(catalog_policy, "_usage_scan_cache", None)
+    monkeypatch.setattr(catalog_policy, "_load_flow_component_usage", loader)
     monkeypatch.setattr(catalog_policy, "_usage_identity_index", AsyncMock(return_value=index))
-    return client
+    return client, loader
 
 
 def test_usage_counts_each_flow_once_per_component(monkeypatch):
     flow_a, flow_b = uuid4(), uuid4()
-    client = _usage_client(
+    client, _loader = _usage_client(
         monkeypatch,
         flows=[
             (flow_a, "Flow A", {"ChatInput", "Agent"}),
@@ -440,7 +438,7 @@ def test_usage_counts_each_flow_once_per_component(monkeypatch):
 
 def test_usage_resolves_legacy_aliases_to_canonical_identity(monkeypatch):
     flow_a, flow_b = uuid4(), uuid4()
-    client = _usage_client(
+    client, _loader = _usage_client(
         monkeypatch,
         flows=[
             # A legacy alias and its canonical key are the same component and
@@ -463,7 +461,7 @@ def test_usage_resolves_legacy_aliases_to_canonical_identity(monkeypatch):
 
 def test_usage_flows_drilldown_matches_aliases_and_sorts_by_name(monkeypatch):
     flow_a, flow_b, flow_c = uuid4(), uuid4(), uuid4()
-    client = _usage_client(
+    client, _loader = _usage_client(
         monkeypatch,
         flows=[
             (flow_a, "zeta", {"Prompt"}),
@@ -494,7 +492,7 @@ def test_usage_flows_drilldown_matches_aliases_and_sorts_by_name(monkeypatch):
 
 def test_usage_flows_drilldown_truncates_to_limit_but_reports_total(monkeypatch):
     flows = [(uuid4(), f"flow-{index:02d}", {"ChatInput"}) for index in range(5)]
-    client = _usage_client(
+    client, _loader = _usage_client(
         monkeypatch,
         flows=flows,
         flows_scanned=5,
@@ -514,7 +512,7 @@ def test_usage_flows_drilldown_truncates_to_limit_but_reports_total(monkeypatch)
 
 def test_usage_flows_drilldown_unknown_key_matches_exact_only(monkeypatch):
     flow_a = uuid4()
-    client = _usage_client(
+    client, _loader = _usage_client(
         monkeypatch,
         flows=[(flow_a, "Custom", {"MyCustomComponent"})],
         flows_scanned=1,
@@ -531,7 +529,7 @@ def test_usage_flows_drilldown_unknown_key_matches_exact_only(monkeypatch):
 
 
 def test_usage_flows_drilldown_rejects_blank_component(monkeypatch):
-    client = _usage_client(monkeypatch, flows=[], flows_scanned=0, index=_usage_index(set()))
+    client, _loader = _usage_client(monkeypatch, flows=[], flows_scanned=0, index=_usage_index(set()))
 
     missing = client.get("/api/v1/catalog-policy/usage/flows")
     blank = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "   "})
@@ -540,9 +538,47 @@ def test_usage_flows_drilldown_rejects_blank_component(monkeypatch):
     assert blank.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
+def test_usage_endpoints_share_one_flow_scan_within_the_ttl(monkeypatch):
+    client, loader = _usage_client(
+        monkeypatch,
+        flows=[(uuid4(), "Flow A", {"ChatInput"})],
+        flows_scanned=1,
+        index=_usage_index({"ChatInput"}),
+    )
+
+    first = client.get("/api/v1/catalog-policy/usage")
+    second = client.get("/api/v1/catalog-policy/usage")
+    drilldown = client.get("/api/v1/catalog-policy/usage/flows", params={"component": "ChatInput"})
+
+    assert first.status_code == second.status_code == drilldown.status_code == 200
+    assert first.json() == second.json()
+    assert drilldown.json()["total"] == 1
+    loader.assert_awaited_once()
+
+
+def test_usage_scan_cache_expires_after_the_ttl(monkeypatch):
+    client, loader = _usage_client(
+        monkeypatch,
+        flows=[(uuid4(), "Flow A", {"ChatInput"})],
+        flows_scanned=1,
+        index=_usage_index({"ChatInput"}),
+    )
+    monkeypatch.setattr(catalog_policy, "USAGE_SCAN_CACHE_TTL_SECONDS", 0.0)
+
+    first = client.get("/api/v1/catalog-policy/usage")
+    second = client.get("/api/v1/catalog-policy/usage")
+
+    assert first.status_code == second.status_code == 200
+    assert loader.await_count == 2
+
+
 @pytest.mark.anyio
-async def test_usage_scans_persisted_flows_and_excludes_saved_components(client, logged_in_headers_super_user):
+async def test_usage_scans_persisted_flows_and_excludes_saved_components(
+    client, logged_in_headers_super_user, monkeypatch
+):
     """End-to-end: flow rows written through the API are visible to usage reads."""
+    # Discard any scan cached by an earlier test against a different database.
+    monkeypatch.setattr(catalog_policy, "_usage_scan_cache", None)
     custom_key = f"UsageProbeComponent{uuid4().hex}"
 
     def _graph(*component_types: str) -> dict:

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -233,6 +233,22 @@ def _collect_catalog_component_keys(nodes: Any) -> set[str]:
     return component_keys
 
 
+def collect_catalog_component_keys(target: Mapping[str, Any] | Any | None) -> frozenset[str]:
+    """Return the exact component keys stored in a flow payload or Graph-like object.
+
+    Accepts the same targets as :func:`validate_catalog_policy_for_flow` —
+    a raw graph payload, a wrapped ``{"data": {...}}`` flow payload, or a
+    Graph-like object — and includes keys from inlined nested flows. A target
+    without extractable graph data yields an empty set; callers that must
+    fail closed on unparseable payloads should keep using
+    :func:`validate_catalog_policy_for_flow`.
+    """
+    normalized_flow_data = _extract_flow_data(target)
+    if not normalized_flow_data:
+        return frozenset()
+    return frozenset(_collect_catalog_component_keys(normalized_flow_data.get("nodes")))
+
+
 def get_component_identity_index_for_validation() -> ComponentIdentityIndex | None:
     """Return the cached canonical identity index when the registry is ready."""
     from lfx.interface.components import get_component_identity_index

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -19,6 +19,7 @@ from lfx.utils.flow_validation import (
     CatalogPolicyValidationError,
     CustomComponentValidationError,
     PublicFlowValidationError,
+    collect_catalog_component_keys,
     collect_component_code_lookups,
     ensure_component_hash_lookups_loaded,
     prepare_public_flow_build,
@@ -1281,3 +1282,37 @@ def test_frontend_mirrors_tweak_refusal_rules():
     assert _parse_ts_protected_fields(source) == {
         component: set(fields) for component, fields in PROTECTED_TWEAK_FIELDS_BY_COMPONENT.items()
     }
+
+
+def test_collect_catalog_component_keys_includes_nested_flows():
+    """The public collector reports exact keys from the graph and inlined sub-flows."""
+    graph = {
+        "nodes": [
+            {"id": "node-1", "data": {"type": "ChatInput", "node": {}}},
+            {
+                "id": "node-2",
+                "data": {
+                    "type": "RunFlow",
+                    "node": {
+                        "flow": {
+                            "data": {
+                                "nodes": [
+                                    {"id": "nested-1", "data": {"type": "NestedComponent", "node": {}}},
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+        "edges": [],
+    }
+
+    assert collect_catalog_component_keys(graph) == frozenset({"ChatInput", "RunFlow", "NestedComponent"})
+    # Wrapped flow payloads normalize the same way validation does.
+    assert collect_catalog_component_keys({"data": graph}) == frozenset({"ChatInput", "RunFlow", "NestedComponent"})
+
+
+@pytest.mark.parametrize("target", [None, {}, {"nodes": "not-a-list"}, {"data": {"nodes": []}}])
+def test_collect_catalog_component_keys_returns_empty_for_unusable_targets(target):
+    assert collect_catalog_component_keys(target) == frozenset()

--- a/src/lfx/tests/unit/utils/test_flow_validation.py
+++ b/src/lfx/tests/unit/utils/test_flow_validation.py
@@ -1311,8 +1311,21 @@ def test_collect_catalog_component_keys_includes_nested_flows():
     assert collect_catalog_component_keys(graph) == frozenset({"ChatInput", "RunFlow", "NestedComponent"})
     # Wrapped flow payloads normalize the same way validation does.
     assert collect_catalog_component_keys({"data": graph}) == frozenset({"ChatInput", "RunFlow", "NestedComponent"})
+    # Graph-like objects resolve through their authoritative raw_graph_data payload.
+    graph_like = SimpleNamespace(raw_graph_data=graph)
+    assert collect_catalog_component_keys(graph_like) == frozenset({"ChatInput", "RunFlow", "NestedComponent"})
 
 
-@pytest.mark.parametrize("target", [None, {}, {"nodes": "not-a-list"}, {"data": {"nodes": []}}])
+@pytest.mark.parametrize(
+    "target",
+    [
+        None,
+        {},
+        {"nodes": "not-a-list"},
+        {"data": {"nodes": []}},
+        SimpleNamespace(),
+        SimpleNamespace(raw_graph_data="not-a-mapping"),
+    ],
+)
 def test_collect_catalog_component_keys_returns_empty_for_unusable_targets(target):
     assert collect_catalog_component_keys(target) == frozenset()


### PR DESCRIPTION
## Summary

Backs the Admin → Components governance UI (AFFECTED FLOWS stat card, USED IN FLOWS column, and the *View affected flows* drill-down), which currently has no usage data behind it — the policy layer only filters the palette and rejects new writes/runs without ever reading `Flow.data`.

### New superuser endpoints

- **`GET /api/v1/catalog-policy/usage`** — per-component flow-usage counts plus `flows_scanned`:
  ```json
  {"components": {"Agent": 18, "ChatInput": 42}, "flows_scanned": 57}
  ```
  Counts are keyed by canonical registry identity, using the same collision-aware alias resolution the palette filter and flow write/run validation use — a flow saved under a legacy alias key is counted under the component that blocking would actually affect today. Keys not in the registry (custom/synthetic components) are counted under their exact stored key. Saved components (`is_component`) are excluded, and each flow counts once per component.

- **`GET /api/v1/catalog-policy/usage/flows?component=<key>&limit=<n>`** — the drill-down: flows that would be affected by blocking one key, matched with the same shared-canonical-identity rule enforcement applies (so alias keys and canonical keys agree):
  ```json
  {"component": "ChatInput", "total": 42, "flows": [{"id": "…", "name": "…"}]}
  ```
  Sorted by name then id; `total` always reports the full match count while `flows` is truncated to `limit` (default 100, max 500).

### Shared seam

`lfx.utils.flow_validation.collect_catalog_component_keys` is now public so the usage scan collects node keys (including flows inlined in legacy Run Flow nodes) with exactly the code path catalog-policy validation uses, instead of a parallel re-implementation.

## Test plan

- [x] `src/lfx/tests/unit/utils/test_flow_validation.py` — public collector: nested-flow keys, wrapped payload normalization, unusable-target fallbacks (5 tests)
- [x] `src/backend/tests/unit/api/v1/test_catalog_policy.py` — full file passes (31 tests), including new coverage for:
  - once-per-flow counting and `flows_scanned`
  - legacy alias → canonical identity resolution without double-counting; unknown keys preserved
  - drill-down alias matching, name sort, limit truncation with accurate `total`, exact-only match for unknown keys
  - blank/missing `component` rejected with 422
  - superuser required on both new routes (extends the existing 403 parametrization)
  - end-to-end against a real DB and component registry: flows created through `POST /api/v1/flows/` are visible to usage reads, saved components are excluded, duplicate nodes count once
- [x] `ruff check` / `ruff format` clean on changed files

## Notes for reviewers

- Read path only — no schema or migration changes, no changes to enforcement.
- The scan reads each flow's full `data` payload; both endpoints are superuser-only governance reads, not per-request paths.
- Enterprise follow-up (separate repo): bump the `oss-version` pin and extend `check-provider-catalog-policy-contract.py` to require the new seams once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrator tools to view catalog component usage across saved flows.
  * Added per-component usage counts and flow-level drilldowns with sorting and result limits.
  * Component aliases are matched to their canonical catalog identities.
* **Bug Fixes**
  * Improved component detection in nested and wrapped flow definitions.
  * Invalid or unknown component searches are handled with appropriate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->