### PR TITLE
fix(a11y): give every canvas node a unique accessible name

### DIFF
--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "rechts",
   "flow.canvasLabel": "Flow-Arbeitsfläche",
   "flow.nodeAriaLabel": "Knoten {{name}}",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "Änderungen speichern",
   "flow.saveVersion": "Speichere eine Version deines Ablaufs",
   "flow.savedHover": "Zuletzt gespeichert: ",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -162,6 +162,7 @@
   "flow.a11y.direction.right": "right",
   "flow.canvasLabel": "Flow canvas",
   "flow.nodeAriaLabel": "{{name}} node",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "toolsModal.searchPlaceholder": "Search tools...",
   "toolsModal.columnName": "Name",
   "toolsModal.columnFlowName": "Flow Name",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "la derecha",
   "flow.canvasLabel": "Lienzo del flujo",
   "flow.nodeAriaLabel": "Nodo {{name}}",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "Guardar cambios",
   "flow.saveVersion": "Guarda una versión de tu flujo",
   "flow.savedHover": "Última vez guardado: ",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "la droite",
   "flow.canvasLabel": "Canevas du flux",
   "flow.nodeAriaLabel": "Nœud {{name}}",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "Sauvegarder les modifications",
   "flow.saveVersion": "Enregistrer une version de votre flux",
   "flow.savedHover": "Dernière sauvegarde : ",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "右",
   "flow.canvasLabel": "フローキャンバス",
   "flow.nodeAriaLabel": "{{name}} ノード",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "変更を保存",
   "flow.saveVersion": "フローのバージョンを保存する",
   "flow.savedHover": "最終保存日時： ",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "a direita",
   "flow.canvasLabel": "Tela do flow",
   "flow.nodeAriaLabel": "Nó {{name}}",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "Salvar mudanças",
   "flow.saveVersion": "Salve uma versão do seu fluxo",
   "flow.savedHover": "Última gravação: ",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -929,6 +929,7 @@
   "flow.a11y.direction.right": "右",
   "flow.canvasLabel": "流程画布",
   "flow.nodeAriaLabel": "{{name}} 节点",
+  "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   "flow.saveChanges": "保存更改",
   "flow.saveVersion": "保存流程的版本",
   "flow.savedHover": "最后保存时间： ",

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -90,7 +90,7 @@ import {
 } from "./MemoizedComponents";
 import { computeNoteScreenPosition } from "./utils/compute-note-position";
 import { getEdgeAriaLabel } from "./utils/get-edge-aria-label";
-import { getNodeAriaLabel } from "./utils/get-node-aria-label";
+import { getNodeAriaLabels } from "./utils/get-node-aria-label";
 import getRandomName from "./utils/get-random-name";
 import isEventFromOutsideElement from "./utils/is-event-from-outside-element";
 import isWrappedWithClass from "./utils/is-wrapped-with-class";
@@ -125,22 +125,23 @@ export default function Page({
   const edges = useFlowStore((state) => state.edges);
   const isEmptyFlow = useRef(nodes.length === 0);
 
-  const nodesWithAriaLabel = useMemo(
-    () =>
-      nodes.map((node) => ({
-        ...node,
-        ariaLabel: getNodeAriaLabel(node, t),
-        // Nodes are tabbable, so a plain "group" (ReactFlow's fallback)
-        // fails IBM element_tabbable_role_valid — but every widget role with
-        // presentational children (button, option, ...) fails
-        // aria_descendant_valid instead, because nodes contain interactive
-        // handles and fields. "application" is the ARIA role for a composite
-        // canvas widget with its own keyboard model (arrow keys move the
-        // node), permits interactive descendants, and scans clean.
-        ariaRole: "application" as const,
-      })),
-    [nodes, t],
-  );
+  const nodesWithAriaLabel = useMemo(() => {
+    // Labels are derived from the whole list at once: same-type nodes would
+    // otherwise share an accessible name, which role="application" forbids.
+    const ariaLabels = getNodeAriaLabels(nodes, t);
+    return nodes.map((node, index) => ({
+      ...node,
+      ariaLabel: ariaLabels[index],
+      // Nodes are tabbable, so a plain "group" (ReactFlow's fallback)
+      // fails IBM element_tabbable_role_valid — but every widget role with
+      // presentational children (button, option, ...) fails
+      // aria_descendant_valid instead, because nodes contain interactive
+      // handles and fields. "application" is the ARIA role for a composite
+      // canvas widget with its own keyboard model (arrow keys move the
+      // node), permits interactive descendants, and scans clean.
+      ariaRole: "application" as const,
+    }));
+  }, [nodes, t]);
 
   const getNode = useFlowStore((state) => state.getNode);
   // ReactFlow's built-in screen-reader strings (node/edge instructions via

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/utils/__tests__/get-node-aria-label.test.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/utils/__tests__/get-node-aria-label.test.ts
@@ -1,41 +1,105 @@
 import type { AllNodeType } from "@/types/flow";
-import { getNodeAriaLabel } from "../get-node-aria-label";
+import { getNodeAriaLabel, getNodeAriaLabels } from "../get-node-aria-label";
 
 const t = (key: string, options?: Record<string, unknown>) => {
   const translations: Record<string, string> = {
     "noteNode.ariaLabel": "Note node",
     "flow.nodeAriaLabel": "{{name}} node",
+    "flow.nodeAriaLabelOrdinal": "{{label}} {{ordinal}}",
   };
   const raw = translations[key] ?? key;
   if (!options) return raw;
   return raw.replace(/\{\{(\w+)\}\}/g, (_, k) => String(options[k] ?? ""));
 };
 
+const genericNode = (displayName: string, type = "ChatInput") =>
+  ({
+    type: "genericNode",
+    data: { node: { display_name: displayName }, type },
+  }) as unknown as AllNodeType;
+
+const noteNode = () =>
+  ({
+    type: "noteNode",
+    data: { node: { display_name: "" }, type: "" },
+  }) as unknown as AllNodeType;
+
 describe("getNodeAriaLabel", () => {
   it("returns a fixed, non-blank label for note nodes regardless of display_name", () => {
-    const noteNode = {
-      type: "noteNode",
-      data: { node: { display_name: "" }, type: "" },
-    } as unknown as AllNodeType;
-
-    expect(getNodeAriaLabel(noteNode, t)).toBe("Note node");
+    expect(getNodeAriaLabel(noteNode(), t)).toBe("Note node");
   });
 
   it("uses the component display_name for regular nodes", () => {
-    const genericNode = {
-      type: "genericNode",
-      data: { node: { display_name: "Chat Input" }, type: "ChatInput" },
-    } as unknown as AllNodeType;
-
-    expect(getNodeAriaLabel(genericNode, t)).toBe("Chat Input node");
+    expect(getNodeAriaLabel(genericNode("Chat Input"), t)).toBe(
+      "Chat Input node",
+    );
   });
 
   it("falls back to the node type when display_name is an empty string", () => {
-    const genericNode = {
-      type: "genericNode",
-      data: { node: { display_name: "" }, type: "ChatInput" },
-    } as unknown as AllNodeType;
+    expect(getNodeAriaLabel(genericNode("", "ChatInput"), t)).toBe(
+      "ChatInput node",
+    );
+  });
+});
 
-    expect(getNodeAriaLabel(genericNode, t)).toBe("ChatInput node");
+describe("getNodeAriaLabels", () => {
+  it("gives same-type nodes distinct accessible names", () => {
+    const labels = getNodeAriaLabels(
+      [genericNode("Chat Input"), genericNode("Chat Input")],
+      t,
+    );
+
+    expect(labels).toEqual(["Chat Input node 1", "Chat Input node 2"]);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("leaves a node whose label is unique exactly as it is today", () => {
+    const labels = getNodeAriaLabels(
+      [genericNode("Chat Input"), genericNode("Chat Output", "ChatOutput")],
+      t,
+    );
+
+    expect(labels).toEqual(["Chat Input node", "Chat Output node"]);
+  });
+
+  it("only numbers the colliding group, not the unique nodes around it", () => {
+    const labels = getNodeAriaLabels(
+      [
+        genericNode("Chat Input"),
+        genericNode("Agent", "Agent"),
+        genericNode("Chat Input"),
+        genericNode("Chat Output", "ChatOutput"),
+      ],
+      t,
+    );
+
+    expect(labels).toEqual([
+      "Chat Input node 1",
+      "Agent node",
+      "Chat Input node 2",
+      "Chat Output node",
+    ]);
+  });
+
+  it("disambiguates duplicate note nodes too", () => {
+    expect(getNodeAriaLabels([noteNode(), noteNode()], t)).toEqual([
+      "Note node 1",
+      "Note node 2",
+    ]);
+  });
+
+  it("produces stable ordinals across recomputes of the same node list", () => {
+    const nodes = [
+      genericNode("Chat Input"),
+      genericNode("Chat Input"),
+      genericNode("Chat Input"),
+    ];
+
+    expect(getNodeAriaLabels(nodes, t)).toEqual(getNodeAriaLabels(nodes, t));
+    expect(getNodeAriaLabels(nodes, t)).toEqual([
+      "Chat Input node 1",
+      "Chat Input node 2",
+      "Chat Input node 3",
+    ]);
   });
 });

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/utils/get-node-aria-label.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/utils/get-node-aria-label.ts
@@ -1,18 +1,48 @@
 import type { AllNodeType } from "@/types/flow";
 
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
 /**
  * Note nodes don't carry a meaningful component display_name (it's an empty
  * string at runtime, not undefined, so a `??` fallback to node.type never
  * triggers) — branch on the XYFlow node type instead of relying on it.
  */
-export function getNodeAriaLabel(
-  node: AllNodeType,
-  t: (key: string, options?: Record<string, unknown>) => string,
-): string {
+export function getNodeAriaLabel(node: AllNodeType, t: Translate): string {
   if (node.type === "noteNode") {
     return t("noteNode.ariaLabel");
   }
   return t("flow.nodeAriaLabel", {
     name: node.data?.node?.display_name || node.data?.type,
+  });
+}
+
+/**
+ * Accessible names for a whole canvas, aligned by index with `nodes`.
+ *
+ * Canvas nodes expose `role="application"`, so every one of them needs a
+ * unique accessible name (IBM Equal Access `aria_application_label_unique`,
+ * WCAG 4.1.2). A flow with two nodes of the same component type would
+ * otherwise share one name. Only colliding labels get a trailing ordinal
+ * ("Chat Input node 1" / "Chat Input node 2"); a node whose label is already
+ * unique keeps it verbatim. Ordinals follow the order of `nodes`, so the same
+ * list always produces the same names.
+ */
+export function getNodeAriaLabels(
+  nodes: AllNodeType[],
+  t: Translate,
+): string[] {
+  const labels = nodes.map((node) => getNodeAriaLabel(node, t));
+
+  const totals = new Map<string, number>();
+  for (const label of labels) {
+    totals.set(label, (totals.get(label) ?? 0) + 1);
+  }
+
+  const assigned = new Map<string, number>();
+  return labels.map((label) => {
+    if ((totals.get(label) ?? 0) < 2) return label;
+    const ordinal = (assigned.get(label) ?? 0) + 1;
+    assigned.set(label, ordinal);
+    return t("flow.nodeAriaLabelOrdinal", { label, ordinal });
   });
 }


### PR DESCRIPTION
## The problem

Add two Chat Inputs to a flow and a screen reader announces both of them as "Chat Input node". Nothing distinguishes them — a blind user tabbing the canvas has no way to know which of the two identical-sounding nodes they landed on.

This is a Level 1 accessibility violation, not just a rough edge. #14673 gave canvas nodes `role="application"`, which makes each node a composite widget that assistive tech identifies by its accessible name, and those names must be unique. IBM Equal Access flags it as `aria_application_label_unique` (WCAG 4.1.2). A plain 6-node flow with two same-type pairs scans with two violations.

## The fix

Node labels are now derived from the whole node list at once, so collisions are actually visible at the point where labels are built:

- A label that appears only once is emitted verbatim. The overwhelming majority of nodes keep exactly the name they have today — this deliberately does not churn every label on the canvas.
- Only members of a colliding group get a trailing ordinal: "Chat Input node 1", "Chat Input node 2".
- Ordinals follow the order of the node list, so the same flow always produces the same names — no randomness, no reshuffling between renders.
- Duplicate note nodes (which all share one fixed label) are disambiguated the same way.

The ordinal suffix goes through a new `flow.nodeAriaLabelOrdinal` key added to all seven locale files, so translators can reorder or re-punctuate it rather than being stuck with English concatenation.

## Verification

**Fail-before proof.** The new tests were run against the pre-fix labelling behaviour (the old `nodes.map(node => getNodeAriaLabel(node, t))` mapping) and fail on the duplicate cases:

```
● getNodeAriaLabels › gives same-type nodes distinct accessible names

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Array [
    -   "Chat Input node 1",
    -   "Chat Input node 2",
    +   "Chat Input node",
    +   "Chat Input node",
      ]

● getNodeAriaLabels › only numbers the colliding group, not the unique nodes around it

      Array [
    -   "Chat Input node 1",
    +   "Chat Input node",
        "Agent node",
    -   "Chat Input node 2",
    +   "Chat Input node",
        "Chat Output node",
      ]
```

Note that "leaves a node whose label is unique exactly as it is today" **passes** under the old behaviour too — that test exists to pin down that this change does not rename anything it doesn't have to.

**After the fix:**

- `npx jest src/pages/FlowPage/components/PageComponent` — 10 suites, 75 tests, all green.
- `npx tsc --noEmit -p tsconfig.json` — 257 errors, identical to the pre-existing baseline on `release-1.12.0`, and zero of them in the touched files.
- `npx biome check --write` clean on every touched file.
- All seven locale files re-parsed as valid JSON after the insert; keys were inserted next to `flow.nodeAriaLabel` without resorting the files.

E2E is left to CI.

## No screenshots

`aria-label` has no rendered representation, so this change cannot alter a single pixel of the canvas. There is nothing visual to capture — the entire effect is in the accessibility tree.

Jira: [LE-2269](https://datastax.jira.com/browse/LE-2269)


[LE-2269]: https://datastax.jira.com/browse/LE-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved flow node labels for screen readers.
  * Duplicate node names now receive localized ordinal labels, making each node distinguishable.
  * Unique node names remain unchanged, with stable numbering across repeated views.

* **Localization**
  * Added ordinal label translations for English, German, Spanish, French, Japanese, Portuguese, and Simplified Chinese.

* **Tests**
  * Added coverage for duplicate names, note nodes, unique labels, and stable ordinal assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->