### PR TITLE
fix(ci): realign release contracts with the confluent/watsonx bundle changes

### DIFF
--- a/.github/workflows/ci-scripts-test.yml
+++ b/.github/workflows/ci-scripts-test.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "scripts/ci/**"
       - ".github/workflows/ci-scripts-test.yml"
+      - "pyproject.toml"
+      - "src/bundles/*/pyproject.toml"
+      - "src/bundles/lfx-bundles/src/lfx_bundles/*/__init__.py"
       - "src/backend/base/langflow/api/build.py"
       - "src/backend/base/langflow/api/v1/a2a.py"
       - "src/backend/base/langflow/api/v1/chat.py"

--- a/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
+++ b/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
@@ -88,9 +88,9 @@
       "providers": [
         "lfx-ibm"
       ],
-      "requested": ">=0.1.5,<1.0.0",
-      "requirement": "lfx-ibm==0.1.5",
-      "resolved_version": "0.1.5"
+      "requested": ">=0.2.0,<1.0.0",
+      "requirement": "lfx-ibm==0.2.0",
+      "resolved_version": "0.2.0"
     },
     {
       "distribution": "lfx-ollama",
@@ -160,7 +160,7 @@
     "https://pypi.org/simple"
   ],
   "profile": "enterprise-hardened",
-  "profile_digest": "sha256:ee7a74751981376c",
+  "profile_digest": "sha256:16e322d017361d01",
   "providers": [
     "lfx-amazon",
     "lfx-anthropic",

--- a/scripts/ci/bundle_profiles.json
+++ b/scripts/ci/bundle_profiles.json
@@ -31,7 +31,7 @@
         {
           "distribution": "lfx-ibm",
           "extras": [],
-          "version": ">=0.1.5,<1.0.0",
+          "version": ">=0.2.0,<1.0.0",
           "providers": [
             "lfx-ibm"
           ]

--- a/scripts/ci/release_inventory_contract.json
+++ b/scripts/ci/release_inventory_contract.json
@@ -77,6 +77,7 @@
       ],
       "forbidden_distributions_add": [
         "lfx-arxiv",
+        "lfx-confluent",
         "lfx-duckduckgo",
         "lfx-empiriolabs",
         "lfx-exa",
@@ -182,6 +183,7 @@
       "required_distributions_add": [
         "lfx-arxiv",
         "lfx-bundles",
+        "lfx-confluent",
         "lfx-duckduckgo",
         "lfx-empiriolabs",
         "lfx-exa",
@@ -193,6 +195,7 @@
       "forbidden_distributions_remove": [
         "lfx-arxiv",
         "lfx-bundles",
+        "lfx-confluent",
         "lfx-duckduckgo",
         "lfx-empiriolabs",
         "lfx-exa",
@@ -208,6 +211,7 @@
           "lfx-arxiv",
           "lfx-azure",
           "lfx-cohere",
+          "lfx-confluent",
           "lfx-datastax",
           "lfx-docling",
           "lfx-duckduckgo",

--- a/scripts/ci/test_release_inventory.py
+++ b/scripts/ci/test_release_inventory.py
@@ -18,6 +18,7 @@ RELEASE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
 GATE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release-inventory-gate.yml"
 OPT_IN_STANDALONE_EXTENSIONS = {
     "lfx-arxiv",
+    "lfx-confluent",
     "lfx-duckduckgo",
     "lfx-empiriolabs",
     "lfx-exa",


### PR DESCRIPTION
## Problem

`CI Scripts Tests` has been failing on every `release-1.12.0`-based PR since #14612 merged (2026-08-17), regardless of what the PR touches — `serving-plane-uid-sid`, `fix/le-1905-rbac-post-v1`, #14516 and others all show the same four failures:

```
FAILED scripts/ci/test_bundle_profiles.py::test_reviewed_profiles_and_locks_are_current
FAILED scripts/ci/test_bundle_profiles.py::test_every_supported_downstream_image_family_selects_a_build_time_profile
FAILED scripts/ci/test_bundle_profiles.py::test_checked_in_lock_requires_an_intentional_profile_diff
FAILED scripts/ci/test_release_inventory.py::test_full_python_profile_uses_the_reviewed_root_extra
```

#14612 changed the root `pyproject.toml` in two ways these contracts police, but the checked-in contracts still described the previous state:

1. `lfx-ibm` was bumped to `>=0.2.0,<1.0.0` while `scripts/ci/bundle_profiles.json` and its lock still pinned `>=0.1.5,<1.0.0`. (`test_checked_in_lock_requires_an_intentional_profile_diff` is collateral damage — `check_locks` returns early on contract errors, so it never reaches the stale-lock branch that test asserts on.)
2. `lfx-confluent` was added to the `[bundles]` extra without being registered as an opt-in standalone extension.

The reason #14612 stayed green is the trigger: this workflow only runs on `scripts/ci/**` and a list of API files, and that PR touched none of them. The guard first ran — and failed — on unrelated PRs that happened to touch `scripts/ci`.

## Change

- `bundle_profiles.json` + regenerated `enterprise-hardened.lock.json` carry the `lfx-ibm>=0.2.0,<1.0.0` range from `pyproject.toml` (lock regenerated with `manage_bundle_profiles.py compile`, not hand-edited)
- `release_inventory_contract.json` registers `lfx-confluent` the same way as the other opt-in standalone bundles: forbidden in `python-default`, required in `python-full`, present in the full profile's `langflow.extensions` entry points
- `test_release_inventory.py` tracks it in `OPT_IN_STANDALONE_EXTENSIONS`
- The workflow now also triggers on the root `pyproject.toml`, per-bundle `pyproject.toml` files, and long-tail bundle package roots — the actual inputs these contracts describe — so the next bundle PR trips this guard on itself

No product code changes; this only realigns CI contract data with what the application already declares.

## Test plan

- [x] `python -m pytest scripts/ci/ -v` → 146 passed (was 4 failed / 141 passed on `release-1.12.0`)
- [x] Lock regenerated via `python scripts/ci/manage_bundle_profiles.py compile --output-dir scripts/ci/bundle_profile_locks`; the only diff is the `lfx-ibm` range/pin and the resulting `profile_digest`
- [ ] `CI Scripts Tests` green on this PR

Note: PRs that add a new long-tail bundle still need their own entry in `release_inventory_contract.json` (`bundle_names`) — that is a separate, correctly-firing failure on #14516 and #11929.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release profiles to support the latest `lfx-ibm` bundle version.
  - Added `lfx-confluent` to release inventory validation and full-profile packaging rules.
  - Refined automated checks to run when package metadata or bundle initialization files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->