### PR TITLE
fix(lfx): check port 65535 before reporting exhaustion

### DIFF
--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -173,7 +173,7 @@ def is_port_in_use(port: int, host: str = "localhost") -> bool:
 def get_free_port(starting_port: int = 8000) -> int:
     """Get a free port starting from the given port."""
     port = starting_port
-    while port < MAX_PORT_NUMBER:
+    while port <= MAX_PORT_NUMBER:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             try:
                 s.bind(("", port))

--- a/src/lfx/tests/unit/cli/test_common.py
+++ b/src/lfx/tests/unit/cli/test_common.py
@@ -84,6 +84,15 @@ class TestPortUtilities:
             assert free_port != occupied_port
             assert not is_port_in_use(free_port)
 
+    def test_get_free_port_checks_highest_valid_port(self):
+        """Test that port 65535 is considered before reporting exhaustion."""
+        with patch("socket.socket") as mock_socket:
+            mock_bind = mock_socket.return_value.__enter__.return_value.bind
+            mock_bind.side_effect = [OSError, None]
+
+            assert get_free_port(65534) == 65535
+            assert [args[0][0] for args in mock_bind.call_args_list] == [("", 65534), ("", 65535)]
+
     def test_get_free_port_no_ports_available(self):
         """Test error when no free ports are available."""
         with patch("socket.socket") as mock_socket:


### PR DESCRIPTION
## Summary

- Consider port `65535` before reporting that no free ports are available.
- Add a regression test for the upper boundary of the valid TCP port range.

## Problem

`get_free_port()` stops while the candidate is still below `65535`, so it never checks the highest valid TCP port. When `lfx serve` starts at `65534`, that port is occupied, and `65535` is free, the CLI incorrectly raises `RuntimeError: No free ports available` instead of starting on `65535`.

The loop now includes the upper boundary. Existing behavior for exhausted and lower port ranges is unchanged.

## Validation

- Reproduced the failure through `lfx serve` before the fix and verified that it starts on `127.0.0.1:65535` after the fix.
- `uv run pytest tests/unit/cli/test_common.py -q` — 39 passed.
- Full `src/lfx/tests/unit/cli` suite — 1162 passed, 3 xfailed, 2 xpassed.
- Ruff lint and formatting checks pass for the changed files.

AI assistance disclosure: OpenAI Codex helped identify the boundary case and prepare the focused implementation and test. The behavior and test results were verified locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port selection so the highest valid port number can be used when available.
  * Port checks now proceed through the full valid range in the expected order.

* **Tests**
  * Added coverage verifying fallback to the highest available port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->