### PR TITLE
perf(tests): seed the loopback provider into starter templates instead of reloading (release-1.12.0)

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -159,7 +159,7 @@
     "a11y:html-report": "node tests/utils/build-a11y-html-report.mjs",
     "a11y:job-summary": "node tests/utils/build-a11y-job-summary.mjs",
     "e2e:check-report": "node tests/utils/check-playwright-report.mjs",
-    "test:e2e-utilities": "node --test tests/utils/blocking-provider-policy.test.mjs tests/utils/check-playwright-report.test.mjs tests/utils/flow-editor-persistence-policy.test.mjs tests/utils/get-default-project-id-for-test.test.mjs tests/utils/server-error-contract.test.mjs",
+    "test:e2e-utilities": "node --test tests/utils/blocking-provider-policy.test.mjs tests/utils/check-playwright-report.test.mjs tests/utils/flow-editor-persistence-policy.test.mjs tests/utils/get-default-project-id-for-test.test.mjs tests/utils/loopback-provider-policy.test.mjs tests/utils/server-error-contract.test.mjs",
     "serve": "vite preview",
     "format": "npx @biomejs/biome format --write",
     "lint": "npx @biomejs/biome lint",

--- a/src/frontend/tests/core/features/bulk-delete-sessions.spec.ts
+++ b/src/frontend/tests/core/features/bulk-delete-sessions.spec.ts
@@ -3,9 +3,11 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test.describe("Bulk Delete Sessions", () => {
   test.beforeEach(async ({ page }) => {
+    await seedLoopbackProvider(page);
     await page.route(/\/api\/v1\/store\/tags(\?.*)?$/, async (route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({ json: [] });

--- a/src/frontend/tests/core/features/chatInputOutputUser-shard-0.spec.ts
+++ b/src/frontend/tests/core/features/chatInputOutputUser-shard-0.spec.ts
@@ -7,11 +7,13 @@ import {
   closeParametersPanel,
   openParametersPanel,
 } from "../../utils/open-advanced-options";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "user must be able to send an image on chat",
   { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/core/features/token-usage.spec.ts
+++ b/src/frontend/tests/core/features/token-usage.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test.describe("Token Usage Tracking", () => {
   test(
     "node badge should show token count after running an LLM flow",
     { tag: ["@release", "@workspace", "@components"] },
     async ({ page }) => {
+      await seedLoopbackProvider(page);
       await awaitBootstrapTest(page);
 
       await page.getByTestId("side_nav_options_all-templates").click();
@@ -53,6 +55,7 @@ test.describe("Token Usage Tracking", () => {
     "chat message should show token count alongside run duration",
     { tag: ["@release", "@workspace", "@components"] },
     async ({ page }) => {
+      await seedLoopbackProvider(page);
       await awaitBootstrapTest(page);
 
       await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/core/integrations/Basic Prompting.spec.ts
+++ b/src/frontend/tests/core/integrations/Basic Prompting.spec.ts
@@ -3,12 +3,14 @@ import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
 import { buildFlowAndWait } from "../../utils/flow/build-flow-and-wait";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Basic Prompting (Hello, World)",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await openStarterProject(page, "Basic Prompting");
 
     await configureLoopbackOpenAI(page);

--- a/src/frontend/tests/core/integrations/Content Aggregator.spec.ts
+++ b/src/frontend/tests/core/integrations/Content Aggregator.spec.ts
@@ -1,12 +1,14 @@
 import { expect } from "../../fixtures";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Content Aggregator",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await page.goto("/");
     await openStarterProject(page, "Content Aggregator");
 

--- a/src/frontend/tests/core/integrations/Custom Component Generator.spec.ts
+++ b/src/frontend/tests/core/integrations/Custom Component Generator.spec.ts
@@ -3,12 +3,14 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Custom Component Generator",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await page.goto("/");
 
     await awaitBootstrapTest(page);

--- a/src/frontend/tests/core/integrations/Memory Chatbot.spec.ts
+++ b/src/frontend/tests/core/integrations/Memory Chatbot.spec.ts
@@ -5,6 +5,7 @@ import { TEXTS } from "../../utils/constants/texts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
 import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 type MemoryBaseCreateResponse = {
@@ -61,6 +62,7 @@ withEventDeliveryModes(
   "Memory Chatbot",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     const memoryBaseName = `memory_chatbot_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     let memoryBaseId: string | undefined;
 

--- a/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
+++ b/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Research Translation Loop.spec",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/core/integrations/SaaS Pricing.spec.ts
+++ b/src/frontend/tests/core/integrations/SaaS Pricing.spec.ts
@@ -4,12 +4,14 @@ import { TEXTS } from "../../utils/constants/texts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
 import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "SaaS Pricing",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await page.goto("/");
     await openStarterProject(page, "SaaS Pricing");
 

--- a/src/frontend/tests/core/integrations/Simple Agent Memory.spec.ts
+++ b/src/frontend/tests/core/integrations/Simple Agent Memory.spec.ts
@@ -2,12 +2,14 @@ import { expect } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Simple Agent Memory",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     // Open Simple Agent template

--- a/src/frontend/tests/core/integrations/Simple Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Simple Agent.spec.ts
@@ -2,12 +2,14 @@ import { expect } from "../../fixtures";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Simple Agent",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await openStarterProject(page, "Simple Agent");
     await configureLoopbackOpenAI(page);
 

--- a/src/frontend/tests/core/integrations/Social Media Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Social Media Agent.spec.ts
@@ -3,6 +3,7 @@ import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { configureLoopbackWebSearch } from "../../utils/configure-loopback-web-search";
 import { TEXTS } from "../../utils/constants/texts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 function getRandomSocialMediaQuery(): string {
@@ -57,6 +58,7 @@ withEventDeliveryModes(
   "Social Media Agent",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await openStarterProject(page, "Social Media Agent");
 
     await configureLoopbackOpenAI(page);

--- a/src/frontend/tests/core/integrations/Text Sentiment Analysis.spec.ts
+++ b/src/frontend/tests/core/integrations/Text Sentiment Analysis.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { unselectNodes } from "../../utils/unselect-nodes";
 import { uploadFile } from "../../utils/upload-file";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
@@ -10,6 +11,7 @@ withEventDeliveryModes(
   "user should be able to analyze text sentiment",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/core/integrations/Travel Planning Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Travel Planning Agent.spec.ts
@@ -4,12 +4,14 @@ import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { configureLoopbackWebSearch } from "../../utils/configure-loopback-web-search";
 import { TEXTS } from "../../utils/constants/texts";
 import { TIMEOUTS } from "../../utils/constants/timeouts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
 withEventDeliveryModes(
   "Travel Planning Agent",
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await page.goto("/");
     await awaitBootstrapTest(page);
 

--- a/src/frontend/tests/core/integrations/starter-projects-autorun.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects-autorun.spec.ts
@@ -5,6 +5,7 @@ import { TEXTS } from "../../utils/constants/texts";
 import { buildFlowAndWait } from "../../utils/flow/build-flow-and-wait";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import {
   waitForOpenModalWithChatInput,
   waitForOpenModalWithoutChatInput,
@@ -46,6 +47,7 @@ for (const template of TEMPLATES) {
     template.name,
     { tag: ["@release", "@starter-projects"] },
     async ({ page }) => {
+      await seedLoopbackProvider(page);
       await page.goto("/");
 
       if ((template.open ?? "starter") === "heading") {

--- a/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
@@ -6,11 +6,13 @@ import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
 import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "user should be able to use chat memory as expected",
   { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/core/regression/session-deletion-data-leakage.spec.ts
+++ b/src/frontend/tests/core/regression/session-deletion-data-leakage.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test.describe("Session Deletion Data Leakage Fix", () => {
   // Helper to send a message in the playground
@@ -79,6 +80,7 @@ test.describe("Session Deletion Data Leakage Fix", () => {
     "should prevent data leakage when default session is deleted and recreated",
     { tag: ["@release"] },
     async ({ page }) => {
+      await seedLoopbackProvider(page);
       await awaitBootstrapTest(page);
 
       // Load a starter project
@@ -143,6 +145,7 @@ test.describe("Session Deletion Data Leakage Fix", () => {
     "should clear LLM context when session is deleted",
     { tag: ["@release"] },
     async ({ page }) => {
+      await seedLoopbackProvider(page);
       await awaitBootstrapTest(page);
 
       // Load a starter project with memory

--- a/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts
+++ b/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts
@@ -3,12 +3,14 @@ import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { zoomOut } from "../../utils/zoom-out";
 
 test(
   "user must be able to see output inspection",
   { tag: ["@release", "@components"] },
   async ({ page }, testInfo) => {
+    await seedLoopbackProvider(page);
     // Flaky on Windows CI runners: the Basic Prompting template canvas
     // intermittently fails to finish rendering the controls in time (even with
     // the 30s adjustScreenView window). The output-inspection behavior is

--- a/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-2.spec.ts
+++ b/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-2.spec.ts
@@ -7,11 +7,13 @@ import {
   openParametersPanel,
   toggleParameterOnNode,
 } from "../../utils/open-advanced-options";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "user must interact with chat with Input/Output",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/extended/regression/general-bugs-agent-anthropic-integration.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-agent-anthropic-integration.spec.ts
@@ -5,6 +5,7 @@ import { TID } from "../../utils/constants/testIds";
 import { TIMEOUTS } from "../../utils/constants/timeouts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
 import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 const ANTHROPIC_MODEL = "claude-sonnet-4-5-20250929";
 
@@ -55,6 +56,7 @@ test(
   "user can select Anthropic before running Simple Agent through the loopback provider",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await mockAnthropicModelCatalog(page);
     await openStarterProject(page, "Simple Agent");
 

--- a/src/frontend/tests/extended/regression/general-bugs-agent-images-playground.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-agent-images-playground.spec.ts
@@ -4,11 +4,13 @@ import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TID } from "../../utils/constants/testIds";
 import { TIMEOUTS } from "../../utils/constants/timeouts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "user must be able to send images in the playground with the agent component",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await openStarterProject(page, "Simple Agent");
     await configureLoopbackOpenAI(page, { skipUpdateOldComponents: true });
 

--- a/src/frontend/tests/extended/regression/general-bugs-agent-sum-duplicate-message-playground.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-agent-sum-duplicate-message-playground.spec.ts
@@ -5,11 +5,13 @@ import { TID } from "../../utils/constants/testIds";
 import { TEXTS } from "../../utils/constants/texts";
 import { TIMEOUTS } from "../../utils/constants/timeouts";
 import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "user must not experience message duplication in mathematical expressions with agent component",
   { tag: ["@release", "@components", "@workspace"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/extended/regression/general-bugs-shard-3836.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-shard-3836.spec.ts
@@ -8,6 +8,7 @@ import {
   openParametersPanel,
   toggleParameterOnNode,
 } from "../../utils/open-advanced-options";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 import { uploadFile } from "../../utils/upload-file";
 
 // awaitBootstrapTest creates a default "New Flow (n)" whose suffix comes from a
@@ -21,6 +22,7 @@ test(
   "user must be able to send an image on chat using advanced tool on ChatInputComponent",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/frontend/tests/extended/regression/generalBugs-shard-1.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-1.spec.ts
@@ -3,11 +3,13 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { configureLoopbackOpenAI } from "../../utils/configure-loopback-openai";
 import { TEXTS } from "../../utils/constants/texts";
 import { selectStarterTemplate } from "../../utils/flow/select-starter-template";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "should delete rows from table message",
   { tag: ["@release"] },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await awaitBootstrapTest(page);
 
     await selectStarterTemplate(page, TEXTS.templateBasicPrompting);

--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -5,6 +5,7 @@ import { TEXTS } from "../../utils/constants/texts";
 import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
+import { seedLoopbackProvider } from "../../utils/seed-loopback-provider";
 
 test(
   "should copy code from playground modal",
@@ -12,6 +13,7 @@ test(
     tag: ["@release"],
   },
   async ({ page }) => {
+    await seedLoopbackProvider(page);
     await openStarterProject(page, TEXTS.templateBasicPrompting);
     await configureLoopbackOpenAI(page);
     await adjustScreenView(page);

--- a/src/frontend/tests/utils/configure-loopback-openai.ts
+++ b/src/frontend/tests/utils/configure-loopback-openai.ts
@@ -6,160 +6,54 @@ import {
   flushPendingFlowAutosave,
   reloadAndWaitForFlowPersistence,
 } from "./flow-editor-persistence";
+import { modelRefreshNodeCount } from "./flow-editor-persistence-policy.mjs";
+import {
+  applyLoopbackToFlowData,
+  isFlowDataLoopbackConfigured,
+  isNodeLoopbackConfigured,
+  type LoopbackFlowData,
+  type LoopbackNode,
+} from "./loopback-provider-policy.mjs";
+import {
+  isLoopbackProviderSeeded,
+  waitForMountModelRefresh,
+} from "./seed-loopback-provider";
 import { updateOldComponents } from "./update-old-components";
 
-export const LOOPBACK_OPENAI_BASE_URL = "http://127.0.0.1:8787/v1";
-export const LOOPBACK_OPENAI_API_KEY = "langflow-loopback-test-key"; // pragma: allowlist secret
-
-const LOOPBACK_MODEL = {
-  id: "gpt-4o-mini",
-  name: "gpt-4o-mini",
-  icon: "OpenAI",
-  provider: "OpenAI",
-  category: "OpenAI",
-  metadata: {
-    api_key_param: "api_key", // pragma: allowlist secret
-    context_length: 128_000,
-    max_tokens_field_name: "max_tokens",
-    model_class: "ChatOpenAI",
-    model_name_param: "model",
-  },
-};
-
-type TemplateField = {
-  _input_type?: string;
-  load_from_db?: boolean;
-  options?: unknown[];
-  value?: unknown;
-};
-
-type FlowNode = {
-  id?: string;
-  type?: string;
-  data?: {
-    node?: {
-      template?: Record<string, TemplateField>;
-    };
-    type?: string;
-  };
-};
+export {
+  LOOPBACK_MODEL,
+  LOOPBACK_OPENAI_API_KEY,
+  LOOPBACK_OPENAI_BASE_URL,
+} from "./loopback-provider-policy.mjs";
 
 type FlowRead = {
-  data?: {
-    nodes?: FlowNode[];
-    edges?: unknown[];
-    [key: string]: unknown;
-  };
+  data?: LoopbackFlowData;
 };
-
-function configureTemplate(node: FlowNode): boolean {
-  const template = node.data?.node?.template;
-  if (!template) return false;
-
-  const modelInput = template.model;
-  const hasUnifiedModel = modelInput?._input_type === "ModelInput";
-  const isOpenAIComponent = /openai/i.test(node.data?.type ?? "");
-  if (!hasUnifiedModel && !isOpenAIComponent) return false;
-
-  if (hasUnifiedModel) {
-    modelInput.value = [LOOPBACK_MODEL];
-    modelInput.options = [
-      LOOPBACK_MODEL,
-      ...(modelInput.options ?? []).filter(
-        (option) =>
-          !(
-            typeof option === "object" &&
-            option !== null &&
-            "name" in option &&
-            option.name === LOOPBACK_MODEL.name &&
-            "provider" in option &&
-            option.provider === LOOPBACK_MODEL.provider
-          ),
-      ),
-    ];
-  }
-
-  for (const fieldName of ["api_key", "openai_api_key"]) {
-    if (template[fieldName]) {
-      template[fieldName].value = LOOPBACK_OPENAI_API_KEY;
-      template[fieldName].load_from_db = false;
-    }
-  }
-  for (const fieldName of ["openai_api_base", "base_url"]) {
-    if (template[fieldName]) {
-      template[fieldName].value = LOOPBACK_OPENAI_BASE_URL;
-    }
-  }
-  if (template.model_name && template.model_name._input_type !== "ModelInput") {
-    template.model_name.value = LOOPBACK_MODEL.name;
-  }
-  if (template.provider) template.provider.value = LOOPBACK_MODEL.provider;
-  return true;
-}
-
-function isLoopbackConfigured(node: FlowNode): boolean {
-  const template = node.data?.node?.template;
-  if (!template) return false;
-
-  const modelInput = template.model;
-  const hasUnifiedModel = modelInput?._input_type === "ModelInput";
-  const isOpenAIComponent = /openai/i.test(node.data?.type ?? "");
-  if (!hasUnifiedModel && !isOpenAIComponent) return false;
-
-  if (hasUnifiedModel) {
-    if (
-      !Array.isArray(modelInput.value) ||
-      !modelInput.value.some(
-        (model) =>
-          typeof model === "object" &&
-          model !== null &&
-          "name" in model &&
-          model.name === LOOPBACK_MODEL.name &&
-          "provider" in model &&
-          model.provider === LOOPBACK_MODEL.provider,
-      )
-    ) {
-      return false;
-    }
-  }
-
-  for (const fieldName of ["api_key", "openai_api_key"]) {
-    if (
-      template[fieldName] &&
-      (template[fieldName].value !== LOOPBACK_OPENAI_API_KEY ||
-        template[fieldName].load_from_db !== false)
-    ) {
-      return false;
-    }
-  }
-  for (const fieldName of ["openai_api_base", "base_url"]) {
-    if (
-      template[fieldName] &&
-      template[fieldName].value !== LOOPBACK_OPENAI_BASE_URL
-    ) {
-      return false;
-    }
-  }
-  if (
-    template.model_name &&
-    template.model_name._input_type !== "ModelInput" &&
-    template.model_name.value !== LOOPBACK_MODEL.name
-  ) {
-    return false;
-  }
-  if (
-    template.provider &&
-    template.provider.value !== LOOPBACK_MODEL.provider
-  ) {
-    return false;
-  }
-  return true;
-}
 
 function currentFlowId(page: Page): string {
   const match = new URL(page.url()).pathname.match(/\/flow\/([^/]+)/);
   if (!match) throw new Error(`Expected a flow URL, received ${page.url()}`);
   return match[1];
+}
+
+async function readFlow(
+  page: Page,
+  flowId: string,
+  description: string,
+): Promise<FlowRead> {
+  const response = await page.request.get(`/api/v1/flows/${flowId}`);
+  expect(response.ok(), `${description} ${flowId}`).toBeTruthy();
+  return (await response.json()) as FlowRead;
+}
+
+function nodesById(
+  data: LoopbackFlowData | undefined,
+): Map<string, LoopbackNode> {
+  return new Map(
+    (data?.nodes ?? []).flatMap((node) =>
+      node.id ? ([[node.id, node]] as [string, LoopbackNode][]) : [],
+    ),
+  );
 }
 
 export async function configureLoopbackOpenAI(
@@ -174,54 +68,62 @@ export async function configureLoopbackOpenAI(
 
   const flowId = currentFlowId(page);
   await flushPendingFlowAutosave(page);
-  const flowResponse = await page.request.get(`/api/v1/flows/${flowId}`);
-  expect(flowResponse.ok(), `GET flow ${flowId}`).toBeTruthy();
-  const flow = (await flowResponse.json()) as FlowRead;
-  const configuredNodes = (flow.data?.nodes ?? []).filter(configureTemplate);
-  if (configuredNodes.length === 0) {
+  const flow = await readFlow(page, flowId, "GET flow");
+  const { data: configuredData, targetNodeIds } = applyLoopbackToFlowData(
+    flow.data ?? {},
+  );
+  if (targetNodeIds.length === 0) {
     throw new Error(`Flow ${flowId} has no OpenAI-compatible model inputs`);
   }
 
-  const updateResponse = await page.request.patch(`/api/v1/flows/${flowId}`, {
-    data: { data: flow.data },
-  });
-  expect(updateResponse.ok(), `PATCH flow ${flowId}`).toBeTruthy();
+  if (
+    isLoopbackProviderSeeded(page) &&
+    isFlowDataLoopbackConfigured(flow.data ?? {})
+  ) {
+    // The starter template was served pre-configured, so the persisted flow and
+    // the editor already agree — there is no out-of-band patch to reload for.
+    // Only the mount refresh can still write these nodes, so wait for it to
+    // land before anything reads them back. Size the wait the way the editor
+    // does: a target node without a `model`-typed field never refreshes.
+    const expectedRefreshes = modelRefreshNodeCount(flow.data ?? {});
+    if (expectedRefreshes > 0) {
+      await waitForMountModelRefresh(page, flowId, expectedRefreshes);
+    }
+    await flushPendingFlowAutosave(page);
+  } else {
+    if (isLoopbackProviderSeeded(page)) {
+      // Correct but slow: the seed did not reach this flow, so we are paying
+      // for the reload this spec opted out of. Say so rather than letting the
+      // optimization rot silently across every seeded spec.
+      console.warn(
+        `Flow ${flowId} was not seeded with the loopback provider; falling back to patch-and-reload`,
+      );
+    }
+    const updateResponse = await page.request.patch(`/api/v1/flows/${flowId}`, {
+      data: { data: configuredData },
+    });
+    expect(updateResponse.ok(), `PATCH flow ${flowId}`).toBeTruthy();
 
-  const configuredNodeIds = configuredNodes.flatMap((node) =>
-    node.id ? [node.id] : [],
-  );
-  if (configuredNodeIds.length !== configuredNodes.length) {
-    throw new Error(`Flow ${flowId} contains a model node without an id`);
+    await reloadAndWaitForFlowPersistence(
+      page,
+      flowId,
+      configuredData,
+      (persistedData) => {
+        const persistedNodes = nodesById(persistedData);
+        return targetNodeIds.every((id) => {
+          const node = persistedNodes.get(id);
+          return node !== undefined && isNodeLoopbackConfigured(node);
+        });
+      },
+    );
   }
 
-  await reloadAndWaitForFlowPersistence(
-    page,
-    flowId,
-    flow.data ?? {},
-    (persistedData) => {
-      const persistedNodes = new Map(
-        (persistedData.nodes ?? []).flatMap((node) =>
-          node.id ? [[node.id, node]] : [],
-        ),
-      );
-      return configuredNodeIds.every((id) => {
-        const node = persistedNodes.get(id) as FlowNode | undefined;
-        return node !== undefined && isLoopbackConfigured(node);
-      });
-    },
-  );
   await waitForFlowEditorReady(page);
-  const verifyResponse = await page.request.get(`/api/v1/flows/${flowId}`);
-  expect(verifyResponse.ok(), `Verify flow ${flowId}`).toBeTruthy();
-  const verifiedFlow = (await verifyResponse.json()) as FlowRead;
-  const verifiedNodes = new Map(
-    (verifiedFlow.data?.nodes ?? []).flatMap((node) =>
-      node.id ? [[node.id, node]] : [],
-    ),
-  );
-  const clobberedNodeIds = configuredNodeIds.filter((id) => {
+  const verifiedFlow = await readFlow(page, flowId, "Verify flow");
+  const verifiedNodes = nodesById(verifiedFlow.data);
+  const clobberedNodeIds = targetNodeIds.filter((id) => {
     const node = verifiedNodes.get(id);
-    return !node || !isLoopbackConfigured(node);
+    return !node || !isNodeLoopbackConfigured(node);
   });
   if (clobberedNodeIds.length > 0) {
     throw new Error(

--- a/src/frontend/tests/utils/flow-editor-persistence-policy.d.mts
+++ b/src/frontend/tests/utils/flow-editor-persistence-policy.d.mts
@@ -17,6 +17,7 @@ export function isMatchingFullFlowAutosavePayload(
   matchesData: (data: FlowPersistenceData) => boolean,
 ): boolean;
 export function isModelRefreshBody(value: unknown): boolean;
+export function modelRefreshFlowId(value: unknown): string | undefined;
 export function canTrackFullFlowAutosavePayload(
   value: unknown,
   matchesData: (data: FlowPersistenceData) => boolean,

--- a/src/frontend/tests/utils/flow-editor-persistence-policy.mjs
+++ b/src/frontend/tests/utils/flow-editor-persistence-policy.mjs
@@ -10,6 +10,18 @@ export function isModelRefreshBody(value) {
   return isRecord(modelField) && modelField.type === "model";
 }
 
+/**
+ * The flow a model refresh belongs to. `buildRefreshPayload` stamps the id onto
+ * the template as `_frontend_node_flow_id`; the request URL carries no flow, so
+ * this is the only way to attribute a refresh to the editor that issued it.
+ */
+export function modelRefreshFlowId(value) {
+  if (!isModelRefreshBody(value)) return undefined;
+  const stamped = value.template._frontend_node_flow_id;
+  if (!isRecord(stamped) || typeof stamped.value !== "string") return undefined;
+  return stamped.value || undefined;
+}
+
 export function isMatchingFullFlowAutosavePayload(value, matchesData) {
   if (!isRecord(value) || !isRecord(value.data)) return false;
 

--- a/src/frontend/tests/utils/flow-editor-persistence-policy.test.mjs
+++ b/src/frontend/tests/utils/flow-editor-persistence-policy.test.mjs
@@ -5,6 +5,7 @@ import {
   isFlowPersistenceBarrierSatisfied,
   isMatchingFullFlowAutosavePayload,
   isModelRefreshBody,
+  modelRefreshFlowId,
   modelRefreshNodeCount,
   requiresPostRefreshAutosave,
 } from "./flow-editor-persistence-policy.mjs";
@@ -103,6 +104,49 @@ test("recognizes refreshes for dynamically named model fields", () => {
       },
     }),
     false,
+  );
+});
+
+test("attributes a refresh to the flow stamped on its template", () => {
+  assert.equal(
+    modelRefreshFlowId({
+      field: "model",
+      template: {
+        model: { type: "model", value: [] },
+        _frontend_node_flow_id: { value: "flow-1" },
+      },
+    }),
+    "flow-1",
+  );
+});
+
+test("has no flow for an unstamped or non-refresh body", () => {
+  assert.equal(
+    modelRefreshFlowId({
+      field: "model",
+      template: { model: { type: "model", value: [] } },
+    }),
+    undefined,
+  );
+  assert.equal(
+    modelRefreshFlowId({
+      field: "model",
+      template: {
+        model: { type: "model", value: [] },
+        _frontend_node_flow_id: { value: "" },
+      },
+    }),
+    undefined,
+  );
+  assert.equal(
+    modelRefreshFlowId({
+      field: "code",
+      template: {
+        code: { type: "code" },
+        _frontend_node_flow_id: { value: "flow-1" },
+      },
+    }),
+    undefined,
   );
 });
 

--- a/src/frontend/tests/utils/loopback-provider-policy.d.mts
+++ b/src/frontend/tests/utils/loopback-provider-policy.d.mts
@@ -1,0 +1,45 @@
+// Structurally compatible with `FlowPersistenceNode` so a node can cross
+// between the persistence barrier and this policy without a cast.
+export type LoopbackNode = {
+  id?: string;
+  type?: string;
+  data?: {
+    type?: string;
+    node?: {
+      template?: Record<string, unknown>;
+    };
+  };
+};
+
+export type LoopbackFlowData = {
+  nodes?: LoopbackNode[];
+  [key: string]: unknown;
+};
+
+export type LoopbackExample = {
+  data?: LoopbackFlowData;
+  [key: string]: unknown;
+};
+
+export const LOOPBACK_OPENAI_BASE_URL: string;
+export const LOOPBACK_OPENAI_API_KEY: string;
+export const LOOPBACK_MODEL: {
+  id: string;
+  name: string;
+  icon: string;
+  provider: string;
+  category: string;
+  metadata: Record<string, unknown>;
+};
+
+export function isLoopbackTarget(node: LoopbackNode): boolean;
+export function withLoopbackTemplate(node: LoopbackNode): LoopbackNode;
+export function isNodeLoopbackConfigured(node: LoopbackNode): boolean;
+export function applyLoopbackToFlowData(data: LoopbackFlowData): {
+  data: LoopbackFlowData;
+  targetNodeIds: string[];
+};
+export function isFlowDataLoopbackConfigured(data: LoopbackFlowData): boolean;
+export function applyLoopbackToExamples(
+  examples: LoopbackExample[],
+): LoopbackExample[];

--- a/src/frontend/tests/utils/loopback-provider-policy.mjs
+++ b/src/frontend/tests/utils/loopback-provider-policy.mjs
@@ -1,0 +1,215 @@
+export const LOOPBACK_OPENAI_BASE_URL = "http://127.0.0.1:8787/v1";
+export const LOOPBACK_OPENAI_API_KEY = "langflow-loopback-test-key"; // pragma: allowlist secret
+
+export const LOOPBACK_MODEL = {
+  id: "gpt-4o-mini",
+  name: "gpt-4o-mini",
+  icon: "OpenAI",
+  provider: "OpenAI",
+  category: "OpenAI",
+  metadata: {
+    api_key_param: "api_key", // pragma: allowlist secret
+    context_length: 128_000,
+    max_tokens_field_name: "max_tokens",
+    model_class: "ChatOpenAI",
+    model_name_param: "model",
+  },
+};
+
+const API_KEY_FIELDS = ["api_key", "openai_api_key"];
+const BASE_URL_FIELDS = ["openai_api_base", "base_url"];
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
+function template(node) {
+  const candidate = node?.data?.node?.template;
+  return isRecord(candidate) ? candidate : undefined;
+}
+
+function hasUnifiedModelInput(nodeTemplate) {
+  return nodeTemplate.model?._input_type === "ModelInput";
+}
+
+/**
+ * A node is a loopback target when it exposes the unified model input or is an
+ * OpenAI-family component. Everything else is left untouched.
+ */
+export function isLoopbackTarget(node) {
+  const nodeTemplate = template(node);
+  if (!nodeTemplate) return false;
+  return (
+    hasUnifiedModelInput(nodeTemplate) || /openai/i.test(node?.data?.type ?? "")
+  );
+}
+
+function loopbackModelOptions(existingOptions) {
+  return [
+    LOOPBACK_MODEL,
+    ...(existingOptions ?? []).filter(
+      (option) =>
+        !(
+          isRecord(option) &&
+          option.name === LOOPBACK_MODEL.name &&
+          option.provider === LOOPBACK_MODEL.provider
+        ),
+    ),
+  ];
+}
+
+function withLoopbackFields(nodeTemplate) {
+  const next = { ...nodeTemplate };
+
+  if (hasUnifiedModelInput(nodeTemplate)) {
+    next.model = {
+      ...nodeTemplate.model,
+      value: [LOOPBACK_MODEL],
+      options: loopbackModelOptions(nodeTemplate.model.options),
+    };
+  }
+
+  for (const field of API_KEY_FIELDS) {
+    if (nodeTemplate[field]) {
+      next[field] = {
+        ...nodeTemplate[field],
+        value: LOOPBACK_OPENAI_API_KEY,
+        load_from_db: false,
+      };
+    }
+  }
+  for (const field of BASE_URL_FIELDS) {
+    if (nodeTemplate[field]) {
+      next[field] = {
+        ...nodeTemplate[field],
+        value: LOOPBACK_OPENAI_BASE_URL,
+      };
+    }
+  }
+  if (
+    nodeTemplate.model_name &&
+    nodeTemplate.model_name._input_type !== "ModelInput"
+  ) {
+    next.model_name = {
+      ...nodeTemplate.model_name,
+      value: LOOPBACK_MODEL.name,
+    };
+  }
+  if (nodeTemplate.provider) {
+    next.provider = {
+      ...nodeTemplate.provider,
+      value: LOOPBACK_MODEL.provider,
+    };
+  }
+
+  return next;
+}
+
+/**
+ * Returns a new node with the loopback provider applied, or the original node
+ * when it is not a loopback target. Never mutates its argument.
+ */
+export function withLoopbackTemplate(node) {
+  if (!isLoopbackTarget(node)) return node;
+  const nodeTemplate = template(node);
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      node: {
+        ...node.data.node,
+        template: withLoopbackFields(nodeTemplate),
+      },
+    },
+  };
+}
+
+export function isNodeLoopbackConfigured(node) {
+  const nodeTemplate = template(node);
+  if (!nodeTemplate) return false;
+  if (!isLoopbackTarget(node)) return false;
+
+  if (hasUnifiedModelInput(nodeTemplate)) {
+    const value = nodeTemplate.model.value;
+    if (
+      !Array.isArray(value) ||
+      !value.some(
+        (model) =>
+          isRecord(model) &&
+          model.name === LOOPBACK_MODEL.name &&
+          model.provider === LOOPBACK_MODEL.provider,
+      )
+    ) {
+      return false;
+    }
+  }
+
+  for (const field of API_KEY_FIELDS) {
+    if (
+      nodeTemplate[field] &&
+      (nodeTemplate[field].value !== LOOPBACK_OPENAI_API_KEY ||
+        nodeTemplate[field].load_from_db !== false)
+    ) {
+      return false;
+    }
+  }
+  for (const field of BASE_URL_FIELDS) {
+    if (
+      nodeTemplate[field] &&
+      nodeTemplate[field].value !== LOOPBACK_OPENAI_BASE_URL
+    ) {
+      return false;
+    }
+  }
+  if (
+    nodeTemplate.model_name &&
+    nodeTemplate.model_name._input_type !== "ModelInput" &&
+    nodeTemplate.model_name.value !== LOOPBACK_MODEL.name
+  ) {
+    return false;
+  }
+  if (
+    nodeTemplate.provider &&
+    nodeTemplate.provider.value !== LOOPBACK_MODEL.provider
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Applies the loopback provider to every target node in a flow's `data`,
+ * returning the new data plus the ids of the nodes it targeted. `targetNodeIds`
+ * is what callers assert on later — a flow with none of them cannot be driven
+ * against the loopback provider at all.
+ */
+export function applyLoopbackToFlowData(data) {
+  const nodes = data?.nodes ?? [];
+  const targetNodeIds = nodes
+    .filter(isLoopbackTarget)
+    .map((node) => node.id)
+    .filter((id) => typeof id === "string" && id.length > 0);
+
+  return {
+    data: { ...data, nodes: nodes.map(withLoopbackTemplate) },
+    targetNodeIds,
+  };
+}
+
+export function isFlowDataLoopbackConfigured(data) {
+  const targets = (data?.nodes ?? []).filter(isLoopbackTarget);
+  return targets.length > 0 && targets.every(isNodeLoopbackConfigured);
+}
+
+/**
+ * Rewrites the starter-template catalog so templates are born configured for
+ * the loopback provider. Templates without a model input pass through
+ * untouched.
+ */
+export function applyLoopbackToExamples(examples) {
+  return examples.map((example) => {
+    if (!isRecord(example) || !isRecord(example.data)) return example;
+    const { data } = applyLoopbackToFlowData(example.data);
+    return { ...example, data };
+  });
+}

--- a/src/frontend/tests/utils/loopback-provider-policy.test.mjs
+++ b/src/frontend/tests/utils/loopback-provider-policy.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  applyLoopbackToExamples,
+  applyLoopbackToFlowData,
+  isFlowDataLoopbackConfigured,
+  isLoopbackTarget,
+  isNodeLoopbackConfigured,
+  LOOPBACK_MODEL,
+  LOOPBACK_OPENAI_API_KEY,
+  LOOPBACK_OPENAI_BASE_URL,
+  withLoopbackTemplate,
+} from "./loopback-provider-policy.mjs";
+
+function unifiedModelNode(overrides = {}) {
+  return {
+    id: "LanguageModel-abc",
+    type: "genericNode",
+    data: {
+      type: "LanguageModelComponent",
+      node: {
+        template: {
+          model: {
+            _input_type: "ModelInput",
+            type: "model",
+            value: [{ name: "claude-sonnet-4", provider: "Anthropic" }],
+            options: [{ name: "claude-sonnet-4", provider: "Anthropic" }],
+          },
+          api_key: { value: "", load_from_db: true },
+          ...overrides,
+        },
+      },
+    },
+  };
+}
+
+function plainNode() {
+  return {
+    id: "ChatInput-xyz",
+    type: "genericNode",
+    data: {
+      type: "ChatInput",
+      node: { template: { input_value: { value: "hello" } } },
+    },
+  };
+}
+
+test("targets unified model inputs and OpenAI components only", () => {
+  assert.equal(isLoopbackTarget(unifiedModelNode()), true);
+  assert.equal(isLoopbackTarget(plainNode()), false);
+  assert.equal(
+    isLoopbackTarget({
+      id: "OpenAI-1",
+      data: { type: "OpenAIModel", node: { template: { api_key: {} } } },
+    }),
+    true,
+  );
+  assert.equal(isLoopbackTarget({ id: "no-template" }), false);
+});
+
+test("applies the loopback model, key and base url", () => {
+  const node = withLoopbackTemplate(
+    unifiedModelNode({ base_url: { value: "https://api.openai.com/v1" } }),
+  );
+  const template = node.data.node.template;
+
+  assert.deepEqual(template.model.value, [LOOPBACK_MODEL]);
+  assert.equal(template.api_key.value, LOOPBACK_OPENAI_API_KEY);
+  assert.equal(template.api_key.load_from_db, false);
+  assert.equal(template.base_url.value, LOOPBACK_OPENAI_BASE_URL);
+});
+
+test("prepends the loopback model without duplicating it", () => {
+  const once = withLoopbackTemplate(unifiedModelNode());
+  const twice = withLoopbackTemplate(once);
+  const options = twice.data.node.template.model.options;
+
+  assert.equal(options[0].name, LOOPBACK_MODEL.name);
+  assert.equal(
+    options.filter((option) => option.name === LOOPBACK_MODEL.name).length,
+    1,
+  );
+});
+
+test("never mutates its argument", () => {
+  const node = unifiedModelNode();
+  const snapshot = JSON.stringify(node);
+  withLoopbackTemplate(node);
+  assert.equal(JSON.stringify(node), snapshot);
+});
+
+test("leaves non-target nodes identical", () => {
+  const node = plainNode();
+  assert.equal(withLoopbackTemplate(node), node);
+});
+
+test("sets legacy model_name and provider fields", () => {
+  const node = withLoopbackTemplate(
+    unifiedModelNode({
+      model_name: { value: "gpt-4" },
+      provider: { value: "Anthropic" },
+    }),
+  );
+
+  assert.equal(node.data.node.template.model_name.value, LOOPBACK_MODEL.name);
+  assert.equal(node.data.node.template.provider.value, LOOPBACK_MODEL.provider);
+});
+
+test("does not overwrite a model_name that is itself a ModelInput", () => {
+  const node = withLoopbackTemplate(
+    unifiedModelNode({
+      model_name: { _input_type: "ModelInput", value: "keep-me" },
+    }),
+  );
+
+  assert.equal(node.data.node.template.model_name.value, "keep-me");
+});
+
+test("round-trips through the configured predicate", () => {
+  const node = unifiedModelNode({ base_url: { value: "https://x/v1" } });
+  assert.equal(isNodeLoopbackConfigured(node), false);
+  assert.equal(isNodeLoopbackConfigured(withLoopbackTemplate(node)), true);
+});
+
+test("rejects a node whose api key was left bound to the variable store", () => {
+  const node = withLoopbackTemplate(unifiedModelNode());
+  node.data.node.template.api_key.load_from_db = true;
+  assert.equal(isNodeLoopbackConfigured(node), false);
+});
+
+test("reports the target node ids for a flow", () => {
+  const { data, targetNodeIds } = applyLoopbackToFlowData({
+    nodes: [unifiedModelNode(), plainNode()],
+    edges: [],
+  });
+
+  assert.deepEqual(targetNodeIds, ["LanguageModel-abc"]);
+  assert.deepEqual(data.edges, []);
+  assert.equal(isFlowDataLoopbackConfigured(data), true);
+});
+
+test("a flow with no model node is never considered configured", () => {
+  assert.equal(isFlowDataLoopbackConfigured({ nodes: [plainNode()] }), false);
+  assert.equal(isFlowDataLoopbackConfigured({ nodes: [] }), false);
+});
+
+test("seeds every example in the starter catalog", () => {
+  const examples = [
+    { id: "1", name: "Basic Prompting", data: { nodes: [unifiedModelNode()] } },
+    { id: "2", name: "No Model", data: { nodes: [plainNode()] } },
+    { id: "3", name: "Malformed" },
+  ];
+  const seeded = applyLoopbackToExamples(examples);
+
+  assert.equal(isFlowDataLoopbackConfigured(seeded[0].data), true);
+  assert.equal(seeded[0].name, "Basic Prompting");
+  assert.deepEqual(seeded[1].data.nodes, [plainNode()]);
+  assert.equal(seeded[2], examples[2]);
+  assert.equal(isFlowDataLoopbackConfigured(examples[0].data), false);
+});

--- a/src/frontend/tests/utils/seed-loopback-provider.ts
+++ b/src/frontend/tests/utils/seed-loopback-provider.ts
@@ -1,0 +1,148 @@
+import { expect, type Page, type Request } from "@playwright/test";
+import { TIMEOUTS } from "./constants/timeouts";
+import {
+  isModelRefreshBody,
+  modelRefreshFlowId,
+} from "./flow-editor-persistence-policy.mjs";
+import {
+  applyLoopbackToExamples,
+  type LoopbackExample,
+} from "./loopback-provider-policy.mjs";
+
+const STARTER_TEMPLATE_CATALOG = "**/api/v1/flows/basic_examples/**";
+const MODEL_REFRESH_PATH = "/api/v1/custom_component/update";
+
+type MountRefreshTracker = {
+  completedByFlow: Map<string, number>;
+};
+
+const trackers = new WeakMap<Page, MountRefreshTracker>();
+
+function trackMountModelRefreshes(page: Page): MountRefreshTracker {
+  const tracker: MountRefreshTracker = { completedByFlow: new Map() };
+  const inFlight = new Map<Request, string>();
+
+  page.on("request", (request) => {
+    if (
+      request.method() !== "POST" ||
+      new URL(request.url()).pathname !== MODEL_REFRESH_PATH
+    ) {
+      return;
+    }
+    let body: unknown;
+    try {
+      body = request.postDataJSON();
+    } catch {
+      return;
+    }
+    if (!isModelRefreshBody(body)) return;
+    const flowId = modelRefreshFlowId(body);
+    if (flowId) inFlight.set(request, flowId);
+  });
+
+  page.on("response", (response) => {
+    const request = response.request();
+    const flowId = inFlight.get(request);
+    if (!flowId) return;
+    inFlight.delete(request);
+    if (!response.ok()) return;
+    tracker.completedByFlow.set(
+      flowId,
+      (tracker.completedByFlow.get(flowId) ?? 0) + 1,
+    );
+  });
+
+  return tracker;
+}
+
+/**
+ * Serve the starter-template catalog already configured for the loopback
+ * provider, so a flow created from a template is born pointed at the local
+ * fixture server instead of a real provider.
+ *
+ * This is the fast path for {@link configureLoopbackOpenAI}: with the template
+ * pre-seeded there is nothing to patch behind the editor's back, so that helper
+ * can skip its reload — which costs 19-35s on Windows CI, where Playwright
+ * serves the app from a Vite dev server and a reload replays ~3.5k unbundled
+ * module requests.
+ *
+ * Call before the first navigation. `configureLoopbackOpenAI` still works
+ * without it (it falls back to patch-and-reload), so this is an optimization,
+ * never a correctness requirement.
+ */
+export async function seedLoopbackProvider(page: Page): Promise<void> {
+  if (trackers.has(page)) return;
+
+  // React Query caches the catalog for the session, so seeding after the app
+  // has loaded would silently do nothing and leave the slow path in place.
+  expect(
+    page.url(),
+    "seedLoopbackProvider must run before the first navigation",
+  ).toBe("about:blank");
+
+  trackers.set(page, trackMountModelRefreshes(page));
+
+  await page.route(STARTER_TEMPLATE_CATALOG, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    if (!response.ok()) {
+      await route.fulfill({ response });
+      return;
+    }
+
+    let examples: unknown;
+    try {
+      examples = await response.json();
+    } catch {
+      await route.fulfill({ response });
+      return;
+    }
+    if (!Array.isArray(examples)) {
+      await route.fulfill({ response });
+      return;
+    }
+
+    await route.fulfill({
+      status: response.status(),
+      contentType: "application/json",
+      body: JSON.stringify(
+        applyLoopbackToExamples(examples as LoopbackExample[]),
+      ),
+    });
+  });
+}
+
+export function isLoopbackProviderSeeded(page: Page): boolean {
+  return trackers.has(page);
+}
+
+/**
+ * Wait for the model refreshes the editor fires when it mounts a flow.
+ *
+ * `useApplyFlowToCanvas` kicks off `refreshAllModelInputs` for every model node
+ * on mount, and its result is written back into the node. Waiting for it means
+ * a caller that reads the flow afterwards cannot be overtaken by a refresh that
+ * was still in flight.
+ */
+export async function waitForMountModelRefresh(
+  page: Page,
+  flowId: string,
+  expectedRefreshes: number,
+): Promise<void> {
+  const tracker = trackers.get(page);
+  expect(
+    tracker,
+    "waitForMountModelRefresh requires seedLoopbackProvider",
+  ).toBeDefined();
+
+  await expect
+    .poll(() => tracker!.completedByFlow.get(flowId) ?? 0, {
+      timeout: TIMEOUTS.long,
+      message: `Flow ${flowId} did not complete ${expectedRefreshes} mount model refresh(es)`,
+    })
+    .toBeGreaterThanOrEqual(expectedRefreshes);
+}


### PR DESCRIPTION
Ports #14589 to `release-1.12.0`. Cherry-picked verbatim — zero conflicts, and every one of the 34 touched files is byte-identical to its `main` copy, so the two branches carry the same test harness.

Follow-up to #14588 (this branch's copy of #14587), which fixed the *timeout* on the flow-persistence barrier. This removes the reload that made the barrier expensive in the first place.

## Why

`configureLoopbackOpenAI` patched the persisted flow behind the running editor, then reloaded the page so the editor would pick the change up. Playwright serves the app from a Vite dev server, so that reload replays ~3,500 unbundled module requests — **19-35s on Windows CI**, once per test, across **38 call sites**.

Nothing forces the configuration to arrive out of band. `useAddFlow` posts the starter template the browser fetched from `/api/v1/flows/basic_examples/`, so serving that catalog already pointed at the loopback fixture makes the flow **born configured**: the editor and the database never diverge, and there is nothing to reload for.

## How

- **`seedLoopbackProvider(page)`** rewrites the starter-template catalog response. It must run before the first navigation, since React Query caches the catalog for the session — called too late, it throws rather than silently doing nothing.
- **`configureLoopbackOpenAI`** takes a fast path when the flow it reads is already configured, and keeps patch-and-reload otherwise. A spec that does not seed, or builds its flow from a blank canvas, is unaffected. The fallback `console.warn`s rather than staying silent, so the optimization cannot rot unnoticed.
- **Mount refresh.** The one thing that can still write these nodes without a reload is the model refresh `useApplyFlowToCanvas` fires on mount, so the fast path waits for it. Refreshes carry no flow in their URL — `buildRefreshPayload` stamps `_frontend_node_flow_id` onto the template — so `modelRefreshFlowId` attributes them, and the tracker is armed before navigation so the wait can never be retroactive.
- **`loopback-provider-policy.mjs`** holds the shared mutation and predicates, next to the existing `flow-editor-persistence-policy.mjs` — pure and unit tested, so the route seeder and the patch path cannot drift apart.

## Scope

Opt-in per spec rather than folded into `openStarterProject`: `live/llm-provider-smoke.spec.ts` uses that helper and must reach a real provider. Seeding it would let the "live" check pass without touching a real provider — exactly the failure mode #14540 fixed for the live config.

Not rolled out to `decisionFlow`, `similarity`, or `Youtube Analysis`, which build from a blank canvas where seeding the catalog does nothing.

## Measured (on main, #14589)

Local macOS, `bulk-delete-sessions.spec.ts`, 8 tests, 2 workers: **2.8m before → 1.6m after**, green both ways, zero `page.reload` calls on the seeded path under `DEBUG=pw:api`.

On this branch: `tsc` clean over `tests/`, `npm run test:e2e-utilities` 63/63 green.

## Test plan

- [ ] Windows shards covering the 25 seeded specs green, and measurably faster
- [ ] Linux shards green
- [ ] No `was not seeded with the loopback provider` warnings in the shard logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage across session management, chat, image uploads, token usage, starter projects, integrations, and regression scenarios.
  - Improved test setup consistency by ensuring supported model-provider configurations are available before scenarios run.
  - Added validation for flow refresh tracking, provider configuration, starter templates, legacy fields, immutability, and malformed data handling.
  - Enhanced end-to-end test utilities to verify configuration updates and wait for required refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->