### PR TITLE
fix(a11y): give the model-picker listbox its name instead of labelling an input that does not exist

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/modelListboxLabel.a11y.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/modelListboxLabel.a11y.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { Command } from "cmdk";
+import ModelList from "../components/ModelList";
+import { stripDanglingCmdkLabelFor } from "../index";
+import type { ModelOption } from "../types";
+
+/**
+ * WCAG 4.1.2 (IBM `label_ref_valid`): the picker renders no CommandInput, and
+ * cmdk's `Command label` prop renders a `<label htmlFor={inputId}>` for that
+ * input — a label referencing a non-existent element. The accessible name
+ * belongs on the CommandList (the listbox) instead. These pin both halves.
+ */
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+const option = (name: string, provider: string): ModelOption =>
+  ({
+    name,
+    provider,
+    enabled: true,
+  }) as ModelOption;
+
+const groupedOptions = {
+  OpenAI: [option("gpt-4o", "OpenAI")],
+};
+
+function renderList(grouped: Record<string, ModelOption[]>) {
+  // mirror the real picker: Command gets the same ref callback the
+  // component wires, since cmdk renders its dangling label unconditionally
+  return render(
+    <Command ref={stripDanglingCmdkLabelFor}>
+      <ModelList
+        groupedOptions={grouped}
+        selectedModel={null}
+        onSelect={jest.fn()}
+      />
+    </Command>,
+  );
+}
+
+describe("model picker listbox accessible name", () => {
+  it("names the listbox itself, in both the populated and empty states", () => {
+    const { unmount } = renderList(groupedOptions);
+    expect(
+      screen.getByRole("listbox", { name: "Select a model" }),
+    ).toBeInTheDocument();
+    unmount();
+
+    renderList({});
+    expect(
+      screen.getByRole("listbox", { name: "Select a model" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no label that references a non-existent control", () => {
+    const { container } = renderList(groupedOptions);
+    for (const label of container.querySelectorAll("label[for]")) {
+      const target = document.getElementById(label.getAttribute("for")!);
+      expect(target).not.toBeNull();
+    }
+    // cmdk's hidden input-label survives (React owns the node) but must no
+    // longer reference the input it never had
+    expect(container.querySelector("label[cmdk-label][for]")).toBeNull();
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/modelListboxLabel.a11y.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/modelListboxLabel.a11y.test.tsx
@@ -28,7 +28,7 @@ function renderList(grouped: Record<string, ModelOption[]>) {
   // mirror the real picker: Command gets the same ref callback the
   // component wires, since cmdk renders its dangling label unconditionally
   return render(
-    <Command ref={stripDanglingCmdkLabelFor}>
+    <Command ref={stripDanglingCmdkLabelFor} label="Select a model">
       <ModelList
         groupedOptions={grouped}
         selectedModel={null}
@@ -59,7 +59,13 @@ describe("model picker listbox accessible name", () => {
       expect(target).not.toBeNull();
     }
     // cmdk's hidden input-label survives (React owns the node) but must no
-    // longer reference the input it never had
+    // longer reference the input it never had. It must KEEP its text: an
+    // empty label just trades label_ref_valid for label_content_exists,
+    // which ignores aria-hidden. Unassociated, it is inert to screen readers.
     expect(container.querySelector("label[cmdk-label][for]")).toBeNull();
+    const vestige = container.querySelector("label[cmdk-label]");
+    if (vestige) {
+      expect(vestige.textContent).not.toBe("");
+    }
   });
 });

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx
@@ -27,7 +27,10 @@ const ModelList = ({
 
   if (Object.keys(groupedOptions).length === 0) {
     return (
-      <CommandList className="max-h-[300px] overflow-y-auto">
+      <CommandList
+        label={t("model.selectModel")}
+        className="max-h-[300px] overflow-y-auto"
+      >
         <CommandItem
           disabled
           className="w-full px-4 py-2 text-[13px] text-muted-foreground"
@@ -58,7 +61,10 @@ const ModelList = ({
   let position = 0;
 
   return (
-    <CommandList className="max-h-[300px] overflow-y-auto">
+    <CommandList
+      label={t("model.selectModel")}
+      className="max-h-[300px] overflow-y-auto"
+    >
       {providerEntries.map(([provider, models]) => (
         <CommandGroup
           className="p-0 [&_[cmdk-group-heading]]:mx-4 [&_[cmdk-group-heading]]:my-2 [&_[cmdk-group-heading]]:p-0 [&_[cmdk-group-heading]]:font-semibold"

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -18,8 +18,13 @@ import { Command } from "../../../../ui/command";
  * <Command>, even when no CommandInput exists for that id — a label whose
  * `for` references nothing (IBM label_ref_valid, WCAG 1.3.1). The listbox
  * carries the picker's accessible name, so the reference is pure debt.
- * Dropping the ATTRIBUTE (not the node) is reconciliation-safe: React only
- * rewrites props it sees change, and `htmlFor` never changes here.
+ * Only the `for` ATTRIBUTE is removed — never the node (React owns it and
+ * would fight its removal during reconciliation; attribute edits are safe
+ * because React only rewrites props it sees change, and `htmlFor` never
+ * changes here). The `label` prop stays so the element keeps inner text:
+ * an EMPTY label just trades `label_ref_valid` for `label_content_exists`
+ * (which ignores aria-hidden), while a text-bearing label with no `for`
+ * passes every rule and is inert to screen readers — nothing references it.
  */
 export function stripDanglingCmdkLabelFor(root: HTMLElement | null): void {
   const label = root?.querySelector("label[cmdk-label][for]");
@@ -334,12 +339,13 @@ export default function ModelInputComponent({
         {/* Section 1 — the option list (a self-contained listbox). Keeping the
             footer actions out of <Command> stops them from being swept into the
             listbox's composite keyboard/focus model. */}
-        {/* No CommandInput is rendered here, and cmdk's `label` prop renders
-            a <label htmlFor={inputId}> for that input — leaving a label that
-            references a non-existent element (IBM label_ref_valid). The
-            accessible name lives on the CommandList (the listbox) instead. */}
+        {/* The picker's accessible name lives on the CommandList (the
+            listbox). cmdk also renders a hidden <label htmlFor={inputId}>
+            for a CommandInput that does not exist here — the ref strips
+            that dangling reference; see stripDanglingCmdkLabelFor. */}
         <Command
           ref={stripDanglingCmdkLabelFor}
+          label={t("model.selectModel")}
           className="flex flex-col"
           defaultValue={
             selectedModel

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -12,6 +12,22 @@ import type { APIClassType } from "@/types/api";
 import type { NodeDataType } from "@/types/flow";
 import ForwardedIconComponent from "../../../../common/genericIconComponent";
 import { Command } from "../../../../ui/command";
+
+/**
+ * cmdk unconditionally renders a hidden `<label htmlFor={inputId}>` inside
+ * <Command>, even when no CommandInput exists for that id — a label whose
+ * `for` references nothing (IBM label_ref_valid, WCAG 1.3.1). The listbox
+ * carries the picker's accessible name, so the reference is pure debt.
+ * Dropping the ATTRIBUTE (not the node) is reconciliation-safe: React only
+ * rewrites props it sees change, and `htmlFor` never changes here.
+ */
+export function stripDanglingCmdkLabelFor(root: HTMLElement | null): void {
+  const label = root?.querySelector("label[cmdk-label][for]");
+  if (label && !document.getElementById(label.getAttribute("for") ?? "")) {
+    label.removeAttribute("for");
+  }
+}
+
 import {
   Popover,
   PopoverContent,
@@ -318,8 +334,12 @@ export default function ModelInputComponent({
         {/* Section 1 — the option list (a self-contained listbox). Keeping the
             footer actions out of <Command> stops them from being swept into the
             listbox's composite keyboard/focus model. */}
+        {/* No CommandInput is rendered here, and cmdk's `label` prop renders
+            a <label htmlFor={inputId}> for that input — leaving a label that
+            references a non-existent element (IBM label_ref_valid). The
+            accessible name lives on the CommandList (the listbox) instead. */}
         <Command
-          label={t("model.selectModel")}
+          ref={stripDanglingCmdkLabelFor}
           className="flex flex-col"
           defaultValue={
             selectedModel


### PR DESCRIPTION
## What & why

The model picker's option list had an accessible-name defect that was the **last remaining violation on its scan state** and the only thing keeping compliance row 4.1.2 at Partial: `<Command label>` renders a hidden `<label htmlFor={inputId}>` for a `CommandInput` the picker never renders — a label referencing a non-existent element (IBM `label_ref_valid`).

Digging in showed the backlog's one-liner ("drop the `label` prop") was insufficient: **cmdk renders that hidden label unconditionally**, so removing the prop still leaves an empty label with the same dangling `for`.

## The fix

- The accessible name moves to where it belongs: the **listbox** (`CommandList label`), in both the populated and empty states — screen readers now announce "Select a model, listbox".
- A ref callback strips the dangling `for` **attribute** — not the node, which React owns and would fight over during reconciliation. React only rewrites props it diffs, and `htmlFor` never changes here, so the removal sticks across re-renders.
- The `label` prop **stays** on `<Command>`: a second engine pass caught that blanking the hidden label just trades `label_ref_valid` for `label_content_exists` (which fires on any empty `<label>` and ignores `aria-hidden`). A text-bearing label associated with nothing passes every rule and is inert to screen readers.

No visual change is possible from this: cmdk's label is `display: none` by design and the `for` attribute has no rendering.

## Verification

- New unit tests pin the listbox accessible name (both states), that no `label[for]` references a missing element, and that the vestigial label keeps its text — **the first two fail on the previous code** (verified by stashing the fix).
- Full `modelInputComponent` suite: 124/124.
- **Live-verified end to end** on a real canvas: picker opens, listbox announces "Select a model", arrow keys move the highlight, Enter selects and the trigger updates — behaviour identical. IBM engine on the open picker: `label_ref_valid` and `label_content_exists` both absent; the remaining canvas findings (`aria_application_label_unique` ×2 from duplicate node display names, one deprecated SVG attribute) predate or are unrelated to this PR and are tracked separately.
- The model-picker a11y baseline needs no change — it only suppresses the two Radix focus guards; `label_ref_valid` was tracked separately and now simply stops firing.

Was backlog item 09, previously deferred because community PR #14517 touches the same file — per 2026-08-20 decision, community PRs don't gate the roadmap; if #14517 lands later it rebases over this two-line surface.

Jira: [LE-2268](https://datastax.jira.com/browse/LE-2268)


[LE-2268]: https://datastax.jira.com/browse/LE-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen-reader labeling for the model picker in both populated and empty states.
  * Prevented labels from referencing unavailable controls.
  * Added accessibility coverage to verify model picker labels and control references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
