### PR TITLE
fix(models): seed IBM WatsonX with current models and stop deprecated-flag overloading

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2831,7 +2831,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "696e6809b4c7a037e3bfeea796bfbf1e89ce5fbd",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -2839,7 +2839,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "92dfbfc0dd3ae5856bd57631e9c0ea7dd6245711",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 244,
         "is_secret": false
       },
       {
@@ -2847,7 +2847,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "071241279b1ee9edc0e265315fba2833f3c6e1d9",
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 245,
         "is_secret": false
       },
       {
@@ -2855,7 +2855,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "4d67e279837e369ee293a323066ef4a05f30ef40",
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 247,
         "is_secret": false
       },
       {
@@ -2863,7 +2863,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "97f7ca718a0013593c7a0a914474182107af35d0",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 251,
         "is_secret": false
       },
       {
@@ -2871,7 +2871,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "40a6165fa766809c4d5cc31c9d69bf592b2e930e",
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 252,
         "is_secret": false
       },
       {
@@ -2879,7 +2879,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "029a9cd4161ece9fcf5eda09f07874d228daa9e6",
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 254,
         "is_secret": false
       },
       {
@@ -2887,7 +2887,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e71719056a00aeb51887b49912f107d7075e3953",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -2895,7 +2895,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "a24f75c63a48219c05df0f39831e66aa1faa6189",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -2903,7 +2903,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "d66dc430b7aff7717100701ed8a112a9601384ed",
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 285,
         "is_secret": false
       },
       {
@@ -2911,23 +2911,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "94173eade3ec4ad38c084c42138773fa4220afcf",
         "is_verified": false,
-        "line_number": 280,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "eea025da01ac30af81911443bd4e7e6bc02dd458",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/de.json",
-        "hashed_secret": "cdd92c9d2578e0cdc2e57591425298e0d2ecaaed",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -2935,7 +2919,15 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "02d9eee31941ef494b8b63c50484720e21e9a92b",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "eea025da01ac30af81911443bd4e7e6bc02dd458",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -2943,7 +2935,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e7cc230ba82f53830501c9e07f40554ee59596d3",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -2951,7 +2943,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "33401d90fa17dd65aeb2468f398353281be85596",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -2959,7 +2951,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e686334c3bec530179fc0d6f81b75005b8a3541f",
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -2967,7 +2959,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "7981d45b19cca6f0be5538f9864663e7685bf052",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -2975,7 +2967,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cfd32aee63f6617c1aa367ff901f9f16abc25ccc",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 714,
         "is_secret": false
       },
       {
@@ -2983,7 +2975,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "7f9b4ce8fafe27fd7f28e30503ff90be2c51f6f1",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -2991,7 +2983,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "a6b7fa3036809eeab8bb104d9c93e8acff5ea081",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 729,
         "is_secret": false
       },
       {
@@ -2999,7 +2991,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "1233410303742c5b32ae1e69c45ea8cbe59433d4",
         "is_verified": false,
-        "line_number": 722,
+        "line_number": 730,
         "is_secret": false
       },
       {
@@ -3007,7 +2999,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "02eed8625057933776c899e6e60175a552231af3",
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 737,
         "is_secret": false
       },
       {
@@ -3015,7 +3007,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "5781fbe4c19d47db72e814fe889cab2ee138b254",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1005,
         "is_secret": false
       },
       {
@@ -3023,7 +3015,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "0098f0e36ee02376e287e99d76328b76cbf395b8",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -3031,7 +3023,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "85accf06c43563c063d399baf5e1d4dbc2bd69b0",
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1393,
         "is_secret": false
       },
       {
@@ -3039,7 +3031,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "7af90a388f3f51da50bd0ccfc074ac83a5e77abf",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -3047,7 +3039,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e116d3fdaa720e8822922071931a7da18b34ddd3",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -3055,7 +3047,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "06e10503631d5b1680e4a08e3a5e0ab109812c48",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -3063,7 +3055,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "de70a102ac9fe37a0714c25453e50afb4f078359",
         "is_verified": false,
-        "line_number": 1755,
+        "line_number": 1773,
         "is_secret": false
       },
       {
@@ -3071,7 +3063,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "16bce207c70bb100ece74b75c4c4a79e262cfd5c",
         "is_verified": false,
-        "line_number": 1757,
+        "line_number": 1775,
         "is_secret": false
       },
       {
@@ -3079,7 +3071,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "42174448e882bf43f51c70d0ed3f57d377bb74bb",
         "is_verified": false,
-        "line_number": 1758,
+        "line_number": 1776,
         "is_secret": false
       },
       {
@@ -3087,7 +3079,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "da5b4695b6132090955c121e932d6f9b833c0b1d",
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1837,
         "is_secret": false
       },
       {
@@ -3095,7 +3087,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "d4f39052ccfaf9ef5b8fd360ed75d23cf12fa2c4",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1838,
         "is_secret": false
       },
       {
@@ -3103,7 +3095,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "bfc0c1d4d70399476ea81e40a48418ed9962832d",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -3111,7 +3103,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "2a24f50d36559883d2bc391e4e99f9a7afd56ef9",
         "is_verified": false,
-        "line_number": 1843,
+        "line_number": 1861,
         "is_secret": false
       },
       {
@@ -3119,7 +3111,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fd0543de99a00bd6e67f3e522a18ed417089b6b4",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -3127,7 +3119,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "fa4b98297401af5e6ab7a402330a12715e891325",
         "is_verified": false,
-        "line_number": 1993,
+        "line_number": 2013,
         "is_secret": false
       },
       {
@@ -3135,7 +3127,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9c46c22e7a8ff423706b990fc02c85e0d324f134",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -3143,7 +3135,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "91cde4236a3754b4b57733682edfc50571d954c6",
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 2028,
         "is_secret": false
       },
       {
@@ -3151,7 +3143,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "9625c6b66710b648d27ee284940849a6b5abf3f0",
         "is_verified": false,
-        "line_number": 2011,
+        "line_number": 2031,
         "is_secret": false
       },
       {
@@ -3159,7 +3151,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "370c53187d8e550db85edabdcb86547dab96e300",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -3167,7 +3159,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc57a2140542893b4c9396b6a7186b26351c6fe5",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2045,
         "is_secret": false
       },
       {
@@ -3175,7 +3167,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "d922d16c3bbc818b6fab4e8d2662fa361309fa9d",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -3183,7 +3175,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "8ea601e5cac549eef50d2743f915e4af54135789",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2263,
         "is_secret": false
       },
       {
@@ -3191,7 +3183,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "e498ebe977c948f4d1b7eddd6bb77be398ed4d7c",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -3199,7 +3191,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "02e680473cb1ee7473e2cdb5b0b6c48cd8aae081",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2270,
         "is_secret": false
       },
       {
@@ -3207,7 +3199,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "cc50b2aac5d886516a06afb79b4931f4ee66422d",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       },
       {
@@ -3215,7 +3207,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "07039cae9ab794b348576619cb3ec72eab24b781",
         "is_verified": false,
-        "line_number": 2300,
+        "line_number": 2323,
         "is_secret": false
       },
       {
@@ -3223,7 +3215,7 @@
         "filename": "src/frontend/src/locales/de.json",
         "hashed_secret": "0070d28a258282ddfc1e1addf78aa9d773735c5e",
         "is_verified": false,
-        "line_number": 2301,
+        "line_number": 2324,
         "is_secret": false
       }
     ],
@@ -3233,7 +3225,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2c3e84f9a984dfb630b908d617069ef33e1fac5b",
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 26,
         "is_secret": false
       },
       {
@@ -3241,7 +3233,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "d2c98a3ccd3706c8e941300f1ac53c8ae293b69e",
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 35,
         "is_secret": false
       },
       {
@@ -3249,7 +3241,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "d69c3b1ac54be7da3666d9937b9c78e7c309d6e8",
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 36,
         "is_secret": false
       },
       {
@@ -3257,7 +3249,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "3b6227d39791e41b604e65ada04a11cacd7ec4fc",
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 37,
         "is_secret": false
       },
       {
@@ -3265,7 +3257,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "af58392e77ee336caf0d1aad15057ad0745985e5",
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 42,
         "is_secret": false
       },
       {
@@ -3273,7 +3265,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "5faf5025b1a06d16ab0763d128e25b138166792c",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 44,
         "is_secret": false
       },
       {
@@ -3281,7 +3273,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "def70f3dcbf1bcbe925c6d838543917bfc924064",
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 49,
         "is_secret": false
       },
       {
@@ -3289,7 +3281,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4a81761c117cf80ada43fdf5237bbc9e61222651",
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 62,
         "is_secret": false
       },
       {
@@ -3297,7 +3289,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
         "is_verified": false,
-        "line_number": 184,
+        "line_number": 186,
         "is_secret": false
       },
       {
@@ -3305,7 +3297,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "cb88e78a13f07467c3e44000869553e709ecd44f",
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 187,
         "is_secret": false
       },
       {
@@ -3313,7 +3305,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 232,
+        "line_number": 234,
         "is_secret": false
       },
       {
@@ -3321,7 +3313,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 265,
         "is_secret": false
       },
       {
@@ -3329,7 +3321,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29333d2356d5dd3aafb45a8614c6d825b6f58424",
         "is_verified": false,
-        "line_number": 265,
+        "line_number": 267,
         "is_secret": false
       },
       {
@@ -3337,7 +3329,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "198b73ffd1a6d9c83101382c6df255edac0d3625",
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 274,
         "is_secret": false
       },
       {
@@ -3345,7 +3337,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "51d69ae6046d2a3be245449d5b38165d5d78def5",
         "is_verified": false,
-        "line_number": 274,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -3353,7 +3345,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2e19560960addfd442570c5b2830afc1115cd3f0",
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 278,
         "is_secret": false
       },
       {
@@ -3361,7 +3353,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ad0cb64bb04fb2dd4e7072fca59f7f23eb025df9",
         "is_verified": false,
-        "line_number": 282,
+        "line_number": 284,
         "is_secret": false
       },
       {
@@ -3369,7 +3361,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c2d404cb7bad34de0af2136b8efa809ea96170fa",
         "is_verified": false,
-        "line_number": 284,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -3377,7 +3369,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4d5967896006c8a626ecef45e6312f6fc7d5b52f",
         "is_verified": false,
-        "line_number": 287,
+        "line_number": 289,
         "is_secret": false
       },
       {
@@ -3385,7 +3377,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2a2f556b3e73e091f1e21b95ae5bbca523ab1a2a",
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 290,
         "is_secret": false
       },
       {
@@ -3393,7 +3385,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1abaf3f0bb2d459a0fdefe08084901710603a6be",
         "is_verified": false,
-        "line_number": 300,
+        "line_number": 302,
         "is_secret": false
       },
       {
@@ -3401,7 +3393,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 431,
+        "line_number": 433,
         "is_secret": false
       },
       {
@@ -3409,7 +3401,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c23d0f85d66cef95852d6a63811ab919de76b02a",
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 469,
         "is_secret": false
       },
       {
@@ -3417,7 +3409,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "76b33d23eee6aaa96f11abb4cbf1e5abd66aa46d",
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 574,
         "is_secret": false
       },
       {
@@ -3425,7 +3417,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e9013532fd4966ed4b3aab1ae711b21f180e4c26",
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 575,
         "is_secret": false
       },
       {
@@ -3433,7 +3425,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f16563f8a1751c141fd1c47148369ca1c380bb1",
         "is_verified": false,
-        "line_number": 612,
+        "line_number": 614,
         "is_secret": false
       },
       {
@@ -3441,7 +3433,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2c4e1babc2d1448dfcfdd24fb92068644227d6f1",
         "is_verified": false,
-        "line_number": 705,
+        "line_number": 707,
         "is_secret": false
       },
       {
@@ -3449,7 +3441,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "7ce9180d54b399cafbe6515ca2ca4710a6b9554c",
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 713,
         "is_secret": false
       },
       {
@@ -3457,7 +3449,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "924cf2c6cefbba9e88dc676bd2575b7f21f9661e",
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 720,
         "is_secret": false
       },
       {
@@ -3465,7 +3457,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "9d6bd29f94e1e565bd5de8f44c875638b26e85b6",
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -3473,7 +3465,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8e77e1ff96d9be727f25fc393a48f767935660db",
         "is_verified": false,
-        "line_number": 1233,
+        "line_number": 1240,
         "is_secret": false
       },
       {
@@ -3481,7 +3473,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4a7c565d4c4430e3bb8fa6c560125d5eb37e7c3d",
         "is_verified": false,
-        "line_number": 1468,
+        "line_number": 1485,
         "is_secret": false
       },
       {
@@ -3489,7 +3481,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29538b53771fff5bad78e3a48a3a8f88c2f141d2",
         "is_verified": false,
-        "line_number": 1550,
+        "line_number": 1570,
         "is_secret": false
       },
       {
@@ -3497,7 +3489,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8d24e5afd2e9b40d21e4300c893a486aab979795",
         "is_verified": false,
-        "line_number": 1551,
+        "line_number": 1571,
         "is_secret": false
       },
       {
@@ -3505,7 +3497,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ed05045c1666dd556d9a09f9eb6889f42a81aa5a",
         "is_verified": false,
-        "line_number": 1647,
+        "line_number": 1667,
         "is_secret": false
       },
       {
@@ -3513,7 +3505,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f616a4d4abc959d505a5b83f1b3fa1a6bce6b2e",
         "is_verified": false,
-        "line_number": 1649,
+        "line_number": 1669,
         "is_secret": false
       },
       {
@@ -3521,7 +3513,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1bbb8fd38e8fef4280c7218b961ae2ceeb83bbc9",
         "is_verified": false,
-        "line_number": 1650,
+        "line_number": 1670,
         "is_secret": false
       },
       {
@@ -3529,7 +3521,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "0b8eacdde75bb24c6f29adf660f50ca4d9846358",
         "is_verified": false,
-        "line_number": 1652,
+        "line_number": 1672,
         "is_secret": false
       },
       {
@@ -3537,7 +3529,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8cde7462c1ce55676dc45124068d844ad3b86dcf",
         "is_verified": false,
-        "line_number": 1673,
+        "line_number": 1693,
         "is_secret": false
       },
       {
@@ -3545,7 +3537,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "afbf9aed8c22c3faf4d92dccadabe324d49bc5a8",
         "is_verified": false,
-        "line_number": 1904,
+        "line_number": 1926,
         "is_secret": false
       },
       {
@@ -3553,7 +3545,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "651f66f27bbfaed040c836e22515162e20c4fa0d",
         "is_verified": false,
-        "line_number": 1918,
+        "line_number": 1940,
         "is_secret": false
       },
       {
@@ -3561,15 +3553,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e38ef0e653c39ce1a4dde13da87333c43ced6cab",
         "is_verified": false,
-        "line_number": 2003,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/en.json",
-        "hashed_secret": "a3e4ec7cb1a57129b074bdd0b9403a008a7f0019",
-        "is_verified": false,
-        "line_number": 2021,
+        "line_number": 2025,
         "is_secret": false
       },
       {
@@ -3577,7 +3561,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "044b852f30b636aa923b18a61a35c79abc87556f",
         "is_verified": false,
-        "line_number": 2308,
+        "line_number": 2331,
         "is_secret": false
       },
       {
@@ -3585,7 +3569,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e40123b4e7879a56fc22171a9ae637d418288daa",
         "is_verified": false,
-        "line_number": 2309,
+        "line_number": 2332,
         "is_secret": false
       }
     ],
@@ -3595,7 +3579,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "1cf31e02bf7c19d36f7fd85ca673beb6ab075457",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 244,
         "is_secret": false
       },
       {
@@ -3603,7 +3587,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "fce2533c38ef22f06740a61818d9f399856b45ad",
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 245,
         "is_secret": false
       },
       {
@@ -3611,7 +3595,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6776e8e8ad87a11f849d602165885c18b7ffd9c2",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 251,
         "is_secret": false
       },
       {
@@ -3619,7 +3603,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "5a6d1c612954979ea99ee33dbb2d231b00f6ac0a",
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 252,
         "is_secret": false
       },
       {
@@ -3627,7 +3611,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "e0bb5d3509b1c0a528192ba194fd358e7cf68aa1",
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 254,
         "is_secret": false
       },
       {
@@ -3635,7 +3619,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "641e0eab068bccd95b4b55a4c361e4115c418a5f",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -3643,7 +3627,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "fc4cb17d803c31094c9d646d708e73a8f618f1f3",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -3651,7 +3635,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "cd21bce173804809539fac60a9168e184f12b284",
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 285,
         "is_secret": false
       },
       {
@@ -3659,23 +3643,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "c37c841b6c7b009dad7db06b8d78c5a60e231dce",
         "is_verified": false,
-        "line_number": 280,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "13a8cca2ca0db558c6a15f4d856d5137f2498f20",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/es.json",
-        "hashed_secret": "5457a352b60f70e37ab5066d7cadbbe5e0271ef1",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -3683,7 +3651,15 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "82842c3c911be2b0d80d3c5f8d94b52ac2413de9",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "13a8cca2ca0db558c6a15f4d856d5137f2498f20",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -3691,7 +3667,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "f5503a4b8c5a1977fffa2f0e95d877eb7c7c4ee6",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -3699,7 +3675,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "192b20f92ccd805d527886bed6301b7b371fe348",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -3707,7 +3683,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "765294f5f2dd1748dbd78e9b59afc3a1787697a2",
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -3715,7 +3691,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "d469771eafcb03655d11eed0f3e8811f2c721d02",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -3723,7 +3699,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "9b230eabf26be3b9d702c89641b984f98d206061",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 714,
         "is_secret": false
       },
       {
@@ -3731,7 +3707,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "dbfcc263a0fdacc0d688abea5294c8c4968f6dcb",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -3739,7 +3715,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "d4c5cdf17c6b6a46dd939ad3f9304e726e60384f",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 729,
         "is_secret": false
       },
       {
@@ -3747,7 +3723,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "701b1c64da678bb0b94154c2027363e6b7a7909b",
         "is_verified": false,
-        "line_number": 722,
+        "line_number": 730,
         "is_secret": false
       },
       {
@@ -3755,7 +3731,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "8014424f8694a36a30603e437661446e2eb8c299",
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 737,
         "is_secret": false
       },
       {
@@ -3763,7 +3739,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "c2051bb5c40f7970a7dfe6cc779623aab444c55e",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1005,
         "is_secret": false
       },
       {
@@ -3771,7 +3747,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "8986077949f64e6ae0027b081075699ce824e0dd",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -3779,7 +3755,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "96457c5a9db1de39b24d9043cdbe6360f2b19f86",
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1393,
         "is_secret": false
       },
       {
@@ -3787,7 +3763,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "0f89cb19175c596fc2ae829f5c09d4d04512cc0d",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -3795,7 +3771,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bd8021713f01b31ab9cb3aa0a88e9a88c6531598",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -3803,7 +3779,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "d35e35ce246c917e0d30a073363f12eb6b412d5e",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -3811,7 +3787,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6848bf99f0e8cbaa9e3afe15724b0592761c9895",
         "is_verified": false,
-        "line_number": 1757,
+        "line_number": 1775,
         "is_secret": false
       },
       {
@@ -3819,7 +3795,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "71e1d05cafdbe483092571dc8fa209cb4fb602d2",
         "is_verified": false,
-        "line_number": 1758,
+        "line_number": 1776,
         "is_secret": false
       },
       {
@@ -3827,7 +3803,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bd2d890bd01b9843827f1583db8f9ee99564f270",
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1837,
         "is_secret": false
       },
       {
@@ -3835,7 +3811,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "b245ddc4e5dfcb57cba8d08000e59c5dc0809ceb",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1838,
         "is_secret": false
       },
       {
@@ -3843,7 +3819,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "443fd1115c9bd30afaac31a42fc192b86476f288",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -3851,7 +3827,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "5c324bbf8f0a15d640a2ca93b4bb0183d106edd8",
         "is_verified": false,
-        "line_number": 1843,
+        "line_number": 1861,
         "is_secret": false
       },
       {
@@ -3859,7 +3835,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "49d8b438094e36554d1d2ec73dbc4adbdca1a891",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -3867,7 +3843,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "bdd17febdd742a928650952ec63b0ab0d7eeddac",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -3875,7 +3851,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "15e4f8d5f1d2759b1e83f9082a8ce8e194eb5600",
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 2028,
         "is_secret": false
       },
       {
@@ -3883,7 +3859,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "c8700cb4716f270e7c37191104366e7b1cadc9de",
         "is_verified": false,
-        "line_number": 2011,
+        "line_number": 2031,
         "is_secret": false
       },
       {
@@ -3891,7 +3867,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "60b0610326aa371e079775047f4e66c77aabb0a2",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -3899,7 +3875,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "0147f29ee8d8343d8d70f94b71b0053b268461e3",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2045,
         "is_secret": false
       },
       {
@@ -3907,7 +3883,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "3c89182cf4fc330080cfb2352105827a904d5691",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -3915,7 +3891,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "998c11b06dfd04593f289507da2b499cf4bca6e8",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2263,
         "is_secret": false
       },
       {
@@ -3923,7 +3899,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "ccaa726ee57e4ccdab0a28886273feee26d647ec",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -3931,7 +3907,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "2e329e7c25daa340c17b719f5371248f691de123",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2270,
         "is_secret": false
       },
       {
@@ -3939,7 +3915,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "6e09157ed6a7516c860d26d0747fb229badf190a",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       },
       {
@@ -3947,7 +3923,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "3d04be8b9cef8a2743fc91a6e34c0272a1b3a194",
         "is_verified": false,
-        "line_number": 2300,
+        "line_number": 2323,
         "is_secret": false
       },
       {
@@ -3955,7 +3931,7 @@
         "filename": "src/frontend/src/locales/es.json",
         "hashed_secret": "a0e898048bbec1b000a6a80fb85068f85bae1cc2",
         "is_verified": false,
-        "line_number": 2301,
+        "line_number": 2324,
         "is_secret": false
       }
     ],
@@ -3965,7 +3941,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "8972f0dab3b53b35a68dd4bb860647825d2fd366",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -3973,7 +3949,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "68c76b53ec9073f0ce32372e2ed32f8f77af301e",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 244,
         "is_secret": false
       },
       {
@@ -3981,7 +3957,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "f4cde692d8841bc82500a858c0b039b87d5aac25",
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 245,
         "is_secret": false
       },
       {
@@ -3989,7 +3965,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "75a674a3626e87c539a2518afb33931a57598116",
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 247,
         "is_secret": false
       },
       {
@@ -3997,7 +3973,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "394f48d2520c7e41c4e4913d77d03a84fb6cc356",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 251,
         "is_secret": false
       },
       {
@@ -4005,7 +3981,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "94e2f3ee14b92e2e675a8f6118d28738dbf5c6ba",
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 252,
         "is_secret": false
       },
       {
@@ -4013,7 +3989,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "bd03c54cd14fd738c7cea7add3ae43058b612392",
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 254,
         "is_secret": false
       },
       {
@@ -4021,7 +3997,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "6a4a9f5fd35aba4316eae8fecd22b6520130d3bb",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -4029,7 +4005,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "45c1ab5429738bffb961d2445c838901298f97cc",
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 285,
         "is_secret": false
       },
       {
@@ -4037,23 +4013,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "af0189df8c27e3378d3692a62ce4e75985a787e5",
         "is_verified": false,
-        "line_number": 280,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/fr.json",
-        "hashed_secret": "a51009a48a2d62cd6a67ebf1989fa680dc4506be",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/fr.json",
-        "hashed_secret": "d40974ec3d7496c834d5cfd3287e73336dcf7bf2",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -4061,7 +4021,15 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "5146a90f97b0950b25e7ce9fb097fefa5a3d6817",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "a51009a48a2d62cd6a67ebf1989fa680dc4506be",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -4069,7 +4037,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7af1b1a9f5075623b9535583703bef93d789dfaf",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -4077,7 +4045,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "cb3228774ef442aa34e93da66e3c2ebbac09a3b6",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -4085,7 +4053,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "d3a999088e8965ab9ce5c092d636171c69665666",
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -4093,7 +4061,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "8e55bc411656a3791cd177161db4595e24e459ee",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -4101,7 +4069,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "c1a3d196da57a31bc8f209f520d7b1453bf18313",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 729,
         "is_secret": false
       },
       {
@@ -4109,7 +4077,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "d2c76f41b31e908dc84bc33fa1a3f210f70cf49a",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -4117,7 +4085,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "d3f815b74ab709a72cf9cdce437053fa0dce6287",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -4125,7 +4093,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7f49bb36f7d78041a9c8e79fdead35277249f701",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -4133,7 +4101,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "88362d0d044cf4144e78f646e101110e3f44a9e5",
         "is_verified": false,
-        "line_number": 1755,
+        "line_number": 1773,
         "is_secret": false
       },
       {
@@ -4141,7 +4109,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "f924297673a9a6a8f9362349954b1e5273549e28",
         "is_verified": false,
-        "line_number": 1757,
+        "line_number": 1775,
         "is_secret": false
       },
       {
@@ -4149,7 +4117,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "649624ecf03baa824fd2f66c653ef47a10159656",
         "is_verified": false,
-        "line_number": 1758,
+        "line_number": 1776,
         "is_secret": false
       },
       {
@@ -4157,7 +4125,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "89400786d11d1ee5d936d6cd1890e99e4e3aa54b",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -4165,7 +4133,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "b1df0ac48f734b370fc58c591ef0772266f88bb4",
         "is_verified": false,
-        "line_number": 1843,
+        "line_number": 1861,
         "is_secret": false
       },
       {
@@ -4173,7 +4141,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "541b6268f8abceae80c498212280ee7136eba255",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -4181,7 +4149,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "ff959bbe348ba1b8176852cd2e3d6ba8dbf4062d",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -4189,7 +4157,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "73f311b6a3b5bb2b45eccad848db62d85ae37b58",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -4197,7 +4165,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "7294ab5b6d4cf3ea2deab49cecb0a7baacd16447",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -4205,7 +4173,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "8dfdd0969287ef24a795d71e17f53f148d37d766",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       },
       {
@@ -4213,7 +4181,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "64153b3b2beefe87ab8c005b00b731785d31b4ea",
         "is_verified": false,
-        "line_number": 2300,
+        "line_number": 2323,
         "is_secret": false
       },
       {
@@ -4221,7 +4189,7 @@
         "filename": "src/frontend/src/locales/fr.json",
         "hashed_secret": "6ef3c010ee446fee1446618f12c9a38262ac8e42",
         "is_verified": false,
-        "line_number": 2301,
+        "line_number": 2324,
         "is_secret": false
       }
     ],
@@ -4231,7 +4199,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "2177120edbf5e594d72fdcb9b8fe2183adfc1782",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -4239,7 +4207,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "ad309c2e61dfa1a5c0dc9896da7fd830af70b8f6",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -4247,23 +4215,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "20cff9da46719805d7fe563353ad67624227b054",
         "is_verified": false,
-        "line_number": 270,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/ja.json",
-        "hashed_secret": "72eaf58c3aa4f501f65b26053d3802e3bd7d5620",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/ja.json",
-        "hashed_secret": "3199448fd2effa51a31410243be3e2aa21843521",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -4271,7 +4223,15 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "712dfa64243423e83279b034519831d3d43f1222",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "72eaf58c3aa4f501f65b26053d3802e3bd7d5620",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -4279,7 +4239,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "6d3f6918ae280307281aca3f1dc9489d44565214",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -4287,7 +4247,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "4479d5f53df4c7c7bf5e956086be99f06a1de389",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -4295,7 +4255,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "f94bedb507c27a67d2641721479db8680ce9388e",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -4303,7 +4263,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "6dbe389b0fad2a6c97e803c3b6b5a2d8d22522b5",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 714,
         "is_secret": false
       },
       {
@@ -4311,7 +4271,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "8ce3126ccfb3229f34fe26a2d087ec4e4e159b9d",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -4319,7 +4279,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "de6f8e3f2efe3d1041ea12f5151130da05447df8",
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 737,
         "is_secret": false
       },
       {
@@ -4327,7 +4287,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "dcfb876c95540f212731659ce9603d9741a763cc",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1005,
         "is_secret": false
       },
       {
@@ -4335,7 +4295,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "cd5eda56c4e5deaeeb92d6154d05c3dc9264553f",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -4343,7 +4303,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "d4d29807d5f0a184bd28b2dad2a034da1970042a",
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1393,
         "is_secret": false
       },
       {
@@ -4351,7 +4311,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "3cf78799d5f2ac03456fc62edd2ad65120b64f05",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -4359,7 +4319,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "fcbab870c3fac2547fc10dfe4d134111aabc18b8",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -4367,7 +4327,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "d46f0990d79bb487d60ff3a855f6916f3e4e6a1a",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -4375,7 +4335,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c0428438c20615c80570a0bd88158db6a5cc6003",
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1837,
         "is_secret": false
       },
       {
@@ -4383,7 +4343,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "c22e6661861b4203426d47e3a1a50363c09c812e",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1838,
         "is_secret": false
       },
       {
@@ -4391,7 +4351,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b360f8c2eb4e5aeab3a63c711ffe95b4fa24afde",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -4399,7 +4359,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b6416594e1de4cfc0351c6562ab936519130f5b2",
         "is_verified": false,
-        "line_number": 1830,
+        "line_number": 1848,
         "is_secret": false
       },
       {
@@ -4407,7 +4367,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b7cd1a2885e8998336c89a87d4df110a6b66e2f2",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -4415,7 +4375,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "5e8bcadfaab440649c70e43a015503e9109a7bfa",
         "is_verified": false,
-        "line_number": 1993,
+        "line_number": 2013,
         "is_secret": false
       },
       {
@@ -4423,7 +4383,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "44ed46c9ee10a3a7308c6d1a5df4cb082c57b9e0",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -4431,7 +4391,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "20e6aa34a3dd984dd602c294ee85714b53a0a872",
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 2028,
         "is_secret": false
       },
       {
@@ -4439,7 +4399,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b5426a913c9da60eff621ee15e0b195bf6aaa8da",
         "is_verified": false,
-        "line_number": 2011,
+        "line_number": 2031,
         "is_secret": false
       },
       {
@@ -4447,7 +4407,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "415c03a82cd5f390ad3e28dd82c88e36fb540548",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -4455,7 +4415,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "9e7ba6c71dc246eee615e88e31861a563e33b42d",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2045,
         "is_secret": false
       },
       {
@@ -4463,7 +4423,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "18a887dd97555ab726e7f4d4d999dedd236763eb",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -4471,7 +4431,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "e4777a4b7b9c6fd1911762e35405c0b6b80ae735",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2263,
         "is_secret": false
       },
       {
@@ -4479,7 +4439,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "8847d054d32b57b7a5633fed58444d7237209e24",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -4487,7 +4447,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "369cb27892790b429dacabb4ee12cdfd63d6c250",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2270,
         "is_secret": false
       },
       {
@@ -4495,7 +4455,7 @@
         "filename": "src/frontend/src/locales/ja.json",
         "hashed_secret": "b9743a370a7e12046cbb762dda96137a0327fc28",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       }
     ],
@@ -4505,7 +4465,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "88f195fbbbbeb256d8efac5b6b20e24d319725ee",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -4513,7 +4473,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9c469e53fd34bd270037c7e3309345e0383f7331",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 244,
         "is_secret": false
       },
       {
@@ -4521,7 +4481,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "6d9129298ef5058bb568a75df1daa3171d2f6233",
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 245,
         "is_secret": false
       },
       {
@@ -4529,7 +4489,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "38a814286845e0bf7c437e2f0238e6aa127916b9",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 251,
         "is_secret": false
       },
       {
@@ -4537,7 +4497,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "deba0172511d5701d964202f4e5de698d5e07c67",
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 252,
         "is_secret": false
       },
       {
@@ -4545,7 +4505,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "f5256124567ff538827b07cd38077b4d2f0ff4cd",
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 254,
         "is_secret": false
       },
       {
@@ -4553,7 +4513,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "30ec8da443543f88f3717d8198a3ea4c07734e5f",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -4561,7 +4521,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "8390eaf853b58ba7ac38db1b8a2cc0808e701547",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -4569,7 +4529,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "6fc474866c39ce50d555b284bb6c530d22db3f7c",
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 285,
         "is_secret": false
       },
       {
@@ -4577,23 +4537,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "e2a8853c024be2da10167eb42b19c6cc259f66db",
         "is_verified": false,
-        "line_number": 280,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "6ab7275b94c1be125facd6df7ebdfee8b26931e3",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/pt.json",
-        "hashed_secret": "da4345e5dde7d1d6f387ec90d089cb0a944843cf",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -4601,7 +4545,15 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "15444730dd1d753e5ab5717d1dc9a76f1540352d",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "6ab7275b94c1be125facd6df7ebdfee8b26931e3",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -4609,7 +4561,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "265a547151e5ac45c15a75c94d14dd585066e379",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -4617,7 +4569,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "42f1178697edfac6f6b2532587187fdd33accaf0",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -4625,7 +4577,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "60743e0ecf39ab99f572bb2f4358ce144499395c",
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -4633,7 +4585,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "e8d5154134abcd60165e058618f2cf069841ee38",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -4641,7 +4593,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "1422160d3d897876d721df10805d9fe293add09d",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 714,
         "is_secret": false
       },
       {
@@ -4649,7 +4601,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "cc0bedebf2fadcc1bfbfa9daf41bba27a2d9aad0",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -4657,7 +4609,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "7caaac3befa935700513d4123b881c383af03452",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 729,
         "is_secret": false
       },
       {
@@ -4665,7 +4617,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "36ffc06a145b35e699588e21f91d0847c758b761",
         "is_verified": false,
-        "line_number": 722,
+        "line_number": 730,
         "is_secret": false
       },
       {
@@ -4673,7 +4625,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "792615431c8645d5df08db0bf84f5db8014f4a17",
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 737,
         "is_secret": false
       },
       {
@@ -4681,7 +4633,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "861c6c413b2f9ca56854fb7602d3c690d8a1dc97",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1005,
         "is_secret": false
       },
       {
@@ -4689,7 +4641,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "4306c81dbceadb0effaac422f16658897a8034ef",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -4697,7 +4649,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "539811754f4eced6174b2365b581aca032a29904",
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1393,
         "is_secret": false
       },
       {
@@ -4705,7 +4657,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "8610717164ef598531238326ede1ac540dd7a74c",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -4713,7 +4665,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "50e3a9595f402d5afdd0ee67c71b68cf57bab78d",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -4721,7 +4673,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "29022bd1c2181fbd36940c13cc3fa70041b48ab6",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -4729,7 +4681,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9fc16a99501e66da0391bf67c7a16b236b23bed9",
         "is_verified": false,
-        "line_number": 1757,
+        "line_number": 1775,
         "is_secret": false
       },
       {
@@ -4737,7 +4689,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "6e40094f370649da3568ca1c747fb5a17575c2be",
         "is_verified": false,
-        "line_number": 1758,
+        "line_number": 1776,
         "is_secret": false
       },
       {
@@ -4745,7 +4697,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "924dffdc29e36152ac5c5ad72472d4012c453619",
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1837,
         "is_secret": false
       },
       {
@@ -4753,7 +4705,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "3cf10d8f342037e71cf0fa4f902939cce046db88",
         "is_verified": false,
-        "line_number": 1820,
+        "line_number": 1838,
         "is_secret": false
       },
       {
@@ -4761,7 +4713,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "83107836c3fbb4f7126e1c62127d867f2115c66e",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -4769,7 +4721,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "e5de519e1707a85ae531c311d440ee66c9d92013",
         "is_verified": false,
-        "line_number": 1843,
+        "line_number": 1861,
         "is_secret": false
       },
       {
@@ -4777,7 +4729,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "5e210e2b1f3abec2110bc9be8e64d7f330fa1077",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -4785,7 +4737,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f0b397ea447a3fa2ad71bf2275fef3c57c19ced",
         "is_verified": false,
-        "line_number": 1993,
+        "line_number": 2013,
         "is_secret": false
       },
       {
@@ -4793,7 +4745,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "9a36a9b7c6bfc059b4f02372fff29d59a7d28956",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -4801,7 +4753,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "d041f1238574c9fda80f329a69df103dd0362201",
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 2028,
         "is_secret": false
       },
       {
@@ -4809,7 +4761,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "cb9c85cb748ddd0400375630f5ec0206759ddb89",
         "is_verified": false,
-        "line_number": 2011,
+        "line_number": 2031,
         "is_secret": false
       },
       {
@@ -4817,7 +4769,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "0f426df5e9101c108190dccfd037a953d0d402f2",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -4825,7 +4777,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "01817544892d96dedca2ad884fa493fea87ba133",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2045,
         "is_secret": false
       },
       {
@@ -4833,7 +4785,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "187a0dc92fd69a86bd0e675941e7f1898e3b55e1",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -4841,7 +4793,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "685a15b5a75fafecd74ad06561f50711e97d7275",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2263,
         "is_secret": false
       },
       {
@@ -4849,7 +4801,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "47a5deeb29d9b4f9d88464d050560a7f7b294ddd",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -4857,7 +4809,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "32c3af10cab241e0b425cebc42831cbaa236f1c6",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2270,
         "is_secret": false
       },
       {
@@ -4865,7 +4817,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "4cb21cbeac2b9488b0fde6c6291caf37245c54c2",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       },
       {
@@ -4873,7 +4825,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "eb352ce61357f4686f0bd96845cda822bc6e8f78",
         "is_verified": false,
-        "line_number": 2300,
+        "line_number": 2323,
         "is_secret": false
       },
       {
@@ -4881,7 +4833,7 @@
         "filename": "src/frontend/src/locales/pt.json",
         "hashed_secret": "4fadcd6a2e084d2c9a962254f1944a5b11bd272d",
         "is_verified": false,
-        "line_number": 2301,
+        "line_number": 2324,
         "is_secret": false
       }
     ],
@@ -4891,7 +4843,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "c2c9099cb20503082b8973cbe38e7ba4712379d8",
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -4899,7 +4851,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7d4449172fe7f8214f3b91655c013aa2de3fc8aa",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -4907,23 +4859,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
         "is_verified": false,
-        "line_number": 270,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/zh-Hans.json",
-        "hashed_secret": "3244c8c5d271a1057fc569daacc04432f9c870f7",
-        "is_verified": false,
-        "line_number": 489,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/frontend/src/locales/zh-Hans.json",
-        "hashed_secret": "e15b9952a55ccd2f94bf52984458b57a7b1f8fdd",
-        "is_verified": false,
-        "line_number": 490,
+        "line_number": 276,
         "is_secret": false
       },
       {
@@ -4931,7 +4867,15 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "0ecfe8c3af9e1c44ecb32a27b2e873ea862d972a",
         "is_verified": false,
-        "line_number": 513,
+        "line_number": 518,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "3244c8c5d271a1057fc569daacc04432f9c870f7",
+        "is_verified": false,
+        "line_number": 556,
         "is_secret": false
       },
       {
@@ -4939,7 +4883,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8ccc7338429262ed661178a7bc14e6d9f0d86661",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       },
       {
@@ -4947,7 +4891,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "15017ab3ec0dda97b754524421ed4dcff8bc2252",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 668,
         "is_secret": false
       },
       {
@@ -4955,7 +4899,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "4d24cbb80b72bf05ad9710c3a801359cf417a91a",
         "is_verified": false,
-        "line_number": 678,
+        "line_number": 686,
         "is_secret": false
       },
       {
@@ -4963,7 +4907,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d9bbe5c31c394c33128697ada5ad6bb2386b2d50",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 714,
         "is_secret": false
       },
       {
@@ -4971,7 +4915,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "47d79393f1549ed6bc311a334cda7f88bea287cc",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -4979,7 +4923,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "596d019fb62944b96319dc89f44d017cd8fb7152",
         "is_verified": false,
-        "line_number": 729,
+        "line_number": 737,
         "is_secret": false
       },
       {
@@ -4987,7 +4931,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "f316aecc6ce46d58af4c90ec4c007a3cb2339949",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1005,
         "is_secret": false
       },
       {
@@ -4995,7 +4939,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8559e3a2fe94eb8b5201083eb5e4f50680934376",
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1392,
         "is_secret": false
       },
       {
@@ -5003,7 +4947,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "bbfbbb23d7af0d8f4b452ca1cf95af7bbe98b547",
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1393,
         "is_secret": false
       },
       {
@@ -5011,7 +4955,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "925ec0cb3d802b1c10bd74612833338e38f123e9",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -5019,7 +4963,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "6d09a8bbd2e67a11d0f0be76d5c2f1bc239327bc",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -5027,7 +4971,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "00e66990421091c8a0f9084a1997c317ffe34000",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1770,
         "is_secret": false
       },
       {
@@ -5035,7 +4979,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d370647062f8a9ebf57183122e6aacd46c2a7bda",
         "is_verified": false,
-        "line_number": 1819,
+        "line_number": 1837,
         "is_secret": false
       },
       {
@@ -5043,7 +4987,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7d2d5daebdd522b7de7fab94e153cbea4620c369",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1839,
         "is_secret": false
       },
       {
@@ -5051,7 +4995,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "74a3dd23222f2bc1888171506f585281009f79a4",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -5059,7 +5003,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "c10e8dbe79654ae8ed496c4c50f5e188b7924a4e",
         "is_verified": false,
-        "line_number": 1993,
+        "line_number": 2013,
         "is_secret": false
       },
       {
@@ -5067,7 +5011,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7223cfc50b72fe9b091b46275f561526aba9e705",
         "is_verified": false,
-        "line_number": 2006,
+        "line_number": 2026,
         "is_secret": false
       },
       {
@@ -5075,7 +5019,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "4aa9a3231780af9a37413cb7034ecdf72d43cfec",
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 2028,
         "is_secret": false
       },
       {
@@ -5083,7 +5027,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "68af7627d36cc6b923f5928a198165857f1ba5f1",
         "is_verified": false,
-        "line_number": 2011,
+        "line_number": 2031,
         "is_secret": false
       },
       {
@@ -5091,7 +5035,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7acd3659ef48c980ce4aef1d0f2f218ff25efc89",
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2036,
         "is_secret": false
       },
       {
@@ -5099,7 +5043,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "7443c6e0ef4c013461140fb1aa2a7a60b40a0b89",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2045,
         "is_secret": false
       },
       {
@@ -5107,7 +5051,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "3c274d81d83ceba5bfaaaf2ac4f6b0aedcf431a0",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -5115,7 +5059,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "583ddc85a613ceef2e54f9d2251113f3acef73a3",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2263,
         "is_secret": false
       },
       {
@@ -5123,7 +5067,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8494b7db80f8bfedeef8cc5697bed5339cd1a4ee",
         "is_verified": false,
-        "line_number": 2249,
+        "line_number": 2269,
         "is_secret": false
       },
       {
@@ -5131,7 +5075,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "d45af2467cb991008a273eb0c4590fa9a96fc497",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2270,
         "is_secret": false
       },
       {
@@ -5139,7 +5083,7 @@
         "filename": "src/frontend/src/locales/zh-Hans.json",
         "hashed_secret": "8da5daf1ef780fe5e37ae02bee48cbdb023c7101",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       }
     ],
@@ -7473,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-17T23:57:23Z"
+  "generated_at": "2026-08-19T22:49:42Z"
 }

--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -5,7 +5,7 @@ from collections.abc import Collection
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from lfx.base.models.model_metadata import EXPLICIT_ENABLE_ONLY_PROVIDERS
+from lfx.base.models.model_metadata import EXPLICIT_ENABLE_ONLY_PROVIDERS, LIVE_MODEL_PROVIDERS
 from lfx.base.models.model_utils import inject_custom_enabled_models, replace_with_live_models
 from lfx.base.models.provider_registry import (
     get_provider_descriptor,
@@ -387,8 +387,8 @@ async def list_models(
                 }
             )
 
-    # Run before status is computed so live-only providers appended here (e.g. IBM WatsonX,
-    # whose static catalog is fully deprecated) still receive is_enabled/is_configured (#13735).
+    # Run before status is computed so live-only providers appended here (providers
+    # that ship no static catalog rows) still receive is_enabled/is_configured (#13735).
     configured_providers = {p for p, configured in provider_configured_status.items() if configured}
     configured_providers = {provider for provider in configured_providers if provider_policy.allows(provider)}
     replace_with_live_models(filtered_models, current_user.id, configured_providers, model_type)
@@ -413,10 +413,16 @@ async def list_models(
     if selected_providers:
         filtered_models = [p for p in filtered_models if p.get("provider") in selected_providers]
 
+    # Providers whose model list is discovered from the provider's endpoint
+    # once credentials are configured. The UI uses this to explain an empty
+    # (or seed-only) catalog instead of presenting it as "no models exist".
+    live_discovery_providers = set(LIVE_MODEL_PROVIDERS) | set(get_live_only_providers())
+
     for provider_dict in filtered_models:
         prov_name = provider_dict.get("provider")
         provider_dict["provider_id"] = resolve_provider_id(prov_name) if isinstance(prov_name, str) else None
         provider_dict["is_configured"] = provider_configured_status.get(prov_name, False)
+        provider_dict["live_discovery"] = prov_name in live_discovery_providers
         prov_models_status = enabled_models_map.get(prov_name, {})
         has_active_model = any(prov_models_status.values())
         provider_dict["is_enabled"] = has_active_model

--- a/src/backend/tests/unit/api/v1/test_models_live_only_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_live_only_providers.py
@@ -139,6 +139,40 @@ async def test_live_only_provider_absent_from_model_queries(client: AsyncClient,
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_live_discovery_flag_marks_discovery_providers(
+    client: AsyncClient, logged_in_headers, fake_live_provider
+):
+    """``live_discovery`` tells the UI an empty catalog means "configure me".
+
+    It must be True for both bundle-registered live-only providers and the
+    core live-fetch providers, and False for static-catalog providers.
+    """
+    providers = {p["provider"]: p for p in await _get_models(client, logged_in_headers)}
+
+    assert providers[fake_live_provider]["live_discovery"] is True
+    assert providers["IBM WatsonX"]["live_discovery"] is True
+    assert providers["OpenAI"]["live_discovery"] is False
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_watsonx_seed_catalog_visible_before_configuration(client: AsyncClient, logged_in_headers):
+    """The WatsonX seed catalog must survive the default deprecated filter.
+
+    Regression: every static WatsonX model was once flagged ``deprecated=True``,
+    so the default listing rendered the provider with 0 models ("IBM Langflow
+    ships no IBM models") until credentials were configured.
+    """
+    providers = await _get_models(client, logged_in_headers)
+    entry = next((p for p in providers if p["provider"] == "IBM WatsonX"), None)
+
+    assert entry is not None, "IBM WatsonX missing from the default listing"
+    assert entry["num_models"] > 0, "WatsonX seed catalog fully filtered out (all models deprecated?)"
+    model_types = {m["metadata"].get("model_type") for m in entry["models"]}
+    assert "llm" in model_types
+    assert "embeddings" in model_types
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_non_live_metadata_providers_stay_hidden(client: AsyncClient, logged_in_headers):
     # Azure OpenAI / Groq have provider metadata but neither a static catalog
     # nor live discovery: the union must not resurrect them.

--- a/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
+++ b/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
@@ -14,6 +14,9 @@ export interface ModelProviderInfo {
   api_docs_url?: string;
   /** Icon name from provider metadata (e.g. MODEL_PROVIDER_METADATA). */
   icon?: string;
+  /** True when the model list is discovered from the provider's endpoint
+   *  after credentials are configured (e.g. IBM WatsonX, OpenRouter, vLLM). */
+  live_discovery?: boolean;
 }
 
 export interface ModelProviderWithStatus extends ModelProviderInfo {

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "Deployment- \"{{name}}\" s als Sprachmodell hinzufügen",
   "modelProviders.cancelButton": "Abbrechen",
   "modelProviders.checkOllamaLibrary": "Schau mal in der Ollama-Bibliothek nach",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "Konfiguration",
   "modelProviders.configurationSaved": "{{provider}} Konfiguration gespeichert",
   "modelProviders.configurePrefix": "Konfigurieren Sie Ihre",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1094,6 +1094,8 @@
   "modelProviders.ollamaNoModelsEmbeddings": "It looks like you don't have any embedding models installed for Ollama. Please pull the models you want to use.",
   "modelProviders.ollamaNoModelsAll": "It looks like you don't have any models installed for Ollama. Please pull the models you want to use.",
   "modelProviders.checkOllamaLibrary": "Check Ollama Library",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configurationSaved": "{{provider}} Configuration Saved",
   "modelProviders.providerActivated": "{{provider}} Activated",
   "modelProviders.providerDisconnected": "{{provider}} Disconnected",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "Añadir el modelo de lenguaje « \"{{name}}\" »",
   "modelProviders.cancelButton": "Cancelar",
   "modelProviders.checkOllamaLibrary": "Visita la biblioteca de Ollama",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "Configuración",
   "modelProviders.configurationSaved": "{{provider}} Configuración guardada",
   "modelProviders.configurePrefix": "Configura tu",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "Ajouter l' \"{{name}}\" de déploiement en tant que modèle linguistique",
   "modelProviders.cancelButton": "Annuler",
   "modelProviders.checkOllamaLibrary": "Consultez la bibliothèque Ollama",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "Configuration",
   "modelProviders.configurationSaved": "{{provider}} Configuration enregistrée",
   "modelProviders.configurePrefix": "Configurez votre",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "言語モデルとして「 \"{{name}}\" 」を追加する",
   "modelProviders.cancelButton": "キャンセル",
   "modelProviders.checkOllamaLibrary": "オラマ図書館をチェック",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "構成",
   "modelProviders.configurationSaved": "{{provider}} 設定が保存されました",
   "modelProviders.configurePrefix": "設定を行う",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "Adicionar o modelo de linguagem “ \"{{name}}\" ” da versão de produção",
   "modelProviders.cancelButton": "Cancelar",
   "modelProviders.checkOllamaLibrary": "Visite a Biblioteca Ollama",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "Configuração",
   "modelProviders.configurationSaved": "{{provider}} Configuração salva",
   "modelProviders.configurePrefix": "Configure o seu",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1587,6 +1587,8 @@
   "modelProviders.addLanguageDeployment": "将部署 \"{{name}}\" 添加为语言模型",
   "modelProviders.cancelButton": "取消",
   "modelProviders.checkOllamaLibrary": "查看奥拉马图书馆",
+  "modelProviders.liveDiscoveryTitle": "No models yet",
+  "modelProviders.liveDiscoveryHint": "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
   "modelProviders.configuration": "配置",
   "modelProviders.configurationSaved": "{{provider}} 配置已保存",
   "modelProviders.configurePrefix": "配置您的",

--- a/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelectionLiveDiscovery.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelectionLiveDiscovery.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import ModelSelection from "../components/ModelSelection";
+import { Model } from "../components/types";
+
+// Mock ForwardedIconComponent
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className}>
+      {name}
+    </span>
+  ),
+}));
+
+// Mock enabled models hook
+jest.mock("@/controllers/API/queries/models/use-get-enabled-models", () => ({
+  useGetEnabledModels: jest.fn(() => ({
+    data: { enabled_models: {} },
+    isLoading: false,
+  })),
+}));
+
+const someModels: Model[] = [
+  { model_name: "some-model", metadata: { model_type: "llm", icon: "Bot" } },
+];
+
+const noop = jest.fn();
+
+describe("ModelSelection live-discovery empty state", () => {
+  it("shows the configure-credentials hint for an unconfigured live-discovery provider", () => {
+    render(
+      <ModelSelection
+        modelType="all"
+        availableModels={[]}
+        onModelToggle={noop}
+        providerName="IBM WatsonX"
+        liveDiscovery
+        isConfigured={false}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("live-discovery-empty-state"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the hint once the provider is configured", () => {
+    render(
+      <ModelSelection
+        modelType="all"
+        availableModels={[]}
+        onModelToggle={noop}
+        providerName="IBM WatsonX"
+        liveDiscovery
+        isConfigured
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("live-discovery-empty-state"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the hint when models are available", () => {
+    render(
+      <ModelSelection
+        modelType="all"
+        availableModels={someModels}
+        onModelToggle={noop}
+        providerName="IBM WatsonX"
+        liveDiscovery
+        isConfigured={false}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("live-discovery-empty-state"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("some-model")).toBeInTheDocument();
+  });
+
+  it("keeps Ollama's specialized empty state instead of the generic hint", () => {
+    render(
+      <ModelSelection
+        modelType="all"
+        availableModels={[]}
+        onModelToggle={noop}
+        providerName="Ollama"
+        liveDiscovery
+        isConfigured={false}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("live-discovery-empty-state"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Check Ollama Library")).toBeInTheDocument();
+  });
+
+  it("renders nothing special for static-catalog providers", () => {
+    render(
+      <ModelSelection
+        modelType="all"
+        availableModels={[]}
+        onModelToggle={noop}
+        providerName="OpenAI"
+        liveDiscovery={false}
+        isConfigured={false}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("live-discovery-empty-state"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
@@ -84,9 +84,16 @@ const ModelProvidersContent = ({
   const typedModelCount = (syncedSelectedProvider?.models ?? []).filter(
     (model) => modelType === "all" || model.metadata?.model_type === modelType,
   ).length;
+  // Providers whose catalog is discovered from their endpoint have no models
+  // to show until credentials are configured; ModelSelection renders a
+  // configure-credentials hint for them instead of the generic empty state.
+  const awaitingLiveDiscovery =
+    !!syncedSelectedProvider?.live_discovery &&
+    !syncedSelectedProvider?.is_configured;
   const showNoAvailableModels =
     !!syncedSelectedProvider &&
     typedModelCount === 0 &&
+    !awaitingLiveDiscovery &&
     !hasProviderOwnedEmptyState(syncedSelectedProvider.provider);
 
   return (
@@ -166,6 +173,8 @@ const ModelProvidersContent = ({
                     syncedSelectedProvider?.is_configured
                   )
                 }
+                liveDiscovery={!!syncedSelectedProvider?.live_discovery}
+                isConfigured={!!syncedSelectedProvider?.is_configured}
               />
             </CustomModelProvidersEmptyState>
           </div>

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -30,6 +30,11 @@ export interface ModelProviderSelectionProps {
   modelType: ModelTypeFilter;
   providerName?: string;
   isEnabledModel?: boolean;
+  /** True when the provider's model list is discovered from its endpoint
+   *  after credentials are configured (backend ``live_discovery`` flag). */
+  liveDiscovery?: boolean;
+  /** True when the provider's credentials are already configured. */
+  isConfigured?: boolean;
 }
 
 interface ModelRowProps {
@@ -193,6 +198,8 @@ const ModelSelection = ({
   onModelToggle,
   providerName,
   isEnabledModel,
+  liveDiscovery,
+  isConfigured,
 }: ModelProviderSelectionProps) => {
   const { t } = useTranslation();
   const { data: enabledModelsData } = useGetEnabledModels();
@@ -411,6 +418,11 @@ const ModelSelection = ({
   const providerOwnsEmptyState = hasProviderOwnedEmptyState(providerName);
   const isOllama =
     providerOwnsEmptyState && providerName?.toLowerCase() === "ollama";
+  // Live-discovery providers have nothing to list until credentials are
+  // configured; show a configure-credentials hint instead of the generic
+  // "no models" state. Ollama keeps its own specialized empty state.
+  const awaitsCredentialDiscovery =
+    !!liveDiscovery && !isConfigured && !isOllama;
   // Use the unfiltered list for the empty-state check so an
   // ollama-no-models warning still fires when the search field happens to be
   // populated.
@@ -540,6 +552,28 @@ const ModelSelection = ({
           >
             {t("modelProviders.checkOllamaLibrary")}
           </a>
+        </div>
+      ) : awaitsCredentialDiscovery && noModelsAvailable ? (
+        <div
+          className="flex flex-col items-center justify-center p-8 text-center border border-dashed rounded-lg bg-muted/30"
+          data-testid="live-discovery-empty-state"
+        >
+          <ForwardedIconComponent
+            name="Info"
+            className="w-10 h-10 mb-4 text-muted-foreground"
+          />
+          <h3 className="mb-2 text-sm font-semibold text-foreground">
+            {t("modelProviders.liveDiscoveryTitle", {
+              defaultValue: "No models yet",
+            })}
+          </h3>
+          <p className="max-w-[300px] text-xs text-muted-foreground leading-relaxed">
+            {t("modelProviders.liveDiscoveryHint", {
+              provider: providerName,
+              defaultValue:
+                "{{provider}} models are discovered from your account once credentials are configured. Save your credentials above to load the available models.",
+            })}
+          </p>
         </div>
       ) : (
         <>

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
@@ -53,6 +53,7 @@ const ProviderList = ({
           model_count: matchingModels.length,
           models: matchingModels,
           api_docs_url: provider.api_docs_url,
+          live_discovery: provider.live_discovery,
         };
       });
   }, [rawProviders, modelType, trimmedQuery]);

--- a/src/frontend/src/modals/modelProviderModal/components/types.ts
+++ b/src/frontend/src/modals/modelProviderModal/components/types.ts
@@ -2,6 +2,7 @@
 export type Model = {
   model_name: string;
   /** Arbitrary metadata including icon, model_type, deprecated, default flags */
+  // biome-ignore lint/suspicious/noExplicitAny: legacy
   metadata: Record<string, any>;
 };
 
@@ -14,6 +15,9 @@ export type Provider = {
   model_count?: number;
   models?: Model[];
   api_docs_url?: string;
+  /** True when the model list is discovered from the provider's endpoint
+   *  after credentials are configured (e.g. IBM WatsonX, OpenRouter, vLLM). */
+  live_discovery?: boolean;
 };
 
 /** Map of provider -> model_name -> enabled status */

--- a/src/lfx/src/lfx/base/models/model_utils.py
+++ b/src/lfx/src/lfx/base/models/model_utils.py
@@ -133,9 +133,11 @@ def _ollama_cache_clear() -> None:
     _ollama_capability_cache.clear()
 
 
-# Extract model names from metadata for fallback defaults
-WATSONX_DEFAULT_LLM_MODEL_NAMES = [m["name"] for m in WATSONX_LLM_METADATA]
-WATSONX_DEFAULT_EMBEDDING_MODEL_NAMES = [m["name"] for m in WATSONX_EMBEDDING_METADATA]
+# Extract model names from metadata for fallback defaults. Deprecated seed
+# entries are withdrawn from IBM's catalog, so the API-failure fallback must
+# not offer them.
+WATSONX_DEFAULT_LLM_MODEL_NAMES = [m["name"] for m in WATSONX_LLM_METADATA if not m.get("deprecated")]
+WATSONX_DEFAULT_EMBEDDING_MODEL_NAMES = [m["name"] for m in WATSONX_EMBEDDING_METADATA if not m.get("deprecated")]
 
 
 def _to_str(value: Any) -> str | None:
@@ -1042,8 +1044,12 @@ def fetch_live_watsonx_models(user_id: UUID | str | None, model_type: str = "llm
         # Look up capability flags from the static catalog when known; otherwise
         # fall back to defaults. Without this, the live API path blanket-marks
         # every LLM as tool_calling=True, surfacing models like
-        # ibm/granite-3b-code-instruct and ibm/granite-guardian-3-8b in the
-        # Agent dropdown even though they don't support tool calling.
+        # ibm/granite-guardian-3-8b in the Agent dropdown even though they
+        # don't support tool calling. ``deprecated`` is intentionally NOT
+        # copied from the static seed: the live query already excludes
+        # withdrawn models (``!lifecycle_withdrawn``), and re-stamping the
+        # static flag once hid live, current models whenever the seed data
+        # went stale (the "IBM WatsonX shows 0 models" bug).
         static_metadata = WATSONX_LLM_METADATA if model_type == "llm" else WATSONX_EMBEDDING_METADATA
         known_by_name = {m["name"]: m for m in static_metadata}
         default_tool_calling = model_type == "llm"
@@ -1058,7 +1064,6 @@ def fetch_live_watsonx_models(user_id: UUID | str | None, model_type: str = "llm
                     icon="IBM",
                     model_type=model_type if model_type == "llm" else "embeddings",
                     tool_calling=known.get("tool_calling", default_tool_calling) if known else default_tool_calling,
-                    deprecated=bool(known.get("deprecated", False)) if known else False,
                     default=i < MIN_DEFAULT_MODELS,  # Mark first 5 as default
                 )
             )

--- a/src/lfx/src/lfx/base/models/watsonx_constants.py
+++ b/src/lfx/src/lfx/base/models/watsonx_constants.py
@@ -1,6 +1,72 @@
 from .model_metadata import create_model_metadata
 
+# Pre-credential seed catalog. Once the provider is configured,
+# ``fetch_live_watsonx_models`` replaces these entries with the live
+# ``/ml/v1/foundation_model_specs`` listing (which already excludes
+# withdrawn models), so this list only needs to track the commonly
+# available watsonx.ai models. ``deprecated=True`` is reserved for models
+# IBM has withdrawn from the catalog — kept here so legacy flows that
+# reference them still resolve; the UI hides them behind the
+# "Show deprecated" toggle.
 WATSONX_DEFAULT_LLM_MODELS = [
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="ibm/granite-4-h-small",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="meta-llama/llama-3-3-70b-instruct",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="mistral-large-2512",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="mistralai/mistral-medium-2505",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="mistralai/mistral-small-3-1-24b-instruct-2503",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="openai/gpt-oss-120b",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=True,
+    ),
+    # Guardian is a safety-classification model; it does not support tools.
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="ibm/granite-guardian-3-8b",
+        icon="IBM",
+        model_type="llm",
+        tool_calling=False,
+    ),
+    # Withdrawn from IBM's chat catalog.
     create_model_metadata(
         provider="IBM WatsonX",
         name="ibm/granite-8b-code-instruct",
@@ -9,53 +75,39 @@ WATSONX_DEFAULT_LLM_MODELS = [
         tool_calling=True,
         deprecated=True,
     ),
-    create_model_metadata(
-        provider="IBM WatsonX",
-        name="ibm/granite-guardian-3-8b",
-        icon="IBM",
-        model_type="llm",
-        tool_calling=False,
-        deprecated=True,
-    ),
 ]
 
-# Marked deprecated: not natively supported by the Knowledge Base ingestion
-# flow; hidden from the embedding model picker until support is added.
 WATSONX_DEFAULT_EMBEDDING_MODELS = [
     create_model_metadata(
         provider="IBM WatsonX",
-        name="sentence-transformers/all-minilm-l12-v2",
+        name="ibm/granite-embedding-278m-multilingual",
         icon="IBM",
         model_type="embeddings",
-        tool_calling=True,
-        default=True,
-        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
         name="ibm/slate-125m-english-rtrvr-v2",
         icon="IBM",
         model_type="embeddings",
-        tool_calling=True,
-        default=True,
-        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
         name="ibm/slate-30m-english-rtrvr-v2",
         icon="IBM",
         model_type="embeddings",
-        tool_calling=True,
-        default=True,
-        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
         name="intfloat/multilingual-e5-large",
         icon="IBM",
         model_type="embeddings",
-        tool_calling=True,
-        default=True,
+    ),
+    # Withdrawn from IBM's embedding catalog.
+    create_model_metadata(
+        provider="IBM WatsonX",
+        name="sentence-transformers/all-minilm-l12-v2",
+        icon="IBM",
+        model_type="embeddings",
         deprecated=True,
     ),
 ]

--- a/src/lfx/tests/unit/base/models/test_watsonx_catalog.py
+++ b/src/lfx/tests/unit/base/models/test_watsonx_catalog.py
@@ -1,0 +1,63 @@
+"""WatsonX seed-catalog and live-fetch metadata regressions.
+
+The static seed list once marked every WatsonX model ``deprecated=True`` and
+``fetch_live_watsonx_models`` copied that flag onto matching live results, so
+the Models page showed "0 models" for IBM WatsonX before *and* after
+credentials were configured — the catalog's default deprecated filter dropped
+everything.
+"""
+
+from unittest.mock import patch
+
+from lfx.base.models import model_utils
+from lfx.base.models.watsonx_constants import (
+    WATSONX_DEFAULT_EMBEDDING_MODELS,
+    WATSONX_DEFAULT_LLM_MODELS,
+)
+
+
+def test_seed_catalog_offers_active_models():
+    active_llms = [m for m in WATSONX_DEFAULT_LLM_MODELS if not m.get("deprecated")]
+    active_embeddings = [m for m in WATSONX_DEFAULT_EMBEDDING_MODELS if not m.get("deprecated")]
+    assert active_llms, "every seed LLM is deprecated: the provider renders as '0 models'"
+    assert active_embeddings, "every seed embedding is deprecated: the embedding picker renders empty"
+
+
+def test_fallback_names_exclude_withdrawn_models():
+    withdrawn_llms = {m["name"] for m in WATSONX_DEFAULT_LLM_MODELS if m.get("deprecated")}
+    assert withdrawn_llms.isdisjoint(model_utils.WATSONX_DEFAULT_LLM_MODEL_NAMES)
+
+    withdrawn_embeddings = {m["name"] for m in WATSONX_DEFAULT_EMBEDDING_MODELS if m.get("deprecated")}
+    assert withdrawn_embeddings.isdisjoint(model_utils.WATSONX_DEFAULT_EMBEDDING_MODEL_NAMES)
+
+
+def _fetch_live(model_type: str, names: list[str]) -> list[dict]:
+    with (
+        patch.object(model_utils, "get_provider_variable_value", return_value="https://us-south.ml.cloud.ibm.com"),
+        patch.object(model_utils, "get_watsonx_llm_models", return_value=names),
+        patch.object(model_utils, "get_watsonx_embedding_models", return_value=names),
+    ):
+        return model_utils.fetch_live_watsonx_models("00000000-0000-0000-0000-000000000000", model_type)
+
+
+def test_live_models_do_not_inherit_static_deprecated_flag():
+    # The live query already excludes withdrawn models (!lifecycle_withdrawn):
+    # whatever it returns is current, even when the static seed flags the same
+    # name as deprecated (stale seed data must never hide live models).
+    deprecated_seed_name = next(m["name"] for m in WATSONX_DEFAULT_LLM_MODELS if m.get("deprecated"))
+    result = _fetch_live("llm", [deprecated_seed_name, "brand-new-model"])
+    assert [m["deprecated"] for m in result] == [False, False]
+
+
+def test_live_models_keep_static_tool_calling_flags():
+    result = _fetch_live("llm", ["ibm/granite-guardian-3-8b", "unknown-model"])
+    by_name = {m["name"]: m for m in result}
+    assert by_name["ibm/granite-guardian-3-8b"]["tool_calling"] is False
+    assert by_name["unknown-model"]["tool_calling"] is True
+
+
+def test_live_embedding_models_do_not_inherit_static_deprecated_flag():
+    deprecated_seed_name = next(m["name"] for m in WATSONX_DEFAULT_EMBEDDING_MODELS if m.get("deprecated"))
+    result = _fetch_live("embeddings", [deprecated_seed_name])
+    assert result[0]["deprecated"] is False
+    assert result[0]["model_type"] == "embeddings"


### PR DESCRIPTION
## What

IBM WatsonX rendered as **"0 models"** on the Models settings page. Root cause: every static entry in `watsonx_constants.py` carried `deprecated=True` — the flag had been overloaded to mean "hide from pickers" (#13201 for the LLMs, a KB-ingestion limitation for the embeddings) — and the unified catalog (plus any UI deprecated-filter) drops deprecated models by default. Worse, `fetch_live_watsonx_models` copied the stale static flag onto matching **live** results, so genuinely current models (e.g. `ibm/granite-guardian-3-8b`, which IBM's API returns today) stayed hidden even after credentials were configured.

## Changes

**1. Reseed the WatsonX static catalog** (`watsonx_constants.py`)
- LLMs: the current `foundation_model_specs` chat listing (verified live against `us-south` on 2026-08-19): granite-4-h-small, llama-3-3-70b, llama-4-maverick, mistral-large-2512, mistral-medium/small, gpt-oss-120b, granite-guardian-3-8b.
- Embeddings: granite-embedding-278m-multilingual, slate-125m/30m, multilingual-e5-large. These are visible again — `WatsonxEmbeddings` is fully wired in the unified class registry (`EMBEDDING_PROVIDER_CLASS_MAPPING` + param mappings), so the KB-era hiding rationale no longer applies.
- `deprecated=True` now only marks models IBM actually withdrew (`granite-8b-code-instruct`, `all-minilm-l12-v2`), kept so legacy flows still resolve (they surface under "Show deprecated").

**2. Trust the live API over stale seed data** (`model_utils.py`)
- `fetch_live_watsonx_models` no longer inherits the static `deprecated` flag: the live query already filters `!lifecycle_withdrawn`, so whatever it returns is current. Stale seed data can never hide live models again. The `tool_calling` capability lookup is preserved.
- API-failure fallback name lists exclude withdrawn models.

**3. "Models load after credentials" affordance** (API + UI)
- `GET /api/v1/models` now emits `live_discovery` per provider (core live-fetch providers + bundle-registered live-only providers).
- The Model Providers dialog shows a "models are discovered once credentials are configured" empty state for unconfigured live-discovery providers (e.g. vLLM, OpenAI Compatible) instead of the generic "No available models". Ollama keeps its specialized empty state. The flag is backend-driven — no new hardcoded provider names in the frontend.

## Test plan

- [x] `src/lfx/tests/unit/base/models/` — 393 passed (includes new `test_watsonx_catalog.py`: seed catalog offers active models; live results never inherit static `deprecated`; `tool_calling` flags preserved; fallback names exclude withdrawn models)
- [x] `src/backend/tests/unit/api/v1/test_models_live_only_providers.py` — 7 passed (new: `live_discovery` flag assertions; WatsonX seed catalog visible with LLMs + embeddings before configuration)
- [x] `src/backend/tests/unit/test_unified_models.py`, `test_models_enabled_providers.py`, `agentic/services/test_provider_service_live_models.py` — 112 passed
- [x] Frontend: `src/modals/modelProviderModal` jest suites — 103 passed (includes new `ModelSelectionLiveDiscovery.test.tsx`), i18n consistency tests pass, `tsc --noEmit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model providers discovered from live endpoints are now clearly identified.
  - Added guidance prompting users to configure and save credentials before models are loaded.
  - Added localized empty-state messaging in German, English, Spanish, French, Japanese, Portuguese, and Simplified Chinese.
  - Expanded WatsonX’s available model catalog, including current language and embedding models.

- **Bug Fixes**
  - Removed withdrawn WatsonX models from fallback selections.
  - Preserved accurate model capabilities and availability metadata during live discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->