### PR TITLE
feat(bundles): add Serply search extension bundle

### DIFF
--- a/docs/docs/Components/bundles-serply.mdx
+++ b/docs/docs/Components/bundles-serply.mdx
@@ -1,0 +1,38 @@
+---
+title: Serply
+slug: /bundles-serply
+---
+
+import Icon from "@site/src/components/icon";
+import { GraduatedBundleInstall } from '@site/docs/_partial-bundle-graduated-install.mdx';
+
+<GraduatedBundleInstall packageName="serply" />
+
+<Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
+
+This page describes the components that are available in the **Serply** bundle.
+
+## Serply Search
+
+This component runs a web search through the [Serply](https://serply.io) SERP API and returns the organic Google results.
+
+Get an API key from [serply.io](https://serply.io). For details on the underlying API, see the [Serply documentation](https://serply.io/docs).
+
+It outputs the results as a [`Table`](/data-types#table) with `title`, `link`, `description`, and `position` columns. The `text` of each row is the result description.
+If the request fails, for example because the API key is missing or invalid, the table contains a single row with an `error` column that describes the problem.
+
+In [tool mode](/agents-tools), the component exposes a single tool named `serply_search` that an [**Agent** component](/agents) can call with a search query.
+
+### Serply Search parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| Search Query (`input_value`) | String | Input parameter. The search query to execute with Serply. |
+| Serply API Key (`serply_api_key`) | SecretString | Input parameter. Your Serply API key. |
+| Max Results (`max_results`) | Integer | Input parameter. The maximum number of organic results to return, from `1` to `100`. Default: `10`. |
+
+## See also
+
+* [**Web Search** component](/web-search)
+* [**DuckDuckGo** bundle](/bundles-duckduckgo)
+* [**Serper** bundle](/bundles-serper)

--- a/docs/docs/Lfx/extensions-bundle-list.mdx
+++ b/docs/docs/Lfx/extensions-bundle-list.mdx
@@ -53,6 +53,7 @@ Install one package, or install all of them together with the non-PyTorch provid
 | [`firecrawl`](/bundles-firecrawl) (Firecrawl) | `uv pip install lfx-firecrawl` |
 | [`nextplaid`](/bundles-nextplaid) (NextPlaid) | `uv pip install lfx-nextplaid` |
 | [`paddle`](/bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
+| [`serply`](/bundles-serply) (Serply) | `uv pip install lfx-serply` |
 | [`valkey`](/bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
 
 ## Providers in `lfx-bundles` {#lfx-bundles}

--- a/docs/docs/Lfx/extensions-bundle-list.mdx
+++ b/docs/docs/Lfx/extensions-bundle-list.mdx
@@ -53,7 +53,7 @@ Install one package, or install all of them together with the non-PyTorch provid
 | [`firecrawl`](/bundles-firecrawl) (Firecrawl) | `uv pip install lfx-firecrawl` |
 | [`nextplaid`](/bundles-nextplaid) (NextPlaid) | `uv pip install lfx-nextplaid` |
 | [`paddle`](/bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
-| [`serply`](/bundles-serply) (Serply) | `uv pip install lfx-serply` |
+| [`serply`](./bundles-serply) (Serply) | `uv pip install lfx-serply` |
 | [`valkey`](/bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
 
 ## Providers in `lfx-bundles` {#lfx-bundles}

--- a/docs/docs/_partial-bundle-graduated-install.mdx
+++ b/docs/docs/_partial-bundle-graduated-install.mdx
@@ -22,6 +22,7 @@ export const GraduatedBundleInstall = ({ packageName }) => {
     'openai-compatible':  { name: 'OpenAI Compatible', coreSupport: false, inDefault: true  },
     'oracle':             { name: 'Oracle',          coreSupport: false, inDefault: true  },
     'paddle':             { name: 'PaddleOCR',       coreSupport: false, inDefault: false },
+    'serply':             { name: 'Serply',          coreSupport: false, inDefault: false },
     'valkey':             { name: 'Valkey',          coreSupport: false, inDefault: false },
     'vllm':               { name: 'vLLM',            coreSupport: false, inDefault: true  },
   };

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -568,6 +568,7 @@ module.exports = {
             "Components/bundles-sambanova",
             "Components/bundles-searchapi",
             "Components/bundles-serper",
+            "Components/bundles-serply",
             "Components/bundles-supabase",
             "Components/bundles-upstash",
             "Components/bundles-valkey",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ lfx-exa = { workspace = true }
 lfx-valkey = { workspace = true }
 lfx-google = { workspace = true }
 lfx-confluent = { workspace = true }
+lfx-serply = { workspace = true }
 # langflow-extensions:bundle-sources-end
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
@@ -159,6 +160,7 @@ members = [
     "src/bundles/valkey",
     "src/bundles/google",
     "src/bundles/confluent",
+    "src/bundles/serply",
     # langflow-extensions:bundle-members-end
 ]
 
@@ -180,6 +182,7 @@ bundles = [
     "lfx-firecrawl>=0.1.3,<1.0.0",
     "lfx-nextplaid>=0.1.6,<1.0.0",
     "lfx-paddle>=0.1.4,<1.0.0",
+    "lfx-serply>=0.1.0,<1.0.0",
     "lfx-valkey>=0.1.3,<1.0.0",
 ]
 

--- a/scripts/ci/release_inventory_contract.json
+++ b/scripts/ci/release_inventory_contract.json
@@ -84,6 +84,7 @@
         "lfx-firecrawl",
         "lfx-nextplaid",
         "lfx-paddle",
+        "lfx-serply",
         "lfx-valkey"
       ],
       "forbidden_distributions_remove": [
@@ -190,6 +191,7 @@
         "lfx-firecrawl",
         "lfx-nextplaid",
         "lfx-paddle",
+        "lfx-serply",
         "lfx-valkey"
       ],
       "forbidden_distributions_remove": [
@@ -202,6 +204,7 @@
         "lfx-firecrawl",
         "lfx-nextplaid",
         "lfx-paddle",
+        "lfx-serply",
         "lfx-valkey"
       ],
       "entry_points": {
@@ -226,6 +229,7 @@
           "lfx-openai-compatible",
           "lfx-oracle",
           "lfx-paddle",
+          "lfx-serply",
           "lfx-toolguard",
           "lfx-valkey",
           "lfx-vllm"

--- a/scripts/ci/test_release_inventory.py
+++ b/scripts/ci/test_release_inventory.py
@@ -25,6 +25,7 @@ OPT_IN_STANDALONE_EXTENSIONS = {
     "lfx-firecrawl",
     "lfx-nextplaid",
     "lfx-paddle",
+    "lfx-serply",
     "lfx-valkey",
 }
 

--- a/src/bundles/serply/README.md
+++ b/src/bundles/serply/README.md
@@ -1,0 +1,40 @@
+# lfx-serply
+
+Serply SERP API web-search component as a standalone Langflow Extension Bundle.
+
+The bundle ships a single component, `SerplySearchComponent`, which runs a
+web search through [Serply](https://serply.io) and returns the organic Google
+results as a table. It calls the Serply search endpoint directly with `httpx`
+and needs only a user-supplied API key, so it carries no vendor SDK dependency.
+See the [Serply docs](https://serply.io/docs) for the API details.
+
+## Install
+
+```bash
+pip install lfx-serply
+```
+
+The bundle is registered automatically via the `langflow.extensions`
+entry-point. After install, restart your Langflow server; the
+`SerplySearchComponent` will appear in the palette under the `serply`
+bundle group.
+
+## Configure
+
+Set the **Serply API Key** input to your own key from
+[serply.io](https://serply.io). The component is optional and does nothing
+until a key is supplied, so it changes nothing for anyone who does not use it.
+
+## Develop
+
+```bash
+cd src/bundles/serply
+pip install -e .
+lfx extension validate .
+```
+
+## Manifest
+
+The extension manifest is shipped at `src/lfx_serply/extension.json` and
+points at the bundle at `components/serply`. The component registers under
+the canonical namespaced ID `ext:serply:SerplySearchComponent@official`.

--- a/src/bundles/serply/README.md
+++ b/src/bundles/serply/README.md
@@ -16,8 +16,8 @@ pip install lfx-serply
 
 The bundle is registered automatically via the `langflow.extensions`
 entry-point. After install, restart your Langflow server; the
-`SerplySearchComponent` will appear in the palette under the `serply`
-bundle group.
+`SerplySearchComponent` will appear in the palette's **Bundles** section
+under **Serply**.
 
 ## Configure
 
@@ -25,12 +25,14 @@ Set the **Serply API Key** input to your own key from
 [serply.io](https://serply.io). The component is optional and does nothing
 until a key is supplied, so it changes nothing for anyone who does not use it.
 
+In tool mode, the component exposes a single tool named `serply_search`.
+
 ## Develop
 
 ```bash
 cd src/bundles/serply
 pip install -e .
-lfx extension validate .
+lfx extension validate src/lfx_serply
 ```
 
 ## Manifest

--- a/src/bundles/serply/pyproject.toml
+++ b/src/bundles/serply/pyproject.toml
@@ -1,0 +1,57 @@
+[project]
+name = "lfx-serply"
+version = "0.1.0"
+description = "Serply SERP API web-search component as a standalone Langflow Extension Bundle."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = { text = "MIT" }
+authors = [
+    { name = "Langflow", email = "contact@langflow.org" },
+]
+keywords = ["langflow", "lfx", "extension", "bundle", "serply", "search"]
+
+# Runtime deps: lfx (the BUNDLE_API surface) plus httpx, which the component
+# uses to call the Serply search endpoint directly.  Serply ships no Python
+# SDK, so httpx is the only third-party runtime dependency; it is already an
+# lfx dependency and is listed here as a direct runtime dep because the
+# component imports it, keeping the bundle buildable if lfx drops it later.
+# lfx is floored at the current major.minor line and capped below the next lfx
+# major; the floor is read from src/lfx/pyproject.toml at port time and
+# re-synced on ``make patch`` via scripts/ci/sync_bundle_lfx_pin.py.
+# Fine-grained BUNDLE_API compatibility is enforced via extension.json's
+# lfx.compat list against BUNDLE_API_VERSION.
+dependencies = [
+    "lfx>=1.12.0.dev0,<2.0.0",
+    "httpx>=0.24.0,<1.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/langflow-ai/langflow"
+Documentation = "https://docs.langflow.org/extensions"
+Repository = "https://github.com/langflow-ai/langflow"
+
+# Manifest-shipping distributions are discovered via the
+# ``langflow.extensions`` entry-point.  Editable installs whose
+# ``dist.files`` only surfaces dist-info entries fall back to this
+# entry-point to find the manifest.
+[project.entry-points."langflow.extensions"]
+lfx-serply = "lfx_serply"
+
+[build-system]
+requires = ["hatchling==1.31.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# extension.json + components live inside the lfx_serply package so
+# ``importlib.metadata.files(dist)`` finds them and the loader resolves
+# bundles[].path relative to the manifest's directory.
+packages = ["src/lfx_serply"]
+include = ["src/lfx_serply/extension.json", "src/lfx_serply/components/**/*.py"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/lfx_serply",
+    "extension.json",
+    "README.md",
+    "pyproject.toml",
+]

--- a/src/bundles/serply/pyproject.toml
+++ b/src/bundles/serply/pyproject.toml
@@ -21,7 +21,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "serply", "search"]
 # Fine-grained BUNDLE_API compatibility is enforced via extension.json's
 # lfx.compat list against BUNDLE_API_VERSION.
 dependencies = [
-    "lfx>=1.12.0.dev0,<2.0.0",
+    "lfx>=1.13.0.dev0,<2.0.0",
     "httpx>=0.24.0,<1.0.0",
 ]
 

--- a/src/bundles/serply/src/lfx_serply/__init__.py
+++ b/src/bundles/serply/src/lfx_serply/__init__.py
@@ -1,0 +1,15 @@
+"""lfx-serply: Serply Search bundle.
+
+This package is the distribution unit ``lfx-serply``.  At runtime
+Langflow's loader discovers ``extension.json`` shipped alongside this
+``__init__.py`` and registers ``SerplySearchComponent`` under the
+namespaced ID ``ext:serply:SerplySearchComponent@official``.
+
+Serply (https://serply.io) is a SERP API; the component calls its
+search endpoint directly with ``httpx`` and needs only a user-supplied
+API key, so the bundle carries no vendor SDK dependency.
+"""
+
+from lfx_serply.components.serply.serply_search import SerplySearchComponent
+
+__all__ = ["SerplySearchComponent"]

--- a/src/bundles/serply/src/lfx_serply/components/serply/__init__.py
+++ b/src/bundles/serply/src/lfx_serply/components/serply/__init__.py
@@ -1,0 +1,3 @@
+from .serply_search import SerplySearchComponent
+
+__all__ = ["SerplySearchComponent"]

--- a/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
+++ b/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
@@ -1,0 +1,106 @@
+from urllib.parse import urlencode
+
+import httpx
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import IntInput, MessageTextInput, SecretStrInput
+from lfx.schema.data import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.template.field.base import Output
+
+SEARCH_ENDPOINT = "https://api.serply.io/v1/search/"
+MIN_RESULTS = 1
+MAX_RESULTS = 100
+
+
+class SerplySearchComponent(Component):
+    """Component for performing web searches using the Serply SERP API."""
+
+    display_name = "Serply Search"
+    description = "Search Google results as JSON using the Serply API."
+    documentation = "https://serply.io/docs"
+    icon = "search"
+
+    inputs = [
+        MessageTextInput(
+            name="input_value",
+            display_name="Search Query",
+            required=True,
+            info="The search query to execute with Serply.",
+            tool_mode=True,
+        ),
+        SecretStrInput(
+            name="serply_api_key",
+            display_name="Serply API Key",
+            required=True,
+            info="Your Serply API key. Get one at https://serply.io.",
+            password=True,
+        ),
+        IntInput(
+            name="max_results",
+            display_name="Max Results",
+            value=10,
+            required=False,
+            advanced=True,
+            info="Maximum number of organic results to return (1-100).",
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+    ]
+
+    def _search(self) -> dict:
+        """Call the Serply search endpoint and return the decoded JSON payload."""
+        if not self.serply_api_key:
+            msg = "Serply API key is required. Set the Serply API Key input."
+            raise ValueError(msg)
+
+        num = max(MIN_RESULTS, min(int(self.max_results or 10), MAX_RESULTS))
+        query = urlencode({"q": self.input_value or "", "num": num})
+        headers = {
+            "X-Api-Key": self.serply_api_key,
+            "Accept": "application/json",
+            # Serply sits behind Cloudflare, which blocks the default httpx
+            # User-Agent with a 1010 error, so send an explicit one.
+            "User-Agent": "langflow-serply-bundle",
+        }
+        response = httpx.get(f"{SEARCH_ENDPOINT}{query}", headers=headers, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_content(self) -> list[Data]:
+        """Execute the search and return the organic results as Data objects."""
+        try:
+            payload = self._search()
+            results = payload.get("results") or []
+
+            data_results = [
+                Data(
+                    text=result.get("description", ""),
+                    data={
+                        "title": result.get("title", ""),
+                        "link": result.get("link", ""),
+                        "description": result.get("description", ""),
+                        "position": result.get("position"),
+                    },
+                )
+                for result in results
+            ]
+        except (httpx.HTTPError, ValueError, KeyError) as e:
+            error_data = [Data(text=str(e), data={"error": str(e)})]
+            self.status = error_data
+            return error_data
+        else:
+            self.status = data_results
+            return data_results
+
+    def run_model(self) -> DataFrame:
+        return self.fetch_content_dataframe()
+
+    def fetch_content_dataframe(self) -> DataFrame:
+        """Convert the search results to a DataFrame.
+
+        Returns:
+            DataFrame: A DataFrame containing the Serply search results.
+        """
+        return DataFrame(self.fetch_content())

--- a/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
+++ b/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
@@ -55,7 +55,8 @@ class SerplySearchComponent(Component):
             msg = "Serply API key is required. Set the Serply API Key input."
             raise ValueError(msg)
 
-        num = max(MIN_RESULTS, min(int(self.max_results or 10), MAX_RESULTS))
+        requested = 10 if self.max_results is None else int(self.max_results)
+        num = max(MIN_RESULTS, min(requested, MAX_RESULTS))
         query = urlencode({"q": self.input_value or "", "num": num})
         headers = {
             "X-Api-Key": self.serply_api_key,
@@ -64,7 +65,7 @@ class SerplySearchComponent(Component):
             # User-Agent with a 1010 error, so send an explicit one.
             "User-Agent": "langflow-serply-bundle",
         }
-        response = httpx.get(f"{SEARCH_ENDPOINT}{query}", headers=headers, timeout=30)
+        response = httpx.get(f"{SEARCH_ENDPOINT}?{query}", headers=headers, timeout=30)
         response.raise_for_status()
         return response.json()
 

--- a/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
+++ b/src/bundles/serply/src/lfx_serply/components/serply/serply_search.py
@@ -2,21 +2,34 @@ from urllib.parse import urlencode
 
 import httpx
 from lfx.custom.custom_component.component import Component
+from lfx.field_typing.range_spec import RangeSpec
 from lfx.inputs.inputs import IntInput, MessageTextInput, SecretStrInput
 from lfx.schema.data import Data
 from lfx.schema.dataframe import DataFrame
 from lfx.template.field.base import Output
 
 SEARCH_ENDPOINT = "https://api.serply.io/v1/search/"
+DEFAULT_RESULTS = 10
 MIN_RESULTS = 1
 MAX_RESULTS = 100
+
+
+def _http_error_message(error: httpx.HTTPStatusError) -> str:
+    """Describe a non-2xx Serply response, keeping the API's own ``detail`` reason."""
+    response = error.response
+    try:
+        detail = response.json().get("detail")
+    except (ValueError, AttributeError):
+        detail = None
+    reason = detail or response.reason_phrase or "request failed"
+    return f"Serply API error {response.status_code}: {reason}"
 
 
 class SerplySearchComponent(Component):
     """Component for performing web searches using the Serply SERP API."""
 
     display_name = "Serply Search"
-    description = "Search Google results as JSON using the Serply API."
+    description = "Search Google organic results with the Serply API."
     documentation = "https://serply.io/docs"
     icon = "search"
 
@@ -38,15 +51,20 @@ class SerplySearchComponent(Component):
         IntInput(
             name="max_results",
             display_name="Max Results",
-            value=10,
+            value=DEFAULT_RESULTS,
             required=False,
             advanced=True,
+            range_spec=RangeSpec(min=MIN_RESULTS, max=MAX_RESULTS, step=1, step_type="int"),
             info="Maximum number of organic results to return (1-100).",
         ),
     ]
 
     outputs = [
-        Output(display_name="Table", name="dataframe", method="fetch_content_dataframe"),
+        # The method name is also the tool name in tool mode.  Keep it specific:
+        # DuckDuckGo, Tavily, Wikipedia and other search components already expose
+        # ``fetch_content_dataframe``, and an Agent cannot hold two tools with the
+        # same name.
+        Output(display_name="Table", name="dataframe", method="serply_search"),
     ]
 
     def _search(self) -> dict:
@@ -55,7 +73,7 @@ class SerplySearchComponent(Component):
             msg = "Serply API key is required. Set the Serply API Key input."
             raise ValueError(msg)
 
-        requested = 10 if self.max_results is None else int(self.max_results)
+        requested = DEFAULT_RESULTS if self.max_results is None else int(self.max_results)
         num = max(MIN_RESULTS, min(requested, MAX_RESULTS))
         query = urlencode({"q": self.input_value or "", "num": num})
         headers = {
@@ -69,39 +87,41 @@ class SerplySearchComponent(Component):
         response.raise_for_status()
         return response.json()
 
+    def _error_result(self, message: str) -> list[Data]:
+        error_data = [Data(text=message, data={"error": message})]
+        self.status = error_data
+        return error_data
+
+    @staticmethod
+    def _result_to_data(result: dict) -> Data:
+        description = result.get("description", "")
+        return Data(
+            text=description,
+            data={
+                "title": result.get("title", ""),
+                "link": result.get("link", ""),
+                "description": description,
+                "position": result.get("position"),
+            },
+        )
+
     def fetch_content(self) -> list[Data]:
         """Execute the search and return the organic results as Data objects."""
         try:
             payload = self._search()
-            results = payload.get("results") or []
+        except httpx.HTTPStatusError as e:
+            return self._error_result(_http_error_message(e))
+        except (httpx.HTTPError, ValueError) as e:
+            return self._error_result(str(e))
 
-            data_results = [
-                Data(
-                    text=result.get("description", ""),
-                    data={
-                        "title": result.get("title", ""),
-                        "link": result.get("link", ""),
-                        "description": result.get("description", ""),
-                        "position": result.get("position"),
-                    },
-                )
-                for result in results
-            ]
-        except (httpx.HTTPError, ValueError, KeyError) as e:
-            error_data = [Data(text=str(e), data={"error": str(e)})]
-            self.status = error_data
-            return error_data
-        else:
-            self.status = data_results
-            return data_results
+        if not isinstance(payload, dict):
+            return self._error_result("Serply API returned an unexpected response (expected a JSON object).")
 
-    def run_model(self) -> DataFrame:
-        return self.fetch_content_dataframe()
+        results = payload.get("results") or []
+        data_results = [self._result_to_data(result) for result in results if isinstance(result, dict)]
+        self.status = data_results
+        return data_results
 
-    def fetch_content_dataframe(self) -> DataFrame:
-        """Convert the search results to a DataFrame.
-
-        Returns:
-            DataFrame: A DataFrame containing the Serply search results.
-        """
+    def serply_search(self) -> DataFrame:
+        """Run the search and return the organic results as a DataFrame."""
         return DataFrame(self.fetch_content())

--- a/src/bundles/serply/src/lfx_serply/extension.json
+++ b/src/bundles/serply/src/lfx_serply/extension.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schemas.langflow.org/extension/v1.json",
+  "id": "lfx-serply",
+  "version": "0.1.0",
+  "name": "Serply",
+  "description": "Serply SERP API web-search component as a standalone Langflow Extension Bundle.",
+  "lfx": {
+    "compat": ["1"]
+  },
+  "bundles": [
+    {
+      "name": "serply",
+      "path": "components/serply"
+    }
+  ]
+}

--- a/src/bundles/serply/tests/test_serply_search_component.py
+++ b/src/bundles/serply/tests/test_serply_search_component.py
@@ -63,9 +63,7 @@ def test_missing_api_key_raises(component):
 
 
 def test_search_sends_explicit_user_agent(component):
-    """Serply is behind Cloudflare; the request MUST carry an explicit
-    User-Agent or it is blocked with a 1010 error.
-    """
+    """The request must carry an explicit User-Agent to clear Cloudflare (1010)."""
     mock_get = _mock_get(SAMPLE_PAYLOAD)
     with patch(GET_PATCH_TARGET, mock_get):
         component._search()
@@ -75,13 +73,30 @@ def test_search_sends_explicit_user_agent(component):
     assert headers["X-Api-Key"] == "test-key"  # pragma: allowlist secret
 
 
-def test_max_results_is_clamped(component):
-    """max_results is clamped into the 1-100 range Serply accepts."""
+def test_search_builds_query_string_url(component):
+    """The query is sent as a proper ``?``-delimited query string."""
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        component._search()
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/search/?q=hello&num=10"
+
+
+def test_max_results_is_clamped_high(component):
+    """max_results above the range is clamped to the 100 upper bound."""
     component.max_results = 500
     mock_get = _mock_get(SAMPLE_PAYLOAD)
     with patch(GET_PATCH_TARGET, mock_get):
         component._search()
-    assert "num=100" in mock_get.call_args.args[0]
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/search/?q=hello&num=100"
+
+
+def test_max_results_is_clamped_low(component):
+    """max_results below the range is clamped to the 1 lower bound."""
+    component.max_results = 0
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        component._search()
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/search/?q=hello&num=1"
 
 
 def test_fetch_content_maps_results(component):

--- a/src/bundles/serply/tests/test_serply_search_component.py
+++ b/src/bundles/serply/tests/test_serply_search_component.py
@@ -1,0 +1,119 @@
+"""Unit tests for the Serply Search extension bundle (``lfx-serply``).
+
+The component calls the Serply endpoint with ``httpx``; the tests patch
+``httpx.get`` at the component module, so no network access is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from lfx_serply import SerplySearchComponent
+
+GET_PATCH_TARGET = "lfx_serply.components.serply.serply_search.httpx.get"
+
+SAMPLE_PAYLOAD = {
+    "results": [
+        {
+            "title": "Result one",
+            "description": "First snippet.",
+            "link": "https://example.com/one",
+            "position": 1,
+        },
+        {
+            "title": "Result two",
+            "description": "Second snippet.",
+            "link": "https://example.com/two",
+            "position": 2,
+        },
+    ],
+    "total": 2,
+    "query": "hello",
+}
+
+
+def _mock_get(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return MagicMock(return_value=response)
+
+
+@pytest.fixture
+def component() -> SerplySearchComponent:
+    c = SerplySearchComponent()
+    c.input_value = "hello"
+    c.serply_api_key = "test-key"  # pragma: allowlist secret
+    c.max_results = 10
+    return c
+
+
+def test_component_metadata():
+    """Class name must stay stable for saved flows."""
+    assert SerplySearchComponent.__name__ == "SerplySearchComponent"
+
+
+def test_missing_api_key_raises(component):
+    """No key set -> clear ValueError instead of an anonymous request."""
+    component.serply_api_key = ""
+    with pytest.raises(ValueError, match="Serply API key is required"):
+        component._search()
+
+
+def test_search_sends_explicit_user_agent(component):
+    """Serply is behind Cloudflare; the request MUST carry an explicit
+    User-Agent or it is blocked with a 1010 error."""
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        component._search()
+    headers = mock_get.call_args.kwargs["headers"]
+    assert headers["User-Agent"]
+    assert headers["User-Agent"] != ""
+    assert headers["X-Api-Key"] == "test-key"  # pragma: allowlist secret
+
+
+def test_max_results_is_clamped(component):
+    """max_results is clamped into the 1-100 range Serply accepts."""
+    component.max_results = 500
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        component._search()
+    assert "num=100" in mock_get.call_args.args[0]
+
+
+def test_fetch_content_maps_results(component):
+    """Organic results map to Data(text=description, data={title,link,...})."""
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert len(results) == 2
+    assert results[0].text == "First snippet."
+    assert results[0].data["title"] == "Result one"
+    assert results[0].data["link"] == "https://example.com/one"
+    assert results[0].data["position"] == 1
+
+
+def test_fetch_content_handles_empty_results(component):
+    """A payload with no results yields an empty list, not an error."""
+    mock_get = _mock_get({"results": [], "total": 0})
+    with patch(GET_PATCH_TARGET, mock_get):
+        assert component.fetch_content() == []
+
+
+def test_fetch_content_wraps_http_error(component):
+    """A transport error is surfaced as a single error Data, not raised."""
+    mock_get = MagicMock(side_effect=httpx.HTTPError("boom"))
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert len(results) == 1
+    assert "boom" in results[0].data["error"]
+
+
+def test_fetch_content_dataframe_shape(component):
+    """The default output builds a DataFrame from the mapped results."""
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        frame = component.fetch_content_dataframe()
+    assert len(frame) == 2

--- a/src/bundles/serply/tests/test_serply_search_component.py
+++ b/src/bundles/serply/tests/test_serply_search_component.py
@@ -64,7 +64,8 @@ def test_missing_api_key_raises(component):
 
 def test_search_sends_explicit_user_agent(component):
     """Serply is behind Cloudflare; the request MUST carry an explicit
-    User-Agent or it is blocked with a 1010 error."""
+    User-Agent or it is blocked with a 1010 error.
+    """
     mock_get = _mock_get(SAMPLE_PAYLOAD)
     with patch(GET_PATCH_TARGET, mock_get):
         component._search()

--- a/src/bundles/serply/tests/test_serply_search_component.py
+++ b/src/bundles/serply/tests/test_serply_search_component.py
@@ -1,11 +1,13 @@
 """Unit tests for the Serply Search extension bundle (``lfx-serply``).
 
 The component calls the Serply endpoint with ``httpx``; the tests patch
-``httpx.get`` at the component module, so no network access is required.
+``httpx.get`` at the component module to return real ``httpx.Response``
+objects, so no network access is required.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -13,6 +15,7 @@ import pytest
 from lfx_serply import SerplySearchComponent
 
 GET_PATCH_TARGET = "lfx_serply.components.serply.serply_search.httpx.get"
+SEARCH_URL = "https://api.serply.io/v1/search/"
 
 SAMPLE_PAYLOAD = {
     "results": [
@@ -34,11 +37,12 @@ SAMPLE_PAYLOAD = {
 }
 
 
-def _mock_get(payload: dict) -> MagicMock:
-    response = MagicMock()
-    response.raise_for_status.return_value = None
-    response.json.return_value = payload
-    return MagicMock(return_value=response)
+def _response(status_code: int = 200, **kwargs) -> httpx.Response:
+    return httpx.Response(status_code, request=httpx.Request("GET", SEARCH_URL), **kwargs)
+
+
+def _mock_get(payload: object) -> MagicMock:
+    return MagicMock(return_value=_response(json=payload))
 
 
 @pytest.fixture
@@ -62,14 +66,24 @@ def test_missing_api_key_raises(component):
         component._search()
 
 
+def test_fetch_content_reports_missing_api_key_without_request(component):
+    """The public output turns a missing key into an error row and never calls Serply."""
+    component.serply_api_key = ""
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    mock_get.assert_not_called()
+    assert len(results) == 1
+    assert "Serply API key is required" in results[0].data["error"]
+
+
 def test_search_sends_explicit_user_agent(component):
     """The request must carry an explicit User-Agent to clear Cloudflare (1010)."""
     mock_get = _mock_get(SAMPLE_PAYLOAD)
     with patch(GET_PATCH_TARGET, mock_get):
         component._search()
     headers = mock_get.call_args.kwargs["headers"]
-    assert headers["User-Agent"]
-    assert headers["User-Agent"] != ""
+    assert headers["User-Agent"] == "langflow-serply-bundle"
     assert headers["X-Api-Key"] == "test-key"  # pragma: allowlist secret
 
 
@@ -99,6 +113,14 @@ def test_max_results_is_clamped_low(component):
     assert mock_get.call_args.args[0] == "https://api.serply.io/v1/search/?q=hello&num=1"
 
 
+def test_max_results_range_spec_matches_clamp():
+    """The UI range matches the bounds the request clamps to."""
+    max_results = next(i for i in SerplySearchComponent.inputs if i.name == "max_results")
+    assert max_results.range_spec is not None
+    assert (max_results.range_spec.min, max_results.range_spec.max) == (1, 100)
+    assert max_results.range_spec.step_type == "int"
+
+
 def test_fetch_content_maps_results(component):
     """Organic results map to Data(text=description, data={title,link,...})."""
     mock_get = _mock_get(SAMPLE_PAYLOAD)
@@ -118,6 +140,23 @@ def test_fetch_content_handles_empty_results(component):
         assert component.fetch_content() == []
 
 
+def test_fetch_content_skips_malformed_results(component):
+    """Result entries that are not JSON objects are skipped instead of crashing."""
+    mock_get = _mock_get({"results": ["not-an-object", SAMPLE_PAYLOAD["results"][0]]})
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert [r.data["title"] for r in results] == ["Result one"]
+
+
+def test_fetch_content_rejects_non_object_payload(component):
+    """A JSON body that is not an object becomes an error row, not an AttributeError."""
+    mock_get = _mock_get(["unexpected"])
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert len(results) == 1
+    assert "unexpected response" in results[0].data["error"]
+
+
 def test_fetch_content_wraps_http_error(component):
     """A transport error is surfaced as a single error Data, not raised."""
     mock_get = MagicMock(side_effect=httpx.HTTPError("boom"))
@@ -127,9 +166,41 @@ def test_fetch_content_wraps_http_error(component):
     assert "boom" in results[0].data["error"]
 
 
-def test_fetch_content_dataframe_shape(component):
+def test_fetch_content_surfaces_api_error_detail(component):
+    """A 401 keeps Serply's own reason instead of the generic httpx message."""
+    mock_get = MagicMock(return_value=_response(401, json={"detail": "Invalid API key"}))
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert len(results) == 1
+    assert results[0].data["error"] == "Serply API error 401: Invalid API key"
+
+
+def test_fetch_content_http_error_without_json_body(component):
+    """A non-JSON error body falls back to the HTTP reason phrase."""
+    mock_get = MagicMock(return_value=_response(502, text="upstream down"))
+    with patch(GET_PATCH_TARGET, mock_get):
+        results = component.fetch_content()
+    assert results[0].data["error"] == "Serply API error 502: Bad Gateway"
+
+
+def test_serply_search_dataframe_shape(component):
     """The default output builds a DataFrame from the mapped results."""
     mock_get = _mock_get(SAMPLE_PAYLOAD)
     with patch(GET_PATCH_TARGET, mock_get):
-        frame = component.fetch_content_dataframe()
+        frame = component.serply_search()
     assert len(frame) == 2
+
+
+def test_tool_mode_exposes_a_serply_specific_tool():
+    """The agent-facing tool name must not collide with other search components."""
+    # Tools read inputs the way a graph sets them (constructor kwargs), not
+    # attributes assigned after construction, so build the component directly.
+    component = SerplySearchComponent(serply_api_key="test-key", max_results=10)  # pragma: allowlist secret
+    tools = asyncio.run(component.to_toolkit())
+    assert [tool.name for tool in tools] == ["serply_search"]
+
+    mock_get = _mock_get(SAMPLE_PAYLOAD)
+    with patch(GET_PATCH_TARGET, mock_get):
+        output = asyncio.run(tools[0].ainvoke({"input_value": "langflow"}))
+    assert mock_get.call_args.args[0] == "https://api.serply.io/v1/search/?q=langflow&num=10"
+    assert "Result one" in str(output)

--- a/src/frontend/src/utils/__tests__/sidebarBundles.test.ts
+++ b/src/frontend/src/utils/__tests__/sidebarBundles.test.ts
@@ -25,6 +25,18 @@ describe("SIDEBAR_BUNDLES", () => {
     );
   });
 
+  it("classifies Serply as a sidebar bundle", () => {
+    expect(SIDEBAR_BUNDLES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          display_name: "Serply",
+          icon: "Search",
+          name: "serply",
+        }),
+      ]),
+    );
+  });
+
   it("classifies ToolGuard as a sidebar bundle", () => {
     expect(SIDEBAR_BUNDLES).toEqual(
       expect.arrayContaining([

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -512,6 +512,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "SearchApi", name: "searchapi", icon: "SearchAPI" },
   { display_name: "SerpApi", name: "serpapi", icon: "SerpSearch" },
   { display_name: "Serper", name: "serper", icon: "Serper" },
+  { display_name: "Serply", name: "serply", icon: "Search" },
   { display_name: "Spider", name: "spider", icon: "Spider" },
   { display_name: "Supabase", name: "supabase", icon: "Supabase" },
   { display_name: "Tavily", name: "tavily", icon: "TavilyIcon" },

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -5030,6 +5030,11 @@
       "legacy_slot": "ext:plivo:PlivoSendSMSComponent@official-pre-a",
       "target": "ext:plivo:PlivoSendSMSComponent@official",
       "added_in": "1.13.0"
+    },
+    {
+      "bare_class_name": "SerplySearchComponent",
+      "target": "ext:serply:SerplySearchComponent@official",
+      "added_in": "1.13.0"
     }
   ],
   "ambiguous_bare_names": [

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ members = [
     "lfx-openai-compatible",
     "lfx-oracle",
     "lfx-paddle",
+    "lfx-serply",
     "lfx-toolguard",
     "lfx-valkey",
     "lfx-vllm",
@@ -7912,6 +7913,7 @@ bundles = [
     { name = "lfx-firecrawl" },
     { name = "lfx-nextplaid" },
     { name = "lfx-paddle" },
+    { name = "lfx-serply" },
     { name = "lfx-valkey" },
 ]
 cassio = [
@@ -8032,6 +8034,7 @@ requires-dist = [
     { name = "lfx-openai-compatible", editable = "src/bundles/openai-compatible" },
     { name = "lfx-oracle", editable = "src/bundles/oracle" },
     { name = "lfx-paddle", marker = "extra == 'bundles'", editable = "src/bundles/paddle" },
+    { name = "lfx-serply", marker = "extra == 'bundles'", editable = "src/bundles/serply" },
     { name = "lfx-toolguard", editable = "src/bundles/toolguard" },
     { name = "lfx-valkey", marker = "extra == 'bundles'", editable = "src/bundles/valkey" },
     { name = "lfx-vllm", editable = "src/bundles/vllm" },
@@ -10395,6 +10398,21 @@ requires-dist = [
 name = "lfx-paddle"
 version = "0.1.4"
 source = { editable = "src/bundles/paddle" }
+dependencies = [
+    { name = "httpx" },
+    { name = "lfx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.24.0,<1.0.0" },
+    { name = "lfx", editable = "src/lfx" },
+]
+
+[[package]]
+name = "lfx-serply"
+version = "0.1.0"
+source = { editable = "src/bundles/serply" }
 dependencies = [
     { name = "httpx" },
     { name = "lfx" },


### PR DESCRIPTION
## What

Adds `lfx-serply`, an opt-in standalone Extension Bundle under `src/bundles/serply`
that ships a single `SerplySearchComponent`. The component runs a web search
through the [Serply](https://serply.io) SERP API and returns the organic Google
results as a `DataFrame`. See the [Serply docs](https://serply.io/docs) for the
API details.

It calls the Serply search endpoint directly with `httpx` and needs only a
user-supplied API key, so it carries no vendor SDK dependency.

## Why

Serply is a hosted SERP API. This gives users who already have a Serply key a
first-class web-search source in Langflow, alongside the existing web-search
bundles (`exa`, `duckduckgo`, `firecrawl`). It is registered as an opt-in
bundle, so nothing changes for anyone who does not install it, and the component
does nothing until a key is supplied.

## Notes

- Packaged as a standalone bundle following `src/bundles/PORTING.md`, mirroring
  the opt-in `exa` / `duckduckgo` bundles: workspace member, `uv` source, the
  `bundles` optional-dependency, and the release inventory contract plus its
  test (`scripts/ci/`). `uv.lock` is regenerated to match.
- The size is above the usual single-provider footprint because a new opt-in
  bundle touches the shared registration surfaces the CI inventory gate
  enforces; the code itself is one component and its tests. Happy to split the
  registration out if you would prefer it as a separate change.
- Serply sits behind Cloudflare, which blocks requests that omit a `User-Agent`
  header (error 1010), so the component always sends an explicit `User-Agent`.
  There is a unit test that pins this.

## Testing

Release inventory contract test:

```
uv run --no-project --with pytest --with packaging python -m pytest scripts/ci/test_release_inventory.py -q
11 passed
```

Bundle unit tests (component logic, results mapping, error handling, the
User-Agent and max-results clamping, DataFrame shape; network mocked):

```
uv run --package lfx-serply --with pytest python -m pytest src/bundles/serply/tests/ -q
8 passed
```

`uv lock` resolves cleanly and adds `lfx-serply v0.1.0`.

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this
entirely if it isn't a direction you want for the project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Serply Search integration for querying web results with an API key.
  - Results are available as structured data and table-style outputs.
  - Added automatic extension registration and package distribution support.
  - Added validation, result limits, and clear handling for empty or failed searches.

- **Documentation**
  - Added setup, configuration, usage, and local development guidance.

- **Tests**
  - Added coverage for authentication, request handling, result mapping, limits, errors, and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->