### PR TITLE
fix(frontend): keep the persisted flow when the header list refreshes

### DIFF
--- a/src/frontend/src/stores/__tests__/flowsManagerStore-saved-flow-refresh.test.ts
+++ b/src/frontend/src/stores/__tests__/flowsManagerStore-saved-flow-refresh.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+
+jest.mock("lodash", () => ({
+  cloneDeep: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
+}));
+
+jest.mock("@/constants/constants", () => ({
+  SAVE_DEBOUNCE_TIME: 1000,
+}));
+
+jest.mock("../flowStore", () => ({
+  __esModule: true,
+  default: {
+    getState: jest.fn(() => ({
+      nodes: [],
+      edges: [],
+      resetFlow: jest.fn(),
+      setNodes: jest.fn(),
+      setEdges: jest.fn(),
+    })),
+  },
+}));
+
+import type { FlowType } from "@/types/flow";
+import useFlowsManagerStore from "../flowsManagerStore";
+
+/**
+ * ``currentFlow`` in this store is the *persisted* version of the flow the
+ * editor diffs against: the unsaved-changes dialog reads its ``updated_at``
+ * for the "Last saved" line, and ``useUnsavedChanges`` diffs its ``data``
+ * against the canvas.
+ *
+ * The flow list that feeds ``setFlows`` is not always that shape. The app
+ * header refetches ``GET /flows/?get_all=true&header_flows=true``, whose rows
+ * are ``FlowHeader`` objects: no ``updated_at`` at all, and ``data`` nulled
+ * for anything that is not a component.
+ */
+describe("useFlowsManagerStore saved-flow refresh", () => {
+  const savedFlow = {
+    id: "flow-1",
+    name: "Test Flow",
+    description: "Saved description",
+    data: { nodes: [{ id: "node-1" }], edges: [], viewport: { x: 0, y: 0 } },
+    is_component: false,
+    locked: false,
+    updated_at: "2026-08-19T10:00:00Z",
+  } as unknown as FlowType;
+
+  // What the header refetch actually lands: no updated_at, data nulled.
+  const headerRow = {
+    id: "flow-1",
+    name: "Test Flow",
+    description: "Saved description",
+    data: null,
+    is_component: false,
+    folder_id: "folder-1",
+  } as unknown as FlowType;
+
+  const otherHeaderRow = {
+    id: "flow-2",
+    name: "Another Flow",
+    data: null,
+    is_component: false,
+  } as unknown as FlowType;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    act(() => {
+      useFlowsManagerStore.getState().resetStore();
+    });
+  });
+
+  it("keeps updated_at when a header-only list refresh lands", () => {
+    const { result } = renderHook(() => useFlowsManagerStore());
+
+    act(() => {
+      result.current.setCurrentFlow(savedFlow);
+    });
+    act(() => {
+      result.current.setFlows([headerRow, otherHeaderRow]);
+    });
+
+    expect(result.current.currentFlow?.updated_at).toBe("2026-08-19T10:00:00Z");
+  });
+
+  it("keeps the persisted graph when a header-only list refresh lands", () => {
+    const { result } = renderHook(() => useFlowsManagerStore());
+
+    act(() => {
+      result.current.setCurrentFlow(savedFlow);
+    });
+    act(() => {
+      result.current.setFlows([headerRow, otherHeaderRow]);
+    });
+
+    expect(result.current.currentFlow?.data).toEqual(savedFlow.data);
+    expect(result.current.currentFlow?.locked).toBe(false);
+  });
+
+  it("still applies fields the refreshed row does carry", () => {
+    const { result } = renderHook(() => useFlowsManagerStore());
+
+    act(() => {
+      result.current.setCurrentFlow(savedFlow);
+    });
+    act(() => {
+      result.current.setFlows([
+        { ...headerRow, name: "Renamed elsewhere" },
+        otherHeaderRow,
+      ]);
+    });
+
+    expect(result.current.currentFlow?.name).toBe("Renamed elsewhere");
+    expect(result.current.currentFlow?.folder_id).toBe("folder-1");
+  });
+
+  it("prefers a full row over the previously stored one", () => {
+    const { result } = renderHook(() => useFlowsManagerStore());
+
+    act(() => {
+      result.current.setCurrentFlow(savedFlow);
+    });
+    act(() => {
+      result.current.setFlows([
+        {
+          ...savedFlow,
+          data: { nodes: [], edges: [] },
+          updated_at: "2026-08-19T11:00:00Z",
+        } as unknown as FlowType,
+      ]);
+    });
+
+    expect(result.current.currentFlow?.data).toEqual({ nodes: [], edges: [] });
+    expect(result.current.currentFlow?.updated_at).toBe("2026-08-19T11:00:00Z");
+  });
+
+  it("clears the current flow when it is gone from the refreshed list", () => {
+    const { result } = renderHook(() => useFlowsManagerStore());
+
+    act(() => {
+      result.current.setCurrentFlow(savedFlow);
+    });
+    act(() => {
+      result.current.setFlows([otherHeaderRow]);
+    });
+
+    expect(result.current.currentFlow).toBeUndefined();
+  });
+});

--- a/src/frontend/src/stores/flowsManagerStore.ts
+++ b/src/frontend/src/stores/flowsManagerStore.ts
@@ -17,6 +17,33 @@ const defaultOptions: UseUndoRedoOptions = {
 const past = {};
 const future = {};
 
+/**
+ * ``currentFlow`` is the persisted version of the open flow: the editor diffs
+ * the canvas against it, and the unsaved-changes dialog reads its
+ * ``updated_at`` for the "Last saved" line.
+ *
+ * The refreshed list is not always that shape. The app header polls
+ * ``GET /flows/?get_all=true&header_flows=true``, whose rows are ``FlowHeader``
+ * objects — they carry no ``updated_at`` at all, and ``data`` is nulled for
+ * anything that is not a component. Taking such a row wholesale blanks both,
+ * which is what made the exit dialog claim "Last saved: Never" for a flow that
+ * was in fact persisted. Apply what the refreshed row knows, keep what only the
+ * full flow can tell us.
+ */
+const mergeRefreshedCurrentFlow = (
+  saved: FlowType | undefined,
+  refreshed: FlowType | undefined,
+): FlowType | undefined => {
+  if (!refreshed) return undefined;
+  if (!saved || saved.id !== refreshed.id) return refreshed;
+  return {
+    ...saved,
+    ...refreshed,
+    data: refreshed.data ?? saved.data,
+    updated_at: refreshed.updated_at ?? saved.updated_at,
+  };
+};
+
 const useFlowsManagerStore = create<FlowsManagerStoreType>((set, get) => ({
   IOModalOpen: false,
   setIOModalOpen: (IOModalOpen: boolean) => {
@@ -51,7 +78,10 @@ const useFlowsManagerStore = create<FlowsManagerStoreType>((set, get) => ({
   setFlows: (flows: FlowType[]) => {
     set({
       flows,
-      currentFlow: flows.find((flow) => flow.id === get().currentFlowId),
+      currentFlow: mergeRefreshedCurrentFlow(
+        get().currentFlow,
+        flows.find((flow) => flow.id === get().currentFlowId),
+      ),
     });
   },
   currentFlow: undefined,


### PR DESCRIPTION
Fixes the exit dialog reporting **"Last saved: Never"** for a flow that is already persisted (auto-saving off).

## Root cause

`flowsManagerStore.currentFlow` is the *persisted* version of the open flow. Two things read it:

- the exit dialog's "Last saved" line, via `updated_at` ([`FlowPage/index.tsx`](https://github.com/langflow-ai/langflow/blob/baf3eb3a03/src/frontend/src/pages/FlowPage/index.tsx#L115-L379))
- the dirty check, via `data` ([`use-unsaved-changes.ts`](https://github.com/langflow-ai/langflow/blob/baf3eb3a03/src/frontend/src/hooks/use-unsaved-changes.ts#L5-L13))

`setFlows` replaced it with whatever row the refreshed list happened to hold:

```ts
setFlows: (flows: FlowType[]) => {
  set({
    flows,
    currentFlow: flows.find((flow) => flow.id === get().currentFlowId),
  });
},
```

The list feeding it is not that shape. The app header polls `GET /flows/?get_all=true&header_flows=true` ([`FlowMenu/index.tsx#L68-L74`](https://github.com/langflow-ai/langflow/blob/baf3eb3a03/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx#L68-L74)), and those rows are `FlowHeader` objects — no `updated_at` field at all, and `data` nulled for anything that is not a component ([`flow/model.py#L273-L300`](https://github.com/langflow-ai/langflow/blob/baf3eb3a03/src/backend/base/langflow/services/database/models/flow/model.py#L273-L300)).

That refetch is not incidental — it fires on **every** flow open, because `useGetFlow`'s `onSettled` refetches exactly that query key ([`use-get-flow.ts#L31-L41`](https://github.com/langflow-ai/langflow/blob/baf3eb3a03/src/frontend/src/controllers/API/queries/flows/use-get-flow.ts#L31-L41)). Order is deterministic: the mutation callback starts the refetch, `applyFlowToCanvas` synchronously stores the full flow, then the header response lands and overwrites it. So after any flow open — including a full page reload — the "persisted flow" in the store is a header with no `updated_at`, and the dialog says `Never`.

## Fix

Merge instead of replace: apply the fields the refreshed row carries, keep `data` and `updated_at` when it does not.

```ts
const mergeRefreshedCurrentFlow = (saved, refreshed) => {
  if (!refreshed) return undefined;
  if (!saved || saved.id !== refreshed.id) return refreshed;
  return {
    ...saved,
    ...refreshed,
    data: refreshed.data ?? saved.data,
    updated_at: refreshed.updated_at ?? saved.updated_at,
  };
};
```

A full row (`FlowRead` from `PATCH /flows/{id}` after a save, or a non-header list) still wins outright, and a flow that disappears from the list still clears `currentFlow` — the delete paths are unchanged.

### Second effect, deliberately included

The same overwrite blanked `data`, so `customStringify(canvasFlow) !== customStringify(savedFlow)` was **permanently true** after any header refresh: with auto-saving off the Save button stayed lit and the exit dialog appeared even with zero pending edits. That is the same one-line root cause, so it is fixed here too. The reported "Last saved" line was the visible half; this is the other one.

## Test plan

New regression tests in `src/frontend/src/stores/__tests__/flowsManagerStore-saved-flow-refresh.test.ts` drive the real store through the runtime sequence (`setCurrentFlow(full flow)` → `setFlows([header rows])`):

- [x] `updated_at` survives a header-only refresh — **fails on `release-1.11.5`** (`Expected "2026-08-19T10:00:00Z"`, `Received undefined`)
- [x] `data` / `locked` survive a header-only refresh — **fails on `release-1.11.5`** (`Received null`)
- [x] fields the refreshed row does carry (a rename, `folder_id`) still apply
- [x] a full row's `data` / `updated_at` still win over the stored one
- [x] `currentFlow` still clears when the flow is gone from the refreshed list

```bash
cd src/frontend && npx jest src/stores/__tests__/flowsManagerStore-saved-flow-refresh.test.ts
```

- [x] Full frontend Jest suite: 481 suites / 5581 tests passed
- [x] `biome check` clean; `tsc --noEmit` reports nothing new (the pre-existing errors in the old `flowsManagerStore.test.ts` are untouched)

Frontend-only, so it needs no matching backend version. Wants a forward-port to `release-1.12.0` / `main`, where the code is identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow refresh behavior to preserve saved graph data and update timestamps when list refreshes contain incomplete information.
  * Ensured refreshed flow details are applied when available.
  * Automatically clears the active flow when it is no longer present.
* **Tests**
  * Added coverage for saved-flow refresh scenarios, including complete and header-only flow records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->