### PR TITLE
fix(a11y): stop decorative canvas graphics reporting as unnamed

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/helper-lines.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/helper-lines.tsx
@@ -13,7 +13,8 @@ export default function HelperLines({ helperLines }: HelperLinesProps) {
   }
 
   return (
-    <svg className="helper-lines">
+    // Transient drag-alignment guides: decoration with no meaning to announce.
+    <svg className="helper-lines" aria-hidden="true">
       {helperLines.horizontal && (
         <line
           x1={0}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/hooks/__tests__/usePresentationalEdgeSvgs.test.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/hooks/__tests__/usePresentationalEdgeSvgs.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { usePresentationalEdgeSvgs } from "../usePresentationalEdgeSvgs";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function makeRef(el: HTMLElement | null) {
+  const ref = createRef<HTMLElement>();
+  Object.defineProperty(ref, "current", { value: el, writable: true });
+  return ref;
+}
+
+/** Mirrors ReactFlow's edge layer: `<svg>` wrapper around the named `<g>`. */
+function appendEdge(layer: Element, label: string) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  const g = document.createElementNS(SVG_NS, "g");
+  g.setAttribute("class", "react-flow__edge");
+  g.setAttribute("role", "group");
+  g.setAttribute("aria-label", label);
+  g.setAttribute("tabindex", "0");
+  svg.appendChild(g);
+  layer.appendChild(svg);
+  return { svg, g };
+}
+
+function edgeSvgRoles(canvas: HTMLElement) {
+  return [...canvas.querySelectorAll(".react-flow__edges > svg")].map((svg) =>
+    svg.getAttribute("role"),
+  );
+}
+
+describe("usePresentationalEdgeSvgs", () => {
+  let canvas: HTMLDivElement;
+  let layer: HTMLDivElement;
+
+  beforeEach(() => {
+    canvas = document.createElement("div");
+    layer = document.createElement("div");
+    layer.className = "react-flow__edges";
+    canvas.appendChild(layer);
+    document.body.appendChild(canvas);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(canvas);
+  });
+
+  it("does nothing when the ref is not attached", () => {
+    expect(() =>
+      renderHook(() => usePresentationalEdgeSvgs(makeRef(null))),
+    ).not.toThrow();
+  });
+
+  it("marks edge wrappers already mounted when the hook runs", () => {
+    appendEdge(layer, "Edge from A to B");
+    appendEdge(layer, "Edge from B to C");
+
+    renderHook(() => usePresentationalEdgeSvgs(makeRef(canvas)));
+
+    expect(edgeSvgRoles(canvas)).toEqual(["presentation", "presentation"]);
+  });
+
+  it("marks edge wrappers that mount after the hook runs", async () => {
+    renderHook(() => usePresentationalEdgeSvgs(makeRef(canvas)));
+
+    appendEdge(layer, "Edge from A to B");
+
+    await waitFor(() => {
+      expect(edgeSvgRoles(canvas)).toEqual(["presentation"]);
+    });
+  });
+
+  it("leaves ReactFlow's already-hidden marker <svg> alone", () => {
+    const marker = document.createElementNS(SVG_NS, "svg");
+    marker.setAttribute("class", "react-flow__marker");
+    marker.setAttribute("aria-hidden", "true");
+    marker.setAttribute("role", "presentation");
+    layer.appendChild(marker);
+
+    renderHook(() => usePresentationalEdgeSvgs(makeRef(canvas)));
+
+    expect(marker.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("never hides the wrapper, so the edge's name and tab stop survive", async () => {
+    renderHook(() => usePresentationalEdgeSvgs(makeRef(canvas)));
+
+    const { svg, g } = appendEdge(layer, "Edge from A to B");
+
+    await waitFor(() => {
+      expect(svg.getAttribute("role")).toBe("presentation");
+    });
+    // The regression this guards: an `aria-hidden` wrapper would strip the
+    // accessible name from every edge and drop them out of the a11y tree.
+    expect(svg.hasAttribute("aria-hidden")).toBe(false);
+    expect(g.getAttribute("aria-label")).toBe("Edge from A to B");
+    expect(g.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("stops marking once unmounted", async () => {
+    const { unmount } = renderHook(() =>
+      usePresentationalEdgeSvgs(makeRef(canvas)),
+    );
+    unmount();
+
+    const { svg } = appendEdge(layer, "Edge from A to B");
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(svg.getAttribute("role")).toBeNull();
+  });
+});

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/hooks/usePresentationalEdgeSvgs.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/hooks/usePresentationalEdgeSvgs.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+
+/**
+ * `:not([role])` keeps the pass idempotent and leaves ReactFlow's own
+ * `<svg class="react-flow__marker">` — which already ships `aria-hidden` — and
+ * any future roled wrapper untouched.
+ */
+const UNROLED_EDGE_SVG = ".react-flow__edges > svg:not([role])";
+
+/**
+ * Marks ReactFlow's per-edge `<svg>` wrappers as presentational.
+ *
+ * ReactFlow renders one bare `<svg style="z-index:…">` per edge and gives us no
+ * prop hook for it: the per-edge `domAttributes` escape hatch lands on the
+ * inner `<g>`, not on the wrapper. IBM Equal Access therefore reports each
+ * wrapper as an unnamed graphic (`svg_graphics_labelled`, WCAG 1.1.1). The
+ * wrappers carry no meaning of their own, so `role="presentation"` is the
+ * correct answer — it drops the wrapper's implicit `graphics-document` role
+ * without touching anything inside it.
+ *
+ * Do NOT reach for `aria-hidden` here. The named, tabbable `<g role="group">`
+ * that carries the edge's accessible name lives *inside* each wrapper, so an
+ * `aria-hidden` ancestor would erase every edge name and pull the edges out of
+ * the accessibility tree entirely.
+ *
+ * @param canvasRef Element wrapping the ReactFlow canvas.
+ */
+export function usePresentationalEdgeSvgs(
+  canvasRef: React.RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const markEdgeSvgs = () => {
+      for (const svg of canvas.querySelectorAll(UNROLED_EDGE_SVG)) {
+        svg.setAttribute("role", "presentation");
+      }
+    };
+
+    // Edges mount, unmount and re-mount for the lifetime of the canvas, so a
+    // one-shot pass on mount would only cover the edges present at that moment.
+    markEdgeSvgs();
+    const observer = new MutationObserver(markEdgeSvgs);
+    observer.observe(canvas, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [canvasRef]);
+}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -81,6 +81,7 @@ import {
   type HelperLinesState,
 } from "./helpers/helper-lines";
 import { useCanvasDragSelectFix } from "./hooks/useCanvasDragSelectFix";
+import { usePresentationalEdgeSvgs } from "./hooks/usePresentationalEdgeSvgs";
 import {
   MemoizedBackground,
   MemoizedCanvasControls,
@@ -763,6 +764,7 @@ export default function Page({
   }, []);
 
   useCanvasDragSelectFix(reactFlowWrapper);
+  usePresentationalEdgeSvgs(reactFlowWrapper);
 
   // Workaround to show the menu only after the selection has ended.
   useEffect(() => {
@@ -1027,7 +1029,13 @@ export default function Page({
               onNodeContextMenu={onNodeContextMenu}
             >
               {!effectiveLocked && <UpdateAllComponents />}
-              <MemoizedBackground />
+              {/* The dot grid is pure decoration. ReactFlow's <Background>
+                  does not forward DOM props, so the only way to reach its
+                  <svg> is a wrapper; `display: contents` keeps it out of the
+                  layout entirely. */}
+              <div aria-hidden="true" style={{ display: "contents" }}>
+                <MemoizedBackground />
+              </div>
               {helperLineEnabled && <HelperLines helperLines={helperLines} />}
             </ReactFlow>
             <FlowBuildingComponent />

--- a/src/frontend/tests/extended/features/canvas-decorative-svg-a11y.spec.ts
+++ b/src/frontend/tests/extended/features/canvas-decorative-svg-a11y.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "../../fixtures";
+import { openStarterProject } from "../../utils/flow/open-starter-project";
+
+/**
+ * WCAG 1.1.1 Non-text Content regression tests for the flow canvas.
+ *
+ * IBM Equal Access reported `svg_graphics_labelled` once per edge plus once for
+ * the dot-grid background: ReactFlow renders a bare `<svg>` wrapper around each
+ * edge and a bare `<svg>` for the grid, and an unnamed `<svg>` is an unnamed
+ * graphic. Both are decoration, so neither should reach assistive tech.
+ *
+ * The wrappers and the grid are fixed differently on purpose:
+ *   - the grid is wrapped in an `aria-hidden` container — nothing inside it
+ *     carries meaning;
+ *   - each edge wrapper only gets `role="presentation"`, because the named,
+ *     tabbable `<g role="group">` that carries the edge's accessible name lives
+ *     *inside* it. `aria-hidden` there would silently erase every edge name.
+ *
+ * That last point is what the second test guards: it resolves each edge through
+ * `getByRole` + accessible name, which is computed the way assistive tech
+ * computes it, so it fails the moment an `aria-hidden` ancestor is introduced.
+ */
+
+test(
+  "decorative canvas SVGs are not exposed as unnamed graphics",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await openStarterProject(page, "Basic Prompting");
+
+    const edgeWrappers = page.locator(".react-flow__edges > svg");
+    await expect(edgeWrappers.first()).toBeAttached();
+
+    // Presentational, never hidden — hiding would take the edge names with it.
+    const wrappers = await edgeWrappers.evaluateAll((svgs) =>
+      svgs.map((svg) => ({
+        role: svg.getAttribute("role"),
+        ariaHidden: svg.getAttribute("aria-hidden"),
+      })),
+    );
+    expect(wrappers.length).toBeGreaterThan(0);
+    for (const wrapper of wrappers) {
+      expect(wrapper.role).toBe("presentation");
+      expect(wrapper.ariaHidden).toBeNull();
+    }
+
+    const backgroundHidden = await page
+      .getByTestId("rf__background")
+      .evaluate((svg) => svg.closest('[aria-hidden="true"]') !== null);
+    expect(backgroundHidden).toBe(true);
+  },
+);
+
+test(
+  "every edge keeps its accessible name and tab stop",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await openStarterProject(page, "Basic Prompting");
+
+    const edges = page.locator(".react-flow__edge");
+    await expect(edges.first()).toBeAttached();
+
+    const names = await edges.evaluateAll((groups) =>
+      groups.map((group) => group.getAttribute("aria-label")),
+    );
+    expect(names.length).toBeGreaterThan(0);
+    expect(names).not.toContain(null);
+
+    for (const name of names) {
+      // `getByRole` uses the computed accessible name, so an `aria-hidden`
+      // ancestor anywhere above the edge makes this resolve to nothing.
+      const edge = page.getByRole("group", { name: name!, exact: true });
+      await expect(edge).toHaveCount(1);
+      await expect(edge).toHaveAttribute("tabindex", "0");
+
+      await edge.focus();
+      await expect(edge).toBeFocused();
+    }
+  },
+);


### PR DESCRIPTION
The flow canvas fails WCAG 1.1.1 Non-text Content. IBM Equal Access reports `svg_graphics_labelled` — "the SVG element has no accessible name" — for graphics that are pure decoration and shouldn't be reaching assistive tech at all: ReactFlow renders a bare `<svg>` wrapper around every edge, plus a bare `<svg>` for the dot grid. Screen reader users get a handful of anonymous "graphic" stops for scenery.

It's one violation per edge plus one for the grid, so the count scales with the flow. A 3-edge flow reports 4.

## The catch

The obvious fix — `aria-hidden` the offending `<svg>` — is wrong for the edges, and wrong in a way that's invisible unless you go looking.

#14209 names every edge through xyflow's native mechanism: `ariaLabel` on the edge lands on a `<g role="group" tabindex="0">`, and that `<g>` lives **inside** the very `<svg>` wrapper being flagged. An `aria-hidden` ancestor would strip the accessible name from every edge and drop the whole tabbable edge layer out of the accessibility tree. The scan would go green while the canvas got materially less accessible.

So the two halves are fixed differently, on purpose:

- **Dot grid** — wrapped in an `aria-hidden` container. Nothing inside it carries meaning.
- **Edge wrappers** — `role="presentation"` only. That drops the wrapper's implicit `graphics-document` role without touching anything inside it, so the edge names survive intact.

ReactFlow exposes no prop hook for either element (`<Background>` doesn't forward DOM props; the per-edge `domAttributes` escape hatch lands on the inner `<g>`, not the wrapper), so the edge wrappers are marked by a small `MutationObserver` hook on the canvas as edges mount.

Also hid the transient `<svg class="helper-lines">` drag guide — same defect class. It only renders mid-drag so no scan caught it, but any drag-state scan would.

## Results

Same dev server, same flow, IBM Equal Access via `checker.check(document, ["IBM_Accessibility"])`:

| | `svg_graphics_labelled` | total violations |
|---|---|---|
| before | 4 | 13 |
| after | **0** | 9 |

The remaining 9 (`element_tabbable_role_valid`, `element_scrollable_tabbable`) are pre-existing and out of scope here.

**No visual change:** before/after canvas screenshots are pixel-identical — 0 differing pixels out of 1,124,640.

## Test plan

`canvas-decorative-svg-a11y.spec.ts` has two tests, and the second one is the important one.

It resolves each edge through `getByRole("group", { name })` — the *computed* accessible name, the way assistive tech computes it, not an attribute spot-check. That means it fails the moment an `aria-hidden` ancestor is introduced anywhere above an edge. Verified by injecting exactly that regression: all 3 edges resolve `[1, 1, 1]` as shipped, and drop to `[0, 0, 0]` under `aria-hidden`.

- Spec run against unpatched code → test 1 fails, test 2 passes (confirming #14209 was intact beforehand and this is a genuine before/after).
- Spec run against this branch → both pass.
- 6 jest tests for the hook; full `PageComponent` suite green (63 tests).


Jira: [LE-2210](https://datastax.jira.com/browse/LE-2210)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader behavior by identifying decorative flow-canvas graphics as presentation-only.
  * Marked alignment guides and the background grid as hidden decorative content.
  * Preserved accessible names, roles, keyboard navigation, and focusability for interactive edges.

* **Tests**
  * Added automated coverage for dynamically rendered edges, decorative graphics, accessibility attributes, keyboard focus, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[LE-2210]: https://datastax.jira.com/browse/LE-2210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ