### PR TITLE
fix(security): bind every cmd.exe execution switch to the MCP stdio wrapper allow-list

### DIFF
--- a/src/lfx/src/lfx/base/mcp/security.py
+++ b/src/lfx/src/lfx/base/mcp/security.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lfx.base.mcp.source_policy import (
+    is_cmd_exec_flag,
     parse_mcp_shell_wrapper,
     validate_mcp_stdio_source_policy,
 )
@@ -201,7 +202,10 @@ DOCKER_DANGEROUS_SECURITY_OPT_SUBSTRINGS = ("unconfined", "disable")
 # SECURITY: Shell wrapper commands that can execute other commands.
 SHELL_WRAPPERS = frozenset({"cmd", "sh", "bash"})
 
-# SECURITY: Shell command flags that execute code.
+# SECURITY: Shell command flags that execute code. cmd.exe accepts more spellings than ``/c``
+# (``/k``, ``/r``, and clustered forms such as ``/q/k``); those are recognized by
+# ``is_cmd_exec_flag`` rather than listed here, because a bare ``/k`` token is a legitimate
+# path operand for the non-cmd commands that also consult this set.
 SHELL_EXEC_FLAGS = frozenset({"-c", "/c"})
 MAX_SHELL_WRAPPER_DEPTH = 4
 
@@ -212,16 +216,24 @@ HARDENED_ALLOWED_PYTHON_MODULES = frozenset({"langflow.agentic.mcp", "langflow.a
 PYTHON_MODULE_MIN_ARGS = 2
 
 
-def _is_shell_exec_flag(arg: str) -> bool:
+def _is_shell_exec_flag(arg: str, base_command: str = "") -> bool:
+    """Return whether *arg* makes the shell wrapper execute the tokens that follow it.
+
+    ``base_command`` selects the cmd.exe switch grammar (``/c``, ``/k``, ``/r``, and clustered
+    forms such as ``/q/k``). It is opt-in because a ``/``-prefixed token is an ordinary path
+    operand for every other command that consults this helper.
+    """
     arg_lower = arg.lower()
     if arg_lower in SHELL_EXEC_FLAGS:
+        return True
+    if base_command == "cmd" and is_cmd_exec_flag(arg_lower):
         return True
     return arg_lower.startswith("-") and not arg_lower.startswith("--") and "c" in arg_lower[1:]
 
 
-def _has_leading_shell_exec_flag(args: list[str]) -> bool:
+def _has_leading_shell_exec_flag(args: list[str], base_command: str = "") -> bool:
     """Return whether a shell execution flag appears before every script operand."""
-    return bool(args) and _is_shell_exec_flag(args[0])
+    return bool(args) and _is_shell_exec_flag(args[0], base_command)
 
 
 class MCPStdioSecurityError(ValueError):
@@ -313,7 +325,7 @@ def _validate_interpreter_invocation(base_command: str, args: list[str], *, hard
     if not hardened:
         return
     if base_command in SHELL_WRAPPERS:
-        if _has_leading_shell_exec_flag(args):
+        if _has_leading_shell_exec_flag(args, base_command):
             return
         msg = (
             f"Shell command '{base_command}' must wrap an approved MCP command when "
@@ -543,14 +555,14 @@ def validate_mcp_stdio_config(
         # single-dash token here would misclassify valid uvx values such as
         # ``-wmcp-proxy`` merely because the package name contains a ``c``.
         checks_code_exec_flags = base_command in SHELL_WRAPPERS | {"python", "python3"}
-        has_shell_exec_flag = checks_code_exec_flags and any(_is_shell_exec_flag(arg) for arg in args)
+        has_shell_exec_flag = checks_code_exec_flags and any(_is_shell_exec_flag(arg, base_command) for arg in args)
 
         if has_shell_exec_flag and base_command not in SHELL_WRAPPERS:
             msg = f"Flag -c or /c is only allowed with shell wrappers (cmd/sh/bash), not with '{base_command}'"
             raise MCPStdioSecurityError(msg)
 
         if base_command in SHELL_WRAPPERS:
-            wrapped_command = args[1] if _has_leading_shell_exec_flag(args) and len(args) > 1 else None
+            wrapped_command = args[1] if _has_leading_shell_exec_flag(args, base_command) and len(args) > 1 else None
             wrapped_args = args[2:] if wrapped_command else []
 
             if wrapped_command:

--- a/src/lfx/src/lfx/base/mcp/security.py
+++ b/src/lfx/src/lfx/base/mcp/security.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lfx.base.mcp.source_policy import (
+    has_leading_cmd_exec_flag,
     is_cmd_exec_flag,
     parse_mcp_shell_wrapper,
     validate_mcp_stdio_source_policy,
@@ -233,7 +234,11 @@ def _is_shell_exec_flag(arg: str, base_command: str = "") -> bool:
 
 def _has_leading_shell_exec_flag(args: list[str], base_command: str = "") -> bool:
     """Return whether a shell execution flag appears before every script operand."""
-    return bool(args) and _is_shell_exec_flag(args[0], base_command)
+    if not args:
+        return False
+    if extract_base_command(base_command) == "cmd":
+        return has_leading_cmd_exec_flag(args)
+    return _is_shell_exec_flag(args[0], base_command)
 
 
 class MCPStdioSecurityError(ValueError):
@@ -562,8 +567,25 @@ def validate_mcp_stdio_config(
             raise MCPStdioSecurityError(msg)
 
         if base_command in SHELL_WRAPPERS:
-            wrapped_command = args[1] if _has_leading_shell_exec_flag(args, base_command) and len(args) > 1 else None
-            wrapped_args = args[2:] if wrapped_command else []
+            # Derive the payload from the parsed wrapper rather than a fixed argv index:
+            # cmd.exe allows benign switches ahead of the execution switch ("/d /c uvx ..."),
+            # so args[1] would be "/c" there and this gate would report "cannot execute 'c'".
+            # ``_has_leading_shell_exec_flag`` still guards the position, so a script operand
+            # cannot precede the execution switch.
+            wrapped_command = None
+            wrapped_args: list[str] = []
+            if _has_leading_shell_exec_flag(args, base_command) and len(args) > 1:
+                # cmd.exe allows benign switches ahead of the execution switch ("/d /c uvx ..."),
+                # so a fixed args[1] would be "/c" and this gate would report "cannot execute 'c'".
+                # Only cmd needs the parsed payload: sh/bash carry their whole command in one
+                # argument ("sh -c 'id > /tmp/x'"), and splitting that here would let the gate
+                # inspect only the first token instead of the full command string.
+                parsed_wrapper = parse_mcp_shell_wrapper(base_command, args) if base_command == "cmd" else None
+                if parsed_wrapper is not None:
+                    wrapped_command, wrapped_args = parsed_wrapper
+                else:
+                    wrapped_command = args[1]
+                    wrapped_args = args[2:]
 
             if wrapped_command:
                 wrapped_base = extract_base_command(wrapped_command)

--- a/src/lfx/src/lfx/base/mcp/source_policy.py
+++ b/src/lfx/src/lfx/base/mcp/source_policy.py
@@ -150,6 +150,16 @@ DOCKER_HARDENED_NETWORK_FLAGS = frozenset({"--net", "--network"})
 DOCKER_SAFE_NETWORK_VALUES = frozenset({"none", "bridge", "default"})
 SHELL_CONTROL_CHARS = frozenset({";", "|", "&", "$", "`", "<", ">", "\n", "\r"})
 
+# cmd.exe switches that do NOT run the rest of the command line. ``/c`` is not the only
+# executing switch: ``/k`` runs the command and keeps the session alive, and ``/r`` is an
+# undocumented synonym of ``/c``. Boolean switches may also be clustered ahead of the
+# executing one (``/q/k``), and a switch may carry a value (``/t:0a``).
+#
+# The set is inverted deliberately: anything outside it is treated as executing, so a switch
+# this module does not know about fails safe (the wrapped payload still gets bound to the
+# command allowlist) instead of silently skipping the wrapper check.
+CMD_NON_EXEC_SWITCH_LETTERS = frozenset({"a", "d", "e", "f", "q", "s", "t", "u", "v"})
+
 HARDENED_ALLOWED_PYTHON_MODULES = frozenset({"langflow.agentic.mcp", "langflow.agentic.mcp.server"})
 PYTHON_MODULE_MIN_ARGS = 2
 
@@ -560,7 +570,7 @@ def _validate_interpreter_invocation(base_command: str, args: list[str], *, hard
     if base_command in {"sh", "bash", "cmd"}:
         first_arg = args[0].lower() if args else ""
         has_leading_exec_flag = (
-            first_arg == "/c"
+            is_cmd_exec_flag(first_arg)
             if base_command == "cmd"
             else first_arg.startswith("-") and not first_arg.startswith("--") and "c" in first_arg[1:]
         )
@@ -678,13 +688,23 @@ def _parse_shell_payload(command: str, payload: str) -> tuple[str, list[str]]:
     return parts[0], parts[1:]
 
 
+def is_cmd_exec_flag(arg: str) -> bool:
+    """Return whether a cmd.exe switch token makes cmd execute the rest of its argv."""
+    arg_lower = arg.lower()
+    if not arg_lower.startswith("/"):
+        return False
+    # ``/q/k`` packs several switches into one token and a switch may carry a value
+    # (``/t:0a``), so only the leading letter of each part identifies the switch.
+    return any(part[:1] not in CMD_NON_EXEC_SWITCH_LETTERS for part in arg_lower.split("/") if part)
+
+
 def parse_mcp_shell_wrapper(command: str, args: list[str]) -> tuple[str, list[str]] | None:
     """Return a shell wrapper's canonical executable and argv payload."""
     command = _base_command(command)
     for index, arg in enumerate(args):
         arg_lower = arg.lower()
         if command == "cmd":
-            if arg_lower != "/c" or index + 1 >= len(args):
+            if not is_cmd_exec_flag(arg_lower) or index + 1 >= len(args):
                 continue
             payload = args[index + 1 :]
             if any(char in " ".join(payload) for char in SHELL_CONTROL_CHARS):

--- a/src/lfx/src/lfx/base/mcp/source_policy.py
+++ b/src/lfx/src/lfx/base/mcp/source_policy.py
@@ -570,7 +570,7 @@ def _validate_interpreter_invocation(base_command: str, args: list[str], *, hard
     if base_command in {"sh", "bash", "cmd"}:
         first_arg = args[0].lower() if args else ""
         has_leading_exec_flag = (
-            is_cmd_exec_flag(first_arg)
+            has_leading_cmd_exec_flag(args)
             if base_command == "cmd"
             else first_arg.startswith("-") and not first_arg.startswith("--") and "c" in first_arg[1:]
         )
@@ -696,6 +696,24 @@ def is_cmd_exec_flag(arg: str) -> bool:
     # ``/q/k`` packs several switches into one token and a switch may carry a value
     # (``/t:0a``), so only the leading letter of each part identifies the switch.
     return any(part[:1] not in CMD_NON_EXEC_SWITCH_LETTERS for part in arg_lower.split("/") if part)
+
+
+def has_leading_cmd_exec_flag(args: list[str]) -> bool:
+    """Whether a cmd.exe execution switch precedes every operand.
+
+    cmd.exe accepts benign switches ahead of the execution switch (``/d /c uvx ...``),
+    and a switch may carry a value (``/t:0a``). Those are skipped. Scanning stops at the
+    first token that is not a switch, so a script operand can never precede the execution
+    switch and be mistaken for a validated wrapper -- ``parse_mcp_shell_wrapper`` alone is
+    not sufficient here because it skips non-switch tokens while searching.
+    """
+    for arg in args:
+        arg_lower = arg.lower()
+        if not arg_lower.startswith("/"):
+            return False
+        if is_cmd_exec_flag(arg_lower):
+            return True
+    return False
 
 
 def parse_mcp_shell_wrapper(command: str, args: list[str]) -> tuple[str, list[str]] | None:

--- a/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
+++ b/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
@@ -778,3 +778,54 @@ async def test_update_tools_injects_bound_user_for_agentic_server():
         {},
         current_user_id=user_id,
     )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["/c", "uvx", "mcp-proxy"], id="bare-exec-switch"),
+        pytest.param(["/d", "/c", "uvx", "mcp-proxy"], id="benign-switch-before-exec"),
+        pytest.param(["/q", "/c", "uvx", "mcp-proxy"], id="another-benign-switch-before-exec"),
+        pytest.param(["/t:0a", "/c", "uvx", "mcp-proxy"], id="value-bearing-benign-switch-before-exec"),
+        pytest.param(["/d", "/q", "/c", "uvx", "mcp-proxy"], id="two-benign-switches-before-exec"),
+        pytest.param(["/q/k", "uvx", "mcp-proxy"], id="clustered-benign-and-exec"),
+    ],
+)
+def test_cmd_benign_switches_may_precede_the_exec_switch_under_hardening(args):
+    """cmd.exe accepts benign switches ahead of the execution switch, and so must we.
+
+    Both policy layers previously inspected ``args[0]`` only, so ``cmd /d /c uvx ...`` --
+    a legitimate configuration -- was rejected under interpreter hardening even though the
+    wrapped command is allow-listed.
+    """
+    validate_mcp_stdio_config("cmd", args, {}, interpreter_hardening=True)
+
+
+def test_cmd_operand_before_exec_switch_is_not_a_validated_wrapper():
+    """A non-switch operand ahead of the execution switch must not pass hardening.
+
+    ``parse_mcp_shell_wrapper`` skips any token that is not an execution switch while it
+    searches, so it alone would accept this shape. The leading-switch scan is what keeps a
+    script operand from preceding the execution switch.
+    """
+    with pytest.raises(MCPStdioSecurityError, match="INTERPRETER_HARDENING"):
+        validate_mcp_stdio_config(
+            "cmd",
+            ["foo.bat", "/c", "uvx", "mcp-proxy"],
+            {},
+            interpreter_hardening=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["/d", "/c", "whoami"], id="benign-then-c"),
+        pytest.param(["/d", "/k", "whoami"], id="benign-then-k"),
+        pytest.param(["/q/k", "whoami"], id="clustered"),
+    ],
+)
+def test_cmd_benign_switch_prefix_still_binds_payload_to_the_allow_list(args):
+    """Allowing a benign prefix must not let the wrapped payload escape the allow-list."""
+    with pytest.raises(MCPStdioSecurityError):
+        validate_mcp_stdio_config("cmd", args, {})

--- a/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
+++ b/src/lfx/tests/unit/mcp/test_mcp_stdio_security.py
@@ -393,6 +393,57 @@ def test_python_attached_code_flag_is_still_rejected():
         validate_mcp_stdio_config("python", ["-cpass"], {})
 
 
+# ``cmd /c`` is not the only way cmd.exe runs a command line: ``/k`` runs it and keeps the
+# session alive, ``/r`` is an undocumented synonym of ``/c``, and boolean switches may be
+# clustered ahead of the executing switch (``/q/k``). Every spelling must bind the wrapped
+# payload to the command allowlist exactly like ``/c`` does, otherwise the wrapper check is
+# skipped and cmd.exe launches an arbitrary executable.
+CMD_EXEC_SWITCHES = ["/c", "/C", "/k", "/K", "/r", "/R", "/q/k", "/s/k", "/d/k", "/Q/K"]
+
+
+@pytest.mark.parametrize("switch", CMD_EXEC_SWITCHES)
+def test_cmd_exec_switches_bind_wrapped_command_to_allowlist(switch):
+    with pytest.raises(MCPStdioSecurityError, match="Shell wrapper 'cmd' cannot execute 'whoami'"):
+        validate_mcp_stdio_config("cmd", [switch, "whoami"], {})
+
+
+@pytest.mark.parametrize("switch", CMD_EXEC_SWITCHES)
+def test_cmd_exec_switches_bind_wrapped_payload_to_package_allowlist(switch):
+    with pytest.raises(MCPStdioSecurityError, match="not allowed for MCP npx"):
+        validate_mcp_stdio_config(
+            "cmd",
+            [switch, "npx", "@attacker/owned-package"],
+            {},
+            allowed_packages={"mcp-proxy"},
+        )
+
+
+@pytest.mark.parametrize("switch", CMD_EXEC_SWITCHES)
+def test_cmd_exec_switches_bind_wrapped_payload_to_interpreter_hardening(switch):
+    with pytest.raises(MCPStdioSecurityError, match="INTERPRETER_HARDENING"):
+        validate_mcp_stdio_config(
+            "cmd",
+            [switch, "node", "C:\\Users\\attacker\\server.js"],
+            {},
+            interpreter_hardening=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["/c", "uvx", "mcp-server-fetch"],
+        ["/k", "uvx", "mcp-server-fetch"],
+        ["/q", "/c", "uvx", "mcp-server-fetch"],
+        ["/d", "/k", "uvx", "mcp-server-fetch"],
+        ["/e:on", "/c", "uvx", "mcp-server-fetch"],
+        ["/t:0a", "/k", "uvx", "mcp-server-fetch"],
+    ],
+)
+def test_cmd_wrapper_preserves_allowed_payload_behind_benign_switches(args):
+    validate_mcp_stdio_config("cmd", args, {})
+
+
 @pytest.mark.parametrize(
     "args",
     [

--- a/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
+++ b/src/lfx/tests/unit/mcp/test_stdio_source_policy.py
@@ -2,6 +2,7 @@ import pytest
 from lfx.base.mcp.security import validate_mcp_stdio_config
 from lfx.base.mcp.source_policy import (
     is_package_manager_config_env_var,
+    parse_mcp_shell_wrapper,
     validate_mcp_stdio_source_policy,
 )
 
@@ -299,6 +300,21 @@ def test_npx_noninteractive_flag_remains_allowed_by_shared_policy():
 def test_interpreter_hardening_rejects_tenant_selected_code(command, args):
     with pytest.raises(ValueError, match=r"not allowed"):
         validate_mcp_stdio_source_policy(command, args, interpreter_hardening=True)
+
+
+@pytest.mark.parametrize("switch", ["/c", "/C", "/k", "/K", "/r", "/R", "/q/k", "/s/k", "/d/k"])
+def test_cmd_wrapper_parser_recognises_every_execution_switch(switch):
+    """Every cmd.exe switch that runs a command line must expose the wrapped payload.
+
+    The parser result is what binds a wrapper to the command allowlist; returning ``None``
+    silently skips that check for the switch in question.
+    """
+    assert parse_mcp_shell_wrapper("cmd", [switch, "whoami"]) == ("whoami", [])
+
+
+@pytest.mark.parametrize("switch", ["/a", "/d", "/e:on", "/f:off", "/q", "/s", "/t:0a", "/u", "/v:on"])
+def test_cmd_wrapper_parser_skips_switches_that_do_not_execute(switch):
+    assert parse_mcp_shell_wrapper("cmd", [switch, "/c", "uvx", "mcp-proxy"]) == ("uvx", ["mcp-proxy"])
 
 
 def test_interpreter_hardening_preserves_authenticated_agentic_module():


### PR DESCRIPTION
## Summary

MCP stdio server configs may name a shell wrapper (`cmd` / `sh` / `bash`) only when that wrapper runs another allow-listed command. The binding between a wrapper and the command allow-list is established by `parse_mcp_shell_wrapper()` in `src/lfx/src/lfx/base/mcp/source_policy.py`, which treated `/c` as cmd.exe's only command-execution switch.

cmd.exe has more than one. `/k` runs a command line and keeps the session alive, `/r` behaves as a synonym of `/c`, and boolean switches may be clustered ahead of the executing switch (for example `/q/k`). For any of those spellings the parser returned `None`, and **both** gates that depend on its result were skipped in `validate_mcp_stdio_config()`:

- the inline `Shell wrapper '<w>' cannot execute '<x>'` allow-list check, which is reached only via `_has_leading_shell_exec_flag()`, and
- the recursive `validate_mcp_stdio_config()` call on the wrapped payload.

The checks that still ran (shell-metacharacter scan, dangerous-keyword scan) do not constrain a plain executable name or path, so a wrapper config naming a non-allow-listed executable validated successfully and reached the stdio spawn sink. Impact is limited to Windows hosts, where cmd.exe is the process actually parsing the switch. The equivalent `sh` / `bash` shapes were already rejected, which is what identified this as an oversight in the cmd branch rather than intended policy.

## Changes

**`src/lfx/src/lfx/base/mcp/source_policy.py`**
- New `is_cmd_exec_flag()` plus `CMD_NON_EXEC_SWITCH_LETTERS`. The set is deliberately inverted: only cmd.exe's known non-executing switches (`/a /d /e /f /q /s /t /u /v`) are treated as non-executing, and everything else in a `/`-prefixed switch token counts as executing. A switch this module does not know about therefore fails safe — the payload still gets bound to the command allow-list instead of silently skipping the wrapper check. Value-carrying (`/t:0a`) and clustered (`/q/k`) switch tokens are both handled.
- `parse_mcp_shell_wrapper()` uses it, so the wrapped payload is extracted for every executing switch and the recursive validation runs again.
- The leading-exec-flag test inside `_validate_interpreter_invocation()` uses the same helper.

**`src/lfx/src/lfx/base/mcp/security.py`**
- `_is_shell_exec_flag()` / `_has_leading_shell_exec_flag()` now take the base command and apply the cmd.exe grammar only when the command is `cmd`. This keeps the inline wrapper allow-list gate in step with the parser without changing how a `/`-prefixed token is read for the other commands that consult the same helper (where it is an ordinary path operand), so the change adds no false positives.

Both enforcement points — the REST `MCPServerConfig` validator and the pre-spawn sink in `lfx.base.mcp.util` — go through `validate_mcp_stdio_config`, so this closes the gap at the shared validation boundary rather than at a single caller.

Behaviour for `cmd /c` is unchanged, and the starter-project shape `cmd /c uvx <package>` continues to validate, including when benign switches precede the executing switch.

## Test plan

New regression coverage in `src/lfx/tests/unit/mcp/`:

- `test_stdio_source_policy.py` — parser-level: every executing switch and its cased/clustered variants exposes the wrapped payload; the non-executing switches are stepped over so a later executing switch is still found.
- `test_mcp_stdio_security.py` — validation-level, parametrised over all switch spellings: the command allow-list rejects a non-allow-listed wrapped executable; the configured package allow-list is enforced on the wrapped package runner; interpreter hardening is enforced on the wrapped interpreter. A positive case asserts allow-listed payloads still validate behind benign and clustered switches.

All 23 added assertions fail before the change and pass after.

- `uv run pytest tests/unit/mcp/` (from `src/lfx`) — 475 passed
- `uv run pytest tests/unit` (from `src/lfx`) — 7449 passed, 55 skipped
- `uv run pytest src/backend/tests/unit/test_mcp_command_injection_security.py src/backend/tests/unit/base/mcp/ src/backend/tests/unit/api/v2/test_mcp_servers_file.py` — 474 passed, 7 skipped

Fixes LE-2241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows `cmd.exe` command handling across additional execution switches, including clustered and value-bearing forms.
  - Correctly distinguishes executable switches from ordinary slash-prefixed arguments.
  - Preserves command, package, and interpreter security checks for wrapped and nested shell commands.

- **Tests**
  - Added coverage for supported `cmd.exe` execution switches and non-executing switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->