### PR TITLE
fix: let the caller own the flow span so a run's spans nest under it

### DIFF
--- a/src/backend/base/langflow/agentic/services/flow_executor.py
+++ b/src/backend/base/langflow/agentic/services/flow_executor.py
@@ -66,10 +66,14 @@ async def _run_graph_with_events(
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
         coordinator = await aget_default_coordinator()
-        with execution_protocol("agentic"):
+        # The flow span is opened here, not inside async_start: this is a coroutine, so it can be
+        # made current and everything the run does nests under it. See Graph.async_start.
+        with execution_protocol("agentic"), graph.flow_execution_span():
             results = [
                 payload
-                async for payload in coordinator.stream(graph, initial_inputs=inputs, event_manager=event_manager)
+                async for payload in coordinator.stream(
+                    graph, initial_inputs=inputs, event_manager=event_manager, open_flow_span=False
+                )
             ]
         execution_result.result = extract_structured_result(results)
     except Exception as e:  # noqa: BLE001
@@ -146,8 +150,10 @@ async def execute_flow_file(
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
         coordinator = await aget_default_coordinator()
-        with execution_protocol("agentic"):
-            results = [payload async for payload in coordinator.stream(graph, initial_inputs=inputs)]
+        with execution_protocol("agentic"), graph.flow_execution_span():
+            results = [
+                payload async for payload in coordinator.stream(graph, initial_inputs=inputs, open_flow_span=False)
+            ]
         flow_result = extract_structured_result(results)
     except HTTPException:
         raise

--- a/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 
 import pytest
@@ -57,6 +58,17 @@ async def test_run_graph_uses_default_coordinator():
 
         def prepare(self):
             pass
+
+        @contextlib.contextmanager
+        def flow_execution_span(self, *, make_current: bool = True):
+            """The caller opens the flow span now, so a stand-in graph has to offer one.
+
+            Without it the AttributeError is swallowed by the broad except in
+            _run_graph_with_events and the coordinator is never reached, which reads as "the
+            coordinator was not used" rather than "the fake is missing a method".
+            """
+            _ = make_current
+            yield
 
     queue: asyncio.Queue = asyncio.Queue()
     execution_result = FlowExecutionResult()

--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -451,15 +451,19 @@ async def execute_graph_with_capture(
     stderr_token = stderr_router.activate(captured_stderr)
 
     try:
-        results = [
-            payload
-            async for payload in coordinator.stream(
-                graph,
-                initial_inputs=inputs,
-                fallback_to_env_vars=fallback_to_env_vars,
-                event_manager=event_manager,
-            )
-        ]
+        # Opened here rather than inside async_start, which is a generator and cannot make its
+        # span current. See Graph.async_start.
+        with graph.flow_execution_span():
+            results = [
+                payload
+                async for payload in coordinator.stream(
+                    graph,
+                    initial_inputs=inputs,
+                    fallback_to_env_vars=fallback_to_env_vars,
+                    event_manager=event_manager,
+                    open_flow_span=False,
+                )
+            ]
     except Exception as exc:
         # Capture any error output that was written to stderr
         error_output = captured_stderr.getvalue()

--- a/src/lfx/src/lfx/execution/backends/in_process.py
+++ b/src/lfx/src/lfx/execution/backends/in_process.py
@@ -22,7 +22,9 @@ class InProcessExecutor(Executor):
         opts = unit.runtime_options
 
         if opts.get("_use_arun_legacy") and hasattr(graph, "_arun_legacy"):
-            legacy_kwargs = {k: v for k, v in opts.items() if not k.startswith("_")}
+            # open_flow_span is for async_start, which the legacy path does not go through, and
+            # _arun_legacy would reject the unexpected keyword.
+            legacy_kwargs = {k: v for k, v in opts.items() if not k.startswith("_") and k != "open_flow_span"}
             outputs = await graph._arun_legacy(inputs=unit.inputs, **legacy_kwargs)  # noqa: SLF001
             yield RunComplete(outputs=list(outputs))
             return
@@ -41,6 +43,8 @@ class InProcessExecutor(Executor):
             event_manager=opts.get("event_manager"),
             reset_output_values=opts.get("reset_output_values", True),
             fallback_to_env_vars=opts.get("fallback_to_env_vars", False),
+            # Defaults True, so a consumer that has not been converted still gets a span.
+            open_flow_span=opts.get("open_flow_span", True),
         )
         try:
             async for result in inner:

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -436,6 +436,26 @@ class Graph:
         }
         self._add_edge(edge_data)
 
+    @contextlib.contextmanager
+    def _flow_span_scope(self, *, open_flow_span: bool):
+        """Open the flow span for a run, or defer to the caller that already opened one.
+
+        The guard is here because deferring and then not opening one is the failure this flag
+        makes possible, and it is silent: the run simply produces no flow span. Warn rather than
+        raise, because telemetry must never take a run down.
+        """
+        if open_flow_span:
+            with self.flow_execution_span(make_current=False):
+                yield
+            return
+        if otel_trace is not None and not otel_trace.get_current_span().is_recording():
+            logger.warning(
+                "async_start was told the caller owns the flow span, but no span is current, "
+                "so this run will not be recorded. The caller should open "
+                "graph.flow_execution_span() around its consumption of the stream."
+            )
+        yield
+
     async def async_start(
         self,
         inputs: list[dict] | None = None,
@@ -445,9 +465,20 @@ class Graph:
         *,
         reset_output_values: bool = True,
         fallback_to_env_vars: bool = False,
+        open_flow_span: bool = True,
     ):
-        # make_current=False: this is an async generator, see flow_execution_span.
-        with self.flow_execution_span(make_current=False):
+        """Run the graph, yielding each step.
+
+        open_flow_span=False says the caller already opened the flow span and this run belongs
+        to it. Prefer that: a span opened here cannot be made current, because this is an async
+        generator and the context token would be attached and detached across its suspension
+        points, so nothing that runs inside the graph nests under the flow span. A caller that
+        is a coroutine has no such problem, so the span it opens is a real parent.
+
+        Left defaulting to True so a caller that has not been converted still gets a span rather
+        than silently none. Those runs keep the flat shape.
+        """
+        with self._flow_span_scope(open_flow_span=open_flow_span):
             # Preserve start_component_id from constructor if available
             start_component_id = self._start.get_id() if self._start else None
             self.prepare(start_component_id=start_component_id)
@@ -548,38 +579,41 @@ class Graph:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 
-            try:
-                # Run the async generator
-                async_gen = self.async_start(inputs, max_iterations, event_manager)
+            # A thread entry point rather than a generator, so the span can be current for
+            # every anext below. See async_start.
+            with self.flow_execution_span():
+                try:
+                    # Run the async generator
+                    async_gen = self.async_start(inputs, max_iterations, event_manager, open_flow_span=False)
 
-                while True:
-                    try:
-                        # Get next result from async generator
-                        result = loop.run_until_complete(anext(async_gen))
-                        result_queue.put(result)
+                    while True:
+                        try:
+                            # Get next result from async generator
+                            result = loop.run_until_complete(anext(async_gen))
+                            result_queue.put(result)
 
-                        if isinstance(result, Finish):
+                            if isinstance(result, Finish):
+                                break
+
+                        except StopAsyncIteration:
+                            break
+                        except ValueError as e:
+                            # Put the exception in the queue
+                            result_queue.put(e)
                             break
 
-                    except StopAsyncIteration:
-                        break
-                    except ValueError as e:
-                        # Put the exception in the queue
-                        result_queue.put(e)
-                        break
+                finally:
+                    # Ensure all pending tasks are completed
+                    pending = asyncio.all_tasks(loop)
+                    if pending:
+                        # Create a future to gather all pending tasks
+                        cleanup_future = asyncio.gather(*pending, return_exceptions=True)
+                        loop.run_until_complete(cleanup_future)
 
-            finally:
-                # Ensure all pending tasks are completed
-                pending = asyncio.all_tasks(loop)
-                if pending:
-                    # Create a future to gather all pending tasks
-                    cleanup_future = asyncio.gather(*pending, return_exceptions=True)
-                    loop.run_until_complete(cleanup_future)
-
-                # Close the loop
-                loop.close()
-                # Signal completion
-                result_queue.put(None)
+                    # Close the loop
+                    loop.close()
+                    # Signal completion
+                    result_queue.put(None)
 
         # Start thread for async execution
         thread = threading.Thread(target=run_async_code)

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -584,7 +584,17 @@ class Graph:
             with self.flow_execution_span():
                 try:
                     # Run the async generator
-                    async_gen = self.async_start(inputs, max_iterations, event_manager, open_flow_span=False)
+                    # By keyword: async_start takes (inputs, max_iterations, config,
+                    # event_manager), so positionally the event manager lands in config and
+                    # __apply_config subscripts it. The run dies in this thread and the caller
+                    # gets an empty generator rather than an error. config is already applied
+                    # above, so it is deliberately not forwarded again.
+                    async_gen = self.async_start(
+                        inputs=inputs,
+                        max_iterations=max_iterations,
+                        event_manager=event_manager,
+                        open_flow_span=False,
+                    )
 
                     while True:
                         try:

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -579,51 +579,56 @@ class Graph:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 
-            # A thread entry point rather than a generator, so the span can be current for
-            # every anext below. See async_start.
-            with self.flow_execution_span():
+            try:
+                # Nothing is caught inside this block on purpose. A failure has to leave the
+                # span scope for the span to see it: caught in here, the context manager exits
+                # cleanly and a failed run is exported as status "ok", which is worse than no
+                # telemetry because it looks like a healthy run.
+                #
+                # A thread entry point rather than a generator, so the span can be current for
+                # every anext below. See async_start.
                 try:
-                    # Run the async generator
-                    # By keyword: async_start takes (inputs, max_iterations, config,
-                    # event_manager), so positionally the event manager lands in config and
-                    # __apply_config subscripts it. The run dies in this thread and the caller
-                    # gets an empty generator rather than an error. config is already applied
-                    # above, so it is deliberately not forwarded again.
-                    async_gen = self.async_start(
-                        inputs=inputs,
-                        max_iterations=max_iterations,
-                        event_manager=event_manager,
-                        open_flow_span=False,
-                    )
+                    with self.flow_execution_span():
+                        # By keyword: async_start takes (inputs, max_iterations, config,
+                        # event_manager), so positionally the event manager lands in config and
+                        # __apply_config subscripts it. config is already applied above, so it
+                        # is deliberately not forwarded again.
+                        async_gen = self.async_start(
+                            inputs=inputs,
+                            max_iterations=max_iterations,
+                            event_manager=event_manager,
+                            open_flow_span=False,
+                        )
 
-                    while True:
-                        try:
-                            # Get next result from async generator
-                            result = loop.run_until_complete(anext(async_gen))
-                            result_queue.put(result)
+                        while True:
+                            try:
+                                result = loop.run_until_complete(anext(async_gen))
+                                result_queue.put(result)
 
-                            if isinstance(result, Finish):
+                                if isinstance(result, Finish):
+                                    break
+
+                            except StopAsyncIteration:
                                 break
+                except Exception as exc:  # noqa: BLE001 - the worker boundary; see below
+                    # Every Exception, not just ValueError. This runs on a thread, so anything
+                    # not put on the queue dies with the thread while the caller reads the None
+                    # below and sees a clean end of stream. The generator consumer re-raises
+                    # whatever arrives here, so the caller gets the failure it would have got
+                    # from a synchronous call.
+                    result_queue.put(exc)
+            finally:
+                # Ensure all pending tasks are completed
+                pending = asyncio.all_tasks(loop)
+                if pending:
+                    # Create a future to gather all pending tasks
+                    cleanup_future = asyncio.gather(*pending, return_exceptions=True)
+                    loop.run_until_complete(cleanup_future)
 
-                        except StopAsyncIteration:
-                            break
-                        except ValueError as e:
-                            # Put the exception in the queue
-                            result_queue.put(e)
-                            break
-
-                finally:
-                    # Ensure all pending tasks are completed
-                    pending = asyncio.all_tasks(loop)
-                    if pending:
-                        # Create a future to gather all pending tasks
-                        cleanup_future = asyncio.gather(*pending, return_exceptions=True)
-                        loop.run_until_complete(cleanup_future)
-
-                    # Close the loop
-                    loop.close()
-                    # Signal completion
-                    result_queue.put(None)
+                # Close the loop
+                loop.close()
+                # Signal completion, after any exception above so the caller reads that first.
+                result_queue.put(None)
 
         # Start thread for async execution, carrying the caller's context into it.
         #

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -625,8 +625,20 @@ class Graph:
                     # Signal completion
                     result_queue.put(None)
 
-        # Start thread for async execution
-        thread = threading.Thread(target=run_async_code)
+        # Start thread for async execution, carrying the caller's context into it.
+        #
+        # A new thread starts with an empty context, so without this the flow span opened inside
+        # run_async_code finds no current span and starts a brand-new trace: measured, the
+        # caller's span and flow.execute came back with different trace ids and no parent or
+        # link between them, which is exactly the correlation this PR exists to provide. The
+        # same copy carries the protocol and client contextvars, which are set at the entry
+        # point for the same reason.
+        #
+        # The caller's span is still recording while the generator below is consumed, so the
+        # flow span parents to it normally. A caller that abandons the generator early leaves a
+        # dead parent, which flow_execution_span already handles by linking instead.
+        context = contextvars.copy_context()
+        thread = threading.Thread(target=context.run, args=(run_async_code,))
         thread.start()
 
         # Yield results from queue

--- a/src/lfx/src/lfx/preload.py
+++ b/src/lfx/src/lfx/preload.py
@@ -117,8 +117,10 @@ def _run_flow_once(graph, input_value: str) -> None:
     inputs = InputValueRequest(input_value=input_value) if input_value else None
 
     async def _run() -> None:
-        async for _ in graph.async_start(inputs=inputs):
-            pass
+        # A coroutine, so the span can be made current and the run nests under it.
+        with graph.flow_execution_span():
+            async for _ in graph.async_start(inputs=inputs, open_flow_span=False):
+                pass
 
     asyncio.run(_run())
 

--- a/src/lfx/src/lfx/run/base.py
+++ b/src/lfx/src/lfx/run/base.py
@@ -539,37 +539,40 @@ async def run_flow(
                     "terminal or pass --human-input to enable the interactive prompts.\n"
                 )
             coordinator = await aget_default_coordinator()
-            async for result in coordinator.stream(
-                graph,
-                initial_inputs=inputs,
-                event_manager=event_manager,
-                fallback_to_env_vars=fallback_to_env_vars,
-            ):
-                result_count += 1
-                if verbosity > 0:
-                    logger.debug(f"Processing result #{result_count}")
-                    if hasattr(result, "vertex") and hasattr(result.vertex, "display_name"):
-                        logger.debug(f"Component: {result.vertex.display_name}")
-                if timing:
-                    step_end_time = time.monotonic()
-                    step_duration = step_end_time - execution_step_start
+            # See Graph.async_start: the span belongs to this coroutine, not the generator.
+            with graph.flow_execution_span():
+                async for result in coordinator.stream(
+                    graph,
+                    initial_inputs=inputs,
+                    event_manager=event_manager,
+                    fallback_to_env_vars=fallback_to_env_vars,
+                    open_flow_span=False,
+                ):
+                    result_count += 1
+                    if verbosity > 0:
+                        logger.debug(f"Processing result #{result_count}")
+                        if hasattr(result, "vertex") and hasattr(result.vertex, "display_name"):
+                            logger.debug(f"Component: {result.vertex.display_name}")
+                    if timing:
+                        step_end_time = time.monotonic()
+                        step_duration = step_end_time - execution_step_start
 
-                    # Extract component information
-                    if hasattr(result, "vertex"):
-                        component_name = getattr(result.vertex, "display_name", "Unknown")
-                        component_id = getattr(result.vertex, "id", "Unknown")
-                        component_timings.append(
-                            {
-                                "component": component_name,
-                                "component_id": component_id,
-                                "duration": step_duration,
-                                "cumulative_time": step_end_time - execution_start_time,
-                            }
-                        )
+                        # Extract component information
+                        if hasattr(result, "vertex"):
+                            component_name = getattr(result.vertex, "display_name", "Unknown")
+                            component_id = getattr(result.vertex, "id", "Unknown")
+                            component_timings.append(
+                                {
+                                    "component": component_name,
+                                    "component_id": component_id,
+                                    "duration": step_duration,
+                                    "cumulative_time": step_end_time - execution_start_time,
+                                }
+                            )
 
-                    execution_step_start = step_end_time
+                        execution_step_start = step_end_time
 
-                results.append(result)
+                    results.append(result)
 
         logger.info(f"Graph execution completed. Processed {result_count} results")
 

--- a/src/lfx/tests/unit/graph/graph/test_base.py
+++ b/src/lfx/tests/unit/graph/graph/test_base.py
@@ -467,3 +467,28 @@ async def test_end_all_traces_in_context_runs_on_python_3_10():
     await callable_()
 
     assert seen["marker"] == "captured_value"
+
+
+def test_the_sync_start_forwards_an_event_manager_to_the_right_parameter():
+    """``async_start`` takes (inputs, max_iterations, config, event_manager) in that order.
+
+    Passed positionally, the event manager lands in ``config`` and ``__apply_config`` subscripts
+    it. That happens on the worker thread ``start`` spawns, so nothing propagates to the caller:
+    the exception is logged there and the generator simply finishes empty. A run that produces
+    no results and no error is the worst shape for this to fail in, which is why the assertion
+    is on the results rather than on not raising.
+    """
+    import asyncio
+
+    from lfx.events.event_manager import create_default_event_manager
+
+    chat_input = ChatInput(_id="chat-input")
+    chat_input.set(input_value="hello")
+    chat_output = ChatOutput(_id="chat-output")
+    chat_output.set(input_value=chat_input.message_response)
+    graph = Graph(chat_input, chat_output, flow_id="11111111-1111-1111-1111-111111111111")
+
+    results = list(graph.start(event_manager=create_default_event_manager(asyncio.Queue())))
+
+    assert results, "the run produced nothing; the event manager was interpreted as config"
+    assert any(result is Finish for result in results) or len(results) > 1, results

--- a/src/lfx/tests/unit/graph/test_async_start_flow_span.py
+++ b/src/lfx/tests/unit/graph/test_async_start_flow_span.py
@@ -1,0 +1,133 @@
+"""Who opens the flow span for a run driven through ``async_start``.
+
+``async_start`` is an async generator, so a span it opens cannot be made current: the context
+token would be attached and detached across the generator's suspension points and leak into
+whatever task resumed it. A span that is not current cannot parent anything, so every span the
+run produces (MCP tool calls, database queries) sits beside the flow span rather than under it.
+
+The fix is for the caller to open the span, because the callers are coroutines and thread entry
+points, which have no such problem. ``open_flow_span=False`` says that has happened.
+
+Runs in a subprocess because the tracer provider is process-global.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+PROBE = """
+import asyncio, json, sys
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.graph import Graph
+from lfx.observability import APPLICATION_TRACER_NAME
+
+MODE = sys.argv[1]
+
+
+def build():
+    chat_input = ChatInput(_id="chat-input")
+    chat_input.set(input_value="hello")
+    chat_output = ChatOutput(_id="chat-output")
+    chat_output.set(input_value=chat_input.message_response)
+    return Graph(chat_input, chat_output, flow_id="11111111-1111-1111-1111-111111111111")
+
+
+async def main():
+    graph = build()
+    tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
+    inner_parent = None
+
+    if MODE == "caller_opens":
+        with graph.flow_execution_span():
+            async for _ in graph.async_start(open_flow_span=False):
+                if inner_parent is None:
+                    # A span opened mid-run stands in for anything the graph does: an MCP tool
+                    # call, a database query. What matters is what it parents to.
+                    with tracer.start_as_current_span("probe.inner") as inner:
+                        inner_parent = inner.parent.span_id if inner.parent else None
+    elif MODE == "async_start_opens":
+        async for _ in graph.async_start():
+            if inner_parent is None:
+                with tracer.start_as_current_span("probe.inner") as inner:
+                    inner_parent = inner.parent.span_id if inner.parent else None
+    elif MODE == "deferred_but_nobody_opened":
+        async for _ in graph.async_start(open_flow_span=False):
+            pass
+
+    provider.force_flush()
+    spans = [
+        {"name": s.name, "span_id": s.context.span_id, "parent": s.parent.span_id if s.parent else None}
+        for s in exporter.get_finished_spans()
+    ]
+    print("PROBE_RESULT " + json.dumps({"spans": spans, "inner_parent": inner_parent}))
+
+
+asyncio.run(main())
+"""
+
+
+def run_probe(mode: str) -> dict:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe_path = Path(tmp) / "probe.py"
+        probe_path.write_text(PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe_path), mode],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    assert completed.returncode == 0, completed.stderr
+    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
+    return json.loads(line.removeprefix("PROBE_RESULT "))
+
+
+def test_a_caller_opened_span_parents_what_the_run_does():
+    """The converted shape. This is the whole point of moving the span to the caller."""
+    result = run_probe("caller_opens")
+
+    flow_spans = [s for s in result["spans"] if s["name"] == "flow.execute"]
+    assert len(flow_spans) == 1, "the caller's span should be the only flow span"
+    assert result["inner_parent"] == flow_spans[0]["span_id"]
+
+
+def test_async_start_still_opens_its_own_span_when_the_caller_does_not():
+    """An unconverted caller keeps today's behaviour rather than silently losing telemetry.
+
+    The span exists, and it still cannot parent the run, which is the limitation the flag exists
+    to let callers opt out of.
+    """
+    result = run_probe("async_start_opens")
+
+    flow_spans = [s for s in result["spans"] if s["name"] == "flow.execute"]
+    assert len(flow_spans) == 1
+    assert result["inner_parent"] != flow_spans[0]["span_id"]
+
+
+def test_deferring_without_opening_one_emits_no_flow_span():
+    """The mistake the flag makes possible. It is silent, which is why async_start warns."""
+    result = run_probe("deferred_but_nobody_opened")
+
+    assert [s for s in result["spans"] if s["name"] == "flow.execute"] == []

--- a/src/lfx/tests/unit/graph/test_async_start_flow_span.py
+++ b/src/lfx/tests/unit/graph/test_async_start_flow_span.py
@@ -56,6 +56,7 @@ async def main():
     graph = build()
     tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
     inner_parent = None
+    caller_ids = None
 
     if MODE == "caller_opens":
         with graph.flow_execution_span():
@@ -73,13 +74,36 @@ async def main():
     elif MODE == "deferred_but_nobody_opened":
         async for _ in graph.async_start(open_flow_span=False):
             pass
+    elif MODE == "sync_start_under_a_caller_span":
+        # The sync entry point hands the run to a worker thread, and a new thread starts with an
+        # empty context, so the flow span has to be given the caller's or it begins its own trace.
+        with tracer.start_as_current_span("caller") as caller:
+            caller_context = caller.get_span_context()
+            list(graph.start())
+        caller_ids = (caller_context.trace_id, caller_context.span_id)
 
     provider.force_flush()
     spans = [
-        {"name": s.name, "span_id": s.context.span_id, "parent": s.parent.span_id if s.parent else None}
+        {
+            "name": s.name,
+            "span_id": s.context.span_id,
+            "trace_id": s.context.trace_id,
+            "parent": s.parent.span_id if s.parent else None,
+            "links": [link.context.span_id for link in s.links],
+        }
         for s in exporter.get_finished_spans()
     ]
-    print("PROBE_RESULT " + json.dumps({"spans": spans, "inner_parent": inner_parent}))
+    print(
+        "PROBE_RESULT "
+        + json.dumps(
+            {
+                "spans": spans,
+                "inner_parent": inner_parent,
+                "caller_trace": caller_ids[0] if caller_ids else None,
+                "caller_span": caller_ids[1] if caller_ids else None,
+            }
+        )
+    )
 
 
 asyncio.run(main())
@@ -131,3 +155,25 @@ def test_deferring_without_opening_one_emits_no_flow_span():
     result = run_probe("deferred_but_nobody_opened")
 
     assert [s for s in result["spans"] if s["name"] == "flow.execute"] == []
+
+
+def test_the_sync_start_runs_under_the_caller_span():
+    """``Graph.start`` hands the run to a worker thread, and a thread starts with no context.
+
+    Without the caller's context copied in, the flow span finds no current span and opens a
+    brand-new trace. Measured before the fix: different trace ids, no parent and no link, so a
+    caller's span and the run it started were two unrelated traces in the operator's APM.
+
+    The trace id is the assertion that matters. A parent alone could be satisfied by a span that
+    happened to nest under something else in the worker.
+    """
+    result = run_probe("sync_start_under_a_caller_span")
+
+    flow_spans = [s for s in result["spans"] if s["name"] == "flow.execute"]
+    assert len(flow_spans) == 1, result["spans"]
+    assert result["caller_trace"], "the probe did not record a caller span"
+
+    assert flow_spans[0]["trace_id"] == result["caller_trace"], (
+        f"flow span is in trace {flow_spans[0]['trace_id']:032x}, caller is in {result['caller_trace']:032x}"
+    )
+    assert flow_spans[0]["parent"] == result["caller_span"]

--- a/src/lfx/tests/unit/graph/test_async_start_flow_span.py
+++ b/src/lfx/tests/unit/graph/test_async_start_flow_span.py
@@ -39,6 +39,7 @@ trace.set_tracer_provider(provider)
 
 from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.graph import Graph
+from lfx.io import Output
 from lfx.observability import APPLICATION_TRACER_NAME
 
 MODE = sys.argv[1]
@@ -57,6 +58,7 @@ async def main():
     tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
     inner_parent = None
     caller_ids = None
+    raised = None
 
     if MODE == "caller_opens":
         with graph.flow_execution_span():
@@ -74,6 +76,71 @@ async def main():
     elif MODE == "deferred_but_nobody_opened":
         async for _ in graph.async_start(open_flow_span=False):
             pass
+    elif MODE in ("sync_start_value_error", "sync_start_other_error"):
+        # A failure has to leave the span scope for the span to see it. Two kinds, because the
+        # handler that used to sit inside that scope only named ValueError: async_start raises a
+        # raw ValueError when a cyclic graph hits max_iterations, while a component failure
+        # arrives wrapped as ComponentBuildError and took the other path entirely.
+        if MODE == "sync_start_value_error":
+            from lfx.components.input_output import TextInputComponent, TextOutputComponent
+            from lfx.components.logic.conditional_router import ConditionalRouterComponent
+            from lfx.custom import Component
+            from lfx.io import MessageTextInput
+            from lfx.schema.message import Message
+
+            class Concatenate(Component):
+                display_name = "Concatenate"
+                name = "Concatenate"
+                inputs = [MessageTextInput(name="text", display_name="Text", required=False)]
+                outputs = [Output(display_name="Message", name="some_text", method="concatenate")]
+
+                def concatenate(self) -> Message:
+                    return Message(text=f"{self.text}{self.text}" or "test")
+
+            text_input = TextInputComponent(_id="text_input")
+            router = ConditionalRouterComponent(_id="router")
+            text_input.set(input_value=router.false_response)
+            concat = Concatenate(_id="concatenate")
+            concat.set(text=text_input.text_response)
+            router.set(
+                input_text=text_input.text_response,
+                match_text="testtesttesttest",
+                operator="equals",
+                false_case_message=concat.concatenate,
+            )
+            text_output = TextOutputComponent(_id="text_output")
+            text_output.set(input_value=router.true_response)
+            end = ChatOutput(_id="chat_output")
+            end.set(input_value=text_output.text_response)
+            failing_graph = Graph(text_input, end)
+            runner = lambda: list(failing_graph.start(max_iterations=2, config={"output": {"cache": False}}))
+        else:
+            from lfx.custom import Component
+            from lfx.io import MessageInput
+            from lfx.schema.message import Message
+
+            class Exploding(Component):
+                display_name = "Exploding"
+                name = "Exploding"
+                inputs = [MessageInput(name="input_value", display_name="Input")]
+                outputs = [Output(name="message", display_name="Message", method="respond")]
+
+                def respond(self) -> Message:
+                    raise TypeError("not a ValueError")
+
+            chat_input = ChatInput(_id="chat-input")
+            chat_input.set(input_value="hello")
+            middle = Exploding(_id="exploding")
+            middle.set(input_value=chat_input.message_response)
+            chat_output = ChatOutput(_id="chat-output")
+            chat_output.set(input_value=middle.respond)
+            failing_graph = Graph(chat_input, chat_output, flow_id="11111111-1111-1111-1111-111111111111")
+            runner = lambda: list(failing_graph.start())
+
+        try:
+            runner()
+        except Exception as exc:  # noqa: BLE001 - the probe reports it rather than failing
+            raised = type(exc).__name__
     elif MODE == "sync_start_under_a_caller_span":
         # The sync entry point hands the run to a worker thread, and a new thread starts with an
         # empty context, so the flow span has to be given the caller's or it begins its own trace.
@@ -90,6 +157,8 @@ async def main():
             "trace_id": s.context.trace_id,
             "parent": s.parent.span_id if s.parent else None,
             "links": [link.context.span_id for link in s.links],
+            "status": (s.attributes or {}).get("status"),
+            "error_type": (s.attributes or {}).get("error.type"),
         }
         for s in exporter.get_finished_spans()
     ]
@@ -101,6 +170,7 @@ async def main():
                 "inner_parent": inner_parent,
                 "caller_trace": caller_ids[0] if caller_ids else None,
                 "caller_span": caller_ids[1] if caller_ids else None,
+                "raised": raised,
             }
         )
     )
@@ -177,3 +247,33 @@ def test_the_sync_start_runs_under_the_caller_span():
         f"flow span is in trace {flow_spans[0]['trace_id']:032x}, caller is in {result['caller_trace']:032x}"
     )
     assert flow_spans[0]["parent"] == result["caller_span"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_error"),
+    [
+        ("sync_start_value_error", "ValueError"),
+        ("sync_start_other_error", "ComponentBuildError"),
+    ],
+)
+def test_a_failing_sync_run_reaches_the_caller_and_the_span(mode: str, expected_error: str):
+    """A failure has to leave the span scope, then be caught at the worker boundary.
+
+    Caught inside the scope, the context manager exits cleanly and the run's telemetry is wrong.
+    Not caught at all, the exception dies with the worker thread while the caller reads the
+    end-of-stream sentinel and sees a clean finish. Both halves are asserted here because the
+    old code did one of each: the ValueError handler sat inside the span, and everything else
+    propagated past it and was lost.
+
+    Measured before the fix, for the ValueError case: the exception reached the caller but no
+    flow span was exported at all, because the consumer raises the moment it is queued, the
+    generator is abandoned and the worker never finishes ending the span.
+    """
+    result = run_probe(mode)
+
+    assert result["raised"] == expected_error, result
+
+    flow_spans = [s for s in result["spans"] if s["name"] == "flow.execute"]
+    assert len(flow_spans) == 1, result["spans"]
+    assert flow_spans[0]["status"] == "error", flow_spans[0]
+    assert flow_spans[0]["error_type"] == expected_error, flow_spans[0]

--- a/src/lfx/tests/unit/mcp/test_mcp_tool_span.py
+++ b/src/lfx/tests/unit/mcp/test_mcp_tool_span.py
@@ -88,6 +88,8 @@ async def main():
     # The real helper, not a stand-in span: async_start opens it with make_current=False, and
     # that is the path where parenting was silently wrong.
     graph = Graph()
+    # True is the converted shape: a coroutine caller owns the span, so it is current for the
+    # whole run. False is what async_start could do on its own, and could not make current.
     make_current = sys.argv[2] == "true"
     with graph.flow_execution_span(make_current=make_current):
         flow_span_id = trace.get_current_span().get_span_context().span_id
@@ -242,20 +244,13 @@ def test_http_server_attribute_strips_url_userinfo(url, expected_server):
     assert "secret-token" not in attributes["mcp.server"]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "async_start opens the flow span with make_current=False, so nothing downstream can see "
-        "it: the tool span starts a fresh trace instead of nesting. Not a flip of that flag, "
-        "which is False on purpose (attaching a context token across an async generator's "
-        "suspension points leaks it into whatever task resumes the generator). Carrying the span "
-        "context out of band, so a call site can parent to it without attaching, is a design "
-        "decision this test is here to hold open rather than pre-empt. The probe cannot even read "
-        "the flow span id on that path, which is the same gap seen from the other side."
-    ),
-    strict=True,
-)
-def test_the_tool_span_nests_under_the_flow_span_when_it_is_not_current(detached_probe_result):
-    """The acceptance criterion says 'parented to the flow span', and on this path it is not."""
+def test_a_detached_flow_span_cannot_parent_the_tool_span(detached_probe_result):
+    """Why the span had to move to the caller, pinned so the reason does not get lost.
+
+    A span that is not current cannot be a parent: the tool span starts its own trace instead.
+    That is what async_start could do on its own, being a generator, and it is why the callers
+    now open the span and pass open_flow_span=False.
+    """
     tool_span = next(s for s in detached_probe_result["spans"] if s["name"] == "mcp.tool.call")
 
-    assert tool_span["parent_span_id"] == detached_probe_result["flow_span_id"]
+    assert tool_span["parent_span_id"] is None


### PR DESCRIPTION
## What

A span opened during a flow run did not nest under the flow span on runs driven through `async_start` — the path the coordinator uses, which is the agentic assistant, the lfx CLI, and `lfx run`.

`async_start` is an async generator, so a span it opens cannot be made current: the context token would be attached and detached across the generator's suspension points and leak into whatever task resumed it. A span that is not current cannot parent anything.

Under HTTP the effect is a sibling of the server span rather than a child of `flow.execute` — same trace, flat. With no ambient span (`lfx run`, preload, `Graph.start`) it is a separate trace entirely.

## Approach

The callers are coroutines and thread entry points, which have no such problem, so the span moves to them. `async_start` takes `open_flow_span=False` to say the caller already owns one.

Converted: the agentic assistant (both coordinator consumers — the served path), `lfx/cli/common.py`, `lfx/run/base.py`, `preload.py`, and `Graph.start`. `coordinator.run_to_completion` needed nothing; it is a coroutine and feeds `arun`, which already opened its span correctly.

The flag defaults to `True`, so a caller that has not been converted still gets a span rather than silently none. Those runs keep today's flat shape, which is why this can land without converting everything at once.

## The mistake the flag makes possible

Deferring and then not opening one. That is silent — the run just produces no flow span — so `async_start` warns when it is told the caller owns the span and no span is current. It warns rather than raising, because telemetry must never take a run down.

## Verification

| Case | Assertion |
| --- | --- |
| Caller opens the span | a span opened mid-run parents to it, and there is exactly one flow span |
| Caller does not (unconverted) | still exactly one flow span, and it does not parent the run |
| Deferred, nobody opened one | no flow span at all — the case the warning covers |

The middle row is what fails without this change: a caller that wrapped the run got **two** flow spans, its own and `async_start`'s.

The nesting assertion in `test_mcp_tool_span.py` was a strict xfail and is now real. Its counterpart is kept, asserting a detached span cannot parent, so the reason the span had to move does not get lost.

`752 passed` across graph, mcp and execution. Two catalog-policy tests fail there and fail identically with these changes stashed.

## Known gaps

Only the callers listed above are converted. Anything else reaching `async_start` keeps the flat shape until it opts in — visible in the code as the absence of `open_flow_span=False`, not as missing telemetry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution tracing so flow and tool activity appears under the correct parent span.
  * Prevented duplicate or missing flow spans across asynchronous, synchronous, command-line, and background executions.
  * Improved consistency when execution is initiated within an existing tracing context.

* **Tests**
  * Added coverage for flow-span ownership, nesting, and detached execution scenarios to help ensure reliable observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->