### PR TITLE
fix(tests): finish the public build before closing the popup; widen the messages loading-state wait (release-1.12.0)

### DIFF
--- a/src/frontend/tests/a11y/messages.a11y.spec.ts
+++ b/src/frontend/tests/a11y/messages.a11y.spec.ts
@@ -276,7 +276,15 @@ test.describe("Messages settings route accessibility", () => {
       await awaitBootstrapTest(page, { skipModal: true });
       await page.goto("/settings/messages");
 
-      await expect(page.getByRole("status", { name: "Loading" })).toBeVisible();
+      // A full goto reboots the app: after `load` it still has to run
+      // auto_login -> whoami -> config and pull the lazy settings route before
+      // SessionView mounts and this status renders. On Windows CI that chain
+      // takes 7s+ (nightly 31907290063, shard 24: the page mounted the messages
+      // query 1.4s and 1.7s after the default 5s expect gave up), so use the
+      // same budget the knowledge-bases loading scan already uses.
+      await expect(page.getByRole("status", { name: "Loading" })).toBeVisible({
+        timeout: TIMEOUTS.standard,
+      });
       await page.runA11yScan("settings-messages-loading");
       releaseResponse();
     },

--- a/src/frontend/tests/core/features/publish-flow.spec.ts
+++ b/src/frontend/tests/core/features/publish-flow.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { TID } from "../../utils/constants/testIds";
-import { TEXTS } from "../../utils/constants/texts";
 import { ANIMATIONS, TIMEOUTS } from "../../utils/constants/timeouts";
 import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
+import { sendPlaygroundMessage } from "../../utils/playground/send-playground-message";
 
 test(
   "user should be able to publish a flow",
@@ -40,18 +40,16 @@ test(
     const newPage = await pagePromise;
     await newPage.waitForLoadState("domcontentloaded");
 
-    // Wait for the chat input to actually be present before filling. The
-    // default actionTimeout (20s) was not enough on Windows CI for the
-    // shareable-playground page to mount the message input.
-    await newPage
-      .getByPlaceholder(TEXTS.placeholderSendMessage)
-      .waitFor({ state: "visible", timeout: TIMEOUTS.long });
+    // Run the published flow to completion before leaving the page. The
+    // helper waits for the chat input (slow to mount on Windows CI), sends,
+    // and only returns once the Stop button has cleared. Closing the tab while
+    // the build was still in flight aborted the backend request mid-write; on
+    // SQLite that cancellation can leave a write transaction open until GC and
+    // stall every other writer, which is how the un-publish PATCH below hung
+    // for 10s+ (nightly 31907290063, shard 41). Waiting also proves the
+    // shareable playground actually completes a run.
+    await sendPlaygroundMessage(newPage, "Hello", { surface: "shareable" });
     const newUrl = newPage.url();
-    await newPage.getByPlaceholder(TEXTS.placeholderSendMessage).fill("Hello");
-    await newPage.getByTestId(TID.buttonSend).last().click();
-
-    const stopButton = newPage.getByRole("button", { name: TEXTS.stop });
-    await stopButton.waitFor({ state: "visible", timeout: TIMEOUTS.standard });
 
     await newPage.close();
     await page.bringToFront();


### PR DESCRIPTION
## Summary

Clean cherry-pick of #14595 (main) onto `release-1.12.0` — same commit, no conflicts; both spec files were byte-identical between the branches.

Nightly [31907290063](https://github.com/langflow-ai/langflow/actions/runs/31907290063) failed exactly two Playwright shards, and the release branch has identical exposure (same `@release` suite, same SQLAlchemy 2.0.51 / aiosqlite 0.22.1, and #14593 already ported):

- **Windows 24/70 — `messages.a11y.spec.ts` "scans the named loading state"**: the expect right after `page.goto("/settings/messages")` used the default 5s; the trace shows the messages page mounting 7.0s / 7.5s after goto (post-`load` app boot: `auto_login` 1.6–3.0s → whoami → config → lazy route). Now `TIMEOUTS.standard`, matching the identical loading scan in `knowledge-bases.a11y`.
- **Linux 41/70 — `publish-flow.spec.ts`**: the spec closed the shareable-playground popup 30ms after sending, mid-build. Aborting that request mid-write left the backend with a ~60s window where every SQLite writer stalled while reads answered in ms (un-publish PATCH never answered; retry's `auto_login` hung 34s+; sibling worker's build took 71s vs 0.66s). Now runs the send through `sendPlaygroundMessage(newPage, "Hello", { surface: "shareable" })`, which waits for the Stop button to appear *and clear* before the popup closes — and asserts the published playground actually completes a run.

Full trace/backend-log analysis in #14595.

## Test plan

- [x] Cherry-pick applied without conflicts; biome clean
- [x] Same change verified locally on main against the full Playwright stack (both tests pass, 34.8s / 43.7s)
- [ ] CI shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of accessibility checks for message loading states by allowing sufficient time for the status to appear.
  * Strengthened publish-flow coverage by validating the complete shareable playground experience through the standard messaging flow.
  * Removed redundant test steps and unused configuration, making automated coverage more consistent and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->