### PR TITLE
fix(agui): dedupe tool calls by traversal rank instead of raw block index

### DIFF
--- a/src/lfx/src/lfx/workflow/agui_translator.py
+++ b/src/lfx/src/lfx/workflow/agui_translator.py
@@ -83,8 +83,9 @@ class AGUITranslator:
         # immediately promotes the next buffered one.
         self._buffered_messages: dict[str, _BufferedMessage] = {}
         # Tool-call ids already emitted as TOOL_CALL_START / already resolved
-        # with a TOOL_CALL_RESULT. ``add_message`` can re-fire with the same
-        # (append-only) content_blocks, so emissions must be deduplicated.
+        # with a TOOL_CALL_RESULT. ``add_message`` can re-fire for the same
+        # message as its content grows (or is reindexed — see
+        # ``_translate_tool_use``), so emissions must be deduplicated.
         self._started_tool_calls: set[str] = set()
         self._resulted_tool_calls: set[str] = set()
         # Custom content blocks already emitted as CUSTOM events, mapped to a
@@ -281,12 +282,17 @@ class AGUITranslator:
         # nested contents. ``text`` leaves are skipped here (text rides ``data["text"]``
         # below); a block is either a leaf or a group, so a leaf's empty ``contents``
         # makes the nested loop a no-op and the two paths cannot double-emit.
+        #
+        # ``tool_ordinal`` counts only tool_use leaves, in traversal order, instead of
+        # reusing the leaf's raw list index — see ``_translate_tool_use`` for why.
+        tool_ordinal = 0
         for block_index, block in enumerate(data.get("content_blocks") or []):
             if not isinstance(block, dict):
                 continue
             block_type = block.get("type")
             if block_type == "tool_use":
-                events.extend(self._translate_tool_use(message_id, block_index, 0, block))
+                events.extend(self._translate_tool_use(message_id, tool_ordinal, block))
+                tool_ordinal += 1
             elif block_type in _CUSTOM_CONTENT_TYPES:
                 events.extend(self._translate_custom_content(message_id, block, block_index, 0, block))
             for content_index, content in enumerate(block.get("contents") or []):
@@ -294,7 +300,8 @@ class AGUITranslator:
                     continue
                 content_type = content.get("type")
                 if content_type == "tool_use":
-                    events.extend(self._translate_tool_use(message_id, block_index, content_index, content))
+                    events.extend(self._translate_tool_use(message_id, tool_ordinal, content))
+                    tool_ordinal += 1
                 elif content_type in _CUSTOM_CONTENT_TYPES:
                     events.extend(
                         self._translate_custom_content(message_id, block, block_index, content_index, content)
@@ -337,15 +344,26 @@ class AGUITranslator:
                     self._buffered_messages[message_id] = _BufferedMessage(final_text=text)
         return events
 
-    def _translate_tool_use(
-        self, message_id: str, block_index: int, content_index: int, content: dict
-    ) -> list[BaseEvent]:
+    def _translate_tool_use(self, message_id: str, tool_ordinal: int, content: dict) -> list[BaseEvent]:
         """Map one ``tool_use`` content block to tool-call lifecycle events.
 
-        ``ToolContent`` has no id, so a stable tool-call id is derived from the
-        tool's position in the (append-only) content_blocks structure.
+        The tool-call id prefers ``content["id"]`` — a producer-stamped stable id
+        (e.g. a LangChain ``tool_call_id``) — when present. Otherwise it falls back
+        to ``tool_ordinal``: this call's rank among tool_use leaves encountered so
+        far in the current ``content_blocks`` traversal, not its raw list index.
+
+        Raw list index was tried first and is unsound: ``Message.text``'s setter
+        drops every ``TextContent`` block and appends one consolidated block at the
+        end, which shifts every later block's absolute index whenever ``add_message``
+        re-fires for a message with text ahead of its tool calls (e.g. Chat Output
+        re-emitting an Agent message that already finished streaming). A shifted
+        index looks like a brand-new tool call to the dedup sets below, so the whole
+        START/ARGS/END/RESULT quartet re-emits with a fresh id and ~zero duration.
+        The ordinal is immune to that reindexing: only ``TextContent`` blocks move,
+        so tool_use leaves keep the same relative rank across re-fires.
         """
-        tool_call_id = f"{message_id}:tool:{block_index}:{content_index}"
+        content_id = content.get("id")
+        tool_call_id = f"{message_id}:tool:{content_id}" if content_id else f"{message_id}:tool:{tool_ordinal}"
         events: list[BaseEvent] = []
 
         if tool_call_id not in self._started_tool_calls:

--- a/src/lfx/tests/unit/workflow/test_agui_translator.py
+++ b/src/lfx/tests/unit/workflow/test_agui_translator.py
@@ -841,12 +841,23 @@ def test_repeated_add_message_after_text_consolidation_does_not_duplicate_tool_c
         },
     )
 
-    first_starts = [e for e in first if isinstance(e, ToolCallStartEvent)]
-    second_starts = [e for e in second if isinstance(e, ToolCallStartEvent)]
-    assert len(first_starts) == 1
-    assert len(second_starts) == 0, (
-        f"tool call re-emitted under a new id after content_blocks reindexing: {second_starts}"
-    )
+    def _tool_events(events):
+        return {
+            event_type: [e for e in events if isinstance(e, event_type)]
+            for event_type in (ToolCallStartEvent, ToolCallArgsEvent, ToolCallEndEvent, ToolCallResultEvent)
+        }
+
+    first_tool_events = _tool_events(first)
+    second_tool_events = _tool_events(second)
+
+    # The first firing emits exactly one full START/ARGS/END/RESULT quartet.
+    for event_type, events in first_tool_events.items():
+        assert len(events) == 1, f"expected exactly one {event_type.__name__} on first firing, got {events}"
+
+    # The second firing must re-emit nothing: same tool call, same id, already
+    # started and resolved — not a new quartet under a shifted id.
+    for event_type, events in second_tool_events.items():
+        assert events == [], f"tool call re-emitted {event_type.__name__} after content_blocks reindexing: {events}"
 
 
 def test_tool_use_error_is_reported_via_tool_call_result():

--- a/src/lfx/tests/unit/workflow/test_agui_translator.py
+++ b/src/lfx/tests/unit/workflow/test_agui_translator.py
@@ -781,6 +781,74 @@ def test_repeated_add_message_does_not_re_emit_flat_tool_call():
     assert len([e for e in second if isinstance(e, ToolCallStartEvent)]) == 0
 
 
+def test_repeated_add_message_after_text_consolidation_does_not_duplicate_tool_call():
+    """A tool call must not re-emit under a new id when a later add_message reindexes content_blocks.
+
+    Reproduces the reported AG-UI duplication bug: ``ChatOutput.message_response()``
+    sets ``message.text`` on an already-streamed Agent message, and ``Message.text``'s
+    setter drops the message's ``TextContent`` blocks and appends one consolidated
+    block at the end. When narration text precedes a tool call, that shifts the
+    tool_use block's absolute list index between the two ``add_message`` firings. A
+    position-derived tool-call id treated the shifted block as a brand-new call and
+    re-emitted its whole START/ARGS/END/RESULT quartet under a fresh id, with the
+    same tool name/input/output and near-zero duration.
+    """
+    t = AGUITranslator(run_id="r1", thread_id="t1")
+    t.start()
+
+    # First firing: narration text precedes the tool call, so the tool_use leaf
+    # sits at absolute index 1.
+    first = t.translate(
+        "add_message",
+        {
+            "id": "m1",
+            "text": "",
+            "properties": {"state": "partial"},
+            "content_blocks": [
+                {"type": "text", "contents": [], "text": "Let me check that..."},
+                {
+                    "type": "tool_use",
+                    "contents": [],
+                    "name": "search",
+                    "tool_input": {"q": "weather"},
+                    "output": "sunny",
+                    "error": None,
+                },
+            ],
+        },
+    )
+
+    # Second firing simulates ``Message.text``'s setter: the TextContent block is
+    # dropped and a consolidated one appended at the end, shifting the tool_use
+    # leaf's absolute index from 1 to 0. Same message id, same tool call.
+    second = t.translate(
+        "add_message",
+        {
+            "id": "m1",
+            "text": "Let me check that...",
+            "properties": {"state": "complete"},
+            "content_blocks": [
+                {
+                    "type": "tool_use",
+                    "contents": [],
+                    "name": "search",
+                    "tool_input": {"q": "weather"},
+                    "output": "sunny",
+                    "error": None,
+                },
+                {"type": "text", "contents": [], "text": "Let me check that..."},
+            ],
+        },
+    )
+
+    first_starts = [e for e in first if isinstance(e, ToolCallStartEvent)]
+    second_starts = [e for e in second if isinstance(e, ToolCallStartEvent)]
+    assert len(first_starts) == 1
+    assert len(second_starts) == 0, (
+        f"tool call re-emitted under a new id after content_blocks reindexing: {second_starts}"
+    )
+
+
 def test_tool_use_error_is_reported_via_tool_call_result():
     t = AGUITranslator(run_id="r1", thread_id="t1")
     t.start()


### PR DESCRIPTION
## Summary

`AGUITranslator._translate_tool_use` derived each tool call's AG-UI id from its raw position in a message's `content_blocks` list. `Message.text`'s setter drops every `TextContent` block and appends one consolidated block at the end, which shifts the absolute index of any `tool_use` block that used to sit after narration text. When a downstream component (e.g. Chat Output) re-emits an already fully-streamed Agent message via `message.text = text`, the shifted index looked like a brand-new tool call, so the whole `TOOL_CALL_START/ARGS/END/RESULT` quartet re-emitted under a fresh id with the same name/input/output and near-zero duration — the tool call count roughly doubled by the end of a run.

This PR keys the tool-call id off `content["id"]` when a producer stamps one (the field's documented intent), else off the tool call's rank among `tool_use` leaves in traversal order instead of its raw list index. The rank survives the reindexing because only `TextContent` blocks move; `tool_use` leaves keep their relative order.

Fixes #14668

## Test plan

- [x] Added `test_repeated_add_message_after_text_consolidation_does_not_duplicate_tool_call`, which reproduces the exact scenario (narration text before a tool call, then a re-fire with the text block consolidated to the end). Verified it fails against the pre-fix code (new `tool_call_id` on the second pass) and passes with the fix.
- [x] Full `src/lfx/tests/unit/workflow/` suite passes (286 tests), no regressions.
- [x] `ruff check` / `ruff format --check` clean on both changed files.
- [x] Checked for other dependents on the `tool_call_id` wire format (frontend, other backend modules) — none found; `_translate_custom_content` (the `CUSTOM` event path) is untouched and out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tool-call events when message updates reorder or consolidate text content.
  * Improved consistency of tool-call lifecycle events across partial and complete message updates.

* **Tests**
  * Added regression coverage to verify that repeated message updates emit each tool-call start event only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->