### PR TITLE
fix(ci): assert the base console script the 1.12 line actually ships (main)

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -1000,8 +1000,11 @@ jobs:
               assert not entry_points(group=group), f"Extension entry points registered in {group}"
 
           scripts = Path(sys.executable).parent
-          assert (scripts / "langflow-base").is_file(), f"langflow-base console script missing from {scripts}"
-          assert not (scripts / "langflow").exists(), "langflow console script leaked into the base-only environment"
+          # Must track [project.scripts] in src/backend/base/pyproject.toml. On the
+          # 1.12 line #14339 renamed this entry point back to `langflow`; asserting
+          # `langflow-base` here is only correct on branches that predate it.
+          assert (scripts / "langflow").is_file(), f"langflow console script missing from {scripts}"
+          assert not (scripts / "langflow-base").exists(), "langflow-base console script is not part of the 1.12 base distribution"
           provided_extras = set(metadata("langflow-base").get_all("Provides-Extra", []))
           assert {"complete", "all"} <= provided_extras
           compatibility_requirements = [
@@ -1032,7 +1035,7 @@ jobs:
           export DO_NOT_TRACK=true
           LOG_FILE="$RUNTIME_DIR/server.log"
 
-          base-test-env/bin/langflow-base run \
+          base-test-env/bin/langflow run \
             --host 127.0.0.1 --port 7861 --backend-only --workers 1 >"$LOG_FILE" 2>&1 &
           SERVER_PID=$!
           cleanup() {


### PR DESCRIPTION
Replaces #14585, which conflicted. Same intent, cut from `main` instead of from a `release-1.12.0` branch — the original dragged in #14582/#14583 history that `main` does not share, so git saw both sides editing the same assertion and refused to merge.

Ports #14584 (already merged to `release-1.12.0`).

## Why `main` needs it

`main` inherited the stale `langflow-base` assertion from #14571 when the back-merge (#14581) paired it with `release-1.12.0`'s post-#14339 `pyproject.toml`, where the base wheel declares `langflow`:

```toml
[project.scripts]
langflow = "langflow.langflow_launcher:main"
```

## Why it is urgent

Merging #14584 alone re-opened a `.github/workflows` delta between `main` and `release-1.12.0`. That delta is what broke `create-nightly-tag` earlier tonight: GitHub screens App-token pushes for workflow changes, `GITHUB_TOKEN` cannot carry `workflows`, and the tag push only succeeds while both branches have identical workflow files. Right now they differ by exactly this file, so the next nightly tag push fails until this lands.

## How it was made

Took `release-1.12.0`'s copy of `cross-platform-test.yml` verbatim rather than re-applying the edit, so the branches are byte-identical by construction:

```
git diff origin/release-1.12.0 -- .github/workflows/cross-platform-test.yml   ->  0 lines
```

That file's only difference between the branches was #14584 itself, so nothing else rides along.

## Verification

Coherence check parsed from `main`'s own tree:

```
declared: ['langflow']  asserts present: ['langflow']  invokes: ['langflow']  ->  COHERENT: True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated base-runtime validation to recognize the current `langflow` command.
  * Updated the base server startup check to use the supported console script.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->