### PR TITLE
fix(lfx): bootstrap and flush OTLP telemetry on the lfx run path

### DIFF
--- a/src/lfx/src/lfx/cli/run.py
+++ b/src/lfx/src/lfx/cli/run.py
@@ -1,5 +1,6 @@
 """CLI wrapper for the run command."""
 
+import asyncio
 import json
 from functools import partial
 from pathlib import Path
@@ -7,7 +8,7 @@ from pathlib import Path
 import typer
 from asyncer import syncify
 
-from lfx.observability import execution_protocol
+from lfx.observability import bootstrap_application_telemetry, execution_protocol
 from lfx.run.base import RunError, run_flow
 
 # Verbosity level constants
@@ -154,6 +155,14 @@ async def run(
     # Determine verbosity for output formatting
     verbosity = 3 if verbose_full else (2 if verbose_detailed else (1 if verbose else 0))
 
+    # Application observability for the one-shot surface. ``lfx serve`` and the langflow server
+    # install the OTLP providers from the standard OTEL_* environment variables at boot; this is
+    # the same call, made here because nothing else on this path makes it. Without it the
+    # ``flow.execute`` span the graph emits lands on OpenTelemetry's no-op proxy provider and is
+    # discarded, and an operator who wired ``lfx run`` (a cron job, a CI step, a batch worker)
+    # into their APM has a blind surface with no warning. A no-op when no endpoint is set, or
+    # when lfx was installed without the ``otel`` extra, so the default path costs nothing.
+    telemetry = bootstrap_application_telemetry()
     try:
         # The whole one-shot run happens inside this await, including the graph's own span.
         with execution_protocol("lfx.run"):
@@ -195,3 +204,11 @@ async def run(
             error_response["exception_message"] = str(e)
         typer.echo(json.dumps(error_response))
         raise typer.Exit(1) from e
+    finally:
+        # This process owns the telemetry lifetime, so it flushes on the way out: the span is
+        # sitting in the batch processor when the run ends, and the process exits right after.
+        # On every exit path, because a failed run's ``status=error`` span is the one an
+        # operator most needs to see. After the result has been echoed, so a consumer reading
+        # stdout is never held behind the export, which blocks on the network (up to the OTLP
+        # timeout when the collector is unreachable). Off the event loop for the same reason.
+        await asyncio.to_thread(telemetry.shutdown)

--- a/src/lfx/tests/unit/cli/test_run_command_flow_span.py
+++ b/src/lfx/tests/unit/cli/test_run_command_flow_span.py
@@ -7,6 +7,10 @@ drives the real command rather than that context manager, so a refactor that mov
 off the command's path is caught.
 
 Runs in a subprocess because the tracer provider is process-global and installed once.
+
+This installs its own in-memory provider, so it proves the attribute is bound on the right
+span and nothing about delivery. Whether the command installs a provider from the OTEL_* env
+vars and flushes it before the process exits is ``test_run_command_otlp_export.py``'s job.
 """
 
 import json

--- a/src/lfx/tests/unit/cli/test_run_command_otlp_export.py
+++ b/src/lfx/tests/unit/cli/test_run_command_otlp_export.py
@@ -27,8 +27,11 @@ from pathlib import Path
 import pytest
 
 # opentelemetry is an optional lfx extra (``lfx[otel]``); skip rather than error on an install
-# that did not opt in, matching the sibling probes.
-pytest.importorskip("opentelemetry")
+# that did not opt in, matching the sibling probes. Probed through the OTLP/HTTP trace exporter
+# rather than the bare ``opentelemetry`` namespace, which opentelemetry-api alone satisfies: this
+# file needs the exporter the command installs in the subprocess and the proto module the
+# collector decodes with, and the exporter import brings both (plus the SDK) or fails.
+pytest.importorskip("opentelemetry.exporter.otlp.proto.http.trace_exporter")
 from lfx.observability import APPLICATION_TRACER_NAME
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 

--- a/src/lfx/tests/unit/cli/test_run_command_otlp_export.py
+++ b/src/lfx/tests/unit/cli/test_run_command_otlp_export.py
@@ -1,0 +1,165 @@
+"""``lfx run`` must deliver its flow span over the production OTLP pipeline, not only label it.
+
+The sibling ``test_run_command_flow_span.py`` installs an in-memory tracer provider before it
+invokes the command, which proves the ``protocol`` attribute is bound on the right span. It
+cannot prove what an operator actually gets, which needs two things the command itself has to
+do: install the providers from ``OTEL_EXPORTER_OTLP_*`` and flush them before the one-shot
+process exits. Neither happened: the command never called
+:func:`lfx.observability.bootstrap_application_telemetry`, so the span landed on OpenTelemetry's
+no-op proxy provider and every ``lfx run`` wired into an APM was a silently blind surface.
+
+This drives the real console entry point in a subprocess, with the standard environment
+variables pointed at a loopback OTLP/HTTP collector, and reads the span off the protobuf that
+arrived. The batch processor's own export timer is pushed out to ten minutes, so the only thing
+that can deliver the span is the explicit flush on exit; a run that exported only because the
+timer happened to fire would not pass here.
+"""
+
+import gzip
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+# opentelemetry is an optional lfx extra (``lfx[otel]``); skip rather than error on an install
+# that did not opt in, matching the sibling probes.
+pytest.importorskip("opentelemetry")
+from lfx.observability import APPLICATION_TRACER_NAME
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+FLOW = Path(__file__).resolve().parents[2] / "data" / "simple_chat_no_llm.json"
+
+# A flow whose component raises, so the run ends with the error JSON and exit code 1. The span
+# for that run is the one an operator most needs delivered: it is the only record that a cron
+# job or CI step failed, and it must not be lost to a flush that only happens on success.
+FAILING_FLOW_SCRIPT = """
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.custom.custom_component.component import Component
+from lfx.graph import Graph
+from lfx.io import MessageInput, Output
+from lfx.schema.message import Message
+
+
+class ExplodingComponent(Component):
+    display_name = "Exploding"
+    inputs = [MessageInput(name="input_value", display_name="Input")]
+    outputs = [Output(name="message", display_name="Message", method="explode")]
+
+    def explode(self) -> Message:
+        msg = "inventory service returned 503"
+        raise RuntimeError(msg)
+
+
+chat_input = ChatInput()
+exploding = ExplodingComponent().set(input_value=chat_input.message_response)
+chat_output = ChatOutput().set(input_value=exploding.explode)
+graph = Graph(chat_input, chat_output)
+"""
+
+
+class _Collector(http.server.BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        self.server.requests.append((self.path, body))
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args) -> None:
+        pass
+
+
+@pytest.fixture
+def collector():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Collector)
+    server.requests = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
+def _run_cli(collector, *args: str) -> subprocess.CompletedProcess:
+    """Run ``lfx run`` exactly as an operator would, exporting to the loopback collector."""
+    # Start from a clean slate so the developer's own OTEL_* vars cannot skew the result.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{collector.server_address[1]}"
+    # Ten minutes: the span must arrive because the command flushed on exit, not because the
+    # batch processor's timer fired while the run was still going.
+    env["OTEL_BSP_SCHEDULE_DELAY"] = "600000"
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "lfx", "run", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+def _flow_spans(requests) -> list[dict]:
+    spans = []
+    for path, body in requests:
+        if path != "/v1/traces":
+            continue
+        request = ExportTraceServiceRequest()
+        request.ParseFromString(body)
+        for resource_spans in request.resource_spans:
+            for scope_spans in resource_spans.scope_spans:
+                for span in scope_spans.spans:
+                    if span.name != "flow.execute":
+                        continue
+                    spans.append(
+                        {
+                            "scope": scope_spans.scope.name,
+                            "attrs": {a.key: a.value.string_value for a in span.attributes},
+                        }
+                    )
+    return spans
+
+
+def _the_one_json_line(stdout: str) -> dict:
+    """The CLI's stdout contract: one JSON document, nothing else. Telemetry must not break it."""
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    assert len(lines) == 1, stdout
+    return json.loads(lines[0])
+
+
+def test_a_run_exports_its_flow_span_over_otlp(collector):
+    completed = _run_cli(collector, str(FLOW), "--input-value", "hello operator")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _the_one_json_line(completed.stdout)["success"] is True
+
+    spans = _flow_spans(collector.requests)
+    assert len(spans) == 1, f"expected exactly one flow span at the collector, got {spans}"
+    assert spans[0]["scope"] == APPLICATION_TRACER_NAME
+    assert spans[0]["attrs"]["protocol"] == "lfx.run"
+    assert spans[0]["attrs"]["status"] == "ok"
+
+
+def test_a_failed_run_still_exports_its_flow_span(collector, tmp_path):
+    # A file rather than inline JSON: Component.__init__ reads its own class source with
+    # inspect.getsource, which has nothing to read for a class defined in a ``-c`` string.
+    script = tmp_path / "failing_flow.py"
+    script.write_text(FAILING_FLOW_SCRIPT, encoding="utf-8")
+
+    completed = _run_cli(collector, str(script), "--input-value", "hello operator")
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert _the_one_json_line(completed.stdout)["success"] is False
+
+    spans = _flow_spans(collector.requests)
+    assert len(spans) == 1, f"expected exactly one flow span at the collector, got {spans}"
+    assert spans[0]["attrs"]["protocol"] == "lfx.run"
+    assert spans[0]["attrs"]["status"] == "error"
+    assert spans[0]["attrs"].get("error.type"), spans[0]["attrs"]

--- a/src/lfx/tests/unit/cli/test_run_command_telemetry_lifecycle.py
+++ b/src/lfx/tests/unit/cli/test_run_command_telemetry_lifecycle.py
@@ -1,0 +1,95 @@
+"""``lfx run`` owns the telemetry lifetime of its one-shot process, and the order is the point.
+
+The wire test next door (``test_run_command_otlp_export.py``) proves delivery end to end. This
+one pins the ordering cheaply, in-process and without OpenTelemetry installed: the providers
+must be bootstrapped before the run (a span created earlier lands on the no-op proxy provider
+and is gone), the protocol must be bound while the run executes, and the flush must happen
+after the run ends, on every exit path. A flush that only ran on success would lose exactly the
+span an operator most needs, the ``status=error`` one from the cron job that broke.
+"""
+
+from pathlib import Path
+
+import pytest
+import typer
+from lfx.cli.run import run
+from lfx.observability import get_execution_protocol
+from lfx.run.base import RunError
+
+
+class _RecordingTelemetry:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def shutdown(self) -> None:
+        self._events.append("shutdown")
+
+
+@pytest.fixture
+def events(monkeypatch):
+    """Record the order of bootstrap, run, and shutdown; ``run_flow`` itself is stubbed."""
+    recorded: list[str] = []
+
+    def fake_bootstrap(**_kwargs):
+        recorded.append("bootstrap")
+        return _RecordingTelemetry(recorded)
+
+    monkeypatch.setattr("lfx.cli.run.bootstrap_application_telemetry", fake_bootstrap)
+    return recorded
+
+
+def _invoke() -> None:
+    run(
+        script_path=Path("unused.json"),
+        input_value=None,
+        input_value_option="hello operator",
+        output_format="json",
+        flow_json=None,
+        stdin=False,
+    )
+
+
+def test_bootstrap_precedes_the_run_and_shutdown_follows_it(events, monkeypatch, capsys):
+    async def fake_run_flow(**_kwargs):
+        events.append(f"run_flow protocol={get_execution_protocol()}")
+        return {"result": "hello operator", "success": True}
+
+    monkeypatch.setattr("lfx.cli.run.run_flow", fake_run_flow)
+
+    _invoke()
+
+    assert events == ["bootstrap", "run_flow protocol=lfx.run", "shutdown"]
+    # The result is written before the flush, so a consumer reading stdout is never held
+    # behind the export.
+    assert '"success": true' in capsys.readouterr().out
+
+
+def test_a_failed_run_still_flushes(events, monkeypatch):
+    async def fake_run_flow(**_kwargs):
+        events.append("run_flow")
+        msg = "component exploded"
+        raise RunError(msg)
+
+    monkeypatch.setattr("lfx.cli.run.run_flow", fake_run_flow)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _invoke()
+
+    assert exc_info.value.exit_code == 1
+    assert events == ["bootstrap", "run_flow", "shutdown"]
+
+
+def test_an_unexpected_exception_still_flushes(events, monkeypatch):
+    """Not only the error the command knows how to report: anything that escapes the run."""
+
+    async def fake_run_flow(**_kwargs):
+        events.append("run_flow")
+        msg = "something the command did not anticipate"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("lfx.cli.run.run_flow", fake_run_flow)
+
+    with pytest.raises(RuntimeError):
+        _invoke()
+
+    assert events == ["bootstrap", "run_flow", "shutdown"]

--- a/src/lfx/tests/unit/cli/test_run_command_telemetry_lifecycle.py
+++ b/src/lfx/tests/unit/cli/test_run_command_telemetry_lifecycle.py
@@ -5,7 +5,9 @@ one pins the ordering cheaply, in-process and without OpenTelemetry installed: t
 must be bootstrapped before the run (a span created earlier lands on the no-op proxy provider
 and is gone), the protocol must be bound while the run executes, and the flush must happen
 after the run ends, on every exit path. A flush that only ran on success would lose exactly the
-span an operator most needs, the ``status=error`` one from the cron job that broke.
+span an operator most needs, the ``status=error`` one from the cron job that broke. The result is
+echoed before the flush, so a consumer reading stdout is never held behind the export; that is
+asserted as an ordering too, since a stdout check after the fact cannot tell the two apart.
 """
 
 from pathlib import Path
@@ -27,14 +29,21 @@ class _RecordingTelemetry:
 
 @pytest.fixture
 def events(monkeypatch):
-    """Record the order of bootstrap, run, and shutdown; ``run_flow`` itself is stubbed."""
+    """Record the order of bootstrap, run, echo, and shutdown; ``run_flow`` itself is stubbed."""
     recorded: list[str] = []
 
     def fake_bootstrap(**_kwargs):
         recorded.append("bootstrap")
         return _RecordingTelemetry(recorded)
 
+    original_echo = typer.echo
+
+    def recording_echo(*args, **kwargs):
+        recorded.append("echo")
+        return original_echo(*args, **kwargs)
+
     monkeypatch.setattr("lfx.cli.run.bootstrap_application_telemetry", fake_bootstrap)
+    monkeypatch.setattr("lfx.cli.run.typer.echo", recording_echo)
     return recorded
 
 
@@ -58,9 +67,9 @@ def test_bootstrap_precedes_the_run_and_shutdown_follows_it(events, monkeypatch,
 
     _invoke()
 
-    assert events == ["bootstrap", "run_flow protocol=lfx.run", "shutdown"]
-    # The result is written before the flush, so a consumer reading stdout is never held
-    # behind the export.
+    # The result is echoed before the flush, so a consumer reading stdout is never held behind
+    # the export.
+    assert events == ["bootstrap", "run_flow protocol=lfx.run", "echo", "shutdown"]
     assert '"success": true' in capsys.readouterr().out
 
 
@@ -76,7 +85,8 @@ def test_a_failed_run_still_flushes(events, monkeypatch):
         _invoke()
 
     assert exc_info.value.exit_code == 1
-    assert events == ["bootstrap", "run_flow", "shutdown"]
+    # The error JSON, too, is out before the flush.
+    assert events == ["bootstrap", "run_flow", "echo", "shutdown"]
 
 
 def test_an_unexpected_exception_still_flushes(events, monkeypatch):
@@ -92,4 +102,6 @@ def test_an_unexpected_exception_still_flushes(events, monkeypatch):
     with pytest.raises(RuntimeError):
         _invoke()
 
+    # Nothing is echoed for an exception the command does not know how to report; the flush
+    # still runs.
     assert events == ["bootstrap", "run_flow", "shutdown"]


### PR DESCRIPTION
## What

`lfx run` executes the flow but exports **zero telemetry**, even with `OTEL_EXPORTER_OTLP_ENDPOINT` set. The `OTEL_*` variables are read only by `bootstrap_application_telemetry()` (`src/lfx/src/lfx/observability.py`), which `lfx serve` (`cli/serve_app.py`) and the langflow server (`services/telemetry/opentelemetry.py`) call at boot — and the run command never did. `cli/run.py` only bound `execution_protocol("lfx.run")` around the await, so the `flow.execute` span the graph emits (correctly labelled since #14403) landed on OpenTelemetry's no-op proxy provider and was discarded. Any `lfx run` wired into an APM (cron jobs, CI steps, batch workers) was a blind surface with no warning — the silent-degradation class LE-1463 exists to eliminate.

Not a regression of #14613 (test-only): that PR's CLI probe installs an in-memory provider itself before invoking the command, which is why CI read the LE-1892 `lfx.run` cell as covered while it was red on the wire.

Reproduced on `release-1.12.0` tip (`4f3b9f3772`) with an isolated `lfx[otel]` venv (no langflow) and a loopback OTLP/HTTP collector: `lfx run tests/data/simple_chat_no_llm.json --input-value hello` → flow succeeds, **0 spans**; same command after a `bootstrap_application_telemetry()` call → `flow.execute{protocol=lfx.run, status=ok}` delivered. The missing bootstrap (and the missing exit flush) is the entire defect.

## Changes

**`src/lfx/src/lfx/cli/run.py`** — the one-shot command now owns its telemetry lifetime:
- `bootstrap_application_telemetry()` before the run: the same single entry point `lfx serve` and the langflow server use. No-op when no endpoint is set or lfx was installed without the `otel` extra, so the default path costs nothing.
- `telemetry.shutdown()` in a `finally` after the run, on **every** exit path — including `RunError → exit 1` — so a failed run's `status=error` span reaches the collector too. The result JSON is echoed *before* the flush, so a stdout consumer is never held behind the export; the flush runs via `asyncio.to_thread` (as in `lfx serve`'s lifespan), since the final export blocks on the network.
- stdout contract preserved: the lfx logger has no sink until `run_flow` configures it, so nothing from the bootstrap reaches stdout; SDK exporter diagnostics go to stderr.

**Tests** (`src/lfx/tests/unit/cli/`):
- `test_run_command_otlp_export.py` (new) — drives the real entry point (`python -m lfx run …`) in a subprocess with the standard env vars pointed at a loopback OTLP/HTTP collector and reads the span off the protobuf that arrived. `OTEL_BSP_SCHEDULE_DELAY=600000`, so only the exit flush can deliver it. Success path (`protocol=lfx.run`, `status=ok`, scope `langflow.observability`, stdout = exactly one JSON line) and failure path (exit 1, error JSON on stdout, `status=error` + `error.type`).
- `test_run_command_telemetry_lifecycle.py` (new) — in-process, no otel required: pins the order `bootstrap → run_flow (under protocol=lfx.run) → shutdown`, and that shutdown still runs on `RunError` and on an unexpected exception.
- `test_run_command_flow_span.py` — docstring now states it proves the protocol binding, not delivery, and points at the wire sibling.

## Test plan

- [x] Both new test files **fail on the unpatched tip** (`AssertionError: expected exactly one flow span at the collector, got []`) and pass with the fix
- [x] `test_run_command_otlp_export.py` + `test_run_command_telemetry_lifecycle.py` + `test_run_command_flow_span.py` + `test_run_command.py` + `tests/unit/test_observability.py` — **58 passed** (isolated `lfx[otel]` venv, Python 3.12, langflow not installed)
- [x] Broader in-process `lfx run` suites (`test_run_starter_projects*.py`, `test_run_real_flows.py`, `test_runtime_variables.py`) — identical results with and without the patch (30 pre-existing failures from bundle-dependent starter flows absent in the bundle-free venv; same set A/B)
- [x] Wire check with the real `lfx` console script: success run delivers `flow.execute{protocol=lfx.run, status=ok}` via the exit flush only (batch timer at 10 min; ~2s total; stdout/stderr clean); failing flow delivers `status=error, error.type=ComponentBuildError` with exit 1
- [x] ruff check / ruff format / pre-commit green
- [ ] CI — `make lfx_tests` syncs `--extra otel`, so the wire test runs there rather than skipping

## Notes

- `main` carries the identical `cli/run.py`, so this needs a forward-port after merge.
- Known trade-off, same as `lfx serve`/langflow shutdown: an unreachable collector delays process exit by the SDK's export retry window; tune with `OTEL_EXPORTER_OTLP_TIMEOUT`.
- Follow-up candidate, deliberately not in this PR: `lfx run` configures its logger inside `run_flow` (CRITICAL at default verbosity, and no sink at all before that), so the bootstrap's "OTLP trace export enabled …" / "install `lfx[otel]`" operator lines are not surfaced by `lfx run` the way `lfx serve` surfaces them. `lfx observability doctor` remains the CLI way to verify wiring.

Related: LE-1892 / LE-1861 / #14613 / #14403 / LE-1463.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry support to the `lfx run` command when telemetry export is configured.
  * Telemetry is reliably flushed after successful runs and failures.
  * Execution traces now capture the flow protocol and status.

* **Bug Fixes**
  * Improved telemetry delivery and shutdown handling across all command exit paths.
  * Preserved command output and exit codes for both successful and failed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->