### PR TITLE
fix(a11y): keep visible text in Setup Provider button's accessible name

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.setup-provider-name.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.setup-provider-name.test.tsx
@@ -1,0 +1,217 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { BaseInputProps } from "@/components/core/parameterRenderComponent/types";
+import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
+import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import ModelInputComponent from "../index";
+import type { ModelInputComponentType } from "../types";
+
+Element.prototype.scrollIntoView = jest.fn();
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: () => ({ setErrorData: jest.fn() }),
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({
+    refreshAllModelInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("@/stores/flowStore", () => {
+  const state = {
+    getNode: jest.fn(),
+    setNode: jest.fn(),
+    setFilterEdge: jest.fn(),
+    setFilterType: jest.fn(),
+    nodes: [],
+    edges: [],
+  };
+  const hook = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  hook.getState = () => state;
+  return { __esModule: true, default: hook };
+});
+
+jest.mock("@/stores/typesStore", () => ({
+  useTypesStore: { getState: () => ({ data: {} }) },
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-model-providers", () => ({
+  useGetModelProviders: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-enabled-models", () => ({
+  useGetEnabledModels: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/nodes/use-post-template-value", () => ({
+  usePostTemplateValue: jest.fn(() => ({ mutateAsync: jest.fn() })),
+}));
+
+jest.mock("@/CustomNodes/helpers/mutate-template", () => ({
+  mutateTemplate: jest.fn(),
+}));
+
+jest.mock("@/modals/modelProviderModal", () => ({
+  __esModule: true,
+  default: () => <div data-testid="provider-modal" />,
+}));
+
+// Rendered without a text child on purpose: the real component renders an
+// <svg>, which contributes nothing to an accessible name computed from
+// content. A mock that prints the icon name would hide exactly the bug under
+// test by padding the name with text the user never sees.
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className} />
+  ),
+}));
+
+jest.mock("@/components/common/loadingTextComponent", () => ({
+  __esModule: true,
+  default: ({ text }: { text: string }) => (
+    <span data-testid="loading-text">{text}</span>
+  ),
+}));
+
+const baseProps: BaseInputProps & ModelInputComponentType = {
+  id: "test-model-input",
+  value: [],
+  disabled: false,
+  handleOnNewValue: jest.fn(),
+  options: [],
+  placeholder: "Setup Provider",
+  nodeId: "test-node-id",
+  nodeClass: {
+    template: {
+      model: {
+        model_type: "language",
+        type: "",
+        required: false,
+        list: false,
+        show: false,
+        readonly: false,
+      },
+    },
+    description: "",
+    display_name: "",
+    documentation: "",
+  },
+  handleNodeClass: jest.fn(),
+  editNode: false,
+};
+
+const renderWithQueryClient = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,
+  );
+};
+
+/** No provider configured at all — the trigger collapses to the CTA button. */
+const mockNoProvidersConfigured = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: { enabled_models: {} },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
+/**
+ * WCAG 2.5.3 (Label in Name): the setup-provider branch of the trigger is a
+ * plain button whose visible text *is* its label, not a value. Forwarding the
+ * field label as the sole accessible name dropped "Setup Provider" from it
+ * entirely — screen reader users heard the field name instead of the action,
+ * and speech-input users saying "click Setup Provider" hit nothing.
+ */
+describe("ModelInputComponent — Setup Provider accessible name", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNoProvidersConfigured();
+  });
+
+  it("keeps the visible button text in the accessible name when a field label is forwarded", () => {
+    renderWithQueryClient(
+      <>
+        <span id="model-field-label">Language Model required</span>
+        <ModelInputComponent
+          {...baseProps}
+          ariaLabelledBy="model-field-label"
+        />
+      </>,
+    );
+
+    const button = screen.getByRole("button", { name: /Setup Provider/i });
+    // The field label still supplies context, so the two controls the field
+    // can render (this CTA and the configured-state combobox) stay
+    // distinguishable by name.
+    expect(button).toHaveAccessibleName(
+      "Setup Provider Language Model required",
+    );
+  });
+
+  it("leads the accessible name with the visible text so speech input can target it", () => {
+    renderWithQueryClient(
+      <>
+        <span id="model-field-label">Language Model required</span>
+        <ModelInputComponent
+          {...baseProps}
+          ariaLabelledBy="model-field-label"
+        />
+      </>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Setup Provider/i }),
+    ).toHaveAccessibleName(/^Setup Provider/);
+  });
+
+  it("keeps the visible button text when only a literal aria-label is forwarded", () => {
+    renderWithQueryClient(
+      <ModelInputComponent {...baseProps} aria-label="Embedding model" />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Setup Provider/i }),
+    ).toHaveAccessibleName("Setup Provider, Embedding model");
+  });
+
+  it("names the button from its own content when no field label is forwarded", () => {
+    renderWithQueryClient(<ModelInputComponent {...baseProps} />);
+
+    expect(
+      screen.getByRole("button", { name: /Setup Provider/i }),
+    ).toHaveAccessibleName("Setup Provider");
+  });
+
+  it("still opens the provider manager when activated by its accessible name", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(
+      <>
+        <span id="model-field-label">Language Model required</span>
+        <ModelInputComponent
+          {...baseProps}
+          ariaLabelledBy="model-field-label"
+        />
+      </>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Setup Provider/i }));
+
+    expect(await screen.findByTestId("provider-modal")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -73,23 +73,43 @@ const ModelTrigger = ({
       optionCount: options.length,
     })
   ) {
+    // Unlike the combobox below — whose visible text is its *value*, so the
+    // field label alone is the right accessible name — this branch is a plain
+    // button whose visible text is its label. WCAG 2.5.3 (Label in Name)
+    // requires that text to be part of the accessible name, so the field label
+    // is composed after it rather than replacing it: speech input matches what
+    // the user reads ("click Setup Provider"), and the field label still tells
+    // a screen reader user which field the CTA belongs to.
+    const setupProviderTextId = `${id}-setup-provider-label`;
+    const setupProviderText =
+      placeholder === "Setup Provider" ? t("model.setupProvider") : placeholder;
+
     return (
       <Button
         variant="outline"
         size="xs"
         className="dropdown-component-false-outline w-full justify-start gap-2 py-2 font-normal"
         onClick={onOpenManageProviders}
-        aria-label={!ariaLabelledBy ? ariaLabel : undefined}
-        aria-labelledby={ariaLabelledBy}
+        aria-label={
+          !ariaLabelledBy && ariaLabel
+            ? `${setupProviderText}, ${ariaLabel}`
+            : undefined
+        }
+        aria-labelledby={
+          ariaLabelledBy
+            ? `${setupProviderTextId} ${ariaLabelledBy}`
+            : undefined
+        }
       >
         <ForwardedIconComponent
           name="BrainCircuit"
           className="h-4 w-4 flex-shrink-0 text-muted-foreground"
         />
-        <div className="text-[13px] text-muted-foreground">
-          {placeholder === "Setup Provider"
-            ? t("model.setupProvider")
-            : placeholder}
+        <div
+          id={setupProviderTextId}
+          className="text-[13px] text-muted-foreground"
+        >
+          {setupProviderText}
         </div>
       </Button>
     );


### PR DESCRIPTION
## Problem

On the Agent node with no model provider configured, the **Language Model** field collapses into a `Setup Provider` button. That button forwards the field label as its *sole* accessible name, so its visible text is discarded:

```
- button "Language Model required": Setup Provider
```

```js
getByRole("button", { name: "Setup Provider" })          // 0 matches
locator("button").filter({ hasText: "Setup Provider" })  // 1 match
```

This fails **WCAG 2.5.3 Label in Name (level A)** — the accessible name must contain the visually presented text.

Impact:
- Screen reader users hear the field name, not the action — and the configured-state combobox announces the *same* name, so two different controls are indistinguishable.
- Voice control users cannot target it: "click Setup Provider" finds nothing.
- Automated coverage that addresses controls by accessible name can't reach it.

Introduced by #14444, which wired `aria-labelledby` into the trigger. It also contradicts that PR's own QA item 7 — "the field's label if the button is icon-only, or the visible button text if present" — the visible text is present and was being discarded.

## Fix

`ModelTrigger` has two branches, and they need different name computations:

- The **combobox** branch's visible text is its *value* (the selected model), not a label — so the field label alone is the correct accessible name. **Unchanged.**
- The **setup-provider** branch is a plain button whose visible text *is* its label — so the field label must not replace it.

For the CTA, the button's own text is now composed **first**, with the field label after it:

| context | accessible name before | after |
|---|---|---|
| `ariaLabelledBy` forwarded (canvas node field) | `Language Model required` | `Setup Provider Language Model required` |
| literal `aria-label` forwarded | `Embedding model` | `Setup Provider, Embedding model` |
| neither | `Setup Provider` | `Setup Provider` (unchanged) |

Leading with the visible text matters beyond 2.5.3 itself: some speech-input implementations only match at the start of the name. Keeping the field label after it preserves the context #14444 was after, so the CTA and the configured-state combobox stay distinguishable.

This matches the guard already used elsewhere in the same PR's surface — `linkComponent` applies `aria-labelledby={!text ? ariaLabelledBy : undefined}` for exactly this reason.

## Test plan

New `ModelInputComponent.setup-provider-name.test.tsx` (5 cases, all red before the fix):

- [x] accessible name contains the visible text when a field label is forwarded
- [x] accessible name *leads* with the visible text (`/^Setup Provider/`)
- [x] literal `aria-label` fallback keeps the visible text
- [x] no forwarded label → name comes from content
- [x] the button still opens the provider manager when found by accessible name

The icon is mocked without a text child on purpose — the real component renders an `<svg>`, and a mock that printed the icon name would pad the content-derived name with text the user never sees, hiding the bug under test.

- [x] `npx jest src/components/core/parameterRenderComponent src/CustomNodes` → 72 suites, 579 tests passing
- [x] `biome check` clean on both changed files
- [x] Existing Playwright helpers use `getByText("Setup Provider", { exact: true })` and are unaffected; `getByRole("button", { name: "Setup Provider" })` now resolves (Playwright's default name matching is substring).

## Not included

The reporter's secondary observation — `role="option"` items carry position as sr-only text (`"9 of 90"`) while `aria-posinset`/`aria-setsize` are null — is left alone, as flagged in the report. #14444 chose text deliberately so the count wouldn't reset per provider group; moving to the ARIA attributes is a separate change with its own grouping question.

Refs #14444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Improved accessible naming for the model setup control.
  - Associated visible labels and custom labels more consistently with the control.
  - Preserved translated default text and custom placeholder text for clearer screen reader support.

- **Tests**
  - Added coverage for accessible names and activation of the setup-provider control.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->