### PR TITLE
chore: add bob context file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,6 +305,7 @@ whitesource/
 
 #ai folders
 .bob/
+_context
 
 # Cursor local (personal) settings
 .cursor/settings.local.json


### PR DESCRIPTION
add bob context file to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded the `_context` directory from version control tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->