### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We welcome contributions from developers of all levels. If you'd like to contrib
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=langflow-ai/langflow&type=Timeline)](https://star-history.com/#langflow-ai/langflow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=langflow-ai/langflow&type=Timeline)](https://star-history.dera.page/#langflow-ai/langflow&Date)
 
 ## ❤️ Contributors
 


### PR DESCRIPTION
The star history chart in the README is broken due to GitHub stargazer API restrictions. This change points the chart to an alternative that uses a different data source, requires no API token, and renders the chart correctly again. No other functional changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History Chart image and destination links to use the new Star History website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->