### PR TITLE
fix(auth): reconcile a group set the user moved past instead of serving it from cache (LE-2099)

### DIFF
--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -107,45 +107,99 @@ def _is_retryable_backend_failure(exc: BaseException) -> bool:
 
 
 class _DirectoryReconcileCache:
-    """Bounded, short-lived record of directory states already reconciled.
+    """Bounded, short-lived record of the last directory state reconciled per user.
 
     LE-2109: bearer tokens arrive on every request, and reconciliation opens a
     transaction, takes the authorization plugin's policy locks and appends an
     audit row. Repeating all of that for a directory state that has not moved
     is pure overhead, so one successful *no-op* pass is remembered for a short
-    interval, keyed by the exact state it verified. A claim carrying a
-    different group set produces a different key and always reconciles.
+    interval.
+
+    The cache holds at most one entry per user: the exact state the last
+    confirming pass verified. A request is skipped only while that entry is
+    fresh *and* carries the same state, so any claim that differs from the
+    last reconciled state misses by construction - including a state that
+    was cached earlier and has since been moved past. Keying by state alone
+    would let ``[devs]`` cached before a promotion to ``[admins, devs]`` keep
+    serving after the IdP revokes ``admins`` again, holding the admin role
+    until the entry aged out.
+
+    Two rules keep an entry from outliving the state it verified when passes
+    for one user overlap (an old and a new token in flight together):
+
+    * :meth:`begin` records a miss. It drops the user's entry, because the
+      claim being reconciled supersedes it, and hands the pass a ticket. Only
+      the pass holding the user's *latest* ticket may :meth:`remember`.
+    * :meth:`invalidate` is called after a pass changed the stored state. It
+      drops the entry and revokes the outstanding ticket, so a concurrent
+      no-op pass that verified the *previous* state cannot re-cache it after
+      the change landed.
 
     Entries are per-process and expire on their own, so the worst case is that
-    an out-of-band directory change is observed one interval late.
+    an out-of-band directory change (one that arrives with the *same* claim)
+    is observed one interval late.
     """
 
     def __init__(self, *, max_entries: int = _MAX_DIRECTORY_RECONCILE_CACHE_ENTRIES) -> None:
         self._max_entries = max_entries
-        self._deadlines: OrderedDict[tuple[object, ...], float] = OrderedDict()
+        # user key -> (verified state, monotonic deadline)
+        self._entries: OrderedDict[str, tuple[tuple[object, ...], float]] = OrderedDict()
+        # user key -> ticket of the latest pass that began for the user
+        self._tickets: OrderedDict[str, int] = OrderedDict()
+        self._last_ticket = 0
 
-    def is_fresh(self, key: tuple[object, ...], *, now: float) -> bool:
-        deadline = self._deadlines.get(key)
-        if deadline is None:
+    def is_fresh(self, user_key: str, state: tuple[object, ...], *, now: float) -> bool:
+        entry = self._entries.get(user_key)
+        if entry is None:
             return False
+        verified_state, deadline = entry
         if deadline <= now:
-            del self._deadlines[key]
+            del self._entries[user_key]
             return False
-        return True
+        return verified_state == state
 
-    def remember(self, key: tuple[object, ...], *, now: float, ttl_seconds: float) -> None:
+    def begin(self, user_key: str) -> int:
+        """Record a cache miss and return the ticket the pass must present to remember its result."""
+        self._entries.pop(user_key, None)
+        self._last_ticket += 1
+        self._tickets.pop(user_key, None)
+        self._tickets[user_key] = self._last_ticket
+        while len(self._tickets) > self._max_entries:
+            self._tickets.popitem(last=False)
+        return self._last_ticket
+
+    def remember(
+        self,
+        user_key: str,
+        state: tuple[object, ...],
+        *,
+        ticket: int,
+        now: float,
+        ttl_seconds: float,
+    ) -> None:
         if ttl_seconds <= 0:
             return
+        if self._tickets.get(user_key) != ticket:
+            # A newer pass began for this user, or a change landed, after this
+            # pass verified its state: that verdict is stale and must not
+            # become the entry.
+            return
+        del self._tickets[user_key]
         self._purge_expired(now)
-        self._deadlines.pop(key, None)
-        self._deadlines[key] = now + ttl_seconds
-        while len(self._deadlines) > self._max_entries:
-            self._deadlines.popitem(last=False)
+        self._entries.pop(user_key, None)
+        self._entries[user_key] = (state, now + ttl_seconds)
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+
+    def invalidate(self, user_key: str) -> None:
+        """Forget the user's entry and revoke any in-flight ticket after their stored state changed."""
+        self._entries.pop(user_key, None)
+        self._tickets.pop(user_key, None)
 
     def _purge_expired(self, now: float) -> None:
-        expired = [key for key, deadline in self._deadlines.items() if deadline <= now]
+        expired = [key for key, (_, deadline) in self._entries.items() if deadline <= now]
         for key in expired:
-            del self._deadlines[key]
+            del self._entries[key]
 
 
 def _has_external_group_overage(claims: Mapping[str, object], claim_path: tuple[str, ...]) -> bool:
@@ -664,25 +718,33 @@ class AuthService(BaseAuthService):
         # LE-2109: bearer tokens arrive on every request. Reconciliation writes
         # rows, takes the plugin's policy locks and appends an audit entry, so
         # a directory state that was verified unchanged a moment ago is skipped
-        # until the configured interval elapses. Any difference in the group
-        # set, the claim state or the resolved user changes the key and
-        # reconciles immediately.
+        # until the configured interval elapses. The cache remembers only the
+        # *last* reconciled state per user, so any difference in the group
+        # set, the claim state or the identity from that state reconciles
+        # immediately - even a group set that was itself cached earlier and
+        # has since been moved past (a promotion followed by a revocation).
         reconcile_interval = float(self.settings.auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS)
-        cache_key = (
+        cache_user = str(user.id)
+        cache_state = (
             identity.provider,
             identity.subject,
-            str(user.id),
             claim_name,
             claim_state.value if claim_state is not None else None,
             complete,
             groups,
         )
         now = time.monotonic()
-        if reconcile_interval > 0 and self._directory_reconcile_cache.is_fresh(cache_key, now=now):
+        if reconcile_interval > 0 and self._directory_reconcile_cache.is_fresh(cache_user, cache_state, now=now):
             # Skipping reconciliation must not skip the JIT/profile bookkeeping
             # that materializing the user staged on this session.
             await db.commit()
             return
+        # This claim is about to be reconciled, so whatever the cache holds
+        # for the user describes a state that is being superseded: begin()
+        # drops it and hands this pass the ticket it must present to be
+        # remembered, so an overlapping pass for the same user can never
+        # re-cache a state a later pass moved past.
+        cache_ticket = self._directory_reconcile_cache.begin(cache_user)
 
         if not complete:
             assert claim_state is not None  # noqa: S101 - internal state-machine invariant
@@ -715,7 +777,9 @@ class AuthService(BaseAuthService):
                     },
                 )
                 self._directory_reconcile_cache.remember(
-                    cache_key,
+                    cache_user,
+                    cache_state,
+                    ticket=cache_ticket,
                     now=now,
                     ttl_seconds=reconcile_interval,
                 )
@@ -760,6 +824,11 @@ class AuthService(BaseAuthService):
             changed = bool(getattr(result, "changed", True))
             added = getattr(result, "added", None)
             removed = getattr(result, "removed", None)
+        if changed:
+            # The stored state just moved. Whatever the cache holds for the
+            # user, and any pass still in flight that verified the previous
+            # state, must not be served or remembered after this commit.
+            self._directory_reconcile_cache.invalidate(cache_user)
 
         if not complete:
             assert claim_state is not None  # noqa: S101 - internal state-machine invariant
@@ -780,7 +849,9 @@ class AuthService(BaseAuthService):
                 )
             else:
                 self._directory_reconcile_cache.remember(
-                    cache_key,
+                    cache_user,
+                    cache_state,
+                    ticket=cache_ticket,
                     now=now,
                     ttl_seconds=reconcile_interval,
                 )
@@ -809,7 +880,9 @@ class AuthService(BaseAuthService):
             # something gets one confirming pass before the interval starts, so
             # a post-commit propagation retry is never hidden by the cache.
             self._directory_reconcile_cache.remember(
-                cache_key,
+                cache_user,
+                cache_state,
+                ticket=cache_ticket,
                 now=now,
                 ttl_seconds=reconcile_interval,
             )

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -135,6 +135,10 @@ class _DirectoryReconcileCache:
       no-op pass that verified the *previous* state cannot re-cache it after
       the change landed.
 
+    One slot per user is deliberate: a user alternating between two different
+    identities (two providers, or two subjects) simply misses on each switch
+    and reconciles - never a stale hit, only less caching for that edge case.
+
     Entries are per-process and expire on their own, so the worst case is that
     an out-of-band directory change (one that arrives with the *same* claim)
     is observed one interval late.
@@ -719,10 +723,10 @@ class AuthService(BaseAuthService):
         # rows, takes the plugin's policy locks and appends an audit entry, so
         # a directory state that was verified unchanged a moment ago is skipped
         # until the configured interval elapses. The cache remembers only the
-        # *last* reconciled state per user, so any difference in the group
-        # set, the claim state or the identity from that state reconciles
-        # immediately - even a group set that was itself cached earlier and
-        # has since been moved past (a promotion followed by a revocation).
+        # *last* reconciled state per user, so a claim whose group set, claim
+        # state or identity differs from that state reconciles immediately -
+        # even a group set that was itself cached earlier and has since been
+        # moved past (a promotion followed by a revocation).
         reconcile_interval = float(self.settings.auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS)
         cache_user = str(user.id)
         cache_state = (

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -1886,6 +1887,255 @@ async def test_incomplete_claim_skip_is_not_audited_on_every_request(
     authz.ingest_directory_membership_snapshot.assert_not_awaited()
     assert audit.await_count == 1
     assert db.commit.await_count == 4
+
+
+@pytest.mark.anyio
+async def test_group_revoked_after_promotion_reconciles_immediately(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """A group set the user moved past must not be served from an earlier cache entry.
+
+    LE-2099 QA follow-up: ``[devs]`` reconciled and cached, then a promotion to
+    ``[admins, devs]``, then the IdP revokes ``admins``. The claim now differs
+    from the last reconciled state, so it must reconcile on the next request
+    rather than after the interval expires - privilege removal is the case
+    that must not be delayed.
+    """
+    from lfx.services.authorization import DirectoryMembershipIngestResult
+
+    auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS = 3600
+    user = _dummy_user(uuid4())
+    db = AsyncMock()
+    authz = _DirectoryAuthorizationStub(result=DirectoryMembershipIngestResult(changed=True, added=1))
+    audit = AsyncMock()
+    developer = _external_identity({"groups": ["lf-devs"]})
+    promoted = _external_identity({"groups": ["lf-admins", "lf-devs"]})
+    ingest = authz.ingest_directory_membership_snapshot
+
+    async def reconcile(identity, *, changed: bool) -> None:
+        ingest.return_value = DirectoryMembershipIngestResult(changed=changed, added=int(changed))
+        await auth_service._reconcile_verified_external_groups(identity=identity, user=user, db=db)
+
+    def memberships_seen() -> list[tuple[str, ...]]:
+        return [call.kwargs["snapshot"].memberships for call in ingest.await_args_list]
+
+    with (
+        patch("langflow.services.deps.get_authorization_service", return_value=authz),
+        patch("langflow.services.authorization.audit.audit_decision", new=audit),
+    ):
+        # 1) first login grants developer, 2) the confirming pass caches [devs]
+        await reconcile(developer, changed=True)
+        await reconcile(developer, changed=False)
+        await reconcile(developer, changed=False)
+        assert ingest.await_count == 2, "the confirming pass must be cached"
+
+        # 3) promotion: a group set never seen before reconciles at once
+        await reconcile(promoted, changed=True)
+        assert ingest.await_count == 3
+
+        # 4) revocation back to the earlier group set must reconcile immediately,
+        #    even though [devs] was cached in step 2 and its TTL has not expired.
+        await reconcile(developer, changed=True)
+        assert ingest.await_count == 4, "a revoked group kept its role from a stale cache entry"
+        assert memberships_seen()[-1] == ("lf-devs",)
+
+        # The confirming pass caches the reconciled state again and later
+        # identical requests are still skipped: the cache keeps working.
+        await reconcile(developer, changed=False)
+        await reconcile(developer, changed=False)
+        await reconcile(developer, changed=False)
+        assert ingest.await_count == 5
+
+        # A later promotion is again a change from the last reconciled state.
+        await reconcile(promoted, changed=True)
+        assert ingest.await_count == 6
+
+    assert memberships_seen() == [
+        ("lf-devs",),
+        ("lf-devs",),
+        ("lf-admins", "lf-devs"),
+        ("lf-devs",),
+        ("lf-devs",),
+        ("lf-admins", "lf-devs"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_revocation_reconciles_even_after_the_promotion_was_confirmed_and_cached(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """Both the promoted and the earlier state were cached; the older one must not win."""
+    from lfx.services.authorization import DirectoryMembershipIngestResult
+
+    auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS = 3600
+    user = _dummy_user(uuid4())
+    db = AsyncMock()
+    authz = _DirectoryAuthorizationStub(result=DirectoryMembershipIngestResult(changed=False))
+    audit = AsyncMock()
+    developer = _external_identity({"groups": ["lf-devs"]})
+    promoted = _external_identity({"groups": ["lf-admins", "lf-devs"]})
+    ingest = authz.ingest_directory_membership_snapshot
+
+    with (
+        patch("langflow.services.deps.get_authorization_service", return_value=authz),
+        patch("langflow.services.authorization.audit.audit_decision", new=audit),
+    ):
+        await auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=db)
+        ingest.return_value = DirectoryMembershipIngestResult(changed=True, added=1)
+        await auth_service._reconcile_verified_external_groups(identity=promoted, user=user, db=db)
+        ingest.return_value = DirectoryMembershipIngestResult(changed=False)
+        await auth_service._reconcile_verified_external_groups(identity=promoted, user=user, db=db)
+        assert ingest.await_count == 3
+
+        # Revocation: [devs] is the state cached first, [admins, devs] the one
+        # cached last. Neither may hide the change.
+        ingest.return_value = DirectoryMembershipIngestResult(changed=True, removed=1)
+        await auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=db)
+
+    assert ingest.await_count == 4
+    assert ingest.await_args_list[-1].kwargs["snapshot"].memberships == ("lf-devs",)
+
+
+@pytest.mark.anyio
+async def test_reconcile_cache_is_scoped_per_user(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """Remembering one user's state must not evict or leak into another user's entry."""
+    from lfx.services.authorization import DirectoryMembershipIngestResult
+
+    auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS = 3600
+    first_user = _dummy_user(uuid4())
+    second_user = _dummy_user(uuid4())
+    db = AsyncMock()
+    authz = _DirectoryAuthorizationStub(result=DirectoryMembershipIngestResult(changed=False))
+    audit = AsyncMock()
+    identity = _external_identity({"groups": ["engineering"]})
+
+    with (
+        patch("langflow.services.deps.get_authorization_service", return_value=authz),
+        patch("langflow.services.authorization.audit.audit_decision", new=audit),
+    ):
+        await auth_service._reconcile_verified_external_groups(identity=identity, user=first_user, db=db)
+        await auth_service._reconcile_verified_external_groups(identity=identity, user=second_user, db=db)
+        await auth_service._reconcile_verified_external_groups(identity=identity, user=first_user, db=db)
+        await auth_service._reconcile_verified_external_groups(identity=identity, user=second_user, db=db)
+
+    assert authz.ingest_directory_membership_snapshot.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_change_landing_after_a_concurrent_noop_pass_evicts_its_entry(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """An old-token no-op pass must not keep serving once an overlapping pass changed the state.
+
+    The promotion pass begins first and is held inside the plugin. Meanwhile
+    the old token's ``[devs]`` pass verifies the still-unchanged state and is
+    remembered. When the promotion commits, that entry must be evicted, or
+    the next ``[devs]`` request would be skipped while the user holds admin.
+    """
+    from lfx.services.authorization import DirectoryMembershipIngestResult
+
+    auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS = 3600
+    user = _dummy_user(uuid4())
+    db = AsyncMock()
+    audit = AsyncMock()
+    developer = _external_identity({"groups": ["lf-devs"]})
+    promoted = _external_identity({"groups": ["lf-admins", "lf-devs"]})
+    promotion_in_plugin = asyncio.Event()
+    release_promotion = asyncio.Event()
+
+    async def ingest(*, session, snapshot):  # noqa: ARG001
+        if snapshot.memberships == ("lf-admins", "lf-devs"):
+            promotion_in_plugin.set()
+            await release_promotion.wait()
+            return DirectoryMembershipIngestResult(changed=True, added=1)
+        return DirectoryMembershipIngestResult(changed=False)
+
+    authz = _DirectoryAuthorizationStub(result=None)
+    authz.ingest_directory_membership_snapshot = AsyncMock(side_effect=ingest)
+
+    with (
+        patch("langflow.services.deps.get_authorization_service", return_value=authz),
+        patch("langflow.services.authorization.audit.audit_decision", new=audit),
+    ):
+        promotion = asyncio.create_task(
+            auth_service._reconcile_verified_external_groups(identity=promoted, user=user, db=db)
+        )
+        await promotion_in_plugin.wait()
+        await auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=db)
+        assert authz.ingest_directory_membership_snapshot.await_count == 2
+        release_promotion.set()
+        await promotion
+
+        await auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=db)
+
+    assert authz.ingest_directory_membership_snapshot.await_count == 3, (
+        "the [devs] verdict cached before the promotion landed was served after it"
+    )
+    assert authz.ingest_directory_membership_snapshot.await_args_list[-1].kwargs["snapshot"].memberships == ("lf-devs",)
+
+
+@pytest.mark.anyio
+async def test_noop_pass_that_verified_a_superseded_state_is_not_remembered(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """A no-op verdict reached before a change landed must be discarded, not cached after it.
+
+    The old token's ``[devs]`` pass verifies the state and is held at commit.
+    The promotion then begins, changes the state and commits. When the held
+    pass resumes and tries to remember ``[devs]``, its verdict describes a
+    state the user has moved past and must be dropped.
+    """
+    from lfx.services.authorization import DirectoryMembershipIngestResult
+
+    auth_settings.EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS = 3600
+    user = _dummy_user(uuid4())
+    audit = AsyncMock()
+    developer = _external_identity({"groups": ["lf-devs"]})
+    promoted = _external_identity({"groups": ["lf-admins", "lf-devs"]})
+    developer_at_commit = asyncio.Event()
+    release_developer = asyncio.Event()
+
+    async def held_commit() -> None:
+        developer_at_commit.set()
+        await release_developer.wait()
+
+    held_db = AsyncMock()
+    held_db.commit = AsyncMock(side_effect=held_commit)
+    db = AsyncMock()
+
+    async def ingest(*, session, snapshot):  # noqa: ARG001
+        if snapshot.memberships == ("lf-admins", "lf-devs"):
+            return DirectoryMembershipIngestResult(changed=True, added=1)
+        return DirectoryMembershipIngestResult(changed=False)
+
+    authz = _DirectoryAuthorizationStub(result=None)
+    authz.ingest_directory_membership_snapshot = AsyncMock(side_effect=ingest)
+
+    with (
+        patch("langflow.services.deps.get_authorization_service", return_value=authz),
+        patch("langflow.services.authorization.audit.audit_decision", new=audit),
+    ):
+        held = asyncio.create_task(
+            auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=held_db)
+        )
+        await developer_at_commit.wait()
+        await auth_service._reconcile_verified_external_groups(identity=promoted, user=user, db=db)
+        assert authz.ingest_directory_membership_snapshot.await_count == 2
+        release_developer.set()
+        await held
+
+        await auth_service._reconcile_verified_external_groups(identity=developer, user=user, db=db)
+
+    assert authz.ingest_directory_membership_snapshot.await_count == 3, (
+        "a stale [devs] verdict was cached after the promotion had already landed"
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #14579, from QA verification of the LE-2109 reconciliation cache
(LE-2099, Rafael's 2026-08-15 comment). Everything else in that cache checked
out — 10 identical requests reconcile once plus one confirming pass, a
20-request page load reconciles zero times, a new group set reconciles at
once — but one direction did not: **revocation back to a group set that had
been cached earlier.**

## The defect

The cache was keyed by the exact directory state it verified, and entries were
only ever added and aged out by TTL. Nothing invalidated a user's other entries
when a reconciliation moved their state. So a group set that was cached, then
changed, then changed back still matched its old entry:

```
1) login with [lf-devs]           -> roles=developer
2) confirming pass                -> [lf-devs] cached
3) promotion to [lf-admins, lf-devs] -> roles=admin,developer   (reconciles: new key)
4) IdP revokes lf-admins, [lf-devs] again
     request 1..18               -> roles=admin,developer      (served from the step-2 entry)
     request 19 (60s later)      -> roles=developer
```

The plugin was never consulted during that window. The impact is bounded — the
cache is per-process so another replica reconciles the revocation immediately,
the window is capped by `LANGFLOW_EXTERNAL_AUTH_GROUP_RECONCILE_INTERVAL_SECONDS`
(default 60) and self-corrects, and `0` removes it — but it is a regression
against the pre-cache behaviour, in the one direction that must not be delayed,
and it contradicts what #14579 and the settings description promise: *"a group
set that differs from the last reconciled one always reconciles immediately."*

## The fix

`_DirectoryReconcileCache` now holds **one entry per user**: the last state a
confirming pass verified. A request is skipped only while that entry is fresh
*and* carries the same state, so any claim that differs from the last
reconciled state misses by construction — including a state that was itself
cached earlier and has since been moved past. That is Rafael's second
suggested shape, and it makes the settings description true as written.

Two further rules keep an entry from outliving the state it verified when
passes for one user overlap (an old and a new token in flight together on the
same process):

- **`begin()`** records a miss: it drops the user's entry, because the claim
  being reconciled supersedes it, and hands the pass a ticket. Only the pass
  holding the user's *latest* ticket may `remember()`.
- **`invalidate()`** runs right after a commit that changed the stored state:
  it drops the entry and revokes the outstanding ticket, so a concurrent no-op
  pass that verified the *previous* state can neither be served nor re-cache
  it after the change landed.

Both are per-user (an `OrderedDict` bounded like the entries), so first-login
churn for other users does not discard this user's cache. Everything #14579
established still holds: a pass that changed something is not cached until a
confirming pass runs, skipped requests still commit the JIT/profile
bookkeeping, and the interval setting means what it says. No EE change is
needed — the plugin is untouched; EE picks this up at its next `oss-version`
bump.

## Test plan

- [x] `test_group_revoked_after_promotion_reconciles_immediately` — Rafael's
  sequence end to end (login, confirming pass, promotion, revocation, cache
  resumes, second promotion). Fails against the current cache at the revocation
  step (`assert 3 == 4`), passes with the fix.
- [x] `test_revocation_reconciles_even_after_the_promotion_was_confirmed_and_cached`
  — both the earlier and the promoted state cached; the older must not win.
  Fails before, passes after.
- [x] `test_reconcile_cache_is_scoped_per_user` — one user's entry never evicts
  or leaks into another's.
- [x] `test_change_landing_after_a_concurrent_noop_pass_evicts_its_entry` and
  `test_noop_pass_that_verified_a_superseded_state_is_not_remembered` — the two
  overlapping-pass interleavings. Mutation-checked: disabling `invalidate()`
  fails exactly the first, ignoring the ticket fails exactly the second.
- [x] `pytest src/backend/tests/unit/services/auth src/backend/tests/unit/services/database/models/api_key/test_crud.py src/backend/tests/unit/test_login.py` — 229 passed
- [x] `ruff check` / `ruff format --check` clean
- [ ] Re-run the reporter's reproduction on PostgreSQL 16 with the default interval: after step 3, the first `[lf-devs]` request should answer `roles=developer` and the seam counter should show **1** plugin call for the revocation, not 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external group membership reconciliation so promotions and revocations take effect immediately.
  * Prevented outdated membership states from being served or cached during concurrent reconciliation.
  * Improved isolation so one user’s group changes do not affect another user’s access state.

* **Tests**
  * Added coverage for membership changes, per-user isolation, and concurrent reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->