### PR TITLE
test(frontend): forward-port the grouped-node readiness stabilization to 1.11.5

### DIFF
--- a/src/frontend/tests/core/unit/groupFalseError.spec.ts
+++ b/src/frontend/tests/core/unit/groupFalseError.spec.ts
@@ -1,6 +1,7 @@
 import type { APIClassType, APIObjectType } from "../../../src/types/api";
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
 
 /**
  * LE-2045: grouping succeeds but raises "Error while updating the Component".
@@ -110,8 +111,18 @@ test(
     expect(created.status()).toBe(201);
     const flowId = (await created.json()).id;
 
+    const flowLoadPromise = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname.endsWith(`/api/v1/flows/${flowId}`) &&
+        response.request().method() === "GET" &&
+        response.status() === 200,
+      { timeout: TIMEOUTS.standard },
+    );
     await page.goto(`/flow/${flowId}`);
-    await expect(page.getByTestId("div-generic-node")).toHaveCount(1);
+    await flowLoadPromise;
+    await expect(page.getByTestId("div-generic-node")).toHaveCount(1, {
+      timeout: TIMEOUTS.standard,
+    });
     await page.waitForTimeout(4000);
 
     await page.getByTestId("notification_button").click();


### PR DESCRIPTION
## Summary

Forward-port the `groupFalseError` test stabilization from #14411 (commit `46903cca93`) to `release-1.11.5`. Test-only; no application code changes.

## Why

`release-1.11.5` still carries the unstabilized assertion:

```ts
await page.goto(`/flow/${flowId}`);
await expect(page.getByTestId("div-generic-node")).toHaveCount(1);
```

That runs on Playwright's **default 5s** timeout. Under shard contention the flow `GET` often does not start within 5s, so `Playwright Tests - Shard 47/70` fails with:

```
Locator:  getByTestId('div-generic-node')
Expected: 1   Received: 0   Timeout: 5000ms
  - 4 × locator resolved to 0 elements
```

#14411 fixed exactly this on `release-1.12.0` on 2026-08-04 — wait for the specific `GET /api/v1/flows/<id>` 200 response, then assert with the shared 30s `TIMEOUTS.standard`. The fix is in `release-1.12.0` and `main`, but was never forward-ported to `release-1.11.5`:

```
$ git merge-base --is-ancestor 46903cca93 origin/release-1.11.5  -> NOT in release-1.11.5
$ git merge-base --is-ancestor 46903cca93 origin/release-1.12.0  -> IN release-1.12.0
$ git merge-base --is-ancestor 46903cca93 origin/main            -> IN main
```

It is currently hitting every PR on this branch, and it is not PR-specific:

- #14658 (backend-only: `__main__.py`, an lfx settings field, docs) failed shard 47 on **all 3 run attempts**, both `nick-fields/retry` attempts each time.
- #14654 (security backport) failed the same test on retry attempt 1 and only went green because attempt 2 passed.

## Testing

- `biome check tests/core/unit/groupFalseError.spec.ts` — clean
- Cherry-picked cleanly onto the current `release-1.11.5` tip (`c5bf996bc6`, post-#14654); `TIMEOUTS.standard` (30s) already exists in `tests/utils/constants/timeouts.ts` on this branch
- Shard 47 in CI here is the real check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using standard wait timeouts.
  * Added explicit waiting for flow data to load before checking grouped node results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->