### PR TITLE
fix(security): require credentials on the MCP endpoints under AUTO_LOGIN

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -154,8 +154,13 @@ async def verify_project_auth(
         project_auth_type in {"apikey", "oauth"}
     )
 
-    if requires_api_key:
-        api_key = query_param or header_param
+    # A presented API key is always honoured, even when policy would not have demanded one.
+    # Under MCP Composer with a default project and AUTO_LOGIN=true, ``requires_api_key`` is
+    # False; without this, a key minted by ``/install`` would be ignored and the caller would
+    # fall through to the (now-rejecting) superuser fallback. Callers presenting NO credential
+    # still reach ``_superuser_fallback`` and get 403 AUTO_LOGIN_ERROR.
+    api_key = query_param or header_param
+    if requires_api_key or api_key:
         if not api_key:
             if project_auth_type == "oauth":
                 detail = (

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -70,7 +70,7 @@ from langflow.api.v1.schemas import (
     MCPProjectUpdateRequest,
     MCPSettings,
 )
-from langflow.services.auth.constants import AUTO_LOGIN_WARNING
+from langflow.services.auth.constants import AUTO_LOGIN_ERROR, AUTO_LOGIN_WARNING
 from langflow.services.auth.context import (
     AUTH_METHOD_AUTO_LOGIN,
     AuthCredentialContext,
@@ -190,6 +190,15 @@ async def verify_project_auth(
 
 async def _superuser_fallback(settings_service) -> User:
     """Resolve the configured superuser for unauthenticated MCP paths that allow fallback."""
+    # AUTO_LOGIN parity with the non-MCP entrypoints (``_api_key_security_impl``,
+    # ``ws_api_key_security``, ``authenticate_with_credentials``): AUTO_LOGIN alone is not
+    # a credential. Only an explicit ``skip_auth_auto_login`` opt-in may resolve a caller
+    # that presented no API key and no token to the instance superuser.
+    if not settings_service.auth_settings.skip_auth_auto_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=AUTO_LOGIN_ERROR,
+        )
     if not settings_service.auth_settings.SUPERUSER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -854,8 +863,13 @@ async def install_mcp_config(
 
         # Get settings service to build the SSE URL
         settings_service = get_settings_service()
-        if settings_service.auth_settings.AUTO_LOGIN and not settings_service.auth_settings.SUPERUSER:
-            # Without a superuser fallback, require API key auth for MCP installs.
+        if settings_service.auth_settings.AUTO_LOGIN and not (
+            settings_service.auth_settings.skip_auth_auto_login and settings_service.auth_settings.SUPERUSER
+        ):
+            # The MCP transport endpoints only resolve a credential-less caller to the
+            # superuser when skip_auth_auto_login is explicitly enabled and a superuser is
+            # configured. In every other AUTO_LOGIN configuration the installed client must
+            # carry an API key, otherwise it would be rejected at connect time.
             should_generate_api_key = True
         settings = settings_service.settings
         host = settings.host or None

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -1693,6 +1693,16 @@ class AuthService(BaseAuthService):
                     detail="Missing first superuser credentials",
                 )
             if not query_param and not header_param:
+                # AUTO_LOGIN parity with _api_key_security_impl / ws_api_key_security:
+                # AUTO_LOGIN on its own is not a credential. Only an explicit
+                # skip_auth_auto_login opt-in may resolve a credential-less caller to
+                # the superuser; otherwise the MCP transport endpoints would accept
+                # anonymous requests that every other authenticated route rejects.
+                if not settings_service.auth_settings.skip_auth_auto_login:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail=AUTO_LOGIN_ERROR,
+                    )
                 result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
                 if result:
                     logger.warning(AUTO_LOGIN_WARNING)

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -908,7 +908,7 @@ async def test_project_session_manager_lifespan_handles_cleanup(user_test_projec
     assert lifecycle_events == ["enter", "exit"]
 
 
-def _prepare_install_test_env(monkeypatch, tmp_path, filename="cursor.json"):
+def _prepare_install_test_env(monkeypatch, tmp_path, filename="cursor.json", *, skip_auth=True):
     config_path = tmp_path / filename
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -933,6 +933,9 @@ def _prepare_install_test_env(monkeypatch, tmp_path, filename="cursor.json"):
     class DummyAuth:
         AUTO_LOGIN = True
         SUPERUSER = True
+        # The credential-less superuser fallback on the MCP transport endpoints is only
+        # available when this is explicitly enabled; installs otherwise embed an API key.
+        skip_auth_auto_login = skip_auth
 
     dummy_settings = SimpleNamespace(host="localhost", port=9999, mcp_composer_enabled=False)
     dummy_service = SimpleNamespace(settings=dummy_settings, auth_settings=DummyAuth())
@@ -1133,6 +1136,34 @@ async def test_install_mcp_config_streamable_transport(
     assert "--transport" in args
     assert "streamablehttp" in args
     assert args[-1].endswith("/streamable")
+
+
+async def test_install_mcp_config_embeds_api_key_without_skip_auth_auto_login(
+    client: AsyncClient,
+    user_test_project,
+    logged_in_headers,
+    tmp_path,
+    monkeypatch,
+):
+    """AUTO_LOGIN alone no longer authenticates MCP transport callers, so installs need a key.
+
+    With AUTO_LOGIN on and skip_auth_auto_login off (the default), the MCP transport
+    endpoints reject credential-less callers. The generated client config must therefore
+    carry an x-api-key header instead of relying on the superuser fallback.
+    """
+    config_path = _prepare_install_test_env(monkeypatch, tmp_path, "cursor_apikey.json", skip_auth=False)
+
+    response = await client.post(
+        f"/api/v1/mcp/project/{user_test_project.id}/install",
+        headers=logged_in_headers,
+        json={"client": "cursor"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    installed_config = json.loads(config_path.read_text())
+    args = installed_config["mcpServers"]["lf-user_test_project"]["args"]
+    assert "--headers" in args
+    assert "x-api-key" in args
 
 
 async def test_init_mcp_servers(user_test_project, other_test_project):

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -1164,6 +1164,11 @@ async def test_install_mcp_config_embeds_api_key_without_skip_auth_auto_login(
     args = installed_config["mcpServers"]["lf-user_test_project"]["args"]
     assert "--headers" in args
     assert "x-api-key" in args
+    # The header NAME alone proves nothing: assert the generated key value is actually present,
+    # otherwise an empty or missing value would still satisfy the membership checks above.
+    api_key_value = args[args.index("x-api-key") + 1]
+    assert api_key_value
+    assert api_key_value != "x-api-key"  # pragma: allowlist secret
 
 
 async def test_init_mcp_servers(user_test_project, other_test_project):

--- a/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
@@ -1,0 +1,78 @@
+"""AUTO_LOGIN guard coverage for the per-project MCP credential resolver.
+
+``verify_project_auth`` historically fell back to the configured superuser whenever a
+project carried no explicit MCP auth settings and ``AUTO_LOGIN`` was on — regardless of
+``skip_auth_auto_login``. Every other authenticated entrypoint (``api_key_security``,
+``ws_api_key_security``, ``authenticate_with_credentials``) rejects credential-less
+callers in that configuration, so the MCP transport endpoints must do the same.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
+from langflow.api.v1.mcp_projects import verify_project_auth
+from langflow.services.auth.constants import AUTO_LOGIN_ERROR
+
+MODULE = "langflow.api.v1.mcp_projects"
+
+
+def _settings(*, auto_login: bool, skip_auth: bool, superuser: str = "admin") -> SimpleNamespace:
+    return SimpleNamespace(
+        auth_settings=SimpleNamespace(
+            AUTO_LOGIN=auto_login,
+            skip_auth_auto_login=skip_auth,
+            SUPERUSER=superuser,
+        )
+    )
+
+
+def _session_scope_yielding(project) -> object:
+    """Build a ``session_scope`` replacement whose session resolves to ``project``."""
+
+    @asynccontextmanager
+    async def _scope():
+        session = MagicMock()
+        session.exec = AsyncMock(return_value=SimpleNamespace(first=lambda: project))
+        session.get = AsyncMock(return_value=None)
+        yield session
+
+    return _scope
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_auto_login_alone_rejects_credential_less_caller():
+    """Default config (AUTO_LOGIN on, skip_auth_auto_login off) must not resolve to the superuser."""
+    project = SimpleNamespace(id=uuid4(), user_id=uuid4(), auth_settings=None)
+    superuser = SimpleNamespace(id=uuid4(), username="admin")
+
+    with (
+        patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=False)),
+        patch(f"{MODULE}.session_scope", _session_scope_yielding(project)),
+        patch(f"{MODULE}.get_user_by_username", new=AsyncMock(return_value=superuser)) as mock_lookup,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await verify_project_auth(project.id, query_param=None, header_param=None)
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc.value.detail == AUTO_LOGIN_ERROR
+    mock_lookup.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_auto_login_skip_keeps_superuser_fallback():
+    """AUTO_LOGIN + skip_auth_auto_login preserves the documented single-user MCP fallback."""
+    project = SimpleNamespace(id=uuid4(), user_id=uuid4(), auth_settings=None)
+    superuser = SimpleNamespace(id=uuid4(), username="admin")
+
+    with (
+        patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=True)),
+        patch(f"{MODULE}.session_scope", _session_scope_yielding(project)),
+        patch(f"{MODULE}.get_user_by_username", new=AsyncMock(return_value=superuser)),
+    ):
+        result = await verify_project_auth(project.id, query_param=None, header_param=None)
+
+    assert result is superuser

--- a/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
@@ -76,3 +76,48 @@ async def test_verify_project_auth_auto_login_skip_keeps_superuser_fallback():
         result = await verify_project_auth(project.id, query_param=None, header_param=None)
 
     assert result is superuser
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_honours_presented_api_key_under_auto_login():
+    """A presented API key must authenticate even when policy would not have demanded one.
+
+    Under MCP Composer with a default project (no ``auth_settings``) and ``AUTO_LOGIN`` on,
+    ``requires_api_key`` is False. Before the presented-key branch existed, a key minted by
+    ``POST /{id}/install`` was ignored and the caller fell through to the now-rejecting
+    superuser fallback, so the generated client config could never authenticate.
+    """
+    owner_id = uuid4()
+    project = SimpleNamespace(id=uuid4(), user_id=owner_id, auth_settings=None)
+    owner = SimpleNamespace(id=owner_id, username="owner")
+    api_key_result = SimpleNamespace(user=owner)
+
+    with (
+        patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=False)),
+        patch(f"{MODULE}.session_scope", _session_scope_yielding(project)),
+        patch(f"{MODULE}.authenticate_api_key", new=AsyncMock(return_value=api_key_result)),
+        patch(f"{MODULE}.AuthCredentialContext.from_api_key_result", return_value=MagicMock()),
+        patch(f"{MODULE}.get_user_by_username", new=AsyncMock()) as mock_lookup,
+    ):
+        result = await verify_project_auth(project.id, query_param=None, header_param="generated-key")
+
+    assert result is owner
+    mock_lookup.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_rejects_presented_key_from_another_owner():
+    """A valid key belonging to a different user must not unlock this project."""
+    project = SimpleNamespace(id=uuid4(), user_id=uuid4(), auth_settings=None)
+    other_user = SimpleNamespace(id=uuid4(), username="someone-else")
+
+    with (
+        patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=False)),
+        patch(f"{MODULE}.session_scope", _session_scope_yielding(project)),
+        patch(f"{MODULE}.authenticate_api_key", new=AsyncMock(return_value=SimpleNamespace(user=other_user))),
+        patch(f"{MODULE}.AuthCredentialContext.from_api_key_result", return_value=MagicMock()),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await verify_project_auth(project.id, query_param=None, header_param="someone-elses-key")
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -12,9 +12,10 @@ import jwt
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 from fastapi import HTTPException, WebSocketException, status
-from langflow.services.auth.constants import AUTO_LOGIN_WARNING
+from langflow.services.auth.constants import AUTO_LOGIN_ERROR, AUTO_LOGIN_WARNING
 from langflow.services.auth.context import (
     AUTH_METHOD_API_KEY,
+    AUTH_METHOD_AUTO_LOGIN,
     AUTH_METHOD_EXTERNAL,
     AUTH_METHOD_JWT,
     AuthCredentialContext,
@@ -2821,3 +2822,105 @@ async def test_api_key_entrypoint_clears_stale_external_access_ceiling(
         set_current_external_access_context(None)
 
     assert result.id == user.id
+
+
+# =============================================================================
+# get_current_user_mcp Tests — AUTO_LOGIN parity with the non-MCP entrypoints
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_get_current_user_mcp_auto_login_alone_still_rejects(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """MCP credential resolution must honour skip_auth_auto_login like every other entrypoint.
+
+    With the default configuration (AUTO_LOGIN on, skip_auth_auto_login off) a caller
+    that presents no token and no API key must be rejected. Without this guard the MCP
+    transport endpoints resolve an anonymous request to the configured superuser while
+    every other authenticated route returns 403.
+    """
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = False
+    auth_settings.SUPERUSER = "admin"
+    superuser = _dummy_user(uuid4())
+
+    with (
+        patch(
+            "langflow.services.auth.service.get_user_by_username",
+            new=AsyncMock(return_value=superuser),
+        ) as mock_lookup,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await auth_service.get_current_user_mcp(
+            token=None,
+            query_param=None,
+            header_param=None,
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc.value.detail == AUTO_LOGIN_ERROR
+    mock_lookup.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_get_current_user_mcp_auto_login_skip_returns_superuser(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """AUTO_LOGIN + skip_auth_auto_login keeps the documented single-user MCP fallback."""
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
+    superuser = _dummy_user(uuid4())
+
+    try:
+        with (
+            patch(
+                "langflow.services.auth.service.get_user_by_username",
+                new=AsyncMock(return_value=superuser),
+            ) as mock_lookup,
+            patch("langflow.services.auth.service.logger") as mock_logger,
+        ):
+            result = await auth_service.get_current_user_mcp(
+                token=None,
+                query_param=None,
+                header_param=None,
+                db=AsyncMock(),
+            )
+
+        assert result is superuser
+        mock_lookup.assert_awaited_once()
+        mock_logger.warning.assert_called_once_with(AUTO_LOGIN_WARNING)
+        assert get_current_auth_context().method == AUTH_METHOD_AUTO_LOGIN
+    finally:
+        clear_current_auth_context()
+
+
+@pytest.mark.anyio
+async def test_get_current_user_mcp_auto_login_skip_missing_superuser_rejects(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+):
+    """AUTO_LOGIN + skip_auth_auto_login with no superuser row must not fall through to allow."""
+    auth_settings.AUTO_LOGIN = True
+    auth_settings.skip_auth_auto_login = True
+    auth_settings.SUPERUSER = "admin"
+
+    with (
+        patch(
+            "langflow.services.auth.service.get_user_by_username",
+            new=AsyncMock(return_value=None),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await auth_service.get_current_user_mcp(
+            token=None,
+            query_param=None,
+            header_param=None,
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
## Summary

The MCP credential resolvers were the only authenticated entrypoints that did not honour `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`.

Since v1.5, `LANGFLOW_AUTO_LOGIN=true` on its own is not treated as a credential: `api_key_security`, `ws_api_key_security` and `authenticate_with_credentials` all reject a caller that presents no token and no API key with `403 AUTO_LOGIN_ERROR` unless `LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true` is explicitly set. The MCP resolvers instead resolved such a caller to the configured superuser and served the request, so the MCP HTTP surface accepted requests that every other authenticated route rejects — in the default configuration (`AUTO_LOGIN=true`, `skip_auth_auto_login=false`).

This is an authentication-bypass / missing-authentication-guard class of issue on the MCP transport surface.

## Code paths changed

Two resolvers were affected, both now applying the same guard the standard paths use:

- `AuthService.get_current_user_mcp` — `src/backend/base/langflow/services/auth/service.py`. Backs the `CurrentActiveMCPUser` dependency used by the global MCP router (`api/v1/mcp.py`), the per-project MCP routes (`api/v1/mcp_projects.py`) and the agentic MCP router (`api/v1/agentic_mcp.py`).
- `verify_project_auth` / `_superuser_fallback` — `src/backend/base/langflow/api/v1/mcp_projects.py`. Reached by the per-project MCP transport endpoints when MCP Composer is enabled (the default).

A credential-less caller is now rejected with `403 AUTO_LOGIN_ERROR` unless `skip_auth_auto_login` is explicitly enabled. The opt-in fallback behaviour is unchanged, and callers presenting a JWT or a valid API key are unaffected.

`/api/v2/mcp/*` already used `CurrentActiveUser` and was never affected.

## Compatibility

`POST /api/v1/mcp/project/{id}/install` now provisions a Langflow API key whenever the superuser fallback is unavailable — previously it only did so when no superuser was configured. Generated client configs therefore carry an `x-api-key` header and keep working in the default configuration instead of being rejected at connect time.

An audit of every remaining `get_user_by_username` superuser-resolution site confirms all of them are now behind either `skip_auth_auto_login` or a validated credential.

## Test coverage

- `src/backend/tests/unit/services/auth/test_auth_service.py` — `get_current_user_mcp` rejects a credential-less caller under `AUTO_LOGIN` alone (and does not reach the superuser lookup); still returns the superuser with `skip_auth_auto_login=true`; still rejects when the superuser row is absent.
- `src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py` (new) — the same two cases for `verify_project_auth` on a project with no explicit MCP auth settings.
- `src/backend/tests/unit/api/v1/test_mcp_projects.py` — install handler embeds an `x-api-key` header when `skip_auth_auto_login` is off.

Both new negative tests were confirmed to fail before the change and pass after. Full runs of the auth service, MCP, MCP-projects, agentic MCP and MCP-utils modules pass (222 tests), plus the adjacent AUTO_LOGIN-sensitive suites (59 tests).

Fixes LE-2239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened MCP authentication by rejecting credential-less requests when automatic login is not explicitly permitted.
  * Requests that are rejected now return HTTP 403 with the configured authentication error message.
  * MCP client installations automatically include an API key when required for authentication.
  * Preserved the existing superuser fallback when automatic-login authentication is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->