### PR TITLE
chore(mcp): remove dead client code and fix stale MCP docs

### DIFF
--- a/docs/docs/API-Reference/api-reference-api-examples.mdx
+++ b/docs/docs/API-Reference/api-reference-api-examples.mdx
@@ -378,7 +378,8 @@ The following endpoints are most often used when contributing to the Langflow co
 
 * MCP servers: The following endpoints are for managing Langflow MCP servers and MCP server connections.
 They aren't typically called directly; instead, they are used to drive internal functionality in the Langflow frontend and when running flows that call MCP servers.
-Langflow MCP servers support both streamable HTTP and SSE transport.
+Langflow MCP servers support streamable HTTP and, for backward compatibility, the legacy SSE transport.
+New clients should use streamable HTTP.
   * HEAD `/v1/mcp/streamable`: Health check for streamable HTTP MCP.
   * GET `/v1/mcp/streamable`: Open streamable HTTP connection for MCP server.
   * POST `/v1/mcp/streamable`: Post messages to the MCP server via streamable HTTP.

--- a/docs/docs/Agents/mcp-client.mdx
+++ b/docs/docs/Agents/mcp-client.mdx
@@ -77,7 +77,7 @@ This component has two modes, depending on the type of server you want to access
 Every Langflow project runs a separate MCP server that exposes the project's flows as MCP tools.
 For more information about your projects' MCP servers, including exposing flows as MCP tools, see [Use Langflow as an MCP server](/mcp-server).
 
-Langflow MCP servers support both the **streamable HTTP** transport and **Server-Sent Events (SSE)** as a fallback.
+Langflow MCP servers support the **streamable HTTP** transport and, for backward compatibility, the legacy **Server-Sent Events (SSE)** transport.
 
 To leverage flows-as-tools, register your Langflow MCP endpoint as a server first, and then add the **MCP Tools** component from the <McpIcon /> **MCP** sidebar.
 

--- a/docs/docs/Agents/mcp-server.mdx
+++ b/docs/docs/Agents/mcp-server.mdx
@@ -11,7 +11,7 @@ Langflow integrates with the [Model Context Protocol (MCP)](https://modelcontext
 
 This page describes how to use Langflow as an MCP server that exposes your flows as [tools](https://modelcontextprotocol.io/docs/concepts/tools) that [MCP clients](https://modelcontextprotocol.io/clients) can use when generating responses.
 
-Langflow MCP servers support both the **streamable HTTP** transport and **Server-Sent Events (SSE)** as a fallback.
+Langflow MCP servers support the **streamable HTTP** transport and, for backward compatibility, the legacy **Server-Sent Events (SSE)** transport.
 The default project MCP server configuration uses streamable HTTP transport at the URL path `/streamable`.
 
 For information about using Langflow as an MCP client and managing MCP server connections within flows, see [Use Langflow as an MCP client](/mcp-client).
@@ -388,7 +388,7 @@ The default address is `http://localhost:6274`.
       </TabItem>
       <TabItem value="None" label="None">
 
-        - **Transport Type**: Select **SSE**.
+        - **Transport Type**: Select **Streamable HTTP**.
         - **URL**: Enter the Langflow MCP server's endpoint. For example:
             ```bash
             http://localhost:7860/api/v1/mcp/project/d359cbd4-6fa2-4002-9d53-fa05c645319c/streamable

--- a/docs/docs/Support/troubleshooting.mdx
+++ b/docs/docs/Support/troubleshooting.mdx
@@ -613,7 +613,7 @@ If Claude for Desktop doesn't use your server's tools correctly, try explicitly 
           "args": [
             "-y",
             "supergateway",
-            "--sse",
+            "--streamableHttp",
             "http://LANGFLOW_SERVER_ADDRESS/api/v1/mcp/project/PROJECT_ID/streamable"
           ]
         }

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -374,7 +374,6 @@ langchain-huggingface = ["langchain-huggingface~=1.2.0; sys_platform != 'darwin'
 langchain-unstructured = ["langchain-unstructured~=1.0.0"]
 # graph-retriever graduated to the standalone lfx-datastax bundle (a regular
 # dep of langflow); langchain-graph-retriever / graph-retriever live there now.
-langchain-mcp-adapters = ["langchain-mcp-adapters>=0.1.14,<0.2.0"]
 
 # Additional monitoring
 opik = ["opik>=2.0.0,<3.0.0"]
@@ -421,9 +420,6 @@ mlx = [
     "mlx>=0.29.0; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.12'",
     "mlx-vlm~=0.3.9; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.12'",
 ]
-
-# MCP
-fastmcp = ["fastmcp>=3.2.0"]
 
 # AWS async client. S3 storage uses aiobotocore directly so boto3 is no longer
 # constrained by aioboto3's exact pin to aiobotocore 2.25.1.

--- a/src/backend/tests/integration/components/mcp/test_mcp_memory_leak.py
+++ b/src/backend/tests/integration/components/mcp/test_mcp_memory_leak.py
@@ -322,47 +322,6 @@ async def test_session_manager_server_key_generation():
 
 
 @pytest.mark.asyncio
-async def test_session_manager_connectivity_validation():
-    """Test session connectivity validation."""
-    session_manager = MCPSessionManager()
-
-    # Mock a session that responds to list_tools
-    class MockSession:
-        def __init__(self, should_fail=False):  # noqa: FBT002
-            self.should_fail = should_fail
-
-        async def list_tools(self):
-            if self.should_fail:
-                msg = "Connection failed"
-                raise Exception(msg)  # noqa: TRY002
-
-            class MockResponse:
-                def __init__(self):
-                    self.tools = ["tool1", "tool2"]
-
-            return MockResponse()
-
-    # Test healthy session
-    healthy_session = MockSession(should_fail=False)
-    is_healthy = await session_manager._validate_session_connectivity(healthy_session)
-    assert is_healthy is True
-
-    # Test unhealthy session
-    unhealthy_session = MockSession(should_fail=True)
-    is_healthy = await session_manager._validate_session_connectivity(unhealthy_session)
-    assert is_healthy is False
-
-    # Test session that returns None
-    class MockNoneSession:
-        async def list_tools(self):
-            return None
-
-    none_session = MockNoneSession()
-    is_healthy = await session_manager._validate_session_connectivity(none_session)
-    assert is_healthy is False
-
-
-@pytest.mark.asyncio
 async def test_session_manager_cleanup_all(process_tracker):
     """Test that cleanup_all properly cleans up all sessions."""
     process, initial_count = process_tracker

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -1355,6 +1355,36 @@ class TestUpdateToolsPerToolResilience:
         assert "bad_linear_like" in joined, f"failing tool name must appear in log; got: {joined!r}"
 
     @pytest.mark.asyncio
+    async def test_non_object_input_schema_skips_one_tool_not_the_whole_server(self):
+        """A ValueError from schema conversion must skip that tool, not abort the listing.
+
+        ``create_input_schema_from_json_schema`` raises ``ValueError("Root schema must be
+        type 'object'")`` for any tool whose ``inputSchema`` is empty or not an object.
+        That is reachable from a real server, and it used to be in the fatal except tuple,
+        so one such tool dropped every other tool on the same server.
+        """
+        good_a = self._make_tool("good_a", {"type": "object", "properties": {"q": {"type": "string"}}})
+        # Empty schema: a real, common shape for a no-argument tool.
+        bad = self._make_tool("bad_empty_schema", {})
+        good_b = self._make_tool("good_b", {"type": "object", "properties": {"n": {"type": "integer"}}})
+
+        mock_stdio = AsyncMock(spec=MCPStdioClient)
+        mock_stdio.connect_to_server.return_value = [good_a, bad, good_b]
+        mock_stdio._connected = True
+
+        _mode, tool_list, tool_cache = await update_tools(
+            server_name="empty-schema-server",
+            server_config={"command": "uvx", "args": []},
+            mcp_stdio_client=mock_stdio,
+        )
+
+        loaded_names = [t.name for t in tool_list]
+        assert "good_a" in loaded_names
+        assert "good_b" in loaded_names
+        assert "bad_empty_schema" not in loaded_names
+        assert set(tool_cache.keys()) == {"good_a", "good_b"}
+
+    @pytest.mark.asyncio
     async def test_resilience_under_many_mixed_tools(self):
         """Stress: 20 tools, 10 healthy + 10 broken with varied error types — all 10 good survive."""
         from lfx.schema.json_schema import create_input_schema_from_json_schema as real_converter
@@ -4137,16 +4167,6 @@ class TestStreamableHttpTransportPolicy:
         finally:
             await manager.cleanup_all()
 
-    @pytest.mark.asyncio
-    async def test_validate_connectivity_mcp_session_terminated_returns_false(self):
-        manager = MCPSessionManager()
-        try:
-            mock_session = AsyncMock()
-            mock_session.list_tools = AsyncMock(side_effect=RuntimeError("Session terminated"))
-            assert await manager._validate_session_connectivity(mock_session) is False
-        finally:
-            await manager.cleanup_all()
-
     def test_classify_transient_includes_connection_and_taskgroup_hints(self):
         assert _is_transient_streamable_http_error(ConnectionError("x")) is True
         assert _is_transient_streamable_http_error(RuntimeError("unhandled errors in a TaskGroup")) is True
@@ -4241,9 +4261,9 @@ class TestCleanupTaskStartup:
 class TestGetSessionNoBlockingHealthCheck:
     """get_session() must NOT call list_tools() on the hot path.
 
-    Before the fix, every get_session() called _validate_session_connectivity()
-    which did a list_tools() RPC (~3 s timeout). With 10 sessions that added
-    ~30 s of blocking to every single tool invocation.
+    Before the fix, every get_session() ran a connectivity check that did a
+    list_tools() RPC (~3 s timeout). With 10 sessions that added ~30 s of
+    blocking to every single tool invocation.
     """
 
     @pytest.fixture
@@ -4269,9 +4289,7 @@ class TestGetSessionNoBlockingHealthCheck:
                 # First call creates the session.
                 s1 = await manager.get_session("ctx_1", connection_params, "streamable_http")
                 # Second call must reuse it — list_tools must never be called.
-                with patch.object(manager, "_validate_session_connectivity") as mock_validate:
-                    s2 = await manager.get_session("ctx_2", connection_params, "streamable_http")
-                    mock_validate.assert_not_called()
+                s2 = await manager.get_session("ctx_2", connection_params, "streamable_http")
             assert s1 is mock_session
             assert s2 is mock_session
             mock_session.list_tools.assert_not_awaited()
@@ -4316,11 +4334,11 @@ class TestGetSessionNoBlockingHealthCheck:
                 }
                 manager._session_id_counters[server_key] = 1
 
-                with patch.object(manager, "_validate_session_connectivity") as mock_validate:
-                    result = await manager.get_session("ctx_new", connection_params, "streamable_http")
-                    mock_validate.assert_not_called()
+                result = await manager.get_session("ctx_new", connection_params, "streamable_http")
 
             assert result is mock_session_2
+            mock_session_1.list_tools.assert_not_awaited()
+            mock_session_2.list_tools.assert_not_awaited()
         finally:
             await manager.cleanup_all()
 

--- a/src/lfx/LFX_MCP.md
+++ b/src/lfx/LFX_MCP.md
@@ -2,7 +2,7 @@
 
 `lfx-mcp` is an MCP (Model Context Protocol) server that gives any MCP-compatible client full programmatic control over a Langflow instance to build and run flows.
 
-The server is implemented in `src/lfx/src/lfx/mcp/` using [FastMCP](https://github.com/jlowin/fastmcp).
+The server is implemented in `src/lfx/src/lfx/mcp/` using `FastMCP` from the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) (`mcp.server.fastmcp`).
 It connects to Langflow's REST API.
 Flow data is never cached server-side, so every mutating tool does a GET → modify → PATCH cycle.
 The component registry is cached on first access per session.

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import inspect
 import json
 import os
 import re
@@ -57,7 +56,6 @@ is_dangerous_mcp_env_var = mcp_security.is_dangerous_mcp_env_var
 
 # Minimum cleanup interval to prevent tight-loop CPU spin if settings return 0 or fail.
 _MCP_CLEANUP_INTERVAL_MIN = 30  # seconds
-_SESSION_VALIDATION_TIMEOUT_FLOOR = 10.0
 
 
 def _validate_mcp_stdio_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -92,14 +90,6 @@ def _resolve_mcp_tool_execution_timeout(tool_execution_timeout: float | None) ->
 
     configured_timeouts = [float(value) for value in (configured, mcp_server_timeout) if value is not None]
     return max(configured_timeouts) if configured_timeouts else 180.0
-
-
-def get_session_validation_timeout() -> float:
-    """Derive a fast session health-check timeout from the configured connection budget."""
-    connect_timeout = _get_mcp_setting("mcp_server_timeout", None)
-    if connect_timeout is None:
-        return _SESSION_VALIDATION_TIMEOUT_FLOOR
-    return max(_SESSION_VALIDATION_TIMEOUT_FLOOR, float(connect_timeout) / 3.0)
 
 
 def get_max_sessions_per_server() -> int:
@@ -1179,34 +1169,6 @@ class MCPSessionManager:
             if pair[0] == server_key:
                 self._context_to_session.pop(ctx, None)
 
-    async def _validate_session_connectivity(self, session) -> bool:
-        """Validate that the session is actually usable by testing a simple operation."""
-        try:
-            # Try to list tools as a connectivity test (this is a lightweight operation)
-            # Keep the health check shorter than connection setup while honoring its configured budget.
-            response = await asyncio.wait_for(session.list_tools(), timeout=get_session_validation_timeout())
-        except Exception as e:  # noqa: BLE001
-            # Any failure means the session is not safe to reuse (SDK errors, terminated session, etc.)
-            await logger.adebug(f"Session connectivity test failed: {type(e).__name__}: {e}")
-            return False
-        else:
-            # Validate that we got a meaningful response
-            if response is None:
-                await logger.adebug("Session connectivity test failed: received None response")
-                return False
-            try:
-                # Check if we can access the tools list (even if empty)
-                tools = getattr(response, "tools", None)
-                if tools is None:
-                    await logger.adebug("Session connectivity test failed: no tools attribute in response")
-                    return False
-            except (AttributeError, TypeError) as e:
-                await logger.adebug(f"Session connectivity test failed while validating response: {e}")
-                return False
-            else:
-                await logger.adebug(f"Session connectivity test passed: found {len(tools)} tools")
-                return True
-
     async def get_session(self, context_id: str, connection_params, transport_type: str):
         """Get or create a session with improved reuse strategy.
 
@@ -1567,40 +1529,6 @@ class MCPSessionManager:
             return
 
         try:
-            # First try to properly close the session if it exists
-            if "session" in session_info:
-                session = session_info["session"]
-
-                # Try async close first (aclose method)
-                if hasattr(session, "aclose"):
-                    try:
-                        await session.aclose()
-                        await logger.adebug("Successfully closed session %s using aclose()", session_id)
-                    except Exception as e:  # noqa: BLE001
-                        await logger.adebug("Error closing session %s with aclose(): %s", session_id, e)
-
-                # If no aclose, try regular close method
-                elif hasattr(session, "close"):
-                    try:
-                        # Check if close() is awaitable using inspection
-                        if inspect.iscoroutinefunction(session.close):
-                            # It's an async method
-                            await session.close()
-                            await logger.adebug("Successfully closed session %s using async close()", session_id)
-                        else:
-                            # Try calling it and check if result is awaitable
-                            close_result = session.close()
-                            if inspect.isawaitable(close_result):
-                                await close_result
-                                await logger.adebug(
-                                    "Successfully closed session %s using awaitable close()", session_id
-                                )
-                            else:
-                                # It's a synchronous close
-                                await logger.adebug("Successfully closed session %s using sync close()", session_id)
-                    except Exception as e:  # noqa: BLE001
-                        await logger.adebug("Error closing session %s with close(): %s", session_id, e)
-
             # Cancel the background task which will properly close the session
             if "task" in session_info:
                 task = session_info["task"]
@@ -2132,31 +2060,6 @@ class MCPStreamableHttpClient:
         )
         return self.session
 
-    async def _terminate_remote_session(self) -> None:
-        """Attempt to explicitly terminate the remote MCP session via HTTP DELETE (best-effort)."""
-        # Only relevant for Streamable HTTP or SSE transport
-        if not self._connection_params or "url" not in self._connection_params:
-            return
-
-        url: str = self._connection_params["url"]
-
-        # Retrieve session id from the underlying SDK if exposed
-        session_id = None
-        if getattr(self, "session", None) is not None:
-            # Common attributes in MCP python SDK: `session_id` or `id`
-            session_id = getattr(self.session, "session_id", None) or getattr(self.session, "id", None)
-
-        headers: dict[str, str] = dict(self._connection_params.get("headers", {}))
-        if session_id:
-            headers["Mcp-Session-Id"] = str(session_id)
-
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                await client.delete(url, headers=headers)
-        except Exception as e:  # noqa: BLE001
-            # DELETE is advisory—log and continue
-            logger.debug(f"Unable to send session DELETE to '{url}': {e}")
-
     def _tool_span_attributes(self, tool_name: str) -> dict[str, str]:
         """Identifiers for the span: which tool, on which server, over which transport.
 
@@ -2297,9 +2200,6 @@ class MCPStreamableHttpClient:
 
     async def disconnect(self):
         """Properly close the connection and clean up resources."""
-        # Attempt best-effort remote session termination first
-        await self._terminate_remote_session()
-
         # Clean up local session using the session manager
         if self._session_context:
             session_manager = self._get_session_manager()
@@ -2535,17 +2435,17 @@ async def update_tools(
                 func=create_tool_func(tool.name, args_schema, client),
                 coroutine=create_tool_coroutine(tool.name, args_schema, client),
                 tags=[tool.name],
-                metadata={"server_name": server_name, "output_schema": getattr(tool, "outputSchema", None)},
+                metadata={"server_name": server_name},
                 response_format="content_and_artifact",
             )
 
             tool_list.append(tool_obj)
             tool_cache[tool.name] = tool_obj
-        except (ConnectionError, TimeoutError, OSError, ValueError) as e:
+        except (ConnectionError, TimeoutError, OSError) as e:
             logger.error(f"Failed to create tool '{tool.name}' from server '{server_name}': {e}")
             msg = f"Failed to create tool '{tool.name}' from server '{server_name}': {e}"
             raise ValueError(msg) from e
-        except (TypeError, AttributeError, KeyError, NameError, RecursionError) as e:
+        except (TypeError, AttributeError, KeyError, NameError, RecursionError, ValueError) as e:
             # Per-tool resilience (#11229): isolate one bad schema, keep the rest of the toolset.
             logger.exception(
                 f"Skipping tool '{getattr(tool, 'name', '<unknown>')}' from MCP server "

--- a/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
+++ b/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
@@ -3,11 +3,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from lfx.base.mcp.util import (
-    MCPSessionManager,
     MCPStdioClient,
     MCPStreamableHttpClient,
     _resolve_mcp_tool_execution_timeout,
-    get_session_validation_timeout,
 )
 from lfx.observability import _root_error_type
 
@@ -58,43 +56,6 @@ def test_resolve_mcp_tool_execution_timeout_uses_server_timeout_when_tool_timeou
 def test_resolve_mcp_tool_execution_timeout_falls_back_to_180_when_no_settings_exist():
     with patch("lfx.base.mcp.util._get_mcp_setting", return_value=None):
         assert _resolve_mcp_tool_execution_timeout(None) == 180.0
-
-
-@pytest.mark.parametrize(
-    ("server_timeout", "expected"),
-    [
-        (None, 10.0),
-        (20, 10.0),
-        (60, 20.0),
-    ],
-)
-def test_get_session_validation_timeout_uses_connection_budget(server_timeout, expected):
-    with patch("lfx.base.mcp.util._get_mcp_setting", return_value=server_timeout):
-        assert get_session_validation_timeout() == expected
-
-
-@pytest.mark.asyncio
-async def test_session_connectivity_validation_uses_resolved_timeout():
-    manager = MCPSessionManager()
-    session = AsyncMock()
-    session.list_tools.return_value = SimpleNamespace(tools=[])
-    observed_timeout = None
-
-    async def wait_for(awaitable, *, timeout):
-        nonlocal observed_timeout
-        observed_timeout = timeout
-        return await awaitable
-
-    try:
-        with (
-            patch("lfx.base.mcp.util.get_session_validation_timeout", return_value=20.0),
-            patch("lfx.base.mcp.util.asyncio.wait_for", side_effect=wait_for),
-        ):
-            assert await manager._validate_session_connectivity(session) is True
-    finally:
-        await manager.cleanup_all()
-
-    assert observed_timeout == 20.0
 
 
 def test_mcp_stdio_client_uses_resolved_timeout():

--- a/uv.lock
+++ b/uv.lock
@@ -7543,9 +7543,9 @@ name = "langchain-mcp-adapters"
 version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
-    { name = "mcp" },
-    { name = "typing-extensions" },
+    { name = "langchain-core", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "mcp", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/36/0179462acf344ad18cf6d7190b7a6797e015386a3b4518fcd960bb831c61/langchain_mcp_adapters-0.1.14.tar.gz", hash = "sha256:36f8131d0b3b5ca28df03440be4dc2a3636e2f73e3e4a0a266d606ffaa12adda", size = 31119, upload-time = "2025-11-24T15:00:54.591Z" }
 wheels = [
@@ -8233,9 +8233,6 @@ fastavro = [
     { name = "fastavro", version = "1.9.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "fastavro", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-fastmcp = [
-    { name = "fastmcp" },
-]
 fastparquet = [
     { name = "fastparquet" },
 ]
@@ -8277,9 +8274,6 @@ kubernetes = [
 ]
 langchain-huggingface = [
     { name = "langchain-huggingface", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-]
-langchain-mcp-adapters = [
-    { name = "langchain-mcp-adapters" },
 ]
 langchain-unstructured = [
     { name = "langchain-unstructured" },
@@ -8559,7 +8553,6 @@ requires-dist = [
     { name = "fastapi-pagination", specifier = ">=0.13.1,<1.0.0" },
     { name = "fastavro", marker = "python_full_version >= '3.13' and extra == 'fastavro'", specifier = ">=1.9.8,<2.0.0" },
     { name = "fastavro", marker = "python_full_version < '3.13' and extra == 'fastavro'", specifier = "==1.9.7" },
-    { name = "fastmcp", marker = "extra == 'fastmcp'", specifier = ">=3.2.0" },
     { name = "fastparquet", marker = "extra == 'fastparquet'", specifier = ">=2024.11.0,<2025.0.0" },
     { name = "filelock", specifier = ">=3.20.1,<4.0.0" },
     { name = "gassist", marker = "sys_platform == 'win32' and extra == 'gassist'", specifier = ">=0.0.1" },
@@ -8603,7 +8596,6 @@ requires-dist = [
     { name = "langchain-litellm", marker = "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'cuga'", specifier = "==0.5.1" },
     { name = "langchain-litellm", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64' and extra == 'opendsstar') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'opendsstar')", specifier = "==0.5.1" },
     { name = "langchain-litellm", marker = "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'cuga'", specifier = "==0.5.1" },
-    { name = "langchain-mcp-adapters", marker = "extra == 'langchain-mcp-adapters'", specifier = ">=0.1.14,<0.2.0" },
     { name = "langchain-milvus", marker = "extra == 'milvus'", specifier = "~=0.3.2" },
     { name = "langchain-mistralai", marker = "extra == 'mistral'", specifier = "~=1.1.1" },
     { name = "langchain-mongodb", specifier = ">=0.11.0" },
@@ -8737,7 +8729,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["audio", "postgresql", "local", "sandbox", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "qdrant-vectors", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "smolagents", "opendsstar", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "toolguard", "langchain-huggingface", "langchain-unstructured", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "docling-chunking", "docling-image-description", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aiobotocore", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
+provides-extras = ["audio", "postgresql", "local", "sandbox", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "qdrant-vectors", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "smolagents", "opendsstar", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "toolguard", "langchain-huggingface", "langchain-unstructured", "opik", "traceloop", "openlayer", "docling", "docling-chunking", "docling-image-description", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "aiobotocore", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Pre-work ahead of the MCP protocol 2026-07-28 / python-sdk 2.0 upgrade. Everything here is correct against the current `mcp<2.0` pin and none of it depends on the bump, so it can land on its own.

Net -224 / +51.

## Dead code

Four things that cannot do what they claim to do:

- **`_terminate_remote_session`** reads `session_id` / `id` off the session to build an `Mcp-Session-Id` header. Neither `ClientSession` nor `BaseSession` defines either attribute in 1.28.1, so the DELETE has always gone out bare. The SDK already sends the real terminate from `streamablehttp_client`'s `finally`. Deleted, along with its only call in `disconnect()`.
- **The `aclose` / `close` / `iscoroutinefunction` probing** in `_cleanup_session_by_id`. `ClientSession` has neither method, so no branch could ever match. The `task.cancel()` that follows unwinds the session and transport context managers, which is the only correct close path.
- **`_validate_session_connectivity`** had no production callers left, and with it the now-unused `get_session_validation_timeout` helper.
- **The `"output_schema"` tool metadata key** is written and never read.

Also drops the `langchain-mcp-adapters` and `fastmcp` extras. Nothing in `src` imports either package.

## One behaviour change

`ValueError` moves out of the fatal `except` tuple in the tool-building loop of `update_tools` and into the per-tool one.

`create_input_schema_from_json_schema` raises `ValueError("Root schema must be type 'object'")` for any tool whose `inputSchema` is `{}` or not an object, which is a shape real servers ship (an empty schema is the natural spelling for a no-argument tool). Sitting in the fatal tuple, one such tool aborted the whole listing and dropped every other tool on that server. It now skips that one tool, exactly like every other schema-processing failure already did.

New regression test covers it. It fails on `main` with `ValueError: Failed to create tool 'bad_empty_schema'` and passes here.

**Known gap, stated honestly:** a server whose tools *all* fail conversion now returns an empty toolset instead of raising, so `/api/v2/mcp` reports the generic "No tools found" rather than the specific cause, which survives only in the logs. That is a widening of behaviour `TypeError` / `KeyError` / friends already had, not a new failure class, and the mixed-tool case this targets is a strict improvement. Worth a follow-up on the endpoint's error reporting rather than re-introducing a fatal path here.

The guarded block does no I/O, so this cannot mask a connection or auth failure. `connect_to_server`, the SSRF and stdio validation, and `_validate_connection_params` all run above the loop and still propagate. The `ValueError`s the retry loops re-raise originate outside this `try` as well.

## Docs

Four fixes for things that are wrong today, independent of the upgrade:

- `mcp-server.mdx` told users to select **SSE** while giving them a `/streamable` URL.
- `troubleshooting.mdx` ran `supergateway --sse` against a `/streamable` endpoint. Now `--streamableHttp`.
- `LFX_MCP.md` credited jlowin's third-party FastMCP package; the code imports `mcp.server.fastmcp` from the SDK.
- `api-reference-api-examples.mdx` presented SSE as an equal option despite the `(LEGACY)` markers on the routes right below it. `mcp-server.mdx` and `mcp-client.mdx` carried the same sentence and are updated to match, so the three pages agree.

Versioned docs under `docs/versioned_docs/` are deliberately left alone. They describe what those releases shipped.

## Verification

| suite | result |
|---|---|
| `src/lfx/tests/unit/mcp` | 417 passed |
| `src/backend/tests/unit/base/mcp` | 292 passed, 7 skipped |
| `src/backend/tests/unit/api/v1/test_mcp*.py` | 52 passed |
| `test_run_starter_projects_backward_compatibility.py` | passed |
| `ruff check src/` | clean |

The starter-projects test matters here: a frozen 1.6.0 flow imports `MCPSseClient` and passes `mcp_sse_client=`, so the alias and that kwarg are deliberately kept.

## Notes for review

- The two deactivated components (`deactivated/mcp_sse.py`, `mcp_stdio.py`) were on the chopping block and are **not** deleted. `test_mcp_runtime_config_validation.py` imports `MCPStdio` and asserts the stdio command policy is enforced before connecting, so deleting it would delete security coverage. `mcp_sse.py` genuinely has no coverage and could go, but splitting the pair for that seemed worse than leaving both.
- Deleting `_validate_session_connectivity` meant two regression tests lost the `patch.object(...)`/`assert_not_called()` scaffolding they used to prove `get_session` stays off the hot path. Both now assert `list_tools.assert_not_awaited()` directly, which is the property they were really guarding.