### PR TITLE
fix: prevent API key logging

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -1180,10 +1180,12 @@ register_cli_command_plugins(app)
 def api_key_banner(unmasked_api_key) -> None:
     is_mac = platform.system() == "Darwin"
     clipboard_msg = ""
+    clipboard_copied = False
     try:
         import pyperclip
 
         pyperclip.copy(unmasked_api_key.api_key)
+        clipboard_copied = True
         clipboard_msg = (
             f"\nThe API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it."
         )
@@ -1206,13 +1208,16 @@ def api_key_banner(unmasked_api_key) -> None:
     try:
         banner_console.print(panel)
     except UnicodeEncodeError:
-        # Fallback for Windows encoding issues
-        logger.info("API Key Created Successfully:")
-        logger.info(unmasked_api_key.api_key)
-        logger.info("This is the only time the API key will be displayed.")
-        logger.info("Make sure to store it in a secure location.")
-        ctrl_cmd = "Ctrl" if not is_mac else "Cmd"
-        logger.info(f"The API key has been copied to your clipboard. {ctrl_cmd} + V to paste it.")
+        # Fallback for terminal encoding issues.  The key is intentionally
+        # written to the interactive terminal only; logging it would persist
+        # this one-time secret in application logs.
+        typer.echo("API Key Created Successfully:")
+        typer.echo(unmasked_api_key.api_key)
+        typer.echo("This is the only time the API key will be displayed.")
+        typer.echo("Make sure to store it in a secure location.")
+        if clipboard_copied:
+            ctrl_cmd = "Ctrl" if not is_mac else "Cmd"
+            typer.echo(f"The API key has been copied to your clipboard. {ctrl_cmd} + V to paste it.")
 
 
 def main() -> None:

--- a/src/backend/tests/unit/test_cli.py
+++ b/src/backend/tests/unit/test_cli.py
@@ -316,6 +316,31 @@ def test_api_key_banner_shows_clipboard_hint_on_success(capsys):
     assert "clipboard" in output.lower()
 
 
+def test_api_key_banner_unicode_fallback_does_not_log_key(capsys):
+    """Terminal encoding fallback must display the key without logging or false clipboard claims."""
+    api_key_obj = SimpleNamespace(api_key="lf-unicode-fallback-secret")
+
+    def raise_unicode_error(*_args, **_kwargs):
+        encoding = "ascii"
+        input_text = "🔑"
+        reason = "encoding"
+        raise UnicodeEncodeError(encoding, input_text, 0, 1, reason)
+
+    console_instance = SimpleNamespace(print=raise_unicode_error)
+
+    with (
+        patch("pyperclip.copy", side_effect=Exception("clipboard unavailable")),
+        patch("langflow.__main__.Console", return_value=console_instance),
+        patch("langflow.__main__.logger") as mock_logger,
+    ):
+        api_key_banner(api_key_obj)
+
+    output = capsys.readouterr().out
+    assert "lf-unicode-fallback-secret" in output
+    assert "clipboard" not in output.lower()
+    assert all(api_key_obj.api_key not in str(call) for call in mock_logger.mock_calls)
+
+
 def test_build_direct_uvicorn_kwargs_pins_full_shape():
     """Drift guard: the exact key set passed to uvicorn.run must stay stable."""
     result = build_direct_uvicorn_kwargs(**_kwargs())


### PR DESCRIPTION
## What changed

- Kept the one-time API key in interactive CLI output when Rich console encoding fails instead of sending it through the application logger.
- Tracked clipboard success independently so the CLI only claims the key was copied when copying actually succeeded.
- Added regression coverage for the combined clipboard and Unicode fallback path.

## Why

The previous Unicode fallback logged the newly generated API key in clear text, causing secret material to persist in application logs.

## Validation

- Focused CLI, login, and API-key regression tests passed.
- Ruff and repository pre-commit checks passed.
- Verified the patch remained unchanged after rebuilding the branch on the current release base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key display when terminal encoding or clipboard copying fails.
  * API keys are now shown directly in the terminal when needed, without exposing them through logs.
  * Clipboard availability is reported only when copying succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->