### PR TITLE
docs(security): record Mend triage for four unremediable findings

### DIFF
--- a/.github/mend-scan-notes.md
+++ b/.github/mend-scan-notes.md
@@ -1,0 +1,124 @@
+# Mend scan triage notes
+
+Findings that Mend reports repeatedly but which **cannot be remediated by a version
+bump**, with the evidence behind each decision. Re-check the "revisit when" column
+before re-opening any of these — do not raise a floor without first confirming a
+patched version actually exists.
+
+## How to verify a finding before acting on it
+
+Mend severities and "fixed version" hints are not authoritative. Query the real
+advisory data first:
+
+```bash
+# GitHub advisory DB — highest first-patched version
+gh api "/advisories?ecosystem=pip&affects=<pkg>&per_page=100" \
+  --jq '[.[].vulnerabilities[]?|select(.package.name=="<pkg>")|.first_patched_version]
+        |map(select(.!=null))|unique|sort'
+
+# OSV (aggregates PyPA + CVE + GHSA; catches PYSEC ids GHSA misses)
+curl -s -X POST https://api.osv.dev/v1/query \
+  -d '{"package":{"name":"<pkg>","ecosystem":"PyPI"}}' | jq '.vulns[]?|{id,summary}'
+
+# NVD, by exact version
+curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=cpe:2.3:a:<vendor>:<pkg>:<version>:*:*:*:*:*:*:*" \
+  | jq '.totalResults'
+
+# Is there even a newer release to move to?
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.version, .urls[0].upload_time'
+```
+
+A finding is only actionable if a released version exists that is **above every
+`first_patched_version`**. An advisory whose range ends in `last_affected: <latest
+release>` with `first_patched_version: null` means *no fix has shipped*.
+
+## Scan surface
+
+`.github/workflows/mend.yml` exports dependencies with:
+
+```
+uv export --all-packages --all-extras --all-groups
+```
+
+This is the **maximal** closure — every opt-in extra and every dev/test group of
+every workspace package, not what any user actually installs. A package appearing
+in the scan does not imply it ships by default. Check the declaring extra and
+whether it is reachable from `all` / `complete` / the root `langflow` package
+before assessing exposure.
+
+---
+
+## Waived findings
+
+### `transformers` — false positive
+
+| | |
+|---|---|
+| **Mend** | High: 1, against 5.8.1 |
+| **Reality** | Highest `first_patched_version` across **all** published advisories is **5.5.0** (GHSA-fgcw-684q-jj6r). OSV/PYSEC agrees: highest `fixed` is 5.3.0, highest `last_affected` is 5.2.0. NVD CPE query for `transformers:5.8.1` returns **0 results**. |
+| **Resolved** | 5.8.1 — above every patched version |
+| **Action** | None available. The floor is already `>=5.6.0,<6.0.0`. |
+| **Revisit when** | A transformers advisory publishes with `first_patched_version > 5.8.1`. |
+
+Do **not** raise the floor past 5.9.0 as a speculative fix: `docling-ibm-models>=3.13.3`
+declares `transformers<5.9.0; sys_platform == "darwin"`, so a higher floor makes it
+unsatisfiable on macOS and uv silently forks the resolution, backtracking the whole
+docling stack (docling 2.115→2.99, docling-parse 7.8.1→6.2.0, docling-core 2.88→2.78)
+on darwin only. This was already hit once; see the comment in
+`src/backend/base/pyproject.toml`.
+
+### `accelerate` — false positive
+
+| | |
+|---|---|
+| **Mend** | High: 1, against 1.14.0 |
+| **Reality** | **Zero** advisories in GHSA, OSV, and NVD. |
+| **Resolved** | 1.14.0 — the latest release on PyPI |
+| **Reachability** | Opt-in only: the `docling` extra, via `docling-slim` and `docling-ibm-models`. |
+| **Action** | None. There is no vulnerability to remediate and no newer version to move to. |
+| **Revisit when** | Any advisory is published for `accelerate` at all. |
+
+### `chromadb` — unpatched upstream, not reachable
+
+| | |
+|---|---|
+| **Mend** | Critical: 5, against 1.5.9 |
+| **Reality** | CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c, CWE-94, reported CVSS v4 9.3. Affected range is `>= 1.0.0, last_affected: 1.5.9`, `first_patched_version: null`. |
+| **Fix status** | **None released.** 1.5.9 is the newest release on PyPI (uploaded 2026-05-05); the advisory published 2026-05-18. The fix is merged upstream as chroma-core/chroma#7237 but has not shipped. |
+| **Action** | Nothing to bump to. |
+| **Revisit when** | chromadb publishes a release newer than 1.5.9 — bump immediately. |
+
+**Why this is not reachable from Langflow.** The vulnerability is a race between
+ChromaDB's embedding-model-reference parsing and its authentication check, exposed
+through the **Python FastAPI server's** `/api/v2/tenants/{tenant}/databases/{db}/collections`
+endpoint. Langflow never runs that server. It uses chromadb exclusively as a client:
+`PersistentClient` (embedded/local), `CloudClient` (Chroma Cloud), and `HttpClient`
+(connecting to a Chroma server the user operates). The vulnerable endpoint is never
+bound by any Langflow process.
+
+**Why it cannot simply be dropped.** `langchain-chroma` is a default dependency of
+`langflow-base`, and chromadb backs the Knowledge Base feature
+(`lfx/base/knowledge_bases/backends/chroma.py`,
+`lfx/components/files_and_knowledge/knowledge.py`,
+`lfx/components/files_and_knowledge/memory_retrieval.py`). Removing it breaks a core
+feature; this is not an optional integration.
+
+### `diskcache` — no fix exists, opt-in only
+
+| | |
+|---|---|
+| **Mend** | Critical: 1, against 5.6.3 |
+| **Reality** | GHSA-w8v5-vhqr-4h9v / PYSEC-2026-2447. GHSA rates this **medium**, not critical. Range is `last_affected: 5.6.3`, `first_patched_version: null`. |
+| **Fix status** | **None, and none expected.** 5.6.3 is the final release ever published (2023-08-31); the project is unmaintained. |
+| **Action** | Nothing to bump to. |
+| **Revisit when** | diskcache publishes any release after 5.6.3, or the `opendsstar` extra is removed. |
+
+**Exploitation precondition.** The issue is unsafe pickle deserialization: an attacker
+must already hold **write access to the cache directory** to achieve code execution
+when the application later reads from that cache. This is a local-privilege issue, not
+a remote one.
+
+**Reachability.** Two levels inside an opt-in extra:
+`opendsstar` extra → `ragworkbench` → `unitxt` → `diskcache`. The `opendsstar` extra is
+**not** included in `all`, **not** in `complete`, and is not referenced by the root
+`langflow` package, so it is installed only by users who explicitly ask for it.

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -100,6 +100,9 @@ dependencies = [
     "ibm-watsonx-ai>=1.3.1,<2.0.0",
     "langchain-ibm~=1.1.0",
     "trustcall>=0.0.38,<1.0.0",
+    # Not optional: chromadb backs the Knowledge Base (lfx/base/knowledge_bases/backends/chroma.py).
+    # Mend flags chromadb for CVE-2026-45829, which has no released fix and is not reachable here --
+    # it affects Chroma's FastAPI server, which Langflow never runs. See .github/mend-scan-notes.md.
     "langchain-chroma~=0.2.6",
     "jaraco-context>=6.1.0",
     "wheel>=0.46.2,<1.0.0",
@@ -108,9 +111,11 @@ dependencies = [
     "dynaconf>=3.2.13,<4.0.0",
     "pyasn1>=0.6.3,<0.7.0",
     "langgraph-checkpoint>4.0.0,<5.0.0",
-    # 5.6.0 already clears every published transformers advisory (highest patched version is 5.5.0).
-    # Do not raise past 5.9.0: docling-ibm-models>=3.13.3 caps transformers<5.9.0 on macOS, and a
-    # higher floor silently backtracks the whole docling stack to older releases on darwin only.
+    # 5.6.0 already clears every published transformers advisory (highest patched version is 5.5.0),
+    # and NVD returns no CVEs for the 5.8.1 we currently resolve -- Mend's finding here is a false
+    # positive. Do not raise past 5.9.0: docling-ibm-models>=3.13.3 caps transformers<5.9.0 on macOS,
+    # and a higher floor silently backtracks the whole docling stack to older releases on darwin only.
+    # See .github/mend-scan-notes.md.
     "transformers>=5.6.0,<6.0.0",
 ]
 
@@ -212,6 +217,9 @@ faiss = [
 qdrant = ["qdrant-client>=1.12.0,<2.0.0"]
 qdrant-vectors = ["langchain-qdrant>=1.0.0,<2.0.0"]
 weaviate = ["weaviate-client>=4.10.2,<5.0.0"]
+# chromadb 1.5.9 is the newest release; CVE-2026-45829 is unpatched upstream
+# (fix merged as chroma-core/chroma#7237, unreleased). Bump as soon as >1.5.9 ships.
+# See .github/mend-scan-notes.md.
 chroma = [
     "chromadb>=1.0.0,<2.0.0",
     "langchain-chroma~=0.2.6"
@@ -261,6 +269,11 @@ pytube = ["pytube==15.0.0"]
 # crewai is commented out due to httpx version conflict
 # crewai = ["crewai>=0.126.0"]
 smolagents = ["smolagents>=1.8.0"]
+# Pulls diskcache (via ragworkbench -> unitxt), which Mend flags for GHSA-w8v5-vhqr-4h9v.
+# diskcache 5.6.3 is its final release (2023) and the project is unmaintained, so there is
+# nothing to bump to; the issue also requires local write access to the cache directory.
+# This extra is opt-in only -- not in `all`, not in `complete`, not a root langflow dep.
+# See .github/mend-scan-notes.md.
 opendsstar = [
     "OpenDsStar==1.0.26; python_version >= '3.11' and python_version < '3.14' and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
 ]
@@ -360,6 +373,9 @@ traceloop = ["traceloop-sdk>=0.43.1,<1.0.0"]
 openlayer = ["openlayer>=0.9.0,<1.0.0"]
 
 # Document processing / OCR
+# docling-slim / docling-ibm-models pull `accelerate`, which Mend flags -- but accelerate has
+# zero advisories in GHSA, OSV, and NVD, and we already resolve its latest release. False
+# positive; nothing to bump. See .github/mend-scan-notes.md.
 docling = [
     "docling-core>=2.77.0,<3.0.0",
     "docling-slim[cli,convert-core,extract-core,feat-ocr-rapidocr,format-latex,format-office,format-pdf,format-web,models-local,service-client]>=2.36.1,<3.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -36,6 +36,7 @@ assemblyai = ["assemblyai>=0.33.0,<1.0.0"]
 azure = ["langchain-openai>=1.1.6", "langchain-azure-ai>=1.1.0,<2"]
 baidu = ["qianfan==0.3.5", "langchain-community>=0.4.1,<1.0.0"]
 bing = ["langchain-community>=0.4.1,<1.0.0"]
+# chromadb 1.5.9 is the newest release; CVE-2026-45829 is unpatched upstream. See .github/mend-scan-notes.md.
 chroma = ["chromadb>=1.0.0,<2.0.0", "langchain-chroma~=0.2.6", "langchain-community>=0.4.1,<1.0.0"]
 cleanlab = ["cleanlab-tlm>=1.1.2,<2.0.0"]
 clickhouse = ["clickhouse-connect==0.7.19", "langchain-community>=0.4.1,<1.0.0"]

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -71,6 +71,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Pulls diskcache (via ragworkbench -> unitxt), which Mend flags for GHSA-w8v5-vhqr-4h9v.
+# 5.6.3 is diskcache's final release (2023, unmaintained), so there is nothing to bump to.
+# See .github/mend-scan-notes.md.
 opendsstar = [
     "OpenDsStar==1.0.26; python_version >= '3.11' and python_version < '3.14' and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
 ]


### PR DESCRIPTION
Mend continues to flag four packages on `release-1.11.4`. I checked each against the GitHub advisory DB, OSV (PyPA + CVE + GHSA), and NVD directly, and traced the dependency paths in the lock.

**None of the four can be remediated by a version bump.** Two are false positives; two have no released fix upstream. So this PR records the evidence instead of churning dependencies — no constraint changes, and `uv lock --check` is clean.

## Findings

| Package | Mend | Actual advisory data | Fix available? |
|---|---|---|---|
| `transformers` 5.8.1 | High: 1 | Highest `first_patched_version` across **all** advisories = **5.5.0**. NVD CPE query for 5.8.1 → **0 results**. | Already clear |
| `accelerate` 1.14.0 | High: 1 | **Zero** advisories in GHSA, OSV, and NVD. Latest release. | No vuln exists |
| `chromadb` 1.5.9 | Critical: 5 | CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c, CWE-94. `last_affected: 1.5.9`, `first_patched_version: null`. | **No — unpatched** |
| `diskcache` 5.6.3 | Critical: 1 | GHSA-w8v5-vhqr-4h9v / PYSEC-2026-2447. GHSA rates this **medium**, not critical. `last_affected: 5.6.3`, `first_patched_version: null`. | **No — unmaintained** |

### The two false positives

`transformers` 5.8.1 sits above every published patched version. The floor is already `>=5.6.0,<6.0.0` and must not go past 5.9.0 — `docling-ibm-models>=3.13.3` declares `transformers<5.9.0; sys_platform == "darwin"`, so a higher floor makes it unsatisfiable on macOS and uv silently forks the resolution, backtracking the whole docling stack on darwin only. We hit exactly this in a prior round.

`accelerate` has no advisories anywhere, and 1.14.0 is its latest release. It reaches us opt-in via the `docling` extra.

### The two with no fix

**chromadb.** 1.5.9 is the newest release on PyPI (uploaded 2026-05-05), and the advisory published 2026-05-18 — the fix is merged upstream as chroma-core/chroma#7237 but has not shipped. There is nothing to bump to.

It is also not reachable as scanned: CVE-2026-45829 is a pre-authentication injection in Chroma's **Python FastAPI server**, at `/api/v2/tenants/{tenant}/databases/{db}/collections`. Langflow never runs that server — it uses chromadb purely as a client (`PersistentClient`, `CloudClient`, `HttpClient`), so the vulnerable endpoint is never bound. And it can't simply be dropped: `langchain-chroma` is a default dep of `langflow-base` and chromadb backs the Knowledge Base.

**diskcache.** 5.6.3 is that project's final release (2023-08-31) and it is unmaintained, so no fix is coming. The issue is unsafe pickle deserialization requiring an attacker to already hold **write access to the cache directory**. It arrives two levels inside the opt-in `opendsstar` extra (→ `ragworkbench` → `unitxt`), which is absent from `all`, from `complete`, and from the root `langflow` package.

## Why these keep reappearing

`.github/workflows/mend.yml` exports the scan surface with `uv export --all-packages --all-extras --all-groups` — the maximal closure, including every opt-in extra and dev/test group, not what any user installs. A package appearing in the scan doesn't imply it ships. That's how `diskcache`, buried inside an extra nobody installs by default, surfaces as "Critical / Transitive".

## Changes

- Adds `.github/mend-scan-notes.md`: per-finding rationale, the advisory-query recipe to confirm a patched version actually exists before raising any floor, and a note on the scan surface.
- Cross-references it from each affected declaration in `langflow-base`, `lfx`, and `lfx-bundles`.

Comments only — no dependency constraints change.

## Test plan

- [x] All three `pyproject.toml` files parse (`tomllib`)
- [x] `uv lock --check` passes — resolution untouched, zero lock churn
- [x] `git diff` confirms comment-only changes
- [ ] CI green

Tracking issue for the chromadb bump: filed separately, to be linked below.

Backport to `1.12.0` to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security triage guidance for verifying dependency advisories and interpreting scan results.
  * Documented accepted findings, affected dependency versions, exploitability, remediation status, and review conditions.
  * Added dependency notes explaining unpatched upstream issues, false positives, and upgrade constraints.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->