### PR TITLE
fix(a11y): keep menu arrow keys from dragging the node underneath

### DIFF
--- a/src/frontend/src/components/ui/__tests__/stop-canvas-key-propagation.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/stop-canvas-key-propagation.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Popover,
+  PopoverContentWithoutPortal,
+  PopoverTrigger,
+} from "../popover";
+import {
+  Select,
+  SelectContentWithoutPortal,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select";
+
+// React Flow listens for arrow and selection keys on the node element itself,
+// and inline (non-portalled) Radix content renders inside that element. These
+// lock in that such content swallows the keys the canvas reserves, so a menu
+// keypress can no longer move the node underneath it.
+
+const renderInlinePopover = (
+  ancestorOnKeyDown: jest.Mock,
+  contentOnKeyDown?: jest.Mock,
+) =>
+  render(
+    // biome-ignore lint/a11y/noStaticElementInteractions: stands in for React Flow's node wrapper
+    <div onKeyDown={ancestorOnKeyDown} data-testid="node-wrapper">
+      <Popover defaultOpen>
+        <PopoverTrigger>Open menu</PopoverTrigger>
+        <PopoverContentWithoutPortal
+          aria-label="Node actions"
+          onKeyDown={contentOnKeyDown}
+        >
+          <button type="button">Duplicate</button>
+        </PopoverContentWithoutPortal>
+      </Popover>
+    </div>,
+  );
+
+describe("inline Radix content key propagation", () => {
+  beforeAll(() => {
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = jest.fn(() => false);
+    }
+    if (!Element.prototype.releasePointerCapture) {
+      Element.prototype.releasePointerCapture = jest.fn();
+    }
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = jest.fn();
+    }
+  });
+
+  it("should_not_leak_arrow_keys_to_the_canvas_from_popover_content", async () => {
+    const user = userEvent.setup();
+    const ancestorOnKeyDown = jest.fn();
+    renderInlinePopover(ancestorOnKeyDown);
+
+    screen.getByRole("button", { name: "Duplicate" }).focus();
+    await user.keyboard("{ArrowDown}{ArrowUp}{ArrowLeft}{ArrowRight}");
+
+    expect(ancestorOnKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("should_not_leak_selection_keys_to_the_canvas_from_popover_content", async () => {
+    const user = userEvent.setup();
+    const ancestorOnKeyDown = jest.fn();
+    renderInlinePopover(ancestorOnKeyDown);
+
+    screen.getByRole("button", { name: "Duplicate" }).focus();
+    await user.keyboard("{Enter}{ }");
+
+    expect(ancestorOnKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("should_still_let_unreserved_keys_bubble", async () => {
+    const user = userEvent.setup();
+    const ancestorOnKeyDown = jest.fn();
+    renderInlinePopover(ancestorOnKeyDown);
+
+    screen.getByRole("button", { name: "Duplicate" }).focus();
+    await user.keyboard("a");
+
+    expect(ancestorOnKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_still_run_a_caller_supplied_key_handler", async () => {
+    const user = userEvent.setup();
+    const ancestorOnKeyDown = jest.fn();
+    const contentOnKeyDown = jest.fn();
+    renderInlinePopover(ancestorOnKeyDown, contentOnKeyDown);
+
+    screen.getByRole("button", { name: "Duplicate" }).focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(contentOnKeyDown).toHaveBeenCalledTimes(1);
+    expect(ancestorOnKeyDown).not.toHaveBeenCalled();
+  });
+
+  // Radix dismisses on a document capture listener, which runs before the
+  // content's own handler — stopping propagation must not break it.
+  it("should_still_close_the_popover_on_escape", async () => {
+    const user = userEvent.setup();
+    renderInlinePopover(jest.fn());
+
+    expect(screen.getByRole("dialog", { name: "Node actions" })).toBeVisible();
+
+    screen.getByRole("button", { name: "Duplicate" }).focus();
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Node actions" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_not_leak_arrow_keys_to_the_canvas_from_select_content", async () => {
+    const user = userEvent.setup();
+    const ancestorOnKeyDown = jest.fn();
+    render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: stands in for React Flow's node wrapper
+      <div onKeyDown={ancestorOnKeyDown} data-testid="node-wrapper">
+        <Select defaultOpen>
+          <SelectTrigger aria-label="Model">
+            <SelectValue placeholder="Pick a model" />
+          </SelectTrigger>
+          <SelectContentWithoutPortal>
+            <SelectItem value="gpt">GPT</SelectItem>
+            <SelectItem value="claude">Claude</SelectItem>
+          </SelectContentWithoutPortal>
+        </Select>
+      </div>,
+    );
+
+    await user.keyboard("{ArrowDown}{ArrowUp}");
+
+    expect(ancestorOnKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/ui/popover.tsx
+++ b/src/frontend/src/components/ui/popover.tsx
@@ -3,6 +3,7 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
 import { cn } from "../../utils/utils";
+import { stopCanvasKeyPropagation } from "./stop-canvas-key-propagation";
 import { useClosedTriggerAriaControls } from "./use-closed-trigger-aria-controls";
 
 const Popover = PopoverPrimitive.Root;
@@ -42,18 +43,24 @@ PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 const PopoverContentWithoutPortal = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
-));
+>(
+  (
+    { className, align = "center", sideOffset = 4, onKeyDown, ...props },
+    ref,
+  ) => (
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+      onKeyDown={stopCanvasKeyPropagation(onKeyDown)}
+    />
+  ),
+);
 PopoverContentWithoutPortal.displayName = PopoverPrimitive.Content.displayName;
 
 export {

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -4,6 +4,7 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../utils/utils";
+import { stopCanvasKeyPropagation } from "./stop-canvas-key-propagation";
 import { useClosedTriggerAriaControls } from "./use-closed-trigger-aria-controls";
 
 const Select = SelectPrimitive.Root;
@@ -86,7 +87,7 @@ SelectContent.displayName = SelectPrimitive.Content.displayName;
 const SelectContentWithoutPortal = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+>(({ className, children, position = "popper", onKeyDown, ...props }, ref) => (
   <SelectPrimitive.Content
     ref={ref}
     className={cn(
@@ -97,6 +98,7 @@ const SelectContentWithoutPortal = React.forwardRef<
     )}
     position={position}
     {...props}
+    onKeyDown={stopCanvasKeyPropagation(onKeyDown)}
   >
     <SelectPrimitive.Viewport
       className={cn(

--- a/src/frontend/src/components/ui/stop-canvas-key-propagation.ts
+++ b/src/frontend/src/components/ui/stop-canvas-key-propagation.ts
@@ -1,0 +1,43 @@
+import type { KeyboardEventHandler } from "react";
+
+/**
+ * Keys React Flow consumes on a focused node or edge: `elementSelectionKeys`
+ * (Enter/Space/Escape — select and unselect) plus the arrow keys (move a
+ * selected node). Mirrors `elementSelectionKeys` in @xyflow/system and
+ * `arrowKeyDiffs` in @xyflow/react; revisit when upgrading React Flow.
+ */
+const CANVAS_RESERVED_KEYS = new Set([
+  "Enter",
+  " ",
+  "Escape",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+]);
+
+/**
+ * Wraps a keydown handler for Radix content rendered *without* a portal, so the
+ * keys React Flow reserves stop at the menu instead of reaching the canvas.
+ *
+ * Inline content stays in the React tree of whatever renders it, which on the
+ * canvas means React Flow's node wrapper — and that wrapper listens for arrow
+ * and selection keys on the node element itself. Radix consumes those keys for
+ * its own roving focus but lets them keep bubbling, so without this a single
+ * arrow press both navigates the menu and moves the node underneath it.
+ *
+ * Only propagation is stopped, never the default: Radix composes this handler
+ * ahead of its own and skips its own once `defaultPrevented` is set, and its
+ * Escape-to-dismiss listens on the document in the capture phase, so both keep
+ * working.
+ */
+export function stopCanvasKeyPropagation<T extends Element>(
+  handler?: KeyboardEventHandler<T>,
+): KeyboardEventHandler<T> {
+  return (event) => {
+    handler?.(event);
+    if (CANVAS_RESERVED_KEYS.has(event.key)) {
+      event.stopPropagation();
+    }
+  };
+}


### PR DESCRIPTION
Open a menu on a canvas node, press an arrow key to move through it, and the node slides out from under you. The menu navigates *and* the node moves, from the same keypress.

This happens because menus rendered inline rather than in a portal stay inside React Flow's node element in the React tree — and that element listens for arrow and selection keys itself. Radix handles the arrow for its own roving focus but lets the event keep bubbling, so React Flow sees it too and drags the node.

The fix stops the keys React Flow reserves at the content element. It goes in the two shared primitives, `PopoverContentWithoutPortal` and `SelectContentWithoutPortal`, rather than at the ten call sites that use them — so every existing menu is covered and any menu added later gets it for free.

### Scope

Deliberately narrow. Only the seven keys React Flow actually consumes on a focused node or edge are stopped: `Enter`, `Space`, `Escape`, and the four arrows. Everything else still bubbles, so document-level shortcuts behave exactly as before. Blocking every key would have been simpler but would silently change app-wide shortcut behaviour whenever a menu is open, which is well outside this fix.

Only propagation is stopped, never the default. That matters for two reasons worth stating explicitly, both verified against the installed packages rather than assumed:

- Radix composes our handler ahead of its own and skips its own only when `defaultPrevented` is set — so menu navigation is untouched.
- Radix's Escape-to-dismiss listens on the document in the **capture** phase, firing before the content handler — so menus still close on Escape.

### Behaviour today vs. after

The visible symptom only appears once React Flow's keyboard support is switched on, which is a separate change still in progress. On this branch nothing user-facing changes; this lands the prerequisite so that work isn't blocked on it. The unit tests are what demonstrate the fix here.

### Verification

Reproduced end-to-end against a real flow with React Flow's keyboard support temporarily enabled locally, opening the node toolbar's more-options menu (which uses `SelectContentWithoutPortal`) and pressing arrows:

| | Node transform, before → after menu arrows |
|---|---|
| Without this fix | `translate(315px, 300px)` → `translate(315px, 305px)` ❌ |
| With this fix | `translate(315px, 300px)` → unchanged ✅ |

A control assertion in the same run confirmed arrows *do* still move the node when no menu is open, ruling out a false pass from keyboard support simply being off. That temporary scaffolding is not part of this PR.

Also: 6 new unit tests, and 52 existing tests across the primitives and their call sites still pass.

### What QA should test

Everything here is menu keyboard behaviour. There is **no canvas keyboard behaviour to test on this branch** — nodes are still not keyboard-movable, and that is expected and out of scope.

Please check, in any menu built on the non-portalled popover/select primitives (node toolbar more-options, dropdown inputs, multiselect, model/DB provider pickers, note node menu, output component menu):

- Arrow keys still move through menu items normally.
- `Enter` and `Space` still select an item.
- `Escape` still closes the menu and returns focus to the trigger.
- Typing still works in any menu with a search or filter field.
- Non-reserved keys still reach the app — type-ahead within a menu, and global shortcuts while a menu is open, are unchanged.

Regressions to watch for would look like a menu that no longer closes on Escape, or one whose arrow navigation stopped working.

Jira: [LE-2209](https://datastax.jira.com/browse/LE-2209)


[LE-2209]: https://datastax.jira.com/browse/LE-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard behavior in inline popovers and select menus within canvas nodes.
  - Prevented Enter, Space, Escape, and arrow-key interactions from unintentionally reaching the canvas.
  - Preserved expected menu actions, dismissal with Escape, and custom keyboard handlers.
  - Unreserved keys continue to propagate normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->