### PR TITLE
feat: let operators turn off database spans

### DIFF
--- a/src/lfx/src/lfx/cli/_observability_commands.py
+++ b/src/lfx/src/lfx/cli/_observability_commands.py
@@ -96,9 +96,14 @@ def doctor_command(
         if signal.signal == "traces" and signal.status != SKIPPED:
             if db_spans_enabled():
                 console.print(
-                    "    [dim]database spans ARE exported, and they are most of the volume "
-                    "(~50 spans per flow run). Set LANGFLOW_OTEL_DB_SPANS=false to send flow "
-                    "and request spans only, at the cost of losing database latency[/dim]"
+                    # "enabled", not "are exported": this reads the setting, and it cannot
+                    # see whether the instrumentor actually attached. _instrument_sqlalchemy
+                    # swallows an ImportError or a double-instrument, so claiming export
+                    # here would be a confident lie on exactly the box where it is wrong.
+                    "    [dim]database span export is enabled. When the instrumentation "
+                    "attaches, these are most of the volume (~50 spans per flow run). Set "
+                    "LANGFLOW_OTEL_DB_SPANS=false to send flow and request spans only, at "
+                    "the cost of losing database latency[/dim]"
                 )
             else:
                 console.print(

--- a/src/lfx/src/lfx/cli/_observability_commands.py
+++ b/src/lfx/src/lfx/cli/_observability_commands.py
@@ -42,6 +42,7 @@ def doctor_command(
     from rich.markup import escape
 
     from lfx.log.logger import otel_log_bodies_exported
+    from lfx.observability import db_spans_enabled
     from lfx.observability_doctor import FAILED, OK, SKIPPED, run_doctor
 
     # highlight=False: the captured exporter messages are full of URLs and numbers, and rich's
@@ -89,6 +90,20 @@ def doctor_command(
                 console.print(
                     "    [dim]bodies withheld unless a call site opts in; records keep "
                     "severity, scope, callsite, error.type and trace correlation[/dim]"
+                )
+        # Volume, for the same reason the logs note exists: an operator sizing a paid APM needs
+        # to know this before the first bill, not after. Database spans are the bulk of it.
+        if signal.signal == "traces" and signal.status != SKIPPED:
+            if db_spans_enabled():
+                console.print(
+                    "    [dim]database spans ARE exported, and they are most of the volume "
+                    "(~50 spans per flow run). Set LANGFLOW_OTEL_DB_SPANS=false to send flow "
+                    "and request spans only, at the cost of losing database latency[/dim]"
+                )
+            else:
+                console.print(
+                    "    [yellow]database spans are OFF (LANGFLOW_OTEL_DB_SPANS): a slow run "
+                    "waiting on the database will show no cause[/yellow]"
                 )
 
     if not report.ok:

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -202,6 +202,14 @@ _OTLP_ENDPOINT_VARS = (
 # Only asgi and fastapi (installed by instrument_fastapi_app) and APPLICATION_TRACER_NAME (the
 # flow span) are emitted against our provider, so only they are listed. Re-add a scope the same
 # commit that wires its instrumentor with tracer_provider=, never before.
+# Named rather than inlined because two places need the same string: the allowlist below and
+# the instrumentation call that produces the spans. An operator turning them off should get
+# neither, and a literal repeated in both is one edit away from disagreeing.
+DB_INSTRUMENTATION_SCOPE = "opentelemetry.instrumentation.sqlalchemy"
+
+# Values that turn a boolean env var off. Anything else leaves the default in place.
+_FALSE_VALUES = frozenset({"0", "f", "false", "n", "no", "off"})
+
 APPLICATION_INSTRUMENTATION_SCOPES = frozenset(
     {
         "opentelemetry.instrumentation.asgi",
@@ -215,10 +223,43 @@ APPLICATION_INSTRUMENTATION_SCOPES = frozenset(
         # LLM vendor SDKs instrument them globally against whatever provider is global (ours),
         # so admitting them would put one span per outbound LLM call in the operator's APM.
         # Outbound provider health is delivered as leak-safe metrics instead.
-        "opentelemetry.instrumentation.sqlalchemy",
+        DB_INSTRUMENTATION_SCOPE,
         APPLICATION_TRACER_NAME,
     }
 )
+
+
+def db_spans_enabled() -> bool:
+    """Whether database spans are exported. On by default.
+
+    They are the bulk of the span volume -- measured against a live run, roughly 80% of
+    exported spans and about 50 spans per flow run, against one ``flow.execute`` -- and a
+    commercial APM bills per span ingested. An operator who only wants flow and request
+    health should not have to pay for the rest.
+
+    On by default anyway, because the volume buys something. In that same run 17% of pool
+    checkouts took over 50ms and 4% took over 200ms, which is the difference between "the
+    flow was slow" and "the flow was slow waiting for the database". Defaulting this off
+    would hide the most common cause of a slow run behind a setting nobody knows to look for.
+
+    Anything other than a recognised false value keeps them on, so a typo cannot silently
+    turn off telemetry the operator believes is running.
+    """
+    return os.getenv("LANGFLOW_OTEL_DB_SPANS", "true").strip().lower() not in _FALSE_VALUES
+
+
+def exported_span_scopes() -> frozenset[str]:
+    """The scopes this process actually exports, after operator configuration.
+
+    Only ever *subtracts* from ``APPLICATION_INSTRUMENTATION_SCOPES``. That direction is the
+    whole safety property: the allowlist is what keeps prompt-carrying scopes out of the APM,
+    so configuration must not be able to widen it. A setting that could add a scope would be
+    an env var that reopens the leak the allowlist exists to close.
+    """
+    if db_spans_enabled():
+        return APPLICATION_INSTRUMENTATION_SCOPES
+    return APPLICATION_INSTRUMENTATION_SCOPES - {DB_INSTRUMENTATION_SCOPE}
+
 
 # The same boundary for metrics. Separate from the span set because the meter the runtime
 # records its own counters and histograms on is named "langflow", while its application spans
@@ -383,10 +424,13 @@ if _OTEL_AVAILABLE:
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
             self._dropped_scopes: set[str] = set()
+            # Resolved once, at construction, so the set cannot change under a running
+            # process and leave two spans of the same scope treated differently.
+            self._scopes = exported_span_scopes()
 
         def on_end(self, span) -> None:
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
-            if scope in APPLICATION_INSTRUMENTATION_SCOPES:
+            if scope in self._scopes:
                 _redact_url_attributes(span)
                 super().on_end(span)
                 return
@@ -864,6 +908,13 @@ def instrument_database(engine: object) -> None:
 
 
 def _instrument_sqlalchemy(engine: object) -> None:
+    if not db_spans_enabled():
+        # Not instrumenting at all, rather than instrumenting and dropping on the way out.
+        # The spans are never created, so the operator pays no span-creation cost for
+        # telemetry they turned off. The processor subtracts the scope as well, which is what
+        # covers the case of some other library instrumenting sqlalchemy against our provider.
+        logger.debug("LANGFLOW_OTEL_DB_SPANS is off; not instrumenting sqlalchemy")
+        return
     try:
         from opentelemetry import trace
         from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor

--- a/src/lfx/tests/unit/test_db_span_toggle.py
+++ b/src/lfx/tests/unit/test_db_span_toggle.py
@@ -195,3 +195,77 @@ def test_a_real_query_produces_no_database_spans_when_turned_off():
 
     assert DB_INSTRUMENTATION_SCOPE not in result["scopes"], result
     assert "flow.execute" in result["names"], result
+
+
+# Proving the instrumentor never attached, rather than that its spans were filtered out.
+# The distinction is the whole point of the two gates: the export filter alone would still
+# pay the cost of creating every span. This probe deliberately uses a plain
+# SimpleSpanProcessor with no filtering, so a span that exists at all is visible.
+
+UNFILTERED_PROBE = """
+import json
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lfx.observability import instrument_database
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+# No ApplicationOnlySpanProcessor here on purpose: nothing is filtered, so any span the
+# sqlalchemy instrumentor creates will show up.
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+import sqlalchemy as sa
+
+engine = sa.create_engine("sqlite://")
+instrument_database(engine)
+
+with engine.connect() as conn:
+    conn.execute(sa.text("SELECT 1"))
+
+provider.force_flush()
+scopes = [s.instrumentation_scope.name if s.instrumentation_scope else "" for s in exporter.get_finished_spans()]
+print("PROBE_RESULT " + json.dumps({"scopes": scopes}))
+"""
+
+
+def run_unfiltered_probe(env_value: str | None) -> dict:
+    import os
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    env.pop(ENV_VAR, None)
+    if env_value is not None:
+        env[ENV_VAR] = env_value
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = Path(tmp) / "probe.py"
+        probe.write_text(UNFILTERED_PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe)], env=env, capture_output=True, text=True, timeout=300, check=False
+        )
+    assert completed.returncode == 0, completed.stderr
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    return json.loads(lines[0].removeprefix("PROBE_RESULT "))
+
+
+def test_the_instrumentor_attaches_by_default():
+    """The control: with no filtering in the way, a query does produce database spans."""
+    result = run_unfiltered_probe(None)
+
+    assert DB_INSTRUMENTATION_SCOPE in result["scopes"], result
+
+
+def test_the_instrumentor_is_not_attached_when_turned_off():
+    """Skipped, not filtered.
+
+    Nothing filters in this probe, so a database span here would mean the instrumentor had
+    attached and the export boundary was doing the suppressing. The span-creation cost would
+    still be paid on every query, which is half of what turning this off is meant to save.
+    """
+    result = run_unfiltered_probe("false")
+
+    assert DB_INSTRUMENTATION_SCOPE not in result["scopes"], result

--- a/src/lfx/tests/unit/test_db_span_toggle.py
+++ b/src/lfx/tests/unit/test_db_span_toggle.py
@@ -1,0 +1,197 @@
+"""Database spans are the bulk of the export, so an operator can turn them off.
+
+Measured against a live run: database spans were about 80% of everything exported, roughly
+50 spans per flow run against a single ``flow.execute``. A commercial APM bills per span
+ingested, so an operator who only wants flow and request health should not have to pay for
+the rest of it.
+
+They stay on by default because the volume buys something. In that same run 17% of pool
+checkouts took over 50ms and 4% took over 200ms, which is the difference between knowing a
+flow was slow and knowing it was slow waiting for the database.
+
+The property that matters most here is not the toggle. It is that the toggle can only ever
+*subtract* from the allowlist, because the allowlist is what keeps prompt-carrying scopes out
+of the APM. Configuration that could widen it would be an env var that reopens the leak.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace.export.in_memory_span_exporter")
+
+from lfx.observability import (
+    APPLICATION_INSTRUMENTATION_SCOPES,
+    APPLICATION_TRACER_NAME,
+    DB_INSTRUMENTATION_SCOPE,
+    ApplicationOnlySpanProcessor,
+    db_spans_enabled,
+    exported_span_scopes,
+)
+
+ENV_VAR = "LANGFLOW_OTEL_DB_SPANS"
+
+
+def exported_names(env_value: str | None, scopes: list[str], monkeypatch) -> list[str]:
+    """Emit one span per scope through a freshly built processor, return what got exported.
+
+    The processor resolves its scope set at construction, so the environment has to be set
+    before it is built. Building it inside the helper rather than in a fixture is what makes
+    that ordering explicit.
+    """
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    if env_value is None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(ENV_VAR, env_value)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+    try:
+        for scope in scopes:
+            provider.get_tracer(scope).start_span(f"span-from-{scope}").end()
+        provider.force_flush()
+        return [s.name for s in exporter.get_finished_spans()]
+    finally:
+        provider.shutdown()
+
+
+def test_database_spans_are_exported_by_default(monkeypatch):
+    """The default, asserted before any of the absences below mean anything."""
+    exported = exported_names(None, [DB_INSTRUMENTATION_SCOPE], monkeypatch)
+
+    assert exported == [f"span-from-{DB_INSTRUMENTATION_SCOPE}"]
+
+
+@pytest.mark.parametrize("off", ["false", "0", "no", "off", "FALSE", "Off", " false "])
+def test_database_spans_are_dropped_when_turned_off(off, monkeypatch):
+    """Paired with the flow span, which must still export.
+
+    Without that second scope in the same run, an empty list reads the same whether the
+    toggle worked or the processor stopped exporting anything at all.
+    """
+    exported = exported_names(off, [DB_INSTRUMENTATION_SCOPE, APPLICATION_TRACER_NAME], monkeypatch)
+
+    assert exported == [f"span-from-{APPLICATION_TRACER_NAME}"]
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "", "maybe", "flase", "off ish", "2"])
+def test_only_a_recognised_false_value_turns_them_off(value, monkeypatch):
+    """A typo must not silently stop telemetry the operator believes is running.
+
+    ``flase`` is in the list on purpose. It is the plausible typo, and the failure it would
+    cause is invisible: telemetry quietly stops and nothing says so.
+    """
+    exported = exported_names(value, [DB_INSTRUMENTATION_SCOPE], monkeypatch)
+
+    assert exported == [f"span-from-{DB_INSTRUMENTATION_SCOPE}"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["true", "false", "0", "1", "", "garbage", "opentelemetry.instrumentation.openai", "*", "all"],
+)
+def test_configuration_can_only_subtract_from_the_allowlist(value, monkeypatch):
+    """The safety property. No env value may widen the boundary.
+
+    Includes a value naming an LLM scope and a couple of wildcard-looking strings, because
+    the failure worth guarding against is a future parser that treats the variable as a list
+    of scopes to admit rather than as a boolean.
+    """
+    monkeypatch.setenv(ENV_VAR, value)
+
+    assert exported_span_scopes() <= APPLICATION_INSTRUMENTATION_SCOPES
+
+
+def test_turning_them_off_removes_exactly_the_database_scope(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "false")
+
+    assert APPLICATION_INSTRUMENTATION_SCOPES - exported_span_scopes() == {DB_INSTRUMENTATION_SCOPE}
+
+
+def test_db_spans_enabled_reflects_the_variable(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    assert db_spans_enabled() is True
+    monkeypatch.setenv(ENV_VAR, "false")
+    assert db_spans_enabled() is False
+
+
+# The end-to-end half. A real sqlite engine and the real instrumentor, in a subprocess because
+# SQLAlchemyInstrumentor patches globally and the tracer provider is process-wide, so an
+# in-process version of this would leak state into whatever test ran next.
+
+PROBE = """
+import json, sys
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lfx.observability import ApplicationOnlySpanProcessor, instrument_database
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+import sqlalchemy as sa
+
+engine = sa.create_engine("sqlite://")
+instrument_database(engine)
+
+with engine.connect() as conn:
+    conn.execute(sa.text("SELECT 1"))
+
+# A flow span too, so "nothing exported" and "db spans suppressed" cannot be confused.
+provider.get_tracer("langflow.observability").start_span("flow.execute").end()
+
+provider.force_flush()
+names = [s.name for s in exporter.get_finished_spans()]
+scopes = [s.instrumentation_scope.name if s.instrumentation_scope else "" for s in exporter.get_finished_spans()]
+print("PROBE_RESULT " + json.dumps({"names": names, "scopes": scopes}))
+"""
+
+
+def run_probe(env_value: str | None) -> dict:
+    import os
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    env.pop(ENV_VAR, None)
+    if env_value is not None:
+        env[ENV_VAR] = env_value
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = Path(tmp) / "probe.py"
+        probe.write_text(PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe)], env=env, capture_output=True, text=True, timeout=300, check=False
+        )
+    assert completed.returncode == 0, completed.stderr
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    return json.loads(lines[0].removeprefix("PROBE_RESULT "))
+
+
+def test_a_real_query_produces_database_spans_by_default():
+    """The positive control for the test below, run against the real instrumentor."""
+    result = run_probe(None)
+
+    assert DB_INSTRUMENTATION_SCOPE in result["scopes"], result
+    assert "flow.execute" in result["names"], result
+
+
+def test_a_real_query_produces_no_database_spans_when_turned_off():
+    """And the flow span still exports, so the probe is demonstrably still looking."""
+    result = run_probe("false")
+
+    assert DB_INSTRUMENTATION_SCOPE not in result["scopes"], result
+    assert "flow.execute" in result["names"], result


### PR DESCRIPTION
Database spans are the bulk of what Langflow exports. Measured against a live run with a commercial APM on the other end, not estimated:

| span group | count | share |
| --- | --- | --- |
| SQLAlchemy (`connect`, `SELECT`, `INSERT`, `UPDATE`) | 4156 | ~80% |
| `flow.execute` | 98 | ~2% |
| everything else | ~910 | ~18% |
| total | 5164 | |

That is a closed 5 minute window covering 104 flow runs, so roughly 50 spans per run, 40 of them database. APMs bill per span ingested, so an operator who turned export on to watch flow health ends up paying mostly for `connect` and `SELECT`.

`LANGFLOW_OTEL_DB_SPANS=false` drops them.

## Why it is on by default

The volume buys something. In the same run, 17% of pool checkouts took over 50ms and 4% took over 200ms. That is the difference between knowing a run was slow and knowing it was slow waiting for the database. Defaulting this off would hide the most common cause of a slow run behind a setting nobody knows to look for.

Worth saying because it looks like a bug and is not: `connect` wraps `Engine.connect()`, which is a pool checkout, not a new DBAPI connection. About 14 per run is normal, and the pool config is fine.

## Two gates

The instrumentor is not installed at all when it is off, so the spans are never created rather than created and dropped. The export scope set drops the scope too, which covers the case of another library instrumenting sqlalchemy against our provider.

## The part worth reviewing

The setting can only ever **subtract** from the allowlist. The allowlist is what keeps prompt-carrying scopes out of the APM, so configuration must not be able to widen it, and `test_configuration_can_only_subtract_from_the_allowlist` pins that across values including one naming an LLM scope. If you only look at one thing here, look at that.

Anything but a recognised false value leaves db spans on, so a typo cannot quietly stop telemetry an operator believes is running. `flase` is in the test parameters on purpose.

## Verification

30 new tests. I ran a mutation check rather than trusting green: making `db_spans_enabled()` always return `True` turns 10 of them red, including the end-to-end one, and they pass again on restore.

The end-to-end pair runs a real sqlite engine through the real instrumentor in a subprocess (the instrumentor patches globally and the provider is process-wide). Each absence assertion is paired with a `flow.execute` span that must still export, so "no db spans" cannot pass by the probe seeing nothing at all.

Existing suites: 84 lfx observability tests and 170 backend telemetry tests pass.

`lfx observability doctor` now reports which way it is set, next to the existing note about log bodies:

```
OK traces: Accepted by http://localhost:4318/v1/traces over http/protobuf.
    database spans ARE exported, and they are most of the volume (~50 spans per flow run).
    Set LANGFLOW_OTEL_DB_SPANS=false to send flow and request spans only, at the cost of
    losing database latency
```

## Known gap

Not exercised against a long-running server, only against the real instrumentor in the test probe. The numbers above come from a live demo instance exporting to New Relic, but that instance runs the default configuration; I did not restart it on this branch to watch the volume drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database tracing spans for SQLAlchemy operations by default.
  * Added configuration to disable database spans while preserving flow tracing.
  * Observability diagnostics now report database-span export status, estimated volume, and the setting used to disable them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->