### PR TITLE
fix(lfx): preserve document metadata during conversion

### DIFF
--- a/src/lfx/src/lfx/schema/data.py
+++ b/src/lfx/src/lfx/schema/data.py
@@ -127,7 +127,7 @@ class JSON(CrossModuleModel):
         Returns:
             JSON: The converted JSON.
         """
-        data = document.metadata
+        data = document.metadata.copy()
         data["text"] = document.page_content
         return cls(data=data, text_key="text")
 

--- a/src/lfx/tests/unit/test_data_class.py
+++ b/src/lfx/tests/unit/test_data_class.py
@@ -26,10 +26,14 @@ def test_conversion_to_document():
 
 
 def test_conversion_from_document():
-    document = Document(page_content="Doc content", metadata={"meta": "info"})
+    document = Document(page_content="Doc content", metadata={"meta": "info", "text": "Metadata text"})
+    original_metadata = document.metadata.copy()
+
     record = Data.from_document(document)
+
     assert record.text == "Doc content"
     assert record.meta == "info"
+    assert document.metadata == original_metadata
 
 
 def test_add_method_for_strings():


### PR DESCRIPTION
## Summary

- Copy a LangChain `Document`'s metadata before adding its page content to the converted `Data` object.
- Add regression coverage proving that conversion does not modify an existing metadata `text` value on the source document.

## Problem

`Data.from_document()` assigned `document.metadata` directly to a local variable and then wrote the page content into its `text` key. That write mutated the input `Document`, overwriting an existing metadata value or adding a new key as a side effect. Callers that reuse the original document after conversion therefore observe changed metadata.

The reverse conversion already copies `Data.data` before removing its text field. This change applies the same non-mutating boundary to `from_document()`. The converted `Data` output is unchanged; only the source document is preserved.

A shallow copy is sufficient because the conversion only writes one top-level key.

## Validation

- Verified the regression test fails before the fix because `document.metadata["text"]` changes from `"Metadata text"` to `"Doc content"`.
- `uv run --isolated --package lfx pytest src/lfx/tests/unit/test_data_class.py src/lfx/tests/unit/schema src/lfx/tests/unit/helpers -q` — 392 passed, 1 skipped.
- Ruff formatting and lint checks pass for both changed files.
- `uv run --isolated --package lfx lfx --help` completes successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document conversion to preserve the original metadata.
  * Ensured metadata remains intact when it includes a key matching the document’s content field.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->