### PR TITLE
feat(bundles): add Live Tennis API bundle with four free-tier components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ Documentation = "https://docs.langflow.org"
 
 [project.optional-dependencies]
 bundles = [
-    "lfx-bundles[all-no-torch]>=1.1.12,<2.0",
+    "lfx-bundles[all-no-torch]>=1.1.13,<2.0",
     "lfx-arxiv>=0.1.0,<1.0.0",
     "lfx-duckduckgo>=0.1.0,<1.0.0",
     "lfx-empiriolabs>=0.1.0,<1.0.0",

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_fixtures.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_fixtures.py
@@ -88,3 +88,37 @@ class TestLiveTennisFixturesComponent(ComponentTestBaseWithoutClient):
 
         assert len(results) == 1
         assert "error" in results[0].data
+
+    def test_http_error_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """An API error (e.g. 401) comes back as a single error Data row, not an exception."""
+        component = component_class(**default_kwargs)
+        mock_response = mock_httpx_client.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 401
+        mock_response.text = '{"error":"unauthorized"}'
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=mock_response
+        )
+
+        results = component.fetch_fixtures()
+
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+    def test_malformed_payload_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """A 200 response whose body is not the documented shape yields an error Data row."""
+        component = component_class(**default_kwargs)
+        mock_httpx_client.return_value.__enter__.return_value.get.return_value.json.return_value = None
+
+        results = component.fetch_fixtures()
+
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+    def test_limit_is_clamped_to_api_range(self, component_class, default_kwargs, mock_httpx_client):
+        """Out-of-range limit values are clamped to the API's 1-200 range."""
+        component = component_class(**{**default_kwargs, "limit": 0})
+
+        component.fetch_fixtures()
+
+        _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
+        assert kwargs["params"]["limit"] == 1

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_fixtures.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_fixtures.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx_bundles.livetennisapi.fixtures import LiveTennisFixturesComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestLiveTennisFixturesComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return LiveTennisFixturesComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "tour": "all",
+            "limit": 50,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        # New component, no version history yet.
+        return []
+
+    @pytest.fixture(autouse=True)
+    def mock_httpx_client(self):
+        """Keep every test offline, including the inherited test_latest_version."""
+        with patch("lfx_bundles.livetennisapi.fixtures.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [], "meta": {"count": 0}}
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            yield mock_client
+
+    def test_frontend_node(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+
+        frontend_node = component.to_frontend_node()
+
+        node_data = frontend_node["data"]["node"]
+        assert node_data["display_name"] == "Fixtures"
+        assert node_data["icon"] == "LiveTennisAPI"
+        assert node_data["template"]["api_key"]["password"] is True
+
+    def test_fetch_fixtures_success(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_get = mock_httpx_client.return_value.__enter__.return_value.get
+        mock_get.return_value.json.return_value = {
+            "data": [
+                {
+                    "id": 456,
+                    "event_date": "2026-08-17",
+                    "start_time": "2026-08-17T11:00:00Z",
+                    "tournament": "US Open",
+                    "round": "1st Round",
+                    "round_code": "R128",
+                    "tour": "atp",
+                    "surface": "hard",
+                    "player1_name": "Player One",
+                    "player1_id": 1,
+                    "player2_name": "Player Two",
+                    "player2_id": None,
+                    "status": "upcoming",
+                }
+            ],
+            "meta": {"count": 1},
+        }
+
+        results = component.fetch_fixtures()
+
+        assert len(results) == 1
+        row = results[0].data
+        assert row["id"] == 456
+        assert row["start_time"] == "2026-08-17T11:00:00Z"
+        assert row["player2_id"] is None
+        assert results[0].text == "Player One vs Player Two — US Open"
+
+    def test_timeout_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_httpx_client.return_value.__enter__.return_value.get.side_effect = httpx.TimeoutException("timeout")
+
+        results = component.fetch_fixtures()
+
+        assert len(results) == 1
+        assert "error" in results[0].data

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_live_matches.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_live_matches.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx_bundles.livetennisapi.live_matches import LiveTennisMatchesComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestLiveTennisMatchesComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return LiveTennisMatchesComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "match_status": "live",
+            "tour": "all",
+            "limit": 50,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        # New component, no version history yet.
+        return []
+
+    @pytest.fixture(autouse=True)
+    def mock_httpx_client(self):
+        """Keep every test offline, including the inherited test_latest_version."""
+        with patch("lfx_bundles.livetennisapi.live_matches.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [], "meta": {"count": 0}}
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            yield mock_client
+
+    def test_frontend_node(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+
+        frontend_node = component.to_frontend_node()
+
+        node_data = frontend_node["data"]["node"]
+        assert node_data["display_name"] == "Live Matches"
+        assert node_data["icon"] == "LiveTennisAPI"
+        assert "api_key" in node_data["template"]
+        assert node_data["template"]["api_key"]["password"] is True
+        assert node_data["template"]["match_status"]["options"] == ["live", "upcoming"]
+
+    def test_fetch_matches_success(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_get = mock_httpx_client.return_value.__enter__.return_value.get
+        mock_get.return_value.json.return_value = {
+            "data": [
+                {
+                    "id": 123,
+                    "status": "live",
+                    "tour": "atp",
+                    "tournament": "Cincinnati Open",
+                    "round": "Quarterfinal",
+                    "surface": "hard",
+                    "players": {
+                        "p1": {"id": 1, "name": "Player One", "country": "sui", "ranking": 3},
+                        "p2": {"id": 2, "name": "Player Two", "country": "esp", "ranking": 1},
+                    },
+                    "score": {
+                        "sets": [1, 0],
+                        "games": [[6, 3], [4, 2]],
+                        "points": ["30", "15"],
+                        "server": 1,
+                    },
+                }
+            ],
+            "meta": {"count": 1},
+        }
+
+        results = component.fetch_matches()
+
+        assert len(results) == 1
+        row = results[0].data
+        assert row["id"] == 123
+        assert row["player1"] == "Player One"
+        assert row["player2"] == "Player Two"
+        assert row["sets"] == "1-0"
+        assert row["games"] == "6-4 3-2"
+        assert row["points"] == "30-15"
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["status"] == "live"
+        assert "tour" not in kwargs["params"]
+        assert kwargs["headers"]["X-API-Key"] == "test-key"
+
+    def test_tour_filter_is_sent(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**{**default_kwargs, "tour": "wta"})
+
+        component.fetch_matches()
+
+        _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
+        assert kwargs["params"]["tour"] == "wta"
+
+    def test_http_error_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_response = mock_httpx_client.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 401
+        mock_response.text = '{"error":"unauthorized"}'
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=mock_response
+        )
+
+        results = component.fetch_matches()
+
+        assert len(results) == 1
+        assert "error" in results[0].data

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_live_matches.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_live_matches.py
@@ -114,3 +114,22 @@ class TestLiveTennisMatchesComponent(ComponentTestBaseWithoutClient):
 
         assert len(results) == 1
         assert "error" in results[0].data
+
+    def test_malformed_payload_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """A 200 response whose body is not the documented shape yields an error Data row."""
+        component = component_class(**default_kwargs)
+        mock_httpx_client.return_value.__enter__.return_value.get.return_value.json.return_value = {"data": "nope"}
+
+        results = component.fetch_matches()
+
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+    def test_limit_is_clamped_to_api_range(self, component_class, default_kwargs, mock_httpx_client):
+        """Out-of-range limit values are clamped to the API's 1-200 range."""
+        component = component_class(**{**default_kwargs, "limit": -5})
+
+        component.fetch_matches()
+
+        _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
+        assert kwargs["params"]["limit"] == 1

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_match_score.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_match_score.py
@@ -89,3 +89,12 @@ class TestLiveTennisMatchScoreComponent(ComponentTestBaseWithoutClient):
 
         assert "error" in result.data
         assert "not found" in result.text
+
+    def test_malformed_payload_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """A 200 response whose body is not a score object yields an error Data result."""
+        component = component_class(**default_kwargs)
+        mock_httpx_client.return_value.__enter__.return_value.get.return_value.json.return_value = [1, 2, 3]
+
+        result = component.fetch_score()
+
+        assert "error" in result.data

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_match_score.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_match_score.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx_bundles.livetennisapi.match_score import LiveTennisMatchScoreComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestLiveTennisMatchScoreComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return LiveTennisMatchScoreComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "match_id": "123",
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        # New component, no version history yet.
+        return []
+
+    @pytest.fixture(autouse=True)
+    def mock_httpx_client(self):
+        """Keep every test offline, including the inherited test_latest_version."""
+        with patch("lfx_bundles.livetennisapi.match_score.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {}
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            yield mock_client
+
+    def test_frontend_node(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+
+        frontend_node = component.to_frontend_node()
+
+        node_data = frontend_node["data"]["node"]
+        assert node_data["display_name"] == "Match Score"
+        assert node_data["icon"] == "LiveTennisAPI"
+        assert node_data["template"]["match_id"]["value"] == "123"
+
+    def test_fetch_score_success(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_get = mock_httpx_client.return_value.__enter__.return_value.get
+        mock_get.return_value.json.return_value = {
+            "sets": [1, 0],
+            "games": [[6, 3], [2, 1]],
+            "points": ["40", "30"],
+            "server": 2,
+            "is_tiebreak": False,
+            "timestamp": "2026-08-16T12:00:00Z",
+        }
+
+        result = component.fetch_score()
+
+        assert result.data["sets"] == [1, 0]
+        assert result.data["server"] == 2
+        assert "sets 1-0" in result.text
+        assert "games 6-2 3-1" in result.text
+
+        args, kwargs = mock_get.call_args
+        assert args[0].endswith("/matches/123/score")
+        assert kwargs["headers"]["X-API-Key"] == "test-key"
+
+    def test_non_integer_match_id_returns_error(self, component_class, default_kwargs):
+        component = component_class(**{**default_kwargs, "match_id": "not-a-number"})
+
+        result = component.fetch_score()
+
+        assert "error" in result.data
+
+    def test_not_found_returns_friendly_error(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_response = mock_httpx_client.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 404
+        mock_response.text = '{"error":"not_found"}'
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=mock_response
+        )
+
+        result = component.fetch_score()
+
+        assert "error" in result.data
+        assert "not found" in result.text

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_player_search.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_player_search.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 pytest.importorskip("lfx_bundles")
@@ -85,3 +86,37 @@ class TestLiveTennisPlayerSearchComponent(ComponentTestBaseWithoutClient):
 
         _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
         assert "search" not in kwargs["params"]
+
+    def test_http_error_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """An API error (e.g. 401) comes back as a single error Data row, not an exception."""
+        component = component_class(**default_kwargs)
+        mock_response = mock_httpx_client.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 401
+        mock_response.text = '{"error":"unauthorized"}'
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=mock_response
+        )
+
+        results = component.fetch_players()
+
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+    def test_malformed_payload_returns_error_data(self, component_class, default_kwargs, mock_httpx_client):
+        """A 200 response whose body is not the documented shape yields an error Data row."""
+        component = component_class(**default_kwargs)
+        mock_httpx_client.return_value.__enter__.return_value.get.return_value.json.return_value = ["not", "a", "dict"]
+
+        results = component.fetch_players()
+
+        assert len(results) == 1
+        assert "error" in results[0].data
+
+    def test_limit_is_clamped_to_api_range(self, component_class, default_kwargs, mock_httpx_client):
+        """Out-of-range limit values are clamped to the API's 1-200 range."""
+        component = component_class(**{**default_kwargs, "limit": 999})
+
+        component.fetch_players()
+
+        _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
+        assert kwargs["params"]["limit"] == 200

--- a/src/backend/tests/unit/components/bundles/livetennisapi/test_player_search.py
+++ b/src/backend/tests/unit/components/bundles/livetennisapi/test_player_search.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx_bundles.livetennisapi.player_search import LiveTennisPlayerSearchComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestLiveTennisPlayerSearchComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return LiveTennisPlayerSearchComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "test-key",
+            "search": "alcaraz",
+            "limit": 50,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        # New component, no version history yet.
+        return []
+
+    @pytest.fixture(autouse=True)
+    def mock_httpx_client(self):
+        """Keep every test offline, including the inherited test_latest_version."""
+        with patch("lfx_bundles.livetennisapi.player_search.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [], "meta": {"count": 0}}
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            yield mock_client
+
+    def test_frontend_node(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+
+        frontend_node = component.to_frontend_node()
+
+        node_data = frontend_node["data"]["node"]
+        assert node_data["display_name"] == "Player Search"
+        assert node_data["icon"] == "LiveTennisAPI"
+        assert node_data["template"]["search"]["value"] == "alcaraz"
+
+    def test_fetch_players_success(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**default_kwargs)
+        mock_get = mock_httpx_client.return_value.__enter__.return_value.get
+        mock_get.return_value.json.return_value = {
+            "data": [
+                {
+                    "id": 7,
+                    "name": "Carlos Alcaraz",
+                    "tour": "atp",
+                    "country": "esp",
+                    "ranking": 1,
+                    "ranking_points": 9000,
+                    "ranking_movement": "same",
+                    "hand": "R",
+                    "birthday": "2003-05-05",
+                    "is_doubles_team": False,
+                }
+            ],
+            "meta": {"count": 1},
+        }
+
+        results = component.fetch_players()
+
+        assert len(results) == 1
+        row = results[0].data
+        assert row["name"] == "Carlos Alcaraz"
+        assert row["ranking"] == 1
+        assert row["is_doubles_team"] is False
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["search"] == "alcaraz"
+
+    def test_empty_search_omits_param(self, component_class, default_kwargs, mock_httpx_client):
+        component = component_class(**{**default_kwargs, "search": ""})
+
+        component.fetch_players()
+
+        _, kwargs = mock_httpx_client.return_value.__enter__.return_value.get.call_args
+        assert "search" not in kwargs["params"]

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-bundles"
-version = "1.1.12"
+version = "1.1.13"
 description = "Langflow's long-tail provider bundles as a single manifest-less metapackage (the langchain-community model)."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -59,6 +59,7 @@ icosacomputing = ["requests>=2.32.0"]
 jigsawstack = ["jigsawstack==0.2.7"]
 langwatch = []
 litellm = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0"]
+livetennisapi = []
 lmstudio = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0", "langchain-nvidia-ai-endpoints~=1.0.0"]
 maritalk = ["langchain-community>=0.4.1,<1.0.0"]
 mem0 = ["mem0ai>=2.0.2,<3.0.0"]
@@ -128,6 +129,7 @@ all = [
     "lfx-bundles[jigsawstack]",
     "lfx-bundles[langwatch]",
     "lfx-bundles[litellm]",
+    "lfx-bundles[livetennisapi]",
     "lfx-bundles[lmstudio]",
     "lfx-bundles[maritalk]",
     "lfx-bundles[mem0]",
@@ -195,6 +197,7 @@ all-no-torch = [
     "lfx-bundles[jigsawstack]",
     "lfx-bundles[langwatch]",
     "lfx-bundles[litellm]",
+    "lfx-bundles[livetennisapi]",
     "lfx-bundles[lmstudio]",
     "lfx-bundles[maritalk]",
     "lfx-bundles[mem0]",

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/__init__.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/__init__.py
@@ -1,0 +1,11 @@
+from .fixtures import LiveTennisFixturesComponent
+from .live_matches import LiveTennisMatchesComponent
+from .match_score import LiveTennisMatchScoreComponent
+from .player_search import LiveTennisPlayerSearchComponent
+
+__all__ = [
+    "LiveTennisFixturesComponent",
+    "LiveTennisMatchScoreComponent",
+    "LiveTennisMatchesComponent",
+    "LiveTennisPlayerSearchComponent",
+]

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/fixtures.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/fixtures.py
@@ -1,0 +1,104 @@
+import httpx
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import DropdownInput, IntInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.template.field.base import Output
+
+BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+HTTP_TOO_MANY_REQUESTS = 429
+
+
+class LiveTennisFixturesComponent(Component):
+    display_name = "Fixtures"
+    description = "List upcoming scheduled tennis fixtures, earliest first, with tournament, round and start time."
+    documentation: str = "https://docs.livetennisapi.com"
+    icon = "LiveTennisAPI"
+    name = "LiveTennisFixtures"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Live Tennis API Key",
+            required=True,
+            info=(
+                "Your Live Tennis API key. The free tier covers live scores, players, "
+                "fixtures and usage (30 requests/minute, 100/day)."
+            ),
+        ),
+        DropdownInput(
+            name="tour",
+            display_name="Tour",
+            info="Restrict results to one tour. `all` returns every tour.",
+            options=["all", "atp", "wta", "challenger", "itf", "juniors"],
+            value="all",
+        ),
+        IntInput(
+            name="limit",
+            display_name="Max Results",
+            info="Maximum number of fixtures to return (1-200).",
+            value=50,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Fixtures", name="fixtures", method="fetch_fixtures_dataframe"),
+    ]
+
+    def fetch_fixtures(self) -> list[Data]:
+        try:
+            params: dict = {"limit": self.limit}
+            if self.tour and self.tour != "all":
+                params["tour"] = self.tour
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{BASE_URL}/fixtures",
+                    params=params,
+                    headers={"X-API-Key": self.api_key, "accept": "application/json"},
+                )
+            response.raise_for_status()
+            payload = response.json()
+
+            results = []
+            for fixture in payload.get("data", []):
+                row = {
+                    "id": fixture.get("id"),
+                    "event_date": fixture.get("event_date"),
+                    "start_time": fixture.get("start_time"),
+                    "tournament": fixture.get("tournament"),
+                    "round": fixture.get("round"),
+                    "round_code": fixture.get("round_code"),
+                    "tour": fixture.get("tour"),
+                    "surface": fixture.get("surface"),
+                    "player1_name": fixture.get("player1_name"),
+                    "player1_id": fixture.get("player1_id"),
+                    "player2_name": fixture.get("player2_name"),
+                    "player2_id": fixture.get("player2_id"),
+                    "status": fixture.get("status"),
+                }
+                summary = f"{row.get('player1_name')} vs {row.get('player2_name')} — {row.get('tournament')}"
+                results.append(Data(text=summary, data=row))
+        except httpx.TimeoutException:
+            error_message = "Request timed out (30s). Please try again."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except httpx.HTTPStatusError as exc:
+            error_message = f"HTTP error occurred: {exc.response.status_code} - {exc.response.text}"
+            if exc.response.status_code == HTTP_TOO_MANY_REQUESTS:
+                error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except (httpx.RequestError, ValueError) as exc:
+            error_message = f"Request error occurred: {exc}"
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        else:
+            self.status = results
+            return results
+
+    def fetch_fixtures_dataframe(self) -> DataFrame:
+        data = self.fetch_fixtures()
+        return DataFrame(data)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/fixtures.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/fixtures.py
@@ -8,6 +8,21 @@ from lfx.template.field.base import Output
 
 BASE_URL = "https://api.livetennisapi.com/api/public/v1"
 HTTP_TOO_MANY_REQUESTS = 429
+MIN_LIMIT = 1
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+
+
+def _validated_items(payload: object) -> list[dict]:
+    """Return the list under ``data``, or raise ``TypeError`` on a malformed 200 payload."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        msg = "Live Tennis API returned an unexpected response shape (expected an object with a 'data' list)."
+        raise TypeError(msg)
+    items = payload["data"]
+    if not all(isinstance(item, dict) for item in items):
+        msg = "Live Tennis API returned a malformed 'data' entry (expected objects)."
+        raise TypeError(msg)
+    return items
 
 
 class LiveTennisFixturesComponent(Component):
@@ -37,7 +52,7 @@ class LiveTennisFixturesComponent(Component):
         IntInput(
             name="limit",
             display_name="Max Results",
-            info="Maximum number of fixtures to return (1-200).",
+            info="Maximum number of fixtures to return (1-200). Out-of-range values are clamped.",
             value=50,
             advanced=True,
         ),
@@ -47,9 +62,18 @@ class LiveTennisFixturesComponent(Component):
         Output(display_name="Fixtures", name="fixtures", method="fetch_fixtures_dataframe"),
     ]
 
-    def fetch_fixtures(self) -> list[Data]:
+    def _clamped_limit(self) -> int:
+        """Clamp the limit input to the API's documented 1-200 range."""
         try:
-            params: dict = {"limit": self.limit}
+            limit = int(self.limit)
+        except (TypeError, ValueError):
+            return DEFAULT_LIMIT
+        return max(MIN_LIMIT, min(MAX_LIMIT, limit))
+
+    def fetch_fixtures(self) -> list[Data]:
+        """Call ``GET /fixtures`` and return one ``Data`` row per fixture, or a single error row."""
+        try:
+            params: dict = {"limit": self._clamped_limit()}
             if self.tour and self.tour != "all":
                 params["tour"] = self.tour
 
@@ -60,10 +84,9 @@ class LiveTennisFixturesComponent(Component):
                     headers={"X-API-Key": self.api_key, "accept": "application/json"},
                 )
             response.raise_for_status()
-            payload = response.json()
 
             results = []
-            for fixture in payload.get("data", []):
+            for fixture in _validated_items(response.json()):
                 row = {
                     "id": fixture.get("id"),
                     "event_date": fixture.get("event_date"),
@@ -91,7 +114,7 @@ class LiveTennisFixturesComponent(Component):
                 error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ValueError, TypeError) as exc:
             error_message = f"Request error occurred: {exc}"
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
@@ -100,5 +123,6 @@ class LiveTennisFixturesComponent(Component):
             return results
 
     def fetch_fixtures_dataframe(self) -> DataFrame:
+        """Return the fixtures as a ``DataFrame`` (one row per fixture)."""
         data = self.fetch_fixtures()
         return DataFrame(data)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/live_matches.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/live_matches.py
@@ -1,0 +1,144 @@
+import httpx
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import DropdownInput, IntInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.template.field.base import Output
+
+BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+HTTP_TOO_MANY_REQUESTS = 429
+PLAYERS_PER_MATCH = 2
+
+
+class LiveTennisMatchesComponent(Component):
+    display_name = "Live Matches"
+    description = (
+        "List live or upcoming tennis matches across ATP, WTA, Challenger, ITF "
+        "and juniors, with the current score on each match."
+    )
+    documentation: str = "https://docs.livetennisapi.com"
+    icon = "LiveTennisAPI"
+    name = "LiveTennisMatches"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Live Tennis API Key",
+            required=True,
+            info=(
+                "Your Live Tennis API key. The free tier covers live scores, players, "
+                "fixtures and usage (30 requests/minute, 100/day)."
+            ),
+        ),
+        DropdownInput(
+            name="match_status",
+            display_name="Status",
+            info=(
+                "Match lifecycle status. `live` and `upcoming` are available on the "
+                "free tier; completed-match history is a separate paid surface and "
+                "is not offered by this component."
+            ),
+            options=["live", "upcoming"],
+            value="live",
+        ),
+        DropdownInput(
+            name="tour",
+            display_name="Tour",
+            info="Restrict results to one tour. `all` returns every tour.",
+            options=["all", "atp", "wta", "challenger", "itf", "juniors"],
+            value="all",
+            advanced=True,
+        ),
+        IntInput(
+            name="limit",
+            display_name="Max Results",
+            info="Maximum number of matches to return (1-200).",
+            value=50,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Matches", name="matches", method="fetch_matches_dataframe"),
+    ]
+
+    def _flatten_match(self, match: dict) -> dict:
+        players = match.get("players") or {}
+        p1 = players.get("p1") or {}
+        p2 = players.get("p2") or {}
+        score = match.get("score") or {}
+        sets = score.get("sets") or []
+        games = score.get("games") or []
+        points = score.get("points") or []
+
+        games_str = None
+        if len(games) == PLAYERS_PER_MATCH and games[0]:
+            games_str = " ".join(f"{g1}-{g2}" for g1, g2 in zip(games[0], games[1], strict=False))
+
+        return {
+            "id": match.get("id"),
+            "status": match.get("status"),
+            "tour": match.get("tour"),
+            "tournament": match.get("tournament"),
+            "tournament_id": match.get("tournament_id"),
+            "round": match.get("round"),
+            "surface": match.get("surface"),
+            "format": match.get("format"),
+            "is_doubles": match.get("is_doubles"),
+            "scheduled_time": match.get("scheduled_time"),
+            "player1": p1.get("name"),
+            "player1_id": p1.get("id"),
+            "player1_country": p1.get("country"),
+            "player1_ranking": p1.get("ranking"),
+            "player2": p2.get("name"),
+            "player2_id": p2.get("id"),
+            "player2_country": p2.get("country"),
+            "player2_ranking": p2.get("ranking"),
+            "sets": "-".join(str(s) for s in sets) if sets else None,
+            "games": games_str,
+            "points": "-".join(str(p) for p in points) if points else None,
+            "server": score.get("server"),
+        }
+
+    def fetch_matches(self) -> list[Data]:
+        try:
+            params: dict = {"status": self.match_status, "limit": self.limit}
+            if self.tour and self.tour != "all":
+                params["tour"] = self.tour
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{BASE_URL}/matches",
+                    params=params,
+                    headers={"X-API-Key": self.api_key, "accept": "application/json"},
+                )
+            response.raise_for_status()
+            payload = response.json()
+
+            results = []
+            for match in payload.get("data", []):
+                row = self._flatten_match(match)
+                summary = f"{row.get('player1')} vs {row.get('player2')} — {row.get('tournament')}"
+                results.append(Data(text=summary, data=row))
+        except httpx.TimeoutException:
+            error_message = "Request timed out (30s). Please try again."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except httpx.HTTPStatusError as exc:
+            error_message = f"HTTP error occurred: {exc.response.status_code} - {exc.response.text}"
+            if exc.response.status_code == HTTP_TOO_MANY_REQUESTS:
+                error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except (httpx.RequestError, ValueError) as exc:
+            error_message = f"Request error occurred: {exc}"
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        else:
+            self.status = results
+            return results
+
+    def fetch_matches_dataframe(self) -> DataFrame:
+        data = self.fetch_matches()
+        return DataFrame(data)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/live_matches.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/live_matches.py
@@ -9,6 +9,21 @@ from lfx.template.field.base import Output
 BASE_URL = "https://api.livetennisapi.com/api/public/v1"
 HTTP_TOO_MANY_REQUESTS = 429
 PLAYERS_PER_MATCH = 2
+MIN_LIMIT = 1
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+
+
+def _validated_items(payload: object) -> list[dict]:
+    """Return the list under ``data``, or raise ``TypeError`` on a malformed 200 payload."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        msg = "Live Tennis API returned an unexpected response shape (expected an object with a 'data' list)."
+        raise TypeError(msg)
+    items = payload["data"]
+    if not all(isinstance(item, dict) for item in items):
+        msg = "Live Tennis API returned a malformed 'data' entry (expected objects)."
+        raise TypeError(msg)
+    return items
 
 
 class LiveTennisMatchesComponent(Component):
@@ -53,7 +68,7 @@ class LiveTennisMatchesComponent(Component):
         IntInput(
             name="limit",
             display_name="Max Results",
-            info="Maximum number of matches to return (1-200).",
+            info="Maximum number of matches to return (1-200). Out-of-range values are clamped.",
             value=50,
             advanced=True,
         ),
@@ -63,7 +78,16 @@ class LiveTennisMatchesComponent(Component):
         Output(display_name="Matches", name="matches", method="fetch_matches_dataframe"),
     ]
 
+    def _clamped_limit(self) -> int:
+        """Clamp the limit input to the API's documented 1-200 range."""
+        try:
+            limit = int(self.limit)
+        except (TypeError, ValueError):
+            return DEFAULT_LIMIT
+        return max(MIN_LIMIT, min(MAX_LIMIT, limit))
+
     def _flatten_match(self, match: dict) -> dict:
+        """Flatten one match object into a single-level row for the DataFrame output."""
         players = match.get("players") or {}
         p1 = players.get("p1") or {}
         p2 = players.get("p2") or {}
@@ -102,8 +126,9 @@ class LiveTennisMatchesComponent(Component):
         }
 
     def fetch_matches(self) -> list[Data]:
+        """Call ``GET /matches`` and return one ``Data`` row per match, or a single error row."""
         try:
-            params: dict = {"status": self.match_status, "limit": self.limit}
+            params: dict = {"status": self.match_status, "limit": self._clamped_limit()}
             if self.tour and self.tour != "all":
                 params["tour"] = self.tour
 
@@ -114,10 +139,9 @@ class LiveTennisMatchesComponent(Component):
                     headers={"X-API-Key": self.api_key, "accept": "application/json"},
                 )
             response.raise_for_status()
-            payload = response.json()
 
             results = []
-            for match in payload.get("data", []):
+            for match in _validated_items(response.json()):
                 row = self._flatten_match(match)
                 summary = f"{row.get('player1')} vs {row.get('player2')} — {row.get('tournament')}"
                 results.append(Data(text=summary, data=row))
@@ -131,7 +155,7 @@ class LiveTennisMatchesComponent(Component):
                 error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ValueError, TypeError) as exc:
             error_message = f"Request error occurred: {exc}"
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
@@ -140,5 +164,6 @@ class LiveTennisMatchesComponent(Component):
             return results
 
     def fetch_matches_dataframe(self) -> DataFrame:
+        """Return the matches as a ``DataFrame`` (one row per match)."""
         data = self.fetch_matches()
         return DataFrame(data)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/match_score.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/match_score.py
@@ -11,6 +11,14 @@ HTTP_TOO_MANY_REQUESTS = 429
 PLAYERS_PER_MATCH = 2
 
 
+def _validated_score(payload: object) -> dict:
+    """Return the decoded score object, or raise ``TypeError`` on a malformed 200 payload."""
+    if not isinstance(payload, dict):
+        msg = "Live Tennis API returned an unexpected response shape (expected a score object)."
+        raise TypeError(msg)
+    return payload
+
+
 class LiveTennisMatchScoreComponent(Component):
     display_name = "Match Score"
     description = "Get the current score of one match — sets, games, in-game points and who is serving."
@@ -42,6 +50,7 @@ class LiveTennisMatchScoreComponent(Component):
     ]
 
     def fetch_score(self) -> Data:
+        """Call ``GET /matches/{id}/score`` and return the score snapshot as ``Data``."""
         try:
             match_id = int(str(self.match_id).strip())
         except (TypeError, ValueError):
@@ -56,7 +65,7 @@ class LiveTennisMatchScoreComponent(Component):
                     headers={"X-API-Key": self.api_key, "accept": "application/json"},
                 )
             response.raise_for_status()
-            score = response.json()
+            score = _validated_score(response.json())
 
             games = score.get("games") or []
             games_str = None
@@ -83,7 +92,7 @@ class LiveTennisMatchScoreComponent(Component):
                 error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
             logger.error(error_message)
             return Data(text=error_message, data={"error": error_message})
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ValueError, TypeError) as exc:
             error_message = f"Request error occurred: {exc}"
             logger.error(error_message)
             return Data(text=error_message, data={"error": error_message})

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/match_score.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/match_score.py
@@ -1,0 +1,92 @@
+import httpx
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import MessageTextInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+from lfx.template.field.base import Output
+
+BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+HTTP_NOT_FOUND = 404
+HTTP_TOO_MANY_REQUESTS = 429
+PLAYERS_PER_MATCH = 2
+
+
+class LiveTennisMatchScoreComponent(Component):
+    display_name = "Match Score"
+    description = "Get the current score of one match — sets, games, in-game points and who is serving."
+    documentation: str = "https://docs.livetennisapi.com"
+    icon = "LiveTennisAPI"
+    name = "LiveTennisMatchScore"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Live Tennis API Key",
+            required=True,
+            info=(
+                "Your Live Tennis API key. The free tier covers live scores, players, "
+                "fixtures and usage (30 requests/minute, 100/day)."
+            ),
+        ),
+        MessageTextInput(
+            name="match_id",
+            display_name="Match ID",
+            required=True,
+            info="The match id — the `id` field on any match returned by the Live Matches or Fixtures component.",
+            tool_mode=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Score", name="score", method="fetch_score"),
+    ]
+
+    def fetch_score(self) -> Data:
+        try:
+            match_id = int(str(self.match_id).strip())
+        except (TypeError, ValueError):
+            error_message = f"Match ID must be an integer, got: {self.match_id!r}"
+            logger.error(error_message)
+            return Data(text=error_message, data={"error": error_message})
+
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{BASE_URL}/matches/{match_id}/score",
+                    headers={"X-API-Key": self.api_key, "accept": "application/json"},
+                )
+            response.raise_for_status()
+            score = response.json()
+
+            games = score.get("games") or []
+            games_str = None
+            if len(games) == PLAYERS_PER_MATCH and games[0]:
+                games_str = " ".join(f"{g1}-{g2}" for g1, g2 in zip(games[0], games[1], strict=False))
+            sets = score.get("sets") or []
+            summary_parts = []
+            if sets:
+                summary_parts.append("sets " + "-".join(str(s) for s in sets))
+            if games_str:
+                summary_parts.append("games " + games_str)
+            summary = ", ".join(summary_parts) or "No score available"
+
+            result = Data(text=summary, data=score)
+        except httpx.TimeoutException:
+            error_message = "Request timed out (30s). Please try again."
+            logger.error(error_message)
+            return Data(text=error_message, data={"error": error_message})
+        except httpx.HTTPStatusError as exc:
+            error_message = f"HTTP error occurred: {exc.response.status_code} - {exc.response.text}"
+            if exc.response.status_code == HTTP_NOT_FOUND:
+                error_message = f"Match {match_id} was not found."
+            elif exc.response.status_code == HTTP_TOO_MANY_REQUESTS:
+                error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
+            logger.error(error_message)
+            return Data(text=error_message, data={"error": error_message})
+        except (httpx.RequestError, ValueError) as exc:
+            error_message = f"Request error occurred: {exc}"
+            logger.error(error_message)
+            return Data(text=error_message, data={"error": error_message})
+        else:
+            self.status = result
+            return result

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/player_search.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/player_search.py
@@ -1,0 +1,102 @@
+import httpx
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import IntInput, MessageTextInput, SecretStrInput
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.template.field.base import Output
+
+BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+HTTP_TOO_MANY_REQUESTS = 429
+
+
+class LiveTennisPlayerSearchComponent(Component):
+    display_name = "Player Search"
+    description = (
+        "Search tennis players by name across ATP, WTA, Challenger, ITF and "
+        "juniors. Returns bio, country and current ranking, ranked players first."
+    )
+    documentation: str = "https://docs.livetennisapi.com"
+    icon = "LiveTennisAPI"
+    name = "LiveTennisPlayerSearch"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Live Tennis API Key",
+            required=True,
+            info=(
+                "Your Live Tennis API key. The free tier covers live scores, players, "
+                "fixtures and usage (30 requests/minute, 100/day)."
+            ),
+        ),
+        MessageTextInput(
+            name="search",
+            display_name="Search",
+            info="Player name to search for. Leave empty to list players, ranked first.",
+            tool_mode=True,
+        ),
+        IntInput(
+            name="limit",
+            display_name="Max Results",
+            info="Maximum number of players to return (1-200).",
+            value=50,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Players", name="players", method="fetch_players_dataframe"),
+    ]
+
+    def fetch_players(self) -> list[Data]:
+        try:
+            params: dict = {"limit": self.limit}
+            if self.search:
+                params["search"] = self.search
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{BASE_URL}/players",
+                    params=params,
+                    headers={"X-API-Key": self.api_key, "accept": "application/json"},
+                )
+            response.raise_for_status()
+            payload = response.json()
+
+            results = []
+            for player in payload.get("data", []):
+                row = {
+                    "id": player.get("id"),
+                    "name": player.get("name"),
+                    "tour": player.get("tour"),
+                    "country": player.get("country"),
+                    "ranking": player.get("ranking"),
+                    "ranking_points": player.get("ranking_points"),
+                    "ranking_movement": player.get("ranking_movement"),
+                    "hand": player.get("hand"),
+                    "birthday": player.get("birthday"),
+                    "is_doubles_team": player.get("is_doubles_team"),
+                }
+                results.append(Data(text=str(row.get("name")), data=row))
+        except httpx.TimeoutException:
+            error_message = "Request timed out (30s). Please try again."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except httpx.HTTPStatusError as exc:
+            error_message = f"HTTP error occurred: {exc.response.status_code} - {exc.response.text}"
+            if exc.response.status_code == HTTP_TOO_MANY_REQUESTS:
+                error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        except (httpx.RequestError, ValueError) as exc:
+            error_message = f"Request error occurred: {exc}"
+            logger.error(error_message)
+            return [Data(text=error_message, data={"error": error_message})]
+        else:
+            self.status = results
+            return results
+
+    def fetch_players_dataframe(self) -> DataFrame:
+        data = self.fetch_players()
+        return DataFrame(data)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/player_search.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/player_search.py
@@ -8,6 +8,21 @@ from lfx.template.field.base import Output
 
 BASE_URL = "https://api.livetennisapi.com/api/public/v1"
 HTTP_TOO_MANY_REQUESTS = 429
+MIN_LIMIT = 1
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+
+
+def _validated_items(payload: object) -> list[dict]:
+    """Return the list under ``data``, or raise ``TypeError`` on a malformed 200 payload."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        msg = "Live Tennis API returned an unexpected response shape (expected an object with a 'data' list)."
+        raise TypeError(msg)
+    items = payload["data"]
+    if not all(isinstance(item, dict) for item in items):
+        msg = "Live Tennis API returned a malformed 'data' entry (expected objects)."
+        raise TypeError(msg)
+    return items
 
 
 class LiveTennisPlayerSearchComponent(Component):
@@ -39,7 +54,7 @@ class LiveTennisPlayerSearchComponent(Component):
         IntInput(
             name="limit",
             display_name="Max Results",
-            info="Maximum number of players to return (1-200).",
+            info="Maximum number of players to return (1-200). Out-of-range values are clamped.",
             value=50,
             advanced=True,
         ),
@@ -49,9 +64,18 @@ class LiveTennisPlayerSearchComponent(Component):
         Output(display_name="Players", name="players", method="fetch_players_dataframe"),
     ]
 
-    def fetch_players(self) -> list[Data]:
+    def _clamped_limit(self) -> int:
+        """Clamp the limit input to the API's documented 1-200 range."""
         try:
-            params: dict = {"limit": self.limit}
+            limit = int(self.limit)
+        except (TypeError, ValueError):
+            return DEFAULT_LIMIT
+        return max(MIN_LIMIT, min(MAX_LIMIT, limit))
+
+    def fetch_players(self) -> list[Data]:
+        """Call ``GET /players`` and return one ``Data`` row per player, or a single error row."""
+        try:
+            params: dict = {"limit": self._clamped_limit()}
             if self.search:
                 params["search"] = self.search
 
@@ -62,10 +86,9 @@ class LiveTennisPlayerSearchComponent(Component):
                     headers={"X-API-Key": self.api_key, "accept": "application/json"},
                 )
             response.raise_for_status()
-            payload = response.json()
 
             results = []
-            for player in payload.get("data", []):
+            for player in _validated_items(response.json()):
                 row = {
                     "id": player.get("id"),
                     "name": player.get("name"),
@@ -89,7 +112,7 @@ class LiveTennisPlayerSearchComponent(Component):
                 error_message = "Rate limited. The free tier allows 30 requests/minute and 100/day."
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ValueError, TypeError) as exc:
             error_message = f"Request error occurred: {exc}"
             logger.error(error_message)
             return [Data(text=error_message, data={"error": error_message})]
@@ -98,5 +121,6 @@ class LiveTennisPlayerSearchComponent(Component):
             return results
 
     def fetch_players_dataframe(self) -> DataFrame:
+        """Return the players as a ``DataFrame`` (one row per player)."""
         data = self.fetch_players()
         return DataFrame(data)

--- a/src/frontend/src/icons/LiveTennisAPI/LiveTennisAPIIcon.jsx
+++ b/src/frontend/src/icons/LiveTennisAPI/LiveTennisAPIIcon.jsx
@@ -1,0 +1,27 @@
+const LiveTennisAPIIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <rect width="24" height="24" rx="6" fill="#0E0E0E" />
+    <circle cx="12" cy="12" r="7" stroke="#00FF41" strokeWidth="1.5" />
+    <path
+      d="M7.05 7.05 A8 8 0 0 1 7.05 16.95"
+      stroke="#00FF41"
+      strokeWidth="1.5"
+      fill="none"
+    />
+    <path
+      d="M16.95 7.05 A8 8 0 0 0 16.95 16.95"
+      stroke="#00FF41"
+      strokeWidth="1.5"
+      fill="none"
+    />
+  </svg>
+);
+
+export default LiveTennisAPIIcon;

--- a/src/frontend/src/icons/LiveTennisAPI/LiveTennisAPIIcon.jsx
+++ b/src/frontend/src/icons/LiveTennisAPI/LiveTennisAPIIcon.jsx
@@ -1,4 +1,4 @@
-const LiveTennisAPIIcon = (props) => (
+const LiveTennisAPIIcon = ({ isDark, ...props }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={24}
@@ -7,7 +7,7 @@ const LiveTennisAPIIcon = (props) => (
     fill="none"
     {...props}
   >
-    <rect width="24" height="24" rx="6" fill="#0E0E0E" />
+    <rect width="24" height="24" rx="6" fill={isDark ? "#1F2428" : "#0E0E0E"} />
     <circle cx="12" cy="12" r="7" stroke="#00FF41" strokeWidth="1.5" />
     <path
       d="M7.05 7.05 A8 8 0 0 1 7.05 16.95"

--- a/src/frontend/src/icons/LiveTennisAPI/index.tsx
+++ b/src/frontend/src/icons/LiveTennisAPI/index.tsx
@@ -1,12 +1,14 @@
 import type React from "react";
 import { forwardRef } from "react";
+import { useDarkStore } from "@/stores/darkStore";
 import LiveTennisAPISVG from "./LiveTennisAPIIcon";
 
 export const LiveTennisAPIIcon = forwardRef<
   SVGSVGElement,
   React.PropsWithChildren<{}>
 >((props, ref) => {
-  return <LiveTennisAPISVG ref={ref} {...props} />;
+  const isDark = useDarkStore((state) => state.dark);
+  return <LiveTennisAPISVG ref={ref} isDark={isDark} {...props} />;
 });
 
 export default LiveTennisAPIIcon;

--- a/src/frontend/src/icons/LiveTennisAPI/index.tsx
+++ b/src/frontend/src/icons/LiveTennisAPI/index.tsx
@@ -1,0 +1,12 @@
+import type React from "react";
+import { forwardRef } from "react";
+import LiveTennisAPISVG from "./LiveTennisAPIIcon";
+
+export const LiveTennisAPIIcon = forwardRef<
+  SVGSVGElement,
+  React.PropsWithChildren<{}>
+>((props, ref) => {
+  return <LiveTennisAPISVG ref={ref} {...props} />;
+});
+
+export default LiveTennisAPIIcon;

--- a/src/frontend/src/icons/LiveTennisAPI/livetennisapi-icon.svg
+++ b/src/frontend/src/icons/LiveTennisAPI/livetennisapi-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="6" fill="#0E0E0E"/>
+  <circle cx="12" cy="12" r="7" stroke="#00FF41" stroke-width="1.5"/>
+  <path d="M7.05 7.05 A8 8 0 0 1 7.05 16.95" stroke="#00FF41" stroke-width="1.5" fill="none"/>
+  <path d="M16.95 7.05 A8 8 0 0 0 16.95 16.95" stroke="#00FF41" stroke-width="1.5" fill="none"/>
+</svg>

--- a/src/frontend/src/icons/lazyIconImports.ts
+++ b/src/frontend/src/icons/lazyIconImports.ts
@@ -333,6 +333,10 @@ export const lazyIconsMapping = {
     import("@/icons/Listennotes").then((mod) => ({
       default: mod.ListennotesIcon,
     })),
+  LiveTennisAPI: () =>
+    import("@/icons/LiveTennisAPI").then((mod) => ({
+      default: mod.LiveTennisAPIIcon,
+    })),
   Maritalk: () =>
     import("@/icons/Maritalk").then((mod) => ({ default: mod.MaritalkIcon })),
   Mcp: () => import("@/icons/MCP").then((mod) => ({ default: mod.McpIcon })),

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -479,6 +479,11 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "LangChain", name: "langchain_utilities", icon: "LangChain" },
   { display_name: "LangWatch", name: "langwatch", icon: "Langwatch" },
   { display_name: "LiteLLM", name: "litellm", icon: "LiteLLM" },
+  {
+    display_name: "Live Tennis API",
+    name: "livetennisapi",
+    icon: "LiveTennisAPI",
+  },
   { display_name: "LMStudio", name: "lmstudio", icon: "LMStudio" },
   { display_name: "MariTalk", name: "maritalk", icon: "Maritalk" },
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -4910,6 +4910,26 @@
       "legacy_slot": "ext:valkey:ValkeyIndexChatMemory@official-pre-a",
       "target": "ext:valkey:ValkeyIndexChatMemory@official",
       "added_in": "1.11.0"
+    },
+    {
+      "bare_class_name": "LiveTennisMatchesComponent",
+      "target": "ext:livetennisapi:LiveTennisMatchesComponent@official",
+      "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "LiveTennisFixturesComponent",
+      "target": "ext:livetennisapi:LiveTennisFixturesComponent@official",
+      "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "LiveTennisPlayerSearchComponent",
+      "target": "ext:livetennisapi:LiveTennisPlayerSearchComponent@official",
+      "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "LiveTennisMatchScoreComponent",
+      "target": "ext:livetennisapi:LiveTennisMatchScoreComponent@official",
+      "added_in": "1.12.0"
     }
   ],
   "ambiguous_bare_names": [

--- a/uv.lock
+++ b/uv.lock
@@ -9316,7 +9316,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-bundles"
-version = "1.1.12"
+version = "1.1.13"
 source = { editable = "src/bundles/lfx-bundles" }
 dependencies = [
     { name = "lfx" },
@@ -9826,6 +9826,8 @@ requires-dist = [
     { name = "lfx-bundles", extras = ["langwatch"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["litellm"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["litellm"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
+    { name = "lfx-bundles", extras = ["livetennisapi"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
+    { name = "lfx-bundles", extras = ["livetennisapi"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["lmstudio"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["lmstudio"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["maritalk"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
@@ -9942,7 +9944,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "perplexity", "pgvector", "pinecone", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
+provides-extras = ["agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "livetennisapi", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "perplexity", "pgvector", "pinecone", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
 
 [[package]]
 name = "lfx-cohere"


### PR DESCRIPTION
Disclosure: I maintain the Live Tennis API.

This PR adds a new `livetennisapi` provider to the `lfx-bundles` metapackage, wrapping the [Live Tennis API](https://docs.livetennisapi.com) — real-time tennis scores, fixtures and player data across ATP, WTA, Challenger, ITF and juniors.

## Components

All four components are deliberately scoped to the **free tier** (keyed, 30 req/min / 100 req/day), so reviewers can test end-to-end with a self-serve key and no card:

- **Live Matches** — `GET /matches` with `status=live|upcoming` and an optional tour filter; each row carries the current sets/games/points.
- **Fixtures** — `GET /fixtures`, upcoming scheduled matches, earliest first.
- **Player Search** — `GET /players?search=`, name lookup with country, ranking and bio fields (`tool_mode` on the search input for agent use).
- **Match Score** — `GET /matches/{id}/score`, the lowest-latency score snapshot for one match id (`tool_mode` on the id input).

Paid surfaces (completed-match history, market prices, win probability, WebSocket) are intentionally not included.

## Implementation notes

- Provider folder at `src/bundles/lfx-bundles/src/lfx_bundles/livetennisapi/` per the metapackage's manifest-less folder-walk model (the in-tree `lfx/components/` path from the contributing guide is frozen since the bundle split — the freeze gate pointed here).
- Empty `livetennisapi` extra (httpx only, already an lfx core dep), added to `all`/`all-no-torch` in the generated form; `lfx-bundles` bumped 1.1.12 → 1.1.13 via `scripts/ci/bundle_release_plan.py update` (`plan --check` reports `ready`). The uv.lock change is kept surgical (version, the two aggregate entries, `provides-extras`) because a full re-lock rewrites unrelated markers with current uv; `uv sync --frozen --extra bundles` installs cleanly from it.
- Frontend icon (svg + JSX + `index.tsx`) at `src/frontend/src/icons/LiveTennisAPI/`, wired into `lazyIconImports.ts` and `SIDEBAR_BUNDLES`, per the contributing-bundles guide.
- API key is a `SecretStrInput`, sent as `X-API-Key`. Fixed base URL, no user-supplied hosts.
- Errors (401/404/429/timeouts) come back as friendly `Data` rows rather than raising, matching the Tavily components.

## Testing

- `src/backend/tests/unit/components/bundles/livetennisapi` — 18 passed with the bundles extra installed (HTTP fully mocked, including the inherited `test_latest_version`, so CI stays offline). Guarded with `pytest.importorskip("lfx_bundles")` so the bundles-installed job picks them up.
- `tests/unit/test_check_components_frozen.py` — 7 passed; `scripts/ci/check_components_frozen.py` reports OK.
- `test_all_no_torch_structure`, `test_all_modules_importable.py`, `test_bundle_ssrf_wiring.py` — pass.
- `ruff check` / `ruff format` and biome clean on all touched files.
