### PR TITLE
test(observability): run the claims that admit the database and URL spans

### DIFF
--- a/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
+++ b/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
@@ -8,6 +8,7 @@ Each case runs in a subprocess because the tracer provider is process-global.
 
 import gzip
 import http.server
+import json
 import os
 import subprocess
 import sys
@@ -54,8 +55,106 @@ def test_outbound_http_scopes_stay_out_of_the_allowlist():
 
 
 def test_database_spans_are_allowlisted():
-    """Verified separately to carry bound-parameter placeholders, never row values."""
+    """The scope is on the list. What it carries is the next test, which is the part that matters."""
     assert "opentelemetry.instrumentation.sqlalchemy" in APPLICATION_INSTRUMENTATION_SCOPES
+
+
+# Admitting the SQLAlchemy scope rests on one claim: db.statement keeps bound parameters as
+# placeholders, so row values stay in the database. That claim is why chat message text is
+# considered safe from this signal, and it was carried by a comment and a membership check
+# rather than by running a query. This runs the query.
+#
+# The membership check alone passes in every way this can actually break: the instrumentor not
+# installed, instrument() raising and being swallowed, or a future version rendering literals
+# into the statement.
+DB_SENTINEL = "SENTINEL-chat-row-value-QQQ"
+
+DB_SPAN_PROBE = f"""
+import json, sys
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from sqlalchemy import create_engine, text
+
+from lfx.observability import ApplicationOnlySpanProcessor, instrument_database
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+SENTINEL = {DB_SENTINEL!r}
+literal = len(sys.argv) > 1 and sys.argv[1] == "literal"
+
+engine = create_engine("sqlite+pysqlite:///:memory:")
+instrument_database(engine)
+
+with engine.connect() as connection:
+    connection.execute(text("CREATE TABLE messagetable (text VARCHAR)"))
+    if literal:
+        # What a regression to literal rendering would look like. Never how the runtime writes.
+        connection.execute(text("INSERT INTO messagetable (text) VALUES ('" + SENTINEL + "')"))
+    else:
+        # A bound parameter, the shape the runtime uses to store a chat message.
+        connection.execute(text("INSERT INTO messagetable (text) VALUES (:text)"), {{"text": SENTINEL}})
+    connection.commit()
+
+provider.force_flush()
+spans = [
+    {{
+        "name": s.name,
+        "scope": s.instrumentation_scope.name if s.instrumentation_scope else None,
+        "attrs": {{k: str(v) for k, v in (s.attributes or {{}}).items()}},
+    }}
+    for s in exporter.get_finished_spans()
+]
+print("PROBE_RESULT " + json.dumps({{"spans": spans}}))
+"""  # noqa: S608 - the interpolated INSERT is the control, not a query we run
+
+
+def _run_db_probe(*args: str) -> list[dict]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", DB_SPAN_PROBE, *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
+    spans = json.loads(line.removeprefix("PROBE_RESULT "))["spans"]
+    return [s for s in spans if s["scope"] == "opentelemetry.instrumentation.sqlalchemy"]
+
+
+def test_a_database_span_carries_the_placeholder_and_not_the_row_value():
+    """The claim that admits this scope, run rather than asserted.
+
+    A chat message is stored through a bound parameter, so if the instrumentation rendered
+    values into ``db.statement`` the conversation would reach the operator's APM on a scope we
+    allowlisted on the strength of it not doing that.
+    """
+    db_spans = _run_db_probe()
+
+    # Not a formality: without it this passes when the instrumentor is missing entirely.
+    assert db_spans, "no sqlalchemy spans were exported"
+
+    statements = [s["attrs"].get("db.statement", "") for s in db_spans]
+    assert any("INSERT INTO messagetable" in statement for statement in statements), statements
+    assert DB_SENTINEL not in json.dumps(db_spans), f"a bound row value reached the APM: {db_spans}"
+
+
+def test_the_probe_would_have_seen_a_row_value_in_the_statement():
+    """The control, because every assertion above is an absence and an absence proves nothing.
+
+    Same probe, same exporter, the value interpolated into the SQL instead of bound.
+    """
+    db_spans = _run_db_probe("literal")
+
+    assert db_spans
+    assert DB_SENTINEL in json.dumps(db_spans), "the probe cannot see a value in db.statement at all"
 
 
 # The ticket's sampler criterion, run against the real bootstrap rather than a hand-built

--- a/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
+++ b/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
@@ -142,7 +142,9 @@ def test_a_database_span_carries_the_placeholder_and_not_the_row_value():
     assert db_spans, "no sqlalchemy spans were exported"
 
     statements = [s["attrs"].get("db.statement", "") for s in db_spans]
-    assert any("INSERT INTO messagetable" in statement for statement in statements), statements
+    # The placeholder, not just the verb: a statement truncated to "INSERT INTO messagetable"
+    # would satisfy a looser check and satisfy the sentinel check for the wrong reason.
+    assert any("INSERT INTO messagetable (text) VALUES (?)" in statement for statement in statements), statements
     assert DB_SENTINEL not in json.dumps(db_spans), f"a bound row value reached the APM: {db_spans}"
 
 

--- a/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
+++ b/src/backend/tests/unit/services/telemetry/test_dependency_spans.py
@@ -124,8 +124,11 @@ def _run_db_probe(*args: str) -> list[dict]:
         check=False,
     )
     assert completed.returncode == 0, completed.stderr
-    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
-    spans = json.loads(line.removeprefix("PROBE_RESULT "))["spans"]
+    # Not next(): a probe that exits cleanly without printing would raise StopIteration here and
+    # take its own stdout and stderr with it, which is the context needed to see why.
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    spans = json.loads(lines[0].removeprefix("PROBE_RESULT "))["spans"]
     return [s for s in spans if s["scope"] == "opentelemetry.instrumentation.sqlalchemy"]
 
 

--- a/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
+++ b/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
@@ -149,6 +149,9 @@ def test_redaction_keeps_the_host_and_path_an_operator_needs():
 
     for key in ("http.url", "url.full"):
         assert attrs[key] == "https://db.internal:5432/records", attrs[key]
+    # http.target too, and by value: the probe sets it, so blanking it would pass the
+    # secret-is-absent check above while losing the route the attribute exists to carry.
+    assert attrs["http.target"] == "/records", attrs["http.target"]
     # Nothing outside the URL attributes is touched.
     assert attrs["server.address"] == "db.internal"
 

--- a/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
+++ b/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
@@ -79,8 +79,11 @@ def run_probe(source: str) -> dict:
             check=False,
         )
     assert completed.returncode == 0, completed.stderr
-    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
-    return json.loads(line.removeprefix("PROBE_RESULT "))
+    # Not next(): a probe that exits cleanly without printing would raise StopIteration here and
+    # take its own stdout and stderr with it, which is the context needed to see why.
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    return json.loads(lines[0].removeprefix("PROBE_RESULT "))
 
 
 def test_the_serve_api_key_never_reaches_the_apm():
@@ -95,6 +98,7 @@ def test_the_serve_api_key_never_reaches_the_apm():
 def test_redaction_keeps_the_route_an_operator_needs():
     """Blanking everything would be safe and useless; path and method must survive."""
     result = run_probe(SERVER_SPAN_PROBE)
+    assert result["spans"], "expected a server span carrying url.path"
     attrs = result["spans"][0]["attrs"]
 
     assert attrs["url.path"] == "/flows/run"
@@ -145,7 +149,11 @@ def test_a_credential_in_the_authority_never_reaches_the_apm():
 
 def test_redaction_keeps_the_host_and_path_an_operator_needs():
     """Blanking the URL entirely would pass the test above and lose the point of the attribute."""
-    attrs = run_probe(USERINFO_SPAN_PROBE)["spans"][0]["attrs"]
+    result = run_probe(USERINFO_SPAN_PROBE)
+    # Asserted before indexing: an empty list would otherwise surface as an IndexError, which
+    # says nothing about why the probe produced no span.
+    assert result["spans"], "expected the probe span"
+    attrs = result["spans"][0]["attrs"]
 
     for key in ("http.url", "url.full"):
         assert attrs[key] == "https://db.internal:5432/records", attrs[key]

--- a/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
+++ b/src/backend/tests/unit/services/telemetry/test_span_url_redaction.py
@@ -102,6 +102,57 @@ def test_redaction_keeps_the_route_an_operator_needs():
     assert attrs["http.request.method"] == "GET"
 
 
+# The server span carries the credential in a query string, which is the leak that prompted the
+# redaction. It is not the only shape: ``http.url`` and ``url.full`` carry a whole URL, and the
+# vendors that document a collector endpoint with userinfo in the authority put the credential
+# there instead. The redaction handles both; only the query half was covered.
+USERINFO_SPAN_PROBE = f"""
+import json
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lfx.observability import APPLICATION_TRACER_NAME, ApplicationOnlySpanProcessor
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+SECRET = {SECRET!r}
+
+tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
+with tracer.start_as_current_span("probe.outbound") as span:
+    span.set_attribute("http.url", f"https://svc:{{SECRET}}@db.internal:5432/records?token={{SECRET}}")
+    span.set_attribute("url.full", f"https://svc:{{SECRET}}@db.internal:5432/records?token={{SECRET}}")
+    span.set_attribute("http.target", f"/records?token={{SECRET}}")
+    span.set_attribute("server.address", "db.internal")
+
+provider.force_flush()
+spans = [{{"name": s.name, "attrs": dict(s.attributes or {{}})}} for s in exporter.get_finished_spans()]
+print("PROBE_RESULT " + json.dumps({{"spans": spans}}))
+"""
+
+
+def test_a_credential_in_the_authority_never_reaches_the_apm():
+    """Userinfo is the other half of the same leak, and several vendors document it that way."""
+    result = run_probe(USERINFO_SPAN_PROBE)
+
+    assert result["spans"], "expected the probe span"
+    assert SECRET not in json.dumps(result["spans"]), f"a URL credential reached the APM: {result['spans']}"
+
+
+def test_redaction_keeps_the_host_and_path_an_operator_needs():
+    """Blanking the URL entirely would pass the test above and lose the point of the attribute."""
+    attrs = run_probe(USERINFO_SPAN_PROBE)["spans"][0]["attrs"]
+
+    for key in ("http.url", "url.full"):
+        assert attrs[key] == "https://db.internal:5432/records", attrs[key]
+    # Nothing outside the URL attributes is touched.
+    assert attrs["server.address"] == "db.internal"
+
+
 def test_outbound_http_scopes_stay_out_of_the_allowlist():
     """Redacting URLs does not make the LLM transports safe to export; that boundary stands."""
     for scope in (


### PR DESCRIPTION
Two boundary claims in the dependency-span work were carried by a membership check and a comment rather than by exercising the thing they describe. Both gaps were raised by CodeRabbit on #14420; it merged before they were addressed, so this is the follow-up.

## The database claim

The SQLAlchemy scope is on the export allowlist, and the reason it is allowed is specific: `db.statement` keeps bound parameters as placeholders, so chat message text stays in the database and out of the APM. The comment in `observability.py` even says "Verified by probe, because 'it probably does not log values' is how the httpx hole got opened the first time."

There was no probe. The test was:

```python
def test_database_spans_are_allowlisted():
    """Verified separately to carry bound-parameter placeholders, never row values."""
    assert "opentelemetry.instrumentation.sqlalchemy" in APPLICATION_INSTRUMENTATION_SCOPES
```

That asserts a string is in a frozenset. It passes when the instrumentor is not installed, when `instrument()` raises and gets swallowed by the `except Exception` in `_instrument_sqlalchemy`, and if a future version starts rendering literals into the statement — which is exactly the regression the allowlist entry is betting against.

Now a real sqlite engine runs a real parameterized INSERT with a sentinel row value, through `instrument_database`, and the exported span is inspected. Measured:

```
bound    db.statement = 'INSERT INTO messagetable (text) VALUES (?)'
literal  db.statement = "INSERT INTO messagetable (text) VALUES ('SENTINEL-chat-row-value-QQQ')"
```

The second line is the paired control: same probe, value interpolated into the SQL instead of bound. It asserts the sentinel **is** visible, because every other assertion here is an absence and an absence on its own proves nothing — it would read the same if the probe were broken or the instrumentor silent.

## The URL claim

Redaction was covered for `url.query` only. `http.url` and `url.full` carry a whole URL, and a collector endpoint documented with userinfo puts the credential in the authority rather than the query. `_redact_url_attributes` handles both; only one half was tested.

Adds a span carrying `http.url`, `url.full` and `http.target` with a credential in both positions, and asserts it is gone while scheme, host, port and path survive — blanking the attribute entirely would pass a "secret is absent" test and lose the reason the attribute exists.

Verified out of band that the same span exports the credential in full through a processor without the redaction, so this test is not passing for the wrong reason:

```
WITHOUT the redacting processor -> secret present: True
  attr = https://svc:<secret>@db.internal:5432/records?token=<secret>
```

## Scope

Tests only. No production code changes. `src/backend/tests/unit/services/telemetry/`: 167 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Privacy**
  - Improved telemetry safeguards to prevent database parameter values from appearing in exported spans.
  - Enhanced URL redaction to remove embedded credentials while preserving useful host, port, and path information.

- **Tests**
  - Added coverage for database parameter handling and credential removal across URL attributes.
  - Added validation to detect potential sensitive-data leaks in telemetry output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->