### PR TITLE
fix(tests): finish the public build before closing the popup; widen the messages loading-state wait

### DIFF
--- a/src/frontend/tests/a11y/messages.a11y.spec.ts
+++ b/src/frontend/tests/a11y/messages.a11y.spec.ts
@@ -276,7 +276,15 @@ test.describe("Messages settings route accessibility", () => {
       await awaitBootstrapTest(page, { skipModal: true });
       await page.goto("/settings/messages");
 
-      await expect(page.getByRole("status", { name: "Loading" })).toBeVisible();
+      // A full goto reboots the app: after `load` it still has to run
+      // auto_login -> whoami -> config and pull the lazy settings route before
+      // SessionView mounts and this status renders. On Windows CI that chain
+      // takes 7s+ (nightly 31907290063, shard 24: the page mounted the messages
+      // query 1.4s and 1.7s after the default 5s expect gave up), so use the
+      // same budget the knowledge-bases loading scan already uses.
+      await expect(page.getByRole("status", { name: "Loading" })).toBeVisible({
+        timeout: TIMEOUTS.standard,
+      });
       await page.runA11yScan("settings-messages-loading");
       releaseResponse();
     },

--- a/src/frontend/tests/core/features/publish-flow.spec.ts
+++ b/src/frontend/tests/core/features/publish-flow.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { TID } from "../../utils/constants/testIds";
-import { TEXTS } from "../../utils/constants/texts";
 import { ANIMATIONS, TIMEOUTS } from "../../utils/constants/timeouts";
 import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
+import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
 
 test(
   "user should be able to publish a flow",
@@ -40,18 +40,16 @@ test(
     const newPage = await pagePromise;
     await newPage.waitForLoadState("domcontentloaded");
 
-    // Wait for the chat input to actually be present before filling. The
-    // default actionTimeout (20s) was not enough on Windows CI for the
-    // shareable-playground page to mount the message input.
-    await newPage
-      .getByPlaceholder(TEXTS.placeholderSendMessage)
-      .waitFor({ state: "visible", timeout: TIMEOUTS.long });
+    // Run the published flow to completion before leaving the page. The
+    // helper waits for the chat input (slow to mount on Windows CI), sends,
+    // and only returns once the Stop button has cleared. Closing the tab while
+    // the build was still in flight aborted the backend request mid-write; on
+    // SQLite that cancellation can leave a write transaction open until GC and
+    // stall every other writer, which is how the un-publish PATCH below hung
+    // for 10s+ (nightly 31907290063, shard 41). Waiting also proves the
+    // shareable playground actually completes a run.
+    await sendPlaygroundMessage(newPage, "Hello", { surface: "shareable" });
     const newUrl = newPage.url();
-    await newPage.getByPlaceholder(TEXTS.placeholderSendMessage).fill("Hello");
-    await newPage.getByTestId(TID.buttonSend).last().click();
-
-    const stopButton = newPage.getByRole("button", { name: TEXTS.stop });
-    await stopButton.waitFor({ state: "visible", timeout: TIMEOUTS.standard });
 
     await newPage.close();
     await page.bringToFront();


### PR DESCRIPTION
## Summary

Nightly [31907290063](https://github.com/langflow-ai/langflow/actions/runs/31907290063) (main @ b40b405e, first nightly after #14589) failed exactly two Playwright shards. Both are test-side, both diagnosed from the blob-report traces.

### Windows 24/70 — `messages.a11y.spec.ts` "scans the named loading state"

`expect(getByRole('status', {name: 'Loading'})).toBeVisible()` right after `page.goto("/settings/messages")` used the default 5s. The trace shows `goto` returning at `load` (18–24s Vite module storm), then `auto_login` (1.6–3.0s) → `whoami` → `config` → the lazy settings route; the messages query mounted **7.0s / 7.5s** after goto — 1.4s / 1.7s after the expect gave up. The aria snapshot at failure was the app-level `Loading...` boot page, not SessionView's status. Now uses `TIMEOUTS.standard`, which the identical held-response loading scan in `knowledge-bases.a11y` already uses.

### Linux 41/70 — `publish-flow.spec.ts`

The spec sent a message in the shareable-playground popup and called `newPage.close()` **30ms later**, while the public build was still in flight. Aborting that request mid-write made the backend terminate its aiosqlite connections under cancellation, and the trace + backend log show a ~60s window where **every SQLite writer stalled while reads kept answering in ms**:

- the un-publish `PATCH /flows/{id}` sent 0.5s after the close never answered (→ `toBeChecked({checked:false})` failed);
- the retry's `GET /auto_login` hung 34s+ so the app never booted (→ `mainpage_title` timeout);
- the sibling worker's `fresh start playground` build started 0.2s earlier took **71s** vs 0.66s for the identical send moments before;
- backend: `Exception terminating connection <aiosqlite …>` × 3 with `CancelledError … via BaseHTTPMiddleware call_next`, then `Task was destroyed but it is pending!` for `_terminate_graceful_close()` at 20:51:25 — right when the stall cleared (GC).

Fix: run the message through the shared `sendPlaygroundMessage(newPage, "Hello", { surface: "shareable" })`, which waits for the Stop button to appear *and clear* before returning, so the popup is only closed after the build completes. That removes the abort-mid-write trigger from this spec and also proves the published playground actually completes a run rather than merely starting one.

**Not addressed here (backend follow-up):** the underlying leak looks like a SQLAlchemy `terminate()` ↔ aiosqlite `stop()/close()` ordering race under persistent cancellation — the shielded graceful-close task nulls `_connection` before the busy worker thread reaches `close_and_stop`, which then skips `sqlite3.close()`, leaving an open write transaction alive until gen-2 GC. Real users closing a tab mid-build can hit the same stall; happy to write that up as an issue.

Both files are identical on `release-1.12.0`, so this cherry-picks cleanly.

## Test plan

- [x] `npx biome check` clean on both specs; `tsc` clean over both specs (temp config — `tsconfig.json`'s `include` skips `tests/`)
- [x] Local full-stack Playwright run: `messages.a11y "scans the named loading state"` ✓ 34.8s, `publish-flow "user should be able to publish a flow"` ✓ 43.7s
- [ ] CI shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved accessibility test reliability by allowing additional time for loading states during initialization.
  * Streamlined publish-flow test coverage for the shareable playground experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->