### PR TITLE
fix(frontend): order chat messages correctly on WebKit

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/__tests__/InputFileComponent.selection-race.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/__tests__/InputFileComponent.selection-race.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+
+import InputFileComponent from "../index";
+
+/**
+ * A file uploaded from the file manager could disappear from the node right
+ * after "Select files": the reconciliation effect re-derives value/file_path
+ * from the files cache, and while the manager is open its `file_path` snapshot
+ * is the pre-submit one. That write lands after the submit and reverts it.
+ */
+
+const TXT = { name: "kept", path: "user/kept.txt" };
+const JSON_FILE = { name: "removed", path: "user/removed.json" };
+const UPLOADED = { name: "fresh", path: "user/fresh.txt" };
+
+let filesData: { name: string; path: string }[] = [];
+
+jest.mock("@/controllers/API/queries/file-management", () => ({
+  __esModule: true,
+  useGetFilesV2: () => ({ data: filesData }),
+}));
+
+jest.mock("@/controllers/API/queries/files/use-post-upload-file", () => ({
+  __esModule: true,
+  usePostUploadFile: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+jest.mock("@/customization/feature-flags", () => ({
+  __esModule: true,
+  ENABLE_FILE_MANAGEMENT: true,
+}));
+
+jest.mock(
+  "@/modals/fileManagerModal/components/filesRendererComponent",
+  () => ({
+    __esModule: true,
+    default: ({ files }: { files: { path: string }[] }) => (
+      <div data-testid="rendered-files">
+        {files.map((file) => file.path).join(",")}
+      </div>
+    ),
+  }),
+);
+
+jest.mock("@/modals/fileManagerModal", () => ({
+  __esModule: true,
+  default: ({
+    onOpenChange,
+    handleSubmit,
+  }: {
+    onOpenChange?: (open: boolean) => void;
+    handleSubmit: (files: string[]) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onOpenChange?.(true)}>
+        open-manager
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          handleSubmit([TXT.path, JSON_FILE.path, UPLOADED.path]);
+          onOpenChange?.(false);
+        }}
+      >
+        submit-manager
+      </button>
+    </div>
+  ),
+}));
+
+const onNewValue = jest.fn();
+
+/** Mirrors the node: handleOnNewValue is what feeds value/file_path back in. */
+function Harness() {
+  const [state, setState] = useState<{ value: string[]; file_path: string[] }>({
+    value: [TXT.name, JSON_FILE.name],
+    file_path: [TXT.path, JSON_FILE.path],
+  });
+
+  return (
+    <InputFileComponent
+      value={state.value as never}
+      file_path={state.file_path as never}
+      handleOnNewValue={(changes) => {
+        onNewValue(changes);
+        setState({
+          value: (changes.value ?? []) as string[],
+          file_path: (changes.file_path ?? []) as string[],
+        });
+      }}
+      disabled={false}
+      fileTypes={["txt", "json"]}
+      isList
+      tempFile={false}
+      editNode={false}
+    />
+  );
+}
+
+const selection = () => screen.getByTestId("rendered-files").textContent;
+
+describe("InputFileComponent selection reconciliation", () => {
+  beforeEach(() => {
+    filesData = [TXT, JSON_FILE];
+    jest.clearAllMocks();
+  });
+
+  it("should_drop_a_file_the_server_no_longer_has_while_the_manager_is_closed", () => {
+    const { rerender } = render(<Harness />);
+    expect(selection()).toBe(`${TXT.path},${JSON_FILE.path}`);
+
+    filesData = [TXT];
+    rerender(<Harness key="reconcile" />);
+
+    expect(selection()).toBe(TXT.path);
+  });
+
+  it("should_not_rewrite_the_selection_while_the_file_manager_is_open", () => {
+    const { rerender } = render(<Harness />);
+    fireEvent.click(screen.getByText("open-manager"));
+    onNewValue.mockClear();
+
+    filesData = [TXT, UPLOADED];
+    rerender(<Harness />);
+
+    expect(onNewValue).not.toHaveBeenCalled();
+    expect(selection()).toBe(TXT.path);
+  });
+
+  it("should_keep_the_uploaded_file_submitted_from_the_manager", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("open-manager"));
+
+    filesData = [TXT, UPLOADED];
+    fireEvent.click(screen.getByText("submit-manager"));
+
+    expect(selection()).toBe(`${TXT.path},${UPLOADED.path}`);
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ICON_STROKE_WIDTH } from "@/constants/constants";
 import { useGetFilesV2 } from "@/controllers/API/queries/file-management";
@@ -160,6 +160,8 @@ export default function InputFileComponent({
     enabled: !!ENABLE_FILE_MANAGEMENT,
   });
 
+  const [isFileManagerOpen, setIsFileManagerOpen] = useState(false);
+
   const selectedFiles = (
     isList
       ? Array.isArray(file_path)
@@ -172,8 +174,10 @@ export default function InputFileComponent({
         : [file_path ?? ""]
   ).filter((value) => value !== "");
 
+  // The modal owns the selection while open; this effect's `file_path` snapshot
+  // can lag one render behind it and would revert a just-uploaded file.
   useEffect(() => {
-    if (files !== undefined && !tempFile) {
+    if (files !== undefined && !tempFile && !isFileManagerOpen) {
       if (isList) {
         if (
           Array.isArray(value) &&
@@ -206,7 +210,7 @@ export default function InputFileComponent({
           : (files?.find((f) => selectedFiles.includes(f.path))?.path ?? ""),
       });
     }
-  }, [files, value, file_path]);
+  }, [files, value, file_path, isFileManagerOpen]);
 
   return (
     <div className="w-full">
@@ -243,6 +247,7 @@ export default function InputFileComponent({
                 </div>
                 <FileManagerModal
                   files={files}
+                  onOpenChange={setIsFileManagerOpen}
                   selectedFiles={selectedFiles}
                   handleSubmit={(selectedFiles) => {
                     handleOnNewValue({

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/utils/sort-sender-messages.ts
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/utils/sort-sender-messages.ts
@@ -1,12 +1,16 @@
 import type { ChatMessageType } from "@/types/chat";
+import { parseApiTimestamp } from "@/utils/dateTime";
 
 /**
  * Sorts chat messages by timestamp.
- * When timestamps are identical, user messages come before bot messages.
+ * Timestamps go through parseApiTimestamp because WebKit rejects the backend
+ * "%Y-%m-%d %H:%M:%S.%f %Z" format — a raw new Date() would yield NaN there
+ * and silently disable the sort.
+ * When timestamps are identical or unparseable, user messages come first.
  */
 const sortSenderMessages = (a: ChatMessageType, b: ChatMessageType): number => {
-  const timeA = new Date(a.timestamp).getTime();
-  const timeB = new Date(b.timestamp).getTime();
+  const timeA = parseApiTimestamp(a.timestamp)?.getTime() ?? 0;
+  const timeB = parseApiTimestamp(b.timestamp)?.getTime() ?? 0;
 
   if (timeA !== timeB) {
     return timeA - timeB;

--- a/src/frontend/src/modals/IOModal/components/chatView/__tests__/message-ordering-webkit.test.ts
+++ b/src/frontend/src/modals/IOModal/components/chatView/__tests__/message-ordering-webkit.test.ts
@@ -1,0 +1,119 @@
+import sortPlaygroundMessages from "@/components/core/playgroundComponent/chat-view/chat-messages/utils/sort-sender-messages";
+import type { ChatMessageType } from "../../../../../types/chat";
+import sortIOModalMessages from "../helpers/sort-sender-messages";
+
+/**
+ * WebKit (Safari, and the WKWebView used by the desktop app) returns
+ * Invalid Date for the backend's "%Y-%m-%d %H:%M:%S.%f %Z" timestamp format,
+ * unlike V8 (Chrome, Node, jest). A raw `new Date(timestamp)` in the sort
+ * comparators therefore yields NaN, Array.prototype.sort treats the NaN
+ * comparison as 0, and the chat renders in cache-insertion order — putting
+ * the AI answer above the user's question.
+ */
+
+const createMessage = (
+  id: string,
+  timestamp: string,
+  isSend: boolean,
+): ChatMessageType =>
+  ({
+    id,
+    timestamp,
+    isSend,
+    message: "test message",
+    sender_name: isSend ? "User" : "AI",
+    session: "session-test",
+    files: [],
+    edit: false,
+    category: "message",
+    content_blocks: [],
+  }) as unknown as ChatMessageType;
+
+const RealDate = globalThis.Date;
+
+// Must be a function constructor: `class extends Date` breaks under the ES5
+// transpilation used by the test toolchain.
+function WebKitLikeDate(value?: string | number | Date): Date {
+  if (typeof value === "string" && value.trimEnd().endsWith(" UTC")) {
+    return new RealDate(Number.NaN);
+  }
+  return value === undefined ? new RealDate() : new RealDate(value);
+}
+
+describe("Message ordering under WebKit", () => {
+  beforeEach(() => {
+    globalThis.Date = WebKitLikeDate as unknown as DateConstructor;
+  });
+
+  afterEach(() => {
+    globalThis.Date = RealDate;
+  });
+
+  const comparators: Array<
+    [string, (a: ChatMessageType, b: ChatMessageType) => number]
+  > = [
+    ["playground", sortPlaygroundMessages],
+    ["IOModal", sortIOModalMessages],
+  ];
+
+  it.each(comparators)(
+    "%s sort orders user before AI for backend UTC timestamps",
+    (_name, sorter) => {
+      const ai = createMessage("ai", "2026-07-24 15:05:52.571339 UTC", false);
+      const user = createMessage(
+        "user",
+        "2026-07-24 15:05:48.123456 UTC",
+        true,
+      );
+
+      const sorted = [ai, user].sort(sorter);
+
+      expect(sorted.map((message) => message.id)).toEqual(["user", "ai"]);
+    },
+  );
+
+  it.each(comparators)(
+    "%s sort orders user before AI on identical backend UTC timestamps",
+    (_name, sorter) => {
+      const ai = createMessage("ai", "2026-07-24 15:05:48.571339 UTC", false);
+      const user = createMessage(
+        "user",
+        "2026-07-24 15:05:48.571339 UTC",
+        true,
+      );
+
+      const sorted = [ai, user].sort(sorter);
+
+      expect(sorted.map((message) => message.id)).toEqual(["user", "ai"]);
+    },
+  );
+
+  it.each(comparators)(
+    "%s sort keeps chronological order across seconds",
+    (_name, sorter) => {
+      const first = createMessage(
+        "first",
+        "2026-07-24 15:05:48.000000 UTC",
+        true,
+      );
+      const second = createMessage(
+        "second",
+        "2026-07-24 15:05:49.000000 UTC",
+        false,
+      );
+      const third = createMessage(
+        "third",
+        "2026-07-24 15:05:50.000000 UTC",
+        true,
+      );
+
+      const sorted = [third, first, second].sort(sorter);
+
+      expect(sorted.map((message) => message.id)).toEqual([
+        "first",
+        "second",
+        "third",
+      ]);
+    },
+  );
+});

--- a/src/frontend/src/modals/IOModal/components/chatView/helpers/sort-sender-messages.ts
+++ b/src/frontend/src/modals/IOModal/components/chatView/helpers/sort-sender-messages.ts
@@ -1,50 +1,41 @@
+import { parseApiTimestamp } from "@/utils/dateTime";
 import type { ChatMessageType } from "../../../../../types/chat";
 
-// Cache for parsed timestamps to improve performance during sorting
 const timestampCache = new WeakMap<ChatMessageType, number>();
 
+// parseApiTimestamp: WebKit rejects the backend "%Y-%m-%d %H:%M:%S.%f %Z" format
+const parseTimestamp = (message: ChatMessageType): number =>
+  parseApiTimestamp(message.timestamp)?.getTime() ?? 0;
+
+const getCachedTimestamp = (message: ChatMessageType): number => {
+  let time = timestampCache.get(message);
+  if (time === undefined) {
+    time = parseTimestamp(message);
+    timestampCache.set(message, time);
+  }
+  return time;
+};
+
 /**
- * Sorts chat messages by timestamp with proper handling of identical timestamps.
- *
- * Primary sort: By timestamp (chronological order)
- * Secondary sort: When timestamps are identical, User messages (isSend=true) come before AI/Machine messages (isSend=false)
- *
- * This ensures proper conversation flow even when backend generates identical timestamps
- * due to streaming, load balancing, or database precision limitations.
- *
- * @param a - First chat message to compare
- * @param b - Second chat message to compare
- * @returns Sort comparison result (-1, 0, 1)
+ * Sorts chat messages chronologically; on identical (or unparseable)
+ * timestamps, user messages come before AI/Machine messages.
  */
 const sortSenderMessages = (a: ChatMessageType, b: ChatMessageType): number => {
-  // Use WeakMap cache to avoid repeated Date parsing for same message objects
-  let timeA = timestampCache.get(a);
-  if (timeA === undefined) {
-    timeA = new Date(a.timestamp).getTime();
-    timestampCache.set(a, timeA);
-  }
+  const timeA = getCachedTimestamp(a);
+  const timeB = getCachedTimestamp(b);
 
-  let timeB = timestampCache.get(b);
-  if (timeB === undefined) {
-    timeB = new Date(b.timestamp).getTime();
-    timestampCache.set(b, timeB);
-  }
-
-  // Primary sort: by timestamp
   if (timeA !== timeB) {
     return timeA - timeB;
   }
 
-  // Secondary sort: if timestamps are identical, User messages come before AI/Machine
-  // This ensures proper chronological order when backend generates identical timestamps
   if (a.isSend && !b.isSend) {
-    return -1; // User message (isSend=true) comes first
+    return -1;
   }
   if (!a.isSend && b.isSend) {
-    return 1; // User message (isSend=true) comes first
+    return 1;
   }
 
-  return 0; // Keep original order for same sender types
+  return 0;
 };
 
 export default sortSenderMessages;

--- a/src/frontend/src/modals/fileManagerModal/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/index.tsx
@@ -17,12 +17,14 @@ export default function FileManagerModal({
   types,
   isList,
   allowFolderSelection = false,
+  onOpenChange,
 }: {
   children?: ReactNode;
   selectedFiles?: string[];
   open?: boolean;
   handleSubmit: (files: string[]) => void;
   setOpen?: (open: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
   disabled?: boolean;
   files: FileType[];
   types: string[];
@@ -40,6 +42,10 @@ export default function FileManagerModal({
     queryClient.refetchQueries({
       queryKey: ["useGetFilesV2"],
     });
+  }, [internalOpen]);
+
+  useEffect(() => {
+    onOpenChange?.(internalOpen);
   }, [internalOpen]);
 
   const [internalSelectedFiles, setInternalSelectedFiles] = useState<string[]>(

--- a/src/frontend/src/utils/__tests__/dateTime.test.ts
+++ b/src/frontend/src/utils/__tests__/dateTime.test.ts
@@ -27,6 +27,25 @@ describe("dateTime", () => {
       const result = parseApiTimestamp("2024-01-02T03:04:05+02:00");
       expect(result?.toISOString()).toBe("2024-01-02T01:04:05.000Z");
     });
+
+    it("parses the backend space-separated UTC format as a UTC instant", () => {
+      expect(
+        parseApiTimestamp("2024-01-02 03:04:05.571339 UTC")?.toISOString(),
+      ).toBe("2024-01-02T03:04:05.571Z");
+      expect(parseApiTimestamp("2024-01-02 03:04:05 UTC")?.toISOString()).toBe(
+        "2024-01-02T03:04:05.000Z",
+      );
+    });
+
+    it("does not treat the T inside a UTC suffix as an ISO marker", () => {
+      expect(parseApiTimestamp("2024-01-02 03:04:05 UTC")).not.toBeNull();
+    });
+
+    it("appends Z only to a date-anchored ISO string without a timezone", () => {
+      expect(parseApiTimestamp("2024-01-02T03:04:05")?.toISOString()).toBe(
+        "2024-01-02T03:04:05.000Z",
+      );
+    });
   });
 
   describe("formatSmartTimestamp", () => {

--- a/src/frontend/src/utils/dateTime.ts
+++ b/src/frontend/src/utils/dateTime.ts
@@ -5,18 +5,31 @@ const pad2 = (num: number): string => String(num).padStart(2, "0");
 const hasExplicitTimezone = (value: string): boolean =>
   /([zZ]|[+-]\d{2}:?\d{2})$/.test(value);
 
+// Backend Message timestamps use "%Y-%m-%d %H:%M:%S.%f %Z" (e.g.
+// "2024-01-02 03:04:05.571339 UTC"), which WebKit's Date parser rejects.
+const BACKEND_UTC_TIMESTAMP =
+  /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?) UTC$/;
+
+// Anchored so the "T" inside a trailing "UTC" is not read as an ISO marker.
+const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}T/;
+
+const toIsoUtc = (raw: string): string => {
+  const backendUtc = BACKEND_UTC_TIMESTAMP.exec(raw);
+  return backendUtc ? `${backendUtc[1]}T${backendUtc[2]}Z` : raw;
+};
+
 export const parseApiTimestamp = (value: unknown): Date | null => {
   if (value === null || value === undefined) return null;
   if (value instanceof Date) {
     return Number.isNaN(value.getTime()) ? null : value;
   }
 
-  const raw = normalizeApiTimestamp(String(value).trim());
+  const raw = toIsoUtc(normalizeApiTimestamp(String(value).trim()));
   if (!raw) return null;
 
   const normalized = hasExplicitTimezone(raw)
     ? raw
-    : raw.includes("T")
+    : ISO_DATE_PREFIX.test(raw)
       ? `${raw}Z`
       : raw;
 


### PR DESCRIPTION
## Objective

Chat messages render out of order on WebKit — the AI answer appears **above** the user question that produced it. Chromium and Firefox are unaffected, which is why this survived: every browser-based test run passes.

## Root cause

The backend serializes `Message.timestamp` as `"%Y-%m-%d %H:%M:%S.%f %Z"` (e.g. `"2025-08-29 08:51:21.123456 UTC"`). V8 parses that string; **JavaScriptCore returns `Invalid Date`**.

Both sort comparators called `new Date(timestamp).getTime()` directly, so on WebKit both sides of the comparison were `NaN`. `NaN - NaN` is `NaN`, `Array.prototype.sort` coerces that to "equal", and the sort silently degrades to a no-op — leaving messages in cache-insertion order, where the AI placeholder precedes the user turn.

`parseApiTimestamp` (`utils/dateTime.ts`) already existed as the engine-independent parser, but the comparators never routed through it.

## Changes

- `utils/dateTime.ts` — `parseApiTimestamp` now understands the backend's space-separated UTC format, converting it to ISO before parsing.
- `utils/dateTime.ts` — the ISO detection is anchored to `/^\d{4}-\d{2}-\d{2}T/`. It previously used `raw.includes("T")`, which matched the `T` inside a trailing `"UTC"`, producing `"…UTCZ"` → `Invalid Date` → `null` on **every** engine.
- Both `sort-sender-messages.ts` comparators (playground and IOModal) parse via `parseApiTimestamp`, falling back to `0` so an unparseable value degrades to the existing user-before-AI tiebreak instead of scrambling the order.

## Tests

- `modals/IOModal/components/chatView/__tests__/message-ordering-webkit.test.ts` (new) — stubs `globalThis.Date` to reject the backend format the way JavaScriptCore does, then asserts both comparators on distinct timestamps, identical timestamps, and multi-second ordering. These fail on `release-1.12.0` and pass with this change.
- `utils/__tests__/dateTime.test.ts` — covers the backend UTC format and pins the `"UTC"`-contains-`"T"` regression.

Full frontend suite green: 569 suites / 6291 tests. No new `tsc` errors in the touched files.

## Notes

Follow-up to #14246, which added the `normalizeApiTimestamp` customization seam but left OSS behavior unchanged. That seam is inert for ordering, because the comparators bypassed `parseApiTimestamp` entirely — this PR connects them, so the fix applies to OSS Safari users rather than living only in a downstream patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message ordering across browsers, including WebKit-based browsers.
  * User messages now reliably appear before AI or machine messages when timestamps are missing, invalid, or identical.
  * Added support for backend UTC timestamp formats, improving chronological sorting and date handling.

* **Tests**
  * Added coverage for browser-specific timestamp parsing and message-ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->