### PR TITLE
fix(a11y): keep a tabbable row in every AG-Grid table after scrolling

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/hooks/__tests__/use-ag-grid-accessibility-patch.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/hooks/__tests__/use-ag-grid-accessibility-patch.test.ts
@@ -136,6 +136,21 @@ describe("patchEmptyRowGroups", () => {
 });
 
 describe("patchTabbableRow", () => {
+  /** Body rows carrying AG Grid's `row-index`, appended in the given DOM order. */
+  function makeBodyRows(container: HTMLElement, rowIndexes: number[]) {
+    const rowsContainer = document.createElement("div");
+    rowsContainer.className = "ag-center-cols-container";
+    const rows = rowIndexes.map((rowIndex) => {
+      const row = document.createElement("div");
+      row.setAttribute("role", "row");
+      row.setAttribute("row-index", String(rowIndex));
+      rowsContainer.appendChild(row);
+      return row;
+    });
+    container.appendChild(rowsContainer);
+    return rows;
+  }
+
   it("makes only the first body row tabbable (roving tabindex)", () => {
     const container = document.createElement("div");
     const rowsContainer = document.createElement("div");
@@ -194,5 +209,67 @@ describe("patchTabbableRow", () => {
 
     expect(bodyRow.getAttribute("tabindex")).toBe("0");
     expect(headerRow.getAttribute("tabindex")).toBe("-1");
+  });
+
+  // Virtualization recycles row elements, so the rendered window is a moving
+  // range of row indexes rather than rows 0..n. Re-patching must put the tab
+  // stop on whichever row is now topmost.
+  it("moves the tab stop to the topmost row of the rendered window", () => {
+    const container = document.createElement("div");
+    const rows = makeBodyRows(container, [120, 121, 122]);
+
+    patchTabbableRow(container);
+
+    expect(rows[0].getAttribute("tabindex")).toBe("0");
+    expect(rows[1].getAttribute("tabindex")).toBe("-1");
+    expect(rows[2].getAttribute("tabindex")).toBe("-1");
+  });
+
+  // `ensureDomOrder` is on by default but consumers can turn it off through
+  // `gridOptions`, and AG Grid then reuses row elements in place — DOM order no
+  // longer tracks visual order, so `row-index` decides the tab stop.
+  it("picks the lowest row-index, not the first element in the DOM", () => {
+    const container = document.createElement("div");
+    const rows = makeBodyRows(container, [122, 120, 121]);
+
+    patchTabbableRow(container);
+
+    expect(rows[0].getAttribute("tabindex")).toBe("-1");
+    expect(rows[1].getAttribute("tabindex")).toBe("0");
+    expect(rows[2].getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("keeps exactly one tab stop when the rendered window scrolls on", () => {
+    const container = document.createElement("div");
+    const rows = makeBodyRows(container, [0, 1, 2]);
+
+    patchTabbableRow(container);
+    expect(rows[0].getAttribute("tabindex")).toBe("0");
+
+    // AG Grid recycles the element that owned the tab stop onto a later row.
+    rows[0].setAttribute("row-index", "3");
+
+    patchTabbableRow(container);
+
+    const tabbable = rows.filter((row) => row.getAttribute("tabindex") === "0");
+    expect(tabbable).toEqual([rows[1]]);
+  });
+
+  it("falls back to the first rendered row when no row exposes a row-index", () => {
+    const container = document.createElement("div");
+    const rowsContainer = document.createElement("div");
+    rowsContainer.className = "ag-center-cols-container";
+    const rows = [0, 1].map(() => {
+      const row = document.createElement("div");
+      row.setAttribute("role", "row");
+      rowsContainer.appendChild(row);
+      return row;
+    });
+    container.appendChild(rowsContainer);
+
+    patchTabbableRow(container);
+
+    expect(rows[0].getAttribute("tabindex")).toBe("0");
+    expect(rows[1].getAttribute("tabindex")).toBe("-1");
   });
 });

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/hooks/use-ag-grid-accessibility-patch.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/hooks/use-ag-grid-accessibility-patch.ts
@@ -92,27 +92,57 @@ export function patchEmptyRowGroups(container: HTMLElement) {
 }
 
 /**
+ * The rendered body row closest to the top of the viewport — where a keyboard
+ * user should land when they tab into the grid. AG Grid's `row-index` attribute
+ * is the source of truth rather than DOM position: DOM order only tracks visual
+ * order while `ensureDomOrder` is on, and consumers can turn it off through
+ * `gridOptions`. Falls back to the first rendered row if no row carries a
+ * usable index.
+ */
+function getTopRenderedRow(rows: HTMLElement[]): HTMLElement {
+  let topRow = rows[0];
+  let topIndex = Number.POSITIVE_INFINITY;
+  for (const row of rows) {
+    const index = Number.parseInt(row.getAttribute("row-index") ?? "", 10);
+    if (Number.isNaN(index) || index >= topIndex) continue;
+    topIndex = index;
+    topRow = row;
+  }
+  return topRow;
+}
+
+/**
  * A `treegrid`/`grid` must expose a tabbable `row` so keyboard users can reach
  * its content (IBM `aria_child_tabbable`, WCAG 2.1.1 / 4.1.2). AG Grid keeps all
  * rows at `tabindex="-1"` and relies on its tab guards instead. Apply a roving
- * tabindex: the first rendered body row becomes the grid's single tabbable row,
- * the rest stay `-1`. When the body is empty (e.g. filtered to zero matches) the
- * header still exposes `role="row"` descendants, so fall back to the first
- * header row — otherwise IBM flags the treegrid for having no tabbable row.
- * Actual cell navigation is unchanged (arrow keys / the tab guards still drive
- * focus into cells).
+ * tabindex: the topmost rendered body row becomes the grid's single tabbable
+ * row, the rest stay `-1`. When the body is empty (e.g. filtered to zero
+ * matches) the header still exposes `role="row"` descendants, so fall back to
+ * the first header row — otherwise IBM flags the treegrid for having no tabbable
+ * row. Actual cell navigation is unchanged (arrow keys / the tab guards still
+ * drive focus into cells).
+ *
+ * Row virtualization recycles the row holding the tab stop out of the DOM as
+ * soon as the user scrolls past it, which would leave the grid with zero
+ * tabbable rows and no way to enter it from the keyboard. The table component
+ * therefore re-runs this patch on `viewportChanged` and `modelUpdated`, so the
+ * tab stop follows the rendered window instead of dying with the row that
+ * happened to own it first.
  */
 export function patchTabbableRow(container: HTMLElement) {
-  const bodyRows = container.querySelectorAll<HTMLElement>(
-    '.ag-center-cols-container [role="row"]',
+  const bodyRows = Array.from(
+    container.querySelectorAll<HTMLElement>(
+      '.ag-center-cols-container [role="row"]',
+    ),
   );
   const headerRows = container.querySelectorAll<HTMLElement>(
     '.ag-header [role="row"]',
   );
 
   if (bodyRows.length > 0) {
-    bodyRows.forEach((row, index) => {
-      setAttributeIfChanged(row, "tabindex", index === 0 ? "0" : "-1");
+    const tabStop = getTopRenderedRow(bodyRows);
+    bodyRows.forEach((row) => {
+      setAttributeIfChanged(row, "tabindex", row === tabStop ? "0" : "-1");
     });
     // Body rows own the roving tab stop — keep header rows out of the tab order.
     headerRows.forEach((row) => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -644,6 +644,22 @@ const TableComponent = forwardRef<
             scheduleGridAccessibilityPatch();
             props.onPaginationChanged?.(event);
           }}
+          // Row virtualization recycles the row that owns the roving tab stop
+          // out of the DOM once the user scrolls past it, and nothing puts the
+          // tab stop back — the grid then has no tabbable row at all and cannot
+          // be entered from the keyboard (IBM `aria_child_tabbable`, WCAG
+          // 2.1.1). `viewportChanged` fires whenever the rendered row window
+          // moves, `modelUpdated` covers the re-renders that sorting, filtering
+          // and data changes trigger. The patch is rAF-debounced, so the scroll
+          // path stays cheap.
+          onViewportChanged={(event) => {
+            scheduleGridAccessibilityPatch();
+            props.onViewportChanged?.(event);
+          }}
+          onModelUpdated={(event) => {
+            scheduleGridAccessibilityPatch();
+            props.onModelUpdated?.(event);
+          }}
           onColumnMoved={onColumnMoved}
           onCellEditingStarted={onCellEditingStarted}
           onCellKeyDown={onCellKeyDown}

--- a/src/frontend/tests/extended/features/grid-tabbable-row.spec.ts
+++ b/src/frontend/tests/extended/features/grid-tabbable-row.spec.ts
@@ -1,0 +1,201 @@
+import type { Route } from "@playwright/test";
+import { expect, type LangflowPage, test } from "../../fixtures";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
+
+/**
+ * WCAG 2.1.1 Keyboard regression test for the shared AG-Grid wrapper
+ * (components/core/parameterRenderComponent/components/tableComponent).
+ *
+ * The grid exposes exactly one tabbable `role="row"` — the roving tab stop that
+ * lets a keyboard user enter it (IBM `aria_child_tabbable`). Row virtualization
+ * recycles the row holding that tab stop out of the DOM as soon as the user
+ * scrolls past it. Before the `viewportChanged` / `modelUpdated` wiring the tab
+ * stop was assigned once on first render and never reassigned, so scrolling a
+ * long grid left it with zero tabbable rows and no way back in — it did not
+ * even recover on scrolling to the top again.
+ *
+ * The messages table is mocked with enough rows to force recycling; the grids
+ * that pass today (API keys, global variables) only do so because their handful
+ * of rows never scroll far enough to recycle one.
+ */
+
+const MOCK_FLOW_ID = "fcfc747e-0b93-4ff5-a9e1-3788c14a849b";
+const MOCK_MESSAGE_COUNT = 250;
+
+function buildMessages(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    flow_id: MOCK_FLOW_ID,
+    timestamp: `2026-08-19 16:${String(index % 60).padStart(2, "0")}:00.000000 UTC`,
+    sender: index % 2 ? "Machine" : "User",
+    sender_name: index % 2 ? "Language Model" : "User",
+    session_id: MOCK_FLOW_ID,
+    context_id: "",
+    text: `Seeded message ${index}`,
+    files: "[]",
+    edit: false,
+    duration: null,
+    properties: {
+      text_color: null,
+      background_color: null,
+      edited: false,
+      source: { id: null, display_name: null, source: null },
+      icon: null,
+      allow_markdown: false,
+      positive_feedback: null,
+      state: "complete",
+      targets: [],
+      usage: null,
+      build_duration: null,
+    },
+    category: "message",
+    content_blocks: [],
+    session_metadata: { graph_run_id: MOCK_FLOW_ID },
+  }));
+}
+
+/** Rows the grid currently exposes as keyboard tab stops. Must never be empty. */
+async function getTabbableRowIndexes(page: LangflowPage): Promise<string[]> {
+  return page.evaluate(() =>
+    [...document.querySelectorAll('[role="row"]')]
+      .filter((row) => {
+        const tabindex = row.getAttribute("tabindex");
+        return tabindex !== null && tabindex !== "-1";
+      })
+      .map((row) => row.getAttribute("row-index") ?? "header"),
+  );
+}
+
+async function getViewportMetrics(page: LangflowPage) {
+  return page.evaluate(() => {
+    const viewport = document.querySelector(".ag-body-viewport");
+    if (!viewport) throw new Error("grid body viewport not found");
+    return {
+      scrollTop: viewport.scrollTop,
+      scrollHeight: viewport.scrollHeight,
+      clientHeight: viewport.clientHeight,
+    };
+  });
+}
+
+async function scrollGridTo(page: LangflowPage, scrollTop: number) {
+  await page.evaluate((top) => {
+    const viewport = document.querySelector(".ag-body-viewport");
+    if (!viewport) throw new Error("grid body viewport not found");
+    viewport.scrollTop = top;
+  }, scrollTop);
+  // The tab stop is reassigned on the grid's viewportChanged event and applied
+  // on the next animation frame, so wait for the grid to settle before reading.
+  await page.waitForTimeout(400);
+}
+
+test(
+  "messages grid keeps a tabbable row while the rows around it are virtualized away",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }, testInfo) => {
+    await page.route("**/api/v1/monitor/messages*", async (route: Route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      await route.fulfill({ json: buildMessages(MOCK_MESSAGE_COUNT) });
+    });
+
+    await page.goto("/settings/messages");
+    await page
+      .locator('.ag-center-cols-container [role="row"]')
+      .first()
+      .waitFor({ timeout: TIMEOUTS.standard });
+
+    const metrics = await getViewportMetrics(page);
+    // Guard the premise: without overflow no row is ever recycled and the test
+    // would pass against the unfixed code.
+    expect(
+      metrics.scrollHeight,
+      "mocked grid must overflow its viewport, otherwise no row is virtualized away",
+    ).toBeGreaterThan(metrics.clientHeight * 2);
+
+    expect(
+      await getTabbableRowIndexes(page),
+      "grid must expose exactly one tab stop on load",
+    ).toHaveLength(1);
+
+    const maxScroll = metrics.scrollHeight - metrics.clientHeight;
+    const steps = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        Math.round((maxScroll * (i + 1)) / 5),
+      ),
+      maxScroll,
+      0,
+    ];
+
+    for (const scrollTop of steps) {
+      await scrollGridTo(page, scrollTop);
+      expect(
+        await getTabbableRowIndexes(page),
+        `grid lost its keyboard tab stop at scrollTop=${scrollTop}`,
+      ).toHaveLength(1);
+    }
+
+    await testInfo.attach("messages-grid-scrolled-back-to-top", {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+  },
+);
+
+test(
+  "messages grid stays keyboard-enterable and arrow-navigable after scrolling",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await page.route("**/api/v1/monitor/messages*", async (route: Route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      await route.fulfill({ json: buildMessages(MOCK_MESSAGE_COUNT) });
+    });
+
+    await page.goto("/settings/messages");
+    await page
+      .locator('.ag-center-cols-container [role="row"]')
+      .first()
+      .waitFor({ timeout: TIMEOUTS.standard });
+
+    const { scrollHeight, clientHeight } = await getViewportMetrics(page);
+    await scrollGridTo(page, scrollHeight - clientHeight);
+
+    expect(
+      await getTabbableRowIndexes(page),
+      "grid lost its keyboard tab stop after scrolling to the bottom",
+    ).toHaveLength(1);
+
+    // Tab in from the page chrome. AG Grid's tab guards intercept the entry and
+    // hand focus to a header cell rather than to the roving row itself, so the
+    // assertion is "focus ends up inside the grid", not "focus lands on the row".
+    await page.evaluate(() => document.body.focus());
+    let enteredAfter = -1;
+    for (let press = 0; press < 40; press++) {
+      await page.keyboard.press("Tab");
+      const insideGrid = await page.evaluate(() =>
+        Boolean(document.activeElement?.closest(".ag-root-wrapper")),
+      );
+      if (insideGrid) {
+        enteredAfter = press;
+        break;
+      }
+    }
+    expect(
+      enteredAfter,
+      "could not reach the grid with the Tab key after scrolling",
+    ).toBeGreaterThanOrEqual(0);
+
+    // Arrow keys still drive AG Grid's own cell navigation once focus is inside.
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator(".ag-cell-focus")).toHaveCount(1);
+    const firstCell = await page
+      .locator(".ag-cell-focus")
+      .getAttribute("col-id");
+
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator(".ag-cell-focus")).toHaveCount(1);
+    expect(
+      await page.locator(".ag-cell-focus").getAttribute("col-id"),
+      "ArrowDown should stay in the same column while moving down rows",
+    ).toBe(firstCell);
+  },
+);


### PR DESCRIPTION
Scroll a long data table far enough and you can no longer tab into it — at all. Keyboard users lose the grid entirely, and it doesn't come back when you scroll to the top again.

AG-Grid tables use a roving tabindex: exactly one row carries `tabindex="0"`, and that's the keyboard's way in. Our shared wrapper assigned it in `patchTabbableRow()`, but only scheduled the patch on `gridReady`, `firstDataRendered` and `paginationChanged`. Row virtualization is scroll-driven and fires none of those, so as soon as the row holding the tab stop got recycled out of the DOM, nothing put it back.

The fix re-runs the existing patch on `viewportChanged` (the rendered row window moved) and on `modelUpdated`, which closes the same hole for sort/filter/data re-renders. The patch is already rAF-debounced, so the scroll path stays cheap. I deliberately did *not* use `setFocusedCell` — that moves real DOM focus, which would yank focus around while a user is merely scrolling.

The tab stop is now picked by the lowest `row-index` rather than DOM position. `ensureDomOrder` is the wrapper default but consumers can override it through `gridOptions`, and without it DOM order stops tracking visual order.

This is latent on **every** grid using the shared wrapper. API keys and global variables pass today only because their handful of rows never scroll far enough to recycle one; they'd fail the moment the data grows. Fixed once in the wrapper rather than per page.

### Measured on `/settings/messages`

IBM Equal Access engine 4.0.30, via `aChecker.getCompliance` directly rather than our scanner wrapper:

| state | tabbable rows before | tabbable rows after | `aria_child_tabbable` |
|---|---|---|---|
| on load | 1 | 1 | passed either way |
| scrolled to bottom | **0** | 1 | FAIL → clean |
| scrolled back to top | **0** | 1 | FAIL → clean |

The `tabindex` change is invisible in a plain screenshot, so these are annotated with the measured tab-stop count instead of two identical images:

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-grid-tabbable-row/before.png" alt="Messages table scrolled to the bottom of 250 rows, with a red banner reporting zero tabbable rows and that the grid is keyboard-unreachable" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-grid-tabbable-row/after.png" alt="The same table in the same scrolled position, with a green banner reporting one tabbable row and that the keyboard can enter the grid" width="100%"></td>
</tr>
</table>

### Tests

`grid-tabbable-row.spec.ts` scrolls a 250-row grid through its full range and asserts the tab stop survives at every step, then tabs in from the page chrome and arrows through cells. Both tests fail on `release-1.12.0` (`grid lost its keyboard tab stop at scrollTop=775`) and pass here. Four unit tests cover the recycled-window, out-of-order-DOM and missing-`row-index` cases.

`focus-visible.spec.ts` still passes, so the focus ring from #14627 is intact — that PR made grid focus *visible*, this one makes it *reachable*.

### Worth knowing

A real Tab doesn't land on the roving row. AG-Grid's tab guards intercept entry and hand focus to the header cells first; arrow keys then drive cell navigation as usual. The row's `tabindex="0"` serves the ARIA contract that assistive tech relies on, not the sighted-keyboard path. That's pre-existing behaviour, not something this changes — but it's why the keyboard test asserts "focus ends up inside the grid" rather than "focus lands on the row".

Compliance row 2.1.1 is left as-is; it also needs the canvas keyboard work before it can flip.

Jira: [LE-2264](https://datastax.jira.com/browse/LE-2264)


[LE-2264]: https://datastax.jira.com/browse/LE-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in virtualized data grids.
  * Maintains exactly one accessible tab stop as rows are recycled during scrolling.
  * Preserves keyboard entry and ArrowDown navigation after scrolling.
  * Selects the correct topmost visible row for keyboard focus, with a fallback when row positions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->