### PR TITLE
fix(ci): keep skipped package releases green and stop sending target_commitish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,8 +434,8 @@ jobs:
 
           if [ "$version" = "$last_released_version" ] && [ "${{ inputs.release_package_base }}" = "true" ]; then
             echo "Base pypi version $version is already released. Skipping release."
+            echo version=$version >> $GITHUB_OUTPUT
             echo skipped=true >> $GITHUB_OUTPUT
-            exit 1
           else
             echo version=$version >> $GITHUB_OUTPUT
             echo skipped=false >> $GITHUB_OUTPUT
@@ -484,8 +484,8 @@ jobs:
 
           if [ "$version" = "$last_released_version" ] && [ "${{ inputs.release_package_main }}" = "true" ]; then
             echo "Main pypi version $version is already released. Skipping release."
+            echo version=$version >> $GITHUB_OUTPUT
             echo skipped=true >> $GITHUB_OUTPUT
-            exit 1
           else
             echo version=$version >> $GITHUB_OUTPUT
             echo skipped=false >> $GITHUB_OUTPUT
@@ -535,8 +535,8 @@ jobs:
 
           if [ "$version" = "$last_released_version" ]; then
             echo "LFX pypi version $version is already released. Skipping release."
+            echo version=$version >> $GITHUB_OUTPUT
             echo skipped=true >> $GITHUB_OUTPUT
-            exit 1
           else
             echo version=$version >> $GITHUB_OUTPUT
             echo skipped=false >> $GITHUB_OUTPUT
@@ -603,8 +603,8 @@ jobs:
 
           if [ "$version" = "$last_released_version" ]; then
             echo "SDK pypi version $version is already released. Skipping release."
+            echo version=$version >> $GITHUB_OUTPUT
             echo skipped=true >> $GITHUB_OUTPUT
-            exit 1
           else
             echo version=$version >> $GITHUB_OUTPUT
             echo skipped=false >> $GITHUB_OUTPUT
@@ -1624,6 +1624,8 @@ jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
       [
         determine-base-version,
@@ -1666,14 +1668,29 @@ jobs:
       # version (main only adopts the new version via the post-release
       # back-merge). Pre-releases keep their computed tag (e.g. 1.10.0rc1),
       # but `commit` pins any newly minted tag to the release commit.
+      #
+      # `commit` is only safe while the tag is still missing. GitHub ignores
+      # target_commitish once the tag exists, but sending it anyway subjects the
+      # request to the workflow-permission check on the resolved commit, and an
+      # Actions token is never granted the Workflows permission — which is how
+      # the 1.11.4 release earned "403 Resource not accessible by integration"
+      # with contents: write already in hand.
       - name: Resolve release commit
         id: release_commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          PUBLISHED_TAG: ${{ inputs.pre_release && (needs.determine-main-version.outputs.version || needs.determine-base-version.outputs.version) || inputs.release_tag }}
         run: |
-          sha=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.release_tag }}" --jq '.sha')
-          echo "Release tag '${{ inputs.release_tag }}' resolves to commit $sha"
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          sha=$(gh api "repos/${{ github.repository }}/commits/$RELEASE_TAG" --jq '.sha')
+          echo "Release tag '$RELEASE_TAG' resolves to commit $sha"
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$PUBLISHED_TAG" >/dev/null 2>&1; then
+            echo "Tag '$PUBLISHED_TAG' already exists; omitting target_commitish."
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag '$PUBLISHED_TAG' does not exist yet; pinning it to $sha"
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Two independent failures from the 1.11.4 release run ([32159566571](https://github.com/langflow-ai/langflow/actions/runs/32159566571)).

## 1. A package that is already on PyPI fails its version job

`Determine SDK Version` ended its skip path with `exit 1`:

```
SDK version from pyproject.toml: 0.3.3
Latest SDK release version: 0.3.3
SDK pypi version 0.3.3 is already released. Skipping release.
##[error]Process completed with exit code 1
```

The same `exit 1` sat in all four `determine-*-version` jobs (SDK, LFX, base, main). Nothing downstream needs that failure: every consumer gates on `outputs.skipped == 'false'`, never on the job's result. The jobs now emit `version`, set `skipped=true`, and exit clean.

**Behavior note:** because these jobs now succeed, the two `call_docker_build_*` jobs — which gate on `needs.determine-*-version.result == 'success'` — will run in the "already published" case instead of being skipped by the failure. That is the intended recovery path (re-dispatch a release whose PyPI publish already landed but whose Docker build did not), and the skip path now emits `version` so `version_override` is populated.

## 2. `Create Release` fails with 403 while holding `contents: write`

```
##[error]Error 403: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

Five attempts, all identical. This is not the usual missing-permission case — comparing the failing job against the v1.11.3 job that succeeded on 2026-08-11 shows the same action SHA (`ncipollo/release-action` 339a818), the same inputs, and a byte-identical `GITHUB_TOKEN` permission set including `Contents: write`. Also ruled out: no ruleset applies to `refs/tags/v1.11.4`, the tag exists and resolves to the release commit, no draft release holds the tag, and immutable releases are off for the repo.

What is left is the `commit:` (target_commitish) input. GitHub ignores `target_commitish` once the tag exists, but sending it still subjects the request to the create-release endpoint's workflow-permission check on the resolved commit — and an Actions token is never granted the `Workflows` permission, so that check can never pass. It is the same 403 as [cli/cli#9514](https://github.com/cli/cli/issues/9514), where dropping `--target` is the fix.

`Resolve release commit` now looks the tag up first and only pins `target_commitish` when the tag does not exist yet, which is the one case the input was added for (pre-release tags minted by the action — see the comment above the step). The release job also spells out `permissions: contents: write` rather than leaning on the repo default.

**How far this was verified.** v1.11.4 was published by hand to unblock the release. Creating it *with* `target_commitish` succeeded from a user token that carries the `workflow` scope — consistent with the theory (a principal holding workflow permission passes the check that `GITHUB_TOKEN` cannot), and it would have refuted the theory had that token lacked the scope. But the Actions-token path itself cannot be reproduced outside a workflow run, so this change removes the one documented trigger for this 403 rather than a confirmed one. The next release dispatch is the real test; if `Create Release` still 403s with no `target_commitish` in the request, the cause is elsewhere and worth escalating to GitHub Support with these two run comparisons.

## Test plan

- [x] `actionlint` reports no new findings (the added `echo version=$version` lines carry the same pre-existing SC2086 infos as the identical lines beside them)
- [ ] Next release dispatch: a package whose version is already on PyPI reports green and marks itself skipped
- [ ] Next release dispatch: `Create Release` attaches to the existing `v*` tag with no `target_commitish` in the request
