### PR TITLE
ci: run backend tests for provider bundle changes

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -3,6 +3,10 @@ python:
   - "src/backend/**"
   - "src/backend/**.py"
   - "src/lfx/**"
+  # Provider bundles are first-class Python sources since the metapackage
+  # split; without this a bundle-only PR reports python=false and skips the
+  # backend suite entirely, including the bundle's own tests.
+  - "src/bundles/**"
   - "pyproject.toml"
   - "uv.lock"
   - "src/backend/base/pyproject.toml"


### PR DESCRIPTION
## Summary

Adds `src/bundles/**` to the `python` path filter in `.github/changes-filter.yaml`.

## Why

`.github/workflows/ci.yml` gates the backend suite on the `python` filter:

```yaml
  test-backend:
    if: |
      ...
        needs.path-filter.outputs.python == 'true')
```

That gate was added in #13614 (2026-06-15) to stop frontend-only PRs from paying for the backend suite. But the `python` filter still lists only `src/backend/**`, `src/lfx/**`, `pyproject.toml` and `uv.lock` — it never learned about `src/bundles/**` after the bundle metapackage split.

So a PR that only touches a provider bundle resolves `python=false` and **skips the entire backend suite**, including the bundle's own tests under `src/bundles/*/tests/`.

Before the gate landed, this was invisible: #13514 changed exactly two files — `src/bundles/ibm/.../db2_vector.py` and `src/bundles/ibm/tests/test_db2_vector.py` — and still ran all 17 backend jobs, because `test-backend` was then gated only on `docs-only != 'true'`. The same PR today would run none of them, and the test file it modified would never execute.

Bundle PRs that happen to touch `uv.lock` or `pyproject.toml` (most *new* bundles do) still match the filter, which is why this hasn't bitten yet — but any edit confined to an existing bundle's Python silently loses backend coverage.

## Blast radius

`path-filter.outputs.python` has four consumers in `ci.yml`:

| Line | Consumer | Effect |
|---|---|---|
| 253 | `test-backend` | now runs for bundle-only PRs — **the fix** |
| 340 | `test-templates` | now runs for bundle-only PRs — desirable; bundle components appear in starter templates |
| 200 | `docs-only` computation | only ever makes `docs-only` *harder* to be true; cannot mis-skip |
| 493 | `CI Success` echo | cosmetic |

No effect on Playwright shard selection — that is driven by the separate suite filters (`components`, `workspace`, `api`, …), which are deliberately left alone here. See the note below.

## Deliberately not changed

I also considered adding `src/bundles/**` to the `components` suite filter, but that would **reduce** coverage. When no suite matches, `typescript_test.yml` falls through to `@release`:

```bash
if [[ ${#TAGS[@]} -eq 0 ]]; then
  SUITES='["release"]'
  TAGS=("@release")
```

So bundle-only PRs already get the full `@release` suite (~411 tests, 70 shards — #13514 ran 64 shards under the smaller suite of the time). Mapping bundles to `components` would narrow that to `@components` (~73 tests, 16 shards). The frontend side is already behaving conservatively and is left as-is.

Two adjacent gaps, both out of scope here:

- `docker` filter also omits `src/bundles/**`, so bundle-only PRs skip `test-docker` even though bundles ship in the full image.
- `scripts/check_changes_filter.py` (the "Validate Filter Coverage" step) only inspects paths under `src/frontend/`, which is why no one was told about this. Widening it to `src/bundles/` would catch the next instance.

## Validation

- `.github/changes-filter.yaml` parses; `python` list contains `src/bundles/**`.
- Confirmed against the current `ci.yml` that all four `outputs.python` consumers behave as tabulated above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated change classification so modifications within Python bundles are correctly recognized as Python-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->