### PR TITLE
fix: update fast-xml-parser

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10219,9 +10219,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
-      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz",
+      "integrity": "sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==",
       "funding": [
         {
           "type": "github",

--- a/docs/package.json
+++ b/docs/package.json
@@ -63,7 +63,7 @@
     "js-yaml": "^4.3.1",
     "picomatch": "^4.0.4",
     "lodash": "4.17.21",
-    "fast-xml-parser": "4.5.4",
+    "fast-xml-parser": "4.5.5",
     "openapi-to-postmanv2": {
       "lodash": "4.17.21"
     },


### PR DESCRIPTION
## What changed

- Raised the documentation override and lockfile resolution from fast-xml-parser 4.5.4 to 4.5.5.
- Kept the documentation toolchain on the compatible v4 release line.

## Why

Version 4.5.5 contains the legacy v4 entity-processing fixes, removing the vulnerable transitive resolution without requiring a major-version migration.

## Validation

- The package-lock-only dependency tree resolves fast-xml-parser exclusively to 4.5.5.
- Offline npm dry-run validation passed.
- Repository pre-commit checks passed, and the patch remained unchanged after rebuilding on the current release base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the XML parsing package override to version 4.5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->