### PR TITLE
fix: correct sync GET-status session_id; gate result cache behind a flag

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow_execution.py
+++ b/src/backend/base/langflow/api/v2/workflow_execution.py
@@ -455,24 +455,34 @@ async def execute_sync_workflow_with_timeout(
         raise WorkflowTimeoutError from e
 
 
-async def _persist_sync_result(job_service, job_id: UUID, workflow_response, flow_id) -> None:
-    """Best-effort cache of a completed sync run's outputs into ``Job.result``.
+async def _persist_sync_result(job_service, job_id: UUID, workflow_response, request_blob: dict, flow_id) -> None:
+    """Best-effort cache of a completed sync run's outputs + request for GET status.
 
-    Stores the same ``{component_id, ...ComponentOutput}`` list shape the background
-    runner writes, so a later GET status on this sync job_id rebuilds an identical
-    response via ``workflow_response_from_output_events``. The caller already holds
-    the response inline, so a persistence failure must never fail the run — it is
-    logged and swallowed.
+    Writes two things so a later GET status on this sync job_id rebuilds the SAME
+    response the caller received inline:
 
-    The run has already executed and succeeded upstream; this helper only caches
-    the finished result, so EVERY exception it can raise (serialization or the
-    ``set_result`` DB write — e.g. a SQLite ``OperationalError`` under lock
-    contention) is a persistence failure, never a workflow failure. Catch broadly
-    so such an error cannot escape to the caller's terminal ``except Exception`` and
-    be misreported as a failed run. ``asyncio.CancelledError`` is a ``BaseException``
-    and still propagates, so timeouts/disconnects are unaffected.
+    * ``job_metadata["request"]`` — the submit request (mirrors what the background
+      service persists). The GET completed-status path resolves the session from it
+      (``persisted_request.get("session_id")``); only the background service writes
+      this blob, so without it a sync GET would degrade ``session_id`` to the flow id.
+    * ``Job.result`` — the ``{component_id, ...ComponentOutput}`` list shape the
+      background runner stores, rebuilt by ``workflow_response_from_output_events``.
+
+    The request blob is written FIRST so the GET completed-status invariant holds: a
+    persisted ``Job.result`` always has its session alongside it. If the result write
+    then fails, GET falls back to vertex-build reconstruction (which resolves the
+    session independently) instead of serving a result with a flow-id session.
+
+    The caller gates this on ``sync_result_storage_enabled``. The run has already
+    executed and succeeded upstream, so EVERY exception this can raise (serialization
+    or a DB write — e.g. a SQLite ``OperationalError`` under lock contention) is a
+    persistence failure, never a workflow failure. Catch broadly so such an error
+    cannot escape to the caller's terminal ``except Exception`` and be misreported as
+    a failed run. ``asyncio.CancelledError`` is a ``BaseException`` and still
+    propagates, so timeouts/disconnects are unaffected.
     """
     try:
+        await job_service.update_job_metadata(job_id, {"request": request_blob})
         output_events = [
             {"component_id": component_id, **output.model_dump(mode="json")}
             for component_id, output in (workflow_response.outputs or {}).items()
@@ -619,10 +629,21 @@ async def execute_sync_workflow(
             effective_globals=request_variables,
             selected_ids=parsed.output_ids,
         )
-        # Persist the terminal outputs to Job.result so a later GET status on this
-        # sync job_id returns the same outputs the background path stores (same
-        # list-of-OutputEvent shape, so the status read is protocol-uniform).
-        await _persist_sync_result(job_service, job_id, workflow_response, flow.id)
+        # Optionally cache the completed run's outputs + request to the job row so a
+        # later GET status returns the same response. Off by default: sync callers
+        # already hold the full response inline, so this is an opt-in per-request
+        # write for consumers that poll GET status for a sync job. The request blob
+        # mirrors the background service's shape (identifying fields only, no tweaks/
+        # globals — those may carry secrets); GET resolves the session from it.
+        if get_settings_service().settings.sync_result_storage_enabled:
+            request_blob = {
+                "flow_id": str(flow.id),
+                "mode": "sync",
+                "session_id": execution_session_id,
+                "input_value": parsed.input_value,
+                "output_ids": parsed.output_ids,
+            }
+            await _persist_sync_result(job_service, job_id, workflow_response, request_blob, flow.id)
         return workflow_response  # noqa: TRY300 — keep response-building under the broad except below
 
     except GraphPausedException as exc:

--- a/src/backend/tests/unit/api/v2/test_workflow_background.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_background.py
@@ -343,39 +343,89 @@ async def test_finalize_job_status_still_writes_terminal_for_running_job():
     fake_service.update_job_status.assert_awaited_once()
 
 
-async def test_sync_run_persists_job_result(client, created_api_key, bg_flow):
-    """A sync run persists its outputs to Job.result so a later GET status returns them.
+def _enable_sync_persistence(monkeypatch) -> None:
+    """Turn on the opt-in sync-result cache (``sync_result_storage_enabled`` is off by default)."""
+    from lfx.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "sync_result_storage_enabled", True)
+
+
+async def test_sync_run_persists_job_result_when_enabled(client, created_api_key, bg_flow, monkeypatch):
+    """With the flag ON, a sync run caches BOTH its outputs and session for GET status.
 
     Sync already creates a Job row (to support HITL suspend + run_id-keyed builds);
-    this asserts the completed run now also writes Job.result in the same
-    list-of-OutputEvent shape the background path stores, so the status read is
-    protocol-uniform across sync and background.
+    with ``sync_result_storage_enabled`` the completed run also writes Job.result
+    (list-of-OutputEvent shape) and the session to job_metadata, so a later GET
+    status rebuilds the SAME response the caller got inline — outputs AND session_id.
     """
     from uuid import UUID
 
     from langflow.services.database.models.jobs.model import Job
 
-    body = {"flow_id": bg_flow, "mode": "sync", "input_value": "hi"}
+    _enable_sync_persistence(monkeypatch)
+
+    body = {"flow_id": bg_flow, "mode": "sync", "input_value": "hi", "session_id": "ab-session-marker"}
     resp = await client.post("api/v2/workflows", json=body, headers=_headers(created_api_key))
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["status"] == "completed", data
     assert data["outputs"], f"sync response carried no outputs: {data}"
+    assert data["session_id"] == "ab-session-marker"  # inline response is the source of truth
     job_id = data["job_id"]
 
-    # Job.result persisted (same {status, outputs:[...]} blob the runner writes).
+    # Job.result + session persisted on the job row.
     async with session_scope() as session:
         row = await session.get(Job, UUID(job_id))
     assert row is not None
     assert isinstance(row.result, dict), f"Job.result not a dict: {row.result!r}"
-    assert row.result.get("outputs"), f"Job.result has no outputs: {row.result}"
+    assert row.result.get("outputs"), f"Job.result has no outputs: {row.result!r}"
+    assert (row.job_metadata or {}).get("request", {}).get("session_id") == "ab-session-marker"
 
-    # GET status reconstructs the same outputs from Job.result.
+    # GET status returns the SAME outputs AND session_id — not the flow id (regression guard).
     status = await client.get("api/v2/workflows", params={"job_id": job_id}, headers=_headers(created_api_key))
     assert status.status_code == 200, status.text
     sbody = status.json()
     assert sbody["status"] == "completed"
     assert sbody["outputs"], f"GET status carried no outputs for sync job: {sbody}"
+    assert sbody["session_id"] == "ab-session-marker", (
+        f"GET status must report the submitted session, not the flow id: {sbody['session_id']}"
+    )
+
+
+async def test_sync_run_does_not_persist_result_by_default(client, created_api_key, bg_flow):
+    """With the flag OFF (default), a sync run leaves Job.result unwritten.
+
+    The caller already holds outputs + session inline, so the default path adds no
+    per-request result write. GET status still works via vertex-build reconstruction,
+    which resolves the REAL session (the pre-#14353 path) — never the flow id.
+    """
+    from uuid import UUID
+
+    from langflow.services.database.models.jobs.model import Job
+
+    body = {"flow_id": bg_flow, "mode": "sync", "input_value": "hi", "session_id": "ab-session-marker"}
+    resp = await client.post("api/v2/workflows", json=body, headers=_headers(created_api_key))
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["session_id"] == "ab-session-marker"
+    job_id = data["job_id"]
+
+    # Default off: no result blob cached.
+    async with session_scope() as session:
+        row = await session.get(Job, UUID(job_id))
+    assert row is not None
+    assert not (isinstance(row.result, dict) and row.result.get("outputs")), (
+        f"sync result should not be cached when the flag is off: {row.result!r}"
+    )
+
+    # GET status still resolves the real session via vertex-build reconstruction.
+    status = await client.get("api/v2/workflows", params={"job_id": job_id}, headers=_headers(created_api_key))
+    assert status.status_code == 200, status.text
+    sbody = status.json()
+    assert sbody["session_id"] == "ab-session-marker", (
+        f"reconstruction must report the submitted session, not the flow id: {sbody['session_id']}"
+    )
 
 
 async def test_sync_run_survives_result_persist_db_error(client, created_api_key, bg_flow, monkeypatch):
@@ -387,7 +437,10 @@ async def test_sync_run_survives_result_persist_db_error(client, created_api_key
     ``OperationalError`` — not in the old ``(RuntimeError, ValueError, OSError)``
     tuple) used to escape and be misreported by the terminal ``except Exception``
     as a FAILED run. Assert the run still returns 200 ``completed`` with outputs,
-    and that ``Job.result`` was left unwritten (persistence genuinely failed).
+    that ``Job.result`` was left unwritten (persistence genuinely failed), and that
+    GET status still reports the REAL session — never a flow-id degradation. The
+    request blob is written BEFORE the result, so a result-write failure can never
+    leave a cached result paired with a degraded session (the invariant).
     """
     from uuid import UUID
 
@@ -395,13 +448,15 @@ async def test_sync_run_survives_result_persist_db_error(client, created_api_key
     from langflow.services.jobs.service import JobService
     from sqlalchemy.exc import OperationalError
 
+    _enable_sync_persistence(monkeypatch)
+
     async def _raise_locked(self, *args, **kwargs):  # noqa: ARG001
         statement = "UPDATE jobs SET result=?"
         raise OperationalError(statement, {}, Exception("database is locked"))
 
     monkeypatch.setattr(JobService, "set_result", _raise_locked)
 
-    body = {"flow_id": bg_flow, "mode": "sync", "input_value": "hi"}
+    body = {"flow_id": bg_flow, "mode": "sync", "input_value": "hi", "session_id": "ab-session-marker"}
     resp = await client.post("api/v2/workflows", json=body, headers=_headers(created_api_key))
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -416,4 +471,11 @@ async def test_sync_run_survives_result_persist_db_error(client, created_api_key
     assert row is not None
     assert not (isinstance(row.result, dict) and row.result.get("outputs")), (
         f"Job.result should be unwritten after a set_result failure: {row.result!r}"
+    )
+
+    # Invariant: a result-write failure never yields a degraded-session GET.
+    status = await client.get("api/v2/workflows", params={"job_id": data["job_id"]}, headers=_headers(created_api_key))
+    assert status.status_code == 200, status.text
+    assert status.json()["session_id"] == "ab-session-marker", (
+        f"result-persist failure must not degrade GET session to the flow id: {status.json()['session_id']}"
     )

--- a/src/lfx/src/lfx/services/settings/groups/telemetry.py
+++ b/src/lfx/src/lfx/services/settings/groups/telemetry.py
@@ -20,6 +20,14 @@ class TelemetrySettings(BaseModel):
     """If set to True, Langflow will track transactions between flows."""
     vertex_builds_storage_enabled: bool = True
     """If set to True, Langflow will keep track of each vertex builds (outputs) in the UI for any flow."""
+    sync_result_storage_enabled: bool = False
+    """If set to True, a completed ``mode=sync`` workflow run caches its outputs to ``Job.result``
+    (and its session to ``job_metadata``) so a later GET status on that job_id returns them.
+
+    Off by default: sync callers already receive the full outputs and session_id in the inline
+    response, so persisting them again is an extra per-request job-row write with no documented
+    consumer. Enable only for a client that submits sync runs and later polls GET status. Background
+    runs are unaffected — they always persist their result (the caller is detached and must poll)."""
 
     telemetry_writer_enabled: bool = True
     """Route transaction and vertex_build writes through an async batched writer backed by a

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -118,6 +118,7 @@ EXPECTED_FIELDS = {
     "telemetry_base_url",
     "transactions_storage_enabled",
     "vertex_builds_storage_enabled",
+    "sync_result_storage_enabled",
     "deactivate_tracing",
     # ObservabilitySettings
     "prometheus_enabled",


### PR DESCRIPTION
## Summary
Completed `mode=sync` runs reported `session_id == flow_id` on `GET /api/v2/workflows` (regression from #14353). GET's COMPLETED path resolves the session from `job_metadata["request"]`, which only the background path writes  for sync it was absent, so the session degraded to the flow id.

## Changes
- New setting `sync_result_storage_enabled` (**default off**) gating the sync-result cache. Off → no per-request write; GET resolves session via vertex-build reconstruction.
- When on: persist the submit request to `job_metadata` **before** `Job.result`, so a cached result always carries its session. Request blob = identifying fields only (no `tweaks`/`globals`).
- Fixed the `_persist_sync_result` docstring.

## Tests
Flag-on (GET session == submitted), flag-off default (session via reconstruction), and result-persist DB failure (session never degrades). `EXPECTED_FIELDS` updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to save successful synchronous workflow results for later status checks.
  * Saved results include the submitted session information, enabling consistent response recovery.
  * Result storage is disabled by default and does not affect background workflow runs.

* **Bug Fixes**
  * Improved resilience when result persistence fails: completed workflows still return successfully, without cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->