### PR TITLE
fix(ci): assert the base wheel's real console script name

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -985,8 +985,8 @@ jobs:
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
           scripts = Path(sys.executable).parent
-          assert (scripts / "langflow").is_file()
-          assert not (scripts / "langflow-base").exists()
+          assert (scripts / "langflow-base").is_file(), f"langflow-base console script missing from {scripts}"
+          assert not (scripts / "langflow").exists(), "langflow console script leaked into the base-only environment"
           provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
           assert {"complete", "all"} <= provided_extras
           compatibility_requirements = [
@@ -1017,7 +1017,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          base-test-env/bin/langflow run \
+          base-test-env/bin/langflow-base run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {


### PR DESCRIPTION
## Problem

The `Base Distribution Wheel - Linux Python 3.14` job fails on a bare `AssertionError` — first seen on the 1.11.4 release run ([job log](https://github.com/langflow-ai/langflow/actions/runs/31829876818/job/94865939706)):

```python
scripts = Path(sys.executable).parent
assert (scripts / "langflow").is_file()          # ← always False
assert not (scripts / "langflow-base").exists()
```

Both assertions are inverted. The job installs only `langflow-base`, `langflow-sdk` and `lfx`, and `langflow-base` declares:

```
[console_scripts]
langflow-base = langflow.langflow_launcher:main
```

(verified against the exact `langflow_base-0.11.4rc2` wheel the failing run built). The `langflow` script is shipped solely by the root `langflow` distribution — which this very step forbids from the environment three lines earlier. So the assertion cannot pass under any correct build, and the follow-on `Boot installed base server` step invoked `base-test-env/bin/langflow`, which does not exist there either.

## Cause

These expectations were inherited from the `langflow-core` wheel this job used to test. #14352 renamed *Core Runtime Wheel* → *Base Distribution Wheel* and switched the distribution under test to `langflow-base`, but the console-script checks were never re-pointed. `release-1.11.3` branched before #14352 (its run still shows *Core Runtime Wheel* and passed), so 1.11.4 is the first release to hit this.

## Fix

- Assert `langflow-base` exists and `langflow` does **not** — the correct boundary for a base-only environment.
- Add failure messages to both, so the next break is not a bare `AssertionError` on a heredoc line number.
- Boot the server with `bin/langflow-base`, matching `docker/build_and_push_base.Dockerfile` (`CMD ["langflow-base", "run"]`).

Renaming base's script to `langflow` was the alternative and is the wrong direction: the root `langflow` distribution already owns that name and depends on `langflow-base`, so the two would collide on install.

## Test plan

- [x] Confirmed the failing wheel's `entry_points.txt` contains only `langflow-base`
- [x] Confirmed the assertions after the failing line (`Provides-Extra` ⊇ {complete, all}; no `extra == "complete"/"all"` requirements) hold for that wheel, so the step gets past them
- [ ] `Base Distribution Wheel` job green in CI — this also exercises `Boot installed base server`, which has been skipped ever since #14352 gated it behind the failing assert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base runtime verification to ensure the correct console command is available.
  * Updated base server startup to use the appropriate command and prevent unintended command leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->