### PR TITLE
fix: stop requesting a project by an undefined id after the last one is deleted

### DIFF
--- a/src/frontend/src/controllers/API/queries/folders/__tests__/use-get-folder.test.ts
+++ b/src/frontend/src/controllers/API/queries/folders/__tests__/use-get-folder.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { useFolderStore } from "@/stores/foldersStore";
+
+const mockApiGet = jest.fn();
+let capturedQueryFn: (() => Promise<unknown>) | undefined;
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: () => ({
+    query: (_key: unknown, queryFn: () => Promise<unknown>) => {
+      capturedQueryFn = queryFn;
+      return {};
+    },
+  }),
+}));
+
+import { useGetFolderQuery } from "../use-get-folder";
+
+const EXISTING_PROJECT_ID = "5f9b0f2e-0d5e-4f6a-9d3f-2b6f7f0a1c22";
+const DELETED_PROJECT_ID = "b1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e";
+
+const paramsFor = (id: string | null | undefined) => ({
+  id,
+  page: 1,
+  size: 12,
+  is_component: false,
+  is_flow: true,
+  search: "",
+});
+
+const runQuery = async (id: string | null | undefined) => {
+  renderHook(() => useGetFolderQuery(paramsFor(id)));
+
+  let result: unknown;
+  await act(async () => {
+    result = await capturedQueryFn?.();
+  });
+  return result;
+};
+
+describe("useGetFolderQuery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedQueryFn = undefined;
+    useFolderStore.setState({
+      folders: [{ id: EXISTING_PROJECT_ID, name: "Starter Project" }] as never,
+    });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["empty", ""],
+  ])(
+    "sends no request and resolves with null when the project id is %s",
+    async (_label, id) => {
+      const result = await runQuery(id);
+
+      expect(mockApiGet).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    },
+  );
+
+  it("sends no request and resolves with null for a project the store no longer lists", async () => {
+    const result = await runQuery(DELETED_PROJECT_ID);
+
+    expect(mockApiGet).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("requests the project the store still lists", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { folder: { id: EXISTING_PROJECT_ID }, flows: { items: [] } },
+    });
+
+    await runQuery(EXISTING_PROJECT_ID);
+
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+    const requestedUrl = mockApiGet.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain(`/projects/${EXISTING_PROJECT_ID}?`);
+    expect(requestedUrl).not.toContain("undefined");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/folders/use-get-folder.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-get-folder.ts
@@ -10,7 +10,7 @@ import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 interface IGetFolder {
-  id: string;
+  id: string | null | undefined;
   page?: number;
   size?: number;
   is_component?: boolean;
@@ -24,7 +24,7 @@ const addQueryParams = (url: string, params: IGetFolder): string => {
 
 export const useGetFolderQuery: useQueryFunctionType<
   IGetFolder,
-  PaginatedFolderType | undefined
+  PaginatedFolderType | null
 > = (params, options) => {
   const { query } = UseRequestProcessor();
 
@@ -33,17 +33,24 @@ export const useGetFolderQuery: useQueryFunctionType<
 
   const getFolderFn = async (
     params: IGetFolder,
-  ): Promise<PaginatedFolderType | undefined> => {
-    if (params.id) {
-      if (latestIdRef.current !== params.id) {
-        params.page = 1;
-      }
-      latestIdRef.current = params.id;
+  ): Promise<PaginatedFolderType | null> => {
+    // Both guards below must run before the request is built: the account can
+    // hold no project at all (the id resolves to undefined), and a project the
+    // store no longer lists has just been deleted. Either way there is nothing
+    // to read, and interpolating the missing id would send the literal
+    // "undefined" as the path segment.
+    if (!params.id) {
+      return null;
+    }
 
-      const existingFolder = folders.find((f) => f.id === params.id);
-      if (!existingFolder) {
-        return;
-      }
+    if (latestIdRef.current !== params.id) {
+      params.page = 1;
+    }
+    latestIdRef.current = params.id;
+
+    const existingFolder = folders.find((f) => f.id === params.id);
+    if (!existingFolder) {
+      return null;
     }
 
     const url = addQueryParams(`${getURL("PROJECTS")}/${params.id}`, params);

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -91,7 +91,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   const permissionsFolderId = folderId ?? myCollectionId;
 
   const { data: folderData, isLoading } = useGetFolderQuery({
-    id: folderId ?? myCollectionId!,
+    id: folderId ?? myCollectionId,
     page: pageIndex,
     size: pageSize,
     is_component: flowType === "components",
@@ -142,8 +142,8 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
     // folder is empty. This avoids a one-frame flash of <EmptyFolder> on
     // initial mount and right after login, when the store is briefly
     // stale. Gating on isLoading instead of folderData lets us still
-    // resolve when the query errors out (e.g. when there is no valid
-    // folder id to query, after deleting all folders).
+    // resolve when the query settles with no folder to read (it returns
+    // null when there is no valid folder id, after deleting all folders).
     if (flows === undefined || isLoading) return;
     setIsEmptyFolder(
       isFolderEmpty({

--- a/src/frontend/tests/core/features/folder-deletion-integrity.spec.ts
+++ b/src/frontend/tests/core/features/folder-deletion-integrity.spec.ts
@@ -15,8 +15,43 @@ import {
 // case that deletes every project. Keep those destructive transitions ordered.
 test.describe.configure({ mode: "serial" });
 
+const PROJECT_PATH_PREFIX = "/api/v1/projects/";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Deleting the last project leaves the home page re-rendering with a project
+// id that has just become undefined. It used to reach the network as
+// GET /api/v1/projects/undefined and come back 422, so watch every project
+// request these destructive tests make and keep non-id ones out.
+function collectInvalidProjectRequests(page: Page): string[] {
+  const invalidRequests: string[] = [];
+  page.on("request", (request) => {
+    const { pathname } = new URL(request.url());
+    if (!pathname.startsWith(PROJECT_PATH_PREFIX)) return;
+
+    // Everything past the prefix identifies a single project; the list route
+    // ends at the prefix and nested routes (download/, upload/) keep a slash.
+    const projectId = pathname.slice(PROJECT_PATH_PREFIX.length);
+    if (projectId === "" || projectId.includes("/")) return;
+    if (UUID_PATTERN.test(projectId)) return;
+
+    invalidRequests.push(`${request.method()} ${pathname}`);
+  });
+  return invalidRequests;
+}
+
+let invalidProjectRequests: string[] = [];
+
 test.beforeEach(async ({ page }, testInfo) => {
+  invalidProjectRequests = collectInvalidProjectRequests(page);
   await routeTestScopedDefaultFlowNames(page, testInfo, "folder-integrity");
+});
+
+test.afterEach(() => {
+  expect(
+    invalidProjectRequests,
+    "the frontend requested a project by an id that is not a UUID",
+  ).toEqual([]);
 });
 
 async function createAndRenameProject(page: Page, projectName: string) {


### PR DESCRIPTION
## Why

Refs LE-2231

Deleting the last project an account has makes the home page re-render with a project id of `undefined`, and the paginated flows query still fired for it — the literal string reached the URL as `GET /api/v1/projects/undefined?page=1&size=12&is_component=false&is_flow=true&search=`, which the backend rejects with a 422 `uuid_parsing` error. A fresh account ships exactly one project, so this is two clicks away on a new install, and every pass through the transition drops an invalid-UUID 4xx into the API error channel that QA has to discount.

The guard that should have stopped it already existed in `useGetFolderQuery`, but it was nested inside `if (params.id)`: with no id at all, the whole block — including the guard — was skipped and execution fell straight through to the request.

## What

- Both guards now run before the URL is built: a missing id and a project the folder store no longer lists each stop the read, so no request leaves the browser.
- They resolve with `null` instead of returning nothing. Returning `undefined` from a query function is rejected by react-query, which turned every guarded read into a failed query plus a dev-only console error; `null` settles the query as a success carrying no folder, which is what the caller already reads through optional chaining. The empty-project screen still resolves off `isLoading`, exactly as before.
- The query params type accepts a missing id, so the call site no longer asserts away the very state that produced the invalid request.
- No user-facing behavior changes: the empty-project screen renders identically, the request simply stops going out.

## How to validate

1. S1 — Start Langflow with a fresh account (one project) and open the home page with the network tab recording. Delete that project: no request goes out for it, and the empty-project screen renders.
2. S2 — Compare the empty-project screen with the same screen before this change: identical.
3. S3 — With three projects, delete the third and the second, then the last one. No project request carries a non-UUID id at any step.
4. S4 — From the empty screen, create a flow: a default `Starter Project` is created and holds it.
5. S5 — Console shows no new error; the `Failed to load resource: 422` entry that used to follow the last deletion is gone.

This change has no visual surface, so light and dark render the same as on the base; the screenshot below is the end state of S1/S2.

### S2 — the empty-project screen is unchanged

<table>
<tr>
<th>before</th>
<th>after</th>
</tr>
<tr>
<td>
<img width="1280" height="720" alt="01-empty-project-screen-S2-before" src="https://github.com/user-attachments/assets/bf826d65-7244-4b93-b065-1bf7ff8dfaad" />
<br />
<sub>Base: the screen renders, but only after a 422 for the deleted project</sub>
</td>
<td>
<img width="1280" height="720" alt="01-empty-project-screen-S2-after" src="https://github.com/user-attachments/assets/5d634e3a-0aba-4d8d-8415-364d01fb9d76" />
<br />
<sub>Branch: same screen, no request for the missing project</sub>
</td>
</tr>
</table>

## Tests

- New unit test `use-get-folder.test.ts` pins what the hook must not request: a missing id (`undefined`, `null`, empty) and an id the store no longer lists both resolve with `null` and issue no request, while a listed id is requested with the id in the path. Four of its five cases fail against the previous implementation.
- `folder-deletion-integrity.spec.ts` now inspects every project request its tests make and fails the test that asks for a project by a non-UUID id. The suite already walked the one-project-to-none transition, but nothing looked at the URL. Against the previous implementation the last test fails with `GET /api/v1/projects/undefined`; with this change all four pass.
- Measured locally on the same build, deleting every project through the UI: non-UUID project requests 1 → 0, project 4xx responses 1 → 0, related console errors 1 → 0. `npx jest src/pages/MainPage/pages/homePage src/controllers/API/queries/folders`: 88 passed.

## Note

A 404 on `GET /api/v1/projects/{id}` for a project that was just deleted — a real id, not `undefined` — is called out in the ticket as related but distinct and is not addressed here. The existence guard covers it once the store has dropped the project; the store-versus-refetch race was not investigated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder queries now handle missing or deleted folder IDs gracefully by returning no folder result instead of an undefined state.
  * Pagination resets correctly when switching between folders.

* **Tests**
  * Added coverage for missing, deleted, and valid folder IDs.
  * Added checks ensuring folder deletion does not trigger invalid project requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
