### PR TITLE
fix: keep the sqlite file path out of exported database spans

### DIFF
--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -388,6 +388,7 @@ if _OTEL_AVAILABLE:
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
             if scope in APPLICATION_INSTRUMENTATION_SCOPES:
                 _redact_url_attributes(span)
+                _redact_db_path_attributes(span)
                 super().on_end(span)
                 return
             if scope not in self._dropped_scopes:
@@ -805,6 +806,76 @@ def _redact_url_attributes(span) -> None:
     )
     redacted_attributes.dropped = original_attributes.dropped
     span._attributes = redacted_attributes  # noqa: SLF001
+
+
+# Attributes a database instrumentor derives from the database name. For SQLite the "name" is
+# the file path, so each of these carries it: db.operation is built as "<operation> <db.name>",
+# and the span name is that same string.
+_DB_NAME_DERIVED_ATTRIBUTES = ("db.name", "db.operation")
+
+
+def _shorten_db_path(value: str) -> str:
+    """Return the final path segment, or the value unchanged when it is not a path.
+
+    Split on both separators rather than using os.path, because the exporting host and the host
+    that wrote the path are not necessarily the same platform: a Windows deployment's backslash
+    path must still be shortened when this runs anywhere else.
+    """
+    return value.replace("\\", "/").rsplit("/", maxsplit=1)[-1]
+
+
+def _redact_db_path_attributes(span) -> None:
+    """Replace a SQLite database file path with its file name, in place.
+
+    SQLAlchemy's instrumentation sets ``db.name`` from the database name, and for SQLite that
+    name is the file path. It then builds ``db.operation`` and the span name as
+    ``"<operation> <db.name>"``, so a span arrives at the APM named
+    ``SELECT /home/alice/langflow/langflow.db``. Confirmed present in a commercial APM, not only
+    locally, so it survives export to a third party.
+
+    SQLite is the default database, so this is the default configuration rather than an edge
+    case. The path is not a credential, but it is host detail the operator did not choose to
+    send: install directory, the account name on a typical unix path, and whatever their
+    directory naming gives away.
+
+    It is also a cardinality problem. Every deployment path is a distinct span name, so
+    dashboards written against one environment do not port to another.
+
+    The file name is kept rather than dropping the value, because an operator running more than
+    one SQLite database still needs to tell them apart. Postgres and MySQL are unaffected: their
+    ``db.name`` is a logical name with no separator, so it is already its own final segment and
+    nothing changes.
+    """
+    attributes = span.attributes
+    db_name = attributes.get("db.name") if attributes else None
+    if not isinstance(db_name, str):
+        return
+    shortened = _shorten_db_path(db_name)
+    if shortened == db_name:
+        # Not a path. Covers every non-file database, so this costs one comparison there.
+        return
+
+    updated = dict(attributes)
+    for key in _DB_NAME_DERIVED_ATTRIBUTES:
+        value = attributes.get(key)
+        if isinstance(value, str):
+            updated[key] = value.replace(db_name, shortened)
+
+    from opentelemetry.attributes import BoundedAttributes
+
+    original_attributes = span._attributes  # noqa: SLF001
+    shortened_attributes = BoundedAttributes(
+        maxlen=original_attributes.maxlen,
+        attributes=updated,
+        max_value_len=original_attributes.max_value_len,
+    )
+    shortened_attributes.dropped = original_attributes.dropped
+    span._attributes = shortened_attributes  # noqa: SLF001
+
+    # The span name is the other carrier, and the one an operator actually reads. ReadableSpan
+    # exposes name as a read-only property over this attribute, the same shape as _attributes.
+    if isinstance(span.name, str) and db_name in span.name:
+        span._name = span.name.replace(db_name, shortened)  # noqa: SLF001
 
 
 def bootstrap_application_telemetry(*, prometheus_enabled: bool = False) -> ApplicationTelemetry:

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -842,17 +842,25 @@ def _redact_db_path_attributes(span) -> None:
     dashboards written against one environment do not port to another.
 
     The file name is kept rather than dropping the value, because an operator running more than
-    one SQLite database still needs to tell them apart. Postgres and MySQL are unaffected: their
-    ``db.name`` is a logical name with no separator, so it is already its own final segment and
-    nothing changes.
+    one SQLite database still needs to tell them apart.
+
+    Only SQLite spans are touched, and the gate is ``db.system`` rather than "does this value
+    look like a path". A separator is legal inside a Postgres or MySQL database name, so a
+    shape-based test would silently rename a logical database in the operator's dashboards.
     """
     attributes = span.attributes
-    db_name = attributes.get("db.name") if attributes else None
+    if not attributes or attributes.get("db.system") != "sqlite":
+        # Gated on the system rather than on "does this look like a path", because a
+        # separator is legal inside a Postgres or MySQL database name. Shortening one of
+        # those would silently rename a logical database in the operator's dashboards.
+        return
+
+    db_name = attributes.get("db.name")
     if not isinstance(db_name, str):
         return
     shortened = _shorten_db_path(db_name)
     if shortened == db_name:
-        # Not a path. Covers every non-file database, so this costs one comparison there.
+        # An in-memory database, or a bare file name that is already its final segment.
         return
 
     updated = dict(attributes)

--- a/src/lfx/tests/unit/test_db_span_path_redaction.py
+++ b/src/lfx/tests/unit/test_db_span_path_redaction.py
@@ -90,6 +90,29 @@ def test_other_attributes_are_untouched():
     assert span.attributes["db.statement"] == "SELECT flow.name FROM flow WHERE flow.id = ?"
 
 
+def test_a_postgres_name_containing_a_separator_is_left_alone():
+    """The gate is db.system, not the shape of the value.
+
+    A separator is legal inside a Postgres database name. Shortening one would silently
+    rename a logical database in the operator's dashboards, which is a worse bug than the
+    leak this function exists to fix.
+    """
+    span = export(
+        "SELECT tenant/archive",
+        {"db.system": "postgresql", "db.name": "tenant/archive", "db.operation": "SELECT tenant/archive"},
+    )
+
+    assert span.name == "SELECT tenant/archive"
+    assert span.attributes["db.name"] == "tenant/archive"
+
+
+def test_a_path_without_a_sqlite_system_is_left_alone():
+    """No db.system means no evidence it is a file, so nothing is assumed."""
+    span = export(f"SELECT {DB_PATH}", {"db.name": DB_PATH})
+
+    assert span.attributes["db.name"] == DB_PATH
+
+
 def test_a_logical_database_name_is_left_alone():
     """Postgres and MySQL report a name with no separator, so nothing should change."""
     span = export(

--- a/src/lfx/tests/unit/test_db_span_path_redaction.py
+++ b/src/lfx/tests/unit/test_db_span_path_redaction.py
@@ -1,0 +1,199 @@
+"""A SQLite database path must not leave the process as a span name.
+
+SQLAlchemy's instrumentation sets ``db.name`` from the database name, and for SQLite that name
+is the file path. It builds ``db.operation`` and the span name as ``"<operation> <db.name>"``,
+so without this the operator's APM shows spans named
+``SELECT /home/alice/langflow/langflow.db``. SQLite is the default database, so that is the
+default configuration rather than an edge case.
+
+The file name is kept rather than dropped, because someone running more than one SQLite
+database still has to tell them apart.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace.export.in_memory_span_exporter")
+
+from lfx.observability import ApplicationOnlySpanProcessor, _shorten_db_path
+
+# A directory that gives away the account name, which is the part of a real path worth not
+# sending. The file name is the part that survives.
+DB_PATH = "/home/alice/deployments/langflow-prod/langflow.db"
+DB_FILE = "langflow.db"
+
+
+def export(name: str, attributes: dict):
+    """Push one span through the processor and return it as the exporter received it."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+    try:
+        span = provider.get_tracer("opentelemetry.instrumentation.sqlalchemy").start_span(name)
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+        span.end()
+        provider.force_flush()
+        finished = exporter.get_finished_spans()
+        assert len(finished) == 1, finished
+        return finished[0]
+    finally:
+        provider.shutdown()
+
+
+def test_the_span_name_carries_the_file_name_not_the_path():
+    span = export(
+        f"SELECT {DB_PATH}",
+        {"db.system": "sqlite", "db.name": DB_PATH, "db.operation": f"SELECT {DB_PATH}"},
+    )
+
+    assert span.name == f"SELECT {DB_FILE}"
+    assert span.attributes["db.name"] == DB_FILE
+    assert span.attributes["db.operation"] == f"SELECT {DB_FILE}"
+
+
+def test_no_part_of_the_directory_survives_anywhere_on_the_span():
+    """Serialise the whole span, because the path could hide on an attribute not asserted above."""
+    span = export(
+        f"SELECT {DB_PATH}",
+        {"db.system": "sqlite", "db.name": DB_PATH, "db.operation": f"SELECT {DB_PATH}"},
+    )
+    dumped = json.dumps({"name": span.name, "attributes": dict(span.attributes)})
+
+    assert "alice" not in dumped, dumped
+    assert "/home" not in dumped, dumped
+    assert DB_FILE in dumped, "the file name should survive; only the directory is dropped"
+
+
+def test_other_attributes_are_untouched():
+    span = export(
+        f"SELECT {DB_PATH}",
+        {
+            "db.system": "sqlite",
+            "db.name": DB_PATH,
+            "db.operation": f"SELECT {DB_PATH}",
+            "db.statement": "SELECT flow.name FROM flow WHERE flow.id = ?",
+        },
+    )
+
+    assert span.attributes["db.system"] == "sqlite"
+    assert span.attributes["db.statement"] == "SELECT flow.name FROM flow WHERE flow.id = ?"
+
+
+def test_a_logical_database_name_is_left_alone():
+    """Postgres and MySQL report a name with no separator, so nothing should change."""
+    span = export(
+        "SELECT langflow", {"db.system": "postgresql", "db.name": "langflow", "db.operation": "SELECT langflow"}
+    )
+
+    assert span.name == "SELECT langflow"
+    assert span.attributes["db.name"] == "langflow"
+
+
+def test_a_windows_path_is_shortened_too():
+    """The exporting host and the host that wrote the path need not be the same platform."""
+    windows_path = r"C:\\Users\\alice\\langflow\\langflow.db"
+    span = export(f"SELECT {windows_path}", {"db.system": "sqlite", "db.name": windows_path})
+
+    assert span.attributes["db.name"] == DB_FILE
+    assert "alice" not in span.name, span.name
+
+
+def test_a_span_with_no_db_name_is_unchanged():
+    span = export("flow.execute", {"flow_id": "abc", "status": "ok"})
+
+    assert span.name == "flow.execute"
+    assert span.attributes["flow_id"] == "abc"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("/a/b/c.db", "c.db"),
+        ("c.db", "c.db"),
+        ("langflow", "langflow"),
+        (":memory:", ":memory:"),
+        ("", ""),
+        ("/", ""),
+        ("relative/path/x.db", "x.db"),
+    ],
+)
+def test_shorten_db_path(value, expected):
+    assert _shorten_db_path(value) == expected
+
+
+# The end-to-end half. A real SQLite engine and the real instrumentor, in a subprocess because
+# SQLAlchemyInstrumentor patches globally and the tracer provider is process-wide.
+
+PROBE = """
+import json, os, tempfile
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lfx.observability import ApplicationOnlySpanProcessor, instrument_database
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+import sqlalchemy as sa
+
+# A real file, in a directory whose name is the thing that must not be exported.
+root = tempfile.mkdtemp(prefix="SENTINELDIRQQQ-")
+db_file = os.path.join(root, "langflow.db")
+engine = sa.create_engine("sqlite:///" + db_file)
+instrument_database(engine)
+
+with engine.connect() as conn:
+    conn.execute(sa.text("SELECT 1"))
+
+provider.force_flush()
+spans = [
+    {"name": s.name, "attributes": {k: str(v) for k, v in (s.attributes or {}).items()}}
+    for s in exporter.get_finished_spans()
+]
+print("PROBE_RESULT " + json.dumps({"root": root, "db_file": db_file, "spans": spans}))
+"""
+
+
+def run_probe() -> dict:
+    import os
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = Path(tmp) / "probe.py"
+        probe.write_text(PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe)], env=env, capture_output=True, text=True, timeout=300, check=False
+        )
+    assert completed.returncode == 0, completed.stderr
+    lines = [ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT ")]
+    assert lines, f"probe printed no result.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    return json.loads(lines[0].removeprefix("PROBE_RESULT "))
+
+
+def test_a_real_query_exports_no_host_path():
+    """The regression this file exists for, against the real instrumentor rather than a stub."""
+    result = run_probe()
+    dumped = json.dumps(result["spans"])
+
+    # Asserted before the absence: if the probe produced no database spans at all, "the path is
+    # not here" would pass while proving nothing.
+    assert any(s["attributes"].get("db.system") == "sqlite" for s in result["spans"]), result
+
+    assert "SENTINELDIRQQQ" not in dumped, dumped
+    assert result["root"] not in dumped, dumped
+    assert "langflow.db" in dumped, "the file name should survive"


### PR DESCRIPTION
Found while verifying the OpenTelemetry export against a commercial APM. Database spans arrive named:

```
SELECT /home/alice/deployments/langflow-prod/langflow.db
```

SQLAlchemy's instrumentation sets `db.name` from the database name, and for SQLite that name is the file path. It then builds `db.operation` and the span name as `"<operation> <db.name>"`, so the path lands in all three.

Confirmed present in New Relic, not only in a local collector, so it survives export to a third party. SQLite is the default database, which makes this the default configuration rather than an edge case.

## Why it is worth fixing

The path is not a credential, so this is not urgent. It is host detail the operator did not choose to send: install directory, the account name on a typical unix path, and whatever their directory naming gives away.

It is also a cardinality problem. Every deployment path becomes a distinct span name, so dashboards written against one environment do not port to another.

## The fix

Keeps the file name, drops the directory. `SELECT langflow.db` rather than `SELECT /home/.../langflow.db`, so anyone running more than one SQLite database can still tell them apart.

Postgres and MySQL are untouched. Their `db.name` is a logical name with no separator, so it is already its own final segment and the function returns before touching anything.

Done at the export boundary next to the existing URL redaction, because that is already the one place deciding what leaves, and it covers instrumentors the runtime does not install itself. Splits on both separators, since the host that wrote the path and the host exporting it are not necessarily the same platform.

## Verification

14 tests. I ran a mutation check rather than trusting green: making the redaction a no-op turns 4 of them red, including the end-to-end one, and they pass again on restore. The mutated run printed the actual leak, which is what the test is written against:

```
{"name": "SELECT /var/folders/.../SENTINELDIRQQQ-ghuploqp/langflow.db", ...}
```

The end-to-end test drives a real SQLite file through the real instrumentor in a subprocess (the instrumentor patches globally and the provider is process-wide), with the temp directory named after a sentinel. Its absence assertion is preceded by a check that a SQLite span was produced at all, so "no path here" cannot pass by the probe seeing nothing.

Existing suites: 73 lfx observability tests and 170 backend telemetry tests pass.

## Note for review

`span._name` and `span._attributes` are private. `ReadableSpan` exposes both as read-only properties over plain attributes and the SDK freezes them before processors run, so there is no public setter. The URL redaction already does this for `_attributes`; this adds `_name` on the same basis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite database telemetry now removes directory paths before export, exposing only the database filename.
  * Updated span names and operation details consistently reflect the shortened database name.
  * Non-path database names and unrelated span attributes remain unchanged.
  * Improved handling for Unix, Windows, and missing database paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->