### PR TITLE
fix(ci): assert the base wheel's real console script name (forward-port of #14571)

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -1000,8 +1000,8 @@ jobs:
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
           scripts = Path(sys.executable).parent
-          assert (scripts / "langflow").is_file()
-          assert not (scripts / "langflow-base").exists()
+          assert (scripts / "langflow-base").is_file(), f"langflow-base console script missing from {scripts}"
+          assert not (scripts / "langflow").exists(), "langflow console script leaked into the base-only environment"
           provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
           assert {"complete", "all"} <= provided_extras
           compatibility_requirements = [
@@ -1032,7 +1032,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          base-test-env/bin/langflow run \
+          base-test-env/bin/langflow-base run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {


### PR DESCRIPTION
Forward-port of b1b0ce1a50 (#14571) from `main` to `release-1.12.0`. Clean cherry-pick, single commit, no manual edits.

## Why

#14571 fixed the base-only cross-platform job on `main`, but `release-1.12.0` never received it and still carries the pre-fix assertions. The back-merge (#14581) correctly keeps `main`'s fixed version, so without this port the release branch would keep tripping the same failure and would re-introduce the regression on the next back-merge.

## What it changes

`.github/workflows/cross-platform-test.yml` — the base-only environment ships the `langflow-base` console script, not `langflow`:

- `assert (scripts / "langflow-base").is_file()` (was asserting `langflow`)
- `assert not (scripts / "langflow").exists()` (was asserting the inverse)
- `base-test-env/bin/langflow-base run` (was `bin/langflow run`)

Verified on the branch: the three fixed lines are present at 1003/1004/1035 and neither old assertion remains.

Note the file still differs from `main` for unrelated reasons — #14540's workflow hardening lives on the release branch only — so this ports the three lines, not the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base server startup reliability by using the correct runtime command.
  * Added verification to prevent an incorrect console script from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->