### PR TITLE
fix(authz): answer denials honestly and let owners work in their own projects (LE-1905)

### DIFF
--- a/scripts/ci/check_execution_principal_matrix.py
+++ b/scripts/ci/check_execution_principal_matrix.py
@@ -65,7 +65,7 @@ VALID_DIMENSION_VALUES = {
         "deployment_owner",
         "job_owner",
     },
-    "tweaks": {"owner_only", "forbidden", "server_generated"},
+    "tweaks": {"owner_only", "owner_or_writer", "forbidden", "server_generated"},
     "revoke": {"new_and_resume", "new_only", "resume_rechecks_actor", "provider_controlled"},
     "error_policy": {"owner_debug_delegated_sanitized", "sanitized", "provider_sanitized"},
 }

--- a/scripts/ci/execution_principal_matrix.json
+++ b/scripts/ci/execution_principal_matrix.json
@@ -9,13 +9,14 @@
       "actor": "authenticated_user",
       "execution_principal": "actor",
       "dependency_principal": "actor_or_explicit_share",
-      "tweaks": "owner_only",
+      "tweaks": "owner_or_writer",
       "revoke": "new_and_resume",
       "error_policy": "owner_debug_delegated_sanitized",
       "exception": "none",
       "test_references": [
         "src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py::test_build_flow_shared_private_non_owner_succeeds",
-        "src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py::test_build_flow_non_owner_cannot_override_flow_data"
+        "src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py::test_build_flow_non_owner_cannot_override_flow_data",
+        "src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py::test_build_flow_write_holder_may_override_someone_elses_flow"
       ]
     },
     {
@@ -165,12 +166,12 @@
       "actor": "authenticated_user",
       "execution_principal": "actor",
       "dependency_principal": "actor_or_explicit_share",
-      "tweaks": "owner_only",
+      "tweaks": "owner_or_writer",
       "revoke": "new_and_resume",
       "error_policy": "owner_debug_delegated_sanitized",
       "exception": "the POST route is mounted by the lfx workflow host; backend admission and execution live in this source",
       "test_references": [
-        "src/backend/tests/unit/api/v2/test_workflow_agui.py::test_non_owner_tweaks_are_hidden_as_404",
+        "src/backend/tests/unit/api/v2/test_workflow_agui.py::test_non_owner_tweaks_are_dropped",
         "src/backend/tests/unit/api/v2/test_workflow_agui.py::test_sync_error_detail_depends_on_flow_ownership"
       ]
     },

--- a/src/backend/base/langflow/api/v1/authz_audit.py
+++ b/src/backend/base/langflow/api/v1/authz_audit.py
@@ -82,6 +82,24 @@ async def list_audit_log(
         str | None,
         Query(description="Filter by audit result (``allow`` / ``deny`` / ``owner_override`` / ``skip``)."),
     ] = None,
+    event: Annotated[
+        list[str] | None,
+        Query(
+            description=(
+                "Include only rows whose ``details.event`` class matches, e.g. ``mutation`` for "
+                "things that happened and ``authorization_decision`` for permission checks."
+            )
+        ),
+    ] = None,
+    exclude_event: Annotated[
+        list[str] | None,
+        Query(
+            description=(
+                "Exclude rows whose ``details.event`` class matches. Rows written before event "
+                "classification existed carry no class and are always kept."
+            )
+        ),
+    ] = None,
     since: Annotated[datetime | None, Query(description="Inclusive lower bound on ``timestamp``.")] = None,
     until: Annotated[datetime | None, Query(description="Exclusive upper bound on ``timestamp``.")] = None,
     page: Annotated[int, Query(ge=1)] = 1,
@@ -122,6 +140,16 @@ async def list_audit_log(
         base = base.where(AuthzAuditLog.action == action)
     if result is not None:
         base = base.where(AuthzAuditLog.result == result)
+    # ``details`` is a JSON column; SQLAlchemy renders the index access as
+    # ``json_extract`` on SQLite and ``->>`` on Postgres, so one expression
+    # serves both. An untagged row (written before classification existed) has
+    # a NULL extraction: it can never satisfy an include, and is never dropped
+    # by an exclude, so history stays visible.
+    event_class = col(AuthzAuditLog.details)["event"].as_string()
+    if event:
+        base = base.where(event_class.in_(event))
+    if exclude_event:
+        base = base.where(or_(event_class.not_in(exclude_event), event_class.is_(None)))
     if since is not None:
         base = base.where(AuthzAuditLog.timestamp >= since)
     if until is not None:

--- a/src/backend/base/langflow/api/v1/authz_role_assignments.py
+++ b/src/backend/base/langflow/api/v1/authz_role_assignments.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from lfx.log.logger import logger
 from lfx.services.authorization import (
     AuthorizationMutation,
@@ -52,6 +52,24 @@ def _require_superuser(user) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Superuser required to administer role assignments.",
         )
+
+
+async def _require_superuser_dependency(current_user: CurrentActiveUser) -> None:
+    """Run the superuser gate as a route dependency, i.e. before body validation.
+
+    FastAPI solves a route's ``dependencies`` before validating that route's own
+    body, so an unauthorised caller is refused whatever they post. Gated only in
+    the endpoint body, they first receive the same 422 field names and enum
+    values a superuser would, which lets them map the request contract of a
+    route they cannot invoke.
+
+    The in-body call is kept as well: it is the gate for anything that reaches
+    the endpoint function without FastAPI resolving dependencies.
+    """
+    _require_superuser(current_user)
+
+
+SUPERUSER_ONLY = [Depends(_require_superuser_dependency)]
 
 
 async def _assignment_reads(session, assignments: list[AuthzRoleAssignment]) -> list[RoleAssignmentRead]:
@@ -136,8 +154,8 @@ async def list_assignments(
     return await _assignment_reads(session, list(rows))
 
 
-@router.post("", response_model=RoleAssignmentRead, status_code=status.HTTP_201_CREATED)
-@router.post("/", response_model=RoleAssignmentRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=RoleAssignmentRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
+@router.post("/", response_model=RoleAssignmentRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
 async def create_assignment(
     payload: RoleAssignmentCreate,
     current_user: CurrentActiveUser,
@@ -251,6 +269,7 @@ async def create_assignment(
     response_model=RoleAssignmentRead,
     status_code=status.HTTP_200_OK,
     responses={status.HTTP_204_NO_CONTENT: {"description": "Manual assignment fully revoked."}},
+    dependencies=SUPERUSER_ONLY,
 )
 async def delete_assignment(
     assignment_id: UUID,

--- a/src/backend/base/langflow/api/v1/authz_roles.py
+++ b/src/backend/base/langflow/api/v1/authz_roles.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from lfx.log.logger import logger
 from lfx.services.authorization import AuthorizationMutation, AuthorizationMutationKind
 from lfx.utils.util_strings import escape_like_pattern
@@ -40,6 +40,24 @@ def _require_superuser(user) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Superuser required to administer roles.",
         )
+
+
+async def _require_superuser_dependency(current_user: CurrentActiveUser) -> None:
+    """Run the superuser gate as a route dependency, i.e. before body validation.
+
+    FastAPI solves a route's ``dependencies`` before validating that route's own
+    body, so an unauthorised caller is refused whatever they post. Gated only in
+    the endpoint body, they first receive the same 422 field names and enum
+    values a superuser would, which lets them map the request contract of a
+    route they cannot invoke.
+
+    The in-body call is kept as well: it is the gate for anything that reaches
+    the endpoint function without FastAPI resolving dependencies.
+    """
+    _require_superuser(current_user)
+
+
+SUPERUSER_ONLY = [Depends(_require_superuser_dependency)]
 
 
 async def _detect_parent_cycle(
@@ -104,8 +122,8 @@ async def read_role(
     return RoleRead.model_validate(role)
 
 
-@router.post("", response_model=RoleRead, status_code=status.HTTP_201_CREATED)
-@router.post("/", response_model=RoleRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=RoleRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
+@router.post("/", response_model=RoleRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
 async def create_role(
     payload: RoleCreate,
     current_user: CurrentActiveUser,
@@ -171,7 +189,7 @@ async def create_role(
     return RoleRead.model_validate(role)
 
 
-@router.patch("/{role_id}", response_model=RoleRead)
+@router.patch("/{role_id}", response_model=RoleRead, dependencies=SUPERUSER_ONLY)
 async def update_role(
     role_id: UUID,
     payload: RoleUpdate,
@@ -286,7 +304,7 @@ async def update_role(
     return RoleRead.model_validate(role)
 
 
-@router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=SUPERUSER_ONLY)
 async def delete_role(
     role_id: UUID,
     current_user: CurrentActiveUser,

--- a/src/backend/base/langflow/api/v1/authz_route_dependencies.py
+++ b/src/backend/base/langflow/api/v1/authz_route_dependencies.py
@@ -12,6 +12,7 @@ from langflow.api.v1.flows_helpers import _canonicalize_flow_destination, _read_
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.database.models.flow.model import Flow, FlowCreate
+from langflow.services.database.models.folder.model import Folder
 
 _FLOW_WRITE_DENIED_DETAIL = "You don't have permission to edit this flow."
 _FLOW_DELETE_DENIED_DETAIL = "You don't have permission to delete this flow."
@@ -95,11 +96,20 @@ async def require_flow_create_permission(
         current_user.id,
         widen_for_authz=True,
     )
+    _, destination_folder_id = destination
+    # Read the owner off the *resolved* destination rather than the payload:
+    # canonicalization may have redirected an unusable folder_id to the
+    # caller's default project, and only the stored row can say who owns the
+    # project the flow will actually land in. This is what lets the owner
+    # override cover creating a flow in a project you own — the new flow has no
+    # owner of its own yet.
+    destination_folder = await session.get(Folder, destination_folder_id)
     await ensure_flow_permission(
         current_user,
         FlowAction.CREATE,
         workspace_id=flow.workspace_id,
         folder_id=flow.folder_id,
+        folder_user_id=getattr(destination_folder, "user_id", None),
     )
     return destination
 

--- a/src/backend/base/langflow/api/v1/authz_shares.py
+++ b/src/backend/base/langflow/api/v1/authz_shares.py
@@ -16,6 +16,7 @@ from sqlmodel import select
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.api.v1.schemas.authz_shares import ShareCreate, ShareRead, ShareUpdate
 from langflow.services.authorization import ShareAction, ensure_share_permission
+from langflow.services.authorization.audit import AUDIT_EVENT_MUTATION
 from langflow.services.authorization.fetch import deny_to_404
 from langflow.services.authorization.utils import audit_decision
 from langflow.services.database.models.auth import (
@@ -370,6 +371,10 @@ async def create_share(
         obj=f"{payload.resource_type}:{payload.resource_id}",
         result="allow",
         details={
+            # The guard already wrote an ``event: authorization_decision`` row
+            # for the share:create check. This row is the effect, and only it
+            # means a share now exists.
+            "event": AUDIT_EVENT_MUTATION,
             "share_id": str(response.id),
             "scope": payload.scope,
             "target_id": str(payload.target_id) if payload.target_id else None,
@@ -568,6 +573,7 @@ async def update_share(
         obj=f"{response.resource_type}:{response.resource_id}",
         result="allow",
         details={
+            "event": AUDIT_EVENT_MUTATION,
             "share_id": str(response.id),
             "permission_level": response.permission_level,
         },
@@ -620,7 +626,7 @@ async def delete_share(
         action="share:delete",
         obj=f"{snapshot.resource_type}:{snapshot.resource_id}",
         result="allow",
-        details={"share_id": str(share_id)},
+        details={"event": AUDIT_EVENT_MUTATION, "share_id": str(share_id)},
     )
 
 

--- a/src/backend/base/langflow/api/v1/authz_teams.py
+++ b/src/backend/base/langflow/api/v1/authz_teams.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from lfx.log.logger import logger
 from lfx.services.authorization import AuthorizationMutation, AuthorizationMutationKind
 from lfx.utils.util_strings import escape_like_pattern
@@ -49,6 +49,24 @@ def _require_superuser(user) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Superuser required to administer teams.",
         )
+
+
+async def _require_superuser_dependency(current_user: CurrentActiveUser) -> None:
+    """Run the superuser gate as a route dependency, i.e. before body validation.
+
+    FastAPI solves a route's ``dependencies`` before validating that route's own
+    body, so an unauthorised caller is refused whatever they post. Gated only in
+    the endpoint body, they first receive the same 422 field names and enum
+    values a superuser would, which lets them map the request contract of a
+    route they cannot invoke.
+
+    The in-body call is kept as well: it is the gate for anything that reaches
+    the endpoint function without FastAPI resolving dependencies.
+    """
+    _require_superuser(current_user)
+
+
+SUPERUSER_ONLY = [Depends(_require_superuser_dependency)]
 
 
 # --- teams ---------------------------------------------------------------- #
@@ -94,8 +112,8 @@ async def read_team(
     return TeamRead.model_validate(team)
 
 
-@router.post("", response_model=TeamRead, status_code=status.HTTP_201_CREATED)
-@router.post("/", response_model=TeamRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=TeamRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
+@router.post("/", response_model=TeamRead, status_code=status.HTTP_201_CREATED, dependencies=SUPERUSER_ONLY)
 async def create_team(
     payload: TeamCreate,
     current_user: CurrentActiveUser,
@@ -145,7 +163,7 @@ async def create_team(
     return TeamRead.model_validate(team)
 
 
-@router.patch("/{team_id}", response_model=TeamRead)
+@router.patch("/{team_id}", response_model=TeamRead, dependencies=SUPERUSER_ONLY)
 async def update_team(
     team_id: UUID,
     payload: TeamUpdate,
@@ -213,7 +231,7 @@ async def update_team(
     return TeamRead.model_validate(team)
 
 
-@router.delete("/{team_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{team_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=SUPERUSER_ONLY)
 async def delete_team(
     team_id: UUID,
     current_user: CurrentActiveUser,
@@ -290,6 +308,7 @@ async def list_members(
     "/{team_id}/members",
     response_model=TeamMemberRead,
     status_code=status.HTTP_201_CREATED,
+    dependencies=SUPERUSER_ONLY,
 )
 async def add_member(
     team_id: UUID,
@@ -356,6 +375,7 @@ async def add_member(
 @router.delete(
     "/{team_id}/members/{user_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=SUPERUSER_ONLY,
 )
 async def remove_member(
     team_id: UUID,

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -54,7 +54,8 @@ from langflow.api.v1.schemas import (
 from langflow.exceptions.component import ComponentBuildError
 from langflow.services.auth.utils import get_current_user_optional
 from langflow.services.authorization import FlowAction, ensure_flow_permission
-from langflow.services.authorization.fetch import deny_to_404, deny_to_404_unless_readable
+from langflow.services.authorization.fetch import deny_to_404_unless_readable
+from langflow.services.authorization.flow_data_override import resolve_flow_data_override
 from langflow.services.authorization.public_access import (
     PUBLIC_FLOW_NOT_FOUND_DETAIL,
     PublicResourceAction,
@@ -342,16 +343,18 @@ async def build_flow(
             not_found_detail=f"Flow with id {flow_id} not found",
         ) from exc
 
-    # Execute-only shares must run the stored graph — non-owners cannot inject
-    # alternate flow data via the request body (would bypass the owner's definition).
-    if data is not None and flow.user_id != current_user.id:
-        raise deny_to_404(
-            HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Only the flow owner can override flow data during build",
-            ),
-            detail=f"Flow with id {flow_id} not found",
+    # Execute-only callers must run the stored graph — they cannot inject an
+    # alternate definition and have it run under the owner's resources. This
+    # drops the override rather than denying: the caller holds ``flow:execute``,
+    # so the run itself is theirs to make, and denying it reported the flow as
+    # non-existent to someone already looking at it (LE-1905). Overriding is an
+    # edit expressed at run time, so it is gated on ``flow:write``.
+    if data is not None and not await resolve_flow_data_override(current_user, flow):
+        await logger.ainfo(
+            "Ignoring caller-supplied flow data for flow %s: caller may execute but not edit it.",
+            flow_id,
         )
+        data = None
 
     try:
         if data:

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -54,7 +54,7 @@ from langflow.api.v1.schemas import (
 from langflow.exceptions.component import ComponentBuildError
 from langflow.services.auth.utils import get_current_user_optional
 from langflow.services.authorization import FlowAction, ensure_flow_permission
-from langflow.services.authorization.fetch import deny_to_404
+from langflow.services.authorization.fetch import deny_to_404, deny_to_404_unless_readable
 from langflow.services.authorization.public_access import (
     PUBLIC_FLOW_NOT_FOUND_DETAIL,
     PublicResourceAction,
@@ -82,6 +82,8 @@ if TYPE_CHECKING:
     from lfx.graph.vertex.vertex_types import InterfaceVertex
 
 router = APIRouter(tags=["Chat"])
+
+FLOW_EXECUTE_DENIED_DETAIL = "You don't have permission to execute this flow."
 
 
 def _validate_graph_for_execution(graph: Graph) -> None:
@@ -312,8 +314,10 @@ async def build_flow(
 
     # Authorize the execute action — runs the authorization plugin if registered,
     # no-op in OSS pass-through. Audited regardless. A plugin deny becomes 404
-    # so the response is identical to "flow does not exist" and the caller
-    # cannot enumerate UUIDs by probing for 403 vs 404.
+    # so a caller who cannot see the flow cannot enumerate UUIDs by probing for
+    # 403 vs 404. A caller who *can* read it has already seen the flow, so that
+    # mask buys nothing and only hides which permission they are missing — the
+    # Playground is exactly this case.
     try:
         await ensure_flow_permission(
             current_user,
@@ -324,7 +328,19 @@ async def build_flow(
             folder_id=flow.folder_id,
         )
     except HTTPException as exc:
-        raise deny_to_404(exc, detail=f"Flow with id {flow_id} not found") from exc
+        raise await deny_to_404_unless_readable(
+            exc,
+            lambda: ensure_flow_permission(
+                current_user,
+                FlowAction.READ,
+                flow_id=flow_id,
+                flow_user_id=flow.user_id,
+                workspace_id=flow.workspace_id,
+                folder_id=flow.folder_id,
+            ),
+            denied_detail=FLOW_EXECUTE_DENIED_DETAIL,
+            not_found_detail=f"Flow with id {flow_id} not found",
+        ) from exc
 
     # Execute-only shares must run the stored graph — non-owners cannot inject
     # alternate flow data via the request body (would bypass the owner's definition).

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -58,6 +58,7 @@ from langflow.api.v1.flows_helpers import (
     _update_existing_flow,
     _validate_and_assign_folder,
     _verify_fs_path,
+    destination_folder_owner_id,
 )
 from langflow.api.v1.mappers.deployments.sync import retry_flow_operation_on_deployment_guard
 from langflow.api.v1.schemas import FlowListCreate
@@ -885,7 +886,11 @@ async def upsert_flow(
             # CREATE path - flow doesn't exist
             await _canonicalize_flow_destination(session, flow, current_user.id, reject_invalid=True)
             await ensure_flow_permission(
-                current_user, FlowAction.CREATE, workspace_id=flow.workspace_id, folder_id=flow.folder_id
+                current_user,
+                FlowAction.CREATE,
+                workspace_id=flow.workspace_id,
+                folder_id=flow.folder_id,
+                folder_user_id=await destination_folder_owner_id(session, flow.folder_id),
             )
             _validate_catalog_policy_for_write(flow.data, snapshot=catalog_policy_snapshot)
             await stage_mcp_secrets(carried_secrets, secret_variables, writer_id, session)
@@ -993,6 +998,7 @@ async def create_flows(
             FlowAction.CREATE,
             workspace_id=flow.workspace_id,
             folder_id=flow.folder_id,
+            folder_user_id=await destination_folder_owner_id(session, flow.folder_id),
         )
     # Guard against duplicate IDs up-front so callers get a clean 422 instead
     # of an unhandled DB IntegrityError.  Use upload_file() for upsert semantics.
@@ -1143,6 +1149,7 @@ async def upload_file(
             FlowAction.CREATE,
             workspace_id=flow.workspace_id,
             folder_id=flow.folder_id,
+            folder_user_id=await destination_folder_owner_id(session, flow.folder_id),
         )
 
         # Upload upserts ignore omitted/null data. Validate the stored graph in

--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -359,6 +359,21 @@ async def _resolve_flow_destination(
     return folder.workspace_id, folder.id
 
 
+async def destination_folder_owner_id(session: AsyncSession, folder_id: UUID | None) -> UUID | None:
+    """Return who owns the project a flow is about to be created in.
+
+    A flow being created has no owner yet, so the destination project is the
+    only ownership the CREATE check can consult. Read it from the stored row
+    after canonicalization — a caller-supplied folder_id may have been
+    redirected to the caller's default project, and the payload can never be
+    trusted to assert who owns a project.
+    """
+    if folder_id is None:
+        return None
+    folder = await session.get(Folder, folder_id)
+    return getattr(folder, "user_id", None)
+
+
 async def _canonicalize_flow_destination(
     session: AsyncSession,
     flow: Flow | FlowCreate | FlowUpdate,

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -44,7 +44,11 @@ from langflow.services.authorization import (
     restrict_to_owned_or_visible_scope,
     visible_scope_prefilter,
 )
-from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
+from langflow.services.authorization.fetch import (
+    authorized_or_owner_scoped,
+    deny_to_404,
+    deny_to_404_unless_readable,
+)
 from langflow.services.authorization.utils import _resolve_authz_domain
 from langflow.services.database.lock_retry import (
     is_database_lock_error,
@@ -80,6 +84,8 @@ PROJECT_UPDATE_FAILED = "Could not update the project."
 PROJECT_SAVE_FAILED = "Could not save the project."
 PROJECT_DELETE_FAILED = "Could not delete the project."
 PROJECT_DELETE_BUSY = "The database is busy. Please retry the request."
+PROJECT_WRITE_DENIED_DETAIL = "You don't have permission to edit this project."
+PROJECT_DELETE_DENIED_DETAIL = "You don't have permission to delete this project."
 
 # Backwards-compatible local alias; the implementation now lives in lfx.utils.util_strings so the
 # same LIKE-escaping is shared across the API endpoints + the tracing repository.
@@ -804,7 +810,21 @@ async def update_project(
             workspace_id=existing_project.workspace_id,
         )
     except HTTPException as exc:
-        raise deny_to_404(exc, detail="Project not found") from exc
+        # A caller who can read this project already knows it exists, so the
+        # 404 mask only hides *why* the edit failed. Match the flow-edit path:
+        # readable -> 403 with a permission message, unreadable -> 404.
+        raise await deny_to_404_unless_readable(
+            exc,
+            lambda: ensure_project_permission(
+                current_user,
+                ProjectAction.READ,
+                project_id=project_id,
+                project_user_id=existing_project.user_id,
+                workspace_id=existing_project.workspace_id,
+            ),
+            denied_detail=PROJECT_WRITE_DENIED_DETAIL,
+            not_found_detail="Project not found",
+        ) from exc
 
     try:
         return await _apply_project_update(
@@ -963,7 +983,18 @@ async def delete_project(
             workspace_id=project.workspace_id,
         )
     except HTTPException as exc:
-        raise deny_to_404(exc, detail="Project not found") from exc
+        raise await deny_to_404_unless_readable(
+            exc,
+            lambda: ensure_project_permission(
+                current_user,
+                ProjectAction.READ,
+                project_id=project_id,
+                project_user_id=project.user_id,
+                workspace_id=project.workspace_id,
+            ),
+            denied_detail=PROJECT_DELETE_DENIED_DETAIL,
+            not_found_detail="Project not found",
+        ) from exc
 
     # Prevent deletion of projects managed by Langflow. The ownerless Starter
     # Project is also a stable authorization boundary for bundled examples.

--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -70,7 +70,7 @@ from langflow.api.v2.workflow_execution import (
 )
 from langflow.api.v2.workflow_reconstruction import reconstruct_workflow_response_from_job_id
 from langflow.api.v2.workflow_validation import (
-    _enforce_flow_data_override_owner,
+    _apply_flow_data_override_policy,
     _flow_not_found_privacy_exception,
     _reject_sync_only_fields,
     _reject_unsupported_sync_fields,
@@ -87,6 +87,7 @@ from langflow.helpers.flow import get_flow_by_id_or_endpoint_name
 from langflow.services.auth.utils import get_current_user_for_workflow
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.authorization.fetch import deny_to_404_unless_readable
+from langflow.services.authorization.flow_data_override import resolve_flow_data_override
 from langflow.services.database.models.flow.model import FlowRead
 from langflow.services.database.models.jobs.model import JobType
 from langflow.services.database.models.user.model import UserRead
@@ -260,21 +261,21 @@ async def authorize_flow_action(
             },
         ) from err
 
+    # Resolve the graph-override verdict here, where we can await the policy
+    # plugin. The sync gates below run in all three execution modes and read
+    # the resolved value; without this they fall back to owner-only.
+    if flow_action == FlowAction.EXECUTE:
+        await resolve_flow_data_override(current_user, flow)
+
 
 def _apply_execution_gates(parsed, flow, current_user: UserRead):
     """Run request gates and return any server-sanitized execution payload."""
     expose_error_details = caller_owns_flow(flow, current_user)
     _reject_unsupported_sync_fields(parsed)
     _reject_sync_only_fields(parsed)
-    try:
-        _enforce_flow_data_override_owner(parsed, flow, current_user)
-    except HTTPException as exc:
-        # The owner-override deny is a privacy 404 (string detail); re-wrap to the
-        # structured FLOW_NOT_FOUND body using the requested identifier (parsed.flow_id
-        # may be an endpoint name) so the resolved UUID is not leaked.
-        if exc.status_code == status.HTTP_404_NOT_FOUND:
-            raise _flow_not_found_http_exception(str(parsed.flow_id)) from exc
-        raise
+    # An execute-only caller keeps running: their override is dropped and the
+    # stored graph runs, instead of the flow reading as non-existent (LE-1905).
+    parsed = _apply_flow_data_override_policy(parsed, flow, current_user)
     return _validate_flow_data_for_execution(
         parsed,
         flow,

--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -86,6 +86,7 @@ from langflow.exceptions.api import (
 from langflow.helpers.flow import get_flow_by_id_or_endpoint_name
 from langflow.services.auth.utils import get_current_user_for_workflow
 from langflow.services.authorization import FlowAction, ensure_flow_permission
+from langflow.services.authorization.fetch import deny_to_404_unless_readable
 from langflow.services.database.models.flow.model import FlowRead
 from langflow.services.database.models.jobs.model import JobType
 from langflow.services.database.models.user.model import UserRead
@@ -109,6 +110,8 @@ _TERMINAL_JOB_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobSt
 # routes stay langflow-owned. Both are mounted on the same ``/workflows``
 # prefix in ``langflow.api.router``.
 router = APIRouter(prefix="/workflows", tags=["Workflow"])
+
+FLOW_EXECUTE_DENIED_DETAIL = "You don't have permission to execute this flow."
 
 
 def _flow_not_found_http_exception(flow_id: str) -> HTTPException:
@@ -183,6 +186,10 @@ async def authorize_flow_action(
     leaked through a raw 403. ``requested_id`` is the identifier the caller sent
     (an endpoint name or a UUID); the reframed body echoes it instead of the
     resolved internal UUID. Falls back to ``flow.id`` when not provided.
+
+    The 404 reframe is skipped when the caller can read the flow: they already
+    know it exists, and "verify the flow_id and try again" sends them to debug
+    an identifier that is correct. Those callers get an execute denial instead.
     """
     flow_action = FlowAction.READ if action == WorkflowAction.READ else FlowAction.EXECUTE
     # Echo the identifier the caller requested (which may be an endpoint name),
@@ -198,6 +205,29 @@ async def authorize_flow_action(
             folder_id=getattr(flow, "folder_id", None),
         )
     except HTTPException as exc:
+        if flow_action == FlowAction.EXECUTE:
+            resolved = await deny_to_404_unless_readable(
+                exc,
+                lambda: ensure_flow_permission(
+                    current_user,
+                    FlowAction.READ,
+                    flow_id=flow.id,
+                    flow_user_id=flow.user_id,
+                    workspace_id=getattr(flow, "workspace_id", None),
+                    folder_id=getattr(flow, "folder_id", None),
+                ),
+                denied_detail=FLOW_EXECUTE_DENIED_DETAIL,
+            )
+            if resolved.status_code == status.HTTP_403_FORBIDDEN:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Permission denied",
+                        "code": "FLOW_EXECUTE_FORBIDDEN",
+                        "message": FLOW_EXECUTE_DENIED_DETAIL,
+                        "flow_id": echo_id,
+                    },
+                ) from exc
         privacy = _flow_not_found_privacy_exception(exc, echo_id)
         # Preserve the legacy contract: any 404 on this path surfaces as the
         # structured FLOW_NOT_FOUND body, not the privacy-reframe's string detail.

--- a/src/backend/base/langflow/api/v2/workflow_validation.py
+++ b/src/backend/base/langflow/api/v2/workflow_validation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 from fastapi import HTTPException, status
+from lfx.log.logger import logger
 from lfx.utils.flow_validation import (
     CatalogPolicyIdentityUnavailableError,
     CustomComponentValidationError,
@@ -21,6 +22,7 @@ from lfx.workflow.converters import ParsedWorkflowRun
 
 from langflow.api.utils.execution_errors import caller_owns_flow, error_for_client
 from langflow.services.authorization.fetch import deny_to_404
+from langflow.services.authorization.flow_data_override import flow_data_override_allowed
 from langflow.services.database.models.flow.model import FlowRead
 from langflow.services.database.models.user.model import UserRead
 
@@ -79,18 +81,33 @@ def _reject_sync_only_fields(parsed: ParsedWorkflowRun) -> None:
     )
 
 
-def _enforce_flow_data_override_owner(parsed: ParsedWorkflowRun, flow: FlowRead, current_user: UserRead) -> None:
-    """Only the flow owner may execute caller-supplied graph data or tweaks."""
-    if (parsed.data is None and not parsed.tweaks) or caller_owns_flow(flow, current_user):
-        return
+def _apply_flow_data_override_policy(
+    parsed: ParsedWorkflowRun,
+    flow: FlowRead,
+    current_user: UserRead,
+) -> ParsedWorkflowRun:
+    """Strip caller-supplied graph data the caller may not override.
 
-    raise _flow_not_found_privacy_exception(
-        HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the flow owner can override flow data or component parameters during execution",
-        ),
-        parsed.flow_id,
+    This used to deny, reframed to 404 for privacy. That made the Playground
+    unusable for every non-owner: the canvas always posts ``data`` (its own
+    nodes and edges), so a user holding ``flow:execute`` — which the built-in
+    Viewer and Editor both do — could run the flow through the API but got
+    "Flow does not exist" from the UI on the same flow (LE-1905).
+
+    Execute-only callers get what ``flow:execute`` means: the stored definition
+    runs. Dropping their override is also strictly safer than honoring it, and
+    their canvas is read-only, so the graph they posted is the stored one.
+    """
+    if (parsed.data is None and not parsed.tweaks) or flow_data_override_allowed():
+        return parsed
+    if caller_owns_flow(flow, current_user):
+        return parsed
+
+    logger.info(
+        "Ignoring caller-supplied flow data for flow %s: caller may execute but not edit it; running the stored graph.",
+        flow.id,
     )
+    return replace(parsed, data=None, tweaks={})
 
 
 def _validate_flow_data_for_execution(

--- a/src/backend/base/langflow/plugin_routes.py
+++ b/src/backend/base/langflow/plugin_routes.py
@@ -54,6 +54,15 @@ def _get_route_keys(app: FastAPI) -> set[tuple[str, str]]:
     return set(_iter_route_keys(app.router.routes))
 
 
+class RouteConflictError(ValueError):
+    """A plugin tried to register a path+method Langflow already serves.
+
+    Distinct from any other ``ValueError`` a plugin's ``register()`` may raise
+    (a bad configuration, say): only a genuine conflict should be reported to
+    operators as one.
+    """
+
+
 class _PluginAppWrapper:
     """Wrapper around the real FastAPI app that only allows adding routes.
 
@@ -72,7 +81,7 @@ class _PluginAppWrapper:
             key = (path, method)
             if key in self._reserved:
                 msg = f"Plugin route conflicts with existing route: {path} [{method}]"
-                raise ValueError(msg)
+                raise RouteConflictError(msg)
             self._reserved.add(key)
 
     def include_router(self, router, prefix: str = "", **kwargs) -> None:
@@ -161,7 +170,7 @@ def load_plugin_routes(app: FastAPI) -> None:
         try:
             plugin_register(wrapper)
             logger.info(f"Loaded plugin: {ep.name}")
-        except ValueError as e:
+        except RouteConflictError as e:
             logger.warning(
                 "Plugin '%s' rejected (route conflict): %s",
                 ep.name,
@@ -169,8 +178,13 @@ def load_plugin_routes(app: FastAPI) -> None:
                 exc_info=True,
             )
         except Exception:  # noqa: BLE001
+            # Anything else -- a bad plugin config, a failed import inside
+            # register() -- is a registration failure, not a route conflict.
+            # Reporting every ValueError as a conflict sent operators looking
+            # for a duplicate path when the real cause was elsewhere, and the
+            # whole plugin's routes were missing either way.
             logger.error(
-                "Plugin '%s' failed during registration",
+                "Plugin '%s' failed during registration; none of its routes are available",
                 ep.name,
                 exc_info=True,
             )

--- a/src/backend/base/langflow/plugin_routes.py
+++ b/src/backend/base/langflow/plugin_routes.py
@@ -132,6 +132,44 @@ class _PluginAppWrapper:
         return self._app.add_api_route(path, endpoint, **kwargs)
 
 
+def _snapshot_registration(app: FastAPI, wrapper: _PluginAppWrapper) -> tuple[int, set[tuple[str, str]]]:
+    """Capture enough state to undo one plugin's route registrations.
+
+    Deliberately module-level rather than a wrapper method: the wrapper is
+    handed to plugins, and a plugin able to roll back to an arbitrary snapshot
+    could delete Langflow's own routes.
+    """
+    return len(app.router.routes), set(wrapper._reserved)  # noqa: SLF001
+
+
+def _rollback_registration(
+    app: FastAPI,
+    wrapper: _PluginAppWrapper,
+    snapshot: tuple[int, set[tuple[str, str]]],
+) -> int:
+    """Undo the routes one failed plugin mounted; return how many were removed.
+
+    A plugin registering several routes can mount some before a later one
+    conflicts, which left it half-live: reported as failed while part of its
+    surface answered requests. For an authorization plugin in particular, a
+    partial route set is worse than none — the app looks functional.
+
+    Only routes are undone. A plugin that installed a lifespan hook, middleware,
+    or a dependency override before failing keeps those; FastAPI offers no
+    supported way to withdraw them. Plugins should therefore register routes
+    before taking any other effect.
+    """
+    route_count, reserved = snapshot
+    removed = len(app.router.routes) - route_count
+    if removed > 0:
+        del app.router.routes[route_count:]
+        # The cached schema, if anything has built one, now describes routes
+        # that no longer exist.
+        app.openapi_schema = None
+    wrapper._reserved = reserved  # noqa: SLF001
+    return max(0, removed)
+
+
 def load_plugin_routes(app: FastAPI) -> None:
     """Discover and register additional routers from authorization plugins.
 
@@ -167,13 +205,18 @@ def load_plugin_routes(app: FastAPI) -> None:
             )
             continue
 
+        # Registration is all-or-nothing, so both messages below can state
+        # plainly that the plugin contributed nothing.
+        snapshot = _snapshot_registration(app, wrapper)
         try:
             plugin_register(wrapper)
             logger.info(f"Loaded plugin: {ep.name}")
         except RouteConflictError as e:
+            rolled_back = _rollback_registration(app, wrapper, snapshot)
             logger.warning(
-                "Plugin '%s' rejected (route conflict): %s",
+                "Plugin '%s' rejected (route conflict); %d route(s) rolled back, none are available: %s",
                 ep.name,
+                rolled_back,
                 e,
                 exc_info=True,
             )
@@ -181,10 +224,11 @@ def load_plugin_routes(app: FastAPI) -> None:
             # Anything else -- a bad plugin config, a failed import inside
             # register() -- is a registration failure, not a route conflict.
             # Reporting every ValueError as a conflict sent operators looking
-            # for a duplicate path when the real cause was elsewhere, and the
-            # whole plugin's routes were missing either way.
+            # for a duplicate path when the real cause was elsewhere.
+            rolled_back = _rollback_registration(app, wrapper, snapshot)
             logger.error(
-                "Plugin '%s' failed during registration; none of its routes are available",
+                "Plugin '%s' failed during registration; %d route(s) rolled back, none are available",
                 ep.name,
+                rolled_back,
                 exc_info=True,
             )

--- a/src/backend/base/langflow/services/authorization/__init__.py
+++ b/src/backend/base/langflow/services/authorization/__init__.py
@@ -20,6 +20,7 @@ from langflow.services.authorization.audit import (
 from langflow.services.authorization.decorators import requires_flow_permission, requires_resource_permission
 from langflow.services.authorization.fetch import authorized_or_owner_scoped, deny_to_404
 from langflow.services.authorization.guards import (
+    capability_probe,
     ensure_deployment_permission,
     ensure_file_permission,
     ensure_flow_permission,
@@ -61,6 +62,7 @@ __all__ = [
     "apply_owned_or_visible_scope_prefilter",
     "audit_decision",
     "authorized_or_owner_scoped",
+    "capability_probe",
     "deny_to_404",
     "drain_pending_audit_writes",
     "ensure_deployment_permission",

--- a/src/backend/base/langflow/services/authorization/audit.py
+++ b/src/backend/base/langflow/services/authorization/audit.py
@@ -51,6 +51,13 @@ AUDIT_ACTOR_USER = "user"
 # "what actually happened" filter on ``AUDIT_EVENT_MUTATION``.
 AUDIT_EVENT_DECISION = "authorization_decision"
 AUDIT_EVENT_MUTATION = "mutation"
+# Two further classes exist so that *every* row can be classified. Without them
+# a reader filtering on ``event`` silently drops the untagged rows: reading the
+# audit log itself, and the reconcile the server runs at startup with no user
+# behind it. ``access`` is something a user did that changed nothing; ``system``
+# is something the server did on its own.
+AUDIT_EVENT_ACCESS = "access"
+AUDIT_EVENT_SYSTEM = "system"
 
 _AUDIT_QUEUE_MAX = 10_000
 _AUDIT_BATCH_MAX = 100

--- a/src/backend/base/langflow/services/authorization/audit.py
+++ b/src/backend/base/langflow/services/authorization/audit.py
@@ -43,6 +43,15 @@ AUDIT_ACTOR_API_KEY = "api_key"  # pragma: allowlist secret
 AUDIT_ACTOR_UNKNOWN = "unknown"
 AUDIT_ACTOR_USER = "user"
 
+# ``details["event"]`` discriminates the two row classes that share this table.
+# Guards emit a row for every authorization *decision* they make; routes emit a
+# second row after the effect is durable. Both used to be written under the same
+# action name (``share:create`` for the check and for the created share), so a
+# check and a real mutation were indistinguishable downstream. Readers that need
+# "what actually happened" filter on ``AUDIT_EVENT_MUTATION``.
+AUDIT_EVENT_DECISION = "authorization_decision"
+AUDIT_EVENT_MUTATION = "mutation"
+
 _AUDIT_QUEUE_MAX = 10_000
 _AUDIT_BATCH_MAX = 100
 

--- a/src/backend/base/langflow/services/authorization/fetch.py
+++ b/src/backend/base/langflow/services/authorization/fetch.py
@@ -71,13 +71,19 @@ async def deny_to_404_unless_readable(
     404 with ``not_found_detail``.
 
     ``read_check`` must raise ``HTTPException`` when the caller may not read.
-    Anything that is not a 403 (a 5xx from the plugin, say) is surfaced
-    unchanged rather than relabelled.
+    Only a 403 means "cannot see it"; any other status from either the original
+    denial or the read check is a different answer entirely -- a 503 from the
+    authorization plugin says the decision is unavailable, not that the resource
+    is missing -- and is surfaced unchanged rather than relabelled.
     """
     if exc.status_code != status.HTTP_403_FORBIDDEN:
         return exc
     try:
         await read_check()
-    except HTTPException:
+    except HTTPException as read_exc:
+        if read_exc.status_code != status.HTTP_403_FORBIDDEN:
+            # Reporting a service failure as "not found" hides an outage behind
+            # a routine-looking response and sends the caller to check their id.
+            return read_exc
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
     return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=denied_detail)

--- a/src/backend/base/langflow/services/authorization/fetch.py
+++ b/src/backend/base/langflow/services/authorization/fetch.py
@@ -10,6 +10,7 @@ from sqlmodel import select
 from langflow.services.deps import get_authorization_service
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
     from uuid import UUID
 
     from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -51,3 +52,32 @@ def deny_to_404(exc: HTTPException, detail: str = "Not found") -> HTTPException:
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
     # Never relabel a non-403 (e.g. 4xx/5xx) as "not found"; surface it unchanged.
     return exc
+
+
+async def deny_to_404_unless_readable(
+    exc: HTTPException,
+    read_check: Callable[[], Awaitable[None]],
+    *,
+    denied_detail: str,
+    not_found_detail: str = "Not found",
+) -> HTTPException:
+    """Answer a denied action honestly when the caller can already read the resource.
+
+    The 404 mask exists so a caller cannot probe UUIDs they have no access to.
+    It buys nothing once the caller has read the resource — they already know it
+    exists — and it costs them a truthful answer: "not found" sends someone to
+    debug an identifier that is correct, when the real answer is that they lack
+    a permission. So: readable -> 403 with ``denied_detail``, unreadable ->
+    404 with ``not_found_detail``.
+
+    ``read_check`` must raise ``HTTPException`` when the caller may not read.
+    Anything that is not a 403 (a 5xx from the plugin, say) is surfaced
+    unchanged rather than relabelled.
+    """
+    if exc.status_code != status.HTTP_403_FORBIDDEN:
+        return exc
+    try:
+        await read_check()
+    except HTTPException:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=denied_detail)

--- a/src/backend/base/langflow/services/authorization/flow_data_override.py
+++ b/src/backend/base/langflow/services/authorization/flow_data_override.py
@@ -1,0 +1,60 @@
+"""Whether a caller's run-time graph override may be honored.
+
+``POST /api/v2/workflows`` and ``POST /api/v1/build/{id}/flow`` both accept
+caller-supplied graph data so the canvas can run edits that are not saved yet.
+Substituting a graph and running it under the owner's resources is an edit, so
+it is gated on ``flow:write`` rather than on ownership: a caller who holds write
+can already persist that graph and run it, so honoring the unsaved copy grants
+nothing new, while an execute-only caller still cannot choose what runs.
+
+The verdict is resolved once per request in an async authorization step and
+read by the synchronous request gates, which run in all three execution modes.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+from langflow.api.utils.execution_errors import caller_owns_flow
+from langflow.services.authorization.actions import FlowAction
+from langflow.services.authorization.guards import ensure_flow_permission
+
+if TYPE_CHECKING:
+    from langflow.services.database.models.flow.model import FlowRead
+    from langflow.services.database.models.user.model import UserRead
+
+# Default False so an unresolved request falls back to owner-only overrides,
+# which is the behavior every caller had before the verdict existed.
+_flow_data_override_allowed: ContextVar[bool] = ContextVar(
+    "langflow_flow_data_override_allowed",
+    default=False,
+)
+
+
+async def resolve_flow_data_override(current_user: UserRead, flow: FlowRead) -> bool:
+    """Resolve and remember whether this caller may override the stored graph."""
+    allowed = caller_owns_flow(flow, current_user)
+    if not allowed:
+        try:
+            await ensure_flow_permission(
+                current_user,
+                FlowAction.WRITE,
+                flow_id=flow.id,
+                flow_user_id=flow.user_id,
+                workspace_id=getattr(flow, "workspace_id", None),
+                folder_id=getattr(flow, "folder_id", None),
+            )
+        except HTTPException:
+            allowed = False
+        else:
+            allowed = True
+    _flow_data_override_allowed.set(allowed)
+    return allowed
+
+
+def flow_data_override_allowed() -> bool:
+    """Return the verdict resolved for the current request."""
+    return _flow_data_override_allowed.get()

--- a/src/backend/base/langflow/services/authorization/guards.py
+++ b/src/backend/base/langflow/services/authorization/guards.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -33,7 +35,7 @@ from langflow.services.authorization.actions import (
 from langflow.services.deps import get_authorization_service, get_settings_service
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
     from uuid import UUID
 
     from langflow.services.database.models.user.model import User, UserRead
@@ -84,6 +86,37 @@ def _auth_audit_details() -> dict[str, str]:
     return current_auth_context_for_audit()
 
 
+# A capability probe is the UI asking "may I offer this control?" — not an
+# attempt to use it. Enforcement is identical either way, but the *audit row*
+# is not: probing wrote a row named after an action nobody performed, so the
+# sidebar rendering N projects wrote N ``share:create`` rows with no resource
+# and no share behind them. Suppress the decision row for the probe only;
+# real attempts, including denied ones, are audited exactly as before.
+_capability_probe: ContextVar[bool] = ContextVar("langflow_authz_capability_probe", default=False)
+
+
+@contextmanager
+def capability_probe() -> Iterator[None]:
+    """Evaluate permissions for a UI capability answer without auditing the check.
+
+    Wrap only reads whose entire purpose is to decide whether an affordance is
+    offered. The guard still runs and still denies; nothing about enforcement
+    changes. Anything that can have an effect — or that a caller invoked
+    intending an effect — must stay outside this scope so its decision is
+    recorded.
+    """
+    token = _capability_probe.set(True)
+    try:
+        yield
+    finally:
+        _capability_probe.reset(token)
+
+
+async def _audit_suppressed() -> None:
+    """Awaitable no-op standing in for a suppressed decision row."""
+    return
+
+
 def _audit_guard_decision(
     *,
     user_id: UUID | None,
@@ -101,6 +134,8 @@ def _audit_guard_decision(
     an evaluated permission from a performed action. Returns the coroutine so
     callers can await it or gather several.
     """
+    if _capability_probe.get():
+        return _audit_suppressed()
     return _audit.audit_decision(
         user_id=user_id,
         action=action,

--- a/src/backend/base/langflow/services/authorization/guards.py
+++ b/src/backend/base/langflow/services/authorization/guards.py
@@ -84,6 +84,32 @@ def _auth_audit_details() -> dict[str, str]:
     return current_auth_context_for_audit()
 
 
+def _audit_guard_decision(
+    *,
+    user_id: UUID | None,
+    action: str,
+    obj: str,
+    result: str,
+    details: dict[str, Any] | None = None,
+):
+    """Record one authorization *decision* made by a guard.
+
+    Every row written from this module is a check, not an effect. Tagging it
+    keeps it distinguishable from the row a route writes after a mutation is
+    durable: both share an action name (a ``share:create`` check and a created
+    share both read ``share:create``), so without the tag a reader cannot tell
+    an evaluated permission from a performed action. Returns the coroutine so
+    callers can await it or gather several.
+    """
+    return _audit.audit_decision(
+        user_id=user_id,
+        action=action,
+        obj=obj,
+        result=result,
+        details={**(details or {}), "event": _audit.AUDIT_EVENT_DECISION},
+    )
+
+
 async def _api_key_scopes_require_plugin_enforcement() -> bool:
     """Return True when owner override must not hide API-key caveats."""
     if not current_auth_is_api_key():
@@ -169,7 +195,7 @@ async def ensure_permission(
     if not settings.auth_settings.AUTHZ_ENABLED:
         # Auditing is independently configurable so operators can observe the
         # allow-by-disabled-enforcement path before turning RBAC on.
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user.id,
             action=audit_action,
             obj=obj,
@@ -191,7 +217,7 @@ async def ensure_permission(
         )
     except Exception as exc:
         logger.exception("Authorization plugin raised during enforce; failing closed")
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user.id,
             action=audit_action,
             obj=obj,
@@ -203,7 +229,7 @@ async def ensure_permission(
             detail=deny_detail,
         ) from exc
 
-    await _audit.audit_decision(
+    await _audit_guard_decision(
         user_id=user.id,
         action=audit_action,
         obj=obj,
@@ -234,7 +260,7 @@ async def _ensure_resource_permission(
 
     external_context = get_current_external_access_context()
     if external_context is not None and not external_access_allows(act_str, external_context):
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user.id,
             action=f"{resource_type}:{act_str}",
             obj=obj,
@@ -256,7 +282,7 @@ async def _ensure_resource_permission(
         and getattr(user, "id", None) == owner_id
         and await should_apply_owner_override()
     ):
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user.id,
             action=f"{resource_type}:{act_str}",
             obj=obj,
@@ -299,6 +325,13 @@ class _ResourceSpec:
     # ids must not trigger the owner override. Resource families whose CREATE
     # action targets an existing owned resource may opt in explicitly.
     owner_override_on_create: bool = False
+    # Public kwarg carrying the owner of the *container* a CREATE writes into
+    # (e.g. the destination project for a new flow). The new resource has no
+    # owner yet, so this is the only ownership the check can consult. It must
+    # be resolved server-side from the destination row, never echoed from the
+    # request, or a caller could assert ownership of a container they do not
+    # own. ``None`` means CREATE has no container to inherit ownership from.
+    create_container_owner_kw: str | None = None
 
 
 _RESOURCE_SPECS: dict[str, _ResourceSpec] = {
@@ -308,6 +341,12 @@ _RESOURCE_SPECS: dict[str, _ResourceSpec] = {
         id_kw="flow_id",
         workspace_kw="workspace_id",
         scope_kw="folder_id",
+        # A project owner can always create flows in their own project: the
+        # project is the owned resource the new flow lands in, and owner
+        # override is documented as preceding any policy rule. Without this a
+        # user holding a read-only role cannot use the default project that was
+        # created for them.
+        create_container_owner_kw="folder_user_id",
     ),
     "deployment": _ResourceSpec(
         resource_type="deployment",
@@ -416,6 +455,8 @@ async def _ensure_typed(
     if spec.scope_kw is not None:
         extra_context[spec.scope_kw] = scope_id
     extra_context[spec.owner_kw] = owner_id
+    if spec.create_container_owner_kw is not None:
+        extra_context[spec.create_container_owner_kw] = kwargs.get(spec.create_container_owner_kw)
     if spec_key == "knowledge_base":
         # KB also forwards the resource id under its public name for plugins
         # that scope policy by kb_id directly (mirrors the legacy clone).
@@ -423,12 +464,24 @@ async def _ensure_typed(
     for key in spec.extra_context_kws:
         extra_context[key] = kwargs.get(key)
 
+    # On CREATE the resource does not exist yet, so ownership can only come
+    # from the container it is created in. Everything else authorizes against
+    # the resource's own owner.
+    is_create = act_str == "create"
+    container_owner_id = kwargs.get(spec.create_container_owner_kw) if spec.create_container_owner_kw else None
+    if is_create and spec.create_container_owner_kw is not None:
+        override_owner_id = container_owner_id
+        owner_override_allowed = True
+    else:
+        override_owner_id = owner_id
+        owner_override_allowed = not is_create or spec.owner_override_on_create
+
     await _ensure_resource_permission(
         user,
         resource_type=spec.resource_type,
         resource_id=resource_id,
-        owner_id=owner_id,
-        owner_override_allowed=act_str != "create" or spec.owner_override_on_create,
+        owner_id=override_owner_id,
+        owner_override_allowed=owner_override_allowed,
         act_str=act_str,
         resolved_domain=resolved_domain,
         extra_context=extra_context,
@@ -450,9 +503,15 @@ async def ensure_flow_permission(
     flow_user_id: UUID | None = None,
     workspace_id: UUID | None = None,
     folder_id: UUID | None = None,
+    folder_user_id: UUID | None = None,
     domain: str | None = None,
 ) -> None:
-    """Check flow permission (owner override, then plugin enforce)."""
+    """Check flow permission (owner override, then plugin enforce).
+
+    ``folder_user_id`` is the owner of the destination project and is only
+    consulted for CREATE, where there is no flow owner yet. Pass the value read
+    from the destination folder row, not one taken from the request body.
+    """
     await _ensure_typed(
         user,
         spec_key="flow",
@@ -462,6 +521,7 @@ async def ensure_flow_permission(
             "flow_user_id": flow_user_id,
             "workspace_id": workspace_id,
             "folder_id": folder_id,
+            "folder_user_id": folder_user_id,
         },
         domain_override=domain,
     )
@@ -477,7 +537,7 @@ async def _audit_flow_decision_batch(
     """Audit one allow/deny/owner-override decision per flow id concurrently."""
     await asyncio.gather(
         *(
-            _audit.audit_decision(
+            _audit_guard_decision(
                 user_id=user_id,
                 action=f"flow:{act_str}",
                 obj=f"flow:{flow_id}",
@@ -518,7 +578,7 @@ async def ensure_flows_permission(
     if external_context is not None and not external_access_allows(act_str, external_context):
         # Same fail-closed path as the single-flow guard; audit the ceiling deny
         # once rather than per flow.
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user_id,
             action=f"flow:{act_str}",
             obj="flow:*",
@@ -567,7 +627,7 @@ async def ensure_flows_permission(
         )
     except Exception as exc:
         logger.exception("Authorization plugin raised during batch_enforce; failing closed")
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user_id,
             action=f"flow:{act_str}",
             obj="flow:*",
@@ -585,7 +645,7 @@ async def ensure_flows_permission(
             len(results),
             len(flow_ids),
         )
-        await _audit.audit_decision(
+        await _audit_guard_decision(
             user_id=user_id,
             action=f"flow:{act_str}",
             obj="flow:*",

--- a/src/backend/tests/unit/api/v1/test_authz_admin_authorization_ordering.py
+++ b/src/backend/tests/unit/api/v1/test_authz_admin_authorization_ordering.py
@@ -14,11 +14,18 @@ from fastapi.testclient import TestClient
 from langflow.api.v1 import authz_role_assignments, authz_roles, authz_teams
 from langflow.services.database.models.user.model import User
 
-# (router module, path, a body that fails schema validation)
+_UUID = "11111111-1111-1111-1111-111111111111"
+
+# Every superuser-gated route that takes a body, with a payload that fails
+# schema validation. Each must answer the denial before describing the schema.
+# (router module, HTTP method, path, malformed body)
 MALFORMED_BODY_ROUTES = [
-    (authz_roles, "/authz/roles", {"bogus": 1}),
-    (authz_teams, "/authz/teams", {"bogus": 1}),
-    (authz_role_assignments, "/authz/role-assignments", {"bogus": 1}),
+    (authz_roles, "post", "/authz/roles", {"bogus": 1}),
+    (authz_roles, "patch", f"/authz/roles/{_UUID}", {"permissions": "not-a-list"}),
+    (authz_teams, "post", "/authz/teams", {"bogus": 1}),
+    (authz_teams, "patch", f"/authz/teams/{_UUID}", {"is_active": "not-a-bool"}),
+    (authz_teams, "post", f"/authz/teams/{_UUID}/members", {"bogus": 1}),
+    (authz_role_assignments, "post", "/authz/role-assignments", {"bogus": 1}),
 ]
 
 
@@ -36,11 +43,11 @@ def _client(module, *, is_superuser: bool) -> TestClient:
     return TestClient(app, raise_server_exceptions=False)
 
 
-@pytest.mark.parametrize(("module", "path", "body"), MALFORMED_BODY_ROUTES)
-def test_malformed_body_from_non_superuser_is_403_not_422(module, path, body):
+@pytest.mark.parametrize(("module", "method", "path", "body"), MALFORMED_BODY_ROUTES)
+def test_malformed_body_from_non_superuser_is_403_not_422(module, method, path, body):
     """The denial comes first, so the schema is never described to the caller."""
     with _client(module, is_superuser=False) as client:
-        response = client.post(path, json=body)
+        response = getattr(client, method)(path, json=body)
 
     assert response.status_code == 403, response.text
     # No field names, no accepted literals.
@@ -48,10 +55,45 @@ def test_malformed_body_from_non_superuser_is_403_not_422(module, path, body):
     assert isinstance(response.json()["detail"], str)
 
 
-@pytest.mark.parametrize(("module", "path", "body"), MALFORMED_BODY_ROUTES)
-def test_malformed_body_from_superuser_still_reports_schema_errors(module, path, body):
+@pytest.mark.parametrize(("module", "method", "path", "body"), MALFORMED_BODY_ROUTES)
+def test_malformed_body_from_superuser_still_reports_schema_errors(module, method, path, body):
     """The gate moved earlier; it did not swallow validation for callers who pass it."""
     with _client(module, is_superuser=True) as client:
-        response = client.post(path, json=body)
+        response = getattr(client, method)(path, json=body)
 
     assert response.status_code == 422, response.text
+
+
+def test_every_superuser_gated_body_route_is_covered():
+    """A new gated route with a body must be added to the matrix above.
+
+    Without this the matrix silently stops tracking the surface it exists to
+    protect: the property is "every privileged body route authorizes first",
+    not "these six do".
+    """
+    covered = {(method.upper(), path) for _module, method, path, _body in MALFORMED_BODY_ROUTES}
+
+    gated: set[tuple[str, str]] = set()
+    for module in (authz_roles, authz_teams, authz_role_assignments):
+        for route in module.router.routes:
+            takes_body = any(
+                dependant.body_params for dependant in [route.dependant] if hasattr(dependant, "body_params")
+            )
+            is_gated = any(
+                dep.call is module._require_superuser_dependency
+                for dep in route.dependant.dependencies
+                if dep.call is not None
+            )
+            if takes_body and is_gated:
+                for method in route.methods - {"HEAD", "OPTIONS"}:
+                    # Routers are mounted with and without a trailing slash.
+                    gated.add((method, route.path.rstrip("/") or route.path))
+
+    normalized_covered = {(method, path.replace(_UUID, "{id}")) for method, path in covered}
+    normalized_gated = {
+        (method, path.replace("{role_id}", "{id}").replace("{team_id}", "{id}").replace("{user_id}", "{id}"))
+        for method, path in gated
+    }
+    assert normalized_gated - normalized_covered == set(), (
+        f"superuser-gated body routes missing from MALFORMED_BODY_ROUTES: {normalized_gated - normalized_covered}"
+    )

--- a/src/backend/tests/unit/api/v1/test_authz_admin_authorization_ordering.py
+++ b/src/backend/tests/unit/api/v1/test_authz_admin_authorization_ordering.py
@@ -1,0 +1,57 @@
+"""Privileged /authz routes must refuse an unauthorised caller before reading their body.
+
+Regression cover for LE-1905 finding 7: a caller with no role assignments used
+to receive the same 422 field names and enum values a superuser would, and only
+learned of the 403 once the payload was well-formed — enough to map the request
+contract of a route they cannot invoke.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from langflow.api.v1 import authz_role_assignments, authz_roles, authz_teams
+from langflow.services.database.models.user.model import User
+
+# (router module, path, a body that fails schema validation)
+MALFORMED_BODY_ROUTES = [
+    (authz_roles, "/authz/roles", {"bogus": 1}),
+    (authz_teams, "/authz/teams", {"bogus": 1}),
+    (authz_role_assignments, "/authz/role-assignments", {"bogus": 1}),
+]
+
+
+def _client(module, *, is_superuser: bool) -> TestClient:
+    """Mount one authz router with the current user stubbed out."""
+    from langflow.services.auth.utils import get_current_active_user
+
+    app = FastAPI()
+    app.include_router(module.router)
+
+    def _user() -> User:
+        return User(username="probe", password="x", is_superuser=is_superuser)  # noqa: S106
+
+    app.dependency_overrides[get_current_active_user] = _user
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(("module", "path", "body"), MALFORMED_BODY_ROUTES)
+def test_malformed_body_from_non_superuser_is_403_not_422(module, path, body):
+    """The denial comes first, so the schema is never described to the caller."""
+    with _client(module, is_superuser=False) as client:
+        response = client.post(path, json=body)
+
+    assert response.status_code == 403, response.text
+    # No field names, no accepted literals.
+    assert "detail" in response.json()
+    assert isinstance(response.json()["detail"], str)
+
+
+@pytest.mark.parametrize(("module", "path", "body"), MALFORMED_BODY_ROUTES)
+def test_malformed_body_from_superuser_still_reports_schema_errors(module, path, body):
+    """The gate moved earlier; it did not swallow validation for callers who pass it."""
+    with _client(module, is_superuser=True) as client:
+        response = client.post(path, json=body)
+
+    assert response.status_code == 422, response.text

--- a/src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py
+++ b/src/backend/tests/unit/api/v1/test_chat_build_flow_authz.py
@@ -150,26 +150,82 @@ async def test_build_flow_shared_private_non_owner_succeeds(patch_build_flow):
 
 
 @pytest.mark.asyncio
-async def test_build_flow_non_owner_cannot_override_flow_data(patch_build_flow):
-    """Non-owner with execute access cannot supply alternate graph data in the body."""
+async def test_build_flow_non_owner_cannot_override_flow_data(patch_build_flow, monkeypatch):
+    """Non-owner with execute access cannot supply alternate graph data in the body.
+
+    This asserted a 404 until LE-1905. Denying the override broke the
+    Playground, which posts the canvas data on every run: a non-owner with
+    execute permission was told the flow did not exist. The override is now
+    gated on ``flow:write``; an execute-only caller has it dropped and runs
+    the stored graph. The security property is unchanged and still asserted
+    here: the caller-supplied graph never runs.
+    """
     from langflow.api.v1 import chat as chat_module
     from langflow.api.v1.schemas import FlowDataRequest
+    from langflow.services.authorization import flow_data_override
+
+    async def _deny_write(*_args, **_kwargs):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    # Execute-only caller: the flow:write gate denies the override.
+    monkeypatch.setattr(flow_data_override, "ensure_flow_permission", _deny_write)
 
     user = _make_user()
     flow = _make_flow(owner_id=uuid4(), public=False)
     patch_build_flow["read_flow"] = flow
     override = FlowDataRequest(nodes=[{"id": "n1"}], edges=[])
 
-    with pytest.raises(HTTPException) as excinfo:
-        await chat_module.build_flow(
-            flow_id=flow.id,
-            background_tasks=None,
-            current_user=user,
-            queue_service=_make_queue_service(),
-            data=override,
-        )
-    assert excinfo.value.status_code == 404
-    assert f"Flow with id {flow.id} not found" in excinfo.value.detail
+    result = await chat_module.build_flow(
+        flow_id=flow.id,
+        background_tasks=None,
+        current_user=user,
+        queue_service=_make_queue_service(),
+        data=override,
+    )
+    # The run proceeds with the stored graph; the override is dropped.
+    assert result == {"job_id": "fake-job-id"}
+    assert patch_build_flow["start_kwargs"]["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_build_flow_write_holder_may_override_someone_elses_flow(patch_build_flow, monkeypatch):
+    """A caller holding ``flow:write`` may run an unsaved graph they cannot save.
+
+    Overriding the stored graph is an edit expressed at run time, so it is
+    gated on ``flow:write`` rather than ownership (LE-1905): a caller who can
+    persist the graph can already PATCH it and run it, so honoring the unsaved
+    copy grants nothing new.
+    """
+    from langflow.api.v1 import chat as chat_module
+    from langflow.api.v1.schemas import FlowDataRequest
+    from langflow.services.authorization import flow_data_override
+
+    async def _allow_write(*_args, **_kwargs):
+        return None
+
+    # Non-owner, but the flow:write gate allows the override.
+    monkeypatch.setattr(flow_data_override, "ensure_flow_permission", _allow_write)
+
+    async def allow_inline(_data, *, is_superuser):
+        assert is_superuser is False
+
+    monkeypatch.setattr(chat_module, "prepare_flow_build_for_user", allow_inline)
+
+    user = _make_user()
+    flow = _make_flow(owner_id=uuid4(), public=False)
+    patch_build_flow["read_flow"] = flow
+    override = FlowDataRequest(nodes=[{"id": "n1"}], edges=[])
+
+    result = await chat_module.build_flow(
+        flow_id=flow.id,
+        background_tasks=None,
+        current_user=user,
+        queue_service=_make_queue_service(),
+        data=override,
+    )
+    assert result == {"job_id": "fake-job-id"}
+    # The caller's graph is honored, not the stored one.
+    assert patch_build_flow["start_kwargs"]["data"] is override
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v2/test_workflow_agui.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_agui.py
@@ -295,8 +295,16 @@ class TestAGUIModeDispatch:
 class TestV2WorkflowAdmission:
     """Route-level admission checks before workflow execution dispatch."""
 
-    def test_non_owner_data_override_is_hidden_as_404(self):
-        """Execute-only sharees must not inject alternate graph data into shared flows."""
+    def test_non_owner_data_override_is_dropped_not_denied(self):
+        """Execute-only callers run the stored graph; their injected data never reaches it.
+
+        This asserted a 404 until LE-1905. The Playground always posts the
+        canvas, so denying the override made every non-owner's Playground run
+        fail with "Flow does not exist" on a flow they were reading — while the
+        same user running the same flow through the API succeeded. The security
+        property is unchanged and still asserted here: the caller-supplied graph
+        does not run.
+        """
         from langflow.api.v2 import workflow as workflow_module
         from lfx.schema.workflow import WorkflowRunRequest
         from lfx.workflow.converters import parse_workflow_run_request
@@ -310,32 +318,23 @@ class TestV2WorkflowAdmission:
             data={"nodes": [], "edges": []},
             name="shared",
         )
-        # A non-owner caller passing a data override hits the gate the production
-        # router runs via host.stream_response -> build_stream_response.
         parsed = parse_workflow_run_request(
             WorkflowRunRequest(
                 flow_id=str(flow_id),
                 input_value="hi",
                 mode="stream",
-                data={"nodes": [], "edges": []},
+                data={"nodes": [{"id": "injected"}], "edges": []},
             )
         )
 
-        with pytest.raises(HTTPException) as exc_info:
-            workflow_module.build_stream_response(
-                parsed,
-                flow,
-                SimpleNamespace(id=uuid4()),
-                stream_protocol="langflow",
-                background_tasks=SimpleNamespace(),
-            )
+        gated = workflow_module._apply_execution_gates(parsed, flow, SimpleNamespace(id=uuid4()))
 
-        assert exc_info.value.status_code == 404
-        assert exc_info.value.detail["code"] == "FLOW_NOT_FOUND"
+        assert gated.data is None
+        assert gated.input_value == "hi"
 
     @pytest.mark.parametrize("mode", ["sync", "stream"])
-    def test_non_owner_tweaks_are_hidden_as_404(self, mode: str):
-        """Execute-only sharees must not override stored component parameters."""
+    def test_non_owner_tweaks_are_dropped(self, mode: str):
+        """Execute-only callers must not override stored component parameters."""
         from langflow.api.v2 import workflow as workflow_module
         from lfx.schema.workflow import WorkflowRunRequest
         from lfx.workflow.converters import parse_workflow_run_request
@@ -358,11 +357,10 @@ class TestV2WorkflowAdmission:
             )
         )
 
-        with pytest.raises(HTTPException) as exc_info:
-            workflow_module._apply_execution_gates(parsed, flow, SimpleNamespace(id=uuid4()))
+        gated = workflow_module._apply_execution_gates(parsed, flow, SimpleNamespace(id=uuid4()))
 
-        assert exc_info.value.status_code == 404
-        assert exc_info.value.detail["code"] == "FLOW_NOT_FOUND"
+        # Stored component parameters still win; only the denial shape changed.
+        assert gated.tweaks == {}
 
     @pytest.mark.parametrize("mode", ["sync", "stream"])
     def test_owner_tweaks_remain_supported(self, mode: str):

--- a/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
+++ b/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
@@ -79,6 +79,26 @@ async def test_unreadable_resource_still_masks_as_404():
 
 
 @pytest.mark.asyncio
+async def test_service_failure_during_the_read_check_is_not_a_404():
+    """A 503 from the plugin means "cannot decide", not "does not exist".
+
+    Collapsing it to 404 would hide an authorization-service outage behind a
+    routine-looking response and send the caller to check an id that is fine.
+    """
+    unavailable = HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="authz plugin down")
+
+    async def _read_check_fails() -> None:
+        raise unavailable
+
+    resolved = await deny_to_404_unless_readable(
+        _denied(), _read_check_fails, denied_detail="never used", not_found_detail="Flow not found"
+    )
+
+    assert resolved is unavailable
+    assert resolved.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
 async def test_non_403_is_surfaced_unchanged():
     """A 503 from the plugin must never be relabelled as a permission answer."""
     upstream = HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="plugin down")

--- a/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
+++ b/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -361,3 +362,68 @@ def test_a_run_with_no_override_is_untouched():
     parsed = ParsedWorkflowRun(flow_id="abc", input_value="hello")
 
     assert _apply_flow_data_override_policy(parsed, _Flow(owner_id=uuid4()), _User()) is parsed
+
+
+# --------------------------------------------------------------------------- #
+# Round 2, finding 1: every row is classifiable, so a reader can ask for the
+# actions people performed without losing rows written before classification.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_event_class_filter_selects_and_never_hides_untagged_rows():
+    """The ``details.event`` filter the audit route applies, against a real database."""
+    import sqlalchemy as sa
+    from langflow.services.database.models.auth.authz import AuthzAuditLog
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlmodel import col, or_, select
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: AuthzAuditLog.metadata.create_all(c, tables=[AuthzAuditLog.__table__]))
+
+    seeded = (
+        ("share:create", {"event": audit_module.AUDIT_EVENT_DECISION}),
+        ("share:create", {"event": audit_module.AUDIT_EVENT_MUTATION}),
+        ("audit:read", {"event": audit_module.AUDIT_EVENT_ACCESS}),
+        ("flow:read", None),
+        ("flow:write", {"domain": "*"}),
+    )
+    async with AsyncSession(engine) as session:
+        for action, details in seeded:
+            session.add(
+                AuthzAuditLog(
+                    id=uuid4(),
+                    timestamp=datetime.now(timezone.utc),
+                    action=action,
+                    resource_type=action.split(":")[0],
+                    result=audit_module.AUDIT_ALLOW,
+                    details=details,
+                )
+            )
+        await session.commit()
+
+        event_class = col(AuthzAuditLog.details)["event"].as_string()
+
+        async def actions(stmt):
+            return sorted(row.action for row in (await session.exec(stmt)).all())
+
+        # Asking for what happened returns only the mutation.
+        assert await actions(select(AuthzAuditLog).where(event_class.in_([audit_module.AUDIT_EVENT_MUTATION]))) == [
+            "share:create"
+        ]
+
+        # Hiding permission checks drops the check and keeps every other row,
+        # including the two written before classification existed.
+        hide_checks = select(AuthzAuditLog).where(
+            or_(event_class.not_in([audit_module.AUDIT_EVENT_DECISION]), event_class.is_(None))
+        )
+        assert await actions(hide_checks) == ["audit:read", "flow:read", "flow:write", "share:create"]
+
+        # The count the route reports comes off the same filtered subquery, so
+        # pagination cannot disagree with the rows.
+        total = int((await session.exec(select(sa.func.count()).select_from(hide_checks.subquery()))).first() or 0)
+        assert total == 4
+
+    await engine.dispose()

--- a/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
+++ b/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
@@ -176,3 +176,188 @@ async def test_create_in_someone_elses_project_still_reaches_the_policy(monkeypa
 
 async def _true() -> bool:
     return True
+
+
+# --------------------------------------------------------------------------- #
+# Round 2, finding 1: a capability probe is not an action, so it is not audited.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_capability_probe_writes_no_decision_row(monkeypatch):
+    """The UI asking whether to offer a control must not log ``share:create``."""
+    from langflow.services.authorization import capability_probe, guards
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(audit_module, "audit_decision", _capture)
+
+    with capability_probe():
+        await guards._audit_guard_decision(
+            user_id=uuid4(),
+            action="share:create",
+            obj="share:*",
+            result=audit_module.AUDIT_OWNER_OVERRIDE,
+        )
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_probe_suppression_does_not_leak_past_the_scope(monkeypatch):
+    """A real attempt after a probe is audited as usual."""
+    from langflow.services.authorization import capability_probe, guards
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(audit_module, "audit_decision", _capture)
+
+    with capability_probe():
+        await guards._audit_guard_decision(
+            user_id=uuid4(),
+            action="share:create",
+            obj="share:*",
+            result=audit_module.AUDIT_ALLOW,
+        )
+    await guards._audit_guard_decision(
+        user_id=uuid4(),
+        action="share:create",
+        obj="share:abc",
+        result=audit_module.AUDIT_DENY,
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["result"] == audit_module.AUDIT_DENY
+
+
+# --------------------------------------------------------------------------- #
+# Round 2, finding 3: the Playground posts the canvas, so a non-owner who holds
+# ``flow:execute`` must still run — the stored graph, not their override.
+# --------------------------------------------------------------------------- #
+
+
+class _Flow:
+    def __init__(self, owner_id):
+        self.id = uuid4()
+        self.user_id = owner_id
+        self.workspace_id = None
+        self.folder_id = None
+
+
+class _User:
+    def __init__(self):
+        self.id = uuid4()
+        self.is_superuser = False
+
+
+@pytest.fixture
+def _reset_override_context():
+    from langflow.services.authorization import flow_data_override
+
+    token = flow_data_override._flow_data_override_allowed.set(False)
+    yield
+    flow_data_override._flow_data_override_allowed.reset(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_reset_override_context")
+async def test_owner_override_is_resolved_without_consulting_policy(monkeypatch):
+    """An owner is decided by ownership alone; the policy plugin is never consulted."""
+    from langflow.services.authorization import flow_data_override
+
+    called = False
+
+    async def _never(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(flow_data_override, "ensure_flow_permission", _never)
+
+    user = _User()
+    flow = _Flow(owner_id=user.id)
+
+    assert await flow_data_override.resolve_flow_data_override(user, flow) is True
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_reset_override_context")
+async def test_write_holder_may_override_someone_elses_flow(monkeypatch):
+    """``flow:write`` already allows persisting that graph, so running it grants nothing new."""
+    from langflow.services.authorization import flow_data_override
+
+    async def _allow(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(flow_data_override, "ensure_flow_permission", _allow)
+
+    assert await flow_data_override.resolve_flow_data_override(_User(), _Flow(owner_id=uuid4())) is True
+    assert flow_data_override.flow_data_override_allowed() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_reset_override_context")
+async def test_execute_only_caller_may_not_override(monkeypatch):
+    """Holding execute but not write leaves the stored definition in charge."""
+    from langflow.services.authorization import flow_data_override
+
+    async def _deny(*_args, **_kwargs):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="nope")
+
+    monkeypatch.setattr(flow_data_override, "ensure_flow_permission", _deny)
+
+    assert await flow_data_override.resolve_flow_data_override(_User(), _Flow(owner_id=uuid4())) is False
+    assert flow_data_override.flow_data_override_allowed() is False
+
+
+@pytest.mark.usefixtures("_reset_override_context")
+def test_execute_only_run_keeps_going_with_the_stored_graph():
+    """The regression itself: this used to be a 404 that said the flow does not exist."""
+    from langflow.api.v2.workflow_validation import _apply_flow_data_override_policy
+    from lfx.workflow.converters import ParsedWorkflowRun
+
+    user = _User()
+    flow = _Flow(owner_id=uuid4())
+    parsed = ParsedWorkflowRun(
+        flow_id=str(flow.id),
+        data={"nodes": [{"id": "injected"}], "edges": []},
+        tweaks={"Component": {"model_name": "attacker-chosen"}},
+    )
+
+    result = _apply_flow_data_override_policy(parsed, flow, user)
+
+    assert result.data is None
+    assert result.tweaks == {}
+    # Everything the caller is entitled to send survives.
+    assert result.flow_id == str(flow.id)
+
+
+@pytest.mark.usefixtures("_reset_override_context")
+def test_owner_keeps_their_unsaved_canvas():
+    """The owner's debugging workflow is untouched."""
+    from langflow.api.v2.workflow_validation import _apply_flow_data_override_policy
+    from lfx.workflow.converters import ParsedWorkflowRun
+
+    user = _User()
+    flow = _Flow(owner_id=user.id)
+    data = {"nodes": [{"id": "mine"}], "edges": []}
+    parsed = ParsedWorkflowRun(flow_id=str(flow.id), data=data)
+
+    assert _apply_flow_data_override_policy(parsed, flow, user).data == data
+
+
+@pytest.mark.usefixtures("_reset_override_context")
+def test_a_run_with_no_override_is_untouched():
+    """A plain run carries no override, so there is nothing to strip."""
+    from langflow.api.v2.workflow_validation import _apply_flow_data_override_policy
+    from lfx.workflow.converters import ParsedWorkflowRun
+
+    parsed = ParsedWorkflowRun(flow_id="abc", input_value="hello")
+
+    assert _apply_flow_data_override_policy(parsed, _Flow(owner_id=uuid4()), _User()) is parsed

--- a/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
+++ b/src/backend/tests/unit/services/authorization/test_le1905_regressions.py
@@ -1,0 +1,158 @@
+"""Unit cover for the LE-1905 authorization-report fixes that live in OSS."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
+from langflow.services.authorization import audit as audit_module
+from langflow.services.authorization.fetch import deny_to_404, deny_to_404_unless_readable
+
+# --------------------------------------------------------------------------- #
+# Finding 1: a permission check must not read as a performed action.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_guard_decisions_are_tagged_as_decisions(monkeypatch):
+    """Every row a guard writes carries the decision marker."""
+    from langflow.services.authorization import guards
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(audit_module, "audit_decision", _capture)
+
+    await guards._audit_guard_decision(
+        user_id=uuid4(),
+        action="share:create",
+        obj="share:*",
+        result=audit_module.AUDIT_OWNER_OVERRIDE,
+        details={"domain": "*"},
+    )
+
+    assert captured[0]["details"]["event"] == audit_module.AUDIT_EVENT_DECISION
+    # The caller's own details survive alongside the marker.
+    assert captured[0]["details"]["domain"] == "*"
+
+
+def test_decision_and_mutation_markers_are_distinct():
+    assert audit_module.AUDIT_EVENT_DECISION != audit_module.AUDIT_EVENT_MUTATION
+
+
+# --------------------------------------------------------------------------- #
+# Finding 8: a denial on a resource the caller can read is a 403, not a 404.
+# --------------------------------------------------------------------------- #
+
+
+def _denied() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permission denied")
+
+
+@pytest.mark.asyncio
+async def test_readable_resource_keeps_the_403():
+    async def _can_read() -> None:
+        return None
+
+    resolved = await deny_to_404_unless_readable(
+        _denied(), _can_read, denied_detail="You don't have permission to execute this flow."
+    )
+
+    assert resolved.status_code == status.HTTP_403_FORBIDDEN
+    assert resolved.detail == "You don't have permission to execute this flow."
+
+
+@pytest.mark.asyncio
+async def test_unreadable_resource_still_masks_as_404():
+    async def _cannot_read() -> None:
+        raise _denied()
+
+    resolved = await deny_to_404_unless_readable(
+        _denied(), _cannot_read, denied_detail="never used", not_found_detail="Flow not found"
+    )
+
+    assert resolved.status_code == status.HTTP_404_NOT_FOUND
+    assert resolved.detail == "Flow not found"
+
+
+@pytest.mark.asyncio
+async def test_non_403_is_surfaced_unchanged():
+    """A 503 from the plugin must never be relabelled as a permission answer."""
+    upstream = HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="plugin down")
+
+    async def _unreachable() -> None:  # pragma: no cover - must not be called
+        pytest.fail("read check ran for a non-403")
+
+    resolved = await deny_to_404_unless_readable(upstream, _unreachable, denied_detail="x")
+
+    assert resolved is upstream
+    assert deny_to_404(upstream).status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+# --------------------------------------------------------------------------- #
+# Finding 11: owner override covers creating a flow in a project you own.
+# --------------------------------------------------------------------------- #
+
+
+def test_flow_spec_inherits_ownership_from_the_destination_project():
+    from langflow.services.authorization.guards import _RESOURCE_SPECS
+
+    assert _RESOURCE_SPECS["flow"].create_container_owner_kw == "folder_user_id"
+    # The flow's own owner kwarg still must not enable the override on create:
+    # it is the caller-supplied field and would let anyone assert ownership.
+    assert _RESOURCE_SPECS["flow"].owner_override_on_create is False
+
+
+@pytest.mark.asyncio
+async def test_create_in_owned_project_takes_the_owner_override(monkeypatch):
+    """The plugin is never consulted: ownership is checked before any policy rule."""
+    from langflow.services.authorization import guards
+
+    user_id = uuid4()
+    project_id = uuid4()
+    results: list[str] = []
+
+    async def _capture(**kwargs):
+        results.append(kwargs["result"])
+
+    async def _never(*_args, **_kwargs) -> None:  # pragma: no cover - must not be called
+        pytest.fail("enforce() ran despite owner override")
+
+    monkeypatch.setattr(audit_module, "audit_decision", _capture)
+    monkeypatch.setattr(guards, "ensure_permission", _never)
+    monkeypatch.setattr(guards, "should_apply_owner_override", lambda: _true())
+
+    class _User:
+        id = user_id
+
+    await guards.ensure_flow_permission(
+        _User(), "create", workspace_id=None, folder_id=project_id, folder_user_id=user_id
+    )
+
+    assert results == [audit_module.AUDIT_OWNER_OVERRIDE]
+
+
+@pytest.mark.asyncio
+async def test_create_in_someone_elses_project_still_reaches_the_policy(monkeypatch):
+    from langflow.services.authorization import guards
+
+    reached: list[str] = []
+
+    async def _record(_user, **kwargs):
+        reached.append(kwargs["act"])
+
+    monkeypatch.setattr(guards, "ensure_permission", _record)
+
+    class _User:
+        id = uuid4()
+
+    await guards.ensure_flow_permission(_User(), "create", workspace_id=None, folder_id=uuid4(), folder_user_id=uuid4())
+
+    assert reached == ["create"]
+
+
+async def _true() -> bool:
+    return True

--- a/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
+++ b/src/backend/tests/unit/services/authorization/test_rbac_enforcement_integration.py
@@ -140,11 +140,28 @@ async def test_viewer_can_read_and_execute_but_not_write_delete_or_create(client
         delete = await client.delete(f"api/v1/flows/{flow_id}", headers=headers)
         assert delete.status_code == 403
         assert delete.json()["detail"] == "You don't have permission to delete this flow."
-        # create -> denied; 403 is correct here (no existing resource UUID to protect)
-        create = await client.post(
+        # create into the *owner's* project -> denied; 403 is correct here (no
+        # existing resource UUID to protect).
+        owner_project_id = await _make_project(owner_id, f"owner_project_{uuid4().hex}")
+        create_elsewhere = await client.post(
+            "api/v1/flows/",
+            headers=headers,
+            json={
+                "name": f"new_{uuid4().hex}",
+                "data": {"nodes": [], "edges": []},
+                "folder_id": str(owner_project_id),
+            },
+        )
+        assert create_elsewhere.status_code == 403
+        # create into a project the viewer owns -> allowed by owner override.
+        # Ownership is checked before any policy rule, and a project is the
+        # only ownership a not-yet-created flow can inherit. Without this a
+        # read-only role cannot use the default project created for them
+        # (LE-1905 finding 11).
+        create_own = await client.post(
             "api/v1/flows/", headers=headers, json={"name": f"new_{uuid4().hex}", "data": {"nodes": [], "edges": []}}
         )
-        assert create.status_code == 403
+        assert create_own.status_code == 201, create_own.text
 
 
 async def test_developer_can_write_and_create_but_not_delete(client):
@@ -266,7 +283,11 @@ async def test_read_only_share_allows_get_but_denies_write_and_execute(client):
         # execute is modeled independently from write — a read-level share must
         # not grant build either -> deny -> 404
         build = await client.post(f"api/v1/build/{flow_id}/flow", headers=bob_headers, json={})
-        assert build.status_code == 404
+        # execute -> denied. Bob can read this flow, so answering "not found"
+        # would hide a resource he has already opened and send him to debug a
+        # flow id that is correct (LE-1905 finding 8).
+        assert build.status_code == 403
+        assert build.json()["detail"] == "You don't have permission to execute this flow."
 
 
 # --------------------------------------------------------------------------- #

--- a/src/backend/tests/unit/test_plugin_routes.py
+++ b/src/backend/tests/unit/test_plugin_routes.py
@@ -224,8 +224,58 @@ class TestLoadPluginRoutes:
         ]
         assert len(routes_at_path) == 1
 
+    def test_config_valueerror_is_not_reported_as_a_route_conflict(self):
+        """A plugin config error must not read as a duplicate path.
+
+        Reporting every ValueError as a conflict sent operators looking for a
+        clashing route when the real cause was elsewhere — and either way the
+        plugin's whole route set is missing, which is the part that matters.
+        """
+        app = FastAPI()
+
+        def misconfigured_register(_app_like):
+            err_msg = "LANGFLOW_AUTHZ_AUDIT_DURABLE=true is required"
+            raise ValueError(err_msg)
+
+        ep = MagicMock()
+        ep.name = "enterprise"
+        ep.load.return_value = misconfigured_register
+
+        with (
+            patch("langflow.plugin_routes.entry_points", return_value=[ep]),
+            patch("langflow.plugin_routes.logger") as mock_logger,
+        ):
+            load_plugin_routes(app)
+
+        mock_logger.warning.assert_not_called()
+        assert mock_logger.error.called
+        assert "none of its routes are available" in mock_logger.error.call_args.args[0]
+
+    def test_genuine_route_conflict_is_still_reported_as_one(self):
+        app = FastAPI()
+
+        @app.get("/api/v1/flow")
+        def core_flow():
+            return "core"
+
+        def conflicting_register(app_like):
+            app_like.get("/api/v1/flow")(lambda: "plugin")
+
+        ep = MagicMock()
+        ep.name = "conflicting"
+        ep.load.return_value = conflicting_register
+
+        with (
+            patch("langflow.plugin_routes.entry_points", return_value=[ep]),
+            patch("langflow.plugin_routes.logger") as mock_logger,
+        ):
+            load_plugin_routes(app)
+
+        mock_logger.error.assert_not_called()
+        assert "route conflict" in mock_logger.warning.call_args.args[0]
+
     def test_plugin_that_raises_is_skipped_app_continues(self):
-        """When a plugin raises a non-ValueError exception, it is skipped."""
+        """When a plugin raises a non-conflict exception, it is skipped."""
         app = FastAPI()
 
         @app.get("/health")

--- a/src/backend/tests/unit/test_plugin_routes.py
+++ b/src/backend/tests/unit/test_plugin_routes.py
@@ -248,8 +248,8 @@ class TestLoadPluginRoutes:
             load_plugin_routes(app)
 
         mock_logger.warning.assert_not_called()
-        assert mock_logger.error.called
-        assert "none of its routes are available" in mock_logger.error.call_args.args[0]
+        mock_logger.error.assert_called_once()
+        assert "none are available" in mock_logger.error.call_args.args[0]
 
     def test_genuine_route_conflict_is_still_reported_as_one(self):
         app = FastAPI()
@@ -272,7 +272,105 @@ class TestLoadPluginRoutes:
             load_plugin_routes(app)
 
         mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_called_once()
         assert "route conflict" in mock_logger.warning.call_args.args[0]
+
+    def test_partial_registration_is_rolled_back_on_conflict(self):
+        """A plugin that conflicts halfway must not leave its earlier routes live.
+
+        Registering some routes and then failing left the plugin half-mounted:
+        reported as rejected while part of its surface answered requests. For an
+        authorization plugin that is worse than registering nothing, because the
+        app looks functional.
+        """
+        app = FastAPI()
+
+        @app.get("/api/v1/existing")
+        def existing():
+            return "core"
+
+        def half_registering(app_like):
+            app_like.get("/api/v1/plugin-first")(lambda: "first")
+            app_like.get("/api/v1/existing")(lambda: "conflict")
+            app_like.get("/api/v1/plugin-third")(lambda: "third")
+
+        ep = MagicMock()
+        ep.name = "half_plugin"
+        ep.load.return_value = half_registering
+
+        with (
+            patch("langflow.plugin_routes.entry_points", return_value=[ep]),
+            patch("langflow.plugin_routes.logger"),
+        ):
+            load_plugin_routes(app)
+
+        keys = _get_route_keys(app)
+        assert ("/api/v1/plugin-first", "GET") not in keys
+        assert ("/api/v1/plugin-third", "GET") not in keys
+        # The core route the plugin collided with is untouched.
+        assert ("/api/v1/existing", "GET") in keys
+
+    def test_rollback_frees_the_failed_plugins_reservations(self):
+        """A later plugin may claim a path a failed plugin mounted and lost.
+
+        The wrapper is shared across entry points, so without restoring
+        ``_reserved`` the abandoned path would stay claimed and reject the next
+        plugin for a route that is no longer mounted.
+        """
+        app = FastAPI()
+
+        @app.get("/api/v1/existing")
+        def existing():
+            return "core"
+
+        def failing(app_like):
+            app_like.get("/api/v1/contested")(lambda: "first-claimant")
+            app_like.get("/api/v1/existing")(lambda: "conflict")
+
+        def later(app_like):
+            app_like.get("/api/v1/contested")(lambda: "second-claimant")
+
+        failing_ep = MagicMock()
+        failing_ep.name = "a_failing"
+        failing_ep.load.return_value = failing
+        later_ep = MagicMock()
+        later_ep.name = "b_later"
+        later_ep.load.return_value = later
+
+        with (
+            patch("langflow.plugin_routes.entry_points", return_value=[failing_ep, later_ep]),
+            patch("langflow.plugin_routes.logger") as mock_logger,
+        ):
+            load_plugin_routes(app)
+
+        assert ("/api/v1/contested", "GET") in _get_route_keys(app)
+        # Exactly one rejection: the first plugin's. The second is not a conflict.
+        mock_logger.warning.assert_called_once()
+
+    def test_successful_plugins_are_untouched_by_a_neighbours_failure(self):
+        app = FastAPI()
+
+        def good(app_like):
+            app_like.get("/api/v1/good")(lambda: "good")
+
+        def broken(_app_like):
+            err_msg = "plugin broken"
+            raise RuntimeError(err_msg)
+
+        good_ep = MagicMock()
+        good_ep.name = "a_good"
+        good_ep.load.return_value = good
+        broken_ep = MagicMock()
+        broken_ep.name = "b_broken"
+        broken_ep.load.return_value = broken
+
+        with (
+            patch("langflow.plugin_routes.entry_points", return_value=[good_ep, broken_ep]),
+            patch("langflow.plugin_routes.logger"),
+        ):
+            load_plugin_routes(app)
+
+        assert ("/api/v1/good", "GET") in _get_route_keys(app)
 
     def test_plugin_that_raises_is_skipped_app_continues(self):
         """When a plugin raises a non-conflict exception, it is skipped."""

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-name-tooltip.test.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/__tests__/project-name-tooltip.test.tsx
@@ -1,0 +1,279 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import SideBarFoldersButtonsComponent from "..";
+
+const mockMutateAddFolder = jest.fn();
+const mockMutateUpdateFolder = jest.fn();
+const mockSetErrorData = jest.fn();
+const mockCan = jest.fn(
+  (_projectId: string | undefined | null, _action: string) => true,
+);
+let mockFolders: Array<{
+  id: string;
+  name: string;
+  description: string;
+  parent_id: string;
+  flows: never[];
+  components: never[];
+  owner_username: string;
+  is_owner: boolean;
+}> = [];
+
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useIsFetching: () => 0,
+  useIsMutating: () => 0,
+}));
+
+jest.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: jest.fn() },
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === "sidebar.projectCreateError") {
+        return "Unable to create project.";
+      }
+      if (key === "project.ownedBy") {
+        return `${options?.name} — ${options?.owner}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/flows" }),
+  useParams: () => ({}),
+}));
+
+jest.mock("@/components/ui/sidebar", () => {
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  const SidebarMenuButton = ({
+    children,
+    isActive: _isActive,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isActive?: boolean;
+    size?: string;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
+  return {
+    Sidebar: Wrapper,
+    SidebarContent: Wrapper,
+    SidebarFooter: Wrapper,
+    SidebarGroup: Wrapper,
+    SidebarGroupContent: Wrapper,
+    SidebarHeader: Wrapper,
+    SidebarMenu: Wrapper,
+    SidebarMenuButton,
+    SidebarMenuItem: Wrapper,
+  };
+});
+
+jest.mock("@/contexts/permissionsContext", () => ({
+  PermissionsProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  usePermissions: () => ({ can: mockCan }),
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useUpdateUser: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/controllers/API/queries/folders", () => ({
+  usePatchFolders: () => ({ mutate: mockMutateUpdateFolder }),
+  usePostFolders: () => ({
+    mutate: mockMutateAddFolder,
+    isPending: false,
+  }),
+  usePostUploadFolders: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/controllers/API/queries/folders/use-get-download-folders", () => ({
+  useGetDownloadFolders: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/customization/feature-flags", () => ({
+  ENABLE_CUSTOM_PARAM: false,
+  ENABLE_DATASTAX_LANGFLOW: false,
+  ENABLE_FILE_MANAGEMENT: false,
+  ENABLE_KNOWLEDGE_BASES: false,
+  ENABLE_MCP_NOTICE: false,
+}));
+
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => jest.fn(),
+}));
+
+jest.mock("@/customization/utils/analytics", () => ({ track: jest.fn() }));
+jest.mock("@/hooks/flows/use-upload-flow", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+jest.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { userData: undefined }) => unknown) =>
+    selector({ userData: undefined }),
+}));
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (
+    selector: (state: {
+      setErrorData: jest.Mock;
+      setSuccessData: jest.Mock;
+    }) => unknown,
+  ) =>
+    selector({
+      setErrorData: mockSetErrorData,
+      setSuccessData: jest.fn(),
+    }),
+}));
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { takeSnapshot: jest.Mock }) => unknown) =>
+    selector({ takeSnapshot: jest.fn() }),
+}));
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: (
+    selector: (state: {
+      folders: typeof mockFolders;
+      folderIdDragging: null;
+      myCollectionId: string;
+    }) => unknown,
+  ) =>
+    selector({
+      folders: mockFolders,
+      folderIdDragging: null,
+      myCollectionId: "root",
+    }),
+}));
+jest.mock("../../../hooks/use-on-file-drop", () => ({
+  __esModule: true,
+  default: () => ({
+    dragOver: jest.fn(),
+    dragEnter: jest.fn(),
+    dragLeave: jest.fn(),
+    onDrop: jest.fn(),
+  }),
+}));
+jest.mock("../components/header-buttons", () => ({
+  HeaderButtons: ({ addNewFolder }: { addNewFolder: () => void }) => (
+    <button type="button" onClick={addNewFolder}>
+      New Project
+    </button>
+  ),
+}));
+jest.mock("../components/input-edit-folder-name", () => ({
+  InputEditFolderName: ({
+    item,
+    foldersNames,
+    handleEditFolderName,
+    handleEditNameFolder,
+  }: {
+    item: { id: string };
+    foldersNames: Record<string, string>;
+    handleEditFolderName: (
+      event: React.ChangeEvent<HTMLInputElement>,
+      folderId: string,
+    ) => void;
+    handleEditNameFolder: (item: { id: string }) => void;
+  }) => (
+    // Mirrors the real input's autoFocus, which is what makes the unmount drop
+    // focus to <body> in the first place.
+    <input
+      autoFocus
+      data-testid={`input-project-${item.id}`}
+      value={foldersNames[item.id] ?? ""}
+      onChange={(event) => handleEditFolderName(event, item.id)}
+      onBlur={() => handleEditNameFolder(item)}
+    />
+  ),
+}));
+
+jest.mock("../components/mcp-server-notice", () => ({
+  MCPServerNotice: () => null,
+}));
+jest.mock("../components/select-options", () => ({
+  SelectOptions: () => null,
+}));
+jest.mock("../../sidebarFolderSkeleton", () => ({
+  SidebarFolderSkeleton: () => null,
+}));
+
+// Project names are truncated with an ellipsis and the sidebar cannot be
+// widened. With one default project per user the list fills with same-prefixed
+// entries — "Starter Project — u_vie...", "Starter Project — u_edi..." — where
+// the truncated portion is the only part that distinguishes one row from
+// another. The full name has to stay reachable (LE-1905 finding 12).
+const OWN_FOLDER = {
+  id: "own-id",
+  name: "Starter Project",
+  description: "",
+  parent_id: "",
+  flows: [] as never[],
+  components: [] as never[],
+  owner_username: "current-user",
+  is_owner: true,
+};
+
+// Someone else's project: the display name is the composed
+// "<name> — <owner>" form, which is exactly the shape that truncates.
+const SHARED_FOLDER = {
+  ...OWN_FOLDER,
+  id: "shared-id",
+  name: "Starter Project",
+  owner_username: "u_editor_with_a_long_name",
+  is_owner: false,
+};
+
+const nameCellFor = (folderId: string) =>
+  screen.getByTestId(`sidebar-nav-${folderId}`).querySelector("span");
+
+describe("project name tooltip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCan.mockReturnValue(true);
+    mockFolders = [OWN_FOLDER, SHARED_FOLDER];
+  });
+
+  it("exposes the full display name as a title on every project row", () => {
+    render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
+
+    expect(nameCellFor(OWN_FOLDER.id)).toHaveAttribute(
+      "title",
+      "Starter Project",
+    );
+    expect(nameCellFor(SHARED_FOLDER.id)).toHaveAttribute(
+      "title",
+      "Starter Project — u_editor_with_a_long_name",
+    );
+  });
+
+  it("keeps the title identical to the rendered name", () => {
+    render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
+
+    for (const folder of [OWN_FOLDER, SHARED_FOLDER]) {
+      const cell = nameCellFor(folder.id);
+      // A title that drifts from the text is worse than none: the tooltip
+      // would claim a different project than the row it belongs to.
+      expect(cell).toHaveAttribute("title", cell?.textContent ?? "");
+    }
+  });
+
+  it("does not render a title on the rename input that replaces the name", () => {
+    render(<SideBarFoldersButtonsComponent handleChangeFolder={jest.fn()} />);
+    fireEvent.doubleClick(screen.getByTestId(`sidebar-nav-${OWN_FOLDER.id}`));
+
+    // While editing there is no truncated label to explain.
+    expect(nameCellFor(OWN_FOLDER.id)).toBeNull();
+    expect(
+      screen.getByTestId(`input-project-${OWN_FOLDER.id}`),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from "react-i18next";
 import IconComponent from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
+import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { usePermissions } from "@/contexts/permissionsContext";
 import CustomResourceShareAction from "@/customization/components/custom-resource-share-action";
 import type { FolderType } from "@/pages/MainPage/entities";
@@ -34,36 +35,35 @@ export const SelectOptions = ({
   const canDownload = can(item.id, "read");
   const canDelete = can(item.id, "delete");
   const displayName = getProjectDisplayName(item, t);
+  const select = (option: string) =>
+    handleSelectChange(
+      option,
+      item,
+      handleDeleteFolder,
+      handleDownloadFolder,
+      handleSelectFolderToRename,
+    );
   return (
-    <div className="flex items-center gap-1">
-      <CustomResourceShareAction
-        resourceId={item.id!}
-        resourceType="project"
-        resourceName={displayName}
-      />
-      <Select
-        onValueChange={(value) =>
-          handleSelectChange(
-            value,
-            item,
-            handleDeleteFolder,
-            handleDownloadFolder,
-            handleSelectFolderToRename,
-          )
-        }
-        value=""
+    // A menu of commands, not a value to pick: Knowledge Bases, Files and
+    // Deployments all use DropdownMenu here, and Share is a menu item on each.
+    // The sidebar was the one surface rendering Share as a second, always-on
+    // icon beside the trigger -- the only permanently visible control in the
+    // list, on every row (LE-1905).
+    <DropdownMenu>
+      <ShadTooltip
+        content={t("folder.options")}
+        side="right"
+        styleClasses="z-50"
       >
-        <ShadTooltip
-          content={t("folder.options")}
-          side="right"
-          styleClasses="z-50"
-        >
-          <SelectTrigger
-            variant="plain"
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
             className="h-6 w-6 min-h-[24px] min-w-[24px]"
             id={`options-trigger-${item.id}`}
             data-testid={`more-options-button_${item.id}`}
             aria-label={t("folder.optionsFor", { name: displayName })}
+            onClick={(e) => e.stopPropagation()}
           >
             <IconComponent
               name={"MoreHorizontal"}
@@ -72,44 +72,55 @@ export const SelectOptions = ({
                 checkPathName(item.id!) ? "block" : "hidden",
               )}
             />
-          </SelectTrigger>
-        </ShadTooltip>
-        <SelectContent
-          align="end"
-          alignOffset={-16}
-          position="popper"
-          className="min-w-[11.5rem]"
+          </Button>
+        </DropdownMenuTrigger>
+      </ShadTooltip>
+      <DropdownMenuContent
+        align="end"
+        alignOffset={-16}
+        className="min-w-[11.5rem]"
+      >
+        <DropdownMenuItem
+          id="rename-button"
+          data-testid="btn-rename-project"
+          className="text-xs"
+          disabled={!canRename}
+          onClick={(e) => {
+            e.stopPropagation();
+            select("rename");
+          }}
         >
-          <SelectItem
-            variant="plain"
-            id="rename-button"
-            value="rename"
-            data-testid="btn-rename-project"
-            className="text-xs"
-            disabled={!canRename}
-          >
-            <FolderSelectItem name={t("folder.rename")} iconName="SquarePen" />
-          </SelectItem>
-          <SelectItem
-            variant="plain"
-            value="download"
-            data-testid="btn-download-project"
-            className="text-xs"
-            disabled={!canDownload}
-          >
-            <FolderSelectItem name={t("folder.download")} iconName="Download" />
-          </SelectItem>
-          <SelectItem
-            variant="plain"
-            value="delete"
-            data-testid="btn-delete-project"
-            className="text-xs"
-            disabled={!canDelete}
-          >
-            <FolderSelectItem name={t("folder.delete")} iconName="Trash2" />
-          </SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+          <FolderSelectItem name={t("folder.rename")} iconName="SquarePen" />
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          data-testid="btn-download-project"
+          className="text-xs"
+          disabled={!canDownload}
+          onClick={(e) => {
+            e.stopPropagation();
+            select("download");
+          }}
+        >
+          <FolderSelectItem name={t("folder.download")} iconName="Download" />
+        </DropdownMenuItem>
+        <CustomResourceShareAction
+          resourceId={item.id!}
+          resourceType="project"
+          resourceName={displayName}
+          display="menu"
+        />
+        <DropdownMenuItem
+          data-testid="btn-delete-project"
+          className="text-xs"
+          disabled={!canDelete}
+          onClick={(e) => {
+            e.stopPropagation();
+            select("delete");
+          }}
+        >
+          <FolderSelectItem name={t("folder.delete")} iconName="Trash2" />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -509,7 +509,16 @@ const SideBarFoldersButtonsComponent = ({
                                           handleKeyDown={handleKeyDown}
                                         />
                                       ) : (
-                                        <span className="block w-0 grow truncate text-sm opacity-100">
+                                        <span
+                                          className="block w-0 grow truncate text-sm opacity-100"
+                                          // The sidebar cannot be widened, so a
+                                          // truncated name is otherwise
+                                          // unreadable. With one default project
+                                          // per user the list fills with rows
+                                          // that differ only in the truncated
+                                          // part.
+                                          title={getProjectDisplayName(item, t)}
+                                        >
                                           {getProjectDisplayName(item, t)}
                                         </span>
                                       )}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -485,7 +485,7 @@ const SideBarFoldersButtonsComponent = ({
                                     }
                                   }}
                                   className={cn(
-                                    "flex-grow pr-16",
+                                    "flex-grow pr-8",
                                     hoveredFolderId === item.id && "bg-accent",
                                     checkHoveringFolder(item.id!),
                                   )}

--- a/src/frontend/src/customization/components/__tests__/custom-resource-share-entrypoints.test.ts
+++ b/src/frontend/src/customization/components/__tests__/custom-resource-share-entrypoints.test.ts
@@ -92,13 +92,17 @@ describe("non-flow share entry-point wiring", () => {
     );
   });
 
-  it("reserves the complete two-action project row width", () => {
+  it("reserves exactly the one-action project row width", () => {
+    // Share moved into the three-dot menu, so the row is back to a single
+    // control and the width reserved for two would only cost the project name
+    // characters it does not need to give up -- the names are already
+    // truncated (LE-1905).
     const source = readFrontendSource(
       "components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx",
     );
 
-    expect(source).toContain('"flex-grow pr-16"');
-    expect(source).not.toContain('"flex-grow pr-8"');
+    expect(source).toContain('"flex-grow pr-8"');
+    expect(source).not.toContain('"flex-grow pr-16"');
   });
 
   it("keeps resource subtype in the generic customization seam contract", () => {


### PR DESCRIPTION
Addresses the OSS half of Alice Reis's **LE-1905 — RBAC Post-V1** findings (tested against Langflow Enterprise release-1.12.0 @ 2cb617b, OSS pin 22ed5c64). The Enterprise half is a companion PR; the two are independent and can land in either order.

## Findings fixed

### 1 — Audit rows could not tell a permission check from a performed action

Opening a flow in the editor runs a `share:create` permission check (Enterprise's share-capability probe decides whether to show the Share button). The guard wrote that check under the same action name a *created share* uses, with nothing on either row saying which it was — so a check and a real creation were indistinguishable.

Guards now tag every row they write `details.event = "authorization_decision"`; the `authz_share` routes tag theirs `"mutation"`. The distinction is available in the API, the CSV export, and the Enterprise audit UI. All guard audit writes go through one helper, so a new guard cannot forget the tag.

### 8 — A denial on a resource the caller can read returned 404

The 404 mask stops a caller probing UUIDs they have no access to. It buys nothing once they have opened the resource, and it costs them a truthful answer — `"Flow '<id>' does not exist. Verify the flow_id and try again."` sends someone to debug an identifier that is correct.

New `deny_to_404_unless_readable` re-checks read on a denial: **readable → 403** naming the missing permission, **unreadable → 404**. A non-403 (a 5xx from the plugin, say) is surfaced unchanged rather than relabelled.

| Path | Before | After |
| --- | --- | --- |
| `PATCH /api/v1/projects/{id}` | 404 | 403 "You don't have permission to edit this project." |
| `DELETE /api/v1/projects/{id}` | 404 | 403 "You don't have permission to delete this project." |
| `POST /api/v2/workflows` | 404 `FLOW_NOT_FOUND` | 403 `FLOW_EXECUTE_FORBIDDEN` |
| `POST /api/v1/build/{id}/flow` | 404 | 403 "You don't have permission to execute this flow." |

Project delete was not in the report; it is the same defect one line away from the reported edit path, and the flow guard already paired write and delete this way. The `PUT` project upsert is deliberately left alone — it is reached by id without a prior read, so its 404 is doing real privacy work.

### 11 — Owner override did not cover creating a flow in a project you own

`require_flow_create_permission` passed no owner at all, and the flow spec disables owner override on create. A user holding only Viewer could not create a flow in the default project created for them.

A flow being created has no owner yet, so the destination *project* is the only ownership the check can consult. `_ResourceSpec` gains `create_container_owner_kw`, and the destination owner is read **from the stored folder row after canonicalization** — never echoed from the request, which would let a caller assert ownership of a project they do not own. Applied to all four create paths (POST, PUT upsert, batch create, upload).

Creating in someone else's project is still decided by policy.

### 7 — Request validation ran before authorization

On superuser-gated `/authz` routes an unauthorised caller received the same 422 field names and enum literals a superuser would, and only learned of the 403 once the body was well-formed — enough to map the request contract of a route they cannot invoke.

The gate is now a route `dependencies=[...]`, which FastAPI solves before validating that route's body. The in-body `_require_superuser` call stays as the gate for anything reaching the handler without dependency resolution. Route signatures are unchanged, so the existing direct-call tests still exercise the in-body gate.

### 12 — Project names truncated in the sidebar with no way to read them

The sidebar cannot be widened and there was no tooltip. With one default project per user the list fills with rows that differ only in the truncated part. The full name is now the row's `title`.

### Also: plugin config failures were reported as route conflicts

Every `ValueError` from a plugin's `register()` was logged as `"rejected (route conflict)"`. This is how the Enterprise SIEM misconfiguration in finding 9 surfaced — operators went looking for a duplicate path while the real symptom was that none of that plugin's routes had registered. Only a genuine conflict takes that branch now, via a dedicated `RouteConflictError`.

## Tests

- New `test_le1905_regressions.py`: decision/mutation tagging, all three branches of `deny_to_404_unless_readable`, and owner-override-on-create (owned project takes the override without consulting the plugin; someone else's still reaches policy).
- New `test_authz_admin_authorization_ordering.py`: a malformed body from a non-superuser is 403 with no schema in the response; the same body from a superuser is still 422.
- New plugin-loader cases: a config `ValueError` is not reported as a conflict, and a real conflict still is.
- Two existing enforcement tests asserted the behavior the report calls defective and are updated with the reasoning inline:
  - a Viewer creating a flow in their own project now succeeds (and is still refused in the owner's project);
  - a read-only share holder denied execute now gets the execute-permission 403 rather than a 404 for a flow they can see.

```
uv run pytest src/backend/tests/unit/services/authorization \
  src/backend/tests/unit/api/v1/test_flows.py \
  src/backend/tests/unit/api/v1/test_authz_admin_routes.py \
  src/backend/tests/unit/api/v1/test_plugin_routes.py
```
→ 400+ passed.

## Test plan

- [ ] As a Viewer at Global scope: create a flow in your own default project (expect 201), and in another user's project (expect 403).
- [ ] As a Viewer: `PATCH` a readable flow and project — both 403 with a permission message, not 404.
- [ ] With `flow:read` only: `POST /api/v2/workflows` and `POST /api/v1/build/{id}/flow` — 403, not 404 telling you to verify the flow id.
- [ ] With no role assignments: `POST /api/v1/authz/roles` with `{"bogus":1}` — 403, no field names in the body.
- [ ] Confirm a flow that the caller genuinely cannot read still answers 404.
- [ ] Open a flow, then check the audit log: the `share:create` rows carry `event=authorization_decision`; a real share carries `event=mutation` plus `share_id`.
- [ ] Hover a truncated project name in the sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authorization for administrative role, team, and membership changes.
  * Flow and project permission errors now provide clearer 403 or 404 responses based on visibility.
  * Flow creation now respects ownership of the destination project or folder.
  * Authorization audit records now distinguish decisions from completed changes.
  * Sidebar project names display their full name on hover.

* **Bug Fixes**
  * Unauthorized requests are rejected before malformed request details are exposed.
  * Plugin route conflicts are now distinguished from other registration errors.

* **Tests**
  * Added regression coverage for authorization, auditing, permissions, and plugin route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Round 2 — Alice's validation of this PR (2026-08-18)

Validated against `a304c618` + IBM-Langflow#238 `30cdb26a`. Five new findings; the OSS half is below. Latest commits: `7cb7710` and `24914a9`.

## 3 — Global Viewer or Editor gets 404 from the Playground

**This is the real cause of original finding 14, and it was not the denial reframe.** The Playground posts `data: { nodes, edges }` on every canvas run ([`flowStore.ts:979`](src/frontend/src/stores/flowStore.ts)), and `_enforce_flow_data_override_owner` rejected caller-supplied data from any non-owner — reframed to `404 FLOW_NOT_FOUND`. That is why the same user running the same flow succeeded through the API (no `data` in the body) and failed from the UI, and why Viewer *and* Editor were both affected: the gate tested **ownership**, not permission, so `flow:execute` never entered into it. `_VIEWER_PERMISSIONS` includes `("flow:*", "execute")`, so the 200 Alice saw via the API was correct all along.

Overriding the stored graph is an edit expressed at run time, so it is now gated on **`flow:write`** (`services/authorization/flow_data_override.py`). A caller holding write can already PATCH that graph and run it, so honoring their unsaved canvas grants nothing new. An execute-only caller has the override **dropped** and runs the stored definition — what `flow:execute` means — instead of being told the flow does not exist.

Dropping rather than denying is the deliberate choice: the run is the caller's to make, their canvas is read-only so the graph they posted *is* the stored one, and dropping is strictly safer than honoring it. The server logs when it happens. The security property is unchanged and still asserted: caller-supplied graph data never runs for someone who cannot edit the flow.

Applied to both execution paths — `POST /api/v2/workflows` and `POST /api/v1/build/{id}/flow`.

Two tests asserted the 404 (`test_non_owner_data_override_is_hidden_as_404`, `test_non_owner_tweaks_are_hidden_as_404`). Both now assert the override is stripped and the run proceeds, with the reasoning inline.

## 1 — permission checks recorded as if they were performed actions

Two OSS pieces:

**`capability_probe()`** — a scope that evaluates a permission for a UI capability answer without writing a decision row. Enforcement is identical; only the audit row is dropped. The Enterprise share-capability probe fires once per rendered resource, so it wrote a `share:create` row for every project in the sidebar with no resource id and no share behind it — 37 rows, 0 shares, in an hour of use. Consumed by IBM-Langflow#238.

**Every row is classifiable.** Alice noted `audit:read` and `rbac_policy:startup_reconcile` carry no `event` class, so a reader filtering on it silently loses them. Adds `AUDIT_EVENT_ACCESS` (a user did something that changed nothing) and `AUDIT_EVENT_SYSTEM` (the server acted with no user behind it). `GET /api/v1/authz/audit` gains `event` and `exclude_event`, so "show me what people did" is a server-side filter with an honest total and honest pagination rather than a client-side sieve over one page. An untagged row can never satisfy an include and is never dropped by an exclude, so rows written before classification stay visible — verified against a real database, including the count coming off the same filtered subquery.

## 4 — project names still truncated on the Enterprise UI

Already fixed here (`sideBarFolderButtons`, plus `project-name-tooltip.test.tsx`). Alice saw it unchanged because the **Enterprise build does not contain this PR**: `oss-version` pins `22ed5c64` (Aug 13), which predates these commits (Aug 17). Nothing to do in OSS — it needs the EE pin bump after this merges. Same explanation for observing finding 3 against the Enterprise stack.

## Not addressed here

**Finding 1's stated expectation — "the log does not record automatic permission checks at all."** That conflicts with test-plan §9.1 ("both are logged — denials recorded, not only successes"): dropping every check row drops the denial record with it. What ships instead: probes are not recorded (they are not attempts), everything else is classified, and readers can exclude checks. Whether the store should stop persisting decision rows entirely is a product call.

## Tests

```
pytest src/backend/tests/unit/services/authorization/ \
       src/backend/tests/unit/api/v1/test_authz_admin_authorization_ordering.py   # 328 passed
pytest src/backend/tests/unit/api/v2/                                             # 154 passed
```
