### PR TITLE
fix(ci): assert the base console script the 1.12 line actually ships

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -1000,8 +1000,11 @@ jobs:
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
           scripts = Path(sys.executable).parent
-          assert (scripts / "langflow-base").is_file(), f"langflow-base console script missing from {scripts}"
-          assert not (scripts / "langflow").exists(), "langflow console script leaked into the base-only environment"
+          # Must track [project.scripts] in src/backend/base/pyproject.toml. On the
+          # 1.12 line #14339 renamed this entry point back to `langflow`; asserting
+          # `langflow-base` here is only correct on branches that predate it.
+          assert (scripts / "langflow").is_file(), f"langflow console script missing from {scripts}"
+          assert not (scripts / "langflow-base").exists(), "langflow-base console script is not part of the 1.12 base distribution"
           provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
           assert {"complete", "all"} <= provided_extras
           compatibility_requirements = [
@@ -1032,7 +1035,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          base-test-env/bin/langflow-base run \
+          base-test-env/bin/langflow run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {


### PR DESCRIPTION
Fixes `Base Distribution Wheel - Linux Python 3.14`, currently failing 100% in the nightly ([job](https://github.com/langflow-ai/langflow/actions/runs/31864381228/job/94968250912)):

```
AssertionError: langflow-base console script missing from .../base-test-env/bin
```

## Cause

The base wheel on this line declares `langflow`, not `langflow-base`:

```toml
# src/backend/base/pyproject.toml @ release-1.12.0
[project.scripts]
langflow = "langflow.langflow_launcher:main"
```

`a2c015a1d2` (#14339, *consolidate Langflow 1.12 on langflow-base*) renamed that entry point from `langflow-base` back to `langflow`, and that commit exists **only on `release-1.12.0`**.

#14571 was authored against a `main` that predates the rename, where asserting `langflow-base` was correct. The `release-1.12.0` → `main` back-merge (#14581) then kept `main`'s assertion alongside `release-1.12.0`'s post-rename `pyproject.toml`. Those live in two different files with no textual overlap, so git merged them cleanly into a state that is individually valid and jointly wrong. #14582 propagated the stale assertion back onto `release-1.12.0`.

## Change

Restores the assertion and the boot invocation to `langflow`, and adds a comment tying both to `[project.scripts]` so the coupling is visible to whoever next back-merges across this rename.

## Verification

Parsed the base `pyproject.toml` and the workflow **from the same tree**, rather than comparing the workflow against its own history — which is what let the mismatch through:

```
BEFORE  declared: ['langflow']  asserts present: ['langflow-base']  invokes: ['langflow-base']  ->  COHERENT: False
AFTER   declared: ['langflow']  asserts present: ['langflow']       invokes: ['langflow']       ->  COHERENT: True
```

All ten `Install & Run` cross-platform jobs already pass; only the base-distribution job was affected.

## Companion PR

An identical change targets `main`. Both branches must land it: they are currently byte-identical under `.github/workflows`, and the nightly tag push only succeeds while that holds — any workflow-file drift between them re-breaks `create-nightly-tag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated runtime verification to use the current `langflow` command.
  * Improved cross-platform boot testing for the base test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->