### PR TITLE
fix(ci): stop uv run from half-reverting the bundle install it runs against (forward-port of #14631)

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -196,12 +196,19 @@ jobs:
           # the in-repo bundle so the guards pass here too.
           uv sync --dev --extra otel
           uv pip install "../bundles/lfx-bundles[all-no-torch]"
-          uv run python -c "import lfx_bundles; print('lfx_bundles', lfx_bundles.__file__)"
+          # --no-sync from here on: the install above is deliberately outside the lock, and
+          # a plain `uv run` re-syncs the environment to uv.lock. That reverts the lock-managed
+          # packages the bundle install upgraded while leaving the injected ones alone, which
+          # leaves an environment neither resolution ever produced. It bit us the day
+          # langchain-openai 1.5.2 shipped: the bundle install brought openai 1.5.2 with
+          # langchain-core 1.5.6, `uv run` put core back to the locked 1.5.1, and the pair
+          # failed to import. Both resolutions were fine; only the mix was not.
+          uv run --no-sync python -c "import lfx_bundles; print('lfx_bundles', lfx_bundles.__file__)"
           printf 'Running %d bundle-guarded lfx test file(s):\n' "${#guarded[@]}"
           printf '  %s\n' "${guarded[@]}"
           # No --timeout: pytest-timeout is not in lfx's dev group (pytest, pytest-asyncio,
           # pytest-cov only), and `make lfx_tests` does not pass one either.
-          uv run pytest "${guarded[@]}" -v -m "not api_key_required"
+          uv run --no-sync pytest "${guarded[@]}" -v -m "not api_key_required"
 
   integration-tests:
     name: Integration Tests - Python ${{ matrix.python-version }}


### PR DESCRIPTION
Forward-port of #14631 (`d4ab9b82a9`) from `release-1.12.0`. Cherry-picked cleanly; the resulting step is byte-identical to the one on `release-1.12.0`.

## Why now

Nightly [32200512467](https://github.com/langflow-ai/langflow/actions/runs/32200512467) went red on `main` — the first failure after five green nights. All five **Unit Tests (bundles installed)** jobs (Python 3.10–3.14) failed at *Run the bundle-guarded lfx unit tests*:

```
tests/unit/components/test_provider_base_url_ssrf.py::test_lmstudio_get_model_blocks_metadata FAILED
E  ImportError: cannot import name 'GATEWAY_METADATA_RESPONSE_KEY' from 'langchain_core.utils._gateway'
```

That job gates **Run Nightly Langflow Build** and **Run DB Migration Validation**, both of which were skipped — no nightly was published.

## Root cause

Nothing upstream is broken. The step runs `uv sync` → `uv pip install "../bundles/lfx-bundles[all-no-torch]"` (a deliberate out-of-lock resolution) → `uv run pytest`. The plain `uv run` re-syncs the environment to `uv.lock`, reverting the lock-managed packages the bundle install just upgraded while leaving the injected ones alone — an environment neither resolution ever produced.

langchain-openai 1.5.2 shipped 2026-08-18 17:37 UTC requiring `langchain-core>=1.5.6`. The bundle install brought that pair in; `uv run` put core back to the locked 1.5.1; the mix fails to import. (Verified against the wheels: core 1.5.5 lacks the symbol, 1.5.6 has it.) The log tell is a small `Uninstalled 3 packages / Installed 3 packages` between the bundle install and the test run.

`--no-sync` on both post-install `uv run` calls keeps the deliberately-out-of-lock environment intact.

## Why a cherry-pick rather than the back-merge

#14631 landed on `release-1.12.0` at 2026-08-18 19:13 UTC, five hours before the nightly fired, and the nightly runs from `main`'s own copy of the workflow. A full back-merge is open as #14652, but the only fast-forward available moves `main` all the way to `release-1.12.0`'s tip — its tip *is* the `Merge main into release-1.12.0` commit, so `d4ab9b82a9` sits below where `main` joined and there is no intermediate fast-forward point. This lands the one CI-only change now; `main` will be merged into `release-1.12.0` immediately after, keeping that branch strictly ahead and behind by 0.

Scope: one file, `.github/workflows/python_test.yml`, CI only. No product code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment consistency by preventing unintended dependency re-synchronization after bundle installation.
  * Reduced the risk of tests using mismatched or unexpected dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->