### PR TITLE
docs: document the OpenTelemetry export and add a New Relic guide

### DIFF
--- a/docs/docs/Develop/observability-new-relic.mdx
+++ b/docs/docs/Develop/observability-new-relic.mdx
@@ -1,0 +1,110 @@
+---
+title: New Relic
+slug: /observability-new-relic
+description: Export Langflow traces, metrics, and logs to New Relic over OTLP, and verify the data actually landed.
+---
+
+New Relic accepts OpenTelemetry data over OTLP, so Langflow exports to it with configuration only and no vendor code.
+
+This page covers the New Relic specifics. For what Langflow exports, what it withholds, and how to control span volume, see [OpenTelemetry](./observability-opentelemetry.mdx) first.
+
+## Prerequisites
+
+- A New Relic account. The free tier is sufficient.
+- A New Relic **ingest license key**. In New Relic, go to **Administration** > **API keys** and copy a key of type `INGEST - LICENSE`.
+
+  Use an ingest license key, not a user API key. A license key writes data in and cannot query anything back. To run the verification queries at the end of this page, you also need access to the New Relic console for the same account.
+
+## Configure environment variables
+
+Add the following to your Langflow environment. Replace the placeholder with your license key:
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
+OTEL_EXPORTER_OTLP_HEADERS=api-key=YOUR_LICENSE_KEY
+OTEL_SERVICE_NAME=langflow
+OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
+```
+
+If your account is in the EU region, use `https://otlp.eu01.nr-data.net` instead.
+
+Two of these are not optional in practice:
+
+- **`OTEL_EXPORTER_OTLP_COMPRESSION=gzip`.** New Relic rejects payloads over 1 MB. A busy Langflow instance exports large span batches, and gzip keeps them under the cap.
+- **`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`.** New Relic renders counters from delta values, and the OpenTelemetry SDK sends cumulative by default. Without this, request-rate charts read as ever-climbing totals instead of a rate, which looks like a broken integration when it is only the temporality.
+
+If you export through an OpenTelemetry Collector rather than directly, apply the [`cumulativetodelta`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor) processor on the pipeline that feeds New Relic instead of setting the temporality variable, and leave any local pipelines on cumulative.
+
+Restart Langflow and run a flow to generate traffic.
+
+## Verify the data landed
+
+A `2xx` response on export is not evidence. New Relic acknowledges the payload and then validates asynchronously, discarding anything invalid. Confirm by querying.
+
+In New Relic, go to **Query your data** to open the query builder, then run the following NRQL.
+
+1. Confirm spans are arriving and `flow.execute` is among them:
+
+   ```sql
+   SELECT count(*) FROM Span WHERE service.name = 'langflow'
+   SINCE 30 minutes ago UNTIL 5 minutes ago FACET name
+   ```
+
+2. Confirm nothing was accepted and then dropped. This should return zero:
+
+   ```sql
+   SELECT count(*) FROM NrIntegrationError SINCE 1 day ago FACET message
+   ```
+
+3. Retrieve a single run by its trace ID. Take a value from the first query's results, or from the `trace_id` field on any Langflow log line:
+
+   ```sql
+   SELECT * FROM Span WHERE trace.id = 'YOUR_TRACE_ID' SINCE 1 hour ago
+   ```
+
+4. Confirm metrics are arriving:
+
+   ```sql
+   SELECT count(*) FROM Metric WHERE service.name = 'langflow'
+   SINCE 30 minutes ago UNTIL 5 minutes ago FACET metricName
+   ```
+
+A failed run's `flow.execute` span arrives with `error.type` set to the exception class and `Otel.status Description` set to the same value. The exception message is not exported. For the full list of what Langflow withholds, see [OpenTelemetry](./observability-opentelemetry.mdx).
+
+## Troubleshooting
+
+### "Required metrics are missing" on the service page
+
+New Relic's OpenTelemetry APM view matches incoming data against specific semantic conventions to populate its prebuilt charts. Langflow emits current-convention metric names, which do not all match what that view expects, so the banner can appear even when ingest is healthy.
+
+This is a display issue, not an ingest failure. Confirm with query 4 above, and use the query builder or your own dashboards rather than the curated view.
+
+### Span counts look lower than expected
+
+Use a closed time window. A query ending at `NOW` includes a period that data has not finished arriving for, and with steady traffic that shortfall can look like 30% data loss.
+
+Add an explicit `UNTIL`, as in the queries above, or use absolute timestamps:
+
+```sql
+SELECT count(*) FROM Span WHERE service.name = 'langflow'
+SINCE '2026-08-14 13:28:00+0000' UNTIL '2026-08-14 13:33:00+0000' FACET name
+```
+
+### No data at all
+
+Run `lfx observability doctor` to confirm the endpoint accepts data with your configuration. A `401` or `403` means the key is wrong or is not an ingest license key.
+
+### Charts show ever-climbing totals instead of a rate
+
+The temporality preference is missing. See [Configure environment variables](#configure-environment-variables).
+
+### Your bill is higher than expected
+
+Database spans are roughly 80% of Langflow's exported spans. Set `LANGFLOW_OTEL_DB_SPANS=false` to drop them, after reading the trade-off in [Control span volume](./observability-opentelemetry.mdx#control-span-volume).
+
+## See also
+
+- [OpenTelemetry](./observability-opentelemetry.mdx)
+- [Logs](/logging)
+- [Traces](/traces)

--- a/docs/docs/Develop/observability-opentelemetry.mdx
+++ b/docs/docs/Develop/observability-opentelemetry.mdx
@@ -1,0 +1,126 @@
+---
+title: OpenTelemetry
+slug: /observability-opentelemetry
+description: Export Langflow service health, flow execution spans, and runtime metrics to any OpenTelemetry backend.
+---
+
+Langflow emits OpenTelemetry traces, metrics, and logs describing the health of the Langflow service itself: request rate, error rate, duration, runtime health, and one span per flow run.
+
+This telemetry answers operator questions, such as which flows are failing, whether the service is slow, and where the time went. It is not LLM tracing. Langflow deliberately withholds prompts, completions, and other flow payloads from this export. For prompt-level tracing, use one of the [monitoring integrations](/integrations-langfuse) instead.
+
+There is no vendor code in the Langflow runtime. Langflow speaks plain OTLP, so any OpenTelemetry-compatible backend works, either directly or through an OpenTelemetry Collector.
+
+## Prerequisites
+
+- An OTLP endpoint, such as an OpenTelemetry Collector, a Grafana stack, or a commercial APM.
+- The `langflow` distribution already includes the OpenTelemetry packages. If you run the `lfx` engine on its own, install the extra:
+
+  ```bash
+  pip install "lfx[otel]"
+  ```
+
+  If an OTLP endpoint is configured and the packages are missing, Langflow logs a warning at startup rather than exporting nothing silently.
+
+## Configure environment variables
+
+Set the endpoint and a service name. Nothing else is required.
+
+```text
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=langflow
+```
+
+If no OTLP endpoint is set, Langflow installs no providers and the export path stays inert.
+
+The standard OpenTelemetry SDK variables also apply. The following are the ones operators reach for most often:
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `grpc`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Authentication headers, such as an API key. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal endpoint override. The same pattern applies to `METRICS` and `LOGS`. |
+| `OTEL_TRACES_EXPORTER=none` | Disables a single signal. The same pattern applies to `METRICS` and `LOGS`. |
+| `OTEL_EXPORTER_OTLP_COMPRESSION=gzip` | Compresses payloads. Required by backends with a payload size cap. |
+
+## What Langflow exports
+
+### Traces
+
+| Span | Emitted by | Carries |
+|------|-----------|---------|
+| `flow.execute` | Langflow | `flow_id`, `run_id`, `session_id`, `protocol`, `status`, and `error.type` when the run fails |
+| HTTP server spans | FastAPI and ASGI instrumentation | Route, method, status code |
+| Database spans | SQLAlchemy instrumentation | `db.system`, `db.operation`, and `db.statement` with bound parameters left as `?` placeholders |
+
+The `flow.execute` span is the unit of work. There is no span per component, because component spans would carry component payloads.
+
+The `protocol` attribute records which entry point drove the run: `v1`, `v1.build`, `v1.build.public`, `v1.advanced`, `v2`, `webhook`, `mcp`, `a2a`, `openai_responses`, `voice`, `agentic`, `lfx.run`, or `lfx.serve`. Use it to compare error rates across the API, the MCP server, and the UI's build endpoint.
+
+The `status` attribute is `ok`, `error`, `paused`, or `cancelled`. A run stopped by a user is `cancelled` rather than `error`, so a stop button does not inflate your error rate.
+
+### Metrics
+
+- HTTP server metrics, including `http.server.request.duration`, which give you rate, errors, and duration.
+- Process metrics for this interpreter: CPU, memory, threads, open file descriptors, context switches, and garbage collection.
+- Langflow's own gauges, such as `langflow_event_loop_lag_seconds`.
+
+Process metrics deliberately describe the process rather than the host. Under Kubernetes, host metrics would report the node, which is misleading next to a per-pod request rate, and your infrastructure agent already provides them.
+
+### Logs
+
+If an OTLP endpoint is configured, log records at `INFO` and above are exported, and every record carries `trace_id` and `span_id` so you can pivot from a slow trace to the lines it produced.
+
+## What Langflow does not export
+
+The export is an allowlist, not a filter applied after the fact. Spans from instrumentation that is not on the list, including every LLM tracing integration, are dropped on the way out.
+
+The following never reach your backend:
+
+- Prompts, completions, tool arguments, and tool results.
+- Exception **messages**. A failed run reports `error.type` only, because the message frequently embeds flow content. For example, a run that failed with `RuntimeError("inventory service returned 503")` exports `error.type = RuntimeError` and nothing else.
+- Database bound parameters, so chat message text stays in the database.
+- Outbound provider request URLs, since provider keys are sometimes passed as query parameters.
+- Log message bodies, unless a call site explicitly opts in.
+
+Two settings widen this, and both warn when set:
+
+| Variable | Effect |
+|----------|--------|
+| `LANGFLOW_OTEL_LOG_LEVEL=DEBUG` | Exports `DEBUG` records. Langflow logs flow inputs and outputs at `DEBUG`, so prompt and completion content reaches your backend. |
+| `LANGFLOW_OTEL_LOG_BODIES=all` | Exports log message bodies, including completions, chat history, and provider error text. |
+
+## Control span volume
+
+Database spans are the bulk of the export. Measured against a running instance under steady load, they were roughly 80% of exported spans, at about 50 spans per flow run against a single `flow.execute`. Backends that bill per span ingested will bill mostly for them.
+
+To send flow and request spans only:
+
+```text
+LANGFLOW_OTEL_DB_SPANS=false
+```
+
+Consider the trade before you set it. In that same measurement, 17% of database connection checkouts took longer than 50 ms and 4% took longer than 200 ms. Without database spans, a run that was slow waiting on the database looks simply slow, with no cause attached.
+
+When the setting is off, the instrumentation is never installed, so the spans are not created rather than created and discarded.
+
+## Verify your configuration
+
+Run the doctor. It sends a probe on every signal and reports what the backend accepted:
+
+```bash
+lfx observability doctor
+```
+
+The doctor also reports what you are about to send, including whether log bodies are exported and whether database spans are on. Look for items named `lfx.observability.doctor` in your backend.
+
+A successful send is not proof that your backend kept the data. Some backends acknowledge a payload and then discard invalid records during asynchronous validation. Always confirm by querying the backend for the trace or metric you expect.
+
+## Vendor guides
+
+- [New Relic](./observability-new-relic.mdx)
+- [Grafana and Loki](/observability-grafana-loki)
+
+## See also
+
+- [Logs](/logging)
+- [Traces](/traces)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -173,6 +173,8 @@ module.exports = {
           label: "Observability",
           items: [
             "Develop/logging",
+            "Develop/observability-opentelemetry",
+            "Develop/observability-new-relic",
             "Develop/observability-grafana-loki",
             "Develop/traces",
             {


### PR DESCRIPTION
Stacked on #14552, because these pages document `LANGFLOW_OTEL_DB_SPANS`, which lands there. Review that one first; this diff is docs only.

## Why

Langflow has exported OTLP traces, metrics and logs for a while and none of it was documented. Nothing under `docs/` mentioned `OTEL_EXPORTER_OTLP_ENDPOINT`, so the feature was discoverable only by reading the source.

The existing Instana page covers the Traceloop LLM-tracing route, which is a different thing. That one carries prompts and completions on purpose; this export deliberately does not, and the pages say so explicitly so nobody confuses the two.

## Two pages

`observability-opentelemetry.mdx` is the shared base, because every vendor guide needs it and Instana is next.

- What gets exported: the `flow.execute` attribute set, HTTP spans, database spans, the metric families.
- What does not: prompts, completions, tool arguments, exception **messages**, database bound parameters, outbound provider URLs.
- The two settings that widen that boundary, named out loud, since an operator should not learn about `LANGFLOW_OTEL_LOG_BODIES` from a support ticket.
- Span volume and the `LANGFLOW_OTEL_DB_SPANS` trade, with the measured numbers, so nobody meets that on an invoice.

`observability-new-relic.mdx` is the vendor guide: ingest license key (and why a user API key is the wrong one), gzip for the 1 MB cap, delta temporality, and a verification section.

## Things checked rather than assumed

**The protocol values are read off the code, not off the plan.** Actual emitted values are `v1`, `v1.build`, `v1.build.public`, `v1.advanced`, `v2`, `webhook`, `mcp`, `a2a`, `openai_responses`, `voice`, `agentic`, `lfx.run`, `lfx.serve`. Worth knowing for anyone writing dashboards against them.

**Delta temporality actually works via the env var.** I did not assume the SDK honours `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. Checked the exporter's preferred temporality with and without it: without, Counter and Histogram are CUMULATIVE; with `delta`, both are DELTA.

**The verification section is the point of the New Relic page.** A 2xx is not evidence — New Relic acks and then discards invalid data during async validation. The page gives the NRQL to confirm the data is really there, including the `NrIntegrationError` check.

Both traps we actually hit are written down: the "required metrics are missing" banner is the curated OTel APM view matching semantic conventions rather than an ingest failure, and an open-ended time window measures ingest lag and reads as ~30% data loss.

## Verification

`npm run build` passes. The config sets `onBrokenLinks: "throw"`, and the first build failed on exactly the mistake worth catching: absolute slugs between the two new pages resolve against the released docs version, where neither exists yet. Switched the cross-links to relative `.mdx` form, which is what the existing pages use, and the build now exits 0 with both pages rendered.

## Known gap

The screenshot-and-walkthrough treatment of the existing vendor pages is not here; these are text and NRQL. Happy to add UI screenshots if that is the house style for vendor guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenTelemetry observability guidance, including setup, exported telemetry, privacy controls, verification, and troubleshooting.
  * Added a New Relic observability guide covering configuration, EU endpoints, data validation, troubleshooting, and cost controls.
  * Added both guides to the Observability documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->