### PR TITLE
test(mcp): assert against real SDK models and add wire-level coverage

### DIFF
--- a/src/backend/tests/unit/agentic/mcp/test_stdio_wire_protocol.py
+++ b/src/backend/tests/unit/agentic/mcp/test_stdio_wire_protocol.py
@@ -1,0 +1,176 @@
+"""Wire-level test for the agentic MCP server over stdio.
+
+Everything else that covers this server calls the decorated functions in-process,
+so it proves the Python is importable and nothing about the server actually
+speaking MCP. This drives ``python -m langflow.agentic.mcp`` as a real
+subprocess and talks newline-delimited JSON-RPC to it directly.
+
+Deliberately no SDK client. The point is to depend on the wire format rather
+than on ``ClientSession``, so an SDK API change does not force this harness to
+be rewritten in the same PR as the code it is meant to guard. The one part that
+does track the protocol is the ``initialize`` handshake in ``_handshake``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+# Booting the server imports the whole langflow service stack. Measured at ~3.5s.
+# Both ceilings stay under pytest-timeout's global 90s (pyproject.toml), which
+# uses timeout_method="thread" and would os._exit the run rather than let this
+# harness report which call hung.
+STARTUP_TIMEOUT = 45.0
+CALL_TIMEOUT = 30.0
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class _StdioPeer:
+    """Newline-delimited JSON-RPC over a subprocess's stdin/stdout."""
+
+    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+        self._proc = proc
+        self._next_id = 0
+        self._stderr = bytearray()
+        # Drain stderr continuously. The pipe holds 64KB, and a subprocess that
+        # fills it blocks on write, which would deadlock the request loop.
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+    async def _drain_stderr(self) -> None:
+        while True:
+            chunk = await self._proc.stderr.read(4096)
+            if not chunk:
+                return
+            self._stderr.extend(chunk)
+
+    @property
+    def stderr_text(self) -> str:
+        return self._stderr.decode(errors="replace")
+
+    async def _send(self, payload: dict) -> None:
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode())
+        await self._proc.stdin.drain()
+
+    async def notify(self, method: str, params: dict | None = None) -> None:
+        await self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    async def request(self, method: str, params: dict | None = None, *, timeout: float = CALL_TIMEOUT) -> dict:
+        self._next_id += 1
+        request_id = self._next_id
+        await self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+
+        async def _read_matching() -> dict:
+            while True:
+                line = await self._proc.stdout.readline()
+                if not line:
+                    msg = f"server closed stdout before answering {method}; stderr:\n{self.stderr_text}"
+                    raise AssertionError(msg)
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    # Anything that is not JSON on stdout is a framing bug: stdout
+                    # is the JSON-RPC channel and logs belong on stderr.
+                    msg = f"non-JSON line on the JSON-RPC channel: {line!r}"
+                    raise AssertionError(msg) from None
+                if message.get("id") == request_id:
+                    return message
+
+        return await asyncio.wait_for(_read_matching(), timeout=timeout)
+
+
+async def _handshake(peer: _StdioPeer) -> dict:
+    """Run the MCP initialize handshake. This is the part protocol 2026-07-28 removes."""
+    response = await peer.request(
+        "initialize",
+        {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "langflow-wire-test", "version": "0"},
+        },
+        timeout=STARTUP_TIMEOUT,
+    )
+    await peer.notify("notifications/initialized")
+    return response
+
+
+@pytest.fixture
+async def server():
+    env = {
+        **os.environ,
+        "LANGFLOW_AUTO_LOGIN": "true",
+        # Keep the subprocess off any real user database.
+        "LANGFLOW_DATABASE_URL": "sqlite:///:memory:",
+    }
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "langflow.agentic.mcp",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        yield proc
+    finally:
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=15)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+
+
+async def test_stdio_server_completes_handshake_and_lists_tools(server):
+    """The server must answer initialize and tools/list over a real pipe."""
+    peer = _StdioPeer(server)
+
+    init = await _handshake(peer)
+    assert "result" in init, f"initialize failed: {init}"
+    assert init["result"]["protocolVersion"]
+    assert init["result"]["serverInfo"]["name"] == "langflow-agentic"
+
+    listed = await peer.request("tools/list")
+    assert "result" in listed, f"tools/list failed: {listed}"
+
+    tools = listed["result"]["tools"]
+    assert tools, "server advertised no tools"
+
+    names = {tool["name"] for tool in tools}
+    assert "run_assistant" in names, f"run_assistant missing from {sorted(names)}"
+
+    # Every advertised tool must carry a usable input schema. This is the read
+    # that silently returns nothing if the wire model's field name changes.
+    for tool in tools:
+        assert tool.get("inputSchema"), f"{tool['name']} advertised no inputSchema"
+        assert tool["inputSchema"].get("type") == "object", f"{tool['name']} inputSchema is not an object schema"
+
+
+async def test_stdio_server_rejects_unknown_tool_over_the_wire(server):
+    """An unknown tool must come back as a JSON-RPC answer, not kill the process.
+
+    Exercises the tools/call path end to end without depending on any real
+    assistant run, which would need model credentials.
+    """
+    peer = _StdioPeer(server)
+    await _handshake(peer)
+
+    response = await peer.request(
+        "tools/call",
+        {"name": "definitely_not_a_real_tool", "arguments": {}},
+    )
+
+    # Either a JSON-RPC error or an isError result is a correct answer. Silence,
+    # a crash, or a success is not.
+    assert "error" in response or response.get("result", {}).get("isError") is True, (
+        f"unknown tool was not reported as a failure: {response}"
+    )
+
+    # The server must still be alive and answering afterwards.
+    listed = await peer.request("tools/list")
+    assert "result" in listed

--- a/src/backend/tests/unit/api/v1/test_mcp_streamable_wire.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_streamable_wire.py
@@ -1,0 +1,88 @@
+"""Wire-level test for /api/v1/mcp/streamable.
+
+The existing coverage in ``test_mcp.py`` mocks ``StreamableHTTPSessionManager``
+and asserts ``handle_request`` was called, which passes whether or not the
+server can actually speak MCP. This posts real JSON-RPC through ASGI with the
+session manager left alone, so it fails if the server stops answering.
+
+Raw JSON-RPC rather than an SDK client, so that an SDK API change does not
+force this harness to be rewritten alongside the code it guards.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+PROTOCOL_VERSION = "2025-06-18"
+MCP_ACCEPT = "application/json, text/event-stream"
+
+
+def _decode(response) -> dict:
+    """Read one JSON-RPC message out of either a JSON or an SSE response."""
+    content_type = response.headers.get("content-type", "")
+    body = response.text
+
+    if content_type.startswith("application/json"):
+        return json.loads(body)
+
+    if content_type.startswith("text/event-stream"):
+        for line in body.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[len("data:") :].strip())
+        msg = f"no data frame in SSE response: {body!r}"
+        raise AssertionError(msg)
+
+    msg = f"unexpected content-type {content_type!r}, body: {body[:400]!r}"
+    raise AssertionError(msg)
+
+
+async def _post(client: AsyncClient, headers: dict, payload: dict):
+    return await client.post(
+        "api/v1/mcp/streamable",
+        headers={**headers, "Accept": MCP_ACCEPT, "Content-Type": "application/json"},
+        json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamable_endpoint_answers_initialize_over_the_wire(client: AsyncClient, logged_in_headers):
+    """A real initialize must come back as a real MCP result, not just a 200."""
+    response = await _post(
+        client,
+        logged_in_headers,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "langflow-wire-test", "version": "0"},
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    message = _decode(response)
+
+    assert message.get("jsonrpc") == "2.0"
+    assert "result" in message, f"initialize returned an error: {message}"
+    assert message["result"]["protocolVersion"]
+    assert message["result"]["serverInfo"]["name"]
+
+
+@pytest.mark.asyncio
+async def test_streamable_endpoint_requires_auth(client: AsyncClient):
+    """Unauthenticated JSON-RPC must not reach the MCP server."""
+    response = await client.post(
+        "api/v1/mcp/streamable",
+        headers={"Accept": MCP_ACCEPT},
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+    )
+    assert response.status_code == 403

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -31,6 +31,7 @@ from lfx.base.mcp.util import (
     validate_headers,
 )
 from lfx.schema.data import Data
+from mcp.types import CallToolResult, ImageContent, TextContent, Tool
 
 
 def test_validate_mcp_stdio_env_rejects_shellopts_ps4_combo():
@@ -1295,13 +1296,13 @@ class TestUpdateToolsPerToolResilience:
     """update_tools must isolate per-tool schema-parsing failures (#11229)."""
 
     @staticmethod
-    def _make_tool(name: str, schema: dict) -> MagicMock:
-        tool = MagicMock()
-        tool.name = name
-        tool.description = f"{name} description"
-        tool.inputSchema = schema
-        tool.outputSchema = None
-        return tool
+    def _make_tool(name: str, schema: dict) -> Tool:
+        """Real ``Tool``, so the schema field name tracks the SDK.
+
+        A MagicMock accepts whatever attribute the test writes, so it keeps
+        passing after a wire-model rename that breaks every real server.
+        """
+        return Tool(name=name, description=f"{name} description", inputSchema=schema)
 
     @pytest.mark.asyncio
     async def test_one_bad_tool_does_not_drop_the_other_tools_issue_11229(self):
@@ -1401,7 +1402,10 @@ class TestUpdateToolsPerToolResilience:
             tool = self._make_tool(f"tool_{i:02d}", schema)
             tools.append(tool)
             if i % 2 == 1:  # 10 odd indices fail with rotated error types
-                bad_schemas[id(schema)] = error_types[(i // 2) % len(error_types)]
+                # Key off the schema the tool actually carries. Tool is a pydantic
+                # model, so it stores a copy and the local dict's id() is not the
+                # one the converter will be handed.
+                bad_schemas[id(tool.inputSchema)] = error_types[(i // 2) % len(error_types)]
 
         def selective_converter(schema):
             err_cls = bad_schemas.get(id(schema))
@@ -2523,16 +2527,16 @@ class TestMCPStreamableHttpClientWithDeepWikiServer:
 
     @pytest.fixture
     def mock_tool(self):
-        """Create a mock MCP tool."""
-        tool = MagicMock()
-        tool.name = "test_tool"
-        tool.description = "Test tool description"
-        tool.inputSchema = {
-            "type": "object",
-            "properties": {"test_param": {"type": "string", "description": "Test parameter"}},
-            "required": ["test_param"],
-        }
-        return tool
+        """Create a real MCP tool model."""
+        return Tool(
+            name="test_tool",
+            description="Test tool description",
+            inputSchema={
+                "type": "object",
+                "properties": {"test_param": {"type": "string", "description": "Test parameter"}},
+                "required": ["test_param"],
+            },
+        )
 
     @pytest.fixture
     def mock_session(self, mock_tool):
@@ -3710,11 +3714,7 @@ class TestConvertMcpResult:
         return block
 
     def _make_image_block(self, data: str = "abc123", mime: str = "image/png"):
-        block = MagicMock()
-        block.type = "image"
-        block.data = data
-        block.mimeType = mime
-        return block
+        return ImageContent(type="image", data=data, mimeType=mime)
 
     def _make_result(self, content):
         result = MagicMock()
@@ -3930,33 +3930,20 @@ class TestMCPStructuredToolToolCallId:
     is multimodal-ready and whose artifact holds the original CallToolResult.
     """
 
-    def _make_raw_result(self, text: str = "ok", image_data: str | None = None):
-        """Build a minimal CallToolResult-like mock."""
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = text
-
-        content = [text_block]
+    def _make_raw_result(self, text: str = "ok", image_data: str | None = None) -> CallToolResult:
+        """Build a real CallToolResult, so isError and mimeType track the SDK."""
+        content: list[TextContent | ImageContent] = [TextContent(type="text", text=text)]
         if image_data:
-            img_block = MagicMock()
-            img_block.type = "image"
-            img_block.data = image_data
-            img_block.mimeType = "image/png"
-            content.append(img_block)
-
-        result = MagicMock()
-        result.isError = False
-        result.content = content
-        result.structuredContent = None
-        return result
+            content.append(ImageContent(type="image", data=image_data, mimeType="image/png"))
+        return CallToolResult(isError=False, content=content, structuredContent=None)
 
     async def _build_tool_via_update_tools(self, raw_result):
         """Get a real MCPStructuredTool from update_tools() with a mocked client."""
-        mock_tool = MagicMock()
-        mock_tool.name = "get_image"
-        mock_tool.description = "Returns content"
-        mock_tool.inputSchema = {"type": "object", "properties": {}, "required": []}
-        mock_tool.outputSchema = None
+        mock_tool = Tool(
+            name="get_image",
+            description="Returns content",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        )
 
         mock_client = AsyncMock(spec=MCPStdioClient)
         mock_client.connect_to_server = AsyncMock(return_value=[mock_tool])

--- a/src/backend/tests/unit/base/mcp/test_tool_iserror_propagation.py
+++ b/src/backend/tests/unit/base/mcp/test_tool_iserror_propagation.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 from lfx.base.mcp.util import create_tool_coroutine
+from mcp.types import CallToolResult, TextContent
 from pydantic import BaseModel
 
 
@@ -22,10 +23,16 @@ class _ArgSchema(BaseModel):
     input_value: str = ""
 
 
-def _result(*, is_error: bool, text: str = "ok") -> SimpleNamespace:
-    return SimpleNamespace(
+def _result(*, is_error: bool, text: str = "ok") -> CallToolResult:
+    """Build a real ``CallToolResult``, not a duck-typed stand-in.
+
+    A hand-rolled object with an ``isError`` attribute passes whatever the SDK
+    later renames that field to, so it cannot catch a wire-model change. The
+    real model tracks the SDK.
+    """
+    return CallToolResult(
         isError=is_error,
-        content=[SimpleNamespace(type="text", text=text)],
+        content=[TextContent(type="text", text=text)],
     )
 
 

--- a/src/backend/tests/unit/components/models_and_agents/test_mcp_component_cache.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_mcp_component_cache.py
@@ -15,6 +15,7 @@ import pytest
 from lfx.base.agents.utils import safe_cache_get, safe_cache_set
 from lfx.components.models_and_agents.mcp_component import MCPToolsComponent
 from lfx.schema.dataframe import DataFrame
+from mcp.types import CallToolResult, TextContent
 
 from tests.base import ComponentTestBaseWithoutClient
 
@@ -526,10 +527,10 @@ class TestMCPComponentCache(ComponentTestBaseWithoutClient):
         # Mock the execution tool
         exec_tool = MagicMock()
         exec_tool.coroutine = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.isError = False
-        mock_result.content = [MagicMock()]
-        mock_result.content[0].model_dump.return_value = {"result": "test_output"}
+        mock_result = CallToolResult(
+            isError=False,
+            content=[TextContent(type="text", text="test_output")],
+        )
         exec_tool.coroutine.return_value = mock_result
 
         # Set up cached tools
@@ -551,7 +552,10 @@ class TestMCPComponentCache(ComponentTestBaseWithoutClient):
             # DataFrame is a pandas subclass, use to_dict to access data
             result_dict = result.to_dict(orient="records")
             assert len(result_dict) == 1
-            assert result_dict[0]["result"] == "test_output"
+            # Columns come from TextContent.model_dump(), so "text" is the real
+            # shape the component produces. The old mock fabricated a "result"
+            # key that no MCP result ever carries.
+            assert result_dict[0]["text"] == "test_output"
 
     @pytest.mark.asyncio
     async def test_error_handling_with_cache_disabled(self, component_class, default_kwargs):

--- a/src/backend/tests/unit/components/models_and_agents/test_mcp_component_output.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_mcp_component_output.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from lfx.components.models_and_agents.mcp_component import MCPToolsComponent
 from lfx.schema.dataframe import DataFrame
+from mcp.types import CallToolResult, TextContent
 
 
 class TestMCPComponentOutputProcessing:
@@ -83,20 +84,17 @@ class TestMCPComponentOutputProcessing:
 
         # Mock the tool cache
         mock_tool = MagicMock()
-        mock_result = MagicMock()
 
-        # Create mock output with various JSON types
-        mock_content_item1 = MagicMock()
-        mock_content_item1.model_dump.return_value = {"type": "text", "text": '{"status": "success"}'}
-
-        mock_content_item2 = MagicMock()
-        mock_content_item2.model_dump.return_value = {"type": "text", "text": '"just a string"'}
-
-        mock_content_item3 = MagicMock()
-        mock_content_item3.model_dump.return_value = {"type": "text", "text": "42"}
-
-        mock_result.isError = False
-        mock_result.content = [mock_content_item1, mock_content_item2, mock_content_item3]
+        # Real SDK models: field names come from mcp.types, not from literals
+        # frozen in this test, so a wire-model rename shows up here.
+        mock_result = CallToolResult(
+            isError=False,
+            content=[
+                TextContent(type="text", text='{"status": "success"}'),
+                TextContent(type="text", text='"just a string"'),
+                TextContent(type="text", text="42"),
+            ],
+        )
         mock_tool.coroutine = AsyncMock(return_value=mock_result)
 
         component._tool_cache = {"test_tool": mock_tool}
@@ -143,14 +141,15 @@ class TestMCPComponentOutputProcessing:
         component.tool = "test_tool"
         component.tools = []
 
-        error_item = MagicMock()
-        error_item.model_dump.return_value = {
-            "type": "text",
-            "text": "This flow uses Human-in-the-Loop and cannot run as an MCP tool.",
-        }
-        mock_result = MagicMock()
-        mock_result.isError = True
-        mock_result.content = [error_item]
+        mock_result = CallToolResult(
+            isError=True,
+            content=[
+                TextContent(
+                    type="text",
+                    text="This flow uses Human-in-the-Loop and cannot run as an MCP tool.",
+                )
+            ],
+        )
         mock_tool = MagicMock()
         mock_tool.coroutine = AsyncMock(return_value=mock_result)
 
@@ -189,11 +188,10 @@ class TestMCPComponentOutputProcessing:
 
         mock_tool = MagicMock()
         mock_tool.name = "list_tool"
-        mock_result = MagicMock()
-        mock_result.isError = False
-        mock_result.content = [
-            MagicMock(model_dump=MagicMock(return_value={"type": "text", "text": '{"results": []}'}))
-        ]
+        mock_result = CallToolResult(
+            isError=False,
+            content=[TextContent(type="text", text='{"results": []}')],
+        )
         mock_tool.coroutine = AsyncMock(return_value=mock_result)
 
         schema = create_model(


### PR DESCRIPTION
Stacked on #14624. **Merges after it.** The base of this PR is `le-2213-mcp-prework-dead-code-docs`, not `main`, so its green CI proves this change against that branch and not against `main`.

Test-only. No production code changes.

## The problem

The MCP suite goes green on a build where tool discovery returns nothing and failed tool calls become data.

MCP SDK 2.0 moves the wire models to snake_case attributes (`isError` → `is_error`, `inputSchema` → `input_schema`, `mimeType` → `mime_type`), keeping camelCase only as a pydantic validation alias. `populate_by_name=True` accepts either spelling on *construction*; it does not give you attribute access by alias. Production reads these as `getattr(result, "isError", False)`, so at the bump those reads quietly return the default.

The suite could not catch that, because every MCP result was faked with a `MagicMock` or `SimpleNamespace` carrying hand-written camelCase attributes. The field names came from literals in the test files rather than from the SDK, so they keep passing after a rename that breaks every real server.

## Real models instead of fakes

- `CallToolResult` / `TextContent` in `test_tool_iserror_propagation.py` (the HITL guard), `test_mcp_component_output.py`, `test_mcp_component_cache.py`.
- `Tool` in the per-tool resilience helper and the `mock_tool` fixture, so `inputSchema` is read off the real model.
- `ImageContent` in the image-block helper, so `mimeType` is too.

One test deliberately keeps its duck-typed object: the "result without an `isError` attribute" case exists precisely to exercise the `getattr` default for a library variant that lacks the field.

## Two assertions were asserting fiction

Both surfaced by the swap, both worth reading:

- `test_mcp_component_cache` asserted a `result` column that existed only because a `MagicMock.model_dump()` fabricated `{"result": "test_output"}`. No real MCP content block produces that key. Real blocks produce `text`.
- `test_resilience_under_many_mixed_tools` keyed its failure map on `id()` of a locally-built dict. `Tool` is a pydantic model and stores a copy, so none of the 10 "broken" tools were being matched and all 20 loaded. The key now comes from the schema the tool actually carries.

## Two wire-level tests

Both speak raw JSON-RPC rather than using an SDK client, so an SDK API change does not force the harness to be rewritten in the same change as the code it guards.

- **`test_stdio_wire_protocol.py`** drives `python -m langflow.agentic.mcp` as a real subprocess: handshake, `tools/list`, and an unknown-tool call. It asserts every advertised tool carries an object `inputSchema`, and that nothing but JSON-RPC ever appears on stdout (stdout is the wire; logs belong on stderr). Nothing covered this before, tool registration was only checked in-process.
- **`test_mcp_streamable_wire.py`** posts real JSON-RPC to `/api/v1/mcp/streamable` through ASGI with the session manager left alone. The existing tests there mock `StreamableHTTPSessionManager` and assert `handle_request` was called, which passes whether or not the server can answer anything.

Neither needs network, model credentials, or a real database. Together they run in about 18s.

I checked they can actually fail rather than passing vacuously: renaming the server's identity turns the stdio test red (`assert 'langflow-BROKEN' == 'langflow-agentic'`) and it goes green again on revert.

## The live canary stays skipped

The `npx @modelcontextprotocol/server-everything` class was the plan's suggested un-skip, on the grounds that it was the only thing checking `inputSchema` against a real server object. It is unconditionally skipped today and was disabled for flakiness. Using real `Tool` models covers that read deterministically, so putting a flaky live-network dependency back into CI to get the same signal seemed like a bad trade. Happy to be argued out of it.

## Verification

`src/backend/tests/unit/base/mcp` + `api/v1/test_mcp.py` + the new wire test + `unit/agentic`: **1951 passed**, 7 skipped, 10 xfailed.

One failure in that run, `test_assistant_api_report_repro.py::test_execute_named_assistant_flow_is_graceful_not_500`, is pre-existing and unrelated: it fails identically on the base branch, which contains none of these changes.

`src/backend/tests/unit/components/models_and_agents` is 707 passed with 5 pre-existing failures, all `401`s in `TestAgentComponentWithClient` that need live Anthropic credentials. Also reproduced on the base branch.

## Review pass

A reviewer built an mcp-2.0 attribute-rename simulator (subclassing the real models so the attribute is snake_case with camelCase kept as a validation alias only) and ran both branches under it. That settles the central claim:

- This branch, under simulation: **7 failures.** Four fire inside production code, not test code — `util.py` `tool.inputSchema` makes `update_tools` skip every tool, and the `getattr(..., "isError", False)` reads in `util.py` and `mcp_component.py` return the default so the HITL guard no-ops.
- Parent branch, same simulation: **269 passed, 0 failed.**

It also caught a class I had missed, now fixed: `TestMCPStructuredToolToolCallId` still had the exact camelCase fakes this change removes, on the agent tool path, exercising all three broken reads and staying green under simulation.

Two robustness fixes from the same pass: `STARTUP_TIMEOUT` was 120s, above pytest-timeout's global 90s, so it could never fire and a hang would `os._exit` the whole run instead of reporting which call stalled (now 45s/30s against a measured ~3.5s boot); and the harness now drains the subprocess's stderr concurrently, since 64KB of chatty logging would otherwise block the server mid-request.

Deliberate breakages confirming the new tests can fail: a renamed tool, a handler that `os._exit`s, a handler that wrongly succeeds, a stray `print` on stdout, a dropped `handle_request`, and an auth bypass. All six caught.

## Known gap, not closed by this PR

**No test in the suite instantiates a real `mcp.ClientSession`.** Every call site patches `lfx.base.mcp.util.ClientSession`, and the new wire tests deliberately speak raw JSON-RPC instead of using the SDK client. So if mcp 2.0 changes the `ClientSession` / `stdio_client` API surface (signatures, the context-manager shape at `util.py:1299`), nothing here catches it. That gap predates this change and these tests do not close it — it just should not be mistaken for covered.

One related assumption to re-check at the bump: the stdio test reads `isError` off the raw wire JSON, which is correct only as long as 2.0 keeps camelCase as a *serialization* alias. The spec requires it, so it should hold, but it is the one assertion in the new files that depends on it.
