### PR TITLE
fix: prevent double URI decoding

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/__tests__/chat-message.test.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/__tests__/chat-message.test.tsx
@@ -174,6 +174,34 @@ describe("ChatMessage Component", () => {
     ).toBeInTheDocument();
   });
 
+  it.each(["100%25 complete", "malformed % input"])(
+    "preserves percent sequences in user messages: %s",
+    (message) => {
+      render(
+        <ChatMessage
+          {...defaultProps}
+          chat={{ ...mockChat, message, isSend: true }}
+        />,
+      );
+
+      expect(screen.getByText(message)).toBeInTheDocument();
+    },
+  );
+
+  it.each(["100%25 complete", "malformed % input"])(
+    "preserves percent sequences in bot messages: %s",
+    (message) => {
+      render(
+        <ChatMessage
+          {...defaultProps}
+          chat={{ ...mockChat, message, isSend: false, sender_name: "AI" }}
+        />,
+      );
+
+      expect(screen.getByText(message)).toBeInTheDocument();
+    },
+  );
+
   // Regression guard: the actions row used to be hidden with `invisible` +
   // `group-hover:visible`, which removes it from the tab order entirely
   // (visibility:hidden elements can't receive focus) — a keyboard-only user

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/user-message.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/user-message.tsx
@@ -22,12 +22,10 @@ export const UserMessage = memo(
     const isAudioMessage = chat.category === "audio";
     const chatMessage = chat.message ? chat.message.toString() : "";
 
-    let decodedMessage = chatMessage ?? "";
-    try {
-      decodedMessage = decodeURIComponent(chatMessage);
-    } catch (_e) {
-      // ignore decode errors
-    }
+    // Messages arrive as decoded JSON values. DecodeURIComponent here would
+    // turn literal percent sequences (for example, "%25") into different
+    // user-visible text and can double-decode attacker-controlled input.
+    const decodedMessage = chatMessage;
 
     const isEmpty = decodedMessage?.trim() === "";
     const hasFiles = chat.files && chat.files.length > 0;

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-streaming-message.ts
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/hooks/use-streaming-message.ts
@@ -97,13 +97,9 @@ export function useStreamingMessage({
     };
   }, []);
 
-  // Decode the message for display
-  let decodedMessage = chatMessage ?? "";
-  try {
-    decodedMessage = decodeURIComponent(chatMessage);
-  } catch (_e) {
-    // ignore decode errors
-  }
+  // Stream chunks and persisted messages are already decoded JSON values.
+  // Do not decode them again: literal percent sequences must remain intact.
+  const decodedMessage = chatMessage;
 
   return {
     chatMessage: decodedMessage,

--- a/src/frontend/src/controllers/API/queries/vertex/__tests__/use-post-retrieve-vertex-order.test.ts
+++ b/src/frontend/src/controllers/API/queries/vertex/__tests__/use-post-retrieve-vertex-order.test.ts
@@ -1,0 +1,60 @@
+const mockApiPost = jest.fn();
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: mockApiPost },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/build"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    mutate: jest.fn(
+      (_key: unknown, fn: (payload: unknown) => Promise<unknown>) => ({
+        mutate: (payload: unknown) => fn(payload),
+      }),
+    ),
+  })),
+}));
+
+import { usePostRetrieveVertexOrder } from "../use-post-retrieve-vertex-order";
+
+describe("usePostRetrieveVertexOrder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiPost.mockResolvedValue({
+      data: { ids: [], rund_id: "run", vertices_to_run: [] },
+    });
+  });
+
+  it("passes percent sequences in stop node IDs to the request serializer unchanged", async () => {
+    const mutation = usePostRetrieveVertexOrder();
+
+    await mutation.mutate({
+      flowId: "flow-1",
+      stopNodeId: "node%252Fencoded",
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/build/flow-1/vertices",
+      null,
+      { params: { stop_component_id: "node%252Fencoded" } },
+    );
+  });
+
+  it("passes malformed percent sequences in start node IDs unchanged", async () => {
+    const mutation = usePostRetrieveVertexOrder();
+
+    await mutation.mutate({
+      flowId: "flow-1",
+      startNodeId: "node%invalid",
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/build/flow-1/vertices",
+      null,
+      { params: { start_component_id: "node%invalid" } },
+    );
+  });
+});

--- a/src/frontend/src/controllers/API/queries/vertex/use-post-retrieve-vertex-order.tsx
+++ b/src/frontend/src/controllers/API/queries/vertex/use-post-retrieve-vertex-order.tsx
@@ -34,12 +34,12 @@ export const usePostRetrieveVertexOrder: useMutationFunctionType<
   }: retrieveGetVerticesOrder): Promise<retrieveGetVerticesOrderResponse> => {
     // nodeId is optional and is a query parameter
     // if nodeId is not provided, the API will return all vertices
-    const config: AxiosRequestConfig<any> = {};
+    const config: AxiosRequestConfig = {};
     if (stopNodeId) {
-      config["params"] = { stop_component_id: decodeURIComponent(stopNodeId) };
+      config["params"] = { stop_component_id: stopNodeId };
     } else if (startNodeId) {
       config["params"] = {
-        start_component_id: decodeURIComponent(startNodeId),
+        start_component_id: startNodeId,
       };
     }
     let requestBody: { nodes: Node[]; edges: Edge[] } | null = null;

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/__tests__/chat-message-actions.test.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/__tests__/chat-message-actions.test.tsx
@@ -99,6 +99,15 @@ describe("ChatMessage actions (WCAG 2.1.1 keyboard reachability)", () => {
     expect(results).toHaveNoViolations();
   });
 
+  it.each(["100%25 complete", "malformed % input"])(
+    "preserves percent sequences in I/O modal messages: %s",
+    (message) => {
+      render(<ChatMessage {...defaultProps} chat={{ ...mockChat, message }} />);
+
+      expect(screen.getByTestId("markdown-field")).toHaveTextContent(message);
+    },
+  );
+
   // Regression guard: the copy/edit/feedback actions used to be hidden with
   // `invisible` + `group-hover:visible`, which removes them from the tab
   // order entirely (visibility:hidden elements can't receive focus) — a

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
@@ -123,12 +123,10 @@ export default function ChatMessage({
     }
   }, [chat.category]);
 
-  let decodedMessage = chatMessage ?? "";
-  try {
-    decodedMessage = decodeURIComponent(chatMessage);
-  } catch (_e) {
-    // console.error(e);
-  }
+  // Chat messages are decoded by JSON parsing before they reach the UI.
+  // Decoding again changes literal percent sequences and permits double-
+  // unescaping of attacker-controlled content.
+  const decodedMessage = chatMessage;
   const isEmpty = decodedMessage?.trim() === "";
   const { mutate: updateMessageMutation } = useUpdateMessage();
 


### PR DESCRIPTION
## What changed

- Removed redundant decodeURIComponent calls from chat values that are already JSON-decoded.
- Passed raw component IDs to Axios so query parameters are encoded once at the owned request boundary.
- Added regressions for literal percent sequences, malformed percent input, and vertex IDs.

## Why

Decoding application data a second time can transform attacker-controlled or literal percent sequences and cause values to be interpreted differently from what the user or server supplied.

## Validation

- Focused frontend validation: 3 Jest suites and 23 tests passed.
- Biome and repository pre-commit checks passed.
- Verified the patch remained unchanged after rebuilding the branch on the current release base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat messages now preserve literal, encoded, and malformed percent sequences exactly as entered.
  - User, bot, streaming, and I/O modal messages no longer trigger URI-decoding errors or unintended text changes.
  - Vertex order requests now pass start and stop node IDs unchanged, improving handling of special characters.

- **Tests**
  - Added regression coverage for percent-containing messages and vertex node IDs across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->