### PR TITLE
fix(a11y): scanner reported rules from no policy, inflating our violation counts

### DIFF
--- a/.agents/skills/ibm-a11y-route-scan/SKILL.md
+++ b/.agents/skills/ibm-a11y-route-scan/SKILL.md
@@ -146,6 +146,9 @@ Supported state actions:
 - `{ "waitForHidden": "<css selector>" }`
 - `{ "waitForText": "<visible text>" }`
 - `{ "wait": 500 }`
+- `{ "scroll": { "selector": "<css selector>", "to": "bottom" } }` — `to` is `top` or
+  `bottom`; use `"by": <pixels>` for a relative scroll, and omit `selector` to scroll the
+  page. Needed for virtualised grids whose tabbable rows only disappear after scrolling.
 
 ## Report
 

--- a/.github/workflows/a11y-scan.yml
+++ b/.github/workflows/a11y-scan.yml
@@ -232,3 +232,122 @@ jobs:
           retention-days: 30
           overwrite: true
           if-no-files-found: ignore
+
+  # The Python route scanner (scripts/a11y/a11y_scan.py) is the unmocked
+  # counterpart to the Playwright suite: it renders each static route against a
+  # real backend, so it sees DOM the mocked specs never build (e.g. real
+  # provider icon SVGs). Reporting only — the scanner exits 0 regardless of
+  # findings; publish-worthy numbers still come from the Playwright summary.
+  python-route-scan:
+    name: Python route scan (real backend, nightly)
+    needs: resolve-ref
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-ref.outputs.ref }}
+
+      - name: Setup Node.js Environment
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Frontend Dependencies
+        run: npm ci
+        working-directory: ./src/frontend
+
+      - name: "Setup Environment"
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          version: latest-known
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: ${{ env.PYTHON_VERSION }}
+          prune-cache: false
+
+      - name: Install Python Dependencies
+        run: uv sync
+
+      - name: Install Scanner Browser
+        timeout-minutes: 10
+        run: uv run --with playwright playwright install chromium
+
+      - name: Start Backend And Frontend
+        shell: bash
+        env:
+          LANGFLOW_DATABASE_URL: "sqlite:///./temp"
+          LANGFLOW_AUTO_LOGIN: "true"
+          LANGFLOW_SUPERUSER: "langflow"
+          LANGFLOW_SUPERUSER_PASSWORD: "test-superuser-password" # pragma: allowlist secret
+          LANGFLOW_DEACTIVATE_TRACING: "true"
+          LANGFLOW_LOG_LEVEL: "ERROR"
+          DO_NOT_TRACK: "true"
+        run: |
+          uv run uvicorn --factory langflow.main:create_app \
+            --host localhost --port 7860 --loop asyncio \
+            --log-level error --no-access-log &
+          (cd src/frontend && npm start) &
+          timeout 300 bash -c 'until curl -sf http://localhost:7860/health; do sleep 2; done'
+          timeout 120 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
+
+      - name: Run Python Route Scan
+        shell: bash
+        run: |
+          uv run --with playwright python scripts/a11y/a11y_scan.py \
+            --url http://localhost:3000 \
+            --routes-file scripts/a11y/a11y_routes.json \
+            --route-group static \
+            --states-file scripts/a11y/states/settings-messages.json \
+            --out python-route-scan/report.json \
+            --markdown python-route-scan/report.md \
+            --html python-route-scan/report.html \
+            --timeout-ms 45000
+          {
+            echo '## Python route scan (unmocked)'
+            echo ''
+            cat python-route-scan/report.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Python Scan Report
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-route-scan-${{ github.run_attempt }}
+          path: python-route-scan
+          retention-days: 30
+          if-no-files-found: error
+
+  # The Python scanner pins its engine (DEFAULT_ACE_URL) to the same version the
+  # Playwright suite resolves via the accessibility-checker npm dependency. This
+  # guard fails the workflow if the two pins drift apart again.
+  engine-pin-check:
+    name: Engine pin sync check
+    needs: resolve-ref
+    # Advisory for now: a drift failure annotates the run but never turns the
+    # PR red. Drop this line to make the guard enforcing.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-ref.outputs.ref }}
+
+      - name: Compare Engine Pins
+        shell: bash
+        run: |
+          NPM_PIN=$(node -p "require('./src/frontend/package.json').devDependencies['accessibility-checker'].replace(/^[^0-9]*/, '')")
+          PY_PIN=$(grep -oE 'accessibility-checker-engine@[0-9.]+' scripts/a11y/a11y_scan.py | cut -d@ -f2)
+          echo "npm accessibility-checker: $NPM_PIN"
+          echo "python DEFAULT_ACE_URL:    $PY_PIN"
+          if [ -z "$PY_PIN" ] || [ "$NPM_PIN" != "$PY_PIN" ]; then
+            echo "::error::Engine pins differ (npm=$NPM_PIN, python=$PY_PIN). Update DEFAULT_ACE_URL in scripts/a11y/a11y_scan.py or the accessibility-checker dependency so both scanners evaluate the same ruleset."
+            exit 1
+          fi

--- a/scripts/a11y/a11y_routes.json
+++ b/scripts/a11y/a11y_routes.json
@@ -102,7 +102,16 @@
       "id": "settings-messages",
       "path": "/settings/messages",
       "surface": "Messages settings page",
-      "ready": [{ "testId": "settings_menu_header" }]
+      "ready": [
+        { "testId": "settings_menu_header" },
+        {
+          "oneOf": [
+            { "role": "treegrid", "name": "Messages" },
+            { "role": "grid", "name": "Messages" },
+            { "role": "alert", "first": true }
+          ]
+        }
+      ]
     }
   ],
   "dynamic": [

--- a/scripts/a11y/a11y_scan.py
+++ b/scripts/a11y/a11y_scan.py
@@ -19,7 +19,11 @@ from urllib.parse import urljoin, urlparse
 
 from playwright.async_api import Page, Request, async_playwright
 
-DEFAULT_ACE_URL = "https://unpkg.com/accessibility-checker-engine@latest/ace.js"
+# Pinned to the same engine the Playwright a11y suite uses (see src/frontend/.achecker.yml,
+# ruleArchive 19May2026) so both scanners evaluate the same ruleset. Override with --ace-url.
+DEFAULT_ACE_URL = "https://unpkg.com/accessibility-checker-engine@4.0.26/ace.js"
+# Matches the `policies` list in src/frontend/.achecker.yml.
+DEFAULT_POLICIES = "IBM_Accessibility"
 STATIC_RESOURCE_TYPES = {"image", "media", "font"}
 STATIC_EXTENSIONS = (
     ".png",
@@ -66,6 +70,16 @@ def parse_args() -> argparse.Namespace:
         "--levels",
         default="violation",
         help="Comma-separated levels: violation,potentialviolation,recommendation,manual.",
+    )
+    parser.add_argument(
+        "--policies",
+        default=DEFAULT_POLICIES,
+        help=(
+            "Comma-separated IBM ACE guideline ids to evaluate against: "
+            "EXTENSIONS,IBM_Accessibility,IBM_Accessibility_next,WCAG_2_2,WCAG_2_1,WCAG_2_0. "
+            f"Default: {DEFAULT_POLICIES}. Pass an empty string to run unfiltered, which also "
+            "reports rules that belong to no policy and are therefore not compliance findings."
+        ),
     )
     parser.add_argument("--timeout-ms", type=int, default=30000)
     parser.add_argument("--quiet-ms", type=int, default=1000)
@@ -189,10 +203,17 @@ async def wait_for_settled_network(page: Page, pending: set[Request], timeout_ms
         await page.wait_for_timeout(100)
 
 
-async def evaluate_ace(page: Page, levels: list[str]) -> list[dict[str, Any]]:
+async def evaluate_ace(page: Page, levels: list[str], policies: list[str]) -> list[dict[str, Any]]:
+    """Run the loaded ACE checker and return the issues matching ``levels``.
+
+    ``policies`` are IBM ACE guideline ids. ``checker.check`` takes the guideline list as its
+    second argument; omitting it returns *every* rule the engine ships, including rules that
+    belong to no guideline (empty ``rulesets``) and therefore are not compliance findings.
+    Pass an empty list to reproduce that unfiltered behaviour.
+    """
     return await page.evaluate(
         """
-        async (levels) => {
+        async ([levels, policies]) => {
           const wanted = new Set(levels.map((level) => level.toLowerCase()));
           const matchesLevel = (values) => {
             if (!Array.isArray(values)) return false;
@@ -209,7 +230,29 @@ async def evaluate_ace(page: Page, levels: list[str]) -> list[dict[str, Any]]:
           }
 
           const checker = new window.ace.Checker();
-          const report = await checker.check(document);
+          const knownPolicies = new Set(checker.rulesetIds);
+          const unknown = policies.filter((policy) => !knownPolicies.has(policy));
+          if (unknown.length) {
+            throw new Error(
+              `Unknown ACE policy: ${unknown.join(", ")}. Known: ${checker.rulesetIds.join(", ")}`
+            );
+          }
+
+          // Rule id -> the guidelines that contain it. A rule missing from this map is in no
+          // guideline at all, which is what makes it invisible to the IBM browser extension.
+          const rulesetsByRule = new Map();
+          for (const guideline of checker.getGuidelines()) {
+            for (const checkpoint of guideline.checkpoints ?? []) {
+              for (const rule of checkpoint.rules ?? []) {
+                if (!rulesetsByRule.has(rule.id)) rulesetsByRule.set(rule.id, new Set());
+                rulesetsByRule.get(rule.id).add(guideline.id);
+              }
+            }
+          }
+
+          const report = policies.length
+            ? await checker.check(document, policies)
+            : await checker.check(document);
           return report.results
             .filter((item) => matchesLevel(item.value))
             .map((item) => ({
@@ -219,10 +262,11 @@ async def evaluate_ace(page: Page, levels: list[str]) -> list[dict[str, Any]]:
               path: item.path?.dom ?? item.path?.aria ?? null,
               snippet: item.snippet ?? null,
               value: item.value,
+              rulesets: [...(rulesetsByRule.get(item.ruleId) ?? [])],
             }));
         }
         """,
-        levels,
+        [levels, policies],
     )
 
 
@@ -304,6 +348,41 @@ async def run_action(page: Page, action: dict[str, Any], timeout_ms: int) -> Non
             await page.locator(press_action["selector"]).first.press(press_action["key"], timeout=timeout_ms)
         else:
             await page.keyboard.press(str(press_action))
+    elif "scroll" in action:
+        # Lets a states-file capture post-scroll DOM, e.g. virtualised grids that only
+        # drop their tabbable rows once the user scrolls:
+        #   {"scroll": {"selector": ".ag-body-viewport", "to": "bottom"}}
+        scroll_action = action["scroll"]
+        if not isinstance(scroll_action, dict):
+            raise ValueError("scroll action must be an object with an optional selector and to/by")
+        to_value = scroll_action.get("to", "bottom")
+        if to_value not in {"top", "bottom"}:
+            raise ValueError("scroll 'to' must be 'top' or 'bottom'")
+        by_value = scroll_action.get("by")
+        if by_value is not None and not isinstance(by_value, (int, float)):
+            raise ValueError("scroll 'by' must be a number of pixels")
+        options = {"to": to_value, "by": by_value}
+        scroll_js = """
+          (el, options) => {
+            const target = el === document ? document.scrollingElement : el;
+            if (options.by !== null && options.by !== undefined) {
+              target.scrollTop += options.by;
+            } else {
+              target.scrollTop = options.to === "top" ? 0 : target.scrollHeight;
+            }
+            // Two frames so virtualised lists finish re-rendering before the scan reads the DOM.
+            return new Promise((resolve) =>
+              requestAnimationFrame(() => requestAnimationFrame(resolve))
+            );
+          }
+        """
+        selector = scroll_action.get("selector")
+        if selector:
+            locator = page.locator(selector).first
+            await locator.wait_for(state="visible", timeout=timeout_ms)
+            await locator.evaluate(scroll_js, options)
+        else:
+            await page.evaluate(f"(options) => ({scroll_js})(document, options)", options)
     elif "waitFor" in action:
         await page.locator(action["waitFor"]).first.wait_for(state="visible", timeout=timeout_ms)
     elif "waitForHidden" in action:
@@ -333,6 +412,7 @@ async def scan_current_dom(
     *,
     ace_script: str,
     levels: list[str],
+    policies: list[str],
     timeout_ms: int,
     route: str,
     requested_url: str,
@@ -344,7 +424,7 @@ async def scan_current_dom(
     diagnostics: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     await ensure_ace_loaded(page, ace_script, timeout_ms)
-    issues = await evaluate_ace(page, levels)
+    issues = await evaluate_ace(page, levels, policies)
     return {
         "route": route,
         "state": state_name,
@@ -367,6 +447,7 @@ async def scan_route(
     route: str,
     states: list[dict[str, Any]],
     levels: list[str],
+    policies: list[str],
     timeout_ms: int,
     quiet_ms: int,
 ) -> list[dict[str, Any]]:
@@ -425,6 +506,7 @@ async def scan_route(
             page,
             ace_script=ace_script,
             levels=levels,
+            policies=policies,
             timeout_ms=timeout_ms,
             route=route,
             requested_url=target_url,
@@ -457,6 +539,7 @@ async def scan_route(
                 page,
                 ace_script=ace_script,
                 levels=levels,
+                policies=policies,
                 timeout_ms=timeout_ms,
                 route=route,
                 requested_url=target_url,
@@ -920,6 +1003,7 @@ def write_html_report(report: dict[str, Any], output_path: Path) -> None:
       <span class="danger">{report["totalIssues"]} total issues</span>
       <span>{len(report["routes"])} routes</span>
       <span>levels: {html_escape(", ".join(report["reportLevels"]))}</span>
+      <span>policies: {html_escape(", ".join(report["policies"]) or "unfiltered")}</span>
       <span>base: {html_escape(report["url"])}</span>
     </div>
   </section>
@@ -963,6 +1047,7 @@ async def main() -> None:
     manifest_routes = load_routes_file(args.routes_file, args.route_group)
     routes = route_args or manifest_routes or list(states_by_route.keys()) or [urlparse(args.url).path or "/"]
     levels = split_csv(args.levels)
+    policies = split_csv(args.policies)
     ace_script = fetch_ace_script(args.ace_url)
     executable_path = find_chromium_executable(args.browser_executable)
 
@@ -982,6 +1067,7 @@ async def main() -> None:
                     route,
                     states_by_route.get(route, []),
                     levels,
+                    policies,
                     args.timeout_ms,
                     args.quiet_ms,
                 )
@@ -1004,6 +1090,8 @@ async def main() -> None:
         "url": args.url,
         "routes": routes,
         "reportLevels": levels,
+        "policies": policies,
+        "aceUrl": args.ace_url,
         "totalIssues": sum(len(result["issues"]) for result in results),
         "results": results,
     }

--- a/scripts/a11y/a11y_scan_routes.md
+++ b/scripts/a11y/a11y_scan_routes.md
@@ -35,6 +35,27 @@ uv run python scripts/a11y/a11y_scan.py \
 
 Explicit `--route` or `--routes` arguments still work and override the manifest.
 
+### State files
+
+Reusable `--states-file` manifests live in `scripts/a11y/states/`. Commit new state
+files there instead of ad-hoc `/tmp` paths so post-interaction states (open modals,
+scrolled grids) stay rerunnable. `settings-messages.json` covers the AG-Grid
+scroll states on `/settings/messages` that a default-load scan cannot see.
+
+### Policies
+
+`--policies` selects the IBM guideline set the engine evaluates against and defaults
+to `IBM_Accessibility`, matching `policies` in `src/frontend/.achecker.yml` so the
+Python scanner and the Playwright suite report the same rules.
+
+Passing `--policies ""` runs unfiltered. That also surfaces rules belonging to no
+guideline at all (`"rulesets": []` in the report, e.g. `element_scrollable_tabbable`),
+which the IBM browser extension hides and which are **not** compliance findings.
+Every issue in the report carries its `rulesets` so a non-policy rule is easy to spot.
+
+`--ace-url` defaults to the engine version pinned in `a11y_scan.py`, kept in sync with
+the `accessibility-checker` dependency and `ruleArchive` used by the Playwright suite.
+
 ## Playwright CI
 
 `src/frontend/tests/a11y/static-routes.a11y.spec.ts` reads the same manifest and

--- a/scripts/a11y/states/settings-messages.json
+++ b/scripts/a11y/states/settings-messages.json
@@ -1,0 +1,24 @@
+{
+  "routes": [
+    {
+      "route": "/settings/messages",
+      "states": [
+        {
+          "name": "grid-scrolled-to-bottom",
+          "open": [
+            { "waitFor": ".ag-body-viewport" },
+            { "scroll": { "selector": ".ag-body-viewport", "to": "bottom" } },
+            { "wait": 800 }
+          ]
+        },
+        {
+          "name": "grid-scrolled-back-to-top",
+          "open": [
+            { "scroll": { "selector": ".ag-body-viewport", "to": "top" } },
+            { "wait": 800 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/frontend/tests/a11y/model-providers.a11y.spec.ts
+++ b/src/frontend/tests/a11y/model-providers.a11y.spec.ts
@@ -296,7 +296,10 @@ test.describe("Model providers route accessibility", () => {
     "scans provider list loading state",
     { tag: ["@release", "@workspace"] },
     async ({ page }) => {
+      // The catalog is stalled far past the teardown drain window on purpose:
+      // the loading state has to still be on screen when the scan runs.
       await mockProviderCatalog(page, { providersDelayMs: 6000 });
+      page.expectPendingRequest({ method: "GET", path: "/api/v1/models" });
       await mockGlobalVariables(page);
       await awaitBootstrapTest(page, { skipModal: true });
       await page.goto("/settings/model-providers");

--- a/src/frontend/tests/fixtures.ts
+++ b/src/frontend/tests/fixtures.ts
@@ -44,6 +44,17 @@ const RESPONSE_BODY_READ_TIMEOUT_MS = API_REQUEST_DRAIN_TIMEOUT_MS;
 const RESPONSE_INSPECTION_DRAIN_TIMEOUT_MS = API_REQUEST_DRAIN_TIMEOUT_MS;
 const MAX_PENDING_REQUEST_DIAGNOSTICS = 20;
 
+/**
+ * A request a spec intentionally leaves in flight — e.g. a route mocked with a
+ * long delay so a loading state stays on screen for the duration of the test.
+ * Such a request cannot settle inside the teardown drain window, so it must be
+ * declared rather than treated as a stuck request.
+ */
+type AllowedPendingRequest = {
+  method?: string;
+  path: string;
+};
+
 type ObservedHttpError = {
   method: string;
   path: string;
@@ -134,6 +145,14 @@ export const test = base.extend<{ page: LangflowPage }, A11yFixtures>({
       }
     ).expectServerError = (expectation) => {
       expectServerError(serverErrorContract, expectation);
+    };
+    const allowedPendingRequests: AllowedPendingRequest[] = [];
+    (
+      page as Page & {
+        expectPendingRequest?: (expectation: AllowedPendingRequest) => void;
+      }
+    ).expectPendingRequest = (expectation) => {
+      allowedPendingRequests.push(expectation);
     };
 
     let a11yScanIndex = 0;
@@ -427,7 +446,19 @@ export const test = base.extend<{ page: LangflowPage }, A11yFixtures>({
     pendingApiResponseStatuses.stop();
     page.off("request", requestListener);
     await pendingApiResponseStatuses.drain(API_REQUEST_DRAIN_TIMEOUT_MS);
-    const unresolvedApiRequests = pendingApiResponseStatuses.snapshot();
+    const isAllowedPending = (request: Request) => {
+      const { pathname } = new URL(request.url());
+      const method = request.method().toUpperCase();
+      return allowedPendingRequests.some(
+        (allowed) =>
+          pathname === allowed.path &&
+          (allowed.method === undefined ||
+            allowed.method.toUpperCase() === method),
+      );
+    };
+    const unresolvedApiRequests = pendingApiResponseStatuses
+      .snapshot()
+      .filter((request) => !isAllowedPending(request));
     page.off("response", responseListener);
     page.off("requestfinished", requestFinishedListener);
     page.off("requestfailed", requestFailedListener);
@@ -509,14 +540,20 @@ export const test = base.extend<{ page: LangflowPage }, A11yFixtures>({
             .filter(Boolean)
             .join("\n")
         : "";
+      const hasServerErrors =
+        unexpectedServerErrors.length > 0 || missingServerErrors.length > 0;
       throw new Error(
         [
-          "Server-error contract failed:",
+          hasServerErrors
+            ? "Server-error contract failed:"
+            : "API requests did not settle before teardown:",
           unexpected,
           dropped,
           missing,
           unresolved,
-          "Register intentional failures with page.expectServerError({ method, path, status, count }).",
+          hasServerErrors
+            ? "Register intentional failures with page.expectServerError({ method, path, status, count })."
+            : "If the request is deliberately left in flight (e.g. a delayed route mock holding a loading state), declare it with page.expectPendingRequest({ method, path }).",
         ]
           .filter(Boolean)
           .join("\n"),

--- a/src/frontend/tests/utils/build-a11y-html-report.mjs
+++ b/src/frontend/tests/utils/build-a11y-html-report.mjs
@@ -143,6 +143,10 @@ function readReports() {
           bounds: issue.bounds ?? null,
         }));
 
+      const suppressedViolationCount = (report.results ?? []).filter(
+        (issue) => issue.ignored && issue.level === "violation",
+      ).length;
+
       const rules = new Map();
       for (const issue of issues) {
         rules.set(issue.ruleId, (rules.get(issue.ruleId) ?? 0) + 1);
@@ -160,6 +164,7 @@ function readReports() {
         issues,
         violationCount: issues.filter((issue) => issue.level === "violation")
           .length,
+        suppressedViolationCount,
         potentialCount: issues.filter(
           (issue) => issue.level === "potentialviolation",
         ).length,
@@ -609,6 +614,17 @@ const summary = {
   scansWithIssues: scans.filter((scan) => scan.issues.length > 0).length,
   issueCount: scans.reduce((sum, scan) => sum + scan.issues.length, 0),
   violationCount: scans.reduce((sum, scan) => sum + scan.violationCount, 0),
+  // Raw = actionable + baseline-suppressed. Publish these three numbers together,
+  // straight from this file; never hand-compute the split from baseline *files*
+  // (one baseline file can suppress several results).
+  baselineSuppressedCount: scans.reduce(
+    (sum, scan) => sum + scan.suppressedViolationCount,
+    0,
+  ),
+  rawViolationCount: scans.reduce(
+    (sum, scan) => sum + scan.violationCount + scan.suppressedViolationCount,
+    0,
+  ),
   potentialViolationCount: scans.reduce(
     (sum, scan) => sum + scan.potentialCount,
     0,
@@ -622,6 +638,7 @@ const summary = {
     label: scan.label,
     issueCount: scan.issues.length,
     violationCount: scan.violationCount,
+    suppressedViolationCount: scan.suppressedViolationCount,
     potentialViolationCount: scan.potentialCount,
     rules: scan.rules,
     htmlFile: scan.htmlFile,

--- a/src/frontend/tests/utils/types.ts
+++ b/src/frontend/tests/utils/types.ts
@@ -21,6 +21,15 @@ export type ExpectedServerError = {
 export type LangflowPage = Page & {
   allowFlowErrors: () => void;
   expectServerError: (expectation: ExpectedServerError) => void;
+  /**
+   * Declare a request the spec deliberately leaves in flight — e.g. a route
+   * mocked with a delay longer than the test body so a loading state stays
+   * rendered. Without this the teardown drain reports it as unsettled.
+   */
+  expectPendingRequest: (expectation: {
+    method?: string;
+    path: string;
+  }) => void;
   runA11yScan: (
     label: string,
     options?: A11yScanOptions,


### PR DESCRIPTION
## Problem

Our published a11y violation counts were inflated. The Python route scanner (`scripts/a11y/a11y_scan.py`) called `checker.check(document)` with no guideline argument, so the IBM Equal Access engine returned **every rule it ships — including rules that belong to no accessibility policy at all** (`rulesets: []`, no IBM_Accessibility, no WCAG number). The IBM browser extension filters by guideline and hides these, which is why it and our scanner disagreed.

Confirmed on `/settings/messages`: unfiltered reports 1 violation (`element_scrollable_tabbable`, `rulesets: []`); filtered by `IBM_Accessibility` reports 0.

The Playwright suite was **never affected** — `.achecker.yml` always carried `policies: [IBM_Accessibility]`. The inflation was Python-scanner-only.

## Fix

- `--policies` flag (default `IBM_Accessibility`, matching `.achecker.yml`) threaded into `checker.check`. Every reported issue now carries its `rulesets` array, so a non-policy rule is self-evident in the report.
- `DEFAULT_ACE_URL` pinned to `accessibility-checker-engine@4.0.26` (the version the Playwright suite resolves) instead of `@latest`, plus an advisory CI guard that flags future drift without turning PRs red.
- New `scroll` state action for `--states-file`, with the states file committed under `scripts/a11y/states/`. Default-load scans structurally cannot see the `/settings/messages` grid failure: it passes `aria_child_tabbable` on load and fails after scrolling (and does not recover).
- Ready-check fix in `a11y_routes.json`: the `/settings/messages` scan waited only for the settings sidebar, racing AG-Grid hydration (6 phantom violations mid-hydration vs 0 settled — the route has two legitimate terminal states depending on test-DB contents). Verified green with `RUN_A11Y_ASSERT=true`.
- `route-summary.json` now emits `rawViolationCount` / `baselineSuppressedCount` per run and per scan, so the "N = suppressed + actionable" split is generated instead of hand-computed (one baseline file can suppress several results).
- New nightly-only `python-route-scan` CI job scanning real, unmocked routes — it catches DOM the mocked specs never build (e.g. real provider icon SVGs: 3 in-policy `element_attribute_deprecated` findings on `/settings/model-providers` + `/settings/db-providers` that 26 mocked Playwright states miss). Reporting only; never runs on PRs.

**Nothing in this PR blocks PRs.** The required checks on `main`/`release-1.12.0` don't include the a11y workflow, the nightly job is PR-exempt, and the pin guard is `continue-on-error`.

## Verification

- Full static-route sweep, three variants: original script (engine 4.0.30, unfiltered) = 4 issues; patched unfiltered at 4.0.26 = 4 (pin is inert); patched with policy = 3. Exactly one finding disappeared, with `rulesets: []` proving it non-policy. Nothing in-policy vanished.
- All 3 committed baselines suppress in-policy rules (verified against the engine's guideline map) — none was masking a non-policy rule; all kept.
- Full Playwright suite before/after: identical results (23 raw = 4 baseline-suppressed + 19 actionable), 193 passed / 6 flaky.
- Findings tracked by open tickets (`svg_graphics_labelled`, `element_tabbable_role_valid`) are in-policy and unaffected.

<table>
<tr><td width="50%"><b>Before — unfiltered</b></td><td width="50%"><b>After — IBM_Accessibility</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-scan-policy-filter/01-before-unfiltered.png" alt="Scanner report showing 1 violation on /settings/messages from element_scrollable_tabbable, a rule in no policy" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-scan-policy-filter/02-after-policy-filtered.png" alt="Scanner report showing 0 violations on /settings/messages with the IBM_Accessibility policy applied" width="100%"></td>
</tr>
</table>

<details><summary>New scroll state catching the post-scroll grid failure</summary>
<img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-scan-policy-filter/03-after-scroll-state.png" alt="Scanner report where the base state passes and the grid-scrolled-bottom state reports aria_child_tabbable" width="70%">
</details>

Jira: [LE-2263](https://datastax.jira.com/browse/LE-2263)


[LE-2263]: https://datastax.jira.com/browse/LE-2263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accessibility scans now support scrolling pages and selected elements, including virtualized grids.
  * Added reusable scan states for testing message grids at the top and bottom of the list.
  * Accessibility checks can be filtered by policy and include associated ruleset details in reports.
  * Reports now distinguish actionable violations from baseline-suppressed violations.

* **Bug Fixes**
  * Improved readiness detection for the settings messages page to ensure message content has rendered before scanning.

* **Documentation**
  * Documented scan state manifests, policy selection, engine versioning, and scrolling behavior.

* **Chores**
  * Added automated route scanning and accessibility engine consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->