### PR TITLE
perf: halve the database statements a flow run costs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1081,7 +1081,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 613,
+        "line_number": 647,
         "is_secret": false
       },
       {
@@ -1089,7 +1089,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 823,
+        "line_number": 857,
         "is_secret": false
       }
     ],
@@ -7483,5 +7483,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T19:22:46Z"
+  "generated_at": "2026-08-15T03:02:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1081,7 +1081,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 608,
+        "line_number": 613,
         "is_secret": false
       },
       {
@@ -1089,7 +1089,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 818,
+        "line_number": 823,
         "is_secret": false
       }
     ],
@@ -7483,5 +7483,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T19:03:32Z"
+  "generated_at": "2026-08-14T19:22:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1071,7 +1071,7 @@
         "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 173,
+        "line_number": 174,
         "is_secret": false
       }
     ],
@@ -7483,5 +7483,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T17:39:59Z"
+  "generated_at": "2026-08-14T19:03:32Z"
 }

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -235,12 +235,11 @@ async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession
             if asyncio.iscoroutine(result):
                 await result
         await session.commit()
-        # No refresh loop here. It cost one SELECT per message and fetched nothing the caller did
-        # not already hold: the session factory sets expire_on_commit=False, so the commit leaves
-        # these objects loaded, and no column on `message` is filled in by the database -- all 18
-        # are plain columns whose defaults (id, timestamp, error, edit, is_output) are Python-side
-        # and already evaluated before the INSERT. Re-add a refresh only if a column gains a
-        # server_default or a trigger.
+        # The committed objects are complete without a refresh: the session factory sets
+        # expire_on_commit=False, so the commit leaves them loaded, and no column on `message` is
+        # filled in by the database -- every default (id, timestamp, error, edit, is_output) is
+        # Python-side and already evaluated before the INSERT. A column gaining a server_default or
+        # a trigger would need a refresh here again.
     except asyncio.CancelledError:
         try:
             await session.rollback()

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -235,8 +235,12 @@ async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession
             if asyncio.iscoroutine(result):
                 await result
         await session.commit()
-        for message in messages:
-            await session.refresh(message)
+        # No refresh loop here. It cost one SELECT per message and fetched nothing the caller did
+        # not already hold: the session factory sets expire_on_commit=False, so the commit leaves
+        # these objects loaded, and no column on `message` is filled in by the database -- all 18
+        # are plain columns whose defaults (id, timestamp, error, edit, is_output) are Python-side
+        # and already evaluated before the INSERT. Re-add a refresh only if a column gains a
+        # server_default or a trigger.
     except asyncio.CancelledError:
         try:
             await session.rollback()

--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from cryptography.fernet import InvalidToken
 from lfx.log.logger import logger
+from sqlalchemy.orm import joinedload
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -225,9 +226,15 @@ async def _check_key_from_db_with_context(
 
     incoming_hash = hash_api_key(api_key)
 
-    # Fast path: O(1) indexed lookup by hash
-    query = select(ApiKey).where(ApiKey.api_key_hash == incoming_hash, ApiKey.is_active.is_(True))
-    matches = (await session.exec(query)).all()
+    # Fast path: O(1) indexed lookup by hash. The owning user rides along on the same statement:
+    # every authenticated request needs it, and on PostgreSQL a second lookup is a second network
+    # round-trip for a row the join already reached.
+    query = (
+        select(ApiKey)
+        .where(ApiKey.api_key_hash == incoming_hash, ApiKey.is_active.is_(True))
+        .options(joinedload(ApiKey.user))
+    )
+    matches = (await session.exec(query)).unique().all()
 
     if len(matches) == 1:
         api_key_obj = matches[0]
@@ -235,7 +242,7 @@ async def _check_key_from_db_with_context(
             return None
         # Resolve + authorize the user BEFORE the usage counters, so a denied authentication
         # (missing user, blocked external user) does not bump total_uses / last_used_at.
-        user = await session.get(User, api_key_obj.user_id)
+        user = api_key_obj.user
         if user is None or not user.is_active:
             return None
         if await _external_access_ceiling_blocks_user(session, user, settings_service):

--- a/src/backend/base/langflow/services/database/models/jobs/crud.py
+++ b/src/backend/base/langflow/services/database/models/jobs/crud.py
@@ -76,10 +76,9 @@ async def update_job_status(
     Returns:
         True if the job was found and updated, False if no such job exists.
 
-        This used to return the updated Job, which cost a SELECT to re-read the row the UPDATE had
-        just written, twice per flow run. No caller ever bound the result -- every one of them
-        awaits this for its effect -- so the row was fetched and discarded. rowcount already carries
-        the only part anyone could have used, which is whether the job existed.
+        Deliberately not the updated Job: returning the row costs a SELECT to re-read what the
+        UPDATE just wrote, and callers await this for its effect rather than for the row. Fetch it
+        with ``get_job_by_job_id`` if you need it.
     """
     values = {"status": status}
     if finished_timestamp is not None:

--- a/src/backend/base/langflow/services/database/models/jobs/crud.py
+++ b/src/backend/base/langflow/services/database/models/jobs/crud.py
@@ -64,7 +64,7 @@ async def update_job_status(
     status: JobStatus,
     *,
     finished_timestamp: datetime | None = None,
-) -> Job | None:
+) -> bool:
     """Update the status of a job.
 
     Args:
@@ -74,7 +74,12 @@ async def update_job_status(
         finished_timestamp: Optional timestamp to set atomically with the status
 
     Returns:
-        Updated Job object or None if not found
+        True if the job was found and updated, False if no such job exists.
+
+        This used to return the updated Job, which cost a SELECT to re-read the row the UPDATE had
+        just written, twice per flow run. No caller ever bound the result -- every one of them
+        awaits this for its effect -- so the row was fetched and discarded. rowcount already carries
+        the only part anyone could have used, which is whether the job existed.
     """
     values = {"status": status}
     if finished_timestamp is not None:
@@ -83,9 +88,7 @@ async def update_job_status(
     result = await db.exec(
         update(Job).where(Job.job_id == job_id).values(**values).execution_options(synchronize_session=False)
     )
-    if result.rowcount == 0:
-        return None
-    return await get_job_by_job_id(db, job_id)
+    return result.rowcount > 0
 
 
 async def get_latest_jobs_by_asset_ids(db: AsyncSession, asset_ids: Sequence[UUID]) -> dict[UUID, Job]:

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -186,9 +186,7 @@ class JobService(Service):
             await session.flush()
             return job
 
-    async def update_job_status(
-        self, job_id: UUID, status: JobStatus, *, finished_timestamp: bool = False
-    ) -> Job | None:
+    async def update_job_status(self, job_id: UUID, status: JobStatus, *, finished_timestamp: bool = False) -> bool:
         """Update job status and optionally set finished timestamp.
 
         Args:
@@ -197,7 +195,7 @@ class JobService(Service):
             finished_timestamp: If True, set finished_timestamp to current time
 
         Returns:
-            Updated Job object or None if not found
+            True if the job was found and updated, False if no such job exists.
         """
         async with session_scope() as session:
             finished_at = datetime.now(timezone.utc) if finished_timestamp else None

--- a/src/backend/base/langflow/services/tracing/native.py
+++ b/src/backend/base/langflow/services/tracing/native.py
@@ -46,17 +46,17 @@ TYPE_MAP = {
 
 
 async def _upsert_rows(session, model, rows: list) -> None:
-    """Insert rows, overwriting any that already exist, in one statement.
+    """Insert rows, overwriting any that already exist, in one statement per chunk.
 
-    Replaces a ``session.merge()`` per row. merge() has to SELECT each primary key before it can
-    choose between INSERT and UPDATE, so a flush cost ``2 + 2N`` statements for N spans, and the
-    SELECT missed every time on a normal run because the trace id is minted when the run starts and
-    the span ids are derived from it. This costs one statement regardless of N.
+    Deliberately not ``session.merge()`` per row: merge() has to SELECT each primary key before it
+    can choose between INSERT and UPDATE, which costs two statements per row and misses every time
+    on a normal run, because the trace id is minted when the run starts and the span ids are derived
+    from it. The cost here does not grow with the number of rows.
 
-    The upsert, rather than a plain insert, is what keeps HITL working. A paused run flushes its
-    partial spans (``langflow/api/build.py``), and on resume the run flushes again with the same
-    trace id and the same deterministic uuid5 span ids. Those rows must be overwritten with their
-    finished state, so the conflict clause updates every non-key column, exactly as merge() did.
+    An upsert rather than a plain insert, because HITL writes the same rows twice: a paused run
+    flushes its partial spans (``langflow/api/build.py``) and on resume flushes again with the same
+    trace id and the same deterministic uuid5 span ids. Those rows have to end up holding their
+    finished state, so the conflict clause updates every non-key column.
     """
     if not rows:
         return
@@ -76,13 +76,22 @@ async def _upsert_rows(session, model, rows: list) -> None:
     connection = await session.connection()
     if connection.dialect.name == "postgresql":
         from sqlalchemy.dialects.postgresql import insert as dialect_insert
+
+        # PostgreSQL's wire protocol allows 65535 bind parameters per statement.
+        max_bind_parameters = 30_000
     else:
         from sqlalchemy.dialects.sqlite import insert as dialect_insert
 
-    # PostgreSQL's wire protocol allows 65535 bind parameters per statement, and one statement here
-    # carries len(columns) of them per row, so a big enough trace would fail as a whole. Chunking
-    # keeps the round-trip count proportional to spans/chunk_size instead of to spans.
-    chunk_size = max(1, 30000 // len(values[0]))
+        # SQLite allows 32766 since 3.32, but only 999 before it, and a Python linked against a
+        # distro's older libsqlite3 still enforces the lower one. Staying under 999 costs nothing
+        # for the flows that exist -- anything up to 71 spans is still a single statement -- and
+        # avoids failing outright on a host we cannot detect from here.
+        max_bind_parameters = 900
+
+    # One statement carries len(columns) bind parameters per row, and both backends cap that, so a
+    # big enough trace would fail as a whole rather than degrade. Chunking trades that cliff for a
+    # round-trip count of spans/chunk_size instead of the one-per-span merge() used to pay.
+    chunk_size = max(1, max_bind_parameters // len(values[0]))
     for start in range(0, len(values), chunk_size):
         chunk = values[start : start + chunk_size]
         statement = dialect_insert(model).values(chunk)

--- a/src/backend/base/langflow/services/tracing/native.py
+++ b/src/backend/base/langflow/services/tracing/native.py
@@ -45,6 +45,54 @@ TYPE_MAP = {
 }
 
 
+async def _upsert_rows(session, model, rows: list) -> None:
+    """Insert rows, overwriting any that already exist, in one statement.
+
+    Replaces a ``session.merge()`` per row. merge() has to SELECT each primary key before it can
+    choose between INSERT and UPDATE, so a flush cost ``2 + 2N`` statements for N spans, and the
+    SELECT missed every time on a normal run because the trace id is minted when the run starts and
+    the span ids are derived from it. This costs one statement regardless of N.
+
+    The upsert, rather than a plain insert, is what keeps HITL working. A paused run flushes its
+    partial spans (``langflow/api/build.py``), and on resume the run flushes again with the same
+    trace id and the same deterministic uuid5 span ids. Those rows must be overwritten with their
+    finished state, so the conflict clause updates every non-key column, exactly as merge() did.
+    """
+    if not rows:
+        return
+
+    keys = sorted(column.name for column in model.__table__.primary_key)
+
+    # Collapse rows that share a primary key, keeping the last, because a run can legitimately
+    # produce two spans with the same id: the span uuid is uuid5 of (trace id, component id), and a
+    # Loop component or a graph cycle traces the same vertex once per iteration. PostgreSQL refuses
+    # to let one ON CONFLICT DO UPDATE touch a row twice, so an undeduped batch raises
+    # CardinalityViolation and the rollback discards the trace and every span with it. SQLite accepts
+    # it, so this is invisible on the default backend. The merge() loop this replaced collapsed
+    # duplicates through the identity map, and last-write-wins is what it produced.
+    deduped = {tuple(value[key] for key in keys): value for value in (row.model_dump() for row in rows)}
+    values = list(deduped.values())
+
+    connection = await session.connection()
+    if connection.dialect.name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as dialect_insert
+    else:
+        from sqlalchemy.dialects.sqlite import insert as dialect_insert
+
+    # PostgreSQL's wire protocol allows 65535 bind parameters per statement, and one statement here
+    # carries len(columns) of them per row, so a big enough trace would fail as a whole. Chunking
+    # keeps the round-trip count proportional to spans/chunk_size instead of to spans.
+    chunk_size = max(1, 30000 // len(values[0]))
+    for start in range(0, len(values), chunk_size):
+        chunk = values[start : start + chunk_size]
+        statement = dialect_insert(model).values(chunk)
+        statement = statement.on_conflict_do_update(
+            index_elements=keys,
+            set_={name: statement.excluded[name] for name in chunk[0] if name not in keys},
+        )
+        await session.exec(statement)
+
+
 class NativeTracer(BaseTracer):
     """Tracer that stores execution traces in Langflow's database.
 
@@ -348,15 +396,16 @@ class NativeTracer(BaseTracer):
                     total_latency_ms=total_latency_ms,
                     total_tokens=total_tokens,
                 )
-                await session.merge(trace)
+                await _upsert_rows(session, TraceTable, [trace])
 
                 # Pre-compute UUIDs and topologically sort so parents are inserted before children
                 # (required by PostgreSQL's immediate FK enforcement on span.parent_span_id → span.id).
+                # The upsert below preserves this order inside its executemany.
                 resolved = resolve_span_uuids(self.completed_spans, self.trace_id)
                 resolved = topological_sort_spans(resolved)
 
-                for span_data, span_uuid, parent_uuid in resolved:
-                    span = SpanTable(
+                spans = [
+                    SpanTable(
                         id=span_uuid,
                         trace_id=self.trace_id,
                         parent_span_id=parent_uuid,
@@ -371,7 +420,9 @@ class NativeTracer(BaseTracer):
                         error=span_data.get("error"),
                         attributes=span_data.get("attributes") or {},
                     )
-                    await session.merge(span)
+                    for span_data, span_uuid, parent_uuid in resolved
+                ]
+                await _upsert_rows(session, SpanTable, spans)
 
                 logger.debug("Flushed %d spans to database", len(self.completed_spans))
 

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -559,7 +559,12 @@ async def client_fixture(
         def init_app():
             db_dir = tempfile.mkdtemp()
             db_path = Path(db_dir) / "test.db"
-            monkeypatch.setenv("LANGFLOW_DATABASE_URL", f"sqlite:///{db_path}")
+            # Opt in to another backend with LANGFLOW_TEST_DATABASE_URL, e.g. a throwaway
+            # PostgreSQL. Some behaviour only exists off SQLite: PostgreSQL enforces foreign keys
+            # immediately, rejects an ON CONFLICT DO UPDATE that would touch a row twice, and caps
+            # a statement at 65535 bind parameters. Unset, everything below is unchanged.
+            db_url = os.getenv("LANGFLOW_TEST_DATABASE_URL") or f"sqlite:///{db_path}"
+            monkeypatch.setenv("LANGFLOW_DATABASE_URL", db_url)
             monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "false")
             monkeypatch.setenv("LANGFLOW_SUPERUSER", "langflow")
             monkeypatch.setenv("LANGFLOW_SUPERUSER_PASSWORD", "test-superuser-password")
@@ -577,7 +582,7 @@ async def client_fixture(
             get_service_manager().services.clear()  # Clear the services cache
             app = create_app()
             db_service = get_db_service()
-            db_service.database_url = f"sqlite:///{db_path}"
+            db_service.database_url = db_url
             db_service.reload_engine()
             return app, db_path
 

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -354,9 +354,36 @@ def session_fixture():
         engine.dispose()
 
 
+def _async_db_url(url: str) -> str:
+    """Give a database URL an async driver, since this fixture creates its own engine.
+
+    ``LANGFLOW_TEST_DATABASE_URL`` is written the way the app takes it, which is a sync URL.
+    """
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    if url.startswith("sqlite://"):
+        return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+    return url
+
+
 @pytest.fixture
 async def async_session():
-    engine = create_async_engine("sqlite+aiosqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    """A session on its own schema, created and dropped per test.
+
+    Honours ``LANGFLOW_TEST_DATABASE_URL`` like the ``client`` fixture does. Without that, tests
+    written against this fixture always run on SQLite whatever the env var says, which quietly
+    exempts them from the backend they are meant to cover: PostgreSQL enforces foreign keys
+    immediately, refuses an ON CONFLICT DO UPDATE that would touch a row twice, and caps a
+    statement at 65535 bind parameters, and SQLite accepts all three.
+    """
+    url = os.getenv("LANGFLOW_TEST_DATABASE_URL")
+    if url:
+        # create_all/drop_all per test keeps the isolation the in-memory engine gives for free.
+        engine = create_async_engine(_async_db_url(url))
+    else:
+        engine = create_async_engine(
+            "sqlite+aiosqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+        )
     try:
         async with engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
@@ -563,6 +590,13 @@ async def client_fixture(
             # PostgreSQL. Some behaviour only exists off SQLite: PostgreSQL enforces foreign keys
             # immediately, rejects an ON CONFLICT DO UPDATE that would touch a row twice, and caps
             # a statement at 65535 bind parameters. Unset, everything below is unchanged.
+            #
+            # Set, it costs the isolation the SQLite path gets for free. Each test otherwise gets
+            # its own temp file; here every test shares one database, the teardown below only
+            # unlinks a SQLite file that was never created, and rows survive into the next test. So
+            # run it serially (no `-n auto`) and expect suites that count rows to need a fresh
+            # database. Tests that take `async_session` instead are unaffected: that fixture
+            # creates and drops the schema per test on whichever backend it is pointed at.
             db_url = os.getenv("LANGFLOW_TEST_DATABASE_URL") or f"sqlite:///{db_path}"
             monkeypatch.setenv("LANGFLOW_DATABASE_URL", db_url)
             monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "false")

--- a/src/backend/tests/unit/services/jobs/test_jobs_service.py
+++ b/src/backend/tests/unit/services/jobs/test_jobs_service.py
@@ -182,3 +182,22 @@ async def test_sweep_orphans_noop_when_clean():
     await service.update_job_status(job_id, JobStatus.COMPLETED, finished_timestamp=True)
 
     assert await service.sweep_orphans() == []
+
+
+@pytest.mark.usefixtures("client")
+async def test_update_job_status_reports_whether_the_job_existed():
+    """The return value distinguishes a job that was updated from one that does not exist.
+
+    ``update_job_status`` returns a bool rather than the updated Job, so that it does not have to
+    re-read the row it just wrote. That makes the row-found signal the only thing left in the
+    return value, and nothing else asserts on it.
+    """
+    service = JobService()
+    job_id = uuid4()
+    await service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+
+    assert await service.update_job_status(job_id, JobStatus.IN_PROGRESS) is True
+    assert await service.update_job_status(uuid4(), JobStatus.IN_PROGRESS) is False
+
+    job = await service.get_job_by_job_id(job_id)
+    assert job.status == JobStatus.IN_PROGRESS

--- a/src/backend/tests/unit/services/tracing/test_native_tracer.py
+++ b/src/backend/tests/unit/services/tracing/test_native_tracer.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import UUID, uuid4, uuid5
 
 import pytest
-from langflow.services.database.models.traces.model import SpanStatus, SpanType
+from langflow.services.database.models.traces.model import SpanStatus, SpanTable, SpanType, TraceTable
 from langflow.services.tracing.native import NativeTracer
-from langflow.services.tracing.span_sorting import resolve_span_uuids, topological_sort_spans
+from langflow.services.tracing.span_sorting import (
+    LANGFLOW_SPAN_NAMESPACE,
+    resolve_span_uuids,
+    topological_sort_spans,
+)
+from sqlalchemy import event, text
+from sqlalchemy.engine import Engine
+from sqlmodel import select
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -361,48 +369,101 @@ class TestWaitForFlush:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+async def db_flow_id(async_session, monkeypatch) -> str:
+    """Point ``_flush_to_database`` at a real DB session and return a flow_id that exists in it.
+
+    ``_flush_to_database`` imports ``session_scope`` from ``lfx.services.deps`` at call time, so
+    patching the attribute on that module is enough to hand it the in-memory session created by
+    the shared ``async_session`` fixture. The flush then writes real rows, and the tests read
+    those rows back instead of inspecting how they got there.
+    """
+    import lfx.services.deps
+    from langflow.services.database.models.flow.model import Flow
+
+    flow = Flow(id=uuid4(), name=f"flow-{uuid4()}", data={})
+    async_session.add(flow)
+    await async_session.commit()
+
+    @asynccontextmanager
+    async def _scope():
+        yield async_session
+        await async_session.commit()
+
+    monkeypatch.setattr(lfx.services.deps, "session_scope", _scope)
+    return str(flow.id)
+
+
+async def _fetch_trace(session, trace_id: UUID):
+    """Read the persisted trace row back.
+
+    ``populate_existing`` forces a refresh from the DB so a second flush is not masked by rows
+    already in the session's identity map.
+    """
+    statement = select(TraceTable).where(TraceTable.id == trace_id).execution_options(populate_existing=True)
+    return (await session.exec(statement)).first()
+
+
+async def _fetch_spans(session, trace_id: UUID) -> list[SpanTable]:
+    statement = (
+        select(SpanTable)
+        .where(SpanTable.trace_id == trace_id)
+        .order_by(SpanTable.start_time)
+        .execution_options(populate_existing=True)
+    )
+    return list((await session.exec(statement)).all())
+
+
+def _span_uuid(trace_id: UUID, component_id: str) -> UUID:
+    """The id the tracer derives for a non-UUID span id (the upsert's conflict key)."""
+    return uuid5(LANGFLOW_SPAN_NAMESPACE, f"{trace_id}-{component_id}")
+
+
 class TestFlushToDatabase:
-    @pytest.mark.asyncio
-    async def test_flush_invalid_flow_id_logs_error_and_continues(self):
+    async def test_flush_invalid_flow_id_logs_error_and_continues(self, async_session, db_flow_id):  # noqa: ARG002
         tracer = _make_tracer(flow_id="not-a-uuid")
         tracer.add_trace("comp-1", "Comp (comp-1)", "chain", {})
         tracer.end_trace("comp-1", "Comp")
 
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch("langflow.services.tracing.native.logger") as mock_logger,
-            patch("lfx.services.deps.session_scope", return_value=mock_session),
-        ):
+        with patch("langflow.services.tracing.native.logger") as mock_logger:
             await tracer._flush_to_database()
 
         mock_logger.error.assert_called_once()
-        # Verify it continued and attempted to persist with a sentinel flow_id
-        assert mock_session.merge.call_count >= 2
 
-    @pytest.mark.asyncio
-    async def test_flush_writes_trace_and_spans(self):
-        flow_id = str(uuid4())
-        tracer = _make_tracer(flow_id=flow_id)
+        # It continued: the rows are in the DB, filed under the deterministic sentinel flow_id.
+        trace = await _fetch_trace(async_session, tracer.trace_id)
+        assert trace is not None
+        assert trace.flow_id == uuid5(LANGFLOW_SPAN_NAMESPACE, "invalid-flow-id:not-a-uuid")
+        assert [span.name for span in await _fetch_spans(async_session, tracer.trace_id)] == ["Comp"]
+
+    async def test_flush_writes_trace_and_spans(self, async_session, db_flow_id):
+        tracer = _make_tracer(flow_id=db_flow_id)
         tracer.add_trace("comp-1", "Comp (comp-1)", "chain", {"in": "val"})
         tracer.end_trace("comp-1", "Comp", outputs={"out": "result"})
 
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        await tracer._flush_to_database()
 
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
-            await tracer._flush_to_database()
+        trace = await _fetch_trace(async_session, tracer.trace_id)
+        assert trace is not None
+        assert trace.flow_id == UUID(db_flow_id)
+        assert trace.name == tracer.trace_name
+        assert trace.session_id == tracer.session_id
+        assert trace.status == SpanStatus.OK
+        assert trace.end_time is not None
 
-        # merge should be called at least twice: once for trace, once for span
-        assert mock_session.merge.call_count >= 2
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.id == _span_uuid(tracer.trace_id, "comp-1")
+        assert span.name == "Comp"
+        assert span.span_type == SpanType.CHAIN
+        assert span.status == SpanStatus.OK
+        assert span.inputs == {"in": "val"}
+        assert span.outputs == {"out": "result"}
+        assert span.error is None
 
-    @pytest.mark.asyncio
-    async def test_flush_uses_uuid5_for_non_uuid_span_id(self):
-        flow_id = str(uuid4())
-        tracer = _make_tracer(flow_id=flow_id)
+    async def test_flush_uses_uuid5_for_non_uuid_span_id(self, async_session, db_flow_id):
+        tracer = _make_tracer(flow_id=db_flow_id)
         # Manually add a completed span with a non-UUID string id
         tracer.completed_spans.append(
             {
@@ -420,48 +481,31 @@ class TestFlushToDatabase:
             }
         )
 
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        await tracer._flush_to_database()
 
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
-            # Should not raise even with non-UUID span id
-            await tracer._flush_to_database()
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert len(spans) == 1
+        # The persisted primary key is derived from the trace id, not random: this is what makes the
+        # upsert idempotent across a HITL pause/resume.
+        assert spans[0].id == _span_uuid(tracer.trace_id, "not-a-uuid-string")
 
-        assert mock_session.merge.call_count >= 1
-
-    @pytest.mark.asyncio
-    async def test_flush_error_status_when_span_has_error(self):
-        flow_id = str(uuid4())
-        tracer = _make_tracer(flow_id=flow_id)
+    async def test_flush_error_status_when_span_has_error(self, async_session, db_flow_id):
+        tracer = _make_tracer(flow_id=db_flow_id)
         tracer.add_trace("comp-1", "Comp (comp-1)", "chain", {})
         tracer.end_trace("comp-1", "Comp", error=ValueError("boom"))
 
-        captured_traces = []
+        await tracer._flush_to_database()
 
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        trace = await _fetch_trace(async_session, tracer.trace_id)
+        assert trace is not None
+        assert trace.status == SpanStatus.ERROR
 
-        async def capture_merge(obj):
-            captured_traces.append(obj)
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert [span.status for span in spans] == [SpanStatus.ERROR]
+        assert spans[0].error == "boom"
 
-        mock_session.merge = capture_merge
-
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
-            await tracer._flush_to_database()
-
-        # First merged object is the TraceTable
-        from langflow.services.database.models.traces.model import TraceTable
-
-        trace_obj = next((o for o in captured_traces if isinstance(o, TraceTable)), None)
-        assert trace_obj is not None
-        assert trace_obj.status == SpanStatus.ERROR
-
-    @pytest.mark.asyncio
-    async def test_flush_calculates_total_tokens_from_spans(self):
-        flow_id = str(uuid4())
-        tracer = _make_tracer(flow_id=flow_id)
+    async def test_flush_calculates_total_tokens_from_spans(self, async_session, db_flow_id):
+        tracer = _make_tracer(flow_id=db_flow_id)
         tracer.completed_spans = [
             {
                 "id": str(uuid4()),
@@ -493,24 +537,92 @@ class TestFlushToDatabase:
             },
         ]
 
-        captured_traces = []
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        await tracer._flush_to_database()
 
-        async def capture_merge(obj):
-            captured_traces.append(obj)
+        trace = await _fetch_trace(async_session, tracer.trace_id)
+        assert trace is not None
+        assert trace.total_tokens == 80
 
-        mock_session.merge = capture_merge
+    async def test_flush_twice_upserts_instead_of_duplicating(self, async_session, db_flow_id):
+        """The HITL shape: a paused run flushes partial spans, then flushes again after resume.
 
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
+        Both flushes carry the same trace id and the same deterministic span ids, so the second one
+        must overwrite the first's rows rather than insert duplicates or raise on the primary key.
+        """
+        tracer = _make_tracer(flow_id=db_flow_id)
+        tracer.add_trace("comp-1", "Comp (comp-1)", "chain", {"in": "val"})
+        tracer.end_trace("comp-1", "Comp")  # paused: no outputs yet
+
+        await tracer._flush_to_database()
+
+        # Resume: the same span finishes, and a second component runs.
+        tracer.completed_spans[0]["outputs"] = {"out": "done"}
+        tracer.completed_spans[0]["latency_ms"] = 42
+        tracer.add_trace("comp-2", "Second (comp-2)", "chain", {})
+        tracer.end_trace("comp-2", "Second", outputs={"out": "also done"})
+
+        await tracer._flush_to_database()  # must not raise
+
+        traces = (await async_session.exec(select(TraceTable).execution_options(populate_existing=True))).all()
+        assert [trace.id for trace in traces] == [tracer.trace_id]
+
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert len(spans) == 2
+        assert {span.id for span in spans} == {
+            _span_uuid(tracer.trace_id, "comp-1"),
+            _span_uuid(tracer.trace_id, "comp-2"),
+        }
+
+        # The resumed row holds the second flush's values, not the paused ones.
+        first = next(span for span in spans if span.id == _span_uuid(tracer.trace_id, "comp-1"))
+        assert first.outputs == {"out": "done"}
+        assert first.latency_ms == 42
+
+    async def test_flush_collapses_repeated_builds_of_one_vertex(self, async_session, db_flow_id):
+        """A Loop component or a graph cycle builds the same vertex once per iteration.
+
+        Every build appends its own span, and the span id is uuid5 of (trace id, component id), so
+        one flush carries the same primary key more than once. PostgreSQL refuses to let a single
+        ON CONFLICT DO UPDATE touch a row twice and aborts the whole statement, which would discard
+        the trace and every span with it, silently -- the flush error is swallowed. So the rows must
+        be collapsed before they are sent, keeping the last build, which is what the per-row
+        merge() this replaced produced via the identity map.
+
+        SQLite applies the upsert row by row and accepts duplicates, so the stored rows look correct
+        on the default backend either way. That is why this test also asserts on the SHAPE of the
+        statement: it checks that only one row's worth of parameters was sent, which is the thing
+        PostgreSQL rejects. Without the collapse this assertion fails on SQLite too, so the guard
+        works on the backend CI actually runs.
+        """
+        tracer = _make_tracer(flow_id=db_flow_id)
+        for iteration in range(3):
+            tracer.add_trace("loop-body", "Loop Body (loop-body)", "chain", {"i": iteration})
+            tracer.end_trace("loop-body", "Loop Body", outputs={"i": iteration})
+
+        assert [span["id"] for span in tracer.completed_spans] == ["loop-body"] * 3
+
+        span_inserts = []
+
+        def capture(_conn, _cursor, statement, parameters, _context, _executemany):
+            if "INTO span" in statement:
+                span_inserts.append(parameters)
+
+        event.listen(Engine, "before_cursor_execute", capture)
+        try:
             await tracer._flush_to_database()
+        finally:
+            event.remove(Engine, "before_cursor_execute", capture)
 
-        from langflow.services.database.models.traces.model import TraceTable
+        assert len(span_inserts) == 1, "the three builds must go out as one statement"
+        assert len(span_inserts[0]) == len(SpanTable.__table__.columns), (
+            "the statement carried more than one row of values, which PostgreSQL rejects with "
+            "CardinalityViolation on the conflicting primary key"
+        )
 
-        trace_obj = next((o for o in captured_traces if isinstance(o, TraceTable)), None)
-        assert trace_obj is not None
-        assert trace_obj.total_tokens == 80
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert len(spans) == 1
+        assert spans[0].id == _span_uuid(tracer.trace_id, "loop-body")
+        assert spans[0].outputs == {"i": 2}
 
 
 # ---------------------------------------------------------------------------
@@ -829,11 +941,20 @@ class TestResolveSpanUuids:
 
 
 class TestFlushParentChildOrder:
-    @pytest.mark.asyncio
-    async def test_flush_inserts_parent_before_child(self):
-        """Verify that the DB merge order respects parent -> child ordering."""
-        flow_id = str(uuid4())
-        tracer = _make_tracer(flow_id=flow_id)
+    async def test_flush_inserts_parent_before_child(self, async_session, db_flow_id):
+        """Both spans land and the child's FK resolves to the parent row.
+
+        This used to assert the order of the ``session.merge()`` calls. The flush now writes every
+        span in one upsert, so call order is no longer observable from the outside; what that
+        assertion existed to protect is the FK on ``span.parent_span_id`` being satisfiable, i.e.
+        the parent row must exist by the time the child row is written. So the test turns SQLite's
+        FK enforcement on (off by default, unlike PostgreSQL) and asserts on the persisted rows: a
+        regression that emits the child first now fails the INSERT outright.
+        """
+        tracer = _make_tracer(flow_id=db_flow_id)
+
+        await async_session.execute(text("PRAGMA foreign_keys=ON"))
+        assert (await async_session.execute(text("PRAGMA foreign_keys"))).scalar() == 1
 
         parent_uuid = uuid4()
         child_uuid = uuid4()
@@ -871,31 +992,17 @@ class TestFlushParentChildOrder:
             },
         ]
 
-        merged_objects = []
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        await tracer._flush_to_database()
 
-        async def capture_merge(obj):
-            merged_objects.append(obj)
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        by_id = {span.id: span for span in spans}
+        assert set(by_id) == {parent_uuid, child_uuid}
+        assert by_id[parent_uuid].parent_span_id is None
+        assert by_id[child_uuid].parent_span_id == parent_uuid
 
-        mock_session.merge = capture_merge
-
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
-            await tracer._flush_to_database()
-
-        from langflow.services.database.models.traces.model import SpanTable
-
-        span_objects = [o for o in merged_objects if isinstance(o, SpanTable)]
-        assert len(span_objects) == 2
-        # Parent (no parent_span_id) must come before child
-        assert span_objects[0].id == parent_uuid
-        assert span_objects[1].id == child_uuid
-        assert span_objects[1].parent_span_id == parent_uuid
-
-    async def test_flush_detaches_span_from_missing_parent(self):
+    async def test_flush_detaches_span_from_missing_parent(self, async_session, db_flow_id):
         """A missing parent must not leave an invalid self-referential FK."""
-        tracer = _make_tracer(flow_id=str(uuid4()))
+        tracer = _make_tracer(flow_id=db_flow_id)
         tracer.completed_spans = [
             {
                 "id": str(uuid4()),
@@ -914,21 +1021,11 @@ class TestFlushParentChildOrder:
             }
         ]
 
-        merged_objects = []
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+        await async_session.execute(text("PRAGMA foreign_keys=ON"))
 
-        async def capture_merge(obj):
-            merged_objects.append(obj)
+        await tracer._flush_to_database()
 
-        mock_session.merge = capture_merge
-
-        with patch("lfx.services.deps.session_scope", return_value=mock_session):
-            await tracer._flush_to_database()
-
-        from langflow.services.database.models.traces.model import SpanTable
-
-        span_objects = [obj for obj in merged_objects if isinstance(obj, SpanTable)]
-        assert len(span_objects) == 1
-        assert span_objects[0].parent_span_id is None
+        spans = await _fetch_spans(async_session, tracer.trace_id)
+        assert len(spans) == 1
+        assert spans[0].name == "Orphan Span"
+        assert spans[0].parent_span_id is None

--- a/src/backend/tests/unit/services/tracing/test_native_tracer.py
+++ b/src/backend/tests/unit/services/tracing/test_native_tracer.py
@@ -394,6 +394,29 @@ async def db_flow_id(async_session, monkeypatch) -> str:
     return str(flow.id)
 
 
+def _bound_values(parameters):
+    """The bound values of one executed statement, in the order the driver sends them.
+
+    SQLite binds positionally and hands back a tuple; psycopg binds by name and hands back a dict
+    keyed ``name_m0``, ``name_m1``, .... The dict is ordered row by row, so its values are in the
+    same order the tuple would be.
+    """
+    return list(parameters.values()) if isinstance(parameters, dict) else list(parameters)
+
+
+async def _enforce_foreign_keys(session) -> None:
+    """Make the session enforce foreign keys, whichever backend it is on.
+
+    PostgreSQL always does. SQLite does not unless asked, per connection, and ``PRAGMA`` is a
+    syntax error on PostgreSQL, so the statement has to be guarded rather than issued blindly.
+    """
+    connection = await session.connection()
+    if connection.dialect.name != "sqlite":
+        return
+    await session.execute(text("PRAGMA foreign_keys=ON"))
+    assert (await session.execute(text("PRAGMA foreign_keys"))).scalar() == 1
+
+
 async def _fetch_trace(session, trace_id: UUID):
     """Read the persisted trace row back.
 
@@ -421,14 +444,34 @@ def _span_uuid(trace_id: UUID, component_id: str) -> UUID:
 
 class TestFlushToDatabase:
     async def test_flush_invalid_flow_id_logs_error_and_continues(self, async_session, db_flow_id):  # noqa: ARG002
+        """A malformed flow_id is reported and the trace is filed under a sentinel flow_id.
+
+        The sentinel is a uuid5 that by construction matches no row in `flow`, and `trace.flow_id`
+        carries a foreign key to `flow.id`. So on PostgreSQL, which enforces that immediately, this
+        fallback cannot store anything: the INSERT raises, the session rolls back, and
+        `wait_for_flush` swallows the error, which is the opposite of what the fallback's own
+        comment in native.py claims it achieves. That gap predates this change -- `merge()` hit the
+        same foreign key -- so it is documented here rather than fixed, and the persisted-row half
+        of this test only runs where foreign keys are off.
+        """
         tracer = _make_tracer(flow_id="not-a-uuid")
         tracer.add_trace("comp-1", "Comp (comp-1)", "chain", {})
         tracer.end_trace("comp-1", "Comp")
 
+        connection = await async_session.connection()
+        enforces_foreign_keys = connection.dialect.name != "sqlite"
+
         with patch("langflow.services.tracing.native.logger") as mock_logger:
-            await tracer._flush_to_database()
+            try:
+                await tracer._flush_to_database()
+            except Exception:
+                if not enforces_foreign_keys:
+                    raise
 
         mock_logger.error.assert_called_once()
+
+        if enforces_foreign_keys:
+            return
 
         # It continued: the rows are in the DB, filed under the deterministic sentinel flow_id.
         trace = await _fetch_trace(async_session, tracer.trace_id)
@@ -942,19 +985,21 @@ class TestResolveSpanUuids:
 
 class TestFlushParentChildOrder:
     async def test_flush_inserts_parent_before_child(self, async_session, db_flow_id):
-        """Both spans land and the child's FK resolves to the parent row.
+        """The parent is written ahead of the child, and the child's FK resolves to it.
 
-        This used to assert the order of the ``session.merge()`` calls. The flush now writes every
-        span in one upsert, so call order is no longer observable from the outside; what that
-        assertion existed to protect is the FK on ``span.parent_span_id`` being satisfiable, i.e.
-        the parent row must exist by the time the child row is written. So the test turns SQLite's
-        FK enforcement on (off by default, unlike PostgreSQL) and asserts on the persisted rows: a
-        regression that emits the child first now fails the INSERT outright.
+        This used to assert the order of the ``session.merge()`` calls. Asserting only on the
+        persisted rows would not replace it: the flush writes every span in one multi-row INSERT,
+        both backends check an immediate FK at end of statement rather than per row, so the rows
+        land and the FK resolves whichever order they were written in. Reversing the topological
+        sort would not fail such a test.
+
+        Order still matters, because ``_upsert_rows`` chunks: a parent and child far enough apart
+        go out in separate statements, and then the parent's statement has to come first. So the
+        assertion is on the order the statement itself carries.
         """
         tracer = _make_tracer(flow_id=db_flow_id)
 
-        await async_session.execute(text("PRAGMA foreign_keys=ON"))
-        assert (await async_session.execute(text("PRAGMA foreign_keys"))).scalar() == 1
+        await _enforce_foreign_keys(async_session)
 
         parent_uuid = uuid4()
         child_uuid = uuid4()
@@ -992,7 +1037,24 @@ class TestFlushParentChildOrder:
             },
         ]
 
-        await tracer._flush_to_database()
+        span_inserts = []
+
+        def capture(_conn, _cursor, statement, parameters, _context, _executemany):
+            if "INTO span" in statement:
+                span_inserts.append(parameters)
+
+        event.listen(Engine, "before_cursor_execute", capture)
+        try:
+            await tracer._flush_to_database()
+        finally:
+            event.remove(Engine, "before_cursor_execute", capture)
+
+        # The parent is bound ahead of the child, so a chunk boundary between them still writes the
+        # parent first. Matched on the names rather than the ids, which the driver binds as UUIDs.
+        bound = [str(value) for parameters in span_inserts for value in _bound_values(parameters)]
+        assert "Parent Span" in bound, bound
+        assert "Child Span" in bound, bound
+        assert bound.index("Parent Span") < bound.index("Child Span"), bound
 
         spans = await _fetch_spans(async_session, tracer.trace_id)
         by_id = {span.id: span for span in spans}
@@ -1021,7 +1083,7 @@ class TestFlushParentChildOrder:
             }
         ]
 
-        await async_session.execute(text("PRAGMA foreign_keys=ON"))
+        await _enforce_foreign_keys(async_session)
 
         await tracer._flush_to_database()
 

--- a/src/backend/tests/unit/test_db_calls_per_run.py
+++ b/src/backend/tests/unit/test_db_calls_per_run.py
@@ -1,0 +1,188 @@
+"""Count the database work one flow run costs on the request-handling connection pool.
+
+Measures with SQLAlchemy's own ``before_cursor_execute`` and pool ``checkout`` events rather than
+with OpenTelemetry spans. The events are the same source the instrumentor wraps, they need no
+exporter, and they report the statement text directly, so a regression names the table it came
+from instead of a span count.
+
+The listeners attach to the request pool engine only. That is deliberate: the telemetry writer
+owns a dedicated engine, so ``transaction`` and ``vertex_build`` rows are correctly invisible here.
+What this file measures is the work a caller waits on.
+
+Two autouse fixtures in ``tests/conftest.py`` move the suite off the production configuration:
+``disable_telemetry_writer`` forces the legacy synchronous write path, and ``deactivate_tracing``
+switches the internal trace/span tables off. Both are overridden below, because a per-run cost
+measured under test-only settings is not the cost users pay.
+
+Run it as a report::
+
+    uv run pytest src/backend/tests/unit/test_db_calls_per_run.py -s
+
+``-s`` matters: the per-table ledger goes to stdout, and that ledger is the deliverable. The
+asserted budgets are ceilings, set from a measured baseline, not targets.
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+import pytest
+from sqlalchemy import event
+from starlette import status
+
+# Ceilings, not targets. A two-component flow measured 13 statements and 11 checkouts when these
+# were set, down from 27 and 11. The headroom absorbs an extra message or span without failing;
+# anything past it means a new query joined the request path and should be justified on purpose.
+#
+# For reference, the floor a run cannot go below: read the api key, read the flow, read the global
+# variables, write the job row and its terminal status, write the messages, write the trace and its
+# spans. That is 8 or so. The gap between 8 and 13 is listed in the plan doc for this work.
+STATEMENT_BUDGET = 16
+CHECKOUT_BUDGET = 12
+
+
+@pytest.fixture
+def production_telemetry_defaults(monkeypatch):
+    """Undo the two autouse fixtures that take the suite off the shipped configuration.
+
+    Must be requested before ``client``: both settings are read while the app starts up.
+    """
+    monkeypatch.setenv("LANGFLOW_TELEMETRY_WRITER_ENABLED", "true")
+    monkeypatch.setenv("LANGFLOW_DEACTIVATE_TRACING", "false")
+    yield
+    monkeypatch.undo()
+
+
+_OP = re.compile(r"^\s*(SELECT|INSERT|UPDATE|DELETE|BEGIN|COMMIT|ROLLBACK|PRAGMA|SAVEPOINT|RELEASE)", re.IGNORECASE)
+_TABLE = re.compile(r"\b(?:FROM|INTO|UPDATE|JOIN)\s+[\"'`\[]?(\w+)", re.IGNORECASE)
+
+
+def _classify(sql: str) -> tuple[str, str]:
+    """Reduce a statement to (operation, table). Unparsed statements keep their first word."""
+    op_match = _OP.match(sql)
+    op = op_match.group(1).upper() if op_match else sql.split(maxsplit=1)[0].upper()
+    table_match = _TABLE.search(sql)
+    return op, table_match.group(1).lower() if table_match else "-"
+
+
+@dataclass
+class DbLedger:
+    """Every statement and pool checkout seen while the recorder was attached."""
+
+    statements: list[str] = field(default_factory=list)
+    checkouts: int = 0
+
+    @property
+    def by_op_table(self) -> Counter:
+        return Counter(_classify(sql) for sql in self.statements)
+
+    @property
+    def writes(self) -> int:
+        return sum(1 for sql in self.statements if _classify(sql)[0] in {"INSERT", "UPDATE", "DELETE"})
+
+    def report(self, title: str) -> str:
+        lines = [
+            "",
+            f"=== {title} ===",
+            f"statements: {len(self.statements)}   writes: {self.writes}   pool checkouts: {self.checkouts}",
+            "",
+        ]
+        lines.extend(
+            f"  {count:>4}  {op:<9} {table}"
+            for (op, table), count in sorted(self.by_op_table.items(), key=lambda kv: -kv[1])
+        )
+        return "\n".join(lines)
+
+
+@pytest.fixture
+async def db_ledger():
+    """Record statements and pool checkouts on the live engine for the duration of a test."""
+    from langflow.services.deps import get_db_service
+
+    engine = get_db_service().engine
+    sync_engine = engine.sync_engine
+    ledger = DbLedger()
+
+    def on_execute(_conn, _cursor, statement, _params, _context, _executemany):
+        ledger.statements.append(statement)
+
+    def on_checkout(_dbapi_conn, _record, _proxy):
+        ledger.checkouts += 1
+
+    event.listen(sync_engine, "before_cursor_execute", on_execute)
+    event.listen(sync_engine.pool, "checkout", on_checkout)
+    try:
+        yield ledger
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", on_execute)
+        event.remove(sync_engine.pool, "checkout", on_checkout)
+
+
+async def test_db_calls_for_a_healthy_run(
+    production_telemetry_defaults,  # noqa: ARG001 - fixture must apply before `client` builds the app
+    client,
+    simple_api_test,
+    created_api_key,
+    db_ledger,
+):
+    """A successful run stays inside its statement and checkout budget."""
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+
+    # The first request of a process warms caches that are not per-run work. Measure the second.
+    warmup = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json={"output_type": "text"})
+    assert warmup.status_code == status.HTTP_200_OK, warmup.text
+
+    db_ledger.statements.clear()
+    db_ledger.checkouts = 0
+
+    response = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json={"output_type": "text"})
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    print(db_ledger.report("healthy run"))  # noqa: T201 - the ledger is the deliverable
+
+    assert len(db_ledger.statements) <= STATEMENT_BUDGET, db_ledger.report("over statement budget")
+    assert db_ledger.checkouts <= CHECKOUT_BUDGET, db_ledger.report("over checkout budget")
+
+
+async def test_db_calls_for_a_failing_run(
+    production_telemetry_defaults,  # noqa: ARG001 - fixture must apply before `client` builds the app
+    client,
+    simple_api_test,
+    created_api_key,
+    db_ledger,
+):
+    """A run that fails must not cost more database work than one that succeeds.
+
+    The original trace behind this work was a failing run. Failure paths are where retry and
+    rollback bookkeeping accumulates unnoticed, so they get their own budget check.
+
+    The failure is induced by blocking a component the flow uses, which rejects the run after
+    authentication and after the flow load. That covers the same setup work a healthy run does,
+    which a 404 or a 401 would not.
+    """
+    from lfx.services.deps import get_catalog_policy_service
+
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+    catalog_policy_service = get_catalog_policy_service()
+
+    warmup = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json={"output_type": "text"})
+    assert warmup.status_code == status.HTTP_200_OK, warmup.text
+
+    await catalog_policy_service.replace_blocked_component_keys(["ChatInput"], actor_user_id=None)
+    db_ledger.statements.clear()
+    db_ledger.checkouts = 0
+    try:
+        response = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json={"output_type": "text"})
+        # Snapshot before the unblock below, whose own writes would otherwise land in the ledger.
+        run = DbLedger(statements=list(db_ledger.statements), checkouts=db_ledger.checkouts)
+    finally:
+        await catalog_policy_service.replace_blocked_component_keys([], actor_user_id=None)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
+
+    print(run.report(f"failing run (status {response.status_code})"))  # noqa: T201
+
+    assert len(run.statements) <= STATEMENT_BUDGET, run.report("over statement budget")
+    assert run.checkouts <= CHECKOUT_BUDGET, run.report("over checkout budget")

--- a/src/backend/tests/unit/test_db_calls_per_run.py
+++ b/src/backend/tests/unit/test_db_calls_per_run.py
@@ -30,15 +30,23 @@ import pytest
 from sqlalchemy import event
 from starlette import status
 
-# Ceilings, not targets. A two-component flow measured 13 statements and 11 checkouts when these
-# were set, down from 27 and 11. The headroom absorbs an extra message or span without failing;
-# anything past it means a new query joined the request path and should be justified on purpose.
+# Ceilings, not targets. A two-component flow measured 13 statements and 11 checkouts on SQLite
+# when these were set, down from 27 and 11. The headroom absorbs an extra message or span without
+# failing; anything past it means a new query joined the request path and should be justified.
 #
-# For reference, the floor a run cannot go below: read the api key, read the flow, read the global
-# variables, write the job row and its terminal status, write the messages, write the trace and its
-# spans. That is 8 or so. The gap between 8 and 13 is listed in the plan doc for this work.
+# The floor for this flow is 10, counted from what a run cannot skip: read the api key (1), read the
+# flow (1), read the global variables (1), check memory-base (1), insert the job row (1), write its
+# terminal status (1), write the two messages (2), write the trace and its spans (2).
+#
+# The three above that floor are the `UPDATE job` to in_progress, the pre-update `SELECT message`,
+# and the `UPDATE apikey` usage counter. Each is removable and none is removed here.
 STATEMENT_BUDGET = 16
 CHECKOUT_BUDGET = 12
+
+# A run rejected before execution measured 4 statements and 3 checkouts: the api key read and its
+# usage write, the flow read, and the global-variable read. It reaches none of the run's own work.
+REJECTED_RUN_BUDGET = 6
+REJECTED_RUN_CHECKOUT_BUDGET = 4
 
 
 @pytest.fixture
@@ -141,6 +149,17 @@ async def test_db_calls_for_a_healthy_run(
 
     print(db_ledger.report("healthy run"))  # noqa: T201 - the ledger is the deliverable
 
+    # The totals are a backstop. They are ceilings with headroom, so a single query coming back
+    # would slip under them; these name the specific reads that were removed, so each one is
+    # defended on its own. They are also immune to the trace flush occasionally settling after the
+    # response, which moves the totals but not these counts.
+    counts = db_ledger.by_op_table
+    assert counts[("SELECT", "user")] == 0, "the owning user rides along on the api key lookup"
+    assert counts[("SELECT", "job")] == 0, "update_job_status must not re-read the row it wrote"
+    assert counts[("SELECT", "message")] <= 1, "the post-commit message refresh must not come back"
+    assert counts[("INSERT", "span")] <= 1, "spans are written in one statement, not one per span"
+    assert counts[("SELECT", "span")] == 0, "spans are inserted without a merge() primary-key probe"
+
     assert len(db_ledger.statements) <= STATEMENT_BUDGET, db_ledger.report("over statement budget")
     assert db_ledger.checkouts <= CHECKOUT_BUDGET, db_ledger.report("over checkout budget")
 
@@ -152,14 +171,13 @@ async def test_db_calls_for_a_failing_run(
     created_api_key,
     db_ledger,
 ):
-    """A run that fails must not cost more database work than one that succeeds.
+    """A rejected run must not cost more database work than one that succeeds.
 
-    The original trace behind this work was a failing run. Failure paths are where retry and
-    rollback bookkeeping accumulates unnoticed, so they get their own budget check.
-
-    The failure is induced by blocking a component the flow uses, which rejects the run after
-    authentication and after the flow load. That covers the same setup work a healthy run does,
-    which a 404 or a 401 would not.
+    Blocking a component the flow uses rejects the run after authentication and after the flow
+    load, so this covers the setup work a 404 or a 401 would skip. It stops there, though: the
+    run never reaches the job, message or trace writes, so this does NOT cover the failure mode
+    that motivated the check, which is a run that does all of that work and then fails partway
+    through. Covering that needs a component that raises mid-execution, and is still open.
     """
     from lfx.services.deps import get_catalog_policy_service
 
@@ -184,5 +202,10 @@ async def test_db_calls_for_a_failing_run(
 
     print(run.report(f"failing run (status {response.status_code})"))  # noqa: T201
 
-    assert len(run.statements) <= STATEMENT_BUDGET, run.report("over statement budget")
-    assert run.checkouts <= CHECKOUT_BUDGET, run.report("over checkout budget")
+    # Its own budget, not the healthy run's. A rejected run does a fraction of the work, so reusing
+    # the healthy ceiling here would leave a test that cannot fail.
+    counts = run.by_op_table
+    assert counts[("INSERT", "job")] == 0, "a rejected run must not create a job row"
+    assert counts[("INSERT", "message")] == 0, "a rejected run must not persist messages"
+    assert len(run.statements) <= REJECTED_RUN_BUDGET, run.report("over statement budget")
+    assert run.checkouts <= REJECTED_RUN_CHECKOUT_BUDGET, run.report("over checkout budget")

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -140,13 +140,17 @@ async def test_aadd_messagetables_propagates_cancelled_error_from_commit():
     session.refresh.assert_not_awaited()
 
 
-async def test_aadd_messagetables_propagates_cancelled_error_from_refresh():
-    cancellation = asyncio.CancelledError("refresh cancelled")
+async def test_aadd_messagetables_rolls_back_and_propagates_cancellation():
+    # Cancellation used to be injected at the post-commit refresh. That refresh is gone: it re-read
+    # rows the caller already held. The property it was protecting is unchanged, so the injection
+    # point moves to commit, which is now the only await that can be cancelled here. The sibling
+    # test below covers the same cancellation when rollback ITSELF fails; this one covers the
+    # ordinary case where the rollback succeeds.
+    cancellation = asyncio.CancelledError("commit cancelled")
     message = MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")
     session = SimpleNamespace(
         add=lambda _message: None,
-        commit=AsyncMock(),
-        refresh=AsyncMock(side_effect=cancellation),
+        commit=AsyncMock(side_effect=cancellation),
         rollback=AsyncMock(),
     )
 
@@ -155,7 +159,6 @@ async def test_aadd_messagetables_propagates_cancelled_error_from_refresh():
 
     assert exc_info.value is cancellation
     session.commit.assert_awaited_once()
-    session.refresh.assert_awaited_once_with(message)
     session.rollback.assert_awaited_once()
 
 
@@ -167,7 +170,6 @@ async def test_aadd_messagetables_preserves_cancellation_when_rollback_and_loggi
     session = SimpleNamespace(
         add=lambda _message: None,
         commit=AsyncMock(side_effect=cancellation),
-        refresh=AsyncMock(),
         rollback=AsyncMock(side_effect=RuntimeError("rollback failed")),
     )
 
@@ -177,7 +179,6 @@ async def test_aadd_messagetables_preserves_cancellation_when_rollback_and_loggi
     assert exc_info.value is cancellation
     session.commit.assert_awaited_once()
     session.rollback.assert_awaited_once()
-    session.refresh.assert_not_awaited()
     log_exception.assert_awaited_once()
 
 


### PR DESCRIPTION
A flow run issued **27 SQL statements** on the request-handling connection pool. It now issues **13**.

Two PostgreSQL-only defects turned up on the way. Both silently destroy trace data, and both are reproduced against a real PostgreSQL 16.14 below.

## Why this is worth more than the 52%

The halving is measured on a two-component flow. The change that matters is that a term which **scaled with flow size** is gone.

Persisting a trace cost `2 + 2N` statements for N spans, where N is components plus LangChain callback spans:

| flow | span statements before | after |
| --- | ---: | ---: |
| 2 components | 12 | 2 |
| 20 components | ~80 | 2 |
| 50-component agent flow | ~200 | 2 |

The benefit therefore grows with exactly the flows that were already the slowest. Per-run database cost is now roughly flat regardless of graph size.

What that buys:

**Round-trips.** On PostgreSQL every statement is a network hop, so this is about 14 fewer per run on a small flow and far more on a large one. For a flow with an LLM call that is noise next to the model latency; for cheap flows and large graphs it is not.

**Write volume.** Writes per run went from 12 to 8, which is less WAL, less replication lag and less vacuum pressure.

**Concurrency headroom.** Checkouts did not change, but each one now holds its connection for fewer statements, so the same pool serves more concurrent runs before it saturates.

**Export volume.** Database spans were around 80% of exported span volume, so this cuts APM cost as a side effect rather than by hiding the spans.

Worth being explicit about what is not measured here: this counts statements and round-trips. It is not a latency or throughput benchmark, and any millisecond figure above is arithmetic from round-trip counts rather than an observation.

## Why the statements were there

The largest block was the native tracer. `NativeTracer._flush_to_database` wrote its trace row and every span with `await session.merge()`.

`merge()` has to `SELECT` a primary key before it can decide between `INSERT` and `UPDATE`. Every one of those `SELECT`s missed: the trace id is minted with `uuid4` when the run starts, and span ids are `uuid5` values derived from it, so the row cannot already exist. That cost `2 + 2N` statements for N spans. A 50-component flow paid roughly 100 statements just to record itself.

It is now one `INSERT ... ON CONFLICT DO UPDATE` per table. 12 statements became 2, and span count no longer drives round-trips.

The scaling fix is literally that the database call moved out of the per-span loop. It used to be:

```python
for span_data, span_uuid, parent_uuid in resolved:
    span = SpanTable(...)
    await session.merge(span)        # one SELECT plus one INSERT, per span
```

and it is now `native.py:407-425`, where the loop only builds objects and does no I/O:

```python
spans = [
    SpanTable(...)
    for span_data, span_uuid, parent_uuid in resolved
]
await _upsert_rows(session, SpanTable, spans)
```

The loop that remains, in `_upsert_rows` at `native.py:85-93`, iterates chunks rather than rows:

```python
chunk_size = max(1, 30000 // len(values[0]))    # about 2142 for a 14-column span row
for start in range(0, len(values), chunk_size):
    ...
    await session.exec(statement)
```

so the statement count went from `N` to `ceil(N / 2142)`, which is 1 for any realistic flow.

The conflict clause is load-bearing rather than decorative. A paused HITL run flushes its partial spans (`langflow/api/build.py`, comment "merge is idempotent on resume") and re-flushes the same deterministic ids after resume, so those rows have to be overwritten. A plain `add_all()` would raise on the primary key.

## The two PostgreSQL defects

Neither exists on SQLite, which is why no test caught them.

**A repeated vertex loses the whole trace.** Span ids are `uuid5(namespace, f"{trace_id}-{component_id}")`, keyed only on the component. A Loop component or a graph cycle traces the same vertex once per iteration, so one flush can carry the same primary key several times. PostgreSQL refuses to let a single `ON CONFLICT DO UPDATE` touch a row twice and raises `CardinalityViolation`, which rolls back the trace and every span with it. `wait_for_flush` swallows the error, so the run succeeds and the trace just disappears.

`merge()` tolerated this through the identity map. Fixed by collapsing rows on the primary key before sending, last write wins, which is what the `merge()` loop produced.

**A flush past roughly 4681 spans fails entirely.** PostgreSQL allows 65535 bind parameters per statement and a span row binds 14. `merge()` sent one statement per row and had no such ceiling. Fixed by chunking, sized from the column count rather than a constant.

Verified against PostgreSQL 16.14 with langflow's own models and its `postgresql+psycopg` driver:

```
1. duplicate span ids, WITH fix        PASS
2. duplicate span ids, WITHOUT fix     raised psycopg.errors.CardinalityViolation:
                                       ON CONFLICT DO UPDATE command cannot affect row a second time
3. 6000 spans, WITH fix                PASS
4. 6000 spans, WITHOUT fix             raised psycopg.OperationalError: number of parameters...
5. HITL re-flush overwrites            PASS
```

## Three smaller reads

**The post-commit message refresh.** `memory.py` re-read every message it had just written. The session factory sets `expire_on_commit=False`, and no column on `message` is filled in by the database, so that `SELECT` returned exactly what the caller already held. All 18 columns have `server_default=None`, there is no autoincrement primary key, and the five defaults (`id`, `timestamp`, `error`, `edit`, `is_output`) are Python-side and already evaluated before the `INSERT`.

**The job status read-back.** `update_job_status` ran its `UPDATE`, then re-fetched the row by primary key to satisfy a `Job | None` return type. No caller binds the result, in `src/` or in the tests. It returns `bool` from `rowcount` now, which carries the only part a caller could have used.

**The separate user lookup.** `session.get(User, ...)` immediately after the api key `SELECT` is now a `joinedload`. One statement instead of two, on every authenticated request rather than only on runs.

## Per-run ledger

Two-component flow, ChatInput to ChatOutput.

| statement | before | after |
| --- | ---: | ---: |
| `SELECT span` | 5 | 0 |
| `INSERT span` | 5 | 1 |
| `SELECT trace` | 1 | 0 |
| `INSERT trace` | 1 | 1 |
| `SELECT job` | 2 | 0 |
| `UPDATE job` | 2 | 2 |
| `INSERT job` | 1 | 1 |
| `SELECT message` | 2 | 1 |
| `INSERT message` | 1 | 1 |
| `UPDATE message` | 1 | 1 |
| `SELECT apikey` | 1 | 1 |
| `SELECT user` | 1 | 0 |
| `UPDATE apikey` | 1 | 1 |
| `SELECT flow` | 1 | 1 |
| `SELECT variable` | 1 | 1 |
| `SELECT memory_base` | 1 | 1 |
| **total** | **27** | **13** |

Pool checkouts stayed at 11. Cutting statements does not cut checkouts: checkouts track session scopes, not statements.

## How to measure it

```
uv run pytest src/backend/tests/unit/test_db_calls_per_run.py -s
```

It counts with SQLAlchemy's own `before_cursor_execute` and pool `checkout` events rather than with OpenTelemetry spans. No exporter, no Docker, no demo stack, about 10 seconds.

Two corrections were needed before the number meant anything:

Two autouse fixtures in `tests/conftest.py` take the suite off the shipped configuration. `disable_telemetry_writer` forces the legacy synchronous write path and `deactivate_tracing` switches the internal trace and span tables off. Measured under those, a run looks like 30 statements with half of them `vertex_build` and `transaction` retention deletes, which is not what users pay. The harness overrides both.

`transaction` and `vertex_build` writes do not touch the request pool in production. The telemetry writer owns a dedicated engine and amortizes their retention, so they are correctly absent from these counts.

## Running the suite on PostgreSQL

The `client` and `async_session` fixtures hardcoded SQLite, so nothing in the backend suite could exercise the backend most deployments actually run. Both now honour `LANGFLOW_TEST_DATABASE_URL` and fall back to SQLite when it is unset, so default behaviour is unchanged.

Both fixtures matter. Wiring only `client` leaves the tracer tests on SQLite, because they take `async_session` — which would have meant the tests guarding the two PostgreSQL defects were the ones never running on PostgreSQL. Pointing them at it immediately failed three that SQLite had been hiding: two issued `PRAGMA foreign_keys=ON`, a syntax error there, and one asserted that a malformed `flow_id` still persists its trace (see below). With those fixed, `test_flush_collapses_repeated_builds_of_one_vertex` now reproduces the real `CardinalityViolation` on PostgreSQL instead of only checking statement shape on SQLite.

Note the tradeoff on `client`: with the variable set, every test shares one database rather than getting a fresh file, so run it serially and expect row-counting suites to need a clean database. `async_session` is unaffected, since it creates and drops the schema per test.

```
docker run -d --name lf-pg -e POSTGRES_PASSWORD=lf -e POSTGRES_USER=lf -e POSTGRES_DB=lf \
  -p 55432:5432 postgres:16-alpine
LANGFLOW_TEST_DATABASE_URL="postgresql://lf:lf@localhost:55432/lf" uv run pytest ...
```

A run costs 11 to 13 statements and 10 checkouts on PostgreSQL, against 13 and 11 on SQLite. The statement count varies because the trace flush is an asyncio task that sometimes settles just after the response and lands outside the measurement window. The variance is in the measurement, not in the work.

## What a run should cost

Ten statements, derived from what a run has to do rather than picked as a round number: read the api key, read the flow, read the global variables, check memory-base, insert the job row, write its terminal status, write the messages (2), write the trace and its spans (2).

Today's 13 is three above that floor: the redundant `UPDATE job` to `in_progress`, the pre-update `SELECT message`, and the `UPDATE apikey` usage counter.

What the floor does not contain is anything scaling with flow size. That was the real problem, and it is gone.

## Deliberately left alone

**The api key usage counters.** This is the last per-request write before the flow starts. On PostgreSQL it takes a row lock held to commit, so every concurrent request presenting the same key serializes on one row. Deployments using one key per service make that the common case.

`total_uses` and `last_used_at` are read only by the API keys table in the frontend settings page. Nothing in authentication, rate limiting, or billing reads either, so they can be approximate. `disable_track_apikey_usage` already exists and defaults to `False`. Flipping that default or batching the write both work, but it changes visible product behaviour, so it is not this PR's call.

**The 11 pool checkouts.** Reducing them means merging session scopes, starting with the auth scope and the flow load, which run back to back in the same dependency chain. More invasive than anything here and it deserves its own measurement.

**The latency tail.** The 17% of checkouts over 50 ms was a SQLite contention property. On PostgreSQL the equivalent question is different and should be re-asked rather than re-run.

## Tests

The seven tests in `TestFlushToDatabase` and `TestFlushParentChildOrder` asserted `mock_session.merge.call_count`, so they broke on a change that kept behaviour identical. They now assert on rows read back from a real session.

Two were added. `test_flush_twice_upserts_instead_of_duplicating` covers the HITL pause and resume shape. `test_flush_collapses_repeated_builds_of_one_vertex` covers the duplicate span id case, and it asserts on the shape of the statement rather than on the stored rows so that it fails on SQLite too. Verified RED-GREEN: it fails with the collapse removed.

On SQLite: tracing, `test_messages.py`, `services/database`, `test_api_key.py`, `services/auth` and the counter give 799 passed, 3 skipped. `api/v2` and `services/jobs` give 319 passed. `background_execution` gives 107 passed.

## A third PostgreSQL defect, pre-existing and not fixed here

Running the tracer tests on PostgreSQL surfaced one more, older than this change.

When a run has a malformed `flow_id`, the flush falls back to a sentinel `uuid5`, with the stated intent that "malformed flow_ids don't silently discard trace data". But `trace.flow_id` carries a foreign key to `flow.id` and the sentinel matches no row by construction. PostgreSQL enforces that immediately, so the INSERT raises, the session rolls back, and `wait_for_flush` swallows the error. The fallback does the opposite of what its comment claims.

`merge()` hit the same foreign key, so this predates the change and is left alone here. It is documented in `test_flush_invalid_flow_id_logs_error_and_continues`, whose persisted-row assertions now run only where foreign keys are off. Worth its own ticket.

Two known failures, both confirmed pre-existing by checking the changed source files out at the previous commit and reproducing them identically:

`test_endpoints.py::test_concurrent_stream_run_with_input_type_chat` errors on SQLite in a fixture.

Three row-count assertions in `test_messages.py` fail on PostgreSQL because the suite shares one database where each SQLite test gets a fresh file, so rows accumulate across tests. Worth fixing if PostgreSQL runs become routine.
