### PR TITLE
fix: Handle duplicate name in flows batch create with 409 response

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -23,6 +23,7 @@ from lfx.utils.flow_validation import (
 )
 from pydantic import ValidationError
 from sqlalchemy import case
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import and_, col, select
 
 from langflow.api.utils import (
@@ -1018,7 +1019,18 @@ async def create_flows(
         session.add(db_flow)
         db_flows.append(db_flow)
 
-    await session.flush()
+    # Unlike create_flow/upsert_flow, this endpoint does not route through
+    # _new_flow, so a (user_id, name)/(user_id, endpoint_name) collision reaches
+    # the flush unhandled. Left un-rolled-back on SQLite, the failed INSERT pins
+    # the write lock and the next writer busy-waits busy_timeout (30s) before its
+    # own "database is locked"; the raw error would also leak the SQL statement
+    # and bound parameters. Roll back to release the lock immediately, then map
+    # to a clean 409.
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise _handle_unique_constraint_error(exc, status_code=409) from exc
     for db_flow in db_flows:
         await session.refresh(db_flow)
 

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -492,6 +492,41 @@ async def test_create_flows(client: AsyncClient, json_flow: str, logged_in_heade
 
 
 @pytest.mark.usefixtures("session")
+async def test_create_flows_duplicate_name_returns_clean_409(client: AsyncClient, json_flow: str, logged_in_headers):
+    """A (user_id, name) collision in the batch endpoint must surface as a clean 409.
+
+    Regression: the duplicate INSERT used to reach ``session.flush()`` unhandled, leaking the raw
+    SQL statement and bound parameters and — un-rolled-back on SQLite — pinning the write lock so
+    the next writer busy-waited ``busy_timeout`` before "database is locked". The endpoint now rolls
+    back and maps the violation, so the error is fast and the session stays usable.
+    """
+    flow = orjson.loads(json_flow)
+    data = flow["data"]
+    taken_name = str(uuid4())
+
+    # Seed the name once.
+    seed = FlowListCreate(flows=[FlowCreate(name=taken_name, description="seed", data=data)])
+    seed_response = await client.post("api/v1/flows/batch/", json=seed.dict(), headers=logged_in_headers)
+    assert seed_response.status_code == 201
+
+    # Re-inserting the same name collides on UNIQUE(user_id, name).
+    dup = FlowListCreate(flows=[FlowCreate(name=taken_name, description="dup", data=data)])
+    dup_response = await client.post("api/v1/flows/batch/", json=dup.dict(), headers=logged_in_headers)
+    assert dup_response.status_code == 409
+    assert dup_response.json()["detail"] == "Name must be unique"
+    # No SQLAlchemy statement / bound parameters / driver hint may leak to the client.
+    body = dup_response.text.lower()
+    assert "insert into" not in body
+    assert "sqlalche.me" not in body
+    assert "user_id" not in body
+
+    # The session was rolled back (lock released), so a fresh write still succeeds immediately.
+    follow_up = FlowListCreate(flows=[FlowCreate(name=str(uuid4()), description="after", data=data)])
+    follow_up_response = await client.post("api/v1/flows/batch/", json=follow_up.dict(), headers=logged_in_headers)
+    assert follow_up_response.status_code == 201
+
+
+@pytest.mark.usefixtures("session")
 async def test_upload_file(client: AsyncClient, json_flow: str, logged_in_headers):
     flow = orjson.loads(json_flow)
     data = flow["data"]


### PR DESCRIPTION
### Description 
The POST /flows/batch/ endpoint constructs Flow rows directly instead of
going through _new_flow, which pre-deduplicates names. A duplicate name or
endpoint therefore reaches session.flush() as an unhandled
UNIQUE(user_id, name)/(user_id, endpoint_name) violation.

On SQLite the failed INSERT is never rolled back, so it keeps the write lock
held: the next writer busy-waits the full busy_timeout (30s) and then fails
with "database is locked". A duplicate surfaces as a timeout rather than a
clear error, and the unhandled exception also exposes the SQL statement and
bound parameters to the caller.

Catch IntegrityError, roll back to release the lock immediately, and map the
violation to a 409 via _handle_unique_constraint_error (matching upsert_flow).
Add a regression test covering the 409, the absence of leaked SQL, and that
the session stays usable for the next write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate flow names now return a clear conflict message instead of exposing database errors.
  * Failed duplicate creations properly roll back, allowing subsequent changes to succeed.
  * Improved protection of sensitive database details in error responses.

* **Tests**
  * Added coverage to verify duplicate-name handling, sanitized responses, and successful recovery after a conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->