### PR TITLE
fix(ci): grant the label job pull-requests write

### DIFF
--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   validate-pr:


### PR DESCRIPTION
## Symptom

Every `Label PR` run has failed since #14540 landed on 2026-08-14. Across the last 100 runs of the workflow:

| | success | failure |
|---|---|---|
| before #14540 | 67 | 0 |
| after #14540 | 15 | 16 |

(the successes since are runs where the job's `if:` skips it — `merge_group` and bot-authored PRs.)

```
POST /repos/langflow-ai/langflow/issues/14588/labels
403 Resource not accessible by integration
```

## Cause

#14540 added a `permissions:` block to this workflow. Before that there was none, so it ran with the repository default token permissions, which include pull-requests write.

Labelling a **pull request** needs that scope. The `issues` permission only covers real issues, even though the REST path is `/issues/{n}/labels`. GitHub says so in the 403 response itself:

```
x-accepted-github-permissions: issues=write; pull_requests=write
```

## Fix

`pull-requests: read` → `pull-requests: write`. This also unblocks `Namchee/conventional-pr` in the same workflow, which cannot post its report under a read-only pull-requests scope.

Both `main` and `release-1.12.0` carry this — the nightly tag push only succeeds while the two branches have byte-identical `.github/workflows` content (GitHub screens App-token pushes for workflow changes and `GITHUB_TOKEN` cannot carry `workflows`, so any drift re-breaks `create-nightly-tag`).

## Note: this PR cannot go green on itself

`pull_request_target` runs the workflow definition from the **base branch**, not from the PR. So `Label PR` fails here with the same 403 against `/issues/14590/labels` — it is still executing the unfixed `main` copy. The red X is expected and is not evidence against the fix; it clears for the *next* PR opened after this merges.

## Test plan

- [ ] `Label PR` green on the first PR opened after this merges, with the conventional-commit label applied