### PR TITLE
fix(bundles): expose model name on the Azure OpenAI chat component

### DIFF
--- a/src/backend/tests/unit/components/bundles/azure/__init__.py
+++ b/src/backend/tests/unit/components/bundles/azure/__init__.py
@@ -1,0 +1,1 @@
+# Azure OpenAI component tests

--- a/src/backend/tests/unit/components/bundles/azure/test_azure_openai_component.py
+++ b/src/backend/tests/unit/components/bundles/azure/test_azure_openai_component.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return AzureChatOpenAIComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "azure_endpoint": "https://example-resource.openai.azure.com/",
+            "azure_deployment": "gpt-4o-deployment",
+            "model": "gpt-4o",
+            "api_key": "test-azure-key",
+            "api_version": "2024-06-01",
+            "temperature": 1.0,
+            "max_tokens": 0,
+            "stream": False,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_basic_setup(self, component_class, default_kwargs):
+        component = component_class()
+        component.set_attributes(default_kwargs)
+
+        assert component.display_name == "Azure OpenAI"
+        assert component.name == "AzureOpenAIModel"
+        assert component.azure_endpoint == "https://example-resource.openai.azure.com/"
+        assert component.azure_deployment == "gpt-4o-deployment"
+        assert component.model == "gpt-4o"
+
+    def test_component_inputs_structure(self, component_class):
+        component = component_class()
+        input_names = [input_.name for input_ in component.inputs]
+
+        expected_inputs = [
+            "azure_endpoint",
+            "azure_deployment",
+            "model",
+            "api_key",
+            "api_version",
+            "temperature",
+            "max_tokens",
+        ]
+        for input_name in expected_inputs:
+            assert input_name in input_names
+
+    def test_model_is_optional_and_advanced(self, component_class):
+        component = component_class()
+        model_input = next(input_ for input_ in component.inputs if input_.name == "model")
+
+        assert model_input.required is False
+        assert model_input.advanced is True
+
+    @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
+    def test_build_model_passes_model(self, mock_azure_chat_openai, component_class, default_kwargs):
+        mock_instance = MagicMock()
+        mock_azure_chat_openai.return_value = mock_instance
+
+        component = component_class()
+        component.set_attributes(default_kwargs)
+        model = component.build_model()
+
+        mock_azure_chat_openai.assert_called_once_with(
+            azure_endpoint="https://example-resource.openai.azure.com/",
+            azure_deployment="gpt-4o-deployment",
+            model="gpt-4o",
+            api_version="2024-06-01",
+            api_key="test-azure-key",
+            temperature=1.0,
+            max_tokens=None,
+            streaming=False,
+        )
+        assert model == mock_instance
+
+    @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
+    def test_build_model_without_model_defaults_to_none(self, mock_azure_chat_openai, component_class, default_kwargs):
+        """Omitting Model Name must keep prior behavior: no `model` kwarg value, no regression."""
+        default_kwargs = {**default_kwargs, "model": ""}
+        mock_instance = MagicMock()
+        mock_azure_chat_openai.return_value = mock_instance
+
+        component = component_class()
+        component.set_attributes(default_kwargs)
+        component.build_model()
+
+        _args, kwargs = mock_azure_chat_openai.call_args
+        assert kwargs["model"] is None
+
+    @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
+    def test_build_model_exception_handling(self, mock_azure_chat_openai, component_class, default_kwargs):
+        mock_azure_chat_openai.side_effect = ValueError("Invalid API key")
+
+        component = component_class()
+        component.set_attributes(default_kwargs)
+
+        with pytest.raises(ValueError, match="Could not connect to AzureOpenAI API"):
+            component.build_model()

--- a/src/bundles/lfx-bundles/src/lfx_bundles/azure/azure_openai.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/azure/azure_openai.py
@@ -38,6 +38,13 @@ class AzureChatOpenAIComponent(LCModelComponent):
             required=True,
         ),
         MessageTextInput(name="azure_deployment", display_name="Deployment Name", required=True),
+        MessageTextInput(
+            name="model",
+            display_name="Model Name",
+            info="The underlying OpenAI model name (e.g. `gpt-4o`). Required by some Azure "
+            "deployments to resolve the model, and used for accurate token/cost tracing.",
+            advanced=True,
+        ),
         SecretStrInput(name="api_key", display_name="Azure Chat OpenAI API Key", required=True),
         DropdownInput(
             name="api_version",
@@ -71,6 +78,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
         azure_endpoint = self.azure_endpoint
         azure_deployment = self.azure_deployment
+        model = self.model
         api_version = self.api_version
         api_key = self.api_key
         temperature = self.temperature
@@ -81,6 +89,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
             output = AzureChatOpenAI(
                 azure_endpoint=azure_endpoint,
                 azure_deployment=azure_deployment,
+                model=model or None,
                 api_version=api_version,
                 api_key=api_key,
                 temperature=temperature,


### PR DESCRIPTION
## Summary

Fixes #9855.

`AzureChatOpenAIComponent` (the "Azure OpenAI" model component) only exposed **Deployment Name**, with no way to tell `langchain_openai.AzureChatOpenAI` which underlying OpenAI model is behind that deployment. As reported in #9855, some Azure OpenAI configurations need the model name to resolve correctly, and it's also required for:
- Accurate token/cost tracing (`AzureChatOpenAI._get_ls_params` / `_create_chat_result` fall back to the deployment name when `model_name` is `None`, which usually doesn't match a real model id).
- `langchain_openai`'s model-name-gated feature checks (e.g. the `parallel_tool_calls` support check keys off `model_name == "gpt-4o"`, and reasoning-specific params for o-series/gpt-5 models).

Note: for plain Chat Completions routing, `azure_deployment` alone is already enough to reach the right deployment (the endpoint's `base_url` is built from it at client construction), so the change here doesn't affect routing for the common case — it closes the actual gap in the issue (no way to declare the model at all) and the secondary correctness issues above.

## Changes

- Added an optional, advanced `model` input to `AzureChatOpenAIComponent`, matching the field name already used by the sibling `AzureOpenAIEmbeddingsComponent` in the same file.
- Passed it through as `AzureChatOpenAI(model=self.model or None, ...)`.
- When left blank, `model=None` is sent — identical to current behavior, so existing saved flows are unaffected.

Kept deliberately minimal: no default value is forced on the new field (unlike the embeddings sibling / OpenAI component), because a forced default could silently mismatch a user's actual deployed model for existing flows that don't set this field.

One naming detail worth calling out for review: I initially named the field `model_name` (matching `OpenAIModelComponent`), but that collides with `lfx/base/models/model_input_constants.py`'s shared "unified model providers" registry, which special-cases any input literally named `model_name` and expects a `DropdownInput` with `.combobox` support. Since `AzureChatOpenAIComponent` is already registered there (currently `is_active: False`), that name broke import of `model_input_constants.py` itself (and everything that imports it — `altk`, `cuga`, the agent component, etc.) with a pydantic `ValidationError`. Renaming the field to `model` avoids that collision entirely and still matches the sibling embeddings component's convention.

## Test plan

- Added `src/backend/tests/unit/components/bundles/azure/test_azure_openai_component.py` covering:
  - Input structure (the new field exists, is optional and advanced).
  - `build_model()` passes `model=` through to `AzureChatOpenAI`.
  - Omitting the field preserves prior behavior (`model=None`).
  - Exception handling is preserved.
  - The inherited `test_latest_version` smoke test.
- Ran the full suite to confirm no regressions:
  - `uv run pytest src/backend/tests/unit/components/bundles/azure/` — 7 passed, 4 skipped.
  - `uv run pytest src/backend/tests/unit/components/bundles/ src/backend/tests/unit/base/models/ src/backend/tests/unit/test_load_components.py` — 355 passed, 94 skipped, 3 pre-existing failures in `altk` unrelated to this change (verified they fail identically on unmodified `main`, environment/API-key related).
  - `uv run --package lfx pytest src/lfx/tests/unit/base/models/` — 329 passed (covers the shared unified-model-providers registry that the field-name collision above would have broken).
  - `ruff check` / `ruff format --check` on both changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an advanced model configuration option for Azure OpenAI connections.
  * The selected model is now applied when creating the chat model.

* **Bug Fixes**
  * Improved handling of empty model settings and connection errors with clearer contextual messages.

* **Tests**
  * Added coverage for default setup, input definitions, model configuration, argument forwarding, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->