### PR TITLE
fix: exempt runtime-generated tweaks from the deployment policy

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1552,6 +1552,12 @@ async def experimental_run_flow(
                 # than chaining the exception to itself.
                 raise
             raise error_for_client(exc, expose_details=expose_error_details) from exc
+        except TweakRefusedError:
+            # Third run route that applies tweaks, and the generic handler below
+            # would turn a refused tweak into a redacted 500 with a stack trace
+            # in the logs. Let it through so the app-level handler answers 422
+            # naming the refused keys, as the setting documents for every mode.
+            raise
         except Exception as exc:
             await logger.aexception("Failed to build advanced-run graph for flow %s", flow.id)
             client_error = error_for_client(exc, expose_details=expose_error_details)

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -212,7 +212,12 @@ async def _build_graph_from_authorized_flow(
         msg = f"Flow {flow_id} not found"
         raise ValueError(msg)
     if tweaks:
-        graph_data = process_tweaks(graph_data=graph_data, tweaks=tweaks)
+        # Component-side, not caller-side. The only routes here are the generated
+        # flow-as-tool function below and ``CustomComponent.run_flow``, both of
+        # which build these tweaks from their own declared inputs. Judging them
+        # against the deployment policy would make ``off`` stop an agent from
+        # calling a flow as a tool. The protected-field floor still applies.
+        graph_data = process_tweaks(graph_data=graph_data, tweaks=tweaks, caller_supplied=False)
     return Graph.from_payload(graph_data, flow_id=flow_id, user_id=user_id)
 
 

--- a/src/backend/base/langflow/services/flow/flow_runner.py
+++ b/src/backend/base/langflow/services/flow/flow_runner.py
@@ -147,7 +147,9 @@ class LangflowRunnerExperimental:
                     tweaks[vertex.id][db_field] = field_params[db_field]
         if tweaks is not None:
             tweaks = replace_tweaks_with_env(tweaks=tweaks, env_vars=tweaks_values)
-            flow_dict = process_tweaks(flow_dict, tweaks)
+            # Built here from resolved load_from_db values, not sent by a caller,
+            # so the deployment policy does not judge them. The floor still does.
+            flow_dict = process_tweaks(flow_dict, tweaks, caller_supplied=False)
 
         # Recursively update load_from_db fields
         def update_load_from_db(obj):

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -7,6 +7,9 @@ the refused keys. Each route therefore has to let ``TweakRefusedError`` through
 on purpose, and that is easy to drop when a handler is next edited.
 """
 
+from unittest.mock import patch
+
+import pytest
 from fastapi import status
 
 
@@ -66,3 +69,33 @@ async def test_refused_tweak_returns_422_on_the_v1_advanced_run(client, simple_a
     detail = response.json()["detail"]
     assert detail["code"] == "TWEAKS_REFUSED"
     assert detail["fields"] == ["code"]
+
+
+async def test_off_does_not_break_a_flow_called_as_a_tool(simple_api_test, active_user):
+    """``off`` closes the API surface, it must not stop agents calling flows as tools.
+
+    An agent invoking a flow as a tool reaches the runtime through the generated
+    ``flow_function``, which builds tweaks from the tool's own declared arguments
+    and hands them to ``load_flow``. ``RunFlowBaseComponent`` escapes this path by
+    passing a prebuilt graph, so the graph-path exemption alone does not cover it.
+    """
+    from types import SimpleNamespace
+
+    from langflow.helpers.flow import _build_graph_from_authorized_flow
+    from lfx.exceptions.tweaks import TweakRefusedError
+
+    flow_data = simple_api_test["data"]
+    node_id = next(n["id"] for n in flow_data["nodes"] if n["id"].startswith(("ChatInput", "TextInput")))
+    flow = SimpleNamespace(data=flow_data)
+
+    with patch("lfx.processing.process._resolve_tweak_policy", return_value="off"):
+        try:
+            await _build_graph_from_authorized_flow(
+                caller=active_user,
+                flow=flow,
+                flow_id=simple_api_test["id"],
+                user_id=str(active_user.id),
+                tweaks={node_id: {"input_value": "from the agent"}},
+            )
+        except TweakRefusedError as exc:
+            pytest.fail(f"off refused a tool-supplied tweak: {exc.refused}")

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -43,3 +43,26 @@ async def test_an_allowed_tweak_still_runs_on_the_v1_sync_run(client, simple_api
     response = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json=payload)
 
     assert response.status_code == status.HTTP_200_OK, response.text
+
+
+async def test_refused_tweak_returns_422_on_the_v1_advanced_run(client, simple_api_test, created_api_key):
+    """The advanced-run route applies tweaks too, so it needs the same arm.
+
+    Three routes call ``process_tweaks``. Each wraps its body in a broad
+    ``except Exception``, so each has to let ``TweakRefusedError`` through on
+    purpose. This one was missed on the first pass.
+    """
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+    node_id = simple_api_test["data"]["nodes"][0]["id"]
+    payload = {
+        "output_type": "text",
+        "tweaks": {node_id: {"code": "import os; os.system('id')"}},
+    }
+
+    response = await client.post(f"/api/v1/run/advanced/{flow_id}", headers=headers, json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "TWEAKS_REFUSED"
+    assert detail["fields"] == ["code"]

--- a/src/lfx/src/lfx/base/tools/run_flow.py
+++ b/src/lfx/src/lfx/base/tools/run_flow.py
@@ -534,7 +534,12 @@ class RunFlowBaseComponent(Component):
             if tweaks := self._build_flow_tweak_data():
                 from lfx.processing.process import process_tweaks_on_graph
 
-                graph = process_tweaks_on_graph(graph, tweaks)
+                # These tweaks are this component's own declared inputs, not a
+                # caller overriding the sub-flow, so the deployment policy does
+                # not judge them. Without this, ``off`` would stop the Run Flow
+                # component and every flow used as an agent tool from working.
+                # The protected-field floor still applies.
+                graph = process_tweaks_on_graph(graph, tweaks, caller_supplied=False)
 
             result = await run_flow(
                 inputs=self._build_inputs(tweaks),

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -202,33 +202,28 @@ def apply_tweaks(
         logger.warning(f"Template data for node {node.get('id')} should be a dictionary")
         return refused
 
-    # Security: tweaks must never inject executable code, widen the code sandbox,
-    # or repoint a protected sink configured by the flow author.
-    # The previous name-only block on "code" was bypassable because code-execution
-    # components expose their code under other field names (python_code, tool_code,
-    # filter_instruction) that serialize as plain "str". Refuse a tweak when the
-    # field is code-typed, literally named "code", or is a code/sandbox input on a
-    # code-execution component — while leaving benign fields (name, description,
-    # data, ...) on those components tweakable.
-    from lfx.utils.flow_validation import is_protected_tweak_field, is_tweak_refused_by_policy
+    # One function decides refusals, this one only applies them. Re-deriving the
+    # floor and the policy here is exactly the shape that produced the original
+    # bypass: two copies of a security predicate that drifted apart. In the
+    # two-pass callers this list is already empty by the time we get here, so the
+    # skip below only matters to direct callers of this function.
+    refused = _refused_tweak_names(
+        template_data,
+        node.get("data", {}).get("type"),
+        node_tweaks,
+        policy=policy,
+        flow_declares_allowlist=flow_declares_allowlist,
+        exempt_keys=exempt_keys,
+    )
+    refused_names = frozenset(refused)
 
-    component_type = node.get("data", {}).get("type")
     for tweak_name, tweak_value in node_tweaks.items():
-        if tweak_name not in template_data:
+        field = template_data.get(tweak_name)
+        if not isinstance(field, dict):
             continue
-        field_type = template_data[tweak_name].get("type", "")
-        if is_protected_tweak_field(component_type, tweak_name, field_type):
-            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
+        if tweak_name in refused_names:
             continue
-        if tweak_name not in exempt_keys and is_tweak_refused_by_policy(
-            policy,
-            flow_declares_allowlist=flow_declares_allowlist,
-            field_is_api_editable=template_data[tweak_name].get("api_editable") is True,
-        ):
-            logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
-            continue
+        field_type = field.get("type", "")
         if field_type == "NestedDict":
             value = validate_and_repair_json(tweak_value)
             template_data[tweak_name]["value"] = value
@@ -285,6 +280,7 @@ def _refused_tweak_names(
         if not isinstance(field, dict):
             continue
         if is_protected_tweak_field(component_type, tweak_name, field.get("type", "")):
+            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
             refused.append(tweak_name)
             continue
         if tweak_name not in exempt_keys and is_tweak_refused_by_policy(
@@ -292,6 +288,7 @@ def _refused_tweak_names(
             flow_declares_allowlist=flow_declares_allowlist,
             field_is_api_editable=field.get("api_editable") is True,
         ):
+            logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
             refused.append(tweak_name)
     return refused
 
@@ -312,6 +309,22 @@ def _resolve_tweak_policy() -> str:
         logger.warning(f"Unknown tweaks policy {policy!r}; falling back to {TWEAK_POLICY_PERMISSIVE!r}.")
         return TWEAK_POLICY_PERMISSIVE
     return policy
+
+
+def _effective_policy(*, caller_supplied: bool) -> str:
+    """Return the policy to enforce for this application of tweaks.
+
+    The deployment policy answers "what may a caller override". Tweaks the
+    runtime generated for itself are not a caller overriding anything, so they
+    are judged as ``permissive``: the protected-field floor still refuses, and
+    the policy layer stays out of it. This is the same reasoning that exempts
+    the injected ``stream`` key.
+    """
+    from lfx.utils.flow_validation import TWEAK_POLICY_PERMISSIVE
+
+    if not caller_supplied:
+        return TWEAK_POLICY_PERMISSIVE
+    return _resolve_tweak_policy()
 
 
 def _refusal_reason(policy: str, *, flow_declares_allowlist: bool) -> str:
@@ -345,16 +358,25 @@ def apply_tweaks_on_vertex(
     component at runtime, which is the bug the two former private copies of this
     function existed to work around.
     """
-    from lfx.utils.flow_validation import is_protected_tweak_field, is_tweak_refused_by_policy
-
     refused: list[str] = []
     template_data = vertex.data.get("node", {}).get("template", {})
-    component_type = vertex.data.get("type")
     if not isinstance(template_data, dict):
         # No usable template means nothing can be validated, so nothing is
         # applied. Refusing here instead would turn a malformed node into a
         # caller-facing error the caller cannot act on.
         return refused
+
+    # Same single-predicate rule as ``apply_tweaks``: this function applies, it
+    # does not re-decide. Two copies of the floor are what let the graph path
+    # accept tweaks the sync path refused in the first place.
+    refused = _refused_tweak_names(
+        template_data,
+        vertex.data.get("type"),
+        node_tweaks,
+        policy=policy,
+        flow_declares_allowlist=flow_declares_allowlist,
+    )
+    refused_names = frozenset(refused)
 
     accepted: dict[str, Any] = {}
     for tweak_name, tweak_value in node_tweaks.items():
@@ -365,19 +387,7 @@ def apply_tweaks_on_vertex(
         # caller who sends a tweak for a component the flow no longer has.
         if not isinstance(field, dict):
             continue
-        field_type = field.get("type", "")
-
-        if is_protected_tweak_field(component_type, tweak_name, field_type):
-            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
-            continue
-        if is_tweak_refused_by_policy(
-            policy,
-            flow_declares_allowlist=flow_declares_allowlist,
-            field_is_api_editable=isinstance(field, dict) and field.get("api_editable") is True,
-        ):
-            logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
+        if tweak_name in refused_names:
             continue
 
         accepted[tweak_name] = tweak_value
@@ -403,7 +413,11 @@ def apply_tweaks_on_vertex(
 
 
 def process_tweaks(
-    graph_data: dict[str, Any], tweaks: Tweaks | dict[str, dict[str, Any]], *, stream: bool = False
+    graph_data: dict[str, Any],
+    tweaks: Tweaks | dict[str, dict[str, Any]],
+    *,
+    stream: bool = False,
+    caller_supplied: bool = True,
 ) -> dict[str, Any]:
     """This function is used to tweak the graph data using the node id and the tweaks dict.
 
@@ -413,6 +427,11 @@ def process_tweaks(
                    The values can be a dictionary containing the tweaks for the node or the value of the tweak.
     :param stream: A boolean flag indicating whether streaming should be deactivated across all components or not.
                    Default is False.
+    :param caller_supplied: Whether these tweaks came from a run request. Pass False when the runtime
+                   generated them itself, e.g. resolved variable values. Runtime-generated tweaks skip
+                   the deployment policy for the same reason ``stream`` does: the policy governs what a
+                   caller may override, and refusing a value the runtime produced would disable internal
+                   machinery rather than restrict an API. The protected-field floor still applies.
     :return: The modified graph_data dictionary.
     :raises ValueError: If the input is not in the expected format.
     """
@@ -435,7 +454,7 @@ def process_tweaks(
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}
 
-    policy = _resolve_tweak_policy()
+    policy = _effective_policy(caller_supplied=caller_supplied)
     flow_declares_allowlist = flow_declares_api_editable(nodes)
     refused: list[str] = []
 
@@ -480,18 +499,24 @@ def process_tweaks(
     return graph_data
 
 
-def process_tweaks_on_graph(graph: Graph, tweaks: dict[str, dict[str, Any]]):
+def process_tweaks_on_graph(graph: Graph, tweaks: dict[str, dict[str, Any]], *, caller_supplied: bool = True):
     """Apply tweaks to a built graph, enforcing the floor and the policy.
 
     This is the post-construction counterpart to ``process_tweaks``. The
     streaming and background run modes build the graph first, so they land here
     rather than there. Both paths must refuse the same tweaks, or the deployment
     policy would only govern the sync mode.
+
+    ``caller_supplied=False`` marks tweaks the runtime built rather than a caller
+    sending them. The Run Flow component passes its own declared inputs through
+    here to reach a sub-flow, so judging those against the deployment policy
+    would make ``off`` disable flow-as-tool orchestration instead of closing an
+    API surface. The floor still applies.
     """
     from lfx.exceptions.tweaks import TweakRefusedError
     from lfx.utils.flow_validation import flow_declares_api_editable
 
-    policy = _resolve_tweak_policy()
+    policy = _effective_policy(caller_supplied=caller_supplied)
     # ``flow_declares_api_editable`` reads node dicts shaped ``{"data": {...}}``.
     # ``vertex.data`` is already that inner mapping, so wrap it back up.
     flow_declares_allowlist = flow_declares_api_editable(

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -271,11 +271,11 @@ class SecuritySettings(BaseModel):
     Flow component and every flow used as an agent tool, which is not what closing an
     API surface should mean. The protected-field floor still applies to those.
 
-    MCP is the exception, and deliberately so. An MCP client calling a flow as a tool
-    is an external caller, so its inputs travel the caller-facing run API and this
-    setting judges them. Under ``off`` an MCP tool call cannot pass inputs at all,
-    because inputs are the only thing it sends. Leave the deployment on ``permissive``
-    or ``declared`` if MCP tool calls have to keep working."""
+    MCP deserves one qualification. Its primary ``input_value`` travels through the
+    normal graph-input channel and is not a tweak. Additional advertised input fields
+    are translated into tweaks, so this setting judges them. Under ``off`` those extra
+    fields are refused, while ``input_value``-only MCP tools continue to work. Use
+    ``permissive`` or ``declared`` for MCP tools that require tweak-backed parameters."""
     # Serving-plane end-user identity
     serving_end_user_header: str | None = None
     """Name of the trusted request header that carries the end-user identity on the serving plane

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -262,7 +262,14 @@ class SecuritySettings(BaseModel):
 
     Refused tweaks return 422 naming the refused keys in every mode. They previously
     logged a warning and returned 200, which left a caller unable to tell a refused
-    tweak from an applied one."""
+    tweak from an applied one.
+
+    This setting governs what a *caller* may override. ``tweaks`` is also the internal
+    mechanism for passing values into a sub-flow, so tweaks the runtime generates for
+    itself (the Run Flow component feeding its declared inputs to a sub-flow, resolved
+    global-variable values) are not judged by it. Otherwise ``off`` would stop the Run
+    Flow component and every flow used as an agent tool, which is not what closing an
+    API surface should mean. The protected-field floor still applies to those."""
     # Serving-plane end-user identity
     serving_end_user_header: str | None = None
     """Name of the trusted request header that carries the end-user identity on the serving plane

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -269,7 +269,13 @@ class SecuritySettings(BaseModel):
     itself (the Run Flow component feeding its declared inputs to a sub-flow, resolved
     global-variable values) are not judged by it. Otherwise ``off`` would stop the Run
     Flow component and every flow used as an agent tool, which is not what closing an
-    API surface should mean. The protected-field floor still applies to those."""
+    API surface should mean. The protected-field floor still applies to those.
+
+    MCP is the exception, and deliberately so. An MCP client calling a flow as a tool
+    is an external caller, so its inputs travel the caller-facing run API and this
+    setting judges them. Under ``off`` an MCP tool call cannot pass inputs at all,
+    because inputs are the only thing it sends. Leave the deployment on ``permissive``
+    or ``declared`` if MCP tool calls have to keep working."""
     # Serving-plane end-user identity
     serving_end_user_header: str | None = None
     """Name of the trusted request header that carries the end-user identity on the serving plane

--- a/src/lfx/tests/unit/test_tweaks_policy.py
+++ b/src/lfx/tests/unit/test_tweaks_policy.py
@@ -213,6 +213,84 @@ def test_process_tweaks_permissive_leaves_a_normal_flow_working():
     assert result["data"]["nodes"][0]["data"]["node"]["template"]["a"]["value"] == "new"
 
 
+# --- runtime-generated tweaks are not caller overrides ---------------------
+# ``tweaks`` is also the internal mechanism for passing values into a sub-flow.
+# The Run Flow component pushes its own declared inputs through the graph path,
+# and the flow runner turns resolved load_from_db values into tweaks. Judging
+# those against the deployment policy would make ``off`` disable flow-as-tool
+# orchestration rather than close an API surface, which is not what an operator
+# flipping a tweaks policy is asking for.
+
+
+def test_off_does_not_refuse_runtime_generated_tweaks():
+    """``off`` closes the API surface, it does not disable the runtime."""
+    node = _node({"a": {"value": "old", "type": "str"}}, node_id="n1")
+    graph = _graph([node])
+    with patch("lfx.processing.process._resolve_tweak_policy", return_value="off"):
+        process_tweaks(graph, {"n1": {"a": "from-the-runtime"}}, caller_supplied=False)
+    assert graph["data"]["nodes"][0]["data"]["node"]["template"]["a"]["value"] == "from-the-runtime"
+
+
+def test_declared_does_not_refuse_runtime_generated_tweaks():
+    """A sub-flow allowlist constrains callers, not the component feeding it."""
+    node = _node(
+        {
+            "declared": {"value": "old", "type": "str", "api_editable": True},
+            "undeclared": {"value": "old", "type": "str"},
+        },
+        node_id="n1",
+    )
+    graph = _graph([node])
+    with patch("lfx.processing.process._resolve_tweak_policy", return_value="declared"):
+        process_tweaks(graph, {"n1": {"undeclared": "from-the-runtime"}}, caller_supplied=False)
+    assert graph["data"]["nodes"][0]["data"]["node"]["template"]["undeclared"]["value"] == "from-the-runtime"
+
+
+def test_runtime_generated_tweaks_still_hit_the_floor():
+    """The exemption covers the policy layer only. The floor never yields."""
+    graph = _graph(
+        [_node({"database_url": {"value": "stored", "type": "str"}}, node_type="SQLComponent", node_id="n1")]
+    )
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value="permissive"),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks(graph, {"n1": {"database_url": "postgresql://attacker/db"}}, caller_supplied=False)
+    assert exc.value.refused == ["database_url"]
+
+
+def test_off_still_refuses_a_caller_supplied_tweak():
+    """The exemption must not leak into the default caller path."""
+    graph = _graph([_node({"a": {"value": "old", "type": "str"}}, node_id="n1")])
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value="off"),
+        pytest.raises(TweakRefusedError),
+    ):
+        process_tweaks(graph, {"n1": {"a": "from-a-caller"}})
+
+
+def test_graph_path_exempts_runtime_generated_tweaks():
+    """The Run Flow component reaches a sub-flow through this path."""
+    from unittest.mock import MagicMock
+
+    from lfx.graph.vertex.base import Vertex
+    from lfx.processing.process import process_tweaks_on_graph
+
+    vertex = MagicMock(spec=Vertex)
+    vertex.id = "v1"
+    vertex.data = {"node": {"template": {"a": {"value": "old", "type": "str"}}}}
+    vertex.params = {}
+    vertex.load_from_db_fields = []
+
+    class _G:
+        vertices = [vertex]
+
+    with patch("lfx.processing.process._resolve_tweak_policy", return_value="off"):
+        process_tweaks_on_graph(_G(), {"v1": {"a": "from-the-runtime"}}, caller_supplied=False)
+
+    vertex.update_raw_params.assert_called_once_with({"a": "from-the-runtime"}, overwrite=True)
+
+
 # --- the graph-level path (streaming and background run modes) -------------
 # These modes build the graph first, so they land in process_tweaks_on_graph
 # rather than process_tweaks. Before the policy existed this path filtered only


### PR DESCRIPTION
Follow-up to #14538, which merged before these could be pushed onto it. Addresses the three findings from @Cristhianzl's review there.

## The one that matters

`tweaks` is not only a caller-facing API surface. It is also how the runtime passes values into a sub-flow: `RunFlowBaseComponent` builds its own declared inputs into tweaks and pushes them through `process_tweaks_on_graph`, and the flow runner turns resolved `load_from_db` values into tweaks.

Both were being judged against the deployment policy, so under `off` every one of them was refused and **the Run Flow component and every flow used as an agent tool stopped working**. Under `declared` the same happened on any sub-flow whose author declared an allowlist that did not name those fields.

`off` should mean "external callers cannot override fields". It should not mean "sub-flow orchestration is disabled", and the failure surfaced as a component error inside an agent run, far from the setting the operator flipped.

Both entry points now take `caller_supplied`, and runtime-generated tweaks resolve to `permissive`. This is the same reasoning that already exempts the injected `stream` key: the policy governs what a caller may override, and a value the runtime produced is not a caller overriding anything. **The protected-field floor still applies to them**, so nothing gets past the security guard either way.

The setting's docstring now says this, so an operator enabling `off` knows what it does and does not touch.

There are two ways into a sub-flow and both needed it. `RunFlowBaseComponent` hands over a prebuilt graph, so it goes through `process_tweaks_on_graph`. An agent calling a flow as a tool goes somewhere else entirely: the generated `flow_function` in `helpers/flow.py` builds tweaks from the tool's declared arguments and passes them to `load_flow`, which lands in `process_tweaks`. `CustomComponent.run_flow` shares that second route. Only the first was covered at first, so `off` still broke agent tool calls until the second commit here. No API route reaches that helper, so exempting it does not widen the caller-facing surface.

## The advanced-run route

`experimental_run_flow`, serving `POST /api/v1/run/advanced/{flow_id_or_name}`, is a third `process_tweaks` call site whose broad `except Exception` turned a refused tweak into a redacted 500 with a stack trace in the logs. That contradicted the setting's own promise of a 422 in every mode. It now re-raises like the other two, with a test posting a real request to that route.

## One predicate, not three

`_refused_tweak_names` decides refusals for the whole request, but both appliers re-derived the floor and the policy inline afterwards. In the two-pass flow those inline checks are unreachable, so a divergence would not have shown up in the policy tests. That is the same shape that produced the graph-path bypass #14538 fixed: two copies of a security predicate that drifted.

The appliers now delegate. The `logger.warning` calls moved into the predicate, which is the only place that knows whether the floor or the policy refused, so the log still distinguishes them.

## Verification

Each fix has a test that fails without it, confirmed by reverting the fix and watching it go red:

- removing the exemption fails the three runtime-generated cases with `Refused tweak keys ['a']: This deployment does not accept tweaks.`
- removing the advanced-run arm fails with `assert 500 == 422`

82 backend and 170 lfx tests pass, ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Advanced flow requests with refused tweaks now return a structured HTTP 422 response instead of a generic server error.
  - Prevented partial tweak application when protected or disallowed fields are detected.
  - Runtime-generated tweaks now apply correctly without bypassing protected-field safeguards.

- **Documentation**
  - Clarified tweak policy behavior for internally generated values.

- **Tests**
  - Added coverage for refused tweaks, runtime-generated values, deployment policies, and protected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
