### PR TITLE
test(observability): assert the flow span carries no exception event

### DIFF
--- a/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
+++ b/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
@@ -1,0 +1,188 @@
+"""Span *events* are the other carrier, and nothing asserted on them.
+
+Every leak assertion in the suite serialises ``span.attributes``. Events are a separate place a
+span can hold text, and the one that matters here is written by the SDK rather than by us:
+``record_exception`` puts the exception message into an event. That is precisely why the flow
+span opts out of it and sets ``error.type`` by hand.
+
+An attributes-only assertion cannot see that. Delete ``record_exception=False`` from
+``flow_execution_span`` and every existing test still passes while the exception message starts
+reaching the operator's APM on every failed run.
+
+Runs in a subprocess because the tracer provider is process-global.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+# The user's prompt. Present in the flow before anything fails, so a run that leaks inputs
+# rather than errors is caught by the same sweep.
+PROMPT = "SENTINELPROMPTQQQ"
+# The component's own failure text, which is what record_exception would write into an event.
+EXC_MESSAGE = "SENTINELCOMPONENTFAILUREQQQ"
+
+PROBE = '''
+import asyncio, json, os, sys
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.custom import Component
+from lfx.graph import Graph
+from lfx.io import MessageInput, Output
+from lfx.observability import APPLICATION_TRACER_NAME
+from lfx.schema.message import Message
+
+MODE = sys.argv[1]
+
+
+class Passthrough(Component):
+    """Stands in for an LLM component: it sees the prompt and makes no network call."""
+
+    display_name = "Passthrough"
+    name = "Passthrough"
+    inputs = [MessageInput(name="input_value", display_name="Input")]
+    outputs = [Output(name="message", display_name="Message", method="respond")]
+
+    def respond(self) -> Message:
+        if MODE == "failure":
+            raise RuntimeError("SENTINELCOMPONENTFAILUREQQQ")
+        return self.input_value
+
+
+def build():
+    chat_input = ChatInput(_id="chat-input")
+    chat_input.set(input_value="SENTINELPROMPTQQQ")
+    middle = Passthrough(_id="passthrough")
+    middle.set(input_value=chat_input.message_response)
+    chat_output = ChatOutput(_id="chat-output")
+    chat_output.set(input_value=middle.respond)
+    return Graph(chat_input, chat_output, flow_id="11111111-1111-1111-1111-111111111111")
+
+
+async def main():
+    if MODE == "control":
+        # Prove the dump below can see an event at all. Without this, "no events" reads the same
+        # whether the boundary holds or the probe never looked.
+        tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
+        with tracer.start_as_current_span("probe.control") as span:
+            span.record_exception(RuntimeError("SENTINELCOMPONENTFAILUREQQQ"))
+    else:
+        graph = build()
+        # arun, not async_start: async_start opens the span with make_current=False because it
+        # is an async generator, and a span that is never made current never enters use_span, so
+        # record_exception has nothing to act on there. arun makes it current, which is the path
+        # where the argument under test actually applies.
+        try:
+            await graph.arun(inputs=[{"input_value": "SENTINELPROMPTQQQ"}], outputs=["chat-output"])
+        except Exception:
+            pass
+
+    provider.force_flush()
+    spans = [
+        {
+            "name": s.name,
+            "scope": s.instrumentation_scope.name if s.instrumentation_scope else None,
+            "attributes": {k: str(v) for k, v in (s.attributes or {}).items()},
+            "events": [
+                {"name": e.name, "attributes": {k: str(v) for k, v in (e.attributes or {}).items()}}
+                for e in s.events
+            ],
+        }
+        for s in exporter.get_finished_spans()
+    ]
+    print("PROBE_RESULT " + json.dumps(spans))
+
+
+asyncio.run(main())
+'''
+
+
+def run_probe(mode: str) -> list[dict]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = Path(tmp) / "probe.py"
+        probe.write_text(PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe), mode],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    assert completed.returncode == 0, completed.stderr
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    return json.loads(lines[0].removeprefix("PROBE_RESULT "))
+
+
+def application_spans(spans: list[dict]) -> list[dict]:
+    return [s for s in spans if s["scope"] == "langflow.observability"]
+
+
+def test_a_successful_run_is_one_flow_span_and_no_component_spans():
+    """The unit of work is the run. A per-component span would also carry component payloads."""
+    spans = application_spans(run_probe("success"))
+
+    assert [s["name"] for s in spans] == ["flow.execute"], [s["name"] for s in spans]
+
+
+def test_the_prompt_reaches_neither_an_attribute_nor_an_event():
+    """The flow carries a prompt before anything fails, so a run that leaks inputs is caught too."""
+    spans = run_probe("success")
+
+    assert PROMPT not in json.dumps(spans)
+
+
+def test_a_failing_component_puts_its_message_in_no_event():
+    """The regression this file exists for.
+
+    ``record_exception`` writes the exception message into an event, so the flow span turns it
+    off and reports ``error.type`` instead. Deleting that argument leaves every attribute-only
+    assertion green while the message starts reaching the APM on every failed run.
+    """
+    spans = run_probe("failure")
+    flow_spans = [s for s in application_spans(spans) if s["name"] == "flow.execute"]
+
+    assert len(flow_spans) == 1, spans
+    assert flow_spans[0]["attributes"].get("status") == "error", flow_spans[0]["attributes"]
+    # The type is the whole point: it is what an operator gets instead of the message. arun wraps
+    # the component failure as ValueError("Error running graph: Error building Component
+    # Passthrough: <the component's message>"), so the message carries component output and only
+    # the type may cross.
+    assert flow_spans[0]["attributes"].get("error.type") == "ValueError"
+
+    assert flow_spans[0]["events"] == [], flow_spans[0]["events"]
+    assert EXC_MESSAGE not in json.dumps(spans)
+
+
+def test_the_probe_would_have_seen_an_exception_event():
+    """The control, because the assertions above are absences.
+
+    A probe that never reads events produces the same empty list as a span that has none.
+    """
+    spans = run_probe("control")
+    control = [s for s in spans if s["name"] == "probe.control"]
+
+    assert control, spans
+    assert control[0]["events"], "the probe cannot see span events at all"
+    assert EXC_MESSAGE in json.dumps(control[0]["events"])

--- a/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
+++ b/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
@@ -20,10 +20,11 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from string import Template
 
 import pytest
 
-pytest.importorskip("opentelemetry")
+pytest.importorskip("opentelemetry.sdk.trace.export.in_memory_span_exporter")
 
 # The user's prompt. Present in the flow before anything fails, so a run that leaks inputs
 # rather than errors is caught by the same sweep.
@@ -31,7 +32,7 @@ PROMPT = "SENTINELPROMPTQQQ"
 # The component's own failure text, which is what record_exception would write into an event.
 EXC_MESSAGE = "SENTINELCOMPONENTFAILUREQQQ"
 
-PROBE = '''
+PROBE_TEMPLATE = Template('''
 import asyncio, json, os, sys
 
 from opentelemetry import trace
@@ -64,13 +65,13 @@ class Passthrough(Component):
 
     def respond(self) -> Message:
         if MODE == "failure":
-            raise RuntimeError("SENTINELCOMPONENTFAILUREQQQ")
+            raise RuntimeError("$EXC_MESSAGE")
         return self.input_value
 
 
 def build():
     chat_input = ChatInput(_id="chat-input")
-    chat_input.set(input_value="SENTINELPROMPTQQQ")
+    chat_input.set(input_value="$PROMPT")
     middle = Passthrough(_id="passthrough")
     middle.set(input_value=chat_input.message_response)
     chat_output = ChatOutput(_id="chat-output")
@@ -84,7 +85,7 @@ async def main():
         # whether the boundary holds or the probe never looked.
         tracer = trace.get_tracer(APPLICATION_TRACER_NAME)
         with tracer.start_as_current_span("probe.control") as span:
-            span.record_exception(RuntimeError("SENTINELCOMPONENTFAILUREQQQ"))
+            span.record_exception(RuntimeError("$EXC_MESSAGE"))
     else:
         graph = build()
         # arun, not async_start: async_start opens the span with make_current=False because it
@@ -92,7 +93,7 @@ async def main():
         # record_exception has nothing to act on there. arun makes it current, which is the path
         # where the argument under test actually applies.
         try:
-            await graph.arun(inputs=[{"input_value": "SENTINELPROMPTQQQ"}], outputs=["chat-output"])
+            await graph.arun(inputs=[{"input_value": "$PROMPT"}], outputs=["chat-output"])
         except Exception:
             pass
 
@@ -113,14 +114,15 @@ async def main():
 
 
 asyncio.run(main())
-'''
+''')
 
 
 def run_probe(mode: str) -> list[dict]:
     env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    source = PROBE_TEMPLATE.substitute(PROMPT=PROMPT, EXC_MESSAGE=EXC_MESSAGE)
     with tempfile.TemporaryDirectory() as tmp:
         probe = Path(tmp) / "probe.py"
-        probe.write_text(PROBE, encoding="utf-8")
+        probe.write_text(source, encoding="utf-8")
         completed = subprocess.run(  # noqa: S603
             [sys.executable, str(probe), mode],
             env=env,
@@ -149,6 +151,11 @@ def test_a_successful_run_is_one_flow_span_and_no_component_spans():
 def test_the_prompt_reaches_neither_an_attribute_nor_an_event():
     """The flow carries a prompt before anything fails, so a run that leaks inputs is caught too."""
     spans = run_probe("success")
+
+    # Asserted before the absence: an empty list satisfies "the sentinel is not in here", so
+    # without this the check stops running the moment the probe stops producing spans, and stays
+    # green while it does.
+    assert [s for s in application_spans(spans) if s["name"] == "flow.execute"], spans
 
     assert PROMPT not in json.dumps(spans)
 


### PR DESCRIPTION
LE-1885's acceptance criteria asked for a flow whose prompt carries a sentinel to yield one flow span, zero component spans, and the sentinel absent from every span attribute **and event**. It shipped without the event half, and without a prompt in the fixture.

Events matter because they are a separate carrier, and the one that matters is written by the SDK rather than by us. `record_exception` puts the exception message into an event, which is exactly why `flow_execution_span` passes `record_exception=False` and sets `error.type` by hand. Nothing asserted on that, so deleting the argument left every existing test green while the message started reaching the operator's APM on every failed run.

## The part worth reviewing

The test drives `arun`, not `async_start`, and that is load-bearing.

`async_start` opens the span with `make_current=False`, because it is an async generator and a context token attached across its suspension points would leak into whatever task resumes it. A span that is never made current never enters `use_span`, so `record_exception` has nothing to act on there. `arun` makes it current, which is the path where the argument actually applies.

My first version drove `async_start` and **passed with `record_exception=False` deleted** — the precise failure this test exists to prevent. Worth knowing if anyone extends it.

## Evidence

With the argument removed:

```
assert flow_spans[0]["events"] == []
E  assert [{'name': 'exception', 'attributes': {'exception.type': 'Va...}}] == []
```

and the component's own failure text is inside that event. Restored, the file is green.

The wrapped error is `ValueError("Error running graph: Error building Component Passthrough: <the component's message>")`, so the message carries component output and only the type may cross — which is what the `error.type` assertion pins.

## Scope

Four cases, tests only, no production change. One is the control: three of the four assertions are absences, and a probe that never reads events produces the same empty list as a span that has none, so one case asserts the probe *can* see an event.

The component is a passthrough that makes no network call, so no keys and no recorded fixtures.

`src/lfx/tests/unit/graph`: 322 passed. The two `CatalogPolicyIdentityUnavailableError` failures reproduce on untouched `release-1.12.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for OpenTelemetry flow spans and boundary behavior.
  * Verified successful runs emit only the expected flow span.
  * Confirmed prompts and exception messages are not exposed in span attributes or events.
  * Verified failed components report error status and type without leaking exception events.
  * Confirmed supported control spans continue to capture events correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->