### PR TITLE
fix(security): check assignment values whose binding escapes the scanner's scope

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/code_security.py
+++ b/src/backend/base/langflow/agentic/helpers/code_security.py
@@ -259,6 +259,12 @@ class _SecurityChecker(ast.NodeVisitor):
         # control flow so a later finally sees every state that can reach it.
         self._alias_scope_depth = 0
         self._alias_state_collectors: list[tuple[int, list[_AliasState]]] = []
+        # Depth of enclosing class bodies. A name bound directly in a class body
+        # also becomes a class attribute, read later as ``self.x`` / ``Cls.x``.
+        self._class_body_depth = 0
+        # Names declared ``global`` / ``nonlocal`` in the current function scope:
+        # their bindings outlive the alias state restored at scope exit.
+        self._escaping_names: set[str] = set()
 
     def _resolved_names(self, name: str) -> frozenset[str]:
         """Return possible canonical values for a local name."""
@@ -440,10 +446,39 @@ class _SecurityChecker(ast.NodeVisitor):
             for target_element in target.elts:
                 yield from self._iter_assignment_leaves(target_element, value)
 
+    def _binding_escapes(self, name: str) -> bool:
+        """True when a name binding outlives the alias state that would track it.
+
+        Binding a resolvable value to a plain name is normally safe to defer to
+        the use site, because alias tracking keeps following the value. That only
+        holds while the binding stays inside the scope being analysed. A class
+        body publishes the name as a class attribute (later read as ``self.x`` /
+        ``Cls.x``, which cannot be related back to the module or callable), and
+        ``global`` / ``nonlocal`` publish it into a scope this visitor has already
+        restored by the time the reader is visited. Both are opaque boundaries.
+        """
+        return self._class_body_depth > 0 or name in self._escaping_names
+
+    def _check_escaping_binding(self, name: str, values: frozenset[str]) -> None:
+        """Flag a dangerous value published through a binding alias tracking cannot follow."""
+        if not self._binding_escapes(name):
+            return
+        for value in sorted(values):
+            if value in _RESTRICTED_MODULE_REFERENCES:
+                self.violations.append(f"Indirect reference to restricted module '{value}' is forbidden in components")
+                return
+            if violation := self._dangerous_callable_message(value):
+                self.violations.append(violation)
+                return
+
     def _check_assignment_value(self, target: ast.AST, value: ast.AST) -> None:
         """Check assignment values that cannot remain visible to alias tracking."""
         for target_leaf, value_leaf in self._iter_assignment_leaves(target, value):
-            if isinstance(target_leaf, ast.Name) and self._resolved_assignment_value(value_leaf):
+            if (
+                isinstance(target_leaf, ast.Name)
+                and not self._binding_escapes(target_leaf.id)
+                and self._resolved_assignment_value(value_leaf)
+            ):
                 continue
             self._check_opaque_reference(value_leaf)
 
@@ -531,6 +566,8 @@ class _SecurityChecker(ast.NodeVisitor):
             binding = alias.asname or module
             imported_name = alias.name if alias.asname else module
             self._bind_name(binding, frozenset({imported_name}))
+            # An import inside a class body binds a class attribute, not a local.
+            self._check_escaping_binding(binding, frozenset({imported_name}))
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
@@ -556,7 +593,9 @@ class _SecurityChecker(ast.NodeVisitor):
         for alias in node.names:
             if alias.name != "*":
                 binding = alias.asname or alias.name
-                self._bind_name(binding, frozenset({f"{node.module}.{alias.name}"}))
+                imported_names = frozenset({f"{node.module}.{alias.name}"})
+                self._bind_name(binding, imported_names)
+                self._check_escaping_binding(binding, imported_names)
 
         return self.generic_visit(node)
 
@@ -581,6 +620,12 @@ class _SecurityChecker(ast.NodeVisitor):
         self._check_assignment_value(node.target, node.value)
         self._bind_assignment_target(node.target, node.value)
 
+    def visit_Global(self, node: ast.Global):
+        self._escaping_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal):
+        self._escaping_names.update(node.names)
+
     def visit_AugAssign(self, node: ast.AugAssign):
         self.visit(node.target)
         self.visit(node.value)
@@ -603,6 +648,8 @@ class _SecurityChecker(ast.NodeVisitor):
     def _visit_iterating_loop(self, node: ast.For | ast.AsyncFor) -> None:
         """Bind the loop target and merge zero-iteration and body states."""
         self.visit(node.iter)
+        if any(self._binding_escapes(name) for name in self._assignment_target_names(node.target)):
+            self._check_opaque_reference(node.iter)
         before_loop = self._snapshot_alias_state()
         self.visit(node.target)
         self._bind_iterated_target(node.target, node.iter)
@@ -754,7 +801,13 @@ class _SecurityChecker(ast.NodeVisitor):
             self._check_opaque_reference(default)
 
         enclosing_state = self._snapshot_alias_state()
+        enclosing_class_body_depth = self._class_body_depth
+        enclosing_escaping_names = self._escaping_names
         self._alias_scope_depth += 1
+        # A function body is its own scope: names bound here are locals, not class
+        # attributes, and ``global`` / ``nonlocal`` declarations do not carry in.
+        self._class_body_depth = 0
+        self._escaping_names = set()
         try:
             self._bind_name(node.name, frozenset())
             self._shadow_arguments(node.args)
@@ -762,6 +815,8 @@ class _SecurityChecker(ast.NodeVisitor):
                 self.visit(statement)
         finally:
             self._alias_scope_depth -= 1
+            self._class_body_depth = enclosing_class_body_depth
+            self._escaping_names = enclosing_escaping_names
             self._restore_alias_state(enclosing_state)
         self._bind_name(node.name, frozenset())
 
@@ -776,13 +831,19 @@ class _SecurityChecker(ast.NodeVisitor):
         for default in (*node.args.defaults, *(item for item in node.args.kw_defaults if item is not None)):
             self._check_opaque_reference(default)
         enclosing_state = self._snapshot_alias_state()
+        enclosing_class_body_depth = self._class_body_depth
+        enclosing_escaping_names = self._escaping_names
         self._alias_scope_depth += 1
+        self._class_body_depth = 0
+        self._escaping_names = set()
         try:
             self._shadow_arguments(node.args)
             self._check_opaque_reference(node.body)
             self.visit(node.body)
         finally:
             self._alias_scope_depth -= 1
+            self._class_body_depth = enclosing_class_body_depth
+            self._escaping_names = enclosing_escaping_names
             self._restore_alias_state(enclosing_state)
 
     def visit_ClassDef(self, node: ast.ClassDef):
@@ -796,12 +857,18 @@ class _SecurityChecker(ast.NodeVisitor):
             self.visit(type_parameter)
 
         enclosing_state = self._snapshot_alias_state()
+        enclosing_escaping_names = self._escaping_names
         self._alias_scope_depth += 1
+        # Names bound in a class body escape as class attributes; see _binding_escapes.
+        self._class_body_depth += 1
+        self._escaping_names = set()
         try:
             for statement in node.body:
                 self.visit(statement)
         finally:
             self._alias_scope_depth -= 1
+            self._class_body_depth -= 1
+            self._escaping_names = enclosing_escaping_names
             self._restore_alias_state(enclosing_state)
         self._bind_name(node.name, frozenset())
 

--- a/src/backend/tests/unit/agentic/helpers/test_code_security.py
+++ b/src/backend/tests/unit/agentic/helpers/test_code_security.py
@@ -1140,3 +1140,206 @@ class TestScanCodeSecurityDottedSubmoduleAccess:
     def test_should_allow_os_path_dotted_access(self):
         result = scan_code_security("import os\np = os.path.join('a', 'b')")
         assert result.is_safe is True
+
+
+class TestScanCodeSecurityEscapingBindingBypass:
+    """Name bindings that outlive the scanner's scope must be checked at the assignment.
+
+    Alias tracking normally defers the check to the use site: ``module = os`` is
+    fine because ``module.system(...)`` is still resolvable. That deferral is only
+    sound while the binding stays visible to the scanner. Two bindings escape it:
+
+    * a class body binds a *class attribute*, later read as ``self.x`` / ``Cls.x``,
+      which alias tracking cannot relate back to the module or callable;
+    * ``global`` / ``nonlocal`` publish the binding into a scope the scanner has
+      already restored by the time the reader is visited.
+
+    Both must therefore be treated as opaque boundaries at the assignment itself.
+    """
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            pytest.param(
+                "import os\n_os = os\n\n\nclass C:\n    _fn: object = _os.system\n\n"
+                "    def run(self):\n        return self._fn('id')\n",
+                id="annotated-class-attribute-alias",
+            ),
+            pytest.param(
+                "import os\n_os = os\n\n\nclass C:\n    _fn = _os.system\n\n"
+                "    def run(self):\n        return self._fn('id')\n",
+                id="plain-class-attribute-alias",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _fn: object = os.system\n\n"
+                "    def run(self):\n        return self._fn('id')\n",
+                id="class-attribute-direct-module-member",
+            ),
+            pytest.param(
+                "import os\n_a = os\n_b = _a\n\n\nclass C:\n    _fn = _b.system\n\n"
+                "    def run(self):\n        return self._fn('id')\n",
+                id="class-attribute-transitive-alias",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _fn = os.popen\n\n    def run(self):\n        return self._fn('id')\n",
+                id="class-attribute-os-popen",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _mod = os\n\n    def run(self):\n        return self._mod.system('id')\n",
+                id="class-attribute-module-object",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _env = os.environ\n\n"
+                "    def run(self):\n        return dict(self._env)\n",
+                id="class-attribute-environ-read",
+            ),
+            pytest.param(
+                "class C:\n    _fn = exec\n\n    def run(self):\n        return self._fn('import os')\n",
+                id="class-attribute-builtin-exec",
+            ),
+            pytest.param(
+                "class C:\n    _fn = open\n\n    def run(self):\n        return self._fn('/etc/passwd')\n",
+                id="class-attribute-builtin-open",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _a, _b = os.system, os.popen\n",
+                id="class-attribute-tuple-unpack",
+            ),
+            pytest.param(
+                "import os\n\n\nclass Outer:\n    class Inner:\n        _fn = os.system\n",
+                id="nested-class-attribute",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _fn = os.system\n\n\nC._fn('id')\n",
+                id="class-attribute-read-from-outside",
+            ),
+            pytest.param(
+                "import os\n\n\ndef bind():\n    global _fn\n\n    _fn = os.system\n\n\n"
+                "def run():\n    return _fn('id')\n",
+                id="global-declared-binding",
+            ),
+            pytest.param(
+                "import os\n\n\ndef outer():\n    _fn = None\n\n    def bind():\n        nonlocal _fn\n\n"
+                "        _fn = os.system\n\n    return bind\n",
+                id="nonlocal-declared-binding",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    for _fn in (os.system,):\n        pass\n\n"
+                "    def run(self):\n        return self._fn('id')\n",
+                id="class-body-loop-target",
+            ),
+            pytest.param(
+                "class C:\n    import os as _os\n\n    def run(self):\n        return self._os.system('id')\n",
+                id="class-body-import",
+            ),
+            pytest.param(
+                "class C:\n    from os import path as _p\n\n    def run(self):\n        return self._p.os.getcwd()\n",
+                id="class-body-from-import-of-os-path",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _fns = [fn for fn in (os.system,)]\n",
+                id="class-body-comprehension",
+            ),
+            pytest.param(
+                "import os\n\nFLAG = True\n\n\nclass C:\n    if FLAG:\n        _fn = os.system\n"
+                "    else:\n        _fn = print\n",
+                id="class-body-conditional-branch",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    try:\n        _fn = os.system\n"
+                "    except Exception:\n        _fn = print\n",
+                id="class-body-try-except",
+            ),
+            pytest.param(
+                "import os\n\n\ndef make():\n    class C:\n        _fn = os.system\n\n    return C\n",
+                id="class-body-inside-function",
+            ),
+        ],
+    )
+    def test_should_detect_escaping_binding_of_dangerous_value(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is False
+
+    def test_should_report_os_system_for_reported_class_attribute_shape(self):
+        code = """
+import os
+
+_os = os
+
+
+class MyComponent:
+    _fn: object = _os.system
+
+    def run(self):
+        return self._fn("id")
+"""
+        result = scan_code_security(code)
+        assert result.is_safe is False
+        assert any("os.system()" in violation for violation in result.violations)
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            pytest.param(
+                "from lfx.custom import Component\n"
+                "from lfx.io import MessageTextInput, Output\n\n\n"
+                "class MyComponent(Component):\n"
+                '    display_name = "My Component"\n'
+                '    description = "What it does"\n'
+                '    icon = "component-icon"\n'
+                '    documentation: str = "https://docs.langflow.org"\n'
+                '    inputs = [MessageTextInput(name="input_value", display_name="Input")]\n'
+                '    outputs = [Output(display_name="Output", name="output", method="process")]\n\n'
+                "    def process(self):\n"
+                "        return self.input_value\n",
+                id="component-shaped-class-body",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _sep = os.sep\n\n    def run(self):\n        return self._sep\n",
+                id="class-attribute-os-sep",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    _join = os.path.join\n\n"
+                "    def run(self):\n        return self._join('a', 'b')\n",
+                id="class-attribute-os-path-join",
+            ),
+            pytest.param(
+                "import requests\n\n\nclass C:\n    _client = requests\n\n"
+                "    def run(self):\n        return self._client.get('https://example.com')\n",
+                id="class-attribute-safe-module",
+            ),
+            pytest.param("def bind():\n    global _count\n\n    _count = 0\n", id="global-constant"),
+            pytest.param(
+                "import requests\n\n\ndef bind():\n    global _client\n\n    _client = requests\n",
+                id="global-safe-module",
+            ),
+            pytest.param(
+                "class C:\n    from os import sep as _sep\n\n    def run(self):\n        return self._sep\n",
+                id="class-body-from-import-safe-member",
+            ),
+            pytest.param(
+                "class C:\n    import requests as _requests\n\n"
+                "    def run(self):\n        return self._requests.get('https://x')\n",
+                id="class-body-import-safe-module",
+            ),
+            pytest.param("class C:\n    for _n in (1, 2, 3):\n        pass\n", id="class-body-loop-over-constants"),
+            pytest.param(
+                "def helper(value):\n    return value\n\n\nclass C:\n    _helper = helper\n\n"
+                "    def run(self):\n        return self._helper('x')\n",
+                id="class-attribute-local-helper",
+            ),
+            pytest.param(
+                "import os\n\n\nclass C:\n    def run(self):\n        module = os\n        module = object()\n"
+                "        return module.system('not os')\n",
+                id="method-local-alias-stays-deferred",
+            ),
+        ],
+    )
+    def test_should_allow_safe_escaping_binding(self, code):
+        result = scan_code_security(code)
+        assert result.is_safe is True
+
+    def test_should_still_allow_module_alias_deferred_to_use_site(self):
+        """The alias deferral itself must survive: ``module = os`` alone is not a violation."""
+        result = scan_code_security("import os\nmodule = os\nmodule = object()\nmodule.system('not os')")
+        assert result.is_safe is True


### PR DESCRIPTION
## Summary

Hardens the AST security scanner that gates LLM-generated component code
(`langflow/agentic/helpers/code_security.py`) against a protection-mechanism
failure: dangerous values could be bound to a name whose binding leaves the scope
the scanner analyses, so the value was never checked — neither at the binding nor
at any later read.

## Background

`_check_assignment_value` deliberately defers the check for `name = <resolvable>`
to the use site: `module = os` is fine on its own because `module.system(...)` is
still resolvable through alias tracking. That deferral is only sound while the
binding stays inside the scope being analysed.

Two bindings leave that scope:

- **class bodies** publish the name as a class attribute, read later as `self.x`
  / `Cls.x` — an access alias tracking cannot relate back to the module or
  callable. Since a Langflow component *is* a class, this is the natural shape
  for generated code, and it meant a dangerous value stored at class level was
  never checked at all.
- **`global` / `nonlocal`** publish the binding into a scope the visitor has
  already restored by the time the reader is visited.

## Changes

`src/backend/base/langflow/agentic/helpers/code_security.py`

- New `_binding_escapes(name)` predicate: true inside a class body, or for a name
  declared `global` / `nonlocal` in the current function scope.
- `_check_assignment_value` no longer takes the deferral shortcut when the
  binding escapes — the value is run through `_check_opaque_reference`, the same
  boundary check already applied to attribute, subscript, argument, return, yield
  and default-value positions.
- `_SecurityChecker` now tracks class-body depth and per-scope `global` /
  `nonlocal` declarations, saving and restoring them across function, lambda and
  class scopes alongside the existing alias state.
- The same rule is applied to two other class-body bindings that reach a class
  attribute without going through `_check_assignment_value`: class-body `import`
  / `from ... import` (`_check_escaping_binding`) and class-body `for` targets.

## Deliberately unchanged

The deferral itself is preserved. Plain module aliasing (`module = os`,
`path_module = os.path`, `dangerous = exec; dangerous = print`) is still checked
at the use site rather than at the assignment, so existing alias-tracking
behaviour and its false-positive characteristics are unchanged. Removing the
deferral outright instead of scoping it flags legitimate aliasing and breaks 10
existing tests in this module.

## Testing

- `TestScanCodeSecurityEscapingBindingBypass` added to
  `src/backend/tests/unit/agentic/helpers/test_code_security.py`: 21 positive
  cases (annotated and plain class attributes, transitive aliases, module objects
  stored at class level, `exec` / `open` / `os.popen` / `os.environ`, tuple
  unpack, nested classes, class body inside a function, comprehension,
  conditional and `try`/`except` branches, class-body import, class-body loop
  target, `global`, `nonlocal`) and 11 negative cases (component-shaped class
  body, `os.sep`, `os.path.join`, safe modules at class level, safe class-body
  imports, class-level helper functions, method-local aliasing).
- `uv run pytest src/backend/tests/unit/agentic` — 1639 passed, 21 skipped,
  10 xfailed. No pre-existing test changed verdict.
- False-positive canary: scanned all 1548 shipped modules under
  `src/backend/base/langflow`, `src/lfx/src/lfx` and `src/bundles` with the
  scanner before and after the change — 0 newly flagged.

Fixes LE-2249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scanning to detect dangerous imports and callable aliases that escape local scopes through class attributes, global or nonlocal bindings, loops, and nested constructs.
  * Preserved support for safe modules, helpers, constants, and locally rebound aliases.

* **Tests**
  * Added comprehensive coverage for escaping bindings, imports, comprehensions, conditionals, exception handlers, and nested classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->