### PR TITLE
fix(mcp): don't commit a borrowed transaction during startup MCP reconciliation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1447,7 +1447,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_mcp_projects.py",
         "hashed_secret": "4258d43e3b1f9658067ceea9c682a96cbdbb5ca0",
         "is_verified": false,
-        "line_number": 792,
+        "line_number": 794,
         "is_secret": false
       }
     ],
@@ -7248,5 +7248,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T19:30:02Z"
+  "generated_at": "2026-08-13T21:42:05Z"
 }

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -1637,6 +1637,9 @@ async def init_mcp_servers():
                                     project_user,
                                     session,
                                     raise_on_error=True,
+                                    # This savepoint owns the transaction; a commit inside
+                                    # would close it and break every later statement.
+                                    owns_transaction=False,
                                 )
 
                     if persist_reason == "auto_enable_apikey":

--- a/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
+++ b/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
@@ -74,11 +74,17 @@ async def register_mcp_servers_for_project(
     session,
     *,
     raise_on_error: bool = False,
+    owns_transaction: bool = True,
 ) -> bool:
     """Register MCP servers for a newly created project.
 
     This handles the full MCP auto-registration flow: building the transport URL,
     creating API keys if needed, validating conflicts, and calling update_server.
+
+    Pass ``owns_transaction=False`` when the caller already owns the transaction (the
+    startup reconciliation runs inside ``session.begin_nested()``). That keeps the API
+    key created below in the same unit of work as the server write, so a failure rolls
+    both back instead of leaving an unreferenced credential behind.
 
     Returns:
         True when the server config was created or updated, otherwise False.
@@ -167,6 +173,7 @@ async def register_mcp_servers_for_project(
             session,
             get_storage_service(),
             get_settings_service(),
+            owns_transaction=owns_transaction,
         )
     except HTTPException:
         raise

--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -401,6 +401,14 @@ def _clear_server_cache(server_name: str) -> None:
         safe_cache_set(shared_component_cache_service, "servers", servers)
 
 
+async def _persist(session, *, owns_transaction: bool) -> None:
+    """Commit when we own the transaction, otherwise just flush for the owner."""
+    if owns_transaction:
+        await session.commit()
+    else:
+        await session.flush()
+
+
 async def update_server(
     server_name: str,
     server_config: dict,
@@ -412,6 +420,7 @@ async def update_server(
     check_existing: bool = False,
     delete: bool = False,
     merge_existing: bool = False,
+    owns_transaction: bool = True,
 ):
     """Create, update, or delete one MCP server row for the user.
 
@@ -420,6 +429,15 @@ async def update_server(
     and never contend, so no update is lost at any worker/replica count - without an
     in-process lock. A concurrent create of the *same* name is caught by the unique
     constraint and folded into an update.
+
+    ``owns_transaction=False`` is for callers that already own the transaction - notably
+    the startup reconciliation, which runs inside ``session.begin_nested()``. Committing
+    there would end the transaction the caller's context manager owns, so every later
+    statement (including this function's own trailing read) raises ``InvalidRequestError:
+    Can't operate on closed transaction inside context manager``, and it would also
+    escape any rollback the caller relies on for atomicity. Flushing instead keeps the
+    write visible to the rest of the caller's transaction while leaving commit/rollback
+    to whoever opened it.
     """
     settings = getattr(settings_service, "settings", None)
     if not delete:
@@ -434,7 +452,7 @@ async def update_server(
         if existing is None:
             raise HTTPException(status_code=500, detail="Server not found.")
         await session.delete(existing)
-        await session.commit()
+        await _persist(session, owns_transaction=owns_transaction)
         _clear_server_cache(server_name)
         return None
 
@@ -463,11 +481,15 @@ async def update_server(
         session.add(existing)
 
     try:
-        await session.commit()
+        await _persist(session, owns_transaction=owns_transaction)
     except IntegrityError:
         # A concurrent request created the same (user, name) first (we came in with
         # existing=None). Re-apply the create/merge rules against the winning row
         # instead of overwriting it with our pre-race config.
+        if not owns_transaction:
+            # Recovering here needs a rollback, which on a borrowed transaction would
+            # discard the caller's work too. Let the caller's savepoint unwind instead.
+            raise
         await session.rollback()
         result = await session.exec(
             select(MCPServer).where(MCPServer.user_id == current_user.id, MCPServer.name == server_name)
@@ -488,7 +510,7 @@ async def update_server(
         existing.version += 1
         existing.updated_at = datetime.now(timezone.utc)
         session.add(existing)
-        await session.commit()
+        await _persist(session, owns_transaction=owns_transaction)
 
     _clear_server_cache(server_name)
     return await get_server(server_name, current_user, session, storage_service, settings_service)

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException, status
 from httpx import AsyncClient
+from langflow.api.v1 import projects_mcp_helpers
 from langflow.api.v1.mcp_projects import (
     ProjectMCPServer,
     _args_reference_urls,
@@ -20,6 +21,7 @@ from langflow.api.v1.mcp_projects import (
 )
 from langflow.api.v2.mcp import is_mcp_servers_locked
 from langflow.services.auth.utils import create_user_longterm_token, get_password_hash
+from langflow.services.database.models.api_key.model import ApiKey
 from langflow.services.database.models.flow import Flow
 from langflow.services.database.models.folder import Folder
 from langflow.services.database.models.user.model import User
@@ -1299,6 +1301,127 @@ async def test_init_mcp_servers_reconciles_existing_apikey_project_server_config
         assert streamable_http_url in server_args
     finally:
         await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+
+
+async def test_init_mcp_servers_reconciles_stale_config_without_transaction_error(
+    client: AsyncClient,
+    user_test_project,
+    created_api_key,
+    monkeypatch,
+):
+    """Reconciling a pre-1.11.1 config must not break the caller's savepoint (issue #14536).
+
+    ``update_server`` used to commit the transaction owned by ``init_mcp_servers``'
+    ``session.begin_nested()``, so its own trailing read raised ``InvalidRequestError:
+    Can't operate on closed transaction inside context manager`` - after that commit had
+    already persisted the API key created for the config.
+    """
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+    _set_startup_mcp_settings(
+        monkeypatch,
+        auto_login=False,
+        mcp_composer_enabled=False,
+        add_projects_to_mcp_servers=True,
+    )
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        project.auth_settings = {"auth_type": "apikey"}
+        session.add(project)
+
+    server_name = f"lf-{sanitize_mcp_name(user_test_project.name)[: (MAX_MCP_SERVER_NAME_LENGTH - 4)]}"
+    streamable_http_url = await get_project_streamable_http_url(user_test_project.id)
+    # Config as written by <=1.11.0: no `--with mcp~=1.28` constraint prefix, so 1.11.1+
+    # no longer considers it a match and reconciles it on every startup.
+    stale_server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "streamablehttp", streamable_http_url],
+    }
+    headers = {"x-api-key": created_api_key.api_key}
+    response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=stale_server_config, headers=headers)
+    assert response.status_code == 200
+
+    reconcile_errors: list[BaseException] = []
+    real_register = projects_mcp_helpers.register_mcp_servers_for_project
+
+    async def spy(*args, **kwargs):
+        try:
+            return await real_register(*args, **kwargs)
+        except BaseException as exc:
+            reconcile_errors.append(exc)
+            raise
+
+    monkeypatch.setattr(projects_mcp_helpers, "register_mcp_servers_for_project", spy)
+
+    try:
+        with (
+            patch("langflow.api.v1.mcp_projects.get_project_sse"),
+            patch("langflow.api.v1.mcp_projects.get_project_mcp_server"),
+            patch("langflow.api.v1.mcp_projects.auto_configure_starter_projects_mcp", new=AsyncMock()),
+        ):
+            await init_mcp_servers()
+
+        assert not reconcile_errors, f"startup reconciliation raised: {reconcile_errors}"
+
+        response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+        assert response.status_code == 200
+        assert "--with" in response.json()["args"]
+    finally:
+        await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+
+
+async def test_init_mcp_servers_does_not_leak_api_key_when_reconciliation_fails(
+    user_test_project,
+    monkeypatch,
+):
+    """A failed startup reconciliation must leave no orphaned API key behind (issue #14536).
+
+    ``create_api_key`` runs before the server write, so the savepoint is the only thing
+    keeping the two atomic. A commit inside ``update_server`` would persist the key even
+    though the reconciliation it was generated for never completed.
+    """
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+    _set_startup_mcp_settings(
+        monkeypatch,
+        auto_login=False,
+        mcp_composer_enabled=False,
+        add_projects_to_mcp_servers=True,
+    )
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        project.auth_settings = {"auth_type": "apikey"}
+        session.add(project)
+
+    async def count_api_keys() -> int:
+        async with session_scope() as session:
+            return len((await session.exec(select(ApiKey))).all())
+
+    keys_before = await count_api_keys()
+
+    # Fail after create_api_key and after the server row is written, i.e. exactly where
+    # the InvalidRequestError used to surface.
+    real_update_server = projects_mcp_helpers.update_server
+
+    async def failing_update_server(*args, **kwargs):
+        await real_update_server(*args, **kwargs)
+        msg = "server sync failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(projects_mcp_helpers, "update_server", failing_update_server)
+
+    with (
+        patch("langflow.api.v1.mcp_projects.get_project_sse"),
+        patch("langflow.api.v1.mcp_projects.get_project_mcp_server"),
+        patch("langflow.api.v1.mcp_projects.auto_configure_starter_projects_mcp", new=AsyncMock()),
+    ):
+        await init_mcp_servers()
+
+    assert await count_api_keys() == keys_before, "failed reconciliation leaked an API key"
 
 
 async def test_patch_project_mcp_settings_syncs_server_config_for_apikey(


### PR DESCRIPTION
Fixes #14536

## Problem

`init_mcp_servers()` reconciles each project's MCP server config inside `async with session.begin_nested():`, but `update_server()` issued its own `await session.commit()`. `Session.commit()` commits `_to_root=True`, so it ends the transaction the caller's context manager owns — `session._transaction` becomes `None` while `_trans_context_manager` is still set, and the next statement (`update_server`'s own trailing `get_server()` read) raises:

```
InvalidRequestError: Can't operate on closed transaction inside context manager.
```

This shows up on upgrade, not on fresh installs: 1.11.1 added `mcp_server_config_uses_current_uvx_constraint()` to `_server_config_matches_project_auth()`, so configs written by ≤1.11.0 (no `--with mcp~=1.28` prefix) stop matching and get reconciled into this path on every boot.

The same commit also persisted a side effect. `create_api_key()` in `register_mcp_servers_for_project()` only flushes, so the savepoint was the only thing keeping the generated key atomic with the server write. Committing mid-savepoint wrote the key out *before* the read failed, leaving a valid, never-used Langflow API key behind and making the caller's rollback a no-op.

## Fix

Add `owns_transaction` to `update_server()`. When `False` it flushes instead of committing, and re-raises `IntegrityError` rather than calling `session.rollback()` — rolling back a borrowed transaction would discard the caller's work, so the caller's savepoint unwinds instead. The flag is threaded through `register_mcp_servers_for_project()`, and `init_mcp_servers()` passes `False`.

Request paths keep the committing default, and `session_scope`/`DbSession` already auto-commit. Fixing the ownership fixes both symptoms at once, because the API key now rolls back with the savepoint.

## Why CI didn't catch it

`test_init_mcp_servers_reconciles_existing_apikey_project_server_config` asserts only end state, and the commit landed *before* the failure — so it passed either way. `test_init_mcp_servers_rolls_back_auth_update_when_reconciliation_fails` mocks `update_server` out entirely, so the savepoint's atomicity was never exercised against the real function.

## Test plan

- [x] New `test_init_mcp_servers_reconciles_stale_config_without_transaction_error` — fails on unpatched `release-1.11.4` with the exact `InvalidRequestError`, passes with the fix
- [x] New `test_init_mcp_servers_does_not_leak_api_key_when_reconciliation_fails`
- [x] 86 passed — `test_mcp_projects.py`, `test_projects_mcp_helpers.py`, `test_mcp_db_store.py`, `test_mcp_servers_file.py`
- [x] 50 passed / 1 skipped — `test_projects.py` (project-creation path, default `owns_transaction=True`)
- [x] `ruff format` / `ruff check` clean
- [ ] Port to `release-1.12.0` — same defect there (`init_mcp_servers` unchanged, rewritten `update_server` still commits); tracked separately

## Note on the report

The issue's claim that this never self-heals and leaks one key per project per *every* boot did not reproduce locally: with 4 projects, boot 1 produced 4 errors + 4 keys, and boots 2–3 were clean with zero new keys (`get_server_list` reads the `mcp_server` table, so the repaired config matches next boot). The reporter's non-convergence on Postgres may be a second issue — possibly `validate_mcp_server_for_project` swallowing an exception and returning `server_exists=False`. This PR fixes the transaction defect either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server startup synchronization to prevent transaction errors.
  * Preserved updated server settings during configuration reconciliation.
  * Ensured API-key changes are rolled back when server synchronization fails.
* **Tests**
  * Added coverage for successful reconciliation, setting preservation, and rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->