### PR TITLE
fix(test): stop skipping Ollama SSRF regressions in the default install

### DIFF
--- a/src/backend/tests/unit/components/test_ssrf_guarded_ollama_components.py
+++ b/src/backend/tests/unit/components/test_ssrf_guarded_ollama_components.py
@@ -1,0 +1,61 @@
+"""SSRF guard regressions for the Ollama components.
+
+These live apart from ``test_ssrf_guarded_url_components.py`` because Ollama graduated out of
+the ``lfx-bundles`` metapackage into ``lfx-ollama``, which *is* a default ``langflow`` dependency.
+That file's module-level ``pytest.importorskip("lfx_bundles")`` would skip these in the default
+install even though the components are present -- so they guard on ``lfx_ollama`` instead.
+
+They also stay out of ``test_chatollama_component.py`` / ``test_ollama_embeddings_component.py``:
+both of those classes carry an autouse ``disable_ssrf_protection`` fixture, which is exactly the
+protection under test here.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("lfx_ollama")
+
+from lfx.components.ollama.ollama import ChatOllamaComponent
+from lfx.components.ollama.ollama_embeddings import OllamaEmbeddingsComponent
+
+BLOCKED_URL = "http://169.254.169.254/latest/meta-data"
+
+
+@pytest.fixture(autouse=True)
+def enable_ssrf_protection(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "true")
+    monkeypatch.delenv("LANGFLOW_SSRF_ALLOWED_HOSTS", raising=False)
+
+
+# ``ollama.py`` / ``ollama_embeddings.py`` are reachable under several module identities (the
+# ``lfx.components.ollama.*`` shim, the canonical ``lfx_ollama.components.ollama.*``, and the
+# runtime ``_lfx_ext.*`` ext-loader copy). Patch on the module the imported class actually lives
+# in -- a fixed string target misses when an earlier test in the suite resolves it elsewhere.
+_OLLAMA_MODULE = sys.modules[ChatOllamaComponent.__module__]
+_OLLAMA_EMBEDDINGS_MODULE = sys.modules[OllamaEmbeddingsComponent.__module__]
+
+
+def test_ollama_embeddings_build_blocks_metadata_url_before_sdk_client():
+    component = OllamaEmbeddingsComponent(base_url=BLOCKED_URL, model_name="model")
+
+    with (
+        patch.object(_OLLAMA_EMBEDDINGS_MODULE, "OllamaEmbeddings") as mock_embeddings,
+        pytest.raises(ValueError, match="SSRF Protection"),
+    ):
+        component.build_embeddings()
+
+    mock_embeddings.assert_not_called()
+
+
+def test_ollama_build_blocks_metadata_url_before_sdk_client():
+    component = ChatOllamaComponent(base_url=BLOCKED_URL, model_name="model", mirostat="Disabled")
+
+    with (
+        patch.object(_OLLAMA_MODULE, "ChatOllama") as mock_chat_ollama,
+        pytest.raises(ValueError, match="SSRF Protection"),
+    ):
+        component.build_model()
+
+    mock_chat_ollama.assert_not_called()

--- a/src/backend/tests/unit/components/test_ssrf_guarded_url_components.py
+++ b/src/backend/tests/unit/components/test_ssrf_guarded_url_components.py
@@ -12,8 +12,6 @@ from lfx.components.huggingface.huggingface_inference_api import HuggingFaceInfe
 from lfx.components.litellm.litellm_proxy import LiteLLMProxyComponent
 from lfx.components.lmstudio.lmstudioembeddings import LMStudioEmbeddingsComponent
 from lfx.components.lmstudio.lmstudiomodel import LMStudioModelComponent
-from lfx.components.ollama.ollama import ChatOllamaComponent
-from lfx.components.ollama.ollama_embeddings import OllamaEmbeddingsComponent
 from lfx.components.xai.xai import XAI_DEFAULT_MODELS, XAIModelComponent
 from lfx.utils.ssrf_protection import SSRFProtectionError
 
@@ -148,28 +146,9 @@ def test_huggingface_build_blocks_metadata_url_before_sdk_client():
     mock_create.assert_not_called()
 
 
-def test_ollama_embeddings_build_blocks_metadata_url_before_sdk_client():
-    component = OllamaEmbeddingsComponent(base_url=BLOCKED_URL, model_name="model")
-
-    with (
-        patch("lfx.components.ollama.ollama_embeddings.OllamaEmbeddings") as mock_embeddings,
-        pytest.raises(ValueError, match="SSRF Protection"),
-    ):
-        component.build_embeddings()
-
-    mock_embeddings.assert_not_called()
-
-
-def test_ollama_build_blocks_metadata_url_before_sdk_client():
-    component = ChatOllamaComponent(base_url=BLOCKED_URL, model_name="model", mirostat="Disabled")
-
-    with (
-        patch("lfx.components.ollama.ollama.ChatOllama") as mock_chat_ollama,
-        pytest.raises(ValueError, match="SSRF Protection"),
-    ):
-        component.build_model()
-
-    mock_chat_ollama.assert_not_called()
+# The Ollama SSRF regressions live in ``test_ssrf_guarded_ollama_components.py``: Ollama graduated
+# into ``lfx-ollama`` (a default ``langflow`` dependency), so this file's ``lfx_bundles`` skip
+# would hide them in the default install.
 
 
 def test_litellm_build_blocks_metadata_url_before_httpx_and_openai_client():


### PR DESCRIPTION
### What

Two SSRF regression tests for the Ollama components were being skipped in CI even though the components they cover are installed and working.

`src/backend/tests/unit/components/test_ssrf_guarded_url_components.py` carries a module-level `pytest.importorskip("lfx_bundles")`. That guard is correct and necessary — since #13869 made `lfx-bundles` opt-in, an unguarded import of a moved provider shim raises `ModuleNotFoundError` at **collection**, which under `-x` reds the entire pytest-split group.

But Ollama is no longer in that metapackage. It graduated into `lfx-ollama`, which **is** a default `langflow` dependency (`pyproject.toml:38`), so `lfx.components.ollama.*` resolves fine in the default install. The blanket guard was hiding two tests that can and should run.

### Change

Split the two Ollama tests into `test_ssrf_guarded_ollama_components.py`, guarded on `lfx_ollama` instead.

They deliberately do **not** fold into the existing `test_chatollama_component.py` / `test_ollama_embeddings_component.py`: both of those classes carry an autouse `disable_ssrf_protection` fixture, which is exactly the protection under test here. The new file replicates the original's autouse `enable_ssrf_protection` fixture so it doesn't depend on ambient env.

Patch targets are anchored via `sys.modules[Component.__module__]` rather than a fixed dotted string, matching the convention (and the comment explaining it) in `test_chatollama_component.py` — these modules are reachable under the `lfx.components.ollama.*` shim, the canonical `lfx_ollama.components.ollama.*`, and the runtime `_lfx_ext.*` ext-loader copy.

The remaining seven providers in the original file are genuinely bundle-only and keep their `lfx_bundles` guard; a pointer comment marks where the Ollama cases went.

### Test plan

Verified in a default install (`lfx_bundles` absent, `lfx_ollama` present — same shape as CI):

- [x] New file alone: `2 passed`
- [x] New file + original: `2 passed, 1 skipped` (original still correctly skips)
- [x] Alongside both sibling Ollama suites, to exercise the module-identity concern: `101 passed, 8 skipped`
- [x] `ruff check` / `ruff format --check` clean

Before this change both tests reported `SKIPPED ... could not import 'lfx_bundles'`.

### Notes

This targets `release-1.12.0`, where `lfx-bundles` is opt-in. `main` still has it as a default dependency, so the guards are no-ops there and nothing skips.

The broader gap — that **no** CI job installs `lfx-bundles` and runs the backend unit suite, leaving 36 files / 378 tests unexecuted — is filed separately as https://github.com/langflow-ai/langflow/issues/14554 and is not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added regression coverage confirming SSRF protection blocks unsafe metadata URLs for Ollama chat and embeddings components before connections are created.
  * Preserved SSRF URL protection tests for other components while separating Ollama-specific coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->