### PR TITLE
fix(lfx): validate JSON root type

### DIFF
--- a/src/lfx/src/lfx/cli/validation/core.py
+++ b/src/lfx/src/lfx/cli/validation/core.py
@@ -119,7 +119,7 @@ def validate_flow_file(
 
     try:
         raw = path.read_text(encoding="utf-8")
-        flow: dict[str, Any] = json.loads(raw)
+        flow: Any = json.loads(raw)
     except OSError as exc:
         result.issues.append(
             ValidationIssue(

--- a/src/lfx/src/lfx/cli/validation/structural.py
+++ b/src/lfx/src/lfx/cli/validation/structural.py
@@ -51,8 +51,20 @@ _REQUIRED_DATA_KEYS = {"nodes", "edges"}
 # ---------------------------------------------------------------------------
 
 
-def _check_structural(flow: dict[str, Any], result: ValidationResult) -> bool:
+def _check_structural(flow: Any, result: ValidationResult) -> bool:
     """Return False if the flow is so broken that further checks cannot run."""
+    if not isinstance(flow, dict):
+        result.issues.append(
+            _make_issue(
+                level=_LEVEL_STRUCTURAL,
+                severity="error",
+                node_id=None,
+                node_name=None,
+                message="Flow must be a JSON object",
+            )
+        )
+        return False
+
     ok = True
     missing_top = _REQUIRED_TOP_LEVEL - set(flow.keys())
     for key in sorted(missing_top):

--- a/src/lfx/tests/unit/cli/test_validate_command.py
+++ b/src/lfx/tests/unit/cli/test_validate_command.py
@@ -99,6 +99,13 @@ class TestStructural:
         assert not result.ok
         assert any("Invalid JSON" in i.message for i in result.errors)
 
+    @pytest.mark.parametrize("raw", ["[]", "null", '"not-an-object"'])
+    def test_root_not_object(self, tmp_path, raw):
+        p = tmp_path / "flow.json"
+        p.write_text(raw, encoding="utf-8")
+        result = validate_flow_file(p, level=1)
+        assert [issue.message for issue in result.errors] == ["Flow must be a JSON object"]
+
     def test_missing_top_level_id(self, tmp_path):
         flow = {k: v for k, v in _MINIMAL_VALID.items() if k != "id"}
         p = _write_flow(tmp_path, "flow.json", flow)


### PR DESCRIPTION
### Summary

- report a structural validation error when a flow file contains valid JSON whose root is not an object
- prevent array, null, and scalar roots from reaching mapping-only validation code
- add parameterized regression coverage for representative non-object roots

### Testing

- uv run --project src/lfx pytest src/lfx/tests/unit/cli/test_validate_command.py::TestStructural::test_root_not_object -q (3 passed)
- uv run --project src/lfx pytest src/lfx/tests/unit/cli/test_validate_command.py -q (56 passed)
- ruff format --check .
- ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow validation for JSON inputs whose root value is not an object.
  * Arrays, `null`, and strings now produce a clear “Flow must be a JSON object” error instead of causing validation issues.

* **Tests**
  * Added coverage for invalid non-object JSON flow inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->