### PR TITLE
fix: remove legacy API key cookie

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1387,7 +1387,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_api_key.py",
         "hashed_secret": "0d1f7c04669ca1989ea046d30a13c8a03252aa8e",
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 136,
         "is_secret": false
       }
     ],
@@ -2369,7 +2369,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 120,
         "is_secret": false
       }
     ],
@@ -7483,5 +7483,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T17:39:59Z"
+  "generated_at": "2026-08-14T17:52:02Z"
 }

--- a/src/backend/base/langflow/api/v1/api_key.py
+++ b/src/backend/base/langflow/api/v1/api_key.py
@@ -113,9 +113,6 @@ async def save_store_api_key(
     current_user: CurrentActiveUser,
     db: DbSession,
 ):
-    settings_service = get_settings_service()
-    auth_settings = settings_service.auth_settings
-
     try:
         api_key = api_key_request.api_key
 
@@ -124,15 +121,14 @@ async def save_store_api_key(
         current_user.store_api_key = encrypted
         db.add(current_user)
         await db.commit()
-
-        response.set_cookie(
+        auth_settings = get_settings_service().auth_settings
+        response.delete_cookie(
             "apikey_tkn_lflw",
-            encrypted,
+            path="/",
+            domain=auth_settings.COOKIE_DOMAIN,
+            secure=auth_settings.ACCESS_SECURE,
             httponly=auth_settings.ACCESS_HTTPONLY,
             samesite=auth_settings.ACCESS_SAME_SITE,
-            secure=auth_settings.ACCESS_SECURE,
-            expires=None,  # Set to None to make it a session cookie
-            domain=auth_settings.COOKIE_DOMAIN,
         )
 
     except Exception as e:

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -18,6 +18,18 @@ from langflow.services.rate_limit import check_rate_limit
 router = APIRouter(tags=["Login"])
 
 
+def _expire_legacy_store_api_key_cookie(response: Response, auth_settings) -> None:
+    """Remove the obsolete store API-key cookie from clients that still have it."""
+    response.delete_cookie(
+        "apikey_tkn_lflw",
+        path="/",
+        domain=auth_settings.COOKIE_DOMAIN,
+        secure=auth_settings.ACCESS_SECURE,
+        httponly=auth_settings.ACCESS_HTTPONLY,
+        samesite=auth_settings.ACCESS_SAME_SITE,
+    )
+
+
 def get_limiter_from_app(request: Request):
     """Get the rate limiter from app state (initialized after settings load)."""
     return request.app.state.limiter
@@ -78,15 +90,7 @@ async def login_to_get_access_token(
             expires=auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS,
             domain=auth_settings.COOKIE_DOMAIN,
         )
-        response.set_cookie(
-            "apikey_tkn_lflw",
-            str(user.store_api_key),
-            httponly=auth_settings.ACCESS_HTTPONLY,
-            samesite=auth_settings.ACCESS_SAME_SITE,
-            secure=auth_settings.ACCESS_SECURE,
-            expires=None,  # Set to None to make it a session cookie
-            domain=auth_settings.COOKIE_DOMAIN,
-        )
+        _expire_legacy_store_api_key_cookie(response, auth_settings)
         await get_variable_service().initialize_user_variables(user.id, db)
         # Initialize agentic variables if agentic experience is enabled
         from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_user_variables
@@ -134,27 +138,14 @@ async def auto_login(response: Response, db: DbSession):
             expires=None,  # Set to None to make it a session cookie
             domain=auth_settings.COOKIE_DOMAIN,
         )
+        _expire_legacy_store_api_key_cookie(response, auth_settings)
 
         user = await get_user_by_id(db, user_id)
 
-        if user:
-            if user.store_api_key is None:
-                user.store_api_key = ""
+        if user and get_settings_service().settings.agentic_experience:
+            from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_user_variables
 
-            response.set_cookie(
-                "apikey_tkn_lflw",
-                str(user.store_api_key),  # Ensure it's a string
-                httponly=auth_settings.ACCESS_HTTPONLY,
-                samesite=auth_settings.ACCESS_SAME_SITE,
-                secure=auth_settings.ACCESS_SECURE,
-                expires=None,  # Set to None to make it a session cookie
-                domain=auth_settings.COOKIE_DOMAIN,
-            )
-
-            if get_settings_service().settings.agentic_experience:
-                from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_user_variables
-
-                await initialize_agentic_user_variables(user.id, db)
+            await initialize_agentic_user_variables(user.id, db)
 
         return tokens
 

--- a/src/backend/tests/unit/api/v1/test_api_key.py
+++ b/src/backend/tests/unit/api/v1/test_api_key.py
@@ -90,6 +90,9 @@ async def test_save_store_api_key(client: AsyncClient, logged_in_headers):
     assert response.status_code == status.HTTP_200_OK
     assert isinstance(result, dict), "The result must be a dictionary"
     assert "detail" in result, "The dictionary must contain a key called 'detail'"
+    set_cookie = response.headers.get("set-cookie", "")
+    assert "apikey_tkn_lflw=" in set_cookie
+    assert "Max-Age=0" in set_cookie
 
 
 async def test_delete_api_key_route_unauthorized(client: AsyncClient, logged_in_headers, active_user):

--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -101,6 +101,9 @@ async def test_login_successful(client, test_user):
     response = await client.post("api/v1/login", data={"username": "testuser", "password": "testpassword"})
     assert response.status_code == 200
     assert "access_token" in response.json()
+    set_cookie = response.headers.get("set-cookie", "")
+    assert "apikey_tkn_lflw=" in set_cookie
+    assert "Max-Age=0" in set_cookie
 
 
 async def test_login_unsuccessful_wrong_username(client):


### PR DESCRIPTION
## What changed

- Stopped copying the stored API key into the client session cookie.
- Expired previously issued legacy cookies during login, auto-login, and API-key updates.
- Preserved the server-side encrypted database value and existing key compatibility.

## Why

The server already reads the encrypted database value and no production consumer uses this cookie, so retaining client-side secret material creates unnecessary exposure.

## Validation

- Focused CLI, login, and API-key regression tests passed.
- Ruff, secret scanning, and repository pre-commit checks passed.
- Verified the patch remained unchanged after rebuilding the branch on the current release base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API key security by clearing sensitive and obsolete authentication cookies after key storage, login, and automatic login.
  - Ensured cleared cookies use the appropriate security, path, domain, and expiration settings.
  - Initialized agentic experience settings during automatic login when enabled.

- **Tests**
  - Added coverage confirming obsolete authentication cookies are properly expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->