### PR TITLE
fix(ci): assert the base wheel's real console script name (release-1.11.4)

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -985,8 +985,8 @@ jobs:
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
           scripts = Path(sys.executable).parent
-          assert (scripts / "langflow").is_file()
-          assert not (scripts / "langflow-base").exists()
+          assert (scripts / "langflow-base").is_file(), f"langflow-base console script missing from {scripts}"
+          assert not (scripts / "langflow").exists(), "langflow console script leaked into the base-only environment"
           provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
           assert {"complete", "all"} <= provided_extras
           compatibility_requirements = [
@@ -1017,7 +1017,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          base-test-env/bin/langflow run \
+          base-test-env/bin/langflow-base run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {


### PR DESCRIPTION
Backport of #14571 to `release-1.11.4`. Cherry-pick, no conflicts, identical diff.

The `Base Distribution Wheel - Linux Python 3.14` job blocks the 1.11.4 release run ([job log](https://github.com/langflow-ai/langflow/actions/runs/31829876818/job/94865939706)) on a bare `AssertionError`: the step asserts the base-only environment exposes a `langflow` console script and no `langflow-base` one, but `langflow-base` ships `langflow-base = langflow.langflow_launcher:main` (verified against the `langflow_base-0.11.4rc2` wheel that run built), and `langflow` belongs to the root `langflow` distribution — which the same step forbids from that environment.

The expectations were carried over from the `langflow-core` wheel this job used to test and were never re-pointed when #14352 switched it to `langflow-base`. `release-1.11.3` branched before #14352, so 1.11.4 is the first release to hit it.

This swaps both assertions, gives them failure messages, and boots via `bin/langflow-base` to match `docker/build_and_push_base.Dockerfile`.

## Test plan

- [x] Cherry-pick applies cleanly; diff identical to #14571
- [ ] `Base Distribution Wheel` job green on the next 1.11.4 release run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated base server startup to use the correct base runtime command.
  * Improved validation to confirm the base command is available and the regular command is excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->