### PR TITLE
fix: emit the stable HTTP server metric names

### DIFF
--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -39,6 +39,20 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from lfx.log.logger import logger, operator_logger, otel_log_bodies_exported
+
+# Opt into the stable HTTP semantic conventions here, at import, rather than beside the call
+# that needs them.
+#
+# OpenTelemetry reads this once, when its instrumentation package first initialises, and
+# caches it for the life of the process. Setting it inside instrument_fastapi_app looked
+# early enough and is not: bootstrap_application_telemetry runs first on both runtimes, and
+# its SystemMetricsInstrumentor loads that package, freezing the decision while the variable
+# is still unset. The FastAPI metrics then arrive under the pre-stable names, which is a
+# silent defect -- ingest is healthy, and an APM keying its HTTP dashboards off the stable
+# names shows nothing.
+#
+# setdefault, so "http/dup" stays available to an operator mid-migration.
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
 from lfx.observability_fastapi import patch_otel_fastapi_route_details
 
 _BASE_EXCEPTION_GROUP_TYPE = getattr(builtins, "BaseExceptionGroup", None)
@@ -1238,18 +1252,16 @@ def instrument_fastapi_app(app: FastAPI) -> None:
     app, ``lfx serve`` on the multi-flow app. No-op when the FastAPI instrumentation is not
     installed.
 
-    Sets the stable HTTP semantic conventions (http.route, http.request.method,
-    http.response.status_code) rather than the pre-1.0 names, because APMs key their HTTP
-    dashboards and service maps off the stable ones. It has to run before instrument_app: the
-    opt-in is read once, on first instrumentation, and cached for the life of the process.
-    setdefault leaves "http/dup" available to an operator migrating.
+    The stable HTTP semantic conventions (http.route, http.request.method,
+    http.response.status_code) are opted into at module import, not here. The opt-in is read
+    once, when OpenTelemetry's instrumentation package first initialises, and by the time this
+    runs that has already happened.
     """
     try:
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     except ImportError:
         return
 
-    os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
     # FastAPI >=0.137 lazy include_router puts _IncludedRouter wrappers (no .path) in
     # app.routes, which crashes OTel's span route extraction on partial matches (e.g. CORS
     # preflight). Patch the helper before instrumenting.

--- a/src/lfx/tests/unit/test_http_semconv_names.py
+++ b/src/lfx/tests/unit/test_http_semconv_names.py
@@ -1,0 +1,117 @@
+"""The HTTP server metrics must carry the stable semantic-convention names.
+
+An APM keys its HTTP dashboards and service maps off the stable names, so emitting the
+pre-stable ones leaves the curated views empty while ingest looks perfectly healthy. It is
+also a rename once corrected, so every dashboard built on the old names has to be rebuilt.
+
+``instrument_fastapi_app`` sets ``OTEL_SEMCONV_STABILITY_OPT_IN`` before instrumenting, which
+is necessary but not sufficient: OpenTelemetry reads that value when its instrumentation
+package first initialises and caches it for the life of the process. If anything has already
+imported that package, the helper's setdefault is too late and the cached value wins.
+
+Runs in a subprocess because the decision is cached process-wide and cannot be re-made.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("opentelemetry.instrumentation.fastapi")
+
+PROBE = """
+import asyncio, json
+
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+reader = InMemoryMetricReader()
+metrics.set_meter_provider(MeterProvider(metric_readers=[reader]))
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from lfx.observability import bootstrap_application_telemetry, instrument_fastapi_app
+
+# The load-bearing line. This is what both runtimes call before instrumenting their app, and
+# its SystemMetricsInstrumentor pulls in OpenTelemetry's instrumentation package, freezing the
+# semconv decision. Without this call the probe passes whether or not the fix is present.
+bootstrap_application_telemetry()
+
+app = FastAPI()
+
+
+@app.post("/ping")
+async def ping(payload: dict):
+    return {"ok": True, "got": payload}
+
+
+instrument_fastapi_app(app)
+
+
+async def main():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://probe") as client:
+        response = await client.post("/ping", json={"hello": "operator"})
+        assert response.status_code == 200, response.status_code
+
+
+asyncio.run(main())
+
+names = []
+data = reader.get_metrics_data()
+for resource_metric in (data.resource_metrics if data else []):
+    for scope_metric in resource_metric.scope_metrics:
+        for metric in scope_metric.metrics:
+            names.append(metric.name)
+
+print("PROBE_RESULT " + json.dumps(sorted(set(names))))
+"""
+
+
+def run_probe() -> list[str]:
+    # Strip inherited OTEL_ vars: OTEL_SEMCONV_STABILITY_OPT_IN set outside would decide the
+    # thing under test, and the probe would pass without the code being right.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe_path = Path(tmp) / "probe.py"
+        probe_path.write_text(PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    assert completed.returncode == 0, completed.stderr
+    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
+    return json.loads(line.removeprefix("PROBE_RESULT "))
+
+
+def test_the_server_duration_metric_uses_the_stable_name():
+    """``http.server.request.duration``, not the pre-stable ``http.server.duration``."""
+    names = run_probe()
+
+    assert "http.server.request.duration" in names, names
+    assert "http.server.duration" not in names, names
+
+
+def test_the_payload_size_metrics_use_the_stable_names():
+    """The same opt-in renames these, so they catch a partial application of the fix.
+
+    The probe POSTs a body rather than GETting: the request-size histogram is only recorded
+    when there is a body to measure, so a GET would leave this passing on an absence.
+    """
+    names = run_probe()
+
+    assert "http.server.request.body.size" in names, names
+    assert "http.server.response.body.size" in names, names
+    assert "http.server.request.size" not in names, names
+    assert "http.server.response.size" not in names, names

--- a/src/lfx/tests/unit/test_http_semconv_names.py
+++ b/src/lfx/tests/unit/test_http_semconv_names.py
@@ -4,10 +4,9 @@ An APM keys its HTTP dashboards and service maps off the stable names, so emitti
 pre-stable ones leaves the curated views empty while ingest looks perfectly healthy. It is
 also a rename once corrected, so every dashboard built on the old names has to be rebuilt.
 
-``instrument_fastapi_app`` sets ``OTEL_SEMCONV_STABILITY_OPT_IN`` before instrumenting, which
-is necessary but not sufficient: OpenTelemetry reads that value when its instrumentation
-package first initialises and caches it for the life of the process. If anything has already
-imported that package, the helper's setdefault is too late and the cached value wins.
+Importing ``lfx.observability`` sets ``OTEL_SEMCONV_STABILITY_OPT_IN``. This must happen before
+OpenTelemetry's instrumentation package first initialises, because it reads the value once and
+caches it for the life of the process.
 
 Runs in a subprocess because the decision is cached process-wide and cannot be re-made.
 """

--- a/src/lfx/tests/unit/test_observability.py
+++ b/src/lfx/tests/unit/test_observability.py
@@ -307,7 +307,14 @@ def test_root_error_type_keeps_a_multi_exception_group():
 
 
 @requires_otel
-def test_importing_observability_opts_into_stable_semconv():
+@pytest.mark.parametrize(
+    ("env_overrides", "expected"),
+    [
+        pytest.param({}, "http", id="default"),
+        pytest.param({"OTEL_SEMCONV_STABILITY_OPT_IN": "http/dup"}, "http/dup", id="operator-override"),
+    ],
+)
+def test_importing_observability_opts_into_stable_semconv(env_overrides: dict[str, str], expected: str):
     """The opt-in happens at import, which is the only point early enough.
 
     It used to live in ``instrument_fastapi_app``. That reads as early enough and is not:
@@ -316,12 +323,15 @@ def test_importing_observability_opts_into_stable_semconv():
     still unset. Popping the variable and re-calling the helper cannot restore the old
     behaviour, because the cache is already set by then.
 
-    Asserted on the imported module rather than by calling anything: by the time any test
-    runs, ``lfx.observability`` has been imported and the variable is set.
+    Each case runs in a subprocess because the import and the OpenTelemetry decision are both
+    process-wide. The default is stable-only, while an operator can request both conventions
+    during a dashboard migration.
     """
-    import lfx.observability  # noqa: F401
+    probe = "import os\nimport lfx.observability\nprint(os.environ['OTEL_SEMCONV_STABILITY_OPT_IN'])\n"
+    completed = _run(probe, env_overrides)
 
-    assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == expected
 
 
 @requires_otel

--- a/src/lfx/tests/unit/test_observability.py
+++ b/src/lfx/tests/unit/test_observability.py
@@ -307,13 +307,20 @@ def test_root_error_type_keeps_a_multi_exception_group():
 
 
 @requires_otel
-def test_instrument_fastapi_app_sets_stable_semconv():
-    """The shared FastAPI helper opts into the stable HTTP conventions before instrumenting."""
-    os.environ.pop("OTEL_SEMCONV_STABILITY_OPT_IN", None)
-    from fastapi import FastAPI
-    from lfx.observability import instrument_fastapi_app
+def test_importing_observability_opts_into_stable_semconv():
+    """The opt-in happens at import, which is the only point early enough.
 
-    instrument_fastapi_app(FastAPI())
+    It used to live in ``instrument_fastapi_app``. That reads as early enough and is not:
+    ``bootstrap_application_telemetry`` runs first on both runtimes and loads OpenTelemetry's
+    instrumentation package, which caches the decision for the process while the variable is
+    still unset. Popping the variable and re-calling the helper cannot restore the old
+    behaviour, because the cache is already set by then.
+
+    Asserted on the imported module rather than by calling anything: by the time any test
+    runs, ``lfx.observability`` has been imported and the variable is set.
+    """
+    import lfx.observability  # noqa: F401
+
     assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
 
 


### PR DESCRIPTION
Both runtimes were exporting the pre-stable HTTP server metric names.

```
before   http.server.duration, http.server.request.size
after    http.server.request.duration, http.server.request.body.size
```

This is the quiet kind of defect: ingest is healthy, the export returns 2xx, and an APM that keys its HTTP dashboards and service maps off the stable names simply shows nothing.

## Why the existing opt-in was too late

`instrument_fastapi_app` set `OTEL_SEMCONV_STABILITY_OPT_IN` immediately before calling `FastAPIInstrumentor.instrument_app`, and its docstring correctly said the opt-in has to run first because it is read once and cached for the life of the process.

It was still too late. `bootstrap_application_telemetry` runs earlier on both runtimes, and its `SystemMetricsInstrumentor` loads OpenTelemetry's instrumentation package, freezing the decision while the variable is still unset.

Measured, same process, only the call order differing:

```
bare FastAPI app                       -> http.server.request.duration   (stable)
bootstrap first, then instrument       -> http.server.duration           (pre-stable)
```

I originally diagnosed this as import order and was wrong; the env var is set correctly before instrumentation, and the cache is what wins. The bisect above is what actually located it.

## The fix

Move the `setdefault` to module import, the one point that precedes every instrumentor. Still `setdefault`, so `http/dup` stays available to an operator mid-migration.

## Tests

`test_importing_observability_opts_into_stable_semconv` replaces a test that popped the variable and re-called the helper. That can no longer restore the old behaviour, because the cache is already set by then, so it now asserts the import-time contract directly.

The new `test_http_semconv_names.py` drives a real instrumented app in a subprocess and calls `bootstrap_application_telemetry` first. That call is load-bearing: without it the probe passes whether or not the fix is present. Mutation checked, red before green:

```
fix reverted   assert 'http.server.request.duration' in [... 'http.server.duration', ...]   FAILED
fix restored   2 passed
```

Verified: 34 lfx tests, 185 langflow telemetry tests, ruff clean.

## Worth knowing before merging

This renames metrics. Any dashboard already built on `http.server.duration` will need rebuilding, and the longer it waits the more of those exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated telemetry initialization so HTTP metrics consistently use stable OpenTelemetry naming.
  * Preserved support for operators using the combined stable and legacy naming option.

* **Tests**
  * Added regression coverage confirming stable request-duration and payload-size metric names are emitted.
  * Added validation that telemetry settings are applied before instrumentation initializes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->