### PR TITLE
fix(tests): measure the flow persistence barrier from the reload, not before it

### DIFF
--- a/src/frontend/tests/utils/flow-editor-persistence.ts
+++ b/src/frontend/tests/utils/flow-editor-persistence.ts
@@ -231,19 +231,25 @@ export async function reloadAndWaitForFlowPersistence(
     page.on("response", onResponse);
   });
   let persistenceTimeout: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_, reject) => {
-    persistenceTimeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Flow ${flowId} did not finish model refresh and autosave persistence within ${TIMEOUTS.standard}ms`,
-        ),
-      );
-    }, TIMEOUTS.standard);
-  });
+  // The budget covers the model refresh and its autosave, not the page load
+  // that precedes them. Playwright serves the editor from a Vite dev server, so
+  // a reload replays ~3.5k unbundled module requests; on Windows CI that alone
+  // measures 19-35s. Arming the deadline before the reload spent the entire
+  // budget before the first tracked request was even sent.
+  const deadlineAfterReload = () =>
+    new Promise<never>((_, reject) => {
+      persistenceTimeout = setTimeout(() => {
+        reject(
+          new Error(
+            `Flow ${flowId} did not finish model refresh and autosave persistence within ${TIMEOUTS.long}ms after reload`,
+          ),
+        );
+      }, TIMEOUTS.long);
+    });
 
   try {
     await page.reload();
-    await Promise.race([persistence, deadline]);
+    await Promise.race([persistence, deadlineAfterReload()]);
   } catch (error) {
     failPersistence(error);
     await persistence.catch(() => undefined);


### PR DESCRIPTION
## Problem

Windows Playwright shards **30/70** and **31/70** were the only failing jobs in nightly run [31867911970](https://github.com/langflow-ai/langflow/actions/runs/31867911970). All 70 Linux shards passed — including the Linux shards running the same spec, in 5.1m versus 9.7m/10.3m on Windows.

Five of `bulk-delete-sessions.spec.ts`'s fourteen tests failed with:

```
Error: Flow <uuid> did not finish model refresh and autosave persistence within 30000ms
  at tests/utils/flow-editor-persistence.ts:237
```

## Cause

`reloadAndWaitForFlowPersistence` created its deadline `setTimeout` *before* calling `page.reload()`, so the 30s budget had to cover the page load in addition to the model refresh and autosave it exists to observe.

Playwright serves the editor from a Vite dev server (`npm start`), so a reload replays ~3,500 unbundled module requests. Measured from the blob-report traces on Windows:

| trace | `page.reload()` alone | GET `/flows/{id}` | POST `custom_component/update` | autosave PATCH |
|---|---|---|---|---|
| e3fe6e22 | 19.0s | t+27.6s | t+29.7s (1.06s) | deadline fired first |
| 1a49b9dd | 21.5s | t+28.9s | t+47.5s (**10.8s**) | t+47.5s (10.3s) |
| f6f421a4 | **34.9s** | — | — | — |

The third reload outlasts the entire budget on its own, so that run could never pass regardless of how fast the rest of the chain was.

Shards 30/31 are the worst case because `workers: 2` puts two playground-chat-build tests on one 2-core Windows runner — that is why `custom_component/update` stretched to 10.8s there. But the barrier reaches **38 call sites across 30 spec files**, so this was a latent flake for every Windows spec that configures the loopback provider, not only the two shards that happened to pair two heavy tests.

Ruled out: the `page.route(/\/api\/v1\/store\/tags/)` regex in that spec's `beforeEach` is not an amplifier — the trace shows only 2 `Fulfill request` actions, so Playwright is not funneling the dev-module requests through Node.

## Fix

Arm the deadline after the reload resolves, and raise it to `TIMEOUTS.long`. Worst observed post-reload cost was ~37s, so 60s gives ~1.6x headroom; the test timeout is 5 minutes while these tests run 65-95s.

## Follow-up

A separate PR will remove the reload from this path entirely by seeding the loopback configuration into the starter-template payload, so the flow is created already configured. That deletes a 19-35s dev-mode reload from all 38 call sites on Windows.

## Test plan

- [ ] Windows shards 30/70 and 31/70 green
- [ ] No regression in the Linux shards covering the other 36 call sites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when restoring flow editor content after a page reload.
  * Extended the post-reload persistence wait period to allow model refresh and autosave operations to complete.
  * Updated timeout messaging to clarify when the persistence deadline begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->