### PR TITLE
fix(test): stop the live smoke suite inheriting the loopback server list

### DIFF
--- a/src/frontend/playwright.live.config.ts
+++ b/src/frontend/playwright.live.config.ts
@@ -5,7 +5,16 @@ import { PORT } from "./src/customization/config-constants";
 // Deliberately not 7860: that is the blocking suite's backend port.
 const LIVE_BACKEND_PORT = 7861;
 
-export default defineConfig(baseConfig, {
+// Spread the base config rather than passing it as defineConfig's first
+// argument. Multi-argument defineConfig CONCATENATES array options instead of
+// replacing them, so `defineConfig(baseConfig, { webServer: [...] })` starts the
+// base servers *and* these ones — five servers, two of them on port 3000, which
+// fails the run outright with "http://localhost:3000 is already used". Worse,
+// without the port clash the suite would drive the base frontend, whose proxy
+// targets the loopback-fixture backend, and every "live" assertion would pass
+// without ever reaching a real provider. Spreading overrides `webServer`.
+export default defineConfig({
+  ...baseConfig,
   testDir: "./tests/live",
   testIgnore: [],
   fullyParallel: false,


### PR DESCRIPTION
The `Live provider smoke tests` job failed on its **first ever run** ([nightly 31863695147](https://github.com/langflow-ai/langflow/actions/runs/31863695147/job/94961539400)) before executing a single test:

```
Error: http://localhost:3000 is already used, make sure that nothing is running
on the port/url or set reuseExistingServer:true in config.webServer.
```

## Cause

`playwright.live.config.ts` builds itself with `defineConfig(baseConfig, {...})`, expecting its `webServer` list to *replace* the base one. Multi-argument `defineConfig` **concatenates** array options instead. The live run therefore starts five servers:

| # | from | server | port |
|---|---|---|---|
| 1 | base | openai-compatible loopback fixture | 8787 |
| 2 | base | backend, `OPENAI_BASE_URL=127.0.0.1:8787/v1` | 7860 |
| 3 | base | `npm start`, proxy → 7860 | 3000 |
| 4 | live | backend (real providers) | 7861 |
| 5 | live | `npm start`, proxy → 7861 | **3000 — clashes with #3** |

`reuseExistingServer: false` turns the duplicate port into a hard failure. The job log matches exactly: two complete alembic migration runs inside one `playwright test` invocation, then the port error.

## Why this matters more than a red X

The clash was **masking** the real defect. Without it, the tests would have driven the base frontend on 3000 — whose proxy targets the 7860 backend wired to the loopback fixture — and every "live provider" assertion would have passed **without ever reaching a real provider**. That is precisely the leak the config's own comment claims to prevent:

> The live smoke deliberately owns a separate server list so neither that fixture nor its `OPENAI_BASE_URL` can leak into the real-provider check.

The crash was preventing a false green.

## Fix

Spread `baseConfig` instead of passing it as `defineConfig`'s first argument, so `webServer` is overridden rather than appended to. A comment records why, since reverting to the two-argument form silently reintroduces the bug.

## Verification

Bundled the real config with esbuild and inspected the resolved `webServer` list:

```
BEFORE - webServer entries: 5
node tests/fixtures/openai-compati  ->  port undefined
uv run uvicorn --factory langflow.  ->  port 7860
npm start                           ->  port 3000
uv run uvicorn --factory langflow.  ->  port 7861
npm start                           ->  port 3000

AFTER  - webServer entries: 2
uv run uvicorn --factory langflow.  ->  port 7861
npm start                           ->  port 3000
```

`testDir: ./tests/live` and `testIgnore: []` are unchanged by the switch, as are `projects` and `use`.

## Notes

`playwright.live.config.ts` arrived in d65b98fc70 (#14540); no earlier nightly ran a smoke job at all, so this is the config's first execution. The job is `continue-on-error: true`, so it is not blocking the nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live testing configuration to prevent conflicting server definitions.
  * Ensured the correct server port and provider routing are used during live test runs.
  * Added documentation explaining the configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->