### PR TITLE
test(frontend): fix flaky sidebar typeahead wait in connect-tools spec

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-11.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-11.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
+import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 import { skipIfComponentUnavailable } from "../../utils/skip-if-component-unavailable";
 import { zoomOut } from "../../utils/zoom-out";
@@ -46,46 +48,36 @@ test(
 
     await page.getByTestId("blank-flow").click();
 
-    //first component
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("url");
-    await page.waitForSelector('[data-testid="data_sourceURL"]', {
-      timeout: 1000,
-    });
-
     await zoomOut(page, 3);
 
-    await page
-      .getByTestId("data_sourceURL")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 100 },
-      });
+    //first component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("tool calling agent");
-    await page.waitForSelector(
-      '[data-testid="langchain_utilitiesTool Calling Agent"]',
-      {
-        timeout: 1000,
-      },
-    );
+    await addComponentFromSidebar(page, {
+      search: "url",
+      testId: "data_sourceURL",
+      position: { x: 100, y: 100 },
+    });
 
-    await page
-      .getByTestId("langchain_utilitiesTool Calling Agent")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 300, y: 300 },
-      });
+    await addComponentFromSidebar(page, {
+      search: "tool calling agent",
+      testId: "langchain_utilitiesTool Calling Agent",
+      position: { x: 300, y: 300 },
+    });
 
     await adjustScreenView(page);
 
     await page.getByTestId("title-URL").first().click();
+    await expect(page.getByTestId("tool-mode-button")).toBeVisible({
+      timeout: TIMEOUTS.short,
+    });
     await page.getByTestId("tool-mode-button").click();
 
     //connection
     const urlOutput = await page
       .getByTestId("handle-urlcomponent-shownode-toolset-right")
       .first();
+
+    await expect(urlOutput).toBeVisible({ timeout: TIMEOUTS.short });
 
     await urlOutput.hover();
     await page.mouse.down();
@@ -95,6 +87,8 @@ test(
     await toolCallingAgentInput.hover();
     await page.mouse.up();
 
-    expect(await page.locator(".react-flow__edge-interaction").count()).toBe(2);
+    await expect(page.locator(".react-flow__edge-interaction")).toHaveCount(2, {
+      timeout: TIMEOUTS.short,
+    });
   },
 );


### PR DESCRIPTION
The `connect tools` spec in `generalBugs-shard-11.spec.ts` fails on the Windows nightly shard because it gives the sidebar typeahead only 1000ms. That budget has essentially no headroom, so it is a timing race, not a Windows-specific behaviour.

Failing job: [Nightly Build — Run Frontend Tests - Windows / Shard 70/70](https://github.com/langflow-ai/langflow/actions/runs/32432045876/job/96626562847)

## Evidence

Pulled the shard's blob report and read the trace of both attempts:

| step | attempt 1 | attempt 2 |
| --- | --- | --- |
| click `sidebar-search-input` | 2024ms | 1493ms |
| `waitForSelector('[data-testid="data_sourceURL"]', { timeout: 1000 })` | **1193ms — failed** | **1293ms — failed** |

The captured page snapshot at the moment of failure already shows the row rendered (`button "Add URL to canvas" → URL`) — it just crossed the deadline. Another spec on the **same Windows runner** runs the identical search with a 3000ms budget and resolves in **388ms**.

Locally on macOS I measured the same wait at **412–840ms** (`awaitBootstrapTest → blank flow → fill "url"`), i.e. under 200ms of headroom on fast hardware. The 1000ms has to cover the 300ms search debounce (`useDebouncedSearch`) plus the Fuse index rebuild and the full sidebar re-render (`useSidebarSearch`), so a slower runner tips it over.

## Fix

Both hand-rolled search-and-drag blocks are replaced with the existing shared `addComponentFromSidebar` helper, which already uses `TIMEOUTS.componentMount` and asserts the node count after each drop. The remaining steps get web-first assertions instead of bare waits:

- wait for `tool-mode-button` to be visible before clicking it
- wait for the toolset handle to be visible before starting the drag
- `expect(...).toHaveCount(2)` on the edges instead of a one-shot `count()` snapshot

No production code changes; no other spec is touched.

## Validation

Run locally on macOS against a real backend:

- `connect tools` — 3 consecutive passes (10.3–10.6s each, down from 20.3s)
- full spec file with 2 workers — passes (`ComposIO` test skips, the bundle is not installed locally)
- also passes under a 6× CPU throttle (43.6s / 38.3s)
- `npx biome check` clean

## Follow-up (not in this PR)

The same 1000ms sidebar wait exists in 7 other specs — including the identical `data_sourceURL` wait in `tests/extended/features/loop-component.spec.ts` — and is a latent flake for the same reason. Migrating them to `addComponentFromSidebar` is worth a separate pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression coverage for connecting URL and Tool Calling Agent components.
  * Added more reliable placement and visibility checks during component setup.
  * Added verification that the URL output handle is available before connecting.
  * Improved edge-count validation with an explicit wait timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->