### PR TITLE
fix(ci): stop uv run from half-reverting the bundle install it runs against

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -196,12 +196,19 @@ jobs:
           # the in-repo bundle so the guards pass here too.
           uv sync --dev --extra otel
           uv pip install "../bundles/lfx-bundles[all-no-torch]"
-          uv run python -c "import lfx_bundles; print('lfx_bundles', lfx_bundles.__file__)"
+          # --no-sync from here on: the install above is deliberately outside the lock, and
+          # a plain `uv run` re-syncs the environment to uv.lock. That reverts the lock-managed
+          # packages the bundle install upgraded while leaving the injected ones alone, which
+          # leaves an environment neither resolution ever produced. It bit us the day
+          # langchain-openai 1.5.2 shipped: the bundle install brought openai 1.5.2 with
+          # langchain-core 1.5.6, `uv run` put core back to the locked 1.5.1, and the pair
+          # failed to import. Both resolutions were fine; only the mix was not.
+          uv run --no-sync python -c "import lfx_bundles; print('lfx_bundles', lfx_bundles.__file__)"
           printf 'Running %d bundle-guarded lfx test file(s):\n' "${#guarded[@]}"
           printf '  %s\n' "${guarded[@]}"
           # No --timeout: pytest-timeout is not in lfx's dev group (pytest, pytest-asyncio,
           # pytest-cov only), and `make lfx_tests` does not pass one either.
-          uv run pytest "${guarded[@]}" -v -m "not api_key_required"
+          uv run --no-sync pytest "${guarded[@]}" -v -m "not api_key_required"
 
   integration-tests:
     name: Integration Tests - Python ${{ matrix.python-version }}


### PR DESCRIPTION
## What

The `Unit Tests (bundles installed)` job has been failing on every run started after 2026-08-18 17:37Z with:

```
ImportError: cannot import name 'GATEWAY_METADATA_RESPONSE_KEY' from 'langchain_core.utils._gateway'
```

This adds `--no-sync` to the two `uv run` invocations that follow the deliberate out-of-lock bundle install in the lfx step.

## Why this, and not a version pin

The tempting read is "langchain-openai 1.5.2 is broken." It isn't — 1.5.2 works fine against langchain-core 1.5.6, which is what it asks for and what the bundle install resolves.

The problem is that the step builds an environment and then `uv run` partially unbuilds it:

1. `uv sync --dev --extra otel` → langchain-core **1.5.1** (from `uv.lock`)
2. `uv pip install "../bundles/lfx-bundles[all-no-torch]"` → resolves outside the lock, giving langchain-openai **1.5.2** and upgrading core to **1.5.6**. Coherent.
3. `uv run …` re-syncs to `uv.lock` — reverting core to **1.5.1** while leaving the pip-injected openai **1.5.2** in place.
4. openai 1.5.2 against core 1.5.1 cannot import: it reads `GATEWAY_METADATA_RESPONSE_KEY`, added in core 1.5.6.

The tests run against a combination neither resolution ever produced. Before 1.5.2 shipped, the unpinned resolve gave openai 1.5.1, which works against core 1.5.1, so the same re-vert was harmless and the job stayed green. Pinning `langchain-openai!=1.5.2` would restore green today and break again on the next release needing a newer core, so the mix is what gets fixed.

`cross-bundle-test.yml` performs the same out-of-lock install but invokes `.venv/bin/python -m pytest` directly — nothing re-syncs, so it is not exposed and needs no change.

## Test plan

Reproduced the failing job locally from `src/lfx`, running the exact step sequence:

| | after bundle install | after test command | result |
|---|---|---|---|
| `uv run` (before) | openai 1.5.2 / core 1.5.6 | openai 1.5.2 / core **1.5.1** | 1 failed, 7 passed — identical `ImportError` |
| `uv run --no-sync` (after) | openai 1.5.2 / core 1.5.6 | openai 1.5.2 / core **1.5.6** | **8 passed** |

- [x] Failure reproduces locally with the current workflow command
- [x] `--no-sync` keeps the environment coherent and the suite passes
- [ ] `Unit Tests (bundles installed)` green on this PR (3.10 and 3.14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution reliability by preventing unintended environment synchronization after bundle installation.
  * Updated import validation and test commands to use the existing environment consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->