### PR TITLE
feat(a11y): single-pointer non-drag node placement (2.5.7 fallback — hold unless the essential-exception claim is rejected)

### DIFF
--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "Aktualisierung erforderlich",
   "node.upgradeRequiredMessage": "Zur Ausführung des Ablaufs ist ein Upgrade erforderlich",
   "node.viewCode": "Code anzeigen",
+  "nodeToolbar.moveTo": "Verschieben nach …",
+  "nodeToolbar.moveToArmed": "Klicken Sie auf eine Stelle der Arbeitsfläche, um den Knoten zu platzieren. Esc bricht ab.",
   "nodeToolbar.code": "Code erstellen",
   "nodeToolbar.copy": "Kopieren",
   "nodeToolbar.delete": "Löschen",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1126,6 +1126,8 @@
   "modelProviders.showDeprecatedSingular": "Show 1 deprecated model",
   "multiselect.chooseOption": "Choose an option...",
   "multiselect.noValuesFound": "No values found.",
+  "nodeToolbar.moveTo": "Move to…",
+  "nodeToolbar.moveToArmed": "Click a spot on the canvas to place the node. Press Escape to cancel.",
   "nodeToolbar.code": "Code",
   "nodeToolbar.freeze": "Freeze",
   "nodeToolbar.toolMode": "Tool Mode",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "Actualización necesaria",
   "node.upgradeRequiredMessage": "Es necesario actualizar para ejecutar el flujo",
   "node.viewCode": "Ver código",
+  "nodeToolbar.moveTo": "Mover a…",
+  "nodeToolbar.moveToArmed": "Haga clic en un punto del lienzo para colocar el nodo. Pulse Escape para cancelar.",
   "nodeToolbar.code": "Código",
   "nodeToolbar.copy": "Copiar",
   "nodeToolbar.delete": "Suprimir",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "Mise à jour requise",
   "node.upgradeRequiredMessage": "Une mise à niveau est nécessaire pour exécuter le flux",
   "node.viewCode": "Afficher le code",
+  "nodeToolbar.moveTo": "Déplacer vers…",
+  "nodeToolbar.moveToArmed": "Cliquez sur un point du canevas pour placer le nœud. Échap pour annuler.",
   "nodeToolbar.code": "Coder",
   "nodeToolbar.copy": "Copier",
   "nodeToolbar.delete": "Supprimer",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "更新が必要です",
   "node.upgradeRequiredMessage": "フローを実行するにはアップグレードが必要です",
   "node.viewCode": "コードの表示",
+  "nodeToolbar.moveTo": "移動先を選択…",
+  "nodeToolbar.moveToArmed": "キャンバス上の位置をクリックしてノードを配置します。Escape でキャンセルします。",
   "nodeToolbar.code": "コード",
   "nodeToolbar.copy": "コピー",
   "nodeToolbar.delete": "削除",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "Atualização necessária",
   "node.upgradeRequiredMessage": "É necessária uma atualização para executar o fluxo",
   "node.viewCode": "Visualizar código",
+  "nodeToolbar.moveTo": "Mover para…",
+  "nodeToolbar.moveToArmed": "Clique em um ponto da tela para posicionar o nó. Pressione Escape para cancelar.",
   "nodeToolbar.code": "Código",
   "nodeToolbar.copy": "Copiar",
   "nodeToolbar.delete": "Excluir",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1683,6 +1683,8 @@
   "node.updateRequiredLabel": "需要更新",
   "node.upgradeRequiredMessage": "执行该流程需要进行升级",
   "node.viewCode": "查看代码",
+  "nodeToolbar.moveTo": "移动到…",
+  "nodeToolbar.moveToArmed": "点击画布上的位置以放置节点。按 Escape 取消。",
   "nodeToolbar.code": "代码",
   "nodeToolbar.copy": "副本",
   "nodeToolbar.delete": "删除",

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/__tests__/config-transition.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/__tests__/config-transition.test.tsx
@@ -14,6 +14,7 @@ let mockShortcutFreeze: (() => void) | undefined;
 
 jest.mock("@xyflow/react", () => ({
   useUpdateNodeInternals: () => jest.fn(),
+  useReactFlow: () => ({ screenToFlowPosition: jest.fn((p) => p) }),
 }));
 
 jest.mock("@/CustomNodes/helpers/mutate-template", () => ({

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/components/ToolbarMoreMenu.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/components/ToolbarMoreMenu.tsx
@@ -112,6 +112,14 @@ export function ToolbarMoreMenu({
             dataTestId="copy-button-modal"
           />
         </SelectItem>
+        <SelectItem variant="plain" value={"moveTo"}>
+          <ToolbarSelectItem
+            shortcut=""
+            value={t("nodeToolbar.moveTo")}
+            icon={"Move"}
+            dataTestId="move-to-button-modal"
+          />
+        </SelectItem>
         {isOutdated && (
           <SelectItem variant="plain" value={"update"}>
             <ToolbarSelectItem

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/helpers/__tests__/build-toolbar-action-map.test.ts
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/helpers/__tests__/build-toolbar-action-map.test.ts
@@ -22,6 +22,8 @@ const ORIGINAL_SWITCH_CASES: ToolbarActionEvent[] = [
   "copy",
   "duplicate",
   "toolMode",
+  // added after the extraction: single-pointer move (WCAG 2.5.7)
+  "moveTo",
 ];
 
 function makeHandlers(): jest.Mocked<ToolbarActionHandlers> {
@@ -41,6 +43,7 @@ function makeHandlers(): jest.Mocked<ToolbarActionHandlers> {
     copy: jest.fn(),
     duplicate: jest.fn(),
     toolMode: jest.fn(),
+    moveTo: jest.fn(),
   };
 }
 

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/helpers/build-toolbar-action-map.ts
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/helpers/build-toolbar-action-map.ts
@@ -19,7 +19,8 @@ export type ToolbarActionEvent =
   | "update"
   | "copy"
   | "duplicate"
-  | "toolMode";
+  | "toolMode"
+  | "moveTo";
 
 export interface ToolbarActionHandlers {
   save: () => void;
@@ -37,6 +38,7 @@ export interface ToolbarActionHandlers {
   copy: () => void;
   duplicate: () => void;
   toolMode: () => void;
+  moveTo: () => void;
 }
 
 /**
@@ -65,5 +67,6 @@ export function buildToolbarActionMap(
     copy: handlers.copy,
     duplicate: handlers.duplicate,
     toolMode: handlers.toolMode,
+    moveTo: handlers.moveTo,
   };
 }

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/__tests__/use-move-node-to-click.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/__tests__/use-move-node-to-click.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react";
+import { useMoveNodeToClick } from "../use-move-node-to-click";
+
+const screenToFlowPosition = jest.fn((p: { x: number; y: number }) => p);
+jest.mock("@xyflow/react", () => ({
+  useReactFlow: () => ({ screenToFlowPosition }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const takeSnapshot = jest.fn();
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({ takeSnapshot }),
+}));
+
+const setNoticeData = jest.fn();
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({ setNoticeData }),
+}));
+
+const setNode = jest.fn();
+const autoSaveFlow = jest.fn();
+const updateCurrentFlow = jest.fn();
+const storeState = {
+  nodes: [
+    {
+      id: "node-1",
+      position: { x: 0, y: 0 },
+      measured: { width: 100, height: 60 },
+    },
+  ],
+  setNode,
+  autoSaveFlow,
+  updateCurrentFlow,
+};
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: { getState: () => storeState },
+}));
+
+function pane() {
+  const el = document.createElement("div");
+  el.className = "react-flow__pane";
+  document.body.appendChild(el);
+  return el;
+}
+
+function pointerDownOn(el: Element, x = 300, y = 200) {
+  const event = new Event("pointerdown", {
+    bubbles: true,
+    cancelable: true,
+  }) as PointerEvent;
+  Object.defineProperty(event, "clientX", { value: x });
+  Object.defineProperty(event, "clientY", { value: y });
+  el.dispatchEvent(event);
+}
+
+describe("useMoveNodeToClick", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.clearAllMocks();
+  });
+
+  it("places the node centered on the clicked pane position, snapshots first, and persists", () => {
+    const paneEl = pane();
+    const { result } = renderHook(() => useMoveNodeToClick("node-1"));
+    act(() => result.current());
+    expect(setNoticeData).toHaveBeenCalledWith({
+      title: "nodeToolbar.moveToArmed",
+    });
+
+    act(() => pointerDownOn(paneEl, 300, 200));
+
+    expect(takeSnapshot).toHaveBeenCalledTimes(1);
+    expect(setNode).toHaveBeenCalledTimes(1);
+    const [id, updater] = setNode.mock.calls[0];
+    expect(id).toBe("node-1");
+    expect(updater(storeState.nodes[0]).position).toEqual({ x: 250, y: 170 });
+    expect(autoSaveFlow).toHaveBeenCalledTimes(1);
+    expect(updateCurrentFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a one-shot gesture: a second pane click does nothing", () => {
+    const paneEl = pane();
+    const { result } = renderHook(() => useMoveNodeToClick("node-1"));
+    act(() => result.current());
+    act(() => pointerDownOn(paneEl));
+    act(() => pointerDownOn(paneEl));
+    expect(setNode).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on a click that is not on the pane", () => {
+    pane();
+    const other = document.createElement("button");
+    document.body.appendChild(other);
+    const { result } = renderHook(() => useMoveNodeToClick("node-1"));
+    act(() => result.current());
+    act(() => pointerDownOn(other));
+    expect(setNode).not.toHaveBeenCalled();
+    // and the gesture is disarmed — a later pane click must not fire either
+    act(() => pointerDownOn(document.querySelector(".react-flow__pane")!));
+    expect(setNode).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Escape", () => {
+    const paneEl = pane();
+    const { result } = renderHook(() => useMoveNodeToClick("node-1"));
+    act(() => result.current());
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    act(() => pointerDownOn(paneEl));
+    expect(setNode).not.toHaveBeenCalled();
+  });
+
+  it("restores the pane cursor when disarmed", () => {
+    const paneEl = pane();
+    const { result } = renderHook(() => useMoveNodeToClick("node-1"));
+    act(() => result.current());
+    expect(paneEl.style.cursor).toBe("crosshair");
+    act(() => pointerDownOn(paneEl));
+    expect(paneEl.style.cursor).toBe("");
+  });
+});

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/use-move-node-to-click.ts
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/use-move-node-to-click.ts
@@ -1,0 +1,89 @@
+import { useReactFlow } from "@xyflow/react";
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import useAlertStore from "@/stores/alertStore";
+import useFlowStore from "@/stores/flowStore";
+import useFlowsManagerStore from "@/stores/flowsManagerStore";
+
+/**
+ * Single-pointer, non-drag node repositioning (WCAG 2.5.7 Dragging
+ * Movements, technique F108): arm from the node toolbar, then one click on
+ * the canvas pane places the node there. Escape cancels.
+ *
+ * The pointerdown listener is registered on `document` with capture so it
+ * runs before ReactFlow's own pane handler deselects the node (which would
+ * unmount the toolbar this hook lives in mid-gesture). Clicks on anything
+ * that is not the pane (another node, the sidebar, a modal) cancel the
+ * gesture instead of moving the node somewhere surprising.
+ */
+export function useMoveNodeToClick(nodeId: string) {
+  const { t } = useTranslation();
+  const { screenToFlowPosition } = useReactFlow();
+  const takeSnapshot = useFlowsManagerStore((state) => state.takeSnapshot);
+  const setNoticeData = useAlertStore((state) => state.setNoticeData);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const disarm = useCallback(() => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+  }, []);
+
+  useEffect(() => disarm, [disarm]);
+
+  const armMove = useCallback(() => {
+    disarm();
+    const pane = document.querySelector<HTMLElement>(".react-flow__pane");
+    pane?.style.setProperty("cursor", "crosshair");
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target?.classList.contains("react-flow__pane")) {
+        disarm();
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+
+      const store = useFlowStore.getState();
+      const node = store.nodes.find((candidate) => candidate.id === nodeId);
+      if (!node) {
+        disarm();
+        return;
+      }
+      const clicked = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+      // Center the node on the click rather than hanging it off its
+      // top-left corner.
+      const position = {
+        x: clicked.x - (node.measured?.width ?? 0) / 2,
+        y: clicked.y - (node.measured?.height ?? 0) / 2,
+      };
+      takeSnapshot();
+      store.setNode(nodeId, (old) => ({ ...old, position }), false);
+      store.autoSaveFlow?.();
+      store.updateCurrentFlow({ nodes: useFlowStore.getState().nodes });
+      disarm();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        disarm();
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    cleanupRef.current = () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+      pane?.style.removeProperty("cursor");
+    };
+
+    setNoticeData({ title: t("nodeToolbar.moveToArmed") });
+  }, [disarm, nodeId, screenToFlowPosition, takeSnapshot, setNoticeData, t]);
+
+  return armMove;
+}

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -31,6 +31,7 @@ import {
   buildToolbarActionMap,
   type ToolbarActionEvent,
 } from "./helpers/build-toolbar-action-map";
+import { useMoveNodeToClick } from "./hooks/use-move-node-to-click";
 import useShortcuts from "./hooks/use-shortcuts";
 import { useToolbarNodeState } from "./hooks/use-toolbar-node-state";
 
@@ -147,6 +148,10 @@ const NodeToolbarComponent = memo(
         newValue,
       );
     };
+
+    // WCAG 2.5.7: single-pointer, non-drag alternative to dragging a node —
+    // arm here, then one click on the pane places the node.
+    const armMoveNodeToClick = useMoveNodeToClick(data.id);
 
     // LE-1810: any component can be minimized, regardless of how many
     // input/output handles it has.
@@ -341,6 +346,7 @@ const NodeToolbarComponent = memo(
             );
           },
           toolMode: handleActivateToolMode,
+          moveTo: armMoveNodeToClick,
         }),
       [
         saveComponent,
@@ -360,6 +366,7 @@ const NodeToolbarComponent = memo(
         setLastCopiedSelection,
         paste,
         handleActivateToolMode,
+        armMoveNodeToClick,
       ],
     );
 


### PR DESCRIPTION
## What & why

**Fallback for WCAG 2.5.7 Dragging Movements (technique F108) — draft on purpose.**

The compliance form claims the *essential exception* for free-form node positioning on the canvas: a graph editor's node placement is inherently spatial, and keyboard arrow-key movement (shipping separately under LE-1514) covers keyboard users. If a reviewer or auditor rejects that claim, 2.5.7 requires a **single-pointer, non-drag** way to reposition a node — this PR is that alternative, ready to promote instead of scrambling.

## What it does

**"Move to…"** in the node toolbar's more-options menu arms a one-shot gesture:

1. Select a node → more options → **Move to…**
2. A notice explains the gesture; the pane cursor becomes a crosshair.
3. One single click on the canvas pane places the node there (centered on the click) — same undo snapshot + autosave treatment a drag gets.
4. **Escape** cancels, as does clicking anything that isn't the pane (another node, the sidebar, a modal) — the node never jumps somewhere surprising.

The `pointerdown` listener registers on `document` with capture so it runs before ReactFlow's pane handler deselects the node — deselection would unmount the toolbar this hook lives in mid-gesture.

## Verification

- Unit tests: gesture places centered on click + snapshots first + persists; one-shot; cancels on non-pane click; cancels on Escape; cursor restored (5 tests).
- Toolbar action-map key-coverage test extended (`moveTo`); all 48 toolbar suite tests green.
- Verified live against a dev server: menu item renders, crosshair arms, click placement moves the node, cursor restores, **Cmd+Z restores the pre-move position**.
- i18n: `nodeToolbar.moveTo` + `nodeToolbar.moveToArmed` added to all 7 locales.

## Status

**Draft — do not merge unless the 2.5.7 essential-exception claim is rejected.** The compliance row should keep the exception wording; this exists so the decision is reversible at zero notice.

Jira: [LE-1514](https://datastax.jira.com/browse/LE-1514) (related; the exception decision is recorded on compliance row 2.5.7)


[LE-1514]: https://datastax.jira.com/browse/LE-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ