### PR TITLE
feat: link a queued run back to the request that queued it

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow_background.py
+++ b/src/backend/base/langflow/api/v2/workflow_background.py
@@ -309,6 +309,10 @@ async def _buffer_background_run(
             # Build under the job id so the run's vertex builds are persisted
             # keyed by job_id and GET-status reconstruction can find them.
             run_id=job_id,
+            # Also as job_id: run_id keys the persisted vertex builds, job_id is what the
+            # trace carrier is looked up by. Passing only the first reads no carrier, so this
+            # path would quietly produce unlinked runs.
+            job_id=job_uuid,
             track_job_status=False,
             # Distinct from the live v2 stream: same driver, but nobody is holding the connection,
             # so an operator reading latency needs to tell the two apart.

--- a/src/backend/base/langflow/api/v2/workflow_execution.py
+++ b/src/backend/base/langflow/api/v2/workflow_execution.py
@@ -34,7 +34,7 @@ from lfx.graph.checkpoint.store import CheckpointStore
 from lfx.graph.exceptions import GraphPausedException
 from lfx.graph.graph.base import Graph
 from lfx.log.logger import logger
-from lfx.observability import execution_protocol
+from lfx.observability import execution_protocol, extract_trace_link, queued_trace_link
 from lfx.schema.schema import InputValueRequest
 from lfx.schema.workflow import JobStatus, WorkflowExecutionResponse
 from lfx.workflow.adapters import StreamAdapter, StreamEvent
@@ -177,6 +177,22 @@ class _WorkflowEventQueue:
                 await self._overflow_task
 
 
+async def _queued_trace_link_for(job_id: UUID | None):
+    """Return a link to the request that enqueued *job_id*, or None.
+
+    None for a synchronous run, which has no job row, and for a job enqueued while nothing was
+    tracing. Never raises: a run must not fail because its telemetry could not be looked up.
+    """
+    if job_id is None:
+        return None
+    try:
+        job = await get_job_service().get_job_by_job_id(job_id)
+    except Exception:  # noqa: BLE001
+        await logger.adebug("could not read the job row for its trace carrier", exc_info=True)
+        return None
+    return extract_trace_link(job.job_metadata if job else None)
+
+
 async def _stream_event_frames(
     *,
     adapter: StreamAdapter,
@@ -248,7 +264,11 @@ async def _stream_event_frames(
             # Bound here rather than in the enclosing generator: drive() runs as its own task, so
             # the set/reset pair cannot straddle a generator suspension point and leak into the
             # consumer task that resumes it.
-            with execution_protocol(protocol):
+            #
+            # The queued-run link rides alongside for the same reason and in the same place. It
+            # is None for a run with a live request above it, and the context manager is a no-op
+            # then, so this costs a synchronous path nothing.
+            with execution_protocol(protocol), queued_trace_link(await _queued_trace_link_for(job_id)):
                 await asyncio.wait_for(
                     generate_flow_events(
                         flow_id=flow_id,

--- a/src/backend/base/langflow/api/v2/workflow_execution.py
+++ b/src/backend/base/langflow/api/v2/workflow_execution.py
@@ -34,7 +34,7 @@ from lfx.graph.checkpoint.store import CheckpointStore
 from lfx.graph.exceptions import GraphPausedException
 from lfx.graph.graph.base import Graph
 from lfx.log.logger import logger
-from lfx.observability import execution_protocol, extract_trace_link, queued_trace_link
+from lfx.observability import execution_protocol, extract_trace_link, queued_trace_link, tracing_is_available
 from lfx.schema.schema import InputValueRequest
 from lfx.schema.workflow import JobStatus, WorkflowExecutionResponse
 from lfx.workflow.adapters import StreamAdapter, StreamEvent
@@ -184,6 +184,10 @@ async def _queued_trace_link_for(job_id: UUID | None):
     tracing. Never raises: a run must not fail because its telemetry could not be looked up.
     """
     if job_id is None:
+        return None
+    if not tracing_is_available():
+        # The row would be read, parsed, and thrown away. A deployment without the telemetry
+        # extra should not pay a SELECT per run and per resume for a link nothing can render.
         return None
     try:
         job = await get_job_service().get_job_by_job_id(job_id)

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 from lfx.graph.exceptions import GraphPausedException
+from lfx.observability import inject_trace_carrier
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlmodel import col, func, select
 
@@ -187,10 +188,20 @@ class JobService(Service):
                 asset_type=asset_type,
                 user_id=user_id,
                 dedupe_key=dedupe_key,
-                # Stamp the end user atomically with the insert so a later shallow
-                # update_job_metadata (e.g. submit's persisted request) preserves it.
-                # Omit the key entirely when absent to keep non-serving rows byte-identical.
-                job_metadata={"end_user_id": end_user_id} if end_user_id else None,
+                # Two things stamped atomically with the insert, for the same reason: a later
+                # shallow update_job_metadata (e.g. submit's persisted request) preserves what
+                # is already on the row.
+                #
+                # The end user, so serving rows carry who the run was for.
+                #
+                # The trace carrier, because the queued run happens after this request returns,
+                # in a worker that may be a different process, so contextvars cannot carry the
+                # trace there. Written once, here, and never rewritten: job_metadata is saved
+                # back whole, and a second writer on the pause path would race this one.
+                #
+                # Still None when neither applies, so non-serving untraced rows stay
+                # byte-identical to what they were.
+                job_metadata=inject_trace_carrier({"end_user_id": end_user_id} if end_user_id else None) or None,
             )
             session.add(job)
             await session.flush()

--- a/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
+++ b/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
@@ -27,11 +27,19 @@ pytestmark = pytest.mark.usefixtures("client")
 
 @pytest.fixture(scope="module")
 def span_exporter():
-    """Install a provider for this module and hand back its exporter.
+    """Attach an exporter to whatever tracer provider this worker has, and hand it back.
 
     In-process rather than a subprocess because this needs the app, the database and the auth
-    fixtures. ``set_tracer_provider`` is first-write-wins, so the assert is what stops this
-    file passing vacuously when another module in the worker installs one first.
+    fixtures.
+
+    Attaching rather than installing is deliberate. ``set_tracer_provider`` is
+    first-write-wins, so a module that installs its own provider works alone and fails the
+    moment xdist puts another provider-installing module in the same worker -- which is
+    exactly what happened here on one Python version and not the others. Adding a processor
+    to the provider that is already there has no such ordering dependency.
+
+    The tests still cannot pass vacuously: each one asserts that its own spans arrived before
+    asserting anything about their links.
     """
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
@@ -39,12 +47,18 @@ def span_exporter():
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
     exporter = InMemorySpanExporter()
+    current = trace.get_tracer_provider()
+    if isinstance(current, TracerProvider):
+        # Someone already installed a real SDK provider. Ride it rather than fight it; the
+        # helpers below filter to this module's own spans by name and scope.
+        current.add_span_processor(SimpleSpanProcessor(exporter))
+        yield exporter
+        exporter.clear()
+        return
+
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
-    assert trace.get_tracer_provider() is provider, (
-        "another test installed a tracer provider first; these assertions would be vacuous"
-    )
     yield exporter
     provider.shutdown()
     exporter.clear()

--- a/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
+++ b/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
@@ -47,21 +47,30 @@ def span_exporter():
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
     exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
     current = trace.get_tracer_provider()
     if isinstance(current, TracerProvider):
         # Someone already installed a real SDK provider. Ride it rather than fight it; the
         # helpers below filter to this module's own spans by name and scope.
-        current.add_span_processor(SimpleSpanProcessor(exporter))
-        yield exporter
-        exporter.clear()
+        current.add_span_processor(processor)
+        try:
+            yield exporter
+        finally:
+            # Shut the processor down rather than detach it: a provider has no removal API,
+            # so clearing the exporter empties the list and leaves the processor registered,
+            # still appending every later span in this worker to it for the rest of the run.
+            processor.shutdown()
+            exporter.clear()
         return
 
     provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
-    yield exporter
-    provider.shutdown()
-    exporter.clear()
+    try:
+        yield exporter
+    finally:
+        provider.shutdown()
+        exporter.clear()
 
 
 def _flow_spans(exporter):

--- a/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
+++ b/src/backend/tests/unit/services/telemetry/test_queued_trace_continuity.py
@@ -1,0 +1,140 @@
+"""A background run must be reachable from the request that queued it.
+
+Before this, the two were unrelated traces. Measured on a real background run:
+
+    flow.execute  trace_id = 1291125b0d1eaf83ea0508d451d160a9   <- its own trace
+                  parent   = None
+                  links    = []
+
+An operator looking at a slow background run could not get back to the request that caused
+it, and an operator looking at a slow request could not see the work it queued.
+
+Driven through the real route rather than by calling the helpers, because the helpers already
+have unit tests in ``src/lfx/tests/unit/test_trace_carrier.py``. What those cannot show is
+that the carrier survives the actual hop: written on the job row by one request, read by the
+runner that picks the job up afterwards.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from lfx.observability import APPLICATION_TRACER_NAME
+
+pytestmark = pytest.mark.usefixtures("client")
+
+
+@pytest.fixture(scope="module")
+def span_exporter():
+    """Install a provider for this module and hand back its exporter.
+
+    In-process rather than a subprocess because this needs the app, the database and the auth
+    fixtures. ``set_tracer_provider`` is first-write-wins, so the assert is what stops this
+    file passing vacuously when another module in the worker installs one first.
+    """
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    assert trace.get_tracer_provider() is provider, (
+        "another test installed a tracer provider first; these assertions would be vacuous"
+    )
+    yield exporter
+    provider.shutdown()
+    exporter.clear()
+
+
+def _flow_spans(exporter):
+    return [
+        s
+        for s in exporter.get_finished_spans()
+        if s.name == "flow.execute"
+        and s.instrumentation_scope
+        and s.instrumentation_scope.name == APPLICATION_TRACER_NAME
+    ]
+
+
+def _request_spans(exporter):
+    return [s for s in exporter.get_finished_spans() if "workflows" in s.name and s.kind.name == "SERVER"]
+
+
+async def _run_background(client, flow_id, api_key, exporter):
+    """Start a background run and wait for its flow span to arrive."""
+    response = await client.post(
+        "/api/v2/workflows",
+        headers={"x-api-key": api_key},
+        json={"flow_id": str(flow_id), "input_value": "hello", "mode": "background"},
+    )
+    assert response.status_code == 200, response.text
+
+    for _ in range(150):
+        if _flow_spans(exporter):
+            break
+        await asyncio.sleep(0.1)
+    return response.json()
+
+
+async def test_a_background_run_links_back_to_the_request_that_queued_it(
+    client, simple_api_test, created_api_key, span_exporter
+):
+    """The regression this file exists for."""
+    span_exporter.clear()
+
+    await _run_background(client, simple_api_test["id"], created_api_key.api_key, span_exporter)
+
+    flows = _flow_spans(span_exporter)
+    requests = _request_spans(span_exporter)
+
+    # Asserted before the link check: with no spans at all, "the link is right" passes trivially.
+    assert len(flows) == 1, [s.name for s in span_exporter.get_finished_spans()]
+    assert requests, "no server span for the enqueuing request; the link has nothing to point at"
+
+    links = [link.context.trace_id for link in (flows[0].links or [])]
+    assert links == [requests[0].get_span_context().trace_id], (
+        f"flow span links {[format(t, '032x') for t in links]}, "
+        f"request trace {format(requests[0].get_span_context().trace_id, '032x')}"
+    )
+
+
+async def test_the_run_keeps_its_own_trace(client, simple_api_test, created_api_key, span_exporter):
+    """A link, not a parent, and not a merge into the request's trace.
+
+    The run starts after the request finished. Parenting it, or folding it into the same
+    trace, renders as a child that begins after its parent ended.
+    """
+    span_exporter.clear()
+
+    await _run_background(client, simple_api_test["id"], created_api_key.api_key, span_exporter)
+
+    flow = _flow_spans(span_exporter)[0]
+    request = _request_spans(span_exporter)[0]
+
+    assert flow.parent is None, flow.parent
+    assert flow.get_span_context().trace_id != request.get_span_context().trace_id
+
+
+async def test_a_synchronous_run_gets_no_link(client, simple_api_test, created_api_key, span_exporter):
+    """The control, and the thing that would break first if the carrier leaked.
+
+    A sync run has a live request above it, so it is a real child and needs no link. If this
+    grows one, the ambient link is escaping its binding and attaching to runs it has nothing
+    to do with.
+    """
+    span_exporter.clear()
+
+    response = await client.post(
+        "/api/v2/workflows?mode=sync",
+        headers={"x-api-key": created_api_key.api_key},
+        json={"flow_id": str(simple_api_test["id"]), "input_value": "hello"},
+    )
+    assert response.status_code == 200, response.text
+
+    flows = _flow_spans(span_exporter)
+    assert flows, "no flow span for the sync run"
+    assert all(not (s.links or []) for s in flows), [[link.context.trace_id for link in (s.links or [])] for s in flows]

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -39,7 +39,12 @@ from lfx.graph.vertex.base import Vertex, VertexStates
 from lfx.graph.vertex.schema import NodeData, NodeTypeEnum
 from lfx.graph.vertex.vertex_types import ComponentVertex, InterfaceVertex, StateVertex
 from lfx.log.logger import LogConfig, configure, logger
-from lfx.observability import APPLICATION_TRACER_NAME, get_execution_client, get_execution_protocol
+from lfx.observability import (
+    APPLICATION_TRACER_NAME,
+    get_execution_client,
+    get_execution_protocol,
+    get_queued_trace_link,
+)
 from lfx.schema.dotdict import dotdict
 from lfx.schema.schema import INPUT_FIELD_NAME, InputType, OutputValue
 from lfx.services.cache.utils import CacheMiss
@@ -994,6 +999,19 @@ class Graph:
                 FLOW_EXECUTION_SPAN_NAME,
                 context=OtelContext(),
                 links=[otel_trace.Link(parent_context)],
+            )
+        elif (queued_link := get_queued_trace_link()) is not None and not parent_context.is_valid:
+            # A run picked off a queue. Nothing is current here, because the request that
+            # queued it finished in another task and possibly another process, so the branch
+            # above cannot fire. The link travelled on the job row instead.
+            #
+            # Only when no span is current: an in-process parent is better evidence than a
+            # stamped one, and preferring the carrier would relabel a run that really is
+            # nested inside a live request.
+            span = tracer.start_span(
+                FLOW_EXECUTION_SPAN_NAME,
+                context=OtelContext(),
+                links=[queued_link],
             )
         else:
             span = tracer.start_span(FLOW_EXECUTION_SPAN_NAME)

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -994,24 +994,28 @@ class Graph:
         # start_span would pick the dead span up as parent anyway.
         parent = otel_trace.get_current_span()
         parent_context = parent.get_span_context()
-        if parent_context.is_valid and not parent.is_recording():
-            span = tracer.start_span(
-                FLOW_EXECUTION_SPAN_NAME,
-                context=OtelContext(),
-                links=[otel_trace.Link(parent_context)],
-            )
-        elif (queued_link := get_queued_trace_link()) is not None and not parent_context.is_valid:
-            # A run picked off a queue. Nothing is current here, because the request that
-            # queued it finished in another task and possibly another process, so the branch
-            # above cannot fire. The link travelled on the job row instead.
+        queued_link = get_queued_trace_link()
+        if queued_link is not None and not parent.is_recording():
+            # A run picked off a queue, carrying the context of the request that queued it on
+            # the job row.
             #
-            # Only when no span is current: an in-process parent is better evidence than a
-            # stamped one, and preferring the carrier would relabel a run that really is
-            # nested inside a live request.
+            # Checked before the ended-parent branch, and gated on the parent not recording
+            # rather than on no span being current. Whatever ended span the worker happens to
+            # be holding is not necessarily this run's originator: a worker task started from
+            # a request inherits that request's context permanently, so every later run it
+            # serves would link back to that first request. The carrier was written for this
+            # specific job and is the authoritative answer; an ambient ended span is only a
+            # good guess. A live parent still wins over both, below.
             span = tracer.start_span(
                 FLOW_EXECUTION_SPAN_NAME,
                 context=OtelContext(),
                 links=[queued_link],
+            )
+        elif parent_context.is_valid and not parent.is_recording():
+            span = tracer.start_span(
+                FLOW_EXECUTION_SPAN_NAME,
+                context=OtelContext(),
+                links=[otel_trace.Link(parent_context)],
             )
         else:
             span = tracer.start_span(FLOW_EXECUTION_SPAN_NAME)

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -35,7 +35,7 @@ import importlib
 import os
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from lfx.log.logger import logger, operator_logger, otel_log_bodies_exported
@@ -1007,6 +1007,108 @@ def _instrument_sqlalchemy(engine: object) -> None:
         )
     except Exception:  # noqa: BLE001 - see above
         logger.debug("sqlalchemy instrumentation unavailable; DB spans will be missing", exc_info=True)
+
+
+# The key a queued job carries its originating trace context under, inside the job's own
+# metadata dict. Prefixed because that dict is shared with application keys (``request``,
+# ``pending_request_id``, ``pre_pause_outputs``) and this one is machine-owned.
+JOB_TRACE_CARRIER_KEY = "otel_traceparent"
+
+
+def inject_trace_carrier(metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return *metadata* with the current trace context added, if there is one.
+
+    A queued run happens after its request has returned, in a worker that may be a different
+    process. ``contextvars`` do not survive that, so the context has to travel with the job
+    row. This writes it in W3C ``traceparent`` form rather than as a bare trace id: the
+    standard form carries the sampled flag, and a bare id would let a linked run be dropped by
+    a sampler that kept the request it came from.
+
+    Writes nothing when no valid span is current. A missing carrier is an honest "nobody was
+    tracing"; a synthesised one renders in the APM as a real relationship that never existed.
+    Same rule the ``protocol`` attribute follows.
+
+    Call this once, at enqueue. Nothing rewrites it afterwards, which is deliberate: the job
+    metadata blob is written back whole, and a second writer on the pause path would race the
+    one that is already there.
+    """
+    carrier: dict[str, Any] = dict(metadata or {})
+    if not _OTEL_AVAILABLE:
+        return carrier
+    try:
+        from opentelemetry import trace as _trace
+        from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+        if not _trace.get_current_span().get_span_context().is_valid:
+            return carrier
+        headers: dict[str, str] = {}
+        TraceContextTextMapPropagator().inject(headers)
+        traceparent = headers.get("traceparent")
+        if traceparent:
+            carrier[JOB_TRACE_CARRIER_KEY] = traceparent
+    except Exception:  # noqa: BLE001
+        # Telemetry must never fail an enqueue. A job that runs untraced beats a job that
+        # does not run.
+        logger.debug("could not inject the trace carrier into job metadata", exc_info=True)
+    return carrier
+
+
+# The link a queued run carries back to the request that enqueued it. Ambient for the same
+# reason ``protocol`` is: the graph that opens the flow span sits several layers below the
+# runner that reads the job row, and two of those layers hand the run to a fresh asyncio task,
+# which copies the context.
+_current_queued_trace_link: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "lfx_queued_trace_link",
+    default=None,
+)
+
+
+def get_queued_trace_link() -> Any:
+    """Return the link to the request that queued this run, or None outside a queued run."""
+    return _current_queued_trace_link.get()
+
+
+@contextlib.contextmanager
+def queued_trace_link(link: Any) -> Iterator[None]:
+    """Bind *link* for runs started in this context, and reset it on exit.
+
+    Reset matters: a worker serves many jobs on one task, so a link left bound would attach
+    one job's originating request to the next job's run.
+    """
+    if link is None:
+        yield
+        return
+    token = _current_queued_trace_link.set(link)
+    try:
+        yield
+    finally:
+        _current_queued_trace_link.reset(token)
+
+
+def extract_trace_link(metadata: dict[str, Any] | None):
+    """Return a ``Link`` to the request that queued this job, or None.
+
+    None covers every honest case: OpenTelemetry absent, the job enqueued while nothing was
+    tracing, or a carrier that will not parse. The caller starts an unlinked root span, which
+    is what happens today.
+    """
+    if not _OTEL_AVAILABLE or not metadata:
+        return None
+    traceparent = metadata.get(JOB_TRACE_CARRIER_KEY)
+    if not isinstance(traceparent, str) or not traceparent:
+        return None
+    try:
+        from opentelemetry import trace as _trace
+        from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+        context = TraceContextTextMapPropagator().extract({"traceparent": traceparent})
+        span_context = _trace.get_current_span(context).get_span_context()
+        if not span_context.is_valid:
+            return None
+        return _trace.Link(span_context)
+    except Exception:  # noqa: BLE001
+        logger.debug("could not extract the trace carrier from job metadata", exc_info=True)
+        return None
 
 
 class OutboundCallScope:

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from opentelemetry.sdk._logs import LoggerProvider
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.trace import Span
+    from opentelemetry.trace import Link, Span
 
 # The tracer name Langflow's own application spans are emitted under. Deliberately not
 # "langflow": the LLM tracer integrations already take a tracer under that name, and their
@@ -1063,7 +1063,7 @@ _current_queued_trace_link: contextvars.ContextVar[Any] = contextvars.ContextVar
 )
 
 
-def get_queued_trace_link() -> Any:
+def get_queued_trace_link() -> Link | None:
     """Return the link to the request that queued this run, or None outside a queued run."""
     return _current_queued_trace_link.get()
 
@@ -1085,7 +1085,16 @@ def queued_trace_link(link: Any) -> Iterator[None]:
         _current_queued_trace_link.reset(token)
 
 
-def extract_trace_link(metadata: dict[str, Any] | None):
+def tracing_is_available() -> bool:
+    """Whether OpenTelemetry is importable at all.
+
+    Exposed so a caller can skip work that exists only to feed telemetry, such as reading a
+    job row purely for its trace carrier, on a deployment that ships without the extra.
+    """
+    return _OTEL_AVAILABLE
+
+
+def extract_trace_link(metadata: dict[str, Any] | None) -> Link | None:
     """Return a ``Link`` to the request that queued this job, or None.
 
     None covers every honest case: OpenTelemetry absent, the job enqueued while nothing was

--- a/src/lfx/tests/unit/test_queued_link_precedence.py
+++ b/src/lfx/tests/unit/test_queued_link_precedence.py
@@ -1,0 +1,126 @@
+"""A stale span in the worker's context must not outrank the carrier on the job row.
+
+``flow_execution_span`` turns an ended parent into a link, which is right when that parent is
+the request this run came from. It is wrong when the ended span belongs to some *earlier*
+request that the worker task happens to still be holding: the run then links to a request it
+has nothing to do with, and a fabricated relationship renders in the APM as a real one, which
+is worse than the orphan it replaced.
+
+Reachable whenever the executor's worker tasks are first started from a request rather than at
+lifespan, so they inherit that request's context permanently and every later run links back to
+it. The carrier read off the job row is the authoritative answer for a queued run, so it wins
+over any ended ambient span. A genuinely live parent still wins over both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace")
+
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.graph.graph.base import Graph
+from lfx.observability import extract_trace_link, inject_trace_carrier, queued_trace_link
+
+FLOW_ID = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+def tracer_and_exporter():
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    current = trace.get_tracer_provider()
+    if isinstance(current, TracerProvider):
+        processor = SimpleSpanProcessor(exporter)
+        current.add_span_processor(processor)
+        try:
+            yield trace.get_tracer("test.worker"), exporter
+        finally:
+            processor.shutdown()
+            exporter.clear()
+        return
+
+    provider = TracerProvider()
+    processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    try:
+        yield trace.get_tracer("test.worker"), exporter
+    finally:
+        provider.shutdown()
+        exporter.clear()
+
+
+def build_graph() -> Graph:
+    chat_input = ChatInput(_id="chat-input")
+    chat_output = ChatOutput(_id="chat-output")
+    chat_output.set(input_value=chat_input.message_response)
+    return Graph(chat_input, chat_output, flow_id=FLOW_ID)
+
+
+def _flow_links(exporter):
+    spans = [s for s in exporter.get_finished_spans() if s.name == "flow.execute"]
+    assert len(spans) == 1, [s.name for s in exporter.get_finished_spans()]
+    return [link.context.trace_id for link in (spans[0].links or [])]
+
+
+def test_the_carrier_beats_a_stale_ended_span_in_the_workers_context(tracer_and_exporter):
+    """The regression. An older request's ended span must not capture this run."""
+    from opentelemetry import trace
+
+    tracer, exporter = tracer_and_exporter
+
+    # The request that actually queued this job, whose context travelled on the job row.
+    with tracer.start_as_current_span("originating.request") as originating:
+        originating_trace = originating.get_span_context().trace_id
+        carrier = inject_trace_carrier()
+
+    # An unrelated, earlier request whose span the worker task is still holding, ended.
+    stale = tracer.start_span("stale.earlier.request")
+    stale.end()
+    stale_trace = stale.get_span_context().trace_id
+    assert stale_trace != originating_trace
+
+    graph = build_graph()
+    context = trace.set_span_in_context(stale)
+    token = None
+    from opentelemetry import context as otel_context
+
+    token = otel_context.attach(context)
+    try:
+        with queued_trace_link(extract_trace_link(carrier)), graph.flow_execution_span():
+            pass
+    finally:
+        otel_context.detach(token)
+
+    links = _flow_links(exporter)
+    assert links == [originating_trace], (
+        f"linked to {[format(t, '032x') for t in links]}, "
+        f"originating {format(originating_trace, '032x')}, stale {format(stale_trace, '032x')}"
+    )
+
+
+def test_a_live_parent_still_wins_over_the_carrier(tracer_and_exporter):
+    """The control. A run nested inside a live request is a real child, not a link."""
+    tracer, exporter = tracer_and_exporter
+
+    with tracer.start_as_current_span("other.request") as other:
+        carrier = inject_trace_carrier()
+    link = extract_trace_link(carrier)
+
+    graph = build_graph()
+    with tracer.start_as_current_span("live.request") as live:
+        live_trace = live.get_span_context().trace_id
+        with queued_trace_link(link), graph.flow_execution_span():
+            pass
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == "flow.execute"]
+    assert len(spans) == 1
+    # Still a real child of the live request, and no link stamped over it.
+    assert spans[0].get_span_context().trace_id == live_trace
+    assert spans[0].links in (None, ()), spans[0].links
+    assert other.get_span_context().trace_id != live_trace

--- a/src/lfx/tests/unit/test_trace_carrier.py
+++ b/src/lfx/tests/unit/test_trace_carrier.py
@@ -49,6 +49,25 @@ def test_the_carrier_round_trips_the_trace_id(tracer):
     assert link.context.trace_id == expected
 
 
+def test_the_carrier_round_trips_the_sampling_flag(tracer):
+    """The reason this is a traceparent and not a bare trace id.
+
+    A bare id carries no sampling decision, so a linked run could be dropped by a sampler that
+    kept the request it came from -- leaving the operator a request with a reference to a run
+    that was never exported. The flag is the whole argument for the standard form, so it gets
+    its own assertion rather than riding along untested with the trace id.
+    """
+    with tracer.start_as_current_span("originating.request") as span:
+        expected = span.get_span_context().trace_flags
+        carrier = inject_trace_carrier()
+
+    link = extract_trace_link(carrier)
+
+    assert link is not None
+    assert link.context.trace_flags == expected
+    assert link.context.trace_flags.sampled is expected.sampled
+
+
 def test_existing_metadata_is_preserved(tracer):
     """The carrier shares the job's metadata dict with application keys."""
     with tracer.start_as_current_span("originating.request"):

--- a/src/lfx/tests/unit/test_trace_carrier.py
+++ b/src/lfx/tests/unit/test_trace_carrier.py
@@ -1,0 +1,118 @@
+"""The carrier that lets a queued run point back at the request that queued it.
+
+A background run happens after its request has returned, in a worker that may be a different
+process. ``contextvars`` do not survive that, so the trace context has to travel on the job
+row. These tests pin the two ends of that trip and, as much as they pin the happy path, the
+cases where the answer is honestly nothing.
+
+The failure mode worth guarding against is not a missing link. It is a *fabricated* one: a
+carrier that yields a link when no request was ever traced draws a relationship in the
+operator's APM that never existed, which is worse than an orphan because it looks real.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace")
+
+from lfx.observability import (
+    JOB_TRACE_CARRIER_KEY,
+    extract_trace_link,
+    get_queued_trace_link,
+    inject_trace_carrier,
+    queued_trace_link,
+)
+
+
+@pytest.fixture
+def tracer():
+    """A real SDK tracer. The propagator reads the live context, so a stub would prove nothing."""
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    provider = TracerProvider()
+    trace.set_tracer_provider(provider)
+    yield trace.get_tracer("test.originating.request")
+    provider.shutdown()
+
+
+def test_the_carrier_round_trips_the_trace_id(tracer):
+    """The load-bearing case: what the worker extracts is the request's own trace."""
+    with tracer.start_as_current_span("originating.request") as span:
+        expected = span.get_span_context().trace_id
+        carrier = inject_trace_carrier()
+
+    link = extract_trace_link(carrier)
+
+    assert link is not None
+    assert link.context.trace_id == expected
+
+
+def test_existing_metadata_is_preserved(tracer):
+    """The carrier shares the job's metadata dict with application keys."""
+    with tracer.start_as_current_span("originating.request"):
+        carrier = inject_trace_carrier({"request": "keep me", "pre_pause_outputs": [1, 2]})
+
+    assert carrier["request"] == "keep me"
+    assert carrier["pre_pause_outputs"] == [1, 2]
+    assert JOB_TRACE_CARRIER_KEY in carrier
+
+
+def test_nothing_is_written_when_nothing_is_tracing():
+    """Absent rather than invented, the same rule the protocol attribute follows."""
+    carrier = inject_trace_carrier({"request": "keep me"})
+
+    assert JOB_TRACE_CARRIER_KEY not in carrier
+    assert carrier == {"request": "keep me"}
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        {"request": "no carrier here"},
+        {JOB_TRACE_CARRIER_KEY: ""},
+        {JOB_TRACE_CARRIER_KEY: "not-a-traceparent"},
+        {JOB_TRACE_CARRIER_KEY: "00-00000000000000000000000000000000-0000000000000000-01"},
+        {JOB_TRACE_CARRIER_KEY: 12345},
+    ],
+)
+def test_a_carrier_that_cannot_be_trusted_yields_no_link(metadata):
+    """Every one of these must be None rather than a link to something invented.
+
+    The all-zero trace id is in the list deliberately: it parses as well-formed and is the
+    value an invalid context serialises to, so a naive implementation returns a link to a
+    trace that does not exist.
+    """
+    assert extract_trace_link(metadata) is None
+
+
+def test_the_ambient_link_is_unset_by_default():
+    """Asserted before the binding test: otherwise that test could pass on a leaked value."""
+    assert get_queued_trace_link() is None
+
+
+def test_the_ambient_link_binds_and_resets(tracer):
+    """Reset matters: a worker serves many jobs on one task.
+
+    Without the reset, one job's originating request would stay attached and the next job's
+    run would link to the wrong request, which is a fabricated relationship again.
+    """
+    with tracer.start_as_current_span("originating.request"):
+        link = extract_trace_link(inject_trace_carrier())
+
+    assert link is not None
+    with queued_trace_link(link):
+        assert get_queued_trace_link() is link
+
+    assert get_queued_trace_link() is None
+
+
+def test_binding_none_is_a_no_op():
+    """A synchronous run has no queued link, and must not pay for the machinery."""
+    with queued_trace_link(None):
+        assert get_queued_trace_link() is None
+
+    assert get_queued_trace_link() is None


### PR DESCRIPTION
A background run arrived at the APM as an orphan. Measured before the change, on a real run:

```
flow.execute  trace_id = 1291125b0d1eaf83ea0508d451d160a9   (its own trace)
              parent   = None
              links    = []
```

The request that enqueued the job and the run that resulted were **two unrelated traces**. An operator looking at a slow background run could not reach the request that caused it.

A span link points run → request, so that is the direction this fixes. The reverse (starting from a slow request and finding the work it queued) only holds in an APM that exposes reverse-link search, because no span carries a job id today. Stamping one on the enqueuing request's span would make it searchable, and that is worth doing separately.

After:

```
request  trace = ab7192066ce8e0aafd5efc6c4bff8e9c
flow.execute   = f9018f3c7baa56d7305a6b880126a872   (still its own trace, correctly)
         links = ['ab7192066ce8e0aafd5efc6c4bff8e9c']
```

## Why the existing link logic didn't cover it

`graph/base.py` already links back to a finished parent — but only while that parent is reachable in process memory. That covers a run outliving its request inside one process, because contextvars copy into an asyncio task. A job written to the database and read back later has no context to inherit, so the branch never fires.

## The design

Inject the trace context onto the job row at enqueue as a W3C `traceparent`; extract it wherever the job is picked up; attach it to the flow span as a **link**.

**Link, not parent.** The run starts after the request finished. Parenting to an ancestor that already ended renders as a child beginning after its parent — the exact defect the existing branch works around.

**`traceparent`, not a bare trace id.** The bare id loses the sampled flag, so a linked run could be dropped by a sampler that kept the request it came from.

**Written once at enqueue, never rewritten.** The tidier-looking alternative — chaining each pass to the one before — needs a write into `job_metadata` at every suspend. That blob is saved back whole, and the runner already carries a comment about a heartbeat racing a stamp and clobbering the request id. Chaining would add a second writer to a field with a known, previously-hit race, to buy a relationship that is already derivable: passes are grouped by the existing `run_id` (which on the background path **is** the job id — verified) and ordered by timestamp.

**Carried on a contextvar, bound next to `execution_protocol`.** The graph that opens the span sits several layers below the runner that reads the job row, and two of those layers hand the run to a fresh task. Same mechanism and same reason as `protocol`, so no parameter threading.

**Only when no span is current.** An in-process parent is better evidence than a stamped one, so a run genuinely nested inside a live request keeps its real parent.

## Absence stays absent

Nothing traced at enqueue writes no carrier. A missing, unparseable, or invalid carrier yields no link and an ordinary root span — today's behaviour.

The all-zero trace id is covered explicitly: it parses as well-formed and is what an invalid context serialises to, so a naive reader returns a link to a trace that never existed. A fabricated relationship is worse than an orphan, because it looks real.

## Verification

Removing the injection turns the end-to-end link test red with `links []`; green again on restore.

A **synchronous** run is asserted to have *no* link — that is what breaks first if the ambient link escapes its binding and attaches to runs it has nothing to do with.

13 carrier tests, 3 end-to-end. **173** backend telemetry and **294** v2 API tests pass.

## `lfx serve` durable deliberately not wired

An earlier draft of this description called that a gap. It isn't — I checked, and it needs nothing.

`DurableServeWorkflowHost._spawn` is `asyncio.create_task`, so its jobs stay in one process and the task copies the context. By the time the run starts, the submitting request's span has ended, which is exactly the existing `is_valid and not is_recording()` branch. Probed with this PR's changes reverted:

```
flow.execute  own_trace = 011980855068aec8b07396fcd5fc39e0
              links     = ['093bc80d4da9a45b928a6fb2c89fcf0e']
submit_trace  =           093bc80d4da9a45b928a6fb2c89fcf0e
LINKED = True
```

Already the same shape this PR produces on the langflow path.

`queued_workflow_job_ids` in the durable store looks like a restart-recovery drain, which *would* cross a process boundary — but it has no consumer. If one is added, that's the moment to wire this, and the helpers in `lfx.observability` are ready.

Wiring it now would add a metadata write and a `get_job` round-trip per run for a link that is already correct, plus machinery that reads as load-bearing and isn't.

## Known gap

HITL resume needs no extra code — a resumed pass re-enqueues and reads the same unmodified carrier — but this PR does not add a test driving an actual paused-then-resumed run. That's reasoning, not evidence.



## Unrelated

Two catalog-policy tests in `src/lfx/tests/unit/graph` fail on this base branch with none of these changes applied. Verified by reverting both source files and re-running.

## From review

`flow_execution_span` checked the ended-parent branch first, so whatever ended span a worker task happened to be holding captured the run and the carrier was never read. A worker started from a request inherits that request's context permanently, so every later run it served linked back to that **first** request. That is the fabricated relationship this PR argues is worse than an orphan, and it renders in the APM as real.

Reproduced before fixing:

```
linked to ['41e34d580905fa6ca3b08169ce414060']
originating  f90dc1136e4ce3926483c72afe0e44c6
stale        41e34d580905fa6ca3b08169ce414060
```

The queued link is now checked first, gated on the parent not recording, so a carrier written for this specific job beats a stale ambient span. A genuinely live parent still wins over both and stays a real parent, asserted as the control.

Also: the job row is no longer read when OpenTelemetry is absent, the buffered background path passes `job_id` (it passed only `run_id`, so it read no carrier at all), and both helpers are typed `Link | None`.
