### PR TITLE
fix(docker): pin npm and select newest Node 22 in backend/ep images

### DIFF
--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -67,18 +67,23 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-# Install Node.js (required for npx-based MCP stdio servers)
+# Install Node.js (required for npx-based MCP stdio servers).
+# The version is scraped from the latest-v22.x directory listing; `sort -V | tail -1`
+# picks the genuine newest release instead of whatever the listing prints first.
+# npm is pinned to a major known to support the Node 22 line: `npm@latest` floats
+# across majors and raises its `engines` floor without warning (npm 12 requires
+# node ^22.22.2 || ^24.15.0 || >=26.0.0), which breaks the build with EBADENGINE.
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
+                    | sort -V | tail -1) \
     && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@11
 
 # Create non-root user
 RUN useradd --uid 1000 --gid 0 --no-create-home --home-dir /app/data user

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -115,17 +115,23 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
+# Install Node.js (required for npx-based MCP stdio servers).
+# The version is scraped from the latest-v22.x directory listing; `sort -V | tail -1`
+# picks the genuine newest release instead of whatever the listing prints first.
+# npm is pinned to a major known to support the Node 22 line: `npm@latest` floats
+# across majors and raises its `engines` floor without warning (npm 12 requires
+# node ^22.22.2 || ^24.15.0 || >=26.0.0), which breaks the build with EBADENGINE.
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
                     | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
+                    | sort -V | tail -1) \
     && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@11
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv


### PR DESCRIPTION
## Problem

`docker/build_and_push_backend.Dockerfile` and `docker/build_and_push_ep.Dockerfile` both end their Node install layer with:

```dockerfile
&& npm install -g npm@latest
```

`npm@latest` floats across **majors**. npm 12.0.0 raised its engines floor to `{"node": "^22.22.2 || ^24.15.0 || >=26.0.0"}`, so any build landing on an older Node 22 patch now dies with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.16.0"}
```

These branches happen to build today only because `https://nodejs.org/dist/latest-v22.x/` currently serves 22.23.2, which clears npm 12's floor by a hair. That is luck, not design — the next npm major with a raised floor breaks image builds again with no change on our side.

## Changes

Applied identically to both Dockerfiles:

1. **`npm install -g npm@latest` → `npm install -g npm@11`.** npm 11.19.0 declares `engines: {"node": "^20.17.0 || >=22.9.0"}`, which covers the entire Node 22 line these images install, so an unannounced npm major can no longer break the build. This is still a large step up from the npm 10.9.2 bundled with Node 22.
2. **`| head -1` → `| sort -V | tail -1`** when scraping the `latest-v22.x` directory listing, so the genuine newest release is selected rather than whatever the listing happens to print first.
3. A comment block on each layer recording *why* the pin exists, so the next person doesn't "helpfully" restore `@latest`.

## Verification

Local build on `linux/arm64`:

```bash
docker build -t lf-backend-test --build-arg LANGFLOW_IMAGE=langflowai/langflow:latest-dev -f docker/build_and_push_backend.Dockerfile .
```

- Build exits 0.
- Resolved `NODE_VERSION=22.23.2`.
- Inside the resulting image: `node=v22.23.2 npm=11.19.0`, `npx` present.
- `sort -V` confirmed available on the `ubi10/python-314-minimal` base (coreutils-single).

## Notes

- `release-1.12.0` has exactly these two Dockerfiles using `npm@latest`. **`main` has five** — `build_and_push.Dockerfile`, `build_and_push_base.Dockerfile`, and `build_and_push_with_extras.Dockerfile` carry the same unpinned `npm@latest` and are not covered by a back-merge of this PR. They need the same treatment.
- Kept deliberately separate from any dependency PR so it can be reverted or merged on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime images now consistently install the latest available Node.js 22 release.
  * Added clearer handling when a compatible Node.js version cannot be found.
  * Standardized npm installation to version 11 for improved compatibility.

* **Documentation**
  * Added notes clarifying Node.js version selection and npm compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->