### PR TITLE
fix(a11y): give the knowledge base provider picker its field's name

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/__tests__/dbProviderInputComponent.a11y.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/__tests__/dbProviderInputComponent.a11y.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "@/utils/a11y-test";
+import DBProviderInputComponent, { DBProviderInput } from "..";
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useGetGlobalVariables: () => ({
+    data: [],
+    isFetched: true,
+    isFetching: false,
+  }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+const fieldProps = {
+  id: "dbprovider_backend",
+  value: "chroma" as const,
+  disabled: false,
+  editNode: false,
+  handleOnNewValue: jest.fn(),
+};
+
+describe("DBProviderInputComponent accessibility", () => {
+  it("should_have_no_axe_violations", async () => {
+    const { container } = render(
+      <>
+        <span id="db-label">Knowledge Base</span>
+        <DBProviderInputComponent {...fieldProps} ariaLabelledBy="db-label" />
+      </>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("should_name_the_trigger_from_the_forwarded_field_label", () => {
+    render(
+      <>
+        <span id="db-label">Knowledge Base</span>
+        <DBProviderInputComponent {...fieldProps} ariaLabelledBy="db-label" />
+      </>,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Knowledge Base" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should_keep_the_aria_label_when_no_field_label_is_forwarded", () => {
+    // Modal callers (createMemoryModal, knowledgeBaseUploadModal) pass
+    // aria-label directly and have no canvas field label to reference.
+    render(
+      <DBProviderInput
+        id="kb-db-provider"
+        value="chroma"
+        globalVariables={[]}
+        aria-label="Database provider"
+        onValueChange={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Database provider" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should_not_emit_a_dead_aria_label_alongside_the_field_label", () => {
+    render(
+      <>
+        <span id="db-label">Knowledge Base</span>
+        <DBProviderInput
+          id="kb-db-provider"
+          value="chroma"
+          globalVariables={[]}
+          aria-label="Database provider"
+          ariaLabelledBy="db-label"
+          onValueChange={jest.fn()}
+        />
+      </>,
+    );
+    // aria-labelledby already wins; leaving aria-label on the element too
+    // would strand a name no assistive tech ever reads.
+    const trigger = screen.getByRole("combobox", { name: "Knowledge Base" });
+    expect(trigger).not.toHaveAttribute("aria-label");
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/index.tsx
@@ -44,6 +44,12 @@ interface DBProviderInputProps {
   disabled?: boolean;
   /** Accessible name for the combobox trigger (WCAG 4.1.2). */
   "aria-label"?: string;
+  /**
+   * Id of the canvas field's label element. Takes precedence over
+   * `aria-label` when set, so the trigger is named by the field's own
+   * visible label rather than a generic string.
+   */
+  ariaLabelledBy?: string;
   onValueChange: (
     backendType: AvailableDBProviderId,
     backendConfig: Record<string, DBProviderConfigValue>,
@@ -55,6 +61,7 @@ export default function DBProviderInputComponent({
   value,
   disabled,
   handleOnNewValue,
+  ariaLabelledBy,
 }: BaseInputProps<DBProviderSelection | AvailableDBProviderId>) {
   const {
     data: globalVariables = [],
@@ -84,6 +91,7 @@ export default function DBProviderInputComponent({
       value={currentValue.backend_type}
       globalVariables={globalVariables}
       disabled={disabled}
+      ariaLabelledBy={ariaLabelledBy}
       onValueChange={(backendType, backendConfig) => {
         handleOnNewValue({
           value: {
@@ -102,6 +110,7 @@ export function DBProviderInput({
   globalVariables,
   disabled,
   "aria-label": ariaLabel,
+  ariaLabelledBy,
   onValueChange,
 }: DBProviderInputProps) {
   const { t } = useTranslation();
@@ -156,7 +165,10 @@ export function DBProviderInput({
           role="combobox"
           ref={refButton}
           aria-expanded={open}
-          aria-label={ariaLabel}
+          // aria-labelledby wins over aria-label when both are set, so only
+          // one is ever emitted — otherwise the aria-label is dead weight.
+          aria-label={!ariaLabelledBy ? ariaLabel : undefined}
+          aria-labelledby={ariaLabelledBy}
           data-testid={id}
           className={cn(
             "dropdown-component-false-outline py-2",


### PR DESCRIPTION
## Summary

A screen reader user tabbing to the knowledge base provider picker on the canvas heard a generic name instead of the field they were actually on. Every other canvas widget was wired up for this, but this one wasn't.

`ParameterRenderComponent` already spreads `ariaLabelledBy` into every widget it dispatches to — `DBProviderInputComponent` just never read it, so the id of the field's visible label was dropped and the trigger fell back to its own hardcoded `aria-label`.

Now it forwards that id through to the trigger, so the picker is announced with the field's real label.

## What changed

- `DBProviderInputComponent` reads `ariaLabelledBy` off `BaseInputProps` and passes it to `DBProviderInput`.
- The trigger emits only one name: `aria-labelledby` when a field label is available, `aria-label` otherwise. `aria-labelledby` always wins over `aria-label`, so setting both would leave a name nothing ever reads.
- Follows the same pattern already used by `ModelTrigger`.

Modal callers (`createMemoryModal`, `knowledgeBaseUploadModal`) pass `aria-label` directly and have no canvas field label to reference — their behavior is unchanged, and a test covers that.

## Testing

New `dbProviderInputComponent.a11y.test.tsx` — axe scan, naming from the forwarded label, the modal `aria-label` fallback, and a guard that no dead `aria-label` is left alongside `aria-labelledby`.

- New suite: 4/4 pass
- Reverting the fix fails 3 of the 4 (the 4th is the modal path, which already worked and is guarded against regression)
- Full `parameterRenderComponent` suite: 54 suites / 438 tests pass
- `tsc --noEmit` introduces no new errors against the repo's existing baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved database provider selection controls for screen readers.
  - Added support for associating the combobox with an external visible field label.
  - Ensured accessible labels are applied consistently without duplicating or conflicting label information.
- **Quality Improvements**
  - Added accessibility coverage to help prevent regressions in database provider input controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->