### PR TITLE
feat(agui): add LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS to drop non-standard CUSTOM events

### DIFF
--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -129,6 +129,13 @@ class RuntimeSettings(BaseModel):
     event_delivery: Literal["polling", "streaming", "direct"] = "streaming"
     """How to deliver build events to the frontend. Can be 'polling', 'streaming' or 'direct'."""
 
+    agui_disable_custom_events: bool = False
+    """If True, the AG-UI stream protocol (LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS) drops
+    Langflow-specific content blocks (json/code/media/error) instead of emitting them as
+    namespaced ``langflow.*`` CUSTOM events, so the stream carries only the standard AG-UI
+    vocabulary. Tool-call and text-message events, and the other CUSTOM control markers
+    (log, message removal, human-input-required, run cancellation), are unaffected."""
+
     worker_timeout: int = 300
     """Timeout for the API calls in seconds."""
 

--- a/src/lfx/src/lfx/workflow/adapters/agui.py
+++ b/src/lfx/src/lfx/workflow/adapters/agui.py
@@ -60,9 +60,19 @@ class AGUIAdapter:
 
     def __init__(self, context: StreamAdapterContext) -> None:
         self.context = context
+        # Settings (not a raw env read) so this honors the same
+        # LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS -> Settings binding as every other
+        # Langflow toggle; imported at call time so tests can stub
+        # ``lfx.services.deps.get_settings_service`` per run.
+        from lfx.services.deps import get_settings_service
+
+        settings_service = get_settings_service()
+        settings = settings_service.settings if settings_service is not None else None
+        disable_custom_events = bool(settings.agui_disable_custom_events) if settings is not None else False
         self._translator = AGUITranslator(
             run_id=context.run_id,
             thread_id=context.thread_id,
+            disable_custom_events=disable_custom_events,
         )
 
     def initial_events(self) -> Iterable[StreamEvent]:

--- a/src/lfx/src/lfx/workflow/agui_translator.py
+++ b/src/lfx/src/lfx/workflow/agui_translator.py
@@ -69,9 +69,15 @@ class AGUITranslator:
     :meth:`translate` for each ``EventManager`` event.
     """
 
-    def __init__(self, run_id: str, thread_id: str) -> None:
+    def __init__(self, run_id: str, thread_id: str, *, disable_custom_events: bool = False) -> None:
         self.run_id = run_id
         self.thread_id = thread_id
+        # When set, Langflow-specific content blocks (json/code/media/error) are
+        # dropped instead of riding as namespaced ``langflow.*`` CUSTOM events, so
+        # the stream carries only the standard AG-UI vocabulary. Read by the caller
+        # from ``LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS`` — the translator stays pure
+        # (no env/I/O access of its own), so it takes the resolved flag as an arg.
+        self._disable_custom_events = disable_custom_events
         # Id of the text message currently open on the wire, or ``None``.
         self._open_message_id: str | None = None
         # Message ids whose TEXT_MESSAGE_END has been emitted; the protocol
@@ -273,21 +279,23 @@ class AGUITranslator:
         events: list[BaseEvent] = []
 
         # Content blocks: tool_use becomes tool-call events, the Langflow-specific
-        # content types become namespaced CUSTOM events. They arrive in two shapes:
-        # the legacy/grouped shape nests leaves inside a group's ``contents``, while
-        # the agent's flat log (the content-blocks-as-source-of-truth design) carries
-        # ``tool_use`` / custom leaves at the TOP level with empty ``contents``. Handle
-        # both: translate a top-level leaf by its own type, and still walk a group's
-        # nested contents. ``text`` leaves are skipped here (text rides ``data["text"]``
-        # below); a block is either a leaf or a group, so a leaf's empty ``contents``
-        # makes the nested loop a no-op and the two paths cannot double-emit.
+        # content types become namespaced CUSTOM events (unless disabled — see
+        # ``__init__``). They arrive in two shapes: the legacy/grouped shape nests
+        # leaves inside a group's ``contents``, while the agent's flat log (the
+        # content-blocks-as-source-of-truth design) carries ``tool_use`` / custom
+        # leaves at the TOP level with empty ``contents``. Handle both: translate a
+        # top-level leaf by its own type, and still walk a group's nested contents.
+        # ``text`` leaves are skipped here (text rides ``data["text"]`` below); a
+        # block is either a leaf or a group, so a leaf's empty ``contents`` makes
+        # the nested loop a no-op and the two paths cannot double-emit.
+        emit_custom = not self._disable_custom_events
         for block_index, block in enumerate(data.get("content_blocks") or []):
             if not isinstance(block, dict):
                 continue
             block_type = block.get("type")
             if block_type == "tool_use":
                 events.extend(self._translate_tool_use(message_id, block_index, 0, block))
-            elif block_type in _CUSTOM_CONTENT_TYPES:
+            elif block_type in _CUSTOM_CONTENT_TYPES and emit_custom:
                 events.extend(self._translate_custom_content(message_id, block, block_index, 0, block))
             for content_index, content in enumerate(block.get("contents") or []):
                 if not isinstance(content, dict):
@@ -295,7 +303,7 @@ class AGUITranslator:
                 content_type = content.get("type")
                 if content_type == "tool_use":
                     events.extend(self._translate_tool_use(message_id, block_index, content_index, content))
-                elif content_type in _CUSTOM_CONTENT_TYPES:
+                elif content_type in _CUSTOM_CONTENT_TYPES and emit_custom:
                     events.extend(
                         self._translate_custom_content(message_id, block, block_index, content_index, content)
                     )

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -167,6 +167,7 @@ EXPECTED_FIELDS = {
     "dev",
     "warm_reconcile_interval",
     "event_delivery",
+    "agui_disable_custom_events",
     "worker_timeout",
     "workflow_execution_timeout",
     "model_provider_policy_refresh_interval_s",

--- a/src/lfx/tests/unit/workflow/adapters/test_agui_adapter.py
+++ b/src/lfx/tests/unit/workflow/adapters/test_agui_adapter.py
@@ -8,6 +8,7 @@ The agui adapter wraps the existing ``AGUITranslator`` and frames its
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from lfx.workflow.adapters import (
@@ -203,3 +204,69 @@ def test_unknown_event_types_yield_no_events(unknown_event_type):
     adapter = get_stream_adapter("agui", _ctx())
     events = list(adapter.translate(unknown_event_type, {}))
     assert events == []
+
+
+class TestDisableCustomEventsSetting:
+    """``agui_disable_custom_events`` (bound from ``LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS``) gates CUSTOM content events.
+
+    The settings service is STUBBED (``get_settings_service`` is monkeypatched to a
+    ``SimpleNamespace``) for the per-flag matrix, matching the convention in
+    ``test_router_end_user_scoping.py``; ``test_real_settings_env_binding_...`` drives
+    a real env-built ``Settings`` object through the adapter to cover the
+    operator-facing contract end to end.
+    """
+
+    _CONTENT_BLOCKS = [{"title": "Steps", "contents": [{"type": "json", "data": {"k": "v"}}]}]
+
+    def _stub_settings(self, monkeypatch, settings_ns):
+        from lfx.services import deps as deps_module
+
+        # ``AGUIAdapter.__init__`` imports ``get_settings_service`` from
+        # ``lfx.services.deps`` at call time, so the stub belongs on that module.
+        monkeypatch.setattr(deps_module, "get_settings_service", lambda: SimpleNamespace(settings=settings_ns))
+
+    def test_setting_false_still_emits_custom_content_events(self, monkeypatch):
+        self._stub_settings(monkeypatch, SimpleNamespace(agui_disable_custom_events=False))
+        adapter = get_stream_adapter("agui", _ctx())
+
+        events = list(adapter.translate("add_message", {"id": "m1", "content_blocks": self._CONTENT_BLOCKS}))
+
+        assert any(e.type == "CUSTOM" for e in events)
+
+    def test_setting_true_suppresses_custom_content_events(self, monkeypatch):
+        self._stub_settings(monkeypatch, SimpleNamespace(agui_disable_custom_events=True))
+        adapter = get_stream_adapter("agui", _ctx())
+
+        events = list(adapter.translate("add_message", {"id": "m1", "content_blocks": self._CONTENT_BLOCKS}))
+
+        assert not any(e.type == "CUSTOM" for e in events)
+
+    def test_no_settings_service_defaults_to_emitting_custom_events(self, monkeypatch):
+        """A bare context without a registered settings service keeps today's behavior."""
+        from lfx.services import deps as deps_module
+
+        monkeypatch.setattr(deps_module, "get_settings_service", lambda: None)
+        adapter = get_stream_adapter("agui", _ctx())
+
+        events = list(adapter.translate("add_message", {"id": "m1", "content_blocks": self._CONTENT_BLOCKS}))
+
+        assert any(e.type == "CUSTOM" for e in events)
+
+    def test_real_settings_env_binding_suppresses_custom_content_events(self, monkeypatch):
+        """Operator contract end to end: the real ``Settings`` binds the env var, not just the stub.
+
+        The rest of this class stubs the settings namespace; this case builds the
+        actual env-bound ``Settings`` object so a typo in the field name or the
+        ``LANGFLOW_`` prefix cannot silently disable the feature with every other
+        test still green.
+        """
+        from lfx.services import deps as deps_module
+        from lfx.services.settings.base import Settings
+
+        monkeypatch.setenv("LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS", "true")
+        monkeypatch.setattr(deps_module, "get_settings_service", lambda: SimpleNamespace(settings=Settings()))
+
+        adapter = get_stream_adapter("agui", _ctx())
+        events = list(adapter.translate("add_message", {"id": "m1", "content_blocks": self._CONTENT_BLOCKS}))
+
+        assert not any(e.type == "CUSTOM" for e in events)

--- a/src/lfx/tests/unit/workflow/test_agui_translator.py
+++ b/src/lfx/tests/unit/workflow/test_agui_translator.py
@@ -890,6 +890,67 @@ def test_custom_content_types_emit_langflow_custom_events():
     assert customs["langflow.content.code"].value["content"]["code"] == "print(1)"
 
 
+def test_disable_custom_events_suppresses_langflow_content_custom_events():
+    """``disable_custom_events`` drops json/code/media/error CUSTOM events only."""
+    t = AGUITranslator(run_id="r1", thread_id="t1", disable_custom_events=True)
+    t.start()
+
+    out = t.translate(
+        "add_message",
+        {
+            "id": "m1",
+            "content_blocks": [
+                {
+                    "title": "Steps",
+                    "contents": [
+                        {"type": "json", "data": {"k": "v"}},
+                        {"type": "code", "code": "print(1)", "language": "python"},
+                        {"type": "media", "urls": ["http://x/img.png"], "caption": "pic"},
+                        {"type": "error", "reason": "boom", "traceback": "trace"},
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert not any(isinstance(e, CustomEvent) and e.name.startswith("langflow.content.") for e in out)
+
+
+def test_disable_custom_events_does_not_affect_tool_calls_or_text():
+    """``disable_custom_events`` only scopes the json/code/media/error content types.
+
+    Tool-call and text-message events (and the other CUSTOM markers — log,
+    message.removed, human_input_required, run.cancelled) are unrelated control
+    signals, not Langflow-specific content, so they must still emit.
+    """
+    t = AGUITranslator(run_id="r1", thread_id="t1", disable_custom_events=True)
+    t.start()
+
+    out = t.translate(
+        "add_message",
+        {
+            "id": "m1",
+            "text": "The weather is sunny.",
+            "content_blocks": [
+                {
+                    "type": "tool_use",
+                    "contents": [],
+                    "name": "search",
+                    "tool_input": {"q": "weather"},
+                    "output": "sunny",
+                    "error": None,
+                }
+            ],
+        },
+    )
+
+    assert any(isinstance(e, ToolCallStartEvent) for e in out)
+    assert any(isinstance(e, TextMessageStartEvent) for e in out)
+
+    log_out = t.translate("log", {"message": "hi", "type": "text", "name": "Log 1", "component_id": "c1"})
+    assert any(isinstance(e, CustomEvent) and e.name == "langflow.log" for e in log_out)
+
+
 def test_log_event_emits_langflow_log_custom_event():
     t = AGUITranslator(run_id="r1", thread_id="t1")
     t.start()


### PR DESCRIPTION
## Summary

`AGUITranslator` maps four Langflow-specific content-block types (`json`, `code`, `media`, `error`) onto AG-UI `CUSTOM` events namespaced `langflow.*`, unconditionally. Generic AG-UI clients are documented to ignore unknown `CUSTOM` events, but they still cross the wire and get parsed, and the `error` variant in particular can carry sensitive detail (component name, formatted exception reason, and a traceback) straight to whatever consumes the stream.

This PR adds a boolean setting, `agui_disable_custom_events` (bound from `LANGFLOW_AGUI_DISABLE_CUSTOM_EVENTS` via the existing `LANGFLOW_` `env_prefix` on `RuntimeSettings`, next to `event_delivery`), so operators can suppress just these four content-block `CUSTOM` events and get a stream containing only the standard AG-UI vocabulary. Tool-call and text-message events, and the other `CUSTOM` control markers (`log`, message removal, human-input-required, run cancellation), are unaffected — those are control signals, not Langflow-specific content.

The setting is read via the settings service in `AGUIAdapter.__init__` (not a raw `os.getenv`), matching how every other Langflow toggle in this codebase is read (e.g. `developer_api_enabled`, `serving_end_user_header`), and passed into `AGUITranslator` as a plain constructor arg so the translator itself stays a pure, no-I/O transformation — it never reads env/settings on its own.

Fixes #14669

## Test plan

- [x] Added `test_disable_custom_events_suppresses_langflow_content_custom_events` and `test_disable_custom_events_does_not_affect_tool_calls_or_text` to `test_agui_translator.py`.
- [x] Added `TestDisableCustomEventsSetting` to `test_agui_adapter.py`: settings-service-stubbed matrix (false/true/no-service-registered), plus `test_real_settings_env_binding_suppresses_custom_content_events`, which builds a real env-bound `Settings()` object end to end (matching the pattern already used in `test_router_end_user_scoping.py`) so a typo in the field name or the `LANGFLOW_` prefix can't silently break the feature while every stubbed test stays green.
- [x] Added `agui_disable_custom_events` to `test_settings_composition.py`'s `EXPECTED_FIELDS` canary set (that test intentionally fails on any unlisted field addition).
- [x] Full `lfx` test suite in isolation (`cd src/lfx && uv run pytest tests/unit/workflow/ tests/unit/services/settings/`): 436 passed, 5 skipped, no regressions.
- [x] `ruff check` / `ruff format --check` clean on all six changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a runtime setting to control whether Langflow-specific custom events appear in AG-UI streams.
  - Standard text messages, tool-call events, and logs continue to be emitted when custom content events are disabled.
  - Custom events remain enabled by default.

- **Tests**
  - Added coverage for enabled, disabled, and unavailable settings scenarios, including nested content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->