### PR TITLE
fix(background): scope suspended-run supersede to the submitting session

### DIFF
--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -133,7 +133,7 @@ The pause probe is a no-op unless a component requests it, so normal flows are b
 - **When** the same user submits a new background run of that flow
 - **Then** the stale suspended run is cancelled (`CANCELLED`, pending request cleared) before the new run starts, so only the new pause is offered on every surface
 - **And** the persisted chat card of the superseded pause is stamped `superseded` — after a history reload it renders closed ("Superseded by a new run") instead of turning interactive again and 409ing on every click
-- **And** the scope is flow + user on the langflow backend (another user's pause on the same flow is untouched) and flow on `lfx serve` (single API-key identity); running jobs are never superseded, so parallel runs stay supported
+- **And** the scope is flow + user + effective session on the langflow backend (the submitting run's `session_id`, falling back to the flow id) — a rerun replaces stale pauses of the SAME session/thread, while SUSPENDED runs of other sessions stay untouched; the scope is flow on `lfx serve` (single API-key identity); running jobs are never superseded, so parallel runs stay supported
 
 ### Scenario: Supersede loses the race to a resume
 - **Given** a `SUSPENDED` run whose resume arrives while a rerun's supersede is in flight
@@ -242,7 +242,7 @@ Drain the queue **inline** after cancelling the worker (`service.py::_stop`), an
 ## 6. Technical Specification
 
 ### 6.1 Submit supersedes stale pauses
-- `BackgroundExecutionService.submit` calls `supersede_suspended_runs(flow_id, user_id)` after `create_job` (so idempotent retries still return the existing job) and before enqueue: every `SUSPENDED` workflow job of the same flow + user is cancelled through the `_cancel_suspended` path (status `CANCELLED`, card stamped superseded, checkpoint deleted, pending cleared, `run_cancelled` event, bus closed).
+- `BackgroundExecutionService.submit` calls `supersede_suspended_runs(flow_id, user_id, session_id)` after `create_job` (so idempotent retries still return the existing job) and before enqueue: every `SUSPENDED` workflow job of the same flow + user **+ effective session** (`session_id` from the submit request, falling back to the flow id) is cancelled through the `_cancel_suspended` path (status `CANCELLED`, card stamped superseded, checkpoint deleted, pending cleared, `run_cancelled` event, bus closed). SUSPENDED jobs of other sessions — or legacy jobs whose effective session is the flow id — are left untouched.
 - The cancel is an **atomic claim**: `JobService.claim_suspended_for_cancel` (a conditional `UPDATE … WHERE status = SUSPENDED`, the mirror of `claim_suspended_for_resume`) flips the row, and cleanup runs only for rows this caller actually claimed. A resume that won the flip first keeps its run — supersede can never cancel a resumed job or destroy its checkpoint mid-flight. `stop_job` uses the same claim and falls through to the running-job STOP path when it loses.
 - Before metadata is cleared, `mark_card_superseded` (`api/v2/hitl.py`) patches the persisted card's `human_input` content with `superseded: true` (skipping already-answered cards); `HumanInputCard` renders that state closed, so a reloaded history cannot re-offer a decision that would only 409.
 - `DurableServeWorkflowHost.submit_background` mirrors it flow-scoped: `SqliteDurableJobStore.claim_suspended_for_cancel` first, then (only for claimed rows) STOP signal, task cancel, pending metadata cleared — a lost claim also means no stray STOP signal for the resumed continuation to consume.

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -162,37 +162,46 @@ class BackgroundExecutionService(Service):
 
     # ------------------------------------------------------------------ submit
 
-    async def supersede_suspended_runs(self, *, flow_id: UUID, user_id: UUID) -> list[UUID]:
+    async def supersede_suspended_runs(
+        self, *, flow_id: UUID, user_id: UUID, session_id: str | None = None
+    ) -> list[UUID]:
         """Cancel this user's SUSPENDED runs of the flow so a rerun replaces the stale pause.
 
         A suspended run holds a pause nobody will answer once its owner reruns the flow;
         left alive it piles up in every pending surface (badge, cards, trace bar). Scope is
-        flow + user: another user's pause on the same flow is never touched, and running
-        jobs are untouched so parallel runs stay supported.
+        flow + user + effective session: a rerun replaces stale pauses of the SAME
+        session/thread (``session_id`` falling back to the flow id), while SUSPENDED runs
+        of other sessions stay untouched, another user's pause on the same flow is never
+        touched, and running jobs are never superseded so parallel runs stay supported.
         """
         from sqlmodel import select
 
         from langflow.services.database.models.jobs.model import Job
         from langflow.services.deps import session_scope
 
+        effective_session = session_id or str(flow_id)
         job_service = get_job_service()
         async with session_scope() as session:
             result = await session.exec(
-                select(Job.job_id).where(
+                select(Job).where(
                     Job.flow_id == flow_id,
                     Job.user_id == user_id,
                     Job.status == JobStatus.SUSPENDED,
                     Job.type == JobType.WORKFLOW,
                 )
             )
-            stale_job_ids = list(result.all())
+            stale_jobs = list(result.all())
         cancelled: list[UUID] = []
-        for stale_job_id in stale_job_ids:
+        for stale_job in stale_jobs:
+            persisted = (stale_job.job_metadata or {}).get("request") or {}
+            job_session = persisted.get("session_id") or str(stale_job.flow_id)
+            if job_session != effective_session:
+                continue
             if self._scaled:
-                await self._backend.stop(str(stale_job_id))
-                cancelled.append(stale_job_id)
-            elif await self._cancel_suspended(stale_job_id, job_service):
-                cancelled.append(stale_job_id)
+                await self._backend.stop(str(stale_job.job_id))
+                cancelled.append(stale_job.job_id)
+            elif await self._cancel_suspended(stale_job.job_id, job_service):
+                cancelled.append(stale_job.job_id)
         return cancelled
 
     async def submit(self, *, flow_id: UUID, request: dict[str, Any], user: UserRead) -> UUID:
@@ -234,7 +243,7 @@ class BackgroundExecutionService(Service):
         await job_service.update_job_metadata(job_id, {"request": self._redact_request(request)})
         # After create_job so an idempotent retry returns the existing job instead of
         # cancelling it; the new job is QUEUED, so the suspended-only query skips it.
-        await self.supersede_suspended_runs(flow_id=flow_id, user_id=user.id)
+        await self.supersede_suspended_runs(flow_id=flow_id, user_id=user.id, session_id=request.get("session_id"))
         if self._scaled:
             # Scaled mode: hand the QUEUED job id to a worker via the redis claim
             # queue; the worker hydrates the request from the job row.

--- a/src/backend/tests/unit/background_execution/test_supersede_suspended.py
+++ b/src/backend/tests/unit/background_execution/test_supersede_suspended.py
@@ -38,10 +38,13 @@ def _pause_source(request_id: str):
     return _source
 
 
-async def _suspend_a_job(job_service, *, flow_id, user_id, request_id="req-1"):
+async def _suspend_a_job(job_service, *, flow_id, user_id, request_id="req-1", session_id=None):
     job_id = uuid4()
     await job_service.create_job(job_id=job_id, flow_id=flow_id, user_id=user_id)
-    await job_service.update_job_metadata(job_id, {"request": {"flow_id": str(flow_id), "stream_protocol": "langflow"}})
+    request = {"flow_id": str(flow_id), "stream_protocol": "langflow"}
+    if session_id is not None:
+        request["session_id"] = session_id
+    await job_service.update_job_metadata(job_id, {"request": request})
     adapter = get_stream_adapter("langflow", StreamAdapterContext(run_id=str(job_id), thread_id="t"))
     runner = JobRunner(
         job_service=job_service,
@@ -63,6 +66,15 @@ def _service() -> BackgroundExecutionService:
         return _source
 
     return BackgroundExecutionService(get_settings_service(), frame_source_factory=_end_source)
+
+
+async def _wait_for_completed(job_service, job_id):
+    for _ in range(100):
+        job = await job_service.get_job_by_job_id(job_id)
+        if job.status == JobStatus.COMPLETED:
+            return job
+        await asyncio.sleep(0.05)
+    return job
 
 
 async def test_supersede_cancels_suspended_runs_of_same_flow_and_user(real_services_job_service):
@@ -194,3 +206,89 @@ async def test_submit_supersedes_the_previous_suspended_run(real_services_job_se
             break
         await asyncio.sleep(0.05)
     assert new.status == JobStatus.COMPLETED
+
+
+async def test_submit_does_not_supersede_suspended_run_of_a_different_session(real_services_job_service):
+    """Submitting for session-b must leave a SUSPENDED run of session-a alone (issue #14599)."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+
+    service = _service()
+    new_job_id = await service.submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-b", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.SUSPENDED
+    assert (stale.job_metadata or {}).get("pending_request_id") is not None
+    new = await _wait_for_completed(job_service, new_job_id)
+    assert new.status == JobStatus.COMPLETED
+
+
+async def test_submit_supersedes_suspended_run_of_same_session(real_services_job_service):
+    """Re-running the SAME session replaces its own stale pause, as before."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-a", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.CANCELLED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED
+
+
+async def test_submit_supersedes_suspended_run_when_both_have_no_session(real_services_job_service):
+    """Canvas reruns (no session on either side) fall back to flow_id and still replace."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id)
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.CANCELLED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED
+
+
+async def test_supersede_only_targets_matching_session(real_services_job_service):
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    job_a = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+    job_b = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-b")
+
+    superseded = await _service().supersede_suspended_runs(flow_id=flow_id, user_id=user_id, session_id="session-b")
+
+    assert superseded == [job_b]
+    job_a_after = await job_service.get_job_by_job_id(job_a)
+    assert job_a_after.status == JobStatus.SUSPENDED
+    job_b_after = await job_service.get_job_by_job_id(job_b)
+    assert job_b_after.status == JobStatus.CANCELLED
+
+
+async def test_supersede_suspended_run_of_different_session_not_cancelled_when_legacy(real_services_job_service):
+    """A legacy suspended run (no session, effective flow_id) is not cancelled by a sessioned submit."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id)
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-b", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.SUSPENDED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED


### PR DESCRIPTION
Fixes #14599

## Problem

Submitting a new background job via `POST /api/v2/workflows` for the same flow cancelled previously submitted SUSPENDED jobs, even when the two jobs used different `session_id`s. The supersede query in `BackgroundExecutionService.supersede_suspended_runs` keyed cancellation on `(flow_id, user_id, status=SUSPENDED, type=WORKFLOW)` only, so any new submission of the flow replaced every suspended run of that flow and user — including independent runs of other sessions.

## Fix

Scope the supersede to the submitting run's effective session (`session_id`, falling back to the flow id — the same normalization the runner and the status endpoints already use). A rerun now replaces stale pauses of the same session/thread, while SUSPENDED runs of other sessions stay untouched. Running jobs are never superseded.

This is a behavior change worth calling out: a canvas rerun (which submits without a `session_id`, so it resolves to the flow id) no longer cancels suspended runs that were submitted under a different explicit session.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/background_execution/test_supersede_suspended.py` — 11 passed (sqlite); postgres parameterization requires `LANGFLOW_TEST_DATABASE_URI`
- [x] `uv run pytest src/backend/tests/unit/background_execution/` — 112 passed
- [x] `uv run pytest src/backend/tests/unit/api/v2/test_workflow.py` — 29 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rerunning a flow now supersedes only suspended runs from the same flow, user, and session.
  * Suspended runs from other sessions remain available and unaffected.
  * Sessionless suspended runs continue to behave correctly for compatibility.

* **Documentation**
  * Updated durable execution and human-in-the-loop guidance to reflect session-specific rerun behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->