### PR TITLE
feat: add CustomModelProvidersEmptyState seam for model provider modal

### DIFF
--- a/src/frontend/src/customization/components/__tests__/custom-auth-seams.test.tsx
+++ b/src/frontend/src/customization/components/__tests__/custom-auth-seams.test.tsx
@@ -5,7 +5,6 @@ import { CustomAdminPageMenuItem } from "../custom-admin-page-menu-item";
 import CustomLoginBrandTitle from "../custom-login-brand-title";
 import CustomLoginSignupPrompt from "../custom-login-signup-prompt";
 import CustomLoginSsoOptions from "../custom-login-sso-options";
-import CustomModelProvidersEmptyState from "../custom-model-providers-empty-state";
 import CustomResourceShareAction from "../custom-resource-share-action";
 
 describe("OSS auth customization seams", () => {
@@ -51,16 +50,6 @@ describe("OSS auth customization seams", () => {
     );
 
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it("passes model provider empty-state children through", () => {
-    render(
-      <CustomModelProvidersEmptyState kind="providers" show>
-        <p>OSS provider content</p>
-      </CustomModelProvidersEmptyState>,
-    );
-
-    expect(screen.getByText("OSS provider content")).toBeInTheDocument();
   });
 
   it("never skips auth refresh", () => {

--- a/src/frontend/src/customization/components/__tests__/custom-auth-seams.test.tsx
+++ b/src/frontend/src/customization/components/__tests__/custom-auth-seams.test.tsx
@@ -5,6 +5,7 @@ import { CustomAdminPageMenuItem } from "../custom-admin-page-menu-item";
 import CustomLoginBrandTitle from "../custom-login-brand-title";
 import CustomLoginSignupPrompt from "../custom-login-signup-prompt";
 import CustomLoginSsoOptions from "../custom-login-sso-options";
+import CustomModelProvidersEmptyState from "../custom-model-providers-empty-state";
 import CustomResourceShareAction from "../custom-resource-share-action";
 
 describe("OSS auth customization seams", () => {
@@ -50,6 +51,16 @@ describe("OSS auth customization seams", () => {
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("passes model provider empty-state children through", () => {
+    render(
+      <CustomModelProvidersEmptyState kind="providers" show>
+        <p>OSS provider content</p>
+      </CustomModelProvidersEmptyState>,
+    );
+
+    expect(screen.getByText("OSS provider content")).toBeInTheDocument();
   });
 
   it("never skips auth refresh", () => {

--- a/src/frontend/src/customization/components/__tests__/custom-model-providers-empty-state.test.tsx
+++ b/src/frontend/src/customization/components/__tests__/custom-model-providers-empty-state.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import CustomModelProvidersEmptyState from "../custom-model-providers-empty-state";
+
+describe("CustomModelProvidersEmptyState OSS seam", () => {
+  it.each([
+    ["providers", true],
+    ["providers", false],
+    ["models", true],
+    ["models", false],
+  ] as const)("passes %s children through when show is %s", (kind, show) => {
+    render(
+      <CustomModelProvidersEmptyState kind={kind} show={show}>
+        <p>OSS model provider content</p>
+      </CustomModelProvidersEmptyState>,
+    );
+
+    expect(screen.getByText("OSS model provider content")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/customization/components/custom-model-providers-empty-state.tsx
+++ b/src/frontend/src/customization/components/custom-model-providers-empty-state.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export interface CustomModelProvidersEmptyStateProps {
+  children: ReactNode;
+  kind: "providers" | "models";
+  show: boolean;
+}
+
+export default function CustomModelProvidersEmptyState({
+  children,
+}: CustomModelProvidersEmptyStateProps) {
+  return <>{children}</>;
+}

--- a/src/frontend/src/customization/components/custom-model-providers-empty-state.tsx
+++ b/src/frontend/src/customization/components/custom-model-providers-empty-state.tsx
@@ -6,6 +6,8 @@ export interface CustomModelProvidersEmptyStateProps {
   show: boolean;
 }
 
+// OSS pass-through. Enterprise replaces this seam with provider/model empty
+// states and uses `show` to decide whether to replace the supplied content.
 export default function CustomModelProvidersEmptyState({
   children,
 }: CustomModelProvidersEmptyStateProps) {

--- a/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import ModelSelection from "../components/ModelSelection";
+import ModelSelection, {
+  hasProviderOwnedEmptyState,
+} from "../components/ModelSelection";
 import { Model } from "../components/types";
 
 // Mock ForwardedIconComponent
@@ -47,6 +49,22 @@ const mockEmbeddingModels: Model[] = [
 ];
 
 const allModels = [...mockLLMModels, ...mockEmbeddingModels];
+
+describe("hasProviderOwnedEmptyState", () => {
+  it.each(["Azure AI Foundry", "ollama", "OLLAMA"])(
+    "returns true for %s",
+    (providerName) => {
+      expect(hasProviderOwnedEmptyState(providerName)).toBe(true);
+    },
+  );
+
+  it.each(["Anthropic", "", undefined])(
+    "returns false for %s",
+    (providerName) => {
+      expect(hasProviderOwnedEmptyState(providerName)).toBe(false);
+    },
+  );
+});
 
 describe("ModelSelection", () => {
   const defaultProps = {

--- a/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
+import CustomModelProvidersEmptyState from "@/customization/components/custom-model-providers-empty-state";
 import ProviderList from "@/modals/modelProviderModal/components/ProviderList";
 import { Provider } from "@/modals/modelProviderModal/components/types";
 import type { ModelTypeFilter } from "@/types/models";
@@ -80,6 +81,14 @@ const ModelProvidersContent = ({
     );
   };
 
+  const selectedProviderName =
+    syncedSelectedProvider?.provider.toLowerCase() ?? "";
+  const showNoEnabledModels =
+    !!syncedSelectedProvider &&
+    syncedSelectedProvider.models.length === 0 &&
+    selectedProviderName !== "ollama" &&
+    selectedProviderName !== "azure ai foundry";
+
   return (
     <div className="flex flex-row w-full h-full overflow-hidden">
       <div
@@ -142,18 +151,23 @@ const ModelProvidersContent = ({
 
         <div className="relative flex min-h-0 flex-1 flex-col">
           <div className="flex h-full flex-col gap-3 overflow-y-auto px-4 pt-4 pb-6 transition-all duration-300 ease-in-out">
-            <ModelSelection
-              modelType={modelType}
-              availableModels={syncedSelectedProvider?.models || []}
-              onModelToggle={handleModelToggle}
-              providerName={syncedSelectedProvider?.provider}
-              isEnabledModel={
-                !!(
-                  syncedSelectedProvider?.is_enabled ||
-                  syncedSelectedProvider?.is_configured
-                )
-              }
-            />
+            <CustomModelProvidersEmptyState
+              kind="models"
+              show={showNoEnabledModels}
+            >
+              <ModelSelection
+                modelType={modelType}
+                availableModels={syncedSelectedProvider?.models || []}
+                onModelToggle={handleModelToggle}
+                providerName={syncedSelectedProvider?.provider}
+                isEnabledModel={
+                  !!(
+                    syncedSelectedProvider?.is_enabled ||
+                    syncedSelectedProvider?.is_configured
+                  )
+                }
+              />
+            </CustomModelProvidersEmptyState>
           </div>
           <div className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-background via-background/70 to-transparent" />
           <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-background via-background/70 to-transparent" />

--- a/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
@@ -7,7 +7,7 @@ import { Provider } from "@/modals/modelProviderModal/components/types";
 import type { ModelTypeFilter } from "@/types/models";
 import { cn } from "@/utils/utils";
 import { useProviderConfiguration } from "../hooks/useProviderConfiguration";
-import ModelSelection from "./ModelSelection";
+import ModelSelection, { hasProviderOwnedEmptyState } from "./ModelSelection";
 import ProviderConfigurationForm from "./ProviderConfigurationForm";
 
 interface ModelProvidersContentProps {
@@ -81,13 +81,13 @@ const ModelProvidersContent = ({
     );
   };
 
-  const selectedProviderName =
-    syncedSelectedProvider?.provider.toLowerCase() ?? "";
-  const showNoEnabledModels =
+  const typedModelCount = (syncedSelectedProvider?.models ?? []).filter(
+    (model) => modelType === "all" || model.metadata?.model_type === modelType,
+  ).length;
+  const showNoAvailableModels =
     !!syncedSelectedProvider &&
-    syncedSelectedProvider.models.length === 0 &&
-    selectedProviderName !== "ollama" &&
-    selectedProviderName !== "azure ai foundry";
+    typedModelCount === 0 &&
+    !hasProviderOwnedEmptyState(syncedSelectedProvider.provider);
 
   return (
     <div className="flex flex-row w-full h-full overflow-hidden">
@@ -153,7 +153,7 @@ const ModelProvidersContent = ({
           <div className="flex h-full flex-col gap-3 overflow-y-auto px-4 pt-4 pb-6 transition-all duration-300 ease-in-out">
             <CustomModelProvidersEmptyState
               kind="models"
-              show={showNoEnabledModels}
+              show={showNoAvailableModels}
             >
               <ModelSelection
                 modelType={modelType}

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -14,6 +14,12 @@ import { cn } from "@/utils/utils";
 /** Providers where the callable model id is a user-chosen deployment name. */
 const CUSTOM_DEPLOYMENT_PROVIDERS = new Set(["Azure AI Foundry"]);
 
+/** Providers that render their own useful UI when no catalog models exist. */
+export const hasProviderOwnedEmptyState = (providerName?: string): boolean =>
+  !!providerName &&
+  (CUSTOM_DEPLOYMENT_PROVIDERS.has(providerName) ||
+    providerName.toLowerCase() === "ollama");
+
 export interface ModelProviderSelectionProps {
   availableModels: Model[];
   onModelToggle: (
@@ -402,7 +408,9 @@ const ModelSelection = ({
     );
   };
 
-  const isOllama = providerName?.toLowerCase() === "ollama";
+  const providerOwnsEmptyState = hasProviderOwnedEmptyState(providerName);
+  const isOllama =
+    providerOwnsEmptyState && providerName?.toLowerCase() === "ollama";
   // Use the unfiltered list for the empty-state check so an
   // ollama-no-models warning still fires when the search field happens to be
   // populated.

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import LoadingTextComponent from "@/components/common/loadingTextComponent";
 import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import CustomModelProvidersEmptyState from "@/customization/components/custom-model-providers-empty-state";
 import type { ModelTypeFilter } from "@/types/models";
 import ProviderListItem from "./ProviderListItem";
 import { Provider } from "./types";
@@ -88,17 +89,22 @@ const ProviderList = ({
   }
 
   return (
-    <div className="flex flex-col gap-1" data-testid="provider-list">
-      {filteredProviders.map((provider) => (
-        <ProviderListItem
-          key={provider.provider}
-          provider={provider}
-          showIcon={selectedProviderName !== null}
-          isSelected={selectedProviderName === provider.provider}
-          onSelect={handleProviderSelect}
-        />
-      ))}
-    </div>
+    <CustomModelProvidersEmptyState
+      kind="providers"
+      show={filteredProviders.length === 0}
+    >
+      <div className="flex flex-col gap-1" data-testid="provider-list">
+        {filteredProviders.map((provider) => (
+          <ProviderListItem
+            key={provider.provider}
+            provider={provider}
+            showIcon={selectedProviderName !== null}
+            isSelected={selectedProviderName === provider.provider}
+            onSelect={handleProviderSelect}
+          />
+        ))}
+      </div>
+    </CustomModelProvidersEmptyState>
   );
 };
 


### PR DESCRIPTION
## Summary
- Add an OSS-inert `CustomModelProvidersEmptyState` customization seam that passes children through by default
- Wire the seam into the model provider modal provider list and model selection panels so Enterprise can override empty states
- Cover the seam with a customization auth-seams unit test

## Demo of EE and OSS without provider
<img width="1497" height="1258" alt="Screenshot 2026-08-17 at 4 39 27 PM" src="https://github.com/user-attachments/assets/4ca1a2d3-3ce6-48fe-9bd5-957b870a1882" />

## Demo of EE and OSS without models
<img width="1502" height="1250" alt="Screenshot 2026-08-17 at 4 39 03 PM" src="https://github.com/user-attachments/assets/a66983c8-de16-482d-bcb9-1a67c180be65" />


## Test plan
- [ ] Open Model Providers modal with providers present — list and model selection render as before
- [ ] Confirm OSS empty-state seam does not replace children when shown
- [ ] Run `custom-auth-seams.test.tsx` (or frontend unit tests covering customization seams)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable empty states for model providers and model lists.
  * Empty-state content now appears when no providers or enabled models are available.
  * Existing provider and model selection behavior remains unchanged.

* **Tests**
  * Added coverage confirming custom empty-state content renders correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->