### PR TITLE
fix(frontend): scope model picker to the typed enabled-models map

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/build-grouped-options.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/build-grouped-options.test.ts
@@ -15,6 +15,7 @@ const opt = (
 
 const base = {
   enabledModels: undefined,
+  enabledModelsByType: undefined,
   providers: undefined,
   modelType: "llm",
   savedValue: undefined,
@@ -194,5 +195,89 @@ describe("buildGroupedOptions", () => {
     });
     expect(grouped.OpenAI).toHaveLength(1);
     expect(grouped.OpenAI[0].metadata?.not_enabled_locally).toBeUndefined();
+  });
+
+  describe("typed enabled-models map", () => {
+    // An OpenAI-compatible gateway serves chat and embedding models under one
+    // provider. Live discovery cannot tell them apart (`/models` carries no
+    // capability data), so it stamps every model with the type that was
+    // requested — leaving the typed enabled-map as the only usable signal.
+    const CHAT = "gpt-4o-mini";
+    const EMBED = "text-embedding-3-small";
+
+    const gateway: ModelProviderWithStatus[] = [
+      {
+        provider: "OpenAI",
+        is_enabled: true,
+        is_configured: true,
+        models: [
+          { model_name: CHAT, metadata: { model_type: "embeddings" } },
+          { model_name: EMBED, metadata: { model_type: "embeddings" } },
+        ],
+      } as ModelProviderWithStatus,
+    ];
+
+    const flat = { OpenAI: { [CHAT]: true, [EMBED]: true } };
+    const typed = {
+      OpenAI: {
+        llm: { [CHAT]: true, [EMBED]: false },
+        embeddings: { [CHAT]: false, [EMBED]: true },
+      },
+    };
+
+    it("keeps a chat model out of the embedding picker", () => {
+      const grouped = buildGroupedOptions({
+        ...base,
+        modelType: "embeddings",
+        options: [
+          opt(CHAT, "OpenAI", { model_type: "embeddings" }),
+          opt(EMBED, "OpenAI", { model_type: "embeddings" }),
+        ],
+        enabledModels: flat,
+        enabledModelsByType: typed,
+      });
+      expect(grouped.OpenAI.map((o) => o.name)).toEqual([EMBED]);
+    });
+
+    it("scopes the augment pass too, not just the saved options", () => {
+      // Nothing saved: every candidate arrives from the provider registry,
+      // which is how the picker is normally populated.
+      const grouped = buildGroupedOptions({
+        ...base,
+        modelType: "embeddings",
+        options: [],
+        providers: gateway,
+        enabledModels: flat,
+        enabledModelsByType: typed,
+      });
+      expect(grouped.OpenAI.map((o) => o.name)).toEqual([EMBED]);
+    });
+
+    it("falls back to the flat map when no typed map is reported", () => {
+      // Older servers omit `enabled_models_by_type`; behaviour is unchanged,
+      // including the pre-existing cross-type leak.
+      const grouped = buildGroupedOptions({
+        ...base,
+        modelType: "embeddings",
+        options: [],
+        providers: gateway,
+        enabledModels: flat,
+      });
+      expect(grouped.OpenAI.map((o) => o.name).sort()).toEqual(
+        [CHAT, EMBED].sort(),
+      );
+    });
+
+    it("treats a provider with no entry for the requested type as having none enabled", () => {
+      const grouped = buildGroupedOptions({
+        ...base,
+        modelType: "embeddings",
+        options: [opt(CHAT, "OpenAI", { model_type: "embeddings" })],
+        providers: gateway,
+        enabledModels: flat,
+        enabledModelsByType: { OpenAI: { llm: { [CHAT]: true } } },
+      });
+      expect(grouped).toEqual({});
+    });
   });
 });

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/build-grouped-options.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/build-grouped-options.ts
@@ -3,9 +3,25 @@ import type { ModelOption } from "../types";
 
 type EnabledModels = Record<string, Record<string, boolean>>;
 
+/**
+ * Type-aware counterpart of {@link EnabledModels}, keyed
+ * provider -> model type -> name -> enabled.
+ */
+type EnabledModelsByType = Record<
+  string,
+  Partial<Record<string, Record<string, boolean>>>
+>;
+
 export interface BuildGroupedOptionsParams {
   options: ModelOption[];
   enabledModels: EnabledModels | undefined;
+  /**
+   * Per-type enabled-models map, authoritative for any provider it lists.
+   * `enabledModels` merges `llm` and `embeddings` into a single record, so a
+   * model enabled for chat also reads as enabled for embeddings there. Older
+   * servers omit this map, leaving the flat one as the only available signal.
+   */
+  enabledModelsByType: EnabledModelsByType | undefined;
   providers: ModelProviderWithStatus[] | undefined;
   modelType: string;
   savedValue: ModelOption | undefined;
@@ -44,6 +60,7 @@ function passesModelFilters(
 export function buildGroupedOptions({
   options,
   enabledModels,
+  enabledModelsByType,
   providers,
   modelType,
   savedValue,
@@ -52,6 +69,23 @@ export function buildGroupedOptions({
 }: BuildGroupedOptionsParams): Record<string, ModelOption[]> {
   const grouped: Record<string, ModelOption[]> = {};
   const seen = new Set<string>();
+
+  const hasEnabledStatus = !!enabledModels || !!enabledModelsByType;
+
+  /**
+   * Enabled-status record to filter `providerName` against. Prefers the typed
+   * map so a model enabled for another type cannot pass as enabled for this
+   * one. A provider listed there but carrying no entry for `modelType` has
+   * nothing enabled for it, hence `{}` — filtering every candidate out rather
+   * than falling through to the type-agnostic map.
+   */
+  const enabledStatusFor = (
+    providerName: string,
+  ): Record<string, boolean> | undefined => {
+    const typed = enabledModelsByType?.[providerName];
+    if (typed) return typed[modelType] ?? {};
+    return enabledModels?.[providerName];
+  };
   const disconnectedProviders = new Set(
     providerStatusIsReliable
       ? (providers ?? [])
@@ -72,11 +106,11 @@ export function buildGroupedOptions({
     // Filter against client-side enabled models data. This is the source of
     // truth for what the current user has enabled — stale `options` saved in
     // an imported flow may include models from providers the current user
-    // hasn't enabled (e.g. WatsonX). When the provider is tracked in
-    // enabled_models, the model must be explicitly enabled (=== true); a
+    // hasn't enabled (e.g. WatsonX). When the provider is tracked in the
+    // enabled-status map, the model must be explicitly enabled (=== true); a
     // `false` or missing entry means the model should be hidden.
-    if (enabledModels) {
-      const providerModels = enabledModels[provider];
+    if (hasEnabledStatus) {
+      const providerModels = enabledStatusFor(provider);
       if (providerModels && providerModels[option.name] !== true) {
         continue;
       }
@@ -98,17 +132,21 @@ export function buildGroupedOptions({
     seen.add(`${provider}::${option.name}`);
   }
 
-  if (enabledModels && providers) {
+  if (hasEnabledStatus && providers) {
     for (const providerInfo of providers) {
       const providerName = providerInfo.provider;
       if (disconnectedProviders.has(providerName)) continue;
-      const providerModels = enabledModels[providerName];
+      const providerModels = enabledStatusFor(providerName);
       if (!providerModels) continue;
 
       for (const model of providerInfo.models ?? []) {
         const modelName = model.model_name;
         if (providerModels[modelName] !== true) continue;
 
+        // Weaker second line of defence: live discovery stamps each model with
+        // the type that was requested, so against an OpenAI-compatible
+        // endpoint every candidate claims `modelType` and this cannot separate
+        // them on its own — `enabledStatusFor` is what actually scopes them.
         const modelMetadata = (model.metadata ?? {}) as Record<string, unknown>;
         const modelMetadataType = modelMetadata.model_type;
         if (

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -166,6 +166,7 @@ export default function ModelInputComponent({
       buildGroupedOptions({
         options,
         enabledModels: enabledModelsData?.enabled_models,
+        enabledModelsByType: enabledModelsData?.enabled_models_by_type,
         providers: providersData,
         modelType,
         savedValue: value?.[0],


### PR DESCRIPTION
## Problem

`EnabledModelsResponse` documents that the flat `enabled_models` map is a
fallback for older servers only, and that callers must prefer
`enabled_models_by_type` whenever the provider reports one:

```ts
/**
 * Type-aware status map. Older servers omit this field; callers must only
 * fall back to enabled_models when the selected provider has no typed map.
 */
enabled_models_by_type?: ...
```

No caller honours it. `buildGroupedOptions` accepts only the flat map, and
`enabled_models_by_type` has zero consumers in the frontend -- the field is
declared, the backend populates it, nothing reads it.

Because the flat map merges `llm` and `embeddings` into a single
`provider -> name -> bool` record, a model enabled for chat also reads as
enabled for embeddings.

## Impact

Most visible against an OpenAI-compatible gateway configured through
`OPENAI_BASE_URL`, where a single provider commonly serves both kinds.

On such a gateway the **Create Knowledge Base** embedding picker offered nine
options: the models enabled for chat plus the two genuinely enabled embedding
models -- exactly the union of the `llm` and `embeddings` maps, even though
the typed map correctly reported only the two embedding models for that type.

A chat model sorted first and became the **pre-selected default** for building
a vector store. Selecting one fails at ingestion with an opaque
`JSONDecodeError: Expecting value: line 1 column 1 (char 0)`, because the
gateway's reply to an embeddings request against a chat model is not a valid
embeddings payload.

Turning those models off in the **Embedding Models** section of the provider
settings had no effect: the backend recorded the change correctly under the
`embeddings` type, but the picker never consulted the typed map.

## Why the existing guard does not catch this

The augment pass compares each model's own `model_type` metadata against the
requested type. That cannot separate these candidates: live discovery stamps
every model it fetches with the type that was *requested*
(`fetch_live_openai_compatible_models`), so such a provider reports each model
twice -- once as `llm`, once as `embeddings`. Every candidate claims the type
being asked for and the comparison always passes.

## Fix

`buildGroupedOptions` now takes the typed map alongside the flat one and
resolves the enabled-status record through a single helper, used by both
filter passes:

```ts
const enabledStatusFor = (providerName: string) => {
  const typed = enabledModelsByType?.[providerName];
  if (typed) return typed[modelType] ?? {};
  return enabledModels?.[providerName];
};
```

A provider listed in the typed map but carrying no entry for `modelType` has
nothing enabled for it, so this resolves to `{}` and filters every candidate
out rather than falling through to the type-agnostic map.

`enabledModelsByType` is a required param so the type checker forces every
call site to state its intent; `ModelInputComponent` passes
`enabledModelsData?.enabled_models_by_type`.

No backend or API change: the typed map is already returned by
`GET /api/v1/models/enabled_models`.

## Verification

Against a live OpenAI-compatible gateway, the embedding picker narrows to the
two models actually enabled for embeddings, and the default selection becomes
an embedding model instead of a chat model:

| | before | after |
|---|---|---|
| options offered | 9 | 2 |
| chat models present | yes | no |
| default selection | a chat model | an embedding model |

Tests:

- 4 new cases in `build-grouped-options.test.ts` -- typed map scopes the saved
  options; typed map scopes the augment pass (the path that actually populates
  the picker); fallback to the flat map when no typed map is reported; a
  provider with no entry for the requested type has nothing enabled
- `build-grouped-options`: 16 passed
- `modelInputComponent` suites: 89 passed
- `knowledgeBaseUploadModal` suites: 95 passed
- biome clean, no new tsc errors

## Notes

The language-model picker benefits symmetrically: embedding models can no
longer leak into it when a provider has both kinds enabled.

Behaviour is unchanged for servers that omit `enabled_models_by_type` -- the
pre-existing suites cover that path, since their fixtures only provide the
flat map.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model availability filtering based on the selected model type.
  * Ensured saved and provider-listed models are filtered consistently.
  * Providers without enabled models for the selected type no longer display unavailable options.
  * Retained compatibility with existing model availability data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->