### PR TITLE
fix(background): scope suspended-run supersede to the submitting session (release-1.11.4)

### DIFF
--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -130,10 +130,10 @@ The pause probe is a no-op unless a component requests it, so normal flows are b
 
 ### Scenario: Rerunning a paused flow supersedes the stale pause
 - **Given** a flow with a `SUSPENDED` run awaiting a decision
-- **When** the same user submits a new background run of that flow
+- **When** the same user submits a new background run of that flow under the same session
 - **Then** the stale suspended run is cancelled (`CANCELLED`, pending request cleared) before the new run starts, so only the new pause is offered on every surface
 - **And** the persisted chat card of the superseded pause is stamped `superseded` — after a history reload it renders closed ("Superseded by a new run") instead of turning interactive again and 409ing on every click
-- **And** the scope is flow + user on the langflow backend (another user's pause on the same flow is untouched) and flow on `lfx serve` (single API-key identity); running jobs are never superseded, so parallel runs stay supported
+- **And** the scope is flow + user + effective session on the langflow backend (the submitting run's `session_id`, falling back to the flow id) — a rerun replaces stale pauses of the SAME session/thread, while SUSPENDED runs of other sessions stay untouched; the scope is flow on `lfx serve` (single API-key identity); running jobs are never superseded, so parallel runs stay supported
 
 ### Scenario: Supersede loses the race to a resume
 - **Given** a `SUSPENDED` run whose resume arrives while a rerun's supersede is in flight
@@ -242,7 +242,7 @@ Drain the queue **inline** after cancelling the worker (`service.py::_stop`), an
 ## 6. Technical Specification
 
 ### 6.1 Submit supersedes stale pauses
-- `BackgroundExecutionService.submit` calls `supersede_suspended_runs(flow_id, user_id)` after `create_job` (so idempotent retries still return the existing job) and before enqueue: every `SUSPENDED` workflow job of the same flow + user is cancelled through the `_cancel_suspended` path (status `CANCELLED`, card stamped superseded, checkpoint deleted, pending cleared, `run_cancelled` event, bus closed).
+- `BackgroundExecutionService.submit` calls `supersede_suspended_runs(flow_id, user_id, session_id)` after `create_job` (so idempotent retries still return the existing job) and before enqueue: every `SUSPENDED` workflow job of the same flow + user **+ effective session** (`session_id` from the submit request, falling back to the flow id) is cancelled — in-process through `_cancel_suspended` (status `CANCELLED`, card stamped superseded, checkpoint deleted, pending cleared, `run_cancelled` event, bus closed), in scaled mode through `_backend.stop`. A stale run's session is read back off its persisted row (`job_metadata['request']['session_id']`, or the flat `job_metadata['session_id']` legacy rows carry) with the same flow-id fallback the runner uses for `thread_id`, so SUSPENDED jobs of OTHER sessions are left untouched and one flow can serve many concurrent callers ([#14599](https://github.com/langflow-ai/langflow/issues/14599)).
 - The cancel is an **atomic claim**: `JobService.claim_suspended_for_cancel` (a conditional `UPDATE … WHERE status = SUSPENDED`, the mirror of `claim_suspended_for_resume`) flips the row, and cleanup runs only for rows this caller actually claimed. A resume that won the flip first keeps its run — supersede can never cancel a resumed job or destroy its checkpoint mid-flight. `stop_job` uses the same claim and falls through to the running-job STOP path when it loses.
 - Before metadata is cleared, `mark_card_superseded` (`api/v2/hitl.py`) patches the persisted card's `human_input` content with `superseded: true` (skipping already-answered cards); `HumanInputCard` renders that state closed, so a reloaded history cannot re-offer a decision that would only 409.
 - `DurableServeWorkflowHost.submit_background` mirrors it flow-scoped: `SqliteDurableJobStore.claim_suspended_for_cancel` first, then (only for claimed rows) STOP signal, task cancel, pending metadata cleared — a lost claim also means no stray STOP signal for the resumed continuation to consume.

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -162,30 +162,55 @@ class BackgroundExecutionService(Service):
 
     # ------------------------------------------------------------------ submit
 
-    async def supersede_suspended_runs(self, *, flow_id: UUID, user_id: UUID) -> list[UUID]:
+    @staticmethod
+    def _effective_session(job: Job) -> str:
+        """The session/thread a job ran under, normalized the way the runner normalizes it.
+
+        ``submit`` persists the submit request under ``job_metadata['request']`` and the
+        runner threads ``request['session_id'] or str(flow_id)`` into the stream adapter
+        (``_build_adapter``), so the same fallback keys the supersede scope. Legacy rows
+        written before the request was persisted keep a flat ``job_metadata['session_id']``
+        — read it the way ``_reconstruct_request`` does rather than mis-scoping them.
+        """
+        meta = job.job_metadata or {}
+        persisted = meta.get("request")
+        source = persisted if isinstance(persisted, dict) and persisted else meta
+        return source.get("session_id") or str(job.flow_id)
+
+    async def supersede_suspended_runs(
+        self, *, flow_id: UUID, user_id: UUID, session_id: str | None = None
+    ) -> list[UUID]:
         """Cancel this user's SUSPENDED runs of the flow so a rerun replaces the stale pause.
 
-        A suspended run holds a pause nobody will answer once its owner reruns the flow;
-        left alive it piles up in every pending surface (badge, cards, trace bar). Scope is
-        flow + user: another user's pause on the same flow is never touched, and running
-        jobs are untouched so parallel runs stay supported.
+        A suspended run holds a pause nobody will answer once its owner reruns that
+        conversation; left alive it piles up in every pending surface (badge, cards, trace
+        bar). Scope is flow + user + effective session (``session_id``, falling back to the
+        flow id — the runner's own normalization): a rerun replaces the stale pause of the
+        SAME session/thread, while SUSPENDED runs of OTHER sessions stay untouched so one
+        flow can serve many independent callers (#14599). Another user's pause on the same
+        flow is never touched, and running jobs are untouched so parallel runs stay
+        supported.
         """
         from sqlmodel import select
 
         from langflow.services.database.models.jobs.model import Job
         from langflow.services.deps import session_scope
 
+        effective_session = session_id or str(flow_id)
         job_service = get_job_service()
         async with session_scope() as session:
             result = await session.exec(
-                select(Job.job_id).where(
+                select(Job).where(
                     Job.flow_id == flow_id,
                     Job.user_id == user_id,
                     Job.status == JobStatus.SUSPENDED,
                     Job.type == JobType.WORKFLOW,
                 )
             )
-            stale_job_ids = list(result.all())
+            # The session lives in job_metadata, so narrow to matching rows INSIDE the
+            # scope: reading a JSON column off a row already detached from its session
+            # would depend on the engine's expire_on_commit setting.
+            stale_job_ids = [job.job_id for job in result.all() if self._effective_session(job) == effective_session]
         cancelled: list[UUID] = []
         for stale_job_id in stale_job_ids:
             if self._scaled:
@@ -234,7 +259,7 @@ class BackgroundExecutionService(Service):
         await job_service.update_job_metadata(job_id, {"request": self._redact_request(request)})
         # After create_job so an idempotent retry returns the existing job instead of
         # cancelling it; the new job is QUEUED, so the suspended-only query skips it.
-        await self.supersede_suspended_runs(flow_id=flow_id, user_id=user.id)
+        await self.supersede_suspended_runs(flow_id=flow_id, user_id=user.id, session_id=request.get("session_id"))
         if self._scaled:
             # Scaled mode: hand the QUEUED job id to a worker via the redis claim
             # queue; the worker hydrates the request from the job row.

--- a/src/backend/tests/unit/alembic/test_migration_execution.py
+++ b/src/backend/tests/unit/alembic/test_migration_execution.py
@@ -135,11 +135,11 @@ def _parse_revision_values(line: str) -> list[str]:
     return re.findall(r"""["']([a-f0-9]+)["']""", raw)
 
 
-def _get_main_branch_head() -> str | None:
-    """Get the alembic head revision that origin/main is at.
+def _head_revision_at(ref: str) -> str | None:
+    """Get the alembic head revision of the migration files at ``ref``.
 
     Uses ``git grep`` to read the ``revision`` and ``down_revision`` variables
-    directly from migration files on origin/main, then walks the chain to find
+    directly from the migration files at that ref, then walks the chain to find
     the head revision.  This avoids relying on filename conventions (which may
     not match the actual revision IDs inside the files) and works regardless of
     whether the branch adds, modifies, or deletes migration files.
@@ -158,7 +158,7 @@ def _get_main_branch_head() -> str | None:
                     "grep",
                     "-h",
                     pattern,
-                    "origin/main",
+                    ref,
                     "--",
                     "src/backend/base/langflow/alembic/versions/",
                 ],
@@ -175,16 +175,16 @@ def _get_main_branch_head() -> str | None:
             raise
         return result.stdout
 
-    # Extract all revision IDs from origin/main's migration files
+    # Extract all revision IDs from the ref's migration files
     rev_output = _git_grep("^revision:")
     if not rev_output:
         return None
 
-    main_rev_ids: set[str] = set()
+    rev_ids: set[str] = set()
     for line in rev_output.strip().splitlines():
-        main_rev_ids.update(_parse_revision_values(line))
+        rev_ids.update(_parse_revision_values(line))
 
-    if not main_rev_ids:
+    if not rev_ids:
         return None
 
     # Extract all down_revision IDs to determine the chain
@@ -195,13 +195,57 @@ def _get_main_branch_head() -> str | None:
             referenced.update(_parse_revision_values(line))
 
     # Head = revisions not referenced as down_revision by any other revision
-    heads = main_rev_ids - referenced
+    heads = rev_ids - referenced
 
     if len(heads) == 1:
         return heads.pop()
     if len(heads) > 1:
-        pytest.fail(f"origin/main has {len(heads)} head revisions — migration branches need merging: {heads}")
+        pytest.fail(f"{ref} has {len(heads)} head revisions — migration branches need merging: {heads}")
     return None
+
+
+def _fork_point_with_main() -> str | None:
+    """The commit this branch forked from ``origin/main`` (None if git cannot tell)."""
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603
+            [git, "merge-base", "HEAD", "origin/main"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=_WORKSPACE_ROOT,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return None
+        raise
+    return result.stdout.strip() or None
+
+
+def _get_main_branch_head(branch_revisions: set[str] | None = None) -> str | None:
+    """The revision an existing user's DB sits at before upgrading to this branch.
+
+    Normally ``origin/main``'s alembic head. A PR based on a RELEASE branch, though,
+    forked before some of main's migrations, so main's head is not in this branch's
+    version directory at all and ``upgrade(main_head)`` can only raise "Can't locate
+    revision". Pass ``branch_revisions`` to get the release-branch-aware answer: main's
+    head AT THE FORK POINT (``git merge-base HEAD origin/main``), which is by
+    construction reachable from this branch.
+
+    This does not weaken the check for a branch that DELETES a migration main has: that
+    revision exists at the fork point too, so the deletion still fails the upgrade.
+    """
+    main_head = _head_revision_at("origin/main")
+    if main_head is None or branch_revisions is None or main_head in branch_revisions:
+        return main_head
+    fork_point = _fork_point_with_main()
+    if fork_point is None:
+        return main_head
+    return _head_revision_at(fork_point) or main_head
 
 
 def _filter_sqlite_noise(diffs: list) -> list:
@@ -458,7 +502,15 @@ def test_upgrade_from_main_branch(db_url):
     """
     from alembic.script import ScriptDirectory
 
-    main_head = _get_main_branch_head()
+    branch_cfg = Config()
+    branch_cfg.set_main_option("script_location", str(_SCRIPT_LOCATION))
+    branch_script = ScriptDirectory.from_config(branch_cfg)
+    # The branch's own revisions decide whether main's head is even reachable here:
+    # a release branch forked before main's latest migrations, so the upgrade has to
+    # start from main's head AT THE FORK POINT instead. See _get_main_branch_head.
+    branch_revisions = {script.revision for script in branch_script.walk_revisions()}
+
+    main_head = _get_main_branch_head(branch_revisions)
     if main_head is None:
         if os.environ.get("MIGRATION_VALIDATION_CI"):
             pytest.fail("Could not determine main branch head revision — ensure fetch-depth: 0 and origin/main exists")
@@ -468,9 +520,6 @@ def test_upgrade_from_main_branch(db_url):
     # In that case this test is a no-op — alembic won't re-run already-applied
     # migrations, so upgrade(main_head) -> upgrade(head) does nothing.
     # Modified migrations are exercised by test_no_phantom_migrations instead.
-    branch_cfg = Config()
-    branch_cfg.set_main_option("script_location", str(_SCRIPT_LOCATION))
-    branch_script = ScriptDirectory.from_config(branch_cfg)
     branch_heads = branch_script.get_heads()
     if len(branch_heads) == 1 and branch_heads[0] == main_head:
         pytest.skip(

--- a/src/backend/tests/unit/background_execution/test_supersede_suspended.py
+++ b/src/backend/tests/unit/background_execution/test_supersede_suspended.py
@@ -3,9 +3,10 @@
 Re-running a flow while a previous run sits SUSPENDED left both pauses alive: the
 pending list piled up, every surface (badge, cards, trace bar) kept offering a
 decision nobody could meaningfully answer, and the old checkpoint lingered forever.
-Submitting a new run for the same flow + user now cancels the stale suspended runs
-first — running jobs are untouched (parallel runs stay supported), and other flows
-or users are never affected.
+Submitting a new run for the same flow + user + effective session now cancels the
+stale suspended runs first — running jobs are untouched (parallel runs stay
+supported), and other flows, users, or SESSIONS are never affected (#14599: a
+second caller's background run must not cancel the first caller's pause).
 """
 
 from __future__ import annotations
@@ -38,10 +39,18 @@ def _pause_source(request_id: str):
     return _source
 
 
-async def _suspend_a_job(job_service, *, flow_id, user_id, request_id="req-1"):
+async def _suspend_a_job(job_service, *, flow_id, user_id, request_id="req-1", session_id=None, legacy_session_id=None):
     job_id = uuid4()
     await job_service.create_job(job_id=job_id, flow_id=flow_id, user_id=user_id)
-    await job_service.update_job_metadata(job_id, {"request": {"flow_id": str(flow_id), "stream_protocol": "langflow"}})
+    if legacy_session_id is not None:
+        # Row shape from before ``submit`` persisted the request: no ``request`` blob,
+        # just the flat session key ``_reconstruct_request`` falls back to.
+        await job_service.update_job_metadata(job_id, {"session_id": legacy_session_id}, replace=True)
+    else:
+        request = {"flow_id": str(flow_id), "stream_protocol": "langflow"}
+        if session_id is not None:
+            request["session_id"] = session_id
+        await job_service.update_job_metadata(job_id, {"request": request})
     adapter = get_stream_adapter("langflow", StreamAdapterContext(run_id=str(job_id), thread_id="t"))
     runner = JobRunner(
         job_service=job_service,
@@ -63,6 +72,15 @@ def _service() -> BackgroundExecutionService:
         return _source
 
     return BackgroundExecutionService(get_settings_service(), frame_source_factory=_end_source)
+
+
+async def _wait_for_completed(job_service, job_id):
+    for _ in range(100):
+        job = await job_service.get_job_by_job_id(job_id)
+        if job.status == JobStatus.COMPLETED:
+            return job
+        await asyncio.sleep(0.05)
+    return job
 
 
 async def test_supersede_cancels_suspended_runs_of_same_flow_and_user(real_services_job_service):
@@ -194,3 +212,104 @@ async def test_submit_supersedes_the_previous_suspended_run(real_services_job_se
             break
         await asyncio.sleep(0.05)
     assert new.status == JobStatus.COMPLETED
+
+
+async def test_submit_does_not_supersede_suspended_run_of_a_different_session(real_services_job_service):
+    """Submitting for session-b must leave a SUSPENDED run of session-a alone (issue #14599)."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+
+    service = _service()
+    new_job_id = await service.submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-b", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.SUSPENDED
+    assert (stale.job_metadata or {}).get("pending_request_id") is not None
+    new = await _wait_for_completed(job_service, new_job_id)
+    assert new.status == JobStatus.COMPLETED
+
+
+async def test_submit_supersedes_suspended_run_of_same_session(real_services_job_service):
+    """Re-running the SAME session replaces its own stale pause, as before."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-a", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.CANCELLED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED
+
+
+async def test_submit_supersedes_suspended_run_when_both_have_no_session(real_services_job_service):
+    """Canvas reruns (no session on either side) fall back to flow_id and still replace."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id)
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.CANCELLED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED
+
+
+async def test_supersede_only_targets_matching_session(real_services_job_service):
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    job_a = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-a")
+    job_b = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, session_id="session-b")
+
+    superseded = await _service().supersede_suspended_runs(flow_id=flow_id, user_id=user_id, session_id="session-b")
+
+    assert superseded == [job_b]
+    job_a_after = await job_service.get_job_by_job_id(job_a)
+    assert job_a_after.status == JobStatus.SUSPENDED
+    job_b_after = await job_service.get_job_by_job_id(job_b)
+    assert job_b_after.status == JobStatus.CANCELLED
+
+
+async def test_supersede_suspended_run_of_different_session_not_cancelled_when_legacy(real_services_job_service):
+    """A legacy suspended run (no session, effective flow_id) is not cancelled by a sessioned submit."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id)
+
+    new_job_id = await _service().submit(
+        flow_id=flow_id,
+        request={"flow_id": str(flow_id), "session_id": "session-b", "stream_protocol": "langflow"},
+        user=SimpleNamespace(id=user_id),
+    )
+
+    stale = await job_service.get_job_by_job_id(stale_job_id)
+    assert stale.status == JobStatus.SUSPENDED
+    assert (await _wait_for_completed(job_service, new_job_id)).status == JobStatus.COMPLETED
+
+
+async def test_supersede_reads_the_session_off_legacy_flat_metadata(real_services_job_service):
+    """A legacy row carrying a flat ``job_metadata['session_id']`` is scoped by that session."""
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    stale_job_id = await _suspend_a_job(job_service, flow_id=flow_id, user_id=user_id, legacy_session_id="session-a")
+
+    untouched = await _service().supersede_suspended_runs(flow_id=flow_id, user_id=user_id, session_id="session-b")
+    assert untouched == []
+    assert (await job_service.get_job_by_job_id(stale_job_id)).status == JobStatus.SUSPENDED
+
+    superseded = await _service().supersede_suspended_runs(flow_id=flow_id, user_id=user_id, session_id="session-a")
+    assert superseded == [stale_job_id]
+    assert (await job_service.get_job_by_job_id(stale_job_id)).status == JobStatus.CANCELLED


### PR DESCRIPTION
Fixes #14599

Port of @lorenzozanee's #14603 (which targets `release-1.12.0`) to `release-1.11.4`, with two small hardenings on top — see [Changes on top of #14603](#changes-on-top-of-14603). Credit for the diagnosis and the fix approach goes to them.

## Problem

A background submit to `POST /api/v2/workflows` cancelled a still-active run of the same flow, even when the two runs carried entirely different `session_id`s and nobody called `/stop`.

`BackgroundExecutionService.supersede_suspended_runs` keyed the cancel on `(flow_id, user_id, status=SUSPENDED, type=WORKFLOW)` only, so ANY new submission of a flow cancelled EVERY suspended run of that flow for that user.

That matches the reported window exactly: two submits in a tight burst both survive (the query is `SUSPENDED`-only, and a fresh job is `QUEUED`), but once the first run reaches its Human Input node and parks at `SUSPENDED`, the next submit cancels it — status `cancelled`, `errors: []`, no stop request anywhere.

The practical effect is that a flow cannot be used as a shared, multi-tenant background endpoint: a HITL approval queue can only ever hold one pending request per flow, and the second caller silently destroys the first caller's pause.

## Fix

Scope the supersede to the submitting run's **effective session** — `session_id` from the submit request, falling back to the flow id, which is the same normalization the runner already applies to the stream `thread_id` (`request["session_id"] or str(flow_id)`).

- A rerun still replaces the stale pause of its OWN session/thread — the canvas-rerun UX this code was written for is unchanged.
- `SUSPENDED` runs of OTHER sessions are left alone, so one flow can hold many independent pauses.
- Unchanged: another user's pause is never touched, and RUNNING jobs are never superseded.

Behavior change worth calling out: a submit under a different explicit `session_id` (or with none, which resolves to the flow id) no longer cancels a pause parked under a different session. Those pauses are now ended by a resume, an explicit `/stop`, or the input deadline — which is the point of the issue.

`lfx serve`'s `DurableServeWorkflowHost` keeps its flow-scoped supersede (single API-key identity, and its job store does not persist the run's session); the docs section says so explicitly.

## Changes on top of #14603

- **Resolve the session inside the DB session scope.** The effective session lives in the `job_metadata` JSON column; the upstream patch selected whole `Job` rows and read that column after the scope exited, which only works because `DatabaseService` builds sessions with `expire_on_commit=False`. Narrowing to matching `job_id`s inside the scope drops the coupling to that setting.
- **Read legacy row shapes.** Rows written before `submit` persisted the request blob carry a flat `job_metadata['session_id']`; `_effective_session` reads them the way `_reconstruct_request` already does instead of mis-scoping them to the flow id. Covered by a new test.
- **Docs.** Describe the scaled-mode (`_backend.stop`) cancel path next to `_cancel_suspended`, and where the session is read back from — the accuracy nit CodeRabbit raised on #14603.

## Second commit: unblock the migration-validation job on release branches

`test_upgrade_from_main_branch` upgrades a DB to `origin/main`'s alembic head using **this branch's** version directory. On a PR based on a release branch that head does not exist there — `release-1.11.4` predates `a3f8b1c9d7e2_add_policy_bundle_blocked_model_keys` — so the test can only raise `CommandError: Can't locate revision identified by 'a3f8b1c9d7e2'`.

It is not caused by anything here: a pristine `origin/release-1.11.4` checkout with zero changes fails the same test identically. This PR is simply the first 1.11.4 PR to trip the workflow's path filter, which covers `src/backend/base/langflow/services/background_execution/**`.

Fix: when main's tip head is not among the branch's own revisions, fall back to main's head **at the fork point** (`git merge-base HEAD origin/main`), which is reachable by construction. Main-based PRs are unaffected — the tip head is present, so it is used exactly as before. A branch that DELETES a migration main has still fails, because that revision exists at the fork point too, so the fallback cannot skip it away.

On this branch the test now takes its own honest skip path (`No new migrations on this branch — main and branch share the same alembic head`) instead of erroring: `MIGRATION_VALIDATION_CI=true uv run pytest src/backend/tests/unit/alembic/test_migration_execution.py -k sqlite` → 8 passed, 2 skipped.

## Test plan

- [x] Bug reproduced on unpatched `release-1.11.4`: with `service.py` restored to `origin/release-1.11.4`, `test_submit_does_not_supersede_suspended_run_of_a_different_session[sqlite]` FAILS (the session-a run comes back `CANCELLED`).
- [x] `uv run pytest src/backend/tests/unit/background_execution/test_supersede_suspended.py` — 12 passed, 12 skipped (postgres params skip without `LANGFLOW_TEST_DATABASE_URI`)
- [x] `uv run pytest src/backend/tests/unit/background_execution/` — 108 passed, 87 skipped
- [x] `uv run pytest src/backend/tests/unit/api/v2/test_workflow.py`
- [x] `uv run pytest src/backend/tests/unit/api/v2/test_workflow_background.py src/backend/tests/unit/api/v2/test_resume_route.py src/backend/tests/unit/api/v2/test_workflow_facade.py`

New coverage in `test_supersede_suspended.py`:

| test | asserts |
| --- | --- |
| `test_submit_does_not_supersede_suspended_run_of_a_different_session` | the #14599 repro: submit for `session-b` leaves the `session-a` pause `SUSPENDED` with its pending request intact |
| `test_submit_supersedes_suspended_run_of_same_session` | same session still replaces its own stale pause |
| `test_submit_supersedes_suspended_run_when_both_have_no_session` | sessionless runs fall back to the flow id and still replace |
| `test_supersede_only_targets_matching_session` | with `session-a` + `session-b` parked, only `session-b` is cancelled |
| `test_supersede_suspended_run_of_different_session_not_cancelled_when_legacy` | a sessionless pause is not cancelled by a sessioned submit |
| `test_supersede_reads_the_session_off_legacy_flat_metadata` | legacy flat `job_metadata['session_id']` rows are scoped by their real session |
