### PR TITLE
chore(deps): remediate Mend scan findings on release-1.11.4 (backport of #14555)

### DIFF
--- a/src/frontend/jest.setup.js
+++ b/src/frontend/jest.setup.js
@@ -73,6 +73,14 @@ if (typeof global.URL === "undefined") {
   global.URL = require("url").URL;
 }
 
+// jsdom does not expose TextEncoder/TextDecoder, but react-router v7 reads them
+// at module load, so every suite importing react-router-dom fails without these.
+if (typeof global.TextEncoder === "undefined") {
+  const { TextEncoder, TextDecoder } = require("util");
+  global.TextEncoder = TextEncoder;
+  global.TextDecoder = TextDecoder;
+}
+
 // Mock localStorage
 const localStorageMock = {
   getItem: jest.fn(),

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -81,7 +81,7 @@
         "react-icons": "^5.2.1",
         "react-markdown": "^9.1.0",
         "react-pdf": "^9.0.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.2",
         "react-sortablejs": "^6.1.4",
         "react-syntax-highlighter": "^16.1.0",
         "reactflow": "^11.11.3",
@@ -5186,15 +5186,6 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@replit/codemirror-indentation-markers": {
@@ -17967,35 +17958,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-sortablejs": {
@@ -18767,6 +18777,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -125,7 +125,7 @@
     "react-icons": "^5.2.1",
     "react-markdown": "^9.1.0",
     "react-pdf": "^9.0.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.2",
     "react-sortablejs": "^6.1.4",
     "react-syntax-highlighter": "^16.1.0",
     "reactflow": "^11.11.3",

--- a/src/frontend/src/hooks/flows/__tests__/use-flow-events.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-flow-events.test.ts
@@ -201,6 +201,82 @@ describe("useFlowEvents", () => {
     );
   });
 
+  it("should seed the cursor in the past so events posted just before mount survive", async () => {
+    await mountHook();
+
+    const [, config] = apiGetMock.mock.calls[0];
+    // Anything posted between the route committing and this hook mounting must
+    // still be newer than `since`, or the API drops it for good.
+    expect(config.params.since).toBeLessThan(Date.now() / 1000);
+  });
+
+  it("should surface an event posted just before mount on the first poll", async () => {
+    apiGetMock.mockResolvedValueOnce({
+      data: {
+        events: [
+          {
+            type: "component_added",
+            timestamp: Date.now() / 1000 - 1,
+            summary: "Added OpenAI Model",
+          },
+        ],
+        settled: false,
+      },
+    });
+
+    const { result } = await mountHook();
+
+    expect(result.current.isAgentWorking).toBe(true);
+    expect(result.current.events).toHaveLength(1);
+  });
+
+  it("should stay quiet when the catch-up poll only finds finished work", async () => {
+    apiGetMock.mockResolvedValueOnce({
+      data: {
+        events: [
+          {
+            type: "component_added",
+            timestamp: Date.now() / 1000 - 8,
+            summary: "Added OpenAI Model",
+          },
+        ],
+        settled: true,
+      },
+    });
+
+    const { result } = await mountHook();
+
+    expect(result.current.isAgentWorking).toBe(false);
+    expect(result.current.events).toEqual([]);
+    expect(result.current.lastSettledAt).toBeNull();
+  });
+
+  it("should re-arm the catch-up poll when flowId changes", async () => {
+    const { result, rerender } = await mountHook();
+
+    apiGetMock.mockResolvedValueOnce({
+      data: {
+        events: [
+          {
+            type: "component_added",
+            timestamp: Date.now() / 1000 - 8,
+            summary: "Added on flow-2",
+          },
+        ],
+        settled: true,
+      },
+    });
+
+    await act(async () => {
+      rerender({ id: "flow-2" });
+    });
+
+    // The first poll after the switch is a catch-up poll again, so already
+    // settled work on the new flow stays quiet too.
+    expect(result.current.isAgentWorking).toBe(false);
+    expect(result.current.events).toEqual([]);
+  });
+
   it("should reset state when flowId changes", async () => {
     const { result, rerender } = await mountHook();
 

--- a/src/frontend/src/hooks/flows/use-flow-events.ts
+++ b/src/frontend/src/hooks/flows/use-flow-events.ts
@@ -6,6 +6,14 @@ import type { FlowEvent, FlowEventsResponse } from "@/types/flow-events";
 const IDLE_INTERVAL = 5000;
 const ACTIVE_INTERVAL = 1000;
 const MIN_BANNER_DISPLAY_MS = 2000;
+// Seeding the cursor with "now" drops every event posted between the route
+// committing and this hook mounting with the new flow id -- the API only returns
+// events strictly newer than `since`, so a dropped event never comes back. Start
+// the cursor in the past instead and let the server's `settled` flag decide
+// whether what we catch up on is still worth showing.
+const INITIAL_LOOKBACK_SECONDS = 10;
+
+const startingCursor = () => Date.now() / 1000 - INITIAL_LOOKBACK_SECONDS;
 
 type UseFlowEventsReturn = {
   isAgentWorking: boolean;
@@ -19,9 +27,10 @@ export function useFlowEvents(flowId: string | undefined): UseFlowEventsReturn {
   const [events, setEvents] = useState<FlowEvent[]>([]);
   const [lastSettledAt, setLastSettledAt] = useState<number | null>(null);
 
-  const cursorRef = useRef<number>(Date.now() / 1000);
+  const cursorRef = useRef<number>(startingCursor());
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isActiveRef = useRef(false);
+  const isCatchUpPollRef = useRef(true);
   const isPollingRef = useRef(false);
   const mountedRef = useRef(true);
   const activeSinceRef = useRef<number>(0);
@@ -57,6 +66,9 @@ export function useFlowEvents(flowId: string | undefined): UseFlowEventsReturn {
   const poll = useCallback(async () => {
     if (!flowId || isPollingRef.current) return;
 
+    const isCatchUpPoll = isCatchUpPollRef.current;
+    isCatchUpPollRef.current = false;
+
     isPollingRef.current = true;
     try {
       const response = await api.get<FlowEventsResponse>(
@@ -72,16 +84,24 @@ export function useFlowEvents(flowId: string | undefined): UseFlowEventsReturn {
         const maxTs = Math.max(...newEvents.map((e) => e.timestamp));
         cursorRef.current = maxTs;
 
-        setEvents((prev) => [...prev, ...newEvents]);
+        // The catch-up poll reaches back before mount, so it can surface work
+        // that is already over. Advance the cursor past it but stay quiet --
+        // flashing a banner (and re-fetching the flow on the settle that
+        // follows) for finished work is worse than showing nothing.
+        const isFinishedWork = isCatchUpPoll && settled && !isActiveRef.current;
 
-        if (!isActiveRef.current) {
-          isActiveRef.current = true;
-          activeSinceRef.current = Date.now();
-          setIsAgentWorking(true);
-          clearInterval_();
-          intervalRef.current = setInterval(() => {
-            pollRef.current?.();
-          }, ACTIVE_INTERVAL);
+        if (!isFinishedWork) {
+          setEvents((prev) => [...prev, ...newEvents]);
+
+          if (!isActiveRef.current) {
+            isActiveRef.current = true;
+            activeSinceRef.current = Date.now();
+            setIsAgentWorking(true);
+            clearInterval_();
+            intervalRef.current = setInterval(() => {
+              pollRef.current?.();
+            }, ACTIVE_INTERVAL);
+          }
         }
       }
 
@@ -129,11 +149,12 @@ export function useFlowEvents(flowId: string | undefined): UseFlowEventsReturn {
     if (!flowId) return;
 
     mountedRef.current = true;
-    cursorRef.current = Date.now() / 1000;
+    cursorRef.current = startingCursor();
     setEvents([]);
     setIsAgentWorking(false);
     setLastSettledAt(null);
     isActiveRef.current = false;
+    isCatchUpPollRef.current = true;
     isPollingRef.current = false;
     activeSinceRef.current = 0;
 

--- a/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
@@ -28,17 +28,10 @@ const deferred = <T>(): Deferred<T> => {
   return { promise, resolve, reject };
 };
 
+// react-router v7 makes the former v7_relativeSplatPath / v7_startTransition
+// opt-ins the default behavior, so the `future` prop no longer exists.
 const RouterWrapper = ({ children }: PropsWithChildren) =>
-  createElement(
-    MemoryRouter,
-    {
-      future: {
-        v7_relativeSplatPath: true,
-        v7_startTransition: true,
-      },
-    },
-    children,
-  );
+  createElement(MemoryRouter, null, children);
 
 const renderRouteLoader = (
   options: {

--- a/src/frontend/tests/core/features/keyboardComponentSearch.spec.ts
+++ b/src/frontend/tests/core/features/keyboardComponentSearch.spec.ts
@@ -8,8 +8,18 @@ test(
     // Navigate to homepage and handle initial modal
     await awaitBootstrapTest(page);
 
-    // Start with blank flow
+    // Start with blank flow. The click creates the flow and navigates, but the
+    // canvas we are leaving has a sidebar search input too -- so waiting on that
+    // selector alone can resolve against the outgoing page, which is then torn
+    // down mid-test and takes the focus set below with it. Wait for the new
+    // flow's own load to land before touching the keyboard.
+    const newFlowLoaded = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        /\/api\/v1\/flows\/[0-9a-f-]{36}$/.test(response.url()),
+    );
     await page.getByTestId("blank-flow").click();
+    await newFlowLoaded;
     await page.waitForTimeout(500);
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 3000,

--- a/uv.lock
+++ b/uv.lock
@@ -2955,7 +2955,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.8.5"
+version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -2976,9 +2976,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/34/14cd8e76f907f7d4dca2334cfeec9f81d30fd15c25a015f99aaea694eaed/datasets-4.8.5.tar.gz", hash = "sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772", size = 605649, upload-time = "2026-04-27T15:43:57.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/5b/836516269d4f618efe621661cfb6f9acc57e6f95265db3efaee48a5ffe04/datasets-5.0.1.tar.gz", hash = "sha256:ce22bb851efd7494f08aad33b940803784434f6e77763d00679a0dc45fcf686a", size = 641498, upload-time = "2026-07-28T11:09:12.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/99/00f3196036501b53032c4b1ab8337a0b978dee832ed276dae3815df4e8b5/datasets-4.8.5-py3-none-any.whl", hash = "sha256:5079900781719c0e063a8efdd2cd95a31ad0c63209178669cd23cf1b926149ff", size = 528973, upload-time = "2026-04-27T15:43:53.702Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/98fc6eb83333508ca5f44c52b3e287ea8137a0ad582714e2cbc67a02154b/datasets-5.0.1-py3-none-any.whl", hash = "sha256:9fbf73688f8c18f7529b4fe592abd04015f81d1e58001e4bac73ffb2b39d7cc4", size = 559079, upload-time = "2026-07-28T11:09:10.266Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Backport of #14555 to `release-1.11.4`.

`release-1.11.4` starts from exactly the same state as the 1.12.0 branch did — `react-router-dom` `^6.30.4`, `datasets` 4.8.5, and byte-identical copies of every source file the original PR touched — so all four commits cherry-picked with no conflicts and no adaptation. Commits carry `(cherry picked from commit …)` trailers.

## What comes across

| Commit | Change |
|---|---|
| `chore(deps): bump datasets to 5.0.1` | `uv.lock` only, 3-line diff |
| `chore(deps): upgrade react-router-dom to v7.18.2` | `package.json` + lock, `jest.setup.js` TextEncoder polyfill, one test's dropped `future` prop |
| `fix(frontend): keep flow events posted just before mount visible` | `useFlowEvents` cursor seeding |
| `test(frontend): wait for the new flow to load before pressing "/"` | `keyboardComponentSearch.spec.ts` |

The advisory rationale is unchanged from #14555 — all three react-router findings (CVE-2026-53669, CVE-2026-53666, CVE-2026-53668) are first patched at 7.18.0, and CVE-2026-53668 has no 6.x patch at all, so v7 remains the only remediation. The `datasets` range on this branch already permitted 5.x; the lock had just gone stale.

### The two frontend fixes, briefly

Both are v7 fallout found in CI on the original PR, and both apply here for the same reason — the code is identical on this branch:

- **`useFlowEvents`** seeded its `since` cursor with `Date.now()` at mount. v7 renders route updates in a transition, so the flow page can paint before the hook remounts with the new flow id, and the events API only returns events strictly newer than `since` — anything posted in that window was dropped permanently. The cursor now starts 10s in the past (under the backend's 10s `SETTLE_TIMEOUT` and 60s TTL), with a catch-up guard so events for an already-settled flow advance the cursor without flashing a banner or triggering the settle-driven flow refetch.
- **`keyboardComponentSearch.spec.ts`** waited on `sidebar-search-input`, which exists on the flow page being *left* as well, so under v7's later-committing navigation the wait resolved against the outgoing page; focus went to that sidebar and died with the remount. It now waits for the `GET` of the flow in the URL.

## Verification on this branch

- `npm install` reproduces the cherry-picked `package-lock.json` byte-for-byte — no further resolution churn.
- `uv lock --check` passes (837 packages, no drift).
- Full Jest suite: **480 suites / 5576 tests passed**.
- `npm run build` succeeds.
- Every react-router API this branch imports (`BrowserRouter`, `MemoryRouter`, `RouterProvider`, `Routes`, `Route`, `Outlet`, `Navigate`, `Link`, `useBlocker`, `useHref`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams`) exists in v7 — no loaders, actions, fetchers, `defer()`, or `json()` anywhere in the tree.

Playwright coverage is left to CI; shard behavior is the reason both frontend fixes exist.

## Not carried over

Nothing. The five findings #14555 documented as un-remediable (chromadb, diskcache, transformers, accelerate, nanoid) are unchanged here — no patched release exists for any of them, so there is nothing to bump toward on this branch either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Flow pages now catch up on events posted shortly before loading, while avoiding duplicate handling of completed work.
  - Event tracking correctly resets when switching between flows.
  - Improved reliability when searching components immediately after creating a blank flow.

- **Tests**
  - Added coverage for event catch-up polling and flow changes.

- **Chores**
  - Updated React Router to version 7.
  - Improved test environment support for text encoding APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->