### PR TITLE
test: fix playground send race on Windows CI

### DIFF
--- a/src/frontend/tests/utils/playground/send-playground-message.ts
+++ b/src/frontend/tests/utils/playground/send-playground-message.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { TEXTS } from "../../utils/constants/texts";
 import { TID } from "../constants/testIds";
 import { TIMEOUTS } from "../constants/timeouts";
@@ -15,8 +15,8 @@ export type SendOpts = {
  * Replaces 7+ inline implementations across the suite (`sendMessage`,
  * `sendMessageAndWait`, `sendAndWaitForResponse`, etc.). The defaults
  * mirror the most lenient set of predecessor timeouts (60s for chat
- * input visibility on Windows CI, 30s for the Stop button to appear,
- * 120s for it to disappear).
+ * input visibility on Windows CI, 30s for the build to show up, 120s
+ * for it to finish).
  */
 export async function sendPlaygroundMessage(
   page: Page,
@@ -37,13 +37,33 @@ export async function sendPlaygroundMessage(
     await page.getByTestId(TID.inputChatPlayground).last().fill(message);
   }
 
+  const stop = page.getByRole("button", { name: TEXTS.stop });
+  const messages = page.getByTestId(TID.chatMessage);
+  // Counted after the transcript is on screen so a still-loading history is not
+  // mistaken for the answer to this message.
+  const messagesBefore = await messages.count();
+
   if (sendBy === "enter") {
     await page.keyboard.press("Enter");
   } else {
     await page.getByTestId(TID.buttonSend).last().click();
   }
 
-  const stop = page.getByRole("button", { name: TEXTS.stop });
-  await stop.waitFor({ state: "visible", timeout: TIMEOUTS.standard });
+  // Stop is the Send button under a different accessible name, so it only
+  // exists while `isBuilding` is true. A trivial flow answers in ~100ms, which
+  // a slow runner can consume between the keypress and Playwright's first poll
+  // — the Windows CI shards timed out here on builds that had already finished
+  // and rendered their answer. Never having seen Stop is therefore not a
+  // failure; accept a new message in the transcript as the same evidence.
+  await expect
+    .poll(
+      async () =>
+        (await stop.count()) > 0 || (await messages.count()) > messagesBefore,
+      {
+        timeout: TIMEOUTS.standard,
+        message: "build neither started nor produced a message",
+      },
+    )
+    .toBe(true);
   await stop.waitFor({ state: "hidden", timeout: TIMEOUTS.buildComplete });
 }


### PR DESCRIPTION
The `fresh start playground` spec fails intermittently on the Windows CI shards with:

```
TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
  - waiting for getByRole('button', { name: 'Stop' }) to be visible
```

## Root cause

`Stop` is not a separate control: `button-send-wrapper.tsx` renders the *same* button with a different accessible name while `isBuilding` is true. The playground flow under test (Chat Input → Text Output → Chat Output, no model call) answers in ~100 ms, so that state can start and finish between the keypress and Playwright's first poll — after which it never comes back and the wait burns its full 30 s.

The failure artifacts confirm it: in both the first attempt and the retry, the page snapshot at timeout already shows the message sent **and** answered (`Finished in 0.1s`). The build succeeded; only the transient signal was missed. The backend log for the shard has no errors.

This is a test-harness race rather than a Windows-specific defect — Windows CI is just slow enough to lose the window (locally the button stays visible ~600 ms).

## Fix

`sendPlaygroundMessage` no longer requires observing the transient state. It accepts either signal that the build ran: the `Stop` button being present, or a new message in the transcript. The transcript count is taken right before sending so a still-loading history cannot be mistaken for this message's answer. The wait for `Stop` to go hidden is unchanged, so slow flows (agent/LLM specs) still block until the build finishes — `setIsBuilding(true)` is synchronous on send, so those always show the button.

## Verification

Reproduced locally on macOS by delaying the first poll by 2 s after the keypress, which recreates the CI condition deterministically:

- old helper → same `TimeoutError` as CI
- new helper → passes

Also green locally: `playground.spec.ts`, `publish-flow.spec.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and message-sending behavior in automated interactions.
  * Fast-completing builds are now recognized correctly without requiring the Stop button to appear.
* **Documentation**
  * Updated guidance to reference the build appearing instead of the Stop button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->