### PR TITLE
fix(a11y): show where keyboard focus is on the canvas, and keep it after a rename

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -196,6 +196,17 @@ body:has([data-radix-popper-content-wrapper]) .react-flow__pane {
   stroke-width: 2px !important;
 }
 
+/* WCAG 2.4.7 — edges are tab stops, and React Flow clears their outline. A
+   bounding-box outline around a curve reads as noise, so the path itself is the
+   indicator: the app-wide focus color at double the resting width, which stays
+   distinct from both the default stroke and the blue selected state. Needs
+   !important to beat the base rule above, and sits after it so it wins among
+   equally-important declarations. */
+.react-flow .react-flow__edge.selectable:focus-visible .react-flow__edge-path {
+  stroke: hsl(var(--ring)) !important;
+  stroke-width: 4px !important;
+}
+
 .react-flow__edge.running .react-flow__edge-path {
   stroke: hsl(var(--foreground)) !important;
   stroke-width: 2px !important;

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/rename-focus-restore.test.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/rename-focus-restore.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import SideBarFoldersButtonsComponent from "..";
+
+const mockMutateAddFolder = jest.fn();
+const mockMutateUpdateFolder = jest.fn();
+const mockSetErrorData = jest.fn();
+const mockCan = jest.fn(
+  (_projectId: string | undefined | null, _action: string) => true,
+);
+let mockFolders: Array<{
+  id: string;
+  name: string;
+  description: string;
+  parent_id: string;
+  flows: never[];
+  components: never[];
+  owner_username: string;
+  is_owner: boolean;
+}> = [];
+
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useIsFetching: () => 0,
+  useIsMutating: () => 0,
+}));
+
+jest.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: jest.fn() },
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === "sidebar.projectCreateError") {
+        return "Unable to create project.";
+      }
+      if (key === "project.ownedBy") {
+        return `${options?.name} — ${options?.owner}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/flows" }),
+  useParams: () => ({}),
+}));
+
+jest.mock("@/components/ui/sidebar", () => {
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  const SidebarMenuButton = ({
+    children,
+    isActive: _isActive,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isActive?: boolean;
+    size?: string;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
+  return {
+    Sidebar: Wrapper,
+    SidebarContent: Wrapper,
+    SidebarFooter: Wrapper,
+    SidebarGroup: Wrapper,
+    SidebarGroupContent: Wrapper,
+    SidebarHeader: Wrapper,
+    SidebarMenu: Wrapper,
+    SidebarMenuButton,
+    SidebarMenuItem: Wrapper,
+  };
+});
+
+jest.mock("@/contexts/permissionsContext", () => ({
+  PermissionsProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  usePermissions: () => ({ can: mockCan }),
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useUpdateUser: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/controllers/API/queries/folders", () => ({
+  usePatchFolders: () => ({ mutate: mockMutateUpdateFolder }),
+  usePostFolders: () => ({
+    mutate: mockMutateAddFolder,
+    isPending: false,
+  }),
+  usePostUploadFolders: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/controllers/API/queries/folders/use-get-download-folders", () => ({
+  useGetDownloadFolders: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/customization/feature-flags", () => ({
+  ENABLE_CUSTOM_PARAM: false,
+  ENABLE_DATASTAX_LANGFLOW: false,
+  ENABLE_FILE_MANAGEMENT: false,
+  ENABLE_KNOWLEDGE_BASES: false,
+  ENABLE_MCP_NOTICE: false,
+}));
+
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => jest.fn(),
+}));
+
+jest.mock("@/customization/utils/analytics", () => ({ track: jest.fn() }));
+jest.mock("@/hooks/flows/use-upload-flow", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+jest.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { userData: undefined }) => unknown) =>
+    selector({ userData: undefined }),
+}));
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (
+    selector: (state: {
+      setErrorData: jest.Mock;
+      setSuccessData: jest.Mock;
+    }) => unknown,
+  ) =>
+    selector({
+      setErrorData: mockSetErrorData,
+      setSuccessData: jest.fn(),
+    }),
+}));
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { takeSnapshot: jest.Mock }) => unknown) =>
+    selector({ takeSnapshot: jest.fn() }),
+}));
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: (
+    selector: (state: {
+      folders: typeof mockFolders;
+      folderIdDragging: null;
+      myCollectionId: string;
+    }) => unknown,
+  ) =>
+    selector({
+      folders: mockFolders,
+      folderIdDragging: null,
+      myCollectionId: "root",
+    }),
+}));
+jest.mock("../../../hooks/use-on-file-drop", () => ({
+  __esModule: true,
+  default: () => ({
+    dragOver: jest.fn(),
+    dragEnter: jest.fn(),
+    dragLeave: jest.fn(),
+    onDrop: jest.fn(),
+  }),
+}));
+jest.mock("../components/header-buttons", () => ({
+  HeaderButtons: ({ addNewFolder }: { addNewFolder: () => void }) => (
+    <button type="button" onClick={addNewFolder}>
+      New Project
+    </button>
+  ),
+}));
+jest.mock("../components/input-edit-folder-name", () => ({
+  InputEditFolderName: ({
+    item,
+    foldersNames,
+    handleEditFolderName,
+    handleEditNameFolder,
+  }: {
+    item: { id: string };
+    foldersNames: Record<string, string>;
+    handleEditFolderName: (
+      event: React.ChangeEvent<HTMLInputElement>,
+      folderId: string,
+    ) => void;
+    handleEditNameFolder: (item: { id: string }) => void;
+  }) => (
+    // Mirrors the real input's autoFocus, which is what makes the unmount drop
+    // focus to <body> in the first place.
+    <input
+      autoFocus
+      data-testid={`input-project-${item.id}`}
+      value={foldersNames[item.id] ?? ""}
+      onChange={(event) => handleEditFolderName(event, item.id)}
+      onBlur={() => handleEditNameFolder(item)}
+    />
+  ),
+}));
+
+jest.mock("../components/mcp-server-notice", () => ({
+  MCPServerNotice: () => null,
+}));
+jest.mock("../components/select-options", () => ({
+  SelectOptions: () => null,
+}));
+jest.mock("../../sidebarFolderSkeleton", () => ({
+  SidebarFolderSkeleton: () => null,
+}));
+
+const FOLDER = {
+  id: "own-id",
+  name: "Starter Project",
+  description: "",
+  parent_id: "",
+  flows: [] as never[],
+  components: [] as never[],
+  owner_username: "current-user",
+  is_owner: true,
+};
+
+// Committing a rename unmounts the focused input. Without a handoff focus falls
+// to <body>, forcing a keyboard user to tab from the top of the page back to the
+// project they just renamed (WCAG 2.4.3).
+describe("project rename focus handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCan.mockReturnValue(true);
+    mockFolders = [FOLDER];
+  });
+
+  const startRenaming = () => {
+    render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
+    fireEvent.doubleClick(screen.getByTestId(`sidebar-nav-${FOLDER.id}`));
+    return screen.getByTestId(`input-project-${FOLDER.id}`);
+  };
+
+  it("returns focus to the project nav item after a rename is committed", () => {
+    const input = startRenaming();
+    expect(input).toHaveFocus();
+
+    fireEvent.blur(input);
+
+    expect(screen.getByTestId(`sidebar-nav-${FOLDER.id}`)).toHaveFocus();
+  });
+
+  it("does not steal focus when the user moves to another control", () => {
+    const input = startRenaming();
+    const newProjectButton = screen.getByRole("button", {
+      name: "New Project",
+    });
+
+    newProjectButton.focus();
+    fireEvent.blur(input);
+
+    expect(newProjectButton).toHaveFocus();
+  });
+});

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -116,6 +116,27 @@ const SideBarFoldersButtonsComponent = ({
     folders.map((obj) => ({ id: obj.id!, edit: false })) ?? [],
   );
 
+  // Committing or cancelling a rename unmounts the input while it still holds
+  // focus, dropping focus to <body> and forcing a keyboard user to tab from the
+  // top of the page. Hand focus back to the project's nav item instead — but
+  // only when focus was actually lost, so clicking straight to another control
+  // isn't yanked back here.
+  const renamingFolderId =
+    editFolders.find((folder) => folder.edit)?.id ?? null;
+  const previousRenamingFolderId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const justFinished = previousRenamingFolderId.current;
+    previousRenamingFolderId.current = renamingFolderId;
+
+    if (!justFinished || renamingFolderId) return;
+    if (document.activeElement && document.activeElement !== document.body) {
+      return;
+    }
+
+    document.getElementById(`sidebar-nav-${justFinished}`)?.focus();
+  }, [renamingFolderId]);
+
   const isFetchingFolders = !!useIsFetching({
     queryKey: ["useGetFolders"],
     exact: false,

--- a/src/frontend/src/style/classes.css
+++ b/src/frontend/src/style/classes.css
@@ -202,6 +202,24 @@ textarea[class^="ag-"]:focus {
   z-index: 1001 !important;
 }
 
+/* WCAG 2.4.7 — nodes and edges are tab stops, but React Flow's own stylesheet
+   clears their outline (.react-flow__node.selectable:focus-visible and
+   .react-flow__edge:focus-visible in @xyflow/react/dist/style.css), which also
+   suppresses the global :focus-visible fallback in index.css. That stylesheet is
+   imported from App.tsx and so lands after this file, hence the leading
+   .react-flow to out-specify it rather than !important.
+
+   Uses --ring, the app-wide focus token, not the --node-ring used for handle
+   halos: --node-ring is a light grey chosen to sit on a colored handle and does
+   not carry enough contrast to serve as a focus indicator on the canvas. */
+.react-flow .react-flow__node.selectable:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 3px;
+  border-radius: 0.75rem;
+}
+/* The matching edge indicator lives in App.css, next to the other
+   .react-flow__edge-path stroke rules it has to override. */
+
 .card-shine-effect {
   --shine-deg: 135deg;
   position: relative;


### PR DESCRIPTION
Tab across the flow canvas today and you traverse nine stops without a single visual cue as to where you are. Nodes and edges are in the tab order, but neither renders any focus styling — React Flow deliberately clears their outline and leaves the indicator to the app, and we never supplied one.

Separately, renaming a project drops focus entirely: committing the new name unmounts the input while it still holds focus, so focus falls to `<body>` and you have to tab from the top of the page to get back to the project you just renamed.

This adds a focus indicator for canvas nodes and edges, and hands focus back to the project's nav item after a rename.

### Scope

**This is a partial delivery of its ticket, not the whole thing.** The ticket also covers making nodes keyboard-selectable and movable, which is blocked on a separate fix that is still in review. These two were split out because neither depends on that work and both fix problems that exist on this branch today. Nodes still cannot be moved or selected by keyboard after this PR — that is expected and tracked separately.

### Notes on the implementation

- Uses `--ring`, the app-wide focus token, rather than the `--node-ring` used for handle halos. `--node-ring` is a light grey chosen to sit on top of a colored handle and does not carry enough contrast to work as a focus indicator against the canvas.
- Edges are curved, so a bounding-box outline reads as noise. The path itself is the indicator: focus color at double the resting width, which stays distinct from both the default stroke and the blue selected state.
- The edge rule lives in `App.css` next to the other `.react-flow__edge-path` stroke rules, and needs `!important` to beat the existing base rule there. The node rule lives in `classes.css` with the other node rules. Both carry comments pointing at each other.
- The rename handoff only fires when focus was genuinely lost. Clicking straight from the rename input to another control is left alone rather than being yanked back.

### Verification

Focus styles cannot be verified in jsdom, so these were measured in a real browser on a template flow with nodes and edges, driven by actual Tab presses:

| | Before | After |
|---|---|---|
| Focused node | `outline-style: none` | `solid`, `2px`, `rgb(0,0,0)` |
| Focused edge | `rgb(85,85,85)`, `2px` | `rgb(0,0,0)`, `4px` |

Screenshots confirmed both render correctly rather than being clipped. Worth flagging for anyone writing follow-up tests: programmatic `.focus()` does **not** match `:focus-visible` in Chromium, so a check that focuses an element directly will report no indicator and look like a failure. Drive it with real Tab presses.

The rename fix has two unit tests, and was checked against a negative control: with the fix disabled the restore test fails while the "don't steal focus" test still passes.

### What QA should test

**Focus indicators** — tab into the canvas on a flow with several nodes and edges:
- Every node and edge you land on shows a clearly visible indicator.
- The indicator appears on keyboard focus but *not* on mouse click (this is intentional — `:focus-visible`).
- A focused edge stays distinguishable from a selected one.
- Check both light and dark themes.

**Rename focus** — on `/flows`:
- Rename a project with the keyboard and press Enter. Focus should land on that project's nav item, not be lost.
- Same via Escape to cancel.
- Start a rename, then click directly on a different control. Focus should stay where you clicked and *not* jump back to the project.

**Out of scope — please do not raise against this ticket:** nodes not selectable or movable by keyboard, and the tabbable-role scan violations on nodes and edges. Both are the remaining part of this ticket, blocked on a separate in-review fix.

Jira: [LE-1514](https://datastax.jira.com/browse/LE-1514)


[LE-1514]: https://datastax.jira.com/browse/LE-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added clearer keyboard-focus indicators for selectable workflow nodes and connections.
  * Focus indicators now use consistent application styling and improved visibility.

* **Bug Fixes**
  * Restored focus to a project’s sidebar navigation item after renaming when no other control has focus.
  * Preserved the user’s focus when they move to another control during renaming.

* **Tests**
  * Added coverage for project rename focus restoration and focus preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->