### PR TITLE
fix(a11y): distinct tab titles per route, html lang that follows the locale, no nested main

### DIFF
--- a/src/frontend/src/hooks/__tests__/use-document-title.test.ts
+++ b/src/frontend/src/hooks/__tests__/use-document-title.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { formatDocumentTitle, useDocumentTitle } from "../use-document-title";
+
+describe("formatDocumentTitle", () => {
+  it("brands the page title", () => {
+    expect(formatDocumentTitle("Flows")).toBe("Flows | Langflow");
+  });
+
+  it("does not double-brand a title that already names the product", () => {
+    expect(formatDocumentTitle("Langflow API Keys")).toBe("Langflow API Keys");
+  });
+
+  it("falls back to the product name for an empty title", () => {
+    expect(formatDocumentTitle(undefined)).toBe("Langflow");
+    expect(formatDocumentTitle(null)).toBe("Langflow");
+    expect(formatDocumentTitle("   ")).toBe("Langflow");
+  });
+});
+
+describe("useDocumentTitle", () => {
+  it("sets the document title while mounted and resets it on unmount", () => {
+    const { unmount } = renderHook(() => useDocumentTitle("Global Variables"));
+    expect(document.title).toBe("Global Variables | Langflow");
+
+    unmount();
+    expect(document.title).toBe("Langflow");
+  });
+
+  it("follows a title that resolves after the first render", () => {
+    const { rerender } = renderHook(
+      ({ title }: { title?: string }) => useDocumentTitle(title),
+      { initialProps: { title: undefined } },
+    );
+    expect(document.title).toBe("Langflow");
+
+    rerender({ title: "My Flow" });
+    expect(document.title).toBe("My Flow | Langflow");
+  });
+});

--- a/src/frontend/src/hooks/use-document-title.ts
+++ b/src/frontend/src/hooks/use-document-title.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+export const APP_NAME = "Langflow";
+
+/**
+ * Builds the tab title for a page. Titles that already carry the product name
+ * (e.g. the "Langflow API Keys" settings page) are used as-is so the tab does
+ * not read "Langflow API Keys | Langflow".
+ */
+export function formatDocumentTitle(title?: string | null): string {
+  const pageTitle = title?.trim();
+  if (!pageTitle) return APP_NAME;
+  return pageTitle.includes(APP_NAME)
+    ? pageTitle
+    : `${pageTitle} | ${APP_NAME}`;
+}
+
+/**
+ * Names the browser tab after the page the calling component renders
+ * (WCAG 2.4.2 Page Titled).
+ *
+ * Pass the same string the page shows as its heading. Pass a falsy value while
+ * the name is still loading — the tab then shows the product name alone instead
+ * of a stale one. The title resets on unmount, so a route that forgets to call
+ * this never inherits the previous route's title.
+ */
+export function useDocumentTitle(title?: string | null): void {
+  useEffect(() => {
+    document.title = formatDocumentTitle(title);
+    return () => {
+      document.title = APP_NAME;
+    };
+  }, [title]);
+}

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -64,6 +64,18 @@ i18n.use(initReactI18next).init({
 });
 console.info = _consoleInfo;
 
+/**
+ * Keeps `<html lang>` in sync with the active locale so assistive technology
+ * applies the right pronunciation rules (WCAG 3.1.1 Language of Page).
+ * `index.html` only ever ships the hard-coded default.
+ */
+const syncDocumentLanguage = (lang: string) => {
+  document.documentElement.lang = lang;
+};
+
+syncDocumentLanguage(detectedLang);
+i18n.on("languageChanged", syncDocumentLanguage);
+
 export async function loadLanguage(lang: string): Promise<void> {
   if (lang === "en") return;
   if (i18n.hasResourceBundle(lang, "translation")) return;

--- a/src/frontend/src/modals/templatesModal/__tests__/templatesModal.a11y.test.tsx
+++ b/src/frontend/src/modals/templatesModal/__tests__/templatesModal.a11y.test.tsx
@@ -97,10 +97,12 @@ describe("TemplatesModal accessibility", () => {
     );
   });
 
-  it("should_place_the_template_panes_inside_a_main_landmark", () => {
+  it("should_not_nest_a_main_landmark_inside_the_dialog", () => {
     renderModal();
 
-    const main = screen.getByRole("main");
-    expect(main).toContainElement(screen.getByTestId("get-started-component"));
+    // The page behind the modal already owns the single main landmark, so a
+    // second one here would break landmark navigation (WCAG 2.4.1).
+    expect(screen.queryByRole("main")).not.toBeInTheDocument();
+    expect(screen.getByTestId("get-started-component")).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -141,7 +141,9 @@ export default function TemplatesModal({
               currentTab={effectiveTab}
               setCurrentTab={setCurrentTab}
             />
-            <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
+            {/* Not a <main>: the page underneath already owns the single
+                main landmark (WCAG 2.4.1). */}
+            <div className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
               {effectiveTab === "get-started" ? (
                 <GetStartedComponent
                   loading={loading}
@@ -182,7 +184,7 @@ export default function TemplatesModal({
                   </Button>
                 </div>
               </BaseModal.Footer>
-            </main>
+            </div>
           </SidebarProvider>
         </div>
       </BaseModal.Content>

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -381,7 +381,9 @@ export default function ToolsTable({
 
   return (
     <>
-      <main className="flex h-full w-full flex-1 flex-col gap-2 overflow-hidden py-4">
+      {/* Not a <main>: the flow canvas underneath already owns the single
+          main landmark (WCAG 2.4.1). */}
+      <div className="flex h-full w-full flex-1 flex-col gap-2 overflow-hidden py-4">
         <div className="flex-none px-4">
           <Input
             icon="Search"
@@ -411,7 +413,7 @@ export default function ToolsTable({
             onGridReady={handleGridReady}
           />
         </div>
-      </main>
+      </div>
       <Sidebar
         side="right"
         className="flex h-full flex-col overflow-auto border-l border-border"

--- a/src/frontend/src/pages/AdminPage/LoginPage/index.tsx
+++ b/src/frontend/src/pages/AdminPage/LoginPage/index.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 import { useLoginUser } from "@/controllers/API/queries/auth";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import { CONTROL_LOGIN_STATE } from "../../../constants/constants";
@@ -18,6 +19,7 @@ export default function LoginAdminPage() {
   const [inputState, setInputState] =
     useState<loginInputStateType>(CONTROL_LOGIN_STATE);
   const { t } = useTranslation();
+  useDocumentTitle(t("auth.adminTitle"));
   const { login } = useContext(AuthContext);
   const queryClient = useQueryClient();
   const { password, username } = inputState;

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -16,6 +16,7 @@ import { ENABLE_NEW_SIDEBAR } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useApplyFlowToCanvas from "@/hooks/flows/use-apply-flow-to-canvas";
 import useSaveFlow from "@/hooks/flows/use-save-flow";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useWebhookEvents } from "@/hooks/use-webhook-events";
 import { SaveChangesModal } from "@/modals/saveChangesModal";
@@ -94,6 +95,8 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+
+  useDocumentTitle(currentSavedFlow?.name);
 
   const changesNotSaved =
     customStringify(currentFlow) !== customStringify(currentSavedFlow) &&

--- a/src/frontend/src/pages/LoginPage/index.tsx
+++ b/src/frontend/src/pages/LoginPage/index.tsx
@@ -11,6 +11,7 @@ import CustomLoginFormGate from "@/customization/components/custom-login-form-ga
 import CustomLoginSignupPrompt from "@/customization/components/custom-login-signup-prompt";
 import CustomLoginSsoOptions from "@/customization/components/custom-login-sso-options";
 import useTheme from "@/customization/hooks/use-custom-theme";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useSanitizeRedirectUrl } from "@/hooks/use-sanitize-redirect-url";
 import {
   appendErrorSuggestion,
@@ -40,6 +41,7 @@ export default function LoginPage(): JSX.Element {
   useTheme();
 
   const { t } = useTranslation();
+  useDocumentTitle(t("auth.signInButton"));
   const { login, clearAuthSession } = useContext(AuthContext);
   const setErrorData = useAlertStore((state) => state.setErrorData);
 

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import FilesTab from "./components/FilesTab";
 
 export const FilesPage = () => {
   const { t } = useTranslation();
+  useDocumentTitle(t("files.pageTitle"));
   // biome-ignore lint/suspicious/noExplicitAny: legacy
   const [selectedFiles, setSelectedFiles] = useState<any[]>([]);
   const [quantitySelected, setQuantitySelected] = useState(0);

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -14,6 +14,7 @@ import {
   ENABLE_MCP,
 } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { getProjectDisplayName } from "@/utils/project-display-name";
@@ -27,8 +28,15 @@ import DeploymentsPage from "../deploymentsPage/deployments-page";
 import EmptyFolder from "../emptyFolder";
 import { isFolderEmpty } from "./utils/isFolderEmpty";
 
-const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
+const PAGE_TITLE_KEYS = {
+  flows: "mainPage.tabFlows",
+  components: "mainPage.tabComponents",
+  mcp: "mainPage.mcpServer",
+} as const;
+
+const HomePage = ({ type }: { type: keyof typeof PAGE_TITLE_KEYS }) => {
   const { t } = useTranslation();
+  useDocumentTitle(t(PAGE_TITLE_KEYS[type]));
   const [view, setView] = useState<"grid" | "list">(() => {
     const savedView = localStorage.getItem("view");
     return savedView === "grid" || savedView === "list" ? savedView : "list";

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -28,15 +28,17 @@ import DeploymentsPage from "../deploymentsPage/deployments-page";
 import EmptyFolder from "../emptyFolder";
 import { isFolderEmpty } from "./utils/isFolderEmpty";
 
-const PAGE_TITLE_KEYS = {
+// Keyed by the active tab, not the route: Flows and Deployments share /flows
+// and only differ by which header tab is selected.
+const PAGE_TITLE_KEYS: Record<FlowTabType, string> = {
   flows: "mainPage.tabFlows",
+  deployments: "mainPage.tabDeployments",
   components: "mainPage.tabComponents",
   mcp: "mainPage.mcpServer",
-} as const;
+};
 
-const HomePage = ({ type }: { type: keyof typeof PAGE_TITLE_KEYS }) => {
+const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   const { t } = useTranslation();
-  useDocumentTitle(t(PAGE_TITLE_KEYS[type]));
   const [view, setView] = useState<"grid" | "list">(() => {
     const savedView = localStorage.getItem("view");
     return savedView === "grid" || savedView === "list" ? savedView : "list";
@@ -55,6 +57,7 @@ const HomePage = ({ type }: { type: keyof typeof PAGE_TITLE_KEYS }) => {
       ? "deployments"
       : type,
   );
+  useDocumentTitle(t(PAGE_TITLE_KEYS[flowType]));
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
   const folders = useFolderStore((state) => state.folders);
   const currentFolderId = folderId ?? myCollectionId;

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/index.tsx
@@ -5,6 +5,7 @@ import { RadixAriaControlsFix } from "@/components/common/radixAriaControlsFix";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import type { KnowledgeBaseInfo } from "@/controllers/API/queries/knowledge-bases/use-get-knowledge-bases";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import KnowledgeBaseDrawer from "./components/KnowledgeBaseDrawer";
 import KnowledgeBasesTab from "./components/KnowledgeBasesTab";
 
@@ -20,6 +21,7 @@ export const KnowledgePage = () => {
     useState<KnowledgeBaseInfo | null>(null);
 
   const { t } = useTranslation();
+  useDocumentTitle(t("knowledge.pageTitle"));
   const navigate = useCustomNavigate();
   const drawerRef = useRef<HTMLDivElement>(null);
   const drawerTriggerRef = useRef<HTMLElement | null>(null);

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
@@ -22,6 +22,7 @@ import {
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useGetKnowledgeBaseChunks } from "@/controllers/API/queries/knowledge-bases/use-get-knowledge-base-chunks";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import ChunkCard from "./components/ChunkCard";
 import { ChunksMetadataFilter } from "./components/ChunksMetadataFilter";
 import { CHUNKS_PER_PAGE, PAGE_SIZE_OPTIONS } from "./constants";
@@ -29,6 +30,7 @@ import { CHUNKS_PER_PAGE, PAGE_SIZE_OPTIONS } from "./constants";
 export const SourceChunksPage = () => {
   const { t } = useTranslation();
   const { sourceId } = useParams<{ sourceId: string }>();
+  useDocumentTitle(sourceId);
   const navigate = useCustomNavigate();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageInput, setPageInput] = useState("1");

--- a/src/frontend/src/pages/Playground/index.tsx
+++ b/src/frontend/src/pages/Playground/index.tsx
@@ -7,6 +7,7 @@ import { useGetFlow } from "@/controllers/API/queries/flows/use-get-flow";
 import { CustomIOModal } from "@/customization/components/custom-new-modal";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import useAuthStore from "@/stores/authStore";
 import useFlowStore from "@/stores/flowStore";
 import { useUtilityStore } from "@/stores/utilityStore";
@@ -31,6 +32,8 @@ export default function PlaygroundPage() {
   const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
   const setIsLoading = useFlowsManagerStore((state) => state.setIsLoading);
   const setPlaygroundPage = useFlowStore((state) => state.setPlaygroundPage);
+
+  useDocumentTitle(currentSavedFlow?.name);
 
   // The route gate admits anonymous visitors so a public link resolves without
   // a session; if the server declines the link, this is where they are sent.
@@ -81,7 +84,6 @@ export default function PlaygroundPage() {
   }, []);
 
   useEffect(() => {
-    document.title = currentSavedFlow?.name || "Langflow";
     if (currentSavedFlow?.data) {
       const { inputs, outputs } = getInputsAndOutputs(
         currentSavedFlow?.data?.nodes || [],

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Outlet, type To } from "react-router-dom";
+import { Outlet, type To, useLocation } from "react-router-dom";
 import SideBarButtonsComponent from "@/components/core/sidebarComponent";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { CustomStoreSidebar } from "@/customization/components/custom-store-sidebar";
@@ -7,12 +7,14 @@ import {
   ENABLE_DATASTAX_LANGFLOW,
   ENABLE_PROFILE_ICONS,
 } from "@/customization/feature-flags";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import useAuthStore from "@/stores/authStore";
 import { useStoreStore } from "@/stores/storeStore";
 import ForwardedIconComponent from "../../components/common/genericIconComponent";
 import PageLayout from "../../components/common/pageLayout";
 export default function SettingsPage(): JSX.Element {
   const { t } = useTranslation();
+  const { pathname } = useLocation();
   const autoLogin = useAuthStore((state) => state.autoLogin);
   const hasStore = useStoreStore((state) => state.hasStore);
 
@@ -117,6 +119,13 @@ export default function SettingsPage(): JSX.Element {
     const langflowItems = CustomStoreSidebar(true);
     sidebarNavItems.splice(2, 0, ...langflowItems);
   }
+
+  // Every settings section shares this shell, so the tab title has to name the
+  // open section rather than just "Settings" (WCAG 2.4.2).
+  const activeNavItem = sidebarNavItems.find(
+    (item) => item.href && pathname.startsWith(item.href),
+  );
+  useDocumentTitle(activeNavItem?.title ?? t("settings.title"));
 
   return (
     <PageLayout

--- a/src/frontend/src/pages/SignUpPage/index.tsx
+++ b/src/frontend/src/pages/SignUpPage/index.tsx
@@ -10,6 +10,7 @@ import { CustomLink } from "@/customization/components/custom-link";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useTheme from "@/customization/hooks/use-custom-theme";
 import { track } from "@/customization/utils/analytics";
+import { useDocumentTitle } from "@/hooks/use-document-title";
 import {
   appendErrorSuggestion,
   getRequiredFieldError,
@@ -33,6 +34,7 @@ export default function SignUp(): JSX.Element {
   const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
 
   const { t } = useTranslation();
+  useDocumentTitle(t("auth.signupButton"));
   useTheme();
   const { password, cnfPassword, username } = inputState;
   const setSuccessData = useAlertStore((state) => state.setSuccessData);

--- a/src/frontend/tests/extended/features/app-shell-a11y.spec.ts
+++ b/src/frontend/tests/extended/features/app-shell-a11y.spec.ts
@@ -20,10 +20,14 @@ import { TIMEOUTS } from "../../utils/constants/timeouts";
  * Expected titles are exact so the test also catches a route silently
  * inheriting the previous route's title. Settings entries whose label already
  * carries the product name are not double-branded.
+ *
+ * `/components` is deliberately absent: with MCP enabled (the default) it has
+ * no Components tab and force-selects Flows, so it is the same page as `/flows`
+ * and correctly shares its title. The home page titles itself after the active
+ * header tab, which the Deployments test below covers.
  */
 const ROUTE_TITLES = [
   { path: "/flows", title: "Flows | Langflow" },
-  { path: "/components", title: "Components | Langflow" },
   { path: "/mcp", title: "MCP Server | Langflow" },
   { path: "/assets/files", title: "Files | Langflow" },
   { path: "/assets/knowledge-bases", title: "Knowledge | Langflow" },
@@ -55,6 +59,30 @@ test(
 
     // A per-route title is only useful if it actually distinguishes the route.
     expect(new Set(observed).size).toBe(ROUTE_TITLES.length);
+  },
+);
+
+test(
+  "switching to the Deployments tab retitles the page without a route change",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.goto("/flows");
+    await expect(page).toHaveTitle("Flows | Langflow", {
+      timeout: TIMEOUTS.standard,
+    });
+
+    // Flows and Deployments share /flows; only the header tab differs.
+    await page.getByTestId("deployments-btn").click();
+    await expect(page).toHaveURL(/\/flows\/?$/);
+    await expect(page).toHaveTitle("Deployments | Langflow", {
+      timeout: TIMEOUTS.standard,
+    });
+
+    await page.getByTestId("flows-btn").click();
+    await expect(page).toHaveTitle("Flows | Langflow", {
+      timeout: TIMEOUTS.standard,
+    });
   },
 );
 

--- a/src/frontend/tests/extended/features/app-shell-a11y.spec.ts
+++ b/src/frontend/tests/extended/features/app-shell-a11y.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
+
+/**
+ * App-shell accessibility regression tests.
+ *
+ * WCAG 2.4.2 Page Titled — every route must set a `document.title` that names
+ *   the page, so routes are distinguishable in tabs, history and AT window lists.
+ * WCAG 3.1.1 Language of Page — `<html lang>` must track the selected i18n locale.
+ * WCAG 2.4.1 Bypass Blocks — exactly one `<main>` landmark per route, including
+ *   while a modal is open (a nested `<main>` breaks landmark navigation).
+ *
+ * Before the app-shell fix all three fail: every route rendered the generic
+ * "Langflow" title, `lang` stayed `en` for every locale, and the templates
+ * modal added a second `<main>` on top of the page's own.
+ */
+
+/**
+ * Expected titles are exact so the test also catches a route silently
+ * inheriting the previous route's title. Settings entries whose label already
+ * carries the product name are not double-branded.
+ */
+const ROUTE_TITLES = [
+  { path: "/flows", title: "Flows | Langflow" },
+  { path: "/components", title: "Components | Langflow" },
+  { path: "/mcp", title: "MCP Server | Langflow" },
+  { path: "/assets/files", title: "Files | Langflow" },
+  { path: "/assets/knowledge-bases", title: "Knowledge | Langflow" },
+  { path: "/settings/general", title: "General | Langflow" },
+  { path: "/settings/global-variables", title: "Global Variables | Langflow" },
+  { path: "/settings/api-keys", title: "Langflow API Keys" },
+  { path: "/settings/mcp-servers", title: "MCP Servers | Langflow" },
+  { path: "/settings/shortcuts", title: "Shortcuts | Langflow" },
+  { path: "/settings/messages", title: "Messages | Langflow" },
+] as const;
+
+test(
+  "every route sets a document title that names the page",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    const observed: string[] = [];
+    for (const route of ROUTE_TITLES) {
+      await page.goto(route.path);
+      await expect(page).toHaveURL(new RegExp(`${route.path}/?$`), {
+        timeout: TIMEOUTS.standard,
+      });
+      await expect(page).toHaveTitle(route.title, {
+        timeout: TIMEOUTS.standard,
+      });
+      observed.push(await page.title());
+    }
+
+    // A per-route title is only useful if it actually distinguishes the route.
+    expect(new Set(observed).size).toBe(ROUTE_TITLES.length);
+  },
+);
+
+test(
+  "the flow editor titles the tab with the flow name",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("list-card").first().click();
+    await expect(page).toHaveURL(/\/flow\//, { timeout: TIMEOUTS.standard });
+
+    // The header shows a placeholder name until the flow resolves, so poll
+    // until the heading and the tab title agree.
+    await expect(async () => {
+      const flowName = (await page.getByTestId("flow_name").innerText()).trim();
+      expect(flowName.length).toBeGreaterThan(0);
+      await expect(page).toHaveTitle(`${flowName} | Langflow`, {
+        timeout: 2000,
+      });
+    }).toPass({ timeout: TIMEOUTS.standard });
+  },
+);
+
+test(
+  "the html lang attribute follows the selected locale",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.goto("/settings/general");
+
+    const html = page.locator("html");
+    await expect(html).toHaveAttribute("lang", "en");
+
+    await page.getByLabel("Select language").click();
+    await page.getByRole("option", { name: "日本語" }).click();
+    await expect(html).toHaveAttribute("lang", "ja", {
+      timeout: TIMEOUTS.standard,
+    });
+
+    // The attribute must survive a reload, since the preference is persisted.
+    await page.reload();
+    await expect(html).toHaveAttribute("lang", "ja", {
+      timeout: TIMEOUTS.standard,
+    });
+  },
+);
+
+test(
+  "each route exposes exactly one main landmark",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    for (const route of ROUTE_TITLES) {
+      await page.goto(route.path);
+      await expect(page).toHaveURL(new RegExp(`${route.path}/?$`), {
+        timeout: TIMEOUTS.standard,
+      });
+      await expect(page.locator("main"), route.path).toHaveCount(1);
+    }
+  },
+);
+
+test(
+  "the templates modal does not nest a second main landmark",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    // Opens a new flow and the templates modal on top of the flow canvas,
+    // which already owns the page's single <main>.
+    await awaitBootstrapTest(page);
+    await expect(page.getByTestId("modal-title")).toBeVisible({
+      timeout: TIMEOUTS.standard,
+    });
+
+    await expect(page.locator("main")).toHaveCount(1);
+  },
+);


### PR DESCRIPTION
Every route in the app shared one browser tab title: "Langflow". You could not tell three open Langflow tabs apart, browser history was a wall of identical entries, and a screen reader's window list said nothing useful. Only the shared playground bothered to set a title.

Two smaller shell problems came along for the ride: `index.html` hard-codes `lang="en"` and nothing ever updated it, so switching to any of the six translated locales left the page claiming to be English — screen readers then read Japanese or German with English pronunciation rules. And two modals rendered their own `<main>` on top of the page's, so landmark navigation saw two "main" regions and could not tell you which one held the content.

## What changed

A `useDocumentTitle` hook now names the tab after the page, and every route calls it — lists, files, knowledge bases, all settings sections, the flow editor (the flow's name), the auth pages, and the playground. Each call passes the string the page already renders as its own heading, so there are no new translation keys and the tab can never drift from the visible title. The title resets on unmount, so a route that forgets to call it shows the product name rather than inheriting whatever the last route set.

`i18n.ts` now applies the detected locale to `documentElement.lang` at startup and subscribes to `languageChanged`, so the attribute tracks the language picker.

The two modal `<main>` elements became `<div>`. Swept the rest of the shell to be sure this was the whole problem: `PageLayout` renders no `<main>`, and the one in `SidebarInset` is dead code — so every route has exactly one, asserted across 11 routes in the new spec.

Deliberately **not** adding a skip link. 2.4.1 Bypass Blocks is satisfied by the landmarks the shell already exposes (ARIA11), and a skip link is a visible UI addition that wants design input first.

## Before / after

Browser tab chrome cannot be screenshotted, so each capture has the live DOM values painted into the frame and `<main>` landmarks outlined in red.

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/before-03-lang-japanese.png" alt="Settings page rendered entirely in Japanese while the html lang attribute still reads en and the tab title is the generic Langflow" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/after-03-lang-japanese.png" alt="Same Japanese settings page with html lang set to ja and the tab title reading 一般 pipe Langflow" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/before-04-main-landmarks-templates-modal.png" alt="Templates modal over the flow canvas with two main landmarks counted and both outlined in red" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/after-04-main-landmarks-templates-modal.png" alt="Same templates modal with a single main landmark counted, the modal panel no longer outlined" width="100%"></td>
</tr>
</table>

<details>
<summary>Two routes, one indistinguishable title</summary>

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/before-01-title-flows.png" alt="Flows list page with the tab title reading Langflow" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/after-01-title-flows.png" alt="Flows list page with the tab title reading Flows pipe Langflow" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/before-02-title-settings-api-keys.png" alt="API keys settings page with the same generic Langflow tab title as the flows list" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-a11y-app-shell/after-02-title-settings-api-keys.png" alt="API keys settings page with the tab title reading Langflow API Keys" width="100%"></td>
</tr>
</table>

</details>

## Testing

`src/frontend/tests/extended/features/app-shell-a11y.spec.ts` — five tests covering per-route titles, the flow-editor title, `<html lang>` across a locale switch and a reload, one `<main>` per route, and one `<main>` with the templates modal open. Four of the five fail on `release-1.12.0` and all five pass here; the fifth (one `<main>` per plain route) passes on both, which is how we confirmed only the modals nested one.

Also `src/hooks/__tests__/use-document-title.test.ts` for the hook's formatting and unmount behaviour. `templatesModal.a11y.test.tsx` had an assertion requiring the modal to *have* a `main` landmark — it asserted the bug, so it is now inverted.

Full frontend Jest suite green (600 suites / 6555 tests). IBM Equal Access static-route scan clean on all 14 canonical routes, no new violations.

## Reviewer notes

Titles read `"<page> | Langflow"`, except where the page's own name already carries the product name — the settings entries "Langflow API Keys" and "Langflow MCP Client" are used as-is rather than becoming "Langflow API Keys | Langflow".

Adjacent PR: #13674 (ko locale) also touches `i18n.ts`. The two changes are in different parts of the file and this one is additive, so whichever lands second rebases cleanly.

Flips three rows on the Web UI accessibility checklist from Partial to Yes: 2.4.2 Page Titled, 3.1.1 Language of Page, 2.4.1 Bypass Blocks.

Jira: [LE-2234](https://datastax.jira.com/browse/LE-2234)


[LE-2234]: https://datastax.jira.com/browse/LE-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added branded, localized browser titles across login, signup, settings, files, knowledge, flow, playground, and home pages.
  - Browser titles now update when the active flow or knowledge source changes and reset appropriately when leaving a page.
  - The document language attribute now stays synchronized with the selected locale.

- **Accessibility**
  - Improved landmark structure by preventing nested `<main>` regions in templates and tools modals.
  - Added regression coverage for page titles, language updates, and landmark behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->