### PR TITLE
fix(frontend): name a catalog policy only for components it blocks

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1875,6 +1875,34 @@ async def custom_component_update(
         raise SerializationError.from_exception(exc, data=component_node) from exc
 
 
+def _blocked_component_types(snapshot) -> list[str]:
+    """Return the component types the editor should treat as policy-blocked.
+
+    A blocked key is whatever the administrator entered, which may be an alias
+    rather than the registry's canonical name, so it is resolved the same way
+    the enforcement path resolves it. Both the raw key and its canonical
+    candidates are reported: a node's ``type`` can carry either.
+
+    A node whose ``type`` is some *third* alias of a blocked component is not
+    listed and the editor will not name a policy for it. That under-claims
+    rather than over-claims, and the server still refuses the run.
+    """
+    blocked_keys = getattr(snapshot, "blocked_component_keys", None)
+    if not blocked_keys:
+        return []
+
+    types = set(blocked_keys)
+    try:
+        from lfx.utils.flow_validation import get_component_identity_index_for_validation
+
+        identity_index = get_component_identity_index_for_validation()
+    except Exception:  # noqa: BLE001
+        identity_index = None
+    if identity_index is not None:
+        types |= set(identity_index.resolve_many(blocked_keys))
+    return sorted(types)
+
+
 @router.get("/config")
 async def get_config(
     user: Annotated[User | None, Depends(get_optional_user)] = None,
@@ -1896,14 +1924,21 @@ async def get_config(
     """
     try:
         settings_service: SettingsService = get_settings_service()
+        blocked_component_types: list[str] = []
         try:
-            catalog_governance_enabled = get_catalog_policy_service().enabled
+            catalog_policy_service = get_catalog_policy_service()
+            catalog_governance_enabled = catalog_policy_service.enabled
+            # A custom policy service need not expose a snapshot. Reporting no
+            # identities then simply leaves the editor unable to name a cause,
+            # which is the safe direction.
+            blocked_component_types = _blocked_component_types(getattr(catalog_policy_service, "snapshot", None))
         except Exception as exc:  # noqa: BLE001
             # Catalog governance is explicitly fail-open. A broken custom
             # policy implementation must not break the public config endpoint
             # or expose its internal exception text.
             await logger.aexception("Catalog policy status unavailable; reporting governance disabled", exception=exc)
             catalog_governance_enabled = False
+            blocked_component_types = []
 
         if user is None:
             return PublicConfigResponse.from_settings(
@@ -1916,6 +1951,7 @@ async def get_config(
             settings_service.settings,
             settings_service.auth_settings,
             catalog_governance_enabled=catalog_governance_enabled,
+            blocked_component_types=blocked_component_types,
         )
 
     except Exception as exc:

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -484,6 +484,14 @@ class ConfigResponse(BaseConfigResponse):
     # replicas), so the vector-store picker hides the option rather than offering
     # a choice the create endpoint always rejects with 422.
     local_vector_store_available: bool = True
+    # The component types an administrator blocked, for authenticated callers
+    # only. ``catalog_governance_enabled`` says a policy exists somewhere; it
+    # cannot say which component in front of you it applies to, and a missing
+    # template is equally an uninstalled bundle, an imported flow or the
+    # caller's own component. The editor needs the identities to name a cause
+    # truthfully. It reveals nothing the palette does not: these are exactly
+    # the components already withheld from ``/all`` for this caller.
+    blocked_component_types: list[str] = []
 
     @classmethod
     def from_settings(
@@ -492,6 +500,7 @@ class ConfigResponse(BaseConfigResponse):
         auth_settings,
         *,
         catalog_governance_enabled: bool = False,
+        blocked_component_types: list[str] | None = None,
     ) -> "ConfigResponse":
         """Create a ConfigResponse instance using values from a Settings object and AuthSettings.
 
@@ -499,6 +508,7 @@ class ConfigResponse(BaseConfigResponse):
             settings (Settings): The Settings object containing configuration values.
             auth_settings: The AuthSettings object containing authentication configuration values.
             catalog_governance_enabled: Whether any catalog policy currently restricts resources.
+            blocked_component_types: Component types this caller may not use.
 
         Returns:
             ConfigResponse: An instance populated with configuration and feature flag values.
@@ -528,6 +538,7 @@ class ConfigResponse(BaseConfigResponse):
             substitute_outdated_component_code=settings.substitute_outdated_component_code,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
             catalog_governance_enabled=catalog_governance_enabled,
+            blocked_component_types=sorted(blocked_component_types or []),
             embedded_mode=settings.embedded_mode,
             hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
             hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -518,7 +518,7 @@ async def test_get_config_reports_catalog_governance_without_exposing_policy_con
     logged_in_headers: dict,
     monkeypatch,
 ):
-    """Both config variants expose only the derived governance indicator."""
+    """The public variant exposes only the derived governance indicator."""
     monkeypatch.setattr(
         "langflow.api.v1.endpoints.get_catalog_policy_service",
         lambda: SimpleNamespace(enabled=True),
@@ -533,6 +533,82 @@ async def test_get_config_reports_catalog_governance_without_exposing_policy_con
         assert result["catalog_governance_enabled"] is True
         assert "blocked_component_keys" not in result
         assert "blocked_template_keys" not in result
+    # A policy service exposing no snapshot names nothing rather than guessing.
+    assert authenticated_response.json()["blocked_component_types"] == []
+
+
+def test_public_config_never_carries_blocked_component_identities():
+    """The anonymous response withholds the policy contents by construction.
+
+    Asserted on the schema rather than a response: the test client's
+    unauthenticated request resolves a user under auto-login, so it cannot
+    exercise the anonymous branch.
+    """
+    from langflow.api.v1.schemas import ConfigResponse, PublicConfigResponse
+
+    assert "blocked_component_types" not in PublicConfigResponse.model_fields
+    assert "blocked_component_types" in ConfigResponse.model_fields
+
+
+async def test_get_config_names_blocked_components_to_authenticated_callers(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """The editor cannot attribute a missing template without the identities.
+
+    ``catalog_governance_enabled`` says a policy exists somewhere; a node whose
+    template is missing may instead be an uninstalled bundle, an imported flow
+    or the caller's own component, so the editor needs the blocked identities
+    to name a cause truthfully.
+    """
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(
+            enabled=True,
+            snapshot=SimpleNamespace(
+                blocked_component_keys=frozenset({"ChatOutput", "Agent"}),
+                blocked_template_keys=frozenset({"Simple Agent"}),
+            ),
+        ),
+    )
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    assert result["blocked_component_types"] == ["Agent", "ChatOutput"]
+    # Template identities stay withheld: nothing in the editor consumes them.
+    assert "Simple Agent" not in result["blocked_component_types"]
+
+
+async def test_get_config_names_no_components_when_only_a_template_is_blocked(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """Governance is on, yet no component is blocked (LE-2226).
+
+    ``enabled`` is true when *either* blocklist is non-empty, so blocking one
+    starter template used to be enough for the editor to brand every
+    code-bearing node without a template "disabled by an administrator".
+    """
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(
+            enabled=True,
+            snapshot=SimpleNamespace(
+                blocked_component_keys=frozenset(),
+                blocked_template_keys=frozenset({"Simple Agent"}),
+            ),
+        ),
+    )
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["catalog_governance_enabled"] is True
+    assert response.json()["blocked_component_types"] == []
 
 
 async def test_get_config_fails_open_without_exposing_catalog_policy_errors(client: AsyncClient, monkeypatch):

--- a/src/frontend/src/CustomNodes/GenericNode/__tests__/blocked-node-banner.test.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/__tests__/blocked-node-banner.test.tsx
@@ -10,7 +10,7 @@ type ComponentUpdate = {
 };
 
 let mockAllowCustomComponents: boolean;
-let mockCatalogGovernanceEnabled: boolean;
+let mockBlockedComponentTypes: Set<string>;
 let mockComponentsToUpdate: ComponentUpdate[];
 let mockDismissedNodes: string[];
 
@@ -100,7 +100,7 @@ jest.mock("../../../stores/utilityStore", () => ({
   useUtilityStore: (selector: (state: unknown) => unknown) =>
     selector({
       allowCustomComponents: mockAllowCustomComponents,
-      catalogGovernanceEnabled: mockCatalogGovernanceEnabled,
+      blockedComponentTypes: mockBlockedComponentTypes,
     }),
 }));
 
@@ -237,7 +237,8 @@ describe("GenericNode blocked banner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAllowCustomComponents = true;
-    mockCatalogGovernanceEnabled = true;
+    // The fixture node is a Prompt; the policy names it by default.
+    mockBlockedComponentTypes = new Set(["Prompt"]);
     mockDismissedNodes = [];
     mockComponentsToUpdate = [];
   });
@@ -258,7 +259,19 @@ describe("GenericNode blocked banner", () => {
     // A user-authored component has code and no registry template, exactly
     // like a policy-blocked one. With custom components allowed and no policy
     // it is legitimate, so flagging it would stop people running their own work.
-    mockCatalogGovernanceEnabled = false;
+    mockBlockedComponentTypes = new Set<string>();
+    mockComponentsToUpdate = [componentUpdate({ blocked: true })];
+
+    renderNode();
+
+    expect(screen.queryByTestId("node-update-banner")).not.toBeInTheDocument();
+  });
+
+  it("leaves a node alone when the policy names a different component", () => {
+    // LE-2226: a policy that blocks some other component — or only a starter
+    // template — must not brand this node "disabled by an administrator". A
+    // missing template is equally an uninstalled bundle or an imported flow.
+    mockBlockedComponentTypes = new Set(["SomeOtherComponent"]);
     mockComponentsToUpdate = [componentUpdate({ blocked: true })];
 
     renderNode();

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -4,7 +4,10 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
-import { blockedStopsExecution } from "@/CustomNodes/helpers/check-code-validity";
+import {
+  blockedStopsExecution,
+  isBlockedByCatalogPolicy,
+} from "@/CustomNodes/helpers/check-code-validity";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { useIsFlowReadOnly } from "@/contexts/permissionsContext";
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
@@ -112,8 +115,8 @@ function GenericNode({
   const currentFlowId = useFlowStore((state) => state.currentFlow?.id);
   const isReadOnly = useIsFlowReadOnly(currentFlowId);
 
-  const catalogGovernanceEnabled = useUtilityStore(
-    (state) => state.catalogGovernanceEnabled,
+  const blockedComponentTypes = useUtilityStore(
+    (state) => state.blockedComponentTypes,
   );
   const allowCustomComponents = useUtilityStore(
     (state) => state.allowCustomComponents,
@@ -441,10 +444,14 @@ function GenericNode({
   // the flow was run.
   // A user's own custom component has no template either, so the banner only
   // treats a missing one as a problem where it actually stops the node.
+  const blockedByPolicy = isBlockedByCatalogPolicy(
+    blockedComponentTypes,
+    data.type,
+  );
   const blockedIsFatal = blockedStopsExecution(
     allowCustomComponents,
-    catalogGovernanceEnabled,
-    templates,
+    blockedComponentTypes,
+    data.type,
   );
 
   const shouldShowUpdateComponent = useMemo(
@@ -614,13 +621,10 @@ function GenericNode({
             hasBreakingChange={hasBreakingChange}
             blocked={isBlocked && blockedIsFatal}
             blockedByCatalogPolicy={
-              // Restricted mode blocks an unknown code-bearing node on its own,
-              // so it stays the stated cause; the policy is only named when it
-              // is the one that applies.
-              isBlocked &&
-              blockedIsFatal &&
-              allowCustomComponents &&
-              catalogGovernanceEnabled
+              // Restricted mode blocks every unknown code-bearing node on its
+              // own, so it stays the stated cause; the policy is only named
+              // when it is both in force and names this component.
+              isBlocked && allowCustomComponents && blockedByPolicy
             }
             showNode={showNode}
             handleUpdateCode={() =>

--- a/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
+++ b/src/frontend/src/CustomNodes/helpers/check-code-validity.ts
@@ -99,34 +99,36 @@ const codeHasBreakingChange = (
 };
 
 /**
- * Whether a catalog policy can be the reason a template is missing.
+ * Whether an administrator's catalog policy blocks this component type.
  *
- * `blocked` only means "no template for this type", which is also the normal
- * state of a user-authored custom component, an uninstalled bundle and an
- * imported flow. It is a policy block only when a policy is actually in force,
- * and only once the registry has loaded: `templates` starts as `{}`, so every
- * code-bearing node looks unknown until `/all` resolves.
+ * `blocked` only means "no template for this type", which is equally the
+ * normal state of a user-authored component, an uninstalled bundle and a flow
+ * imported from another install. Only the policy's own identities can tell
+ * those apart, so the server sends them and this asks about *this* component
+ * rather than whether some policy exists somewhere.
  */
-export const catalogPolicyCanBlock = (
-  catalogGovernanceEnabled: boolean,
-  templates: { [key: string]: unknown },
+export const isBlockedByCatalogPolicy = (
+  blockedComponentTypes: ReadonlySet<string> | undefined,
+  componentType: string | undefined,
 ): boolean =>
-  catalogGovernanceEnabled && Object.keys(templates ?? {}).length > 0;
+  componentType !== undefined &&
+  blockedComponentTypes !== undefined &&
+  blockedComponentTypes.has(componentType);
 
 /**
  * Whether a missing template should stop the node running.
  *
  * Restricted mode blocks any unknown code-bearing node on its own, as before.
- * With custom components allowed, only a catalog policy makes one fatal —
- * otherwise a user's own component could not run.
+ * With custom components allowed, only an actual policy block makes one fatal
+ * — otherwise a user's own component could not run.
  */
 export const blockedStopsExecution = (
   allowCustomComponents: boolean,
-  catalogGovernanceEnabled: boolean,
-  templates: { [key: string]: unknown },
+  blockedComponentTypes: ReadonlySet<string> | undefined,
+  componentType: string | undefined,
 ): boolean =>
   !allowCustomComponents ||
-  catalogPolicyCanBlock(catalogGovernanceEnabled, templates);
+  isBlockedByCatalogPolicy(blockedComponentTypes, componentType);
 
 export const checkCodeValidity = (
   data: NodeDataType,

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -51,6 +51,9 @@ export interface ConfigResponse extends BaseConfig {
   a2a_enabled: boolean;
   agentic_experience: boolean;
   local_vector_store_available: boolean;
+  /** Component types an administrator blocked. Authenticated callers only:
+   *  the public response deliberately withholds the policy contents. */
+  blocked_component_types?: string[];
 }
 
 // Union type for the response (can be either public or full config)
@@ -99,6 +102,9 @@ export const useGetConfig: useQueryFunctionType<
   );
   const setSubstituteOutdatedComponentCode = useUtilityStore(
     (state) => state.setSubstituteOutdatedComponentCode,
+  );
+  const setBlockedComponentTypes = useUtilityStore(
+    (state) => state.setBlockedComponentTypes,
   );
   const setCatalogGovernanceEnabled = useUtilityStore(
     (state) => state.setCatalogGovernanceEnabled,
@@ -164,6 +170,15 @@ export const useGetConfig: useQueryFunctionType<
 
       // Set authenticated-only fields if present (full config)
       if (isFullConfig(data)) {
+        // Authenticated only: the public response withholds the policy
+        // contents, and an anonymous caller has no editor to inform.
+        setBlockedComponentTypes(
+          Array.isArray(data.blocked_component_types)
+            ? data.blocked_component_types.filter(
+                (type): type is string => typeof type === "string",
+              )
+            : [],
+        );
         setAutoSaving(data.auto_saving);
         setAutoSavingInterval(data.auto_saving_interval);
         setHealthCheckMaxRetries(data.health_check_max_retries);

--- a/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-autosave-flow.test.ts
@@ -31,7 +31,9 @@ jest.mock("@/stores/typesStore", () => ({
 }));
 jest.mock("@/stores/utilityStore", () => ({
   useUtilityStore: {
-    getState: jest.fn(() => ({ catalogGovernanceEnabled: true })),
+    getState: jest.fn(() => ({
+      blockedComponentTypes: new Set(["ChatOutput"]),
+    })),
   },
 }));
 jest.mock("@/stores/flowStore", () => ({
@@ -60,7 +62,7 @@ describe("useAutoSaveFlow", () => {
       templates: { Agent: {} },
     });
     (useUtilityStore.getState as jest.Mock).mockReturnValue({
-      catalogGovernanceEnabled: true,
+      blockedComponentTypes: new Set(["ChatOutput"]),
     });
     (useSaveFlow as jest.Mock).mockReturnValue(mockSaveFlow);
     (useDebounce as jest.Mock).mockImplementation((fn) => {
@@ -206,7 +208,12 @@ describe("useAutoSaveFlow", () => {
   it("reports the paused save once rather than on every attempt", async () => {
     (useFlowStore.getState as jest.Mock).mockReturnValue({
       componentsToUpdate: [
-        { id: "node-1", display_name: "Chat Output", blocked: true },
+        {
+          id: "node-1",
+          type: "ChatOutput",
+          display_name: "Chat Output",
+          blocked: true,
+        },
       ],
     });
     (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
@@ -406,7 +413,9 @@ describe("useAutoSaveFlow", () => {
     // A missing template cannot be persisted, so retrying the save only
     // produces failed requests before the user has touched anything.
     (useFlowStore.getState as jest.Mock).mockReturnValue({
-      componentsToUpdate: [{ id: "node-1", blocked: true, outdated: false }],
+      componentsToUpdate: [
+        { id: "node-1", type: "ChatOutput", blocked: true, outdated: false },
+      ],
     });
     (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
       (selector) =>
@@ -444,13 +453,22 @@ describe("useAutoSaveFlow", () => {
     expect(mockSaveFlow).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps saving while the component registry is still loading", async () => {
-    // templates is {} until /all resolves, which makes every code-bearing node
-    // look unknown. Pausing on that would strand a cold load's edits.
-    (useTypesStore.getState as jest.Mock).mockReturnValue({ templates: {} });
+  it("keeps saving a component the policy does not name", async () => {
+    // LE-2226: a policy blocking some *other* component — or only a starter
+    // template — must not stop persisting this flow. A missing template is
+    // equally an uninstalled bundle, an imported flow, or the user's own
+    // component, all of which the server accepts.
+    (useUtilityStore.getState as jest.Mock).mockReturnValue({
+      blockedComponentTypes: new Set(["SomeOtherComponent"]),
+    });
     (useFlowStore.getState as jest.Mock).mockReturnValue({
       componentsToUpdate: [
-        { id: "node-1", display_name: "Chat Output", blocked: true },
+        {
+          id: "node-1",
+          type: "MyUninstalledBundleComponent",
+          display_name: "Bundle Component",
+          blocked: true,
+        },
       ],
     });
     (useFlowsManagerStore as unknown as jest.Mock).mockImplementation(
@@ -473,7 +491,7 @@ describe("useAutoSaveFlow", () => {
     // Without a policy the server accepts the write, so a missing template is
     // not a reason to stop persisting.
     (useUtilityStore.getState as jest.Mock).mockReturnValue({
-      catalogGovernanceEnabled: false,
+      blockedComponentTypes: new Set<string>(),
     });
     (useFlowStore.getState as jest.Mock).mockReturnValue({
       componentsToUpdate: [
@@ -499,7 +517,12 @@ describe("useAutoSaveFlow", () => {
   it("holds the paused edit so it lands once the block clears", async () => {
     (useFlowStore.getState as jest.Mock).mockReturnValue({
       componentsToUpdate: [
-        { id: "node-1", display_name: "Chat Output", blocked: true },
+        {
+          id: "node-1",
+          type: "ChatOutput",
+          display_name: "Chat Output",
+          blocked: true,
+        },
       ],
     });
     let isLoading = false;

--- a/src/frontend/src/hooks/flows/use-autosave-flow.ts
+++ b/src/frontend/src/hooks/flows/use-autosave-flow.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { catalogPolicyCanBlock } from "@/CustomNodes/helpers/check-code-validity";
+import { isBlockedByCatalogPolicy } from "@/CustomNodes/helpers/check-code-validity";
 import { usePermissions } from "@/contexts/permissionsContext";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
-import { useTypesStore } from "@/stores/typesStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import type { FlowType } from "@/types/flow";
 import { useDebounce } from "../use-debounce";
@@ -21,32 +20,27 @@ type PendingAutoSave = {
  * Autosaving a flow the server rejects retries a write that can never succeed,
  * so opening an affected flow produced a stream of failed requests before the
  * user had touched anything. Pausing instead is only safe where the rejection
- * is certain, because a wrong pause silently stops persisting the user's work:
+ * is certain, because a wrong pause silently stops persisting the user's work.
  *
- *  - the write is only rejected when a catalog policy actually blocks a key.
- *    `validate_catalog_policy_for_flow` returns early on an empty blocklist, so
- *    without a policy the save succeeds and there is nothing to pause for.
- *  - `blocked` means "no template for this type", which is also true of an
- *    uninstalled bundle, a flow imported from another install, and every
- *    code-bearing node while the registry is still loading. `templates` starts
- *    as `{}`, so a cold load would otherwise pause autosave and name every
- *    component in the flow.
- *
- * Anything short of both signals leaves autosave alone and lets the server
- * decide, which is the behaviour that existed before.
+ * `blocked` alone is not that certainty: it means "no template for this type",
+ * which is equally an uninstalled bundle, a flow imported from another
+ * install, and a component the user wrote themselves. Only the policy's own
+ * identities separate the one the server will reject from the three it accepts,
+ * so this asks whether the policy names this component, not whether a policy
+ * exists.
  */
 const blockedComponentNames = (): string[] => {
-  if (
-    !catalogPolicyCanBlock(
-      useUtilityStore.getState().catalogGovernanceEnabled,
-      useTypesStore.getState().templates,
-    )
-  ) {
+  const { blockedComponentTypes } = useUtilityStore.getState();
+  if (blockedComponentTypes.size === 0) {
     return [];
   }
   return useFlowStore
     .getState()
-    .componentsToUpdate.filter((component) => component.blocked)
+    .componentsToUpdate.filter(
+      (component) =>
+        component.blocked &&
+        isBlockedByCatalogPolicy(blockedComponentTypes, component.type),
+    )
     .map((component) => component.display_name ?? component.id);
 };
 

--- a/src/frontend/src/stores/__tests__/flowStore.test.ts
+++ b/src/frontend/src/stores/__tests__/flowStore.test.ts
@@ -146,6 +146,7 @@ describe("useFlowStore", () => {
     type: "genericNode",
     position: { x: 100, y: 100 },
     data: {
+      type: "TestComponent",
       node: {
         display_name: "Test Node",
         icon: "test-icon",
@@ -167,6 +168,7 @@ describe("useFlowStore", () => {
     act(() => {
       mockTemplates = {};
       useUtilityStore.setState({
+        blockedComponentTypes: new Set<string>(),
         allowCustomComponents: true,
         substituteOutdatedComponentCode: true,
       });
@@ -1262,7 +1264,7 @@ describe("useFlowStore", () => {
       useUtilityStore.setState({
         allowCustomComponents: true,
         substituteOutdatedComponentCode: true,
-        catalogGovernanceEnabled: true,
+        blockedComponentTypes: new Set(["TestComponent"]),
       });
       (checkCodeValidity as jest.Mock).mockReturnValueOnce({
         outdated: false,
@@ -1285,7 +1287,11 @@ describe("useFlowStore", () => {
         id: "node-blocked",
         type: "genericNode",
         position: { x: 0, y: 0 },
-        data: { id: "node-blocked", node: { display_name: "Blocked Node" } },
+        data: {
+          id: "node-blocked",
+          type: "BlockedComponent",
+          node: { display_name: "Blocked Node" },
+        },
       } as unknown as AllNodeType;
       const healthyNode = {
         id: "node-healthy",
@@ -1311,7 +1317,7 @@ describe("useFlowStore", () => {
         useUtilityStore.setState({
           allowCustomComponents: true,
           substituteOutdatedComponentCode: true,
-          catalogGovernanceEnabled: true,
+          blockedComponentTypes: new Set(["BlockedComponent"]),
         });
         (checkCodeValidity as jest.Mock).mockImplementation(
           (data: { id: string }) => validityByNodeId(data.id),
@@ -1420,6 +1426,30 @@ describe("useFlowStore", () => {
       expect(mockedRunFlow).not.toHaveBeenCalled();
     });
 
+    it("builds a component the policy does not name", async () => {
+      // LE-2226: a policy blocking some other component — or only a starter
+      // template — must not stop this run. A missing template is equally an
+      // uninstalled bundle, an imported flow, or the user's own component.
+      mockTemplates = { SomeKnownType: {} };
+      useUtilityStore.setState({
+        allowCustomComponents: true,
+        substituteOutdatedComponentCode: true,
+        blockedComponentTypes: new Set(["SomeOtherComponent"]),
+      });
+      (checkCodeValidity as jest.Mock).mockReturnValueOnce({
+        outdated: false,
+        blocked: true,
+        breakingChange: false,
+        userEdited: false,
+      });
+      useFlowStore.setState({ nodes: [mockNode] });
+      mockedRunFlow.mockResolvedValue(undefined);
+
+      await useFlowStore.getState().buildFlow({});
+
+      expect(mockedRunFlow).toHaveBeenCalledTimes(1);
+    });
+
     it("builds a user-authored component when no policy is in force", async () => {
       // A component someone wrote themselves carries code and has no registry
       // template, which is indistinguishable from a policy-blocked one. With
@@ -1429,7 +1459,7 @@ describe("useFlowStore", () => {
       useUtilityStore.setState({
         allowCustomComponents: true,
         substituteOutdatedComponentCode: true,
-        catalogGovernanceEnabled: false,
+        blockedComponentTypes: new Set<string>(),
       });
       (checkCodeValidity as jest.Mock).mockReturnValueOnce({
         outdated: false,

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -158,6 +158,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         if (codeValidity && (codeValidity.outdated || codeValidity.blocked))
           outdatedNodes.push({
             id: node.id,
+            type: node.data.type,
             icon: node.data.node?.icon,
             display_name: node.data.node?.display_name,
             outdated: codeValidity.outdated,
@@ -898,16 +899,17 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     const {
       allowCustomComponents,
       substituteOutdatedComponentCode,
-      catalogGovernanceEnabled,
+      blockedComponentTypes,
     } = useUtilityStore.getState();
     // A missing template is the normal state of a user-authored custom
     // component when those are allowed, so it only stops a run under
-    // restricted mode or an actual catalog policy.
-    const blockedIsFatal = blockedStopsExecution(
-      allowCustomComponents,
-      catalogGovernanceEnabled,
-      useTypesStore.getState().templates,
-    );
+    // restricted mode or when the policy names this component.
+    const stopsExecution = (component: { type?: string }) =>
+      blockedStopsExecution(
+        allowCustomComponents,
+        blockedComponentTypes,
+        component.type,
+      );
     // A partial build only executes its own subgraph, so only that subgraph can
     // block it. componentsToUpdate stays whole-flow for the update banner.
     const validatedNodeIds = new Set(nodesToValidate.map((node) => node.id));
@@ -921,9 +923,9 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     if (!get().playgroundPage && componentsToPreflight.length > 0) {
       // A missing template blocks the run either way. Outdated components are
       // only enforced in restricted mode, as before.
-      const blockedComponents = blockedIsFatal
-        ? componentsToPreflight.filter((component) => component.blocked)
-        : [];
+      const blockedComponents = componentsToPreflight.filter(
+        (component) => component.blocked && stopsExecution(component),
+      );
       const outdatedComponents =
         substituteOutdatedComponentCode || allowCustomComponents
           ? []

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -71,6 +71,9 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   catalogGovernanceEnabled: false,
   setCatalogGovernanceEnabled: (catalogGovernanceEnabled: boolean) =>
     set({ catalogGovernanceEnabled }),
+  blockedComponentTypes: new Set<string>(),
+  setBlockedComponentTypes: (blockedComponentTypes: Iterable<string>) =>
+    set({ blockedComponentTypes: new Set(blockedComponentTypes) }),
   a2aEnabled: false,
   setA2aEnabled: (a2aEnabled: boolean) => set({ a2aEnabled }),
   // Default true (backend default) so the panel doesn't flash the disabled

--- a/src/frontend/src/types/zustand/flow/index.ts
+++ b/src/frontend/src/types/zustand/flow/index.ts
@@ -59,6 +59,8 @@ export type FlowPoolType = {
 
 export type ComponentsToUpdateType = {
   id: string;
+  /** Registry type, needed to ask whether a policy names this component. */
+  type?: string;
   icon?: string;
   display_name: string;
   outdated: boolean;

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -44,6 +44,9 @@ export type UtilityStoreType = {
   ) => void;
   catalogGovernanceEnabled: boolean;
   setCatalogGovernanceEnabled: (catalogGovernanceEnabled: boolean) => void;
+  /** Component types an administrator blocked, as reported by /config. */
+  blockedComponentTypes: ReadonlySet<string>;
+  setBlockedComponentTypes: (blockedComponentTypes: Iterable<string>) => void;
   a2aEnabled: boolean;
   setA2aEnabled: (a2aEnabled: boolean) => void;
   agenticExperienceEnabled: boolean;


### PR DESCRIPTION
## Problem

Reported by QA as **LE-2226 BUG-01** against #14614. Confirmed and reproduced — it is a real regression from that PR.

The editor decided a node was "disabled by an administrator" from `catalog_governance_enabled`, a single boolean meaning *"some policy exists somewhere"*. That flag cannot answer a per-component question, and two things make the gap wide:

- `blocked` only means **"no template for this type"**, which is equally an uninstalled bundle, a flow imported from another install, or a component the user wrote themselves.
- `CatalogPolicySnapshot.enabled` is `bool(blocked_component_keys **or** blocked_template_keys)`, so blocking a single **starter template** — nothing to do with components — flips it true.

So a tenant that blocked one template and zero components would see every code-bearing node without a template branded as admin-disabled, its build refused, and **autosave paused** — parking edits the server would have accepted.

The frontend was never given the information to answer the question. It was using a proxy.

## Fix

The server sends the identities. `/config` now reports `blocked_component_types` to **authenticated callers**, resolved through the same alias index the enforcement path uses (`get_component_identity_index_for_validation`), so an administrator who blocks by alias still matches.

All three surfaces then ask whether the policy names *this* component:

| Surface | Before | After |
| --- | --- | --- |
| Node banner | any policy exists | this component is blocked |
| Build preflight | one flag for the whole flow | per component |
| Autosave pause | any policy exists | this component is blocked |

`componentsToUpdate` carries `type` so the preflight can test each entry individually rather than gating the whole set on one boolean.

### Disclosure

Authenticated callers only — the public response still withholds the policy contents, and an anonymous caller has no editor to inform. For an authenticated caller this reveals nothing new: these are exactly the components already withheld from `/all` for them. Blocked **template** identities are still never sent; nothing in the editor consumes them.

### Deliberate under-claim

A node carrying some *third* alias of a blocked component is not listed, and the editor stays quiet rather than naming a policy. That under-claims instead of over-claiming, and the server still refuses the run. Documented in `_blocked_component_types`.

### Also removed

`catalogPolicyCanBlock` and its cold-registry heuristic. An explicit identity set is unambiguous, so "the registry has not loaded yet" no longer needs guessing at — `templates` is out of the decision entirely.

Restricted mode (`allow_custom_components=false`) keeps its existing precedence: it blocks every unknown code-bearing node on its own, so it stays the stated cause even when a policy also applies.

## Test plan

- [x] `pytest src/backend/tests/unit/api/v1/test_endpoints.py -k config` — **19 passed**
- [x] `jest src/CustomNodes src/stores src/hooks/flows src/controllers/API/queries/config` — **48 suites, 706 passed**
- [x] New backend tests: identities reported to authenticated callers; **no components named when only a template is blocked** (the QA scenario); template identities withheld; a policy service exposing no snapshot names nothing
- [x] `PublicConfigResponse` asserted at the schema level to lack the field — the test client's unauthenticated request resolves a user under auto-login, so it cannot exercise the anonymous branch
- [x] New frontend regression tests on all three surfaces: banner, build preflight, autosave each stay quiet when the policy names a *different* component
- [x] Guards verified non-vacuous — restoring the old "any policy exists" logic fails exactly those 3 new tests
- [x] `ruff check` / `ruff format --check` clean; `biome check` exit 0; no new `tsc` errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated configuration now reports component types blocked by catalog policy.
  * Editor, build, and autosave behavior now identifies blocked components by their specific type.
* **Bug Fixes**
  * Prevented unrelated components and custom components from being blocked when they do not match policy.
  * Preserved public configuration responses without exposing blocked component details.
  * Added safe fallback behavior when policy information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->