### PR TITLE
fix(docker): pin Node and npm major across all image variants

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -9,9 +9,14 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
+# Toolchain versions shared by every stage below. Keeping the Node version here
+# means the build and runtime stages cannot silently resolve different Nodes.
+ARG NODE_VERSION=22.23.2
+
 FROM ghcr.io/astral-sh/uv:latest AS uv_installer
 FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
 USER root
+ARG NODE_VERSION
 COPY --from=uv_installer /uv /usr/local/bin/uv
 COPY --from=uv_installer /uvx /usr/local/bin/uvx
 
@@ -38,7 +43,6 @@ RUN microdnf install -y tar xz python3.14-devel \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION="22.14.0" \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
     && microdnf clean all
@@ -108,17 +112,18 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
+# NODE_VERSION and the npm major below are coupled: npm 12 requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0. Pin the npm major rather than tracking
+# @latest, so the next npm major raising its engines floor cannot break this
+# layer unannounced against a pinned NODE_VERSION.
+ARG NODE_VERSION
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
-    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@12
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -8,6 +8,10 @@
 ################################
 # BUILDER
 ################################
+# Toolchain versions shared by every stage below. Keeping the Node version here
+# means the build and runtime stages cannot silently resolve different Nodes.
+ARG NODE_VERSION=22.23.2
+
 FROM ghcr.io/astral-sh/uv:latest AS uv_installer
 FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
 USER root
@@ -70,18 +74,19 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-# Install Node.js (required for npx-based MCP stdio servers)
+# Install Node.js (required for npx-based MCP stdio servers).
+# NODE_VERSION and the npm major below are coupled: npm 12 requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0. Pin the npm major rather than tracking
+# @latest, so the next npm major raising its engines floor cannot break this
+# layer unannounced against a pinned NODE_VERSION.
+ARG NODE_VERSION
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
-    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@12
 
 # Create non-root user
 RUN useradd --uid 1000 --gid 0 --no-create-home --home-dir /app/data user

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -10,6 +10,10 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
+# Toolchain versions shared by every stage below. Keeping the Node version here
+# means the build and runtime stages cannot silently resolve different Nodes.
+ARG NODE_VERSION=22.23.2
+
 FROM ghcr.io/astral-sh/uv:latest AS uv_installer
 FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
 USER root
@@ -111,17 +115,18 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
+# NODE_VERSION and the npm major below are coupled: npm 12 requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0. Pin the npm major rather than tracking
+# @latest, so the next npm major raising its engines floor cannot break this
+# layer unannounced against a pinned NODE_VERSION.
+ARG NODE_VERSION
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
-    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@12
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -9,6 +9,10 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
+# Toolchain versions shared by every stage below. Keeping the Node version here
+# means the build and runtime stages cannot silently resolve different Nodes.
+ARG NODE_VERSION=22.23.2
+
 FROM ghcr.io/astral-sh/uv:latest AS uv_installer
 FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
 USER root
@@ -99,17 +103,18 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
+# NODE_VERSION and the npm major below are coupled: npm 12 requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0. Pin the npm major rather than tracking
+# @latest, so the next npm major raising its engines floor cannot break this
+# layer unannounced against a pinned NODE_VERSION.
+ARG NODE_VERSION
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
-    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@12
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -9,6 +9,10 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
+# Toolchain versions shared by every stage below. Keeping the Node version here
+# means the build and runtime stages cannot silently resolve different Nodes.
+ARG NODE_VERSION=22.23.2
+
 FROM ghcr.io/astral-sh/uv:latest AS uv_installer
 FROM registry.access.redhat.com/ubi10/python-314-minimal AS builder
 USER root
@@ -99,17 +103,18 @@ RUN microdnf update -y \
 RUN python3.14 -m pip install --upgrade pip
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
+# NODE_VERSION and the npm major below are coupled: npm 12 requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0. Pin the npm major rather than tracking
+# @latest, so the next npm major raising its engines floor cannot break this
+# layer unannounced against a pinned NODE_VERSION.
+ARG NODE_VERSION
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
        elif [ "$ARCH" = "aarch64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
-    && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
-                    | head -1) \
-    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest
+    && npm install -g npm@12
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv


### PR DESCRIPTION
Ports the Node/npm layer shape that #14528 landed on `release-1.12.0` to `main`, where **five** Dockerfiles carry the same layer — three of which #14528 does not reach.

Supersedes #14530 (closed): that PR proposed `npm@11` + `sort -V | tail -1` against the old scrape-based layer, which #14528 replaced wholesale.

## Problem

Every runtime stage on `main` still ends its Node install with:

```dockerfile
&& npm install -g npm@latest
```

`npm@latest` floats across **majors**. npm 12.0.0 raised its engines floor to `{"node": "^22.22.2 || ^24.15.0 || >=26.0.0"}`, so a build landing on an older Node 22 patch dies with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.16.0"}
```

`main` builds today only because the `latest-v22.x` scrape currently returns 22.23.2, which clears that floor by a hair. That is luck, not design.

## Changes

Applied to all five variants — `build_and_push`, `build_and_push_backend`, `build_and_push_base`, `build_and_push_ep`, `build_and_push_with_extras`:

1. **Top-level `ARG NODE_VERSION=22.23.2`**, re-declared in each stage that installs Node, replacing the `latest-v22.x` directory scrape. Same value and same mechanism as `release-1.12.0`.
2. **`npm install -g npm@latest` → `npm install -g npm@12`**, so a future npm major raising its engines floor cannot break the layer unannounced against a pinned Node.
3. #14528's comment documenting that `NODE_VERSION` and the npm major are **coupled** — neither can be bumped without checking the other.

In `build_and_push.Dockerfile` this also folds the builder stage's separate literal (`NODE_VERSION="22.14.0"`) into the shared ARG, so the frontend build and the runtime image stop resolving different Node versions. #14528 made the identical change on `release-1.12.0`.

## Why match #14528 rather than keep the scrape

The two shared files (`build_and_push_backend`, `build_and_push_ep`) are now **byte-identical to `release-1.12.0` in this layer**, so the eventual back-merge of the release branch into `main` has nothing to resolve here. Keeping a different mechanism on `main` would have guaranteed a conflict in exactly these hunks.

## Verification

- `docker build --check` on all five: **no warnings, no errors**.
- Isolated layer on the real `ubi10/python-314-minimal` base: `node=v22.23.2 npm=12.0.2`, `npx` present. This specifically confirms the failure mode #14528 hit at 22.22.2 — where the bundled npm cannot self-upgrade to npm 12 in place (`MODULE_NOT_FOUND: promise-retry`) — does not occur at 22.23.2.
- Full build of `docker/build_and_push_backend.Dockerfile` on `linux/arm64`.
- The builder-stage Node bump (22.14.0 → 22.23.2, which compiles the frontend) is exercised by #14528's own `Test Docker Images` job on `release-1.12.0`, which passed.