### PR TITLE
fix(models): keep a restricted model visible and name it in the runtime error

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3289,7 +3289,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 194,
         "is_secret": false
       },
       {
@@ -3297,7 +3297,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "cb88e78a13f07467c3e44000869553e709ecd44f",
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 195,
         "is_secret": false
       },
       {
@@ -3305,7 +3305,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 242,
         "is_secret": false
       },
       {
@@ -3313,7 +3313,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
         "is_verified": false,
-        "line_number": 265,
+        "line_number": 273,
         "is_secret": false
       },
       {
@@ -3321,7 +3321,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29333d2356d5dd3aafb45a8614c6d825b6f58424",
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 275,
         "is_secret": false
       },
       {
@@ -3329,7 +3329,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "198b73ffd1a6d9c83101382c6df255edac0d3625",
         "is_verified": false,
-        "line_number": 274,
+        "line_number": 282,
         "is_secret": false
       },
       {
@@ -3337,7 +3337,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "51d69ae6046d2a3be245449d5b38165d5d78def5",
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 284,
         "is_secret": false
       },
       {
@@ -3345,7 +3345,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2e19560960addfd442570c5b2830afc1115cd3f0",
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -3353,7 +3353,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ad0cb64bb04fb2dd4e7072fca59f7f23eb025df9",
         "is_verified": false,
-        "line_number": 284,
+        "line_number": 292,
         "is_secret": false
       },
       {
@@ -3361,7 +3361,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c2d404cb7bad34de0af2136b8efa809ea96170fa",
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 294,
         "is_secret": false
       },
       {
@@ -3369,7 +3369,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4d5967896006c8a626ecef45e6312f6fc7d5b52f",
         "is_verified": false,
-        "line_number": 289,
+        "line_number": 297,
         "is_secret": false
       },
       {
@@ -3377,7 +3377,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2a2f556b3e73e091f1e21b95ae5bbca523ab1a2a",
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 298,
         "is_secret": false
       },
       {
@@ -3385,7 +3385,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1abaf3f0bb2d459a0fdefe08084901710603a6be",
         "is_verified": false,
-        "line_number": 302,
+        "line_number": 310,
         "is_secret": false
       },
       {
@@ -3393,7 +3393,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 433,
+        "line_number": 441,
         "is_secret": false
       },
       {
@@ -3401,7 +3401,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "c23d0f85d66cef95852d6a63811ab919de76b02a",
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 477,
         "is_secret": false
       },
       {
@@ -3409,7 +3409,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "76b33d23eee6aaa96f11abb4cbf1e5abd66aa46d",
         "is_verified": false,
-        "line_number": 574,
+        "line_number": 582,
         "is_secret": false
       },
       {
@@ -3417,7 +3417,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e9013532fd4966ed4b3aab1ae711b21f180e4c26",
         "is_verified": false,
-        "line_number": 575,
+        "line_number": 583,
         "is_secret": false
       },
       {
@@ -3425,7 +3425,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f16563f8a1751c141fd1c47148369ca1c380bb1",
         "is_verified": false,
-        "line_number": 614,
+        "line_number": 622,
         "is_secret": false
       },
       {
@@ -3433,7 +3433,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "2c4e1babc2d1448dfcfdd24fb92068644227d6f1",
         "is_verified": false,
-        "line_number": 707,
+        "line_number": 715,
         "is_secret": false
       },
       {
@@ -3441,7 +3441,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "7ce9180d54b399cafbe6515ca2ca4710a6b9554c",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 721,
         "is_secret": false
       },
       {
@@ -3449,7 +3449,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "924cf2c6cefbba9e88dc676bd2575b7f21f9661e",
         "is_verified": false,
-        "line_number": 720,
+        "line_number": 728,
         "is_secret": false
       },
       {
@@ -3457,7 +3457,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "9d6bd29f94e1e565bd5de8f44c875638b26e85b6",
         "is_verified": false,
-        "line_number": 721,
+        "line_number": 729,
         "is_secret": false
       },
       {
@@ -3465,7 +3465,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8e77e1ff96d9be727f25fc393a48f767935660db",
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1247,
         "is_secret": false
       },
       {
@@ -3473,7 +3473,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "4a7c565d4c4430e3bb8fa6c560125d5eb37e7c3d",
         "is_verified": false,
-        "line_number": 1485,
+        "line_number": 1493,
         "is_secret": false
       },
       {
@@ -3481,7 +3481,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "29538b53771fff5bad78e3a48a3a8f88c2f141d2",
         "is_verified": false,
-        "line_number": 1570,
+        "line_number": 1578,
         "is_secret": false
       },
       {
@@ -3489,7 +3489,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8d24e5afd2e9b40d21e4300c893a486aab979795",
         "is_verified": false,
-        "line_number": 1571,
+        "line_number": 1579,
         "is_secret": false
       },
       {
@@ -3497,7 +3497,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "ed05045c1666dd556d9a09f9eb6889f42a81aa5a",
         "is_verified": false,
-        "line_number": 1667,
+        "line_number": 1675,
         "is_secret": false
       },
       {
@@ -3505,7 +3505,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8f616a4d4abc959d505a5b83f1b3fa1a6bce6b2e",
         "is_verified": false,
-        "line_number": 1669,
+        "line_number": 1677,
         "is_secret": false
       },
       {
@@ -3513,7 +3513,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "1bbb8fd38e8fef4280c7218b961ae2ceeb83bbc9",
         "is_verified": false,
-        "line_number": 1670,
+        "line_number": 1678,
         "is_secret": false
       },
       {
@@ -3521,7 +3521,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "0b8eacdde75bb24c6f29adf660f50ca4d9846358",
         "is_verified": false,
-        "line_number": 1672,
+        "line_number": 1680,
         "is_secret": false
       },
       {
@@ -3529,7 +3529,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "8cde7462c1ce55676dc45124068d844ad3b86dcf",
         "is_verified": false,
-        "line_number": 1693,
+        "line_number": 1701,
         "is_secret": false
       },
       {
@@ -3537,7 +3537,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "afbf9aed8c22c3faf4d92dccadabe324d49bc5a8",
         "is_verified": false,
-        "line_number": 1926,
+        "line_number": 1936,
         "is_secret": false
       },
       {
@@ -3545,7 +3545,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "651f66f27bbfaed040c836e22515162e20c4fa0d",
         "is_verified": false,
-        "line_number": 1940,
+        "line_number": 1950,
         "is_secret": false
       },
       {
@@ -3553,7 +3553,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e38ef0e653c39ce1a4dde13da87333c43ced6cab",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2035,
         "is_secret": false
       },
       {
@@ -3561,7 +3561,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "044b852f30b636aa923b18a61a35c79abc87556f",
         "is_verified": false,
-        "line_number": 2331,
+        "line_number": 2342,
         "is_secret": false
       },
       {
@@ -3569,7 +3569,7 @@
         "filename": "src/frontend/src/locales/en.json",
         "hashed_secret": "e40123b4e7879a56fc22171a9ae637d418288daa",
         "is_verified": false,
-        "line_number": 2332,
+        "line_number": 2343,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-19T22:49:42Z"
+  "generated_at": "2026-08-21T15:00:35Z"
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.restricted-model.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.restricted-model.test.tsx
@@ -1,0 +1,254 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { BaseInputProps } from "@/components/core/parameterRenderComponent/types";
+import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
+import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import ModelInputComponent from "../index";
+import type { ModelInputComponentType, ModelOption } from "../types";
+
+Element.prototype.scrollIntoView = jest.fn();
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: () => ({ setErrorData: jest.fn() }),
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({
+    refreshAllModelInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("@/stores/flowStore", () => {
+  const state = {
+    getNode: jest.fn(),
+    setNode: jest.fn(),
+    setFilterEdge: jest.fn(),
+    setFilterType: jest.fn(),
+    nodes: [],
+    edges: [],
+  };
+  const hook = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  hook.getState = () => state;
+  return { __esModule: true, default: hook };
+});
+
+jest.mock("@/stores/typesStore", () => ({
+  useTypesStore: { getState: () => ({ data: {} }) },
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-model-providers", () => ({
+  useGetModelProviders: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/models/use-get-enabled-models", () => ({
+  useGetEnabledModels: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/nodes/use-post-template-value", () => ({
+  usePostTemplateValue: jest.fn(() => ({ mutateAsync: jest.fn() })),
+}));
+
+jest.mock("@/CustomNodes/helpers/mutate-template", () => ({
+  mutateTemplate: jest.fn(),
+}));
+
+jest.mock("@/modals/modelProviderModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className}>
+      {name}
+    </span>
+  ),
+}));
+
+jest.mock("@/components/common/loadingTextComponent", () => ({
+  __esModule: true,
+  default: ({ text }: { text: string }) => (
+    <span data-testid="loading-text">{text}</span>
+  ),
+}));
+
+const SAVED_MODEL: ModelOption = {
+  name: "claude-sonnet-5",
+  icon: "Anthropic",
+  provider: "Anthropic",
+  metadata: { model_type: "llm" },
+};
+
+const OPENAI_MODEL: ModelOption = {
+  name: "gpt-4o-mini",
+  icon: "OpenAI",
+  provider: "OpenAI",
+  metadata: { model_type: "llm" },
+};
+
+const baseProps: BaseInputProps & ModelInputComponentType = {
+  id: "test-model-input",
+  value: [SAVED_MODEL],
+  disabled: false,
+  handleOnNewValue: jest.fn(),
+  options: [OPENAI_MODEL],
+  placeholder: "Setup Provider",
+  nodeId: "test-node-id",
+  nodeClass: {
+    template: {
+      model: {
+        model_type: "language",
+        type: "",
+        required: false,
+        list: false,
+        show: false,
+        readonly: false,
+      },
+    },
+    description: "",
+    display_name: "",
+    documentation: "",
+  },
+  handleNodeClass: jest.fn(),
+  editNode: false,
+};
+
+const renderWithQueryClient = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,
+  );
+};
+
+const OPENAI_PROVIDER = {
+  provider: "OpenAI",
+  is_enabled: true,
+  is_configured: true,
+  icon: "OpenAI",
+  models: [{ model_name: "gpt-4o-mini", metadata: { model_type: "llm" } }],
+};
+
+/**
+ * An administrator hid the saved model after it was selected: the provider is
+ * still configured, but the model is filtered out of both the catalog and the
+ * enabled-models map (it is not reported as disabled — it is simply gone).
+ */
+const mockModelHiddenByPolicy = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [
+      {
+        provider: "Anthropic",
+        is_enabled: false,
+        is_configured: true,
+        icon: "Anthropic",
+        models: [],
+      },
+      OPENAI_PROVIDER,
+    ],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: {
+      enabled_models: { Anthropic: {}, OpenAI: { "gpt-4o-mini": true } },
+    },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
+/** The whole provider was revoked: it no longer appears in /models at all. */
+const mockProviderRevoked = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [OPENAI_PROVIDER],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: { enabled_models: { OpenAI: { "gpt-4o-mini": true } } },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
+describe("ModelInputComponent — saved model restricted after selection (LE-1960)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ["the model was hidden by policy", mockModelHiddenByPolicy],
+    ["the provider was revoked", mockProviderRevoked],
+  ])(
+    "keeps naming the saved model, flags it as not available, and never swaps the value when %s",
+    (_case, arrange) => {
+      arrange();
+      const handleOnNewValue = jest.fn();
+
+      renderWithQueryClient(
+        <ModelInputComponent
+          {...baseProps}
+          handleOnNewValue={handleOnNewValue}
+        />,
+      );
+
+      // The field still says which model it is set to — not "Select a model",
+      // and not the first model of some other provider.
+      expect(screen.getByText("claude-sonnet-5")).toBeInTheDocument();
+      expect(screen.queryByText("gpt-4o-mini")).not.toBeInTheDocument();
+      // ...and says why it cannot be used, aligned with the runtime error.
+      const marker = screen.getByTestId(`${baseProps.id}-unavailable`);
+      expect(marker).toHaveTextContent("Not available");
+      expect(marker).toHaveAttribute(
+        "title",
+        expect.stringContaining("restricted by an administrator"),
+      );
+      // The configure wrench belongs to "not enabled locally", not to this.
+      expect(
+        screen.queryByTestId(`${baseProps.id}-configure`),
+      ).not.toBeInTheDocument();
+      // The saved value is kept so lifting the restriction restores it.
+      expect(handleOnNewValue).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not flag a model that is still offered", () => {
+    (useGetModelProviders as jest.Mock).mockReturnValue({
+      data: [
+        {
+          provider: "Anthropic",
+          is_enabled: true,
+          is_configured: true,
+          icon: "Anthropic",
+          models: [
+            { model_name: "claude-sonnet-5", metadata: { model_type: "llm" } },
+          ],
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+    });
+    (useGetEnabledModels as jest.Mock).mockReturnValue({
+      data: { enabled_models: { Anthropic: { "claude-sonnet-5": true } } },
+      isLoading: false,
+      isFetching: false,
+    });
+
+    renderWithQueryClient(
+      <ModelInputComponent {...baseProps} options={[SAVED_MODEL]} />,
+    );
+
+    expect(screen.getByText("claude-sonnet-5")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${baseProps.id}-unavailable`),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.restricted-model.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.restricted-model.test.tsx
@@ -179,6 +179,20 @@ const mockProviderRevoked = () => {
   });
 };
 
+/** Nothing is offered to this user at all (an Enterprise install that starts closed). */
+const mockNoProvidersOffered = () => {
+  (useGetModelProviders as jest.Mock).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+  });
+  (useGetEnabledModels as jest.Mock).mockReturnValue({
+    data: { enabled_models: {} },
+    isLoading: false,
+    isFetching: false,
+  });
+};
+
 describe("ModelInputComponent — saved model restricted after selection (LE-1960)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -187,6 +201,7 @@ describe("ModelInputComponent — saved model restricted after selection (LE-196
   it.each([
     ["the model was hidden by policy", mockModelHiddenByPolicy],
     ["the provider was revoked", mockProviderRevoked],
+    ["no provider is offered at all", mockNoProvidersOffered],
   ])(
     "keeps naming the saved model, flags it as not available, and never swaps the value when %s",
     (_case, arrange) => {
@@ -211,10 +226,13 @@ describe("ModelInputComponent — saved model restricted after selection (LE-196
         "title",
         expect.stringContaining("restricted by an administrator"),
       );
-      // The configure wrench belongs to "not enabled locally", not to this.
+      // The configure wrench belongs to "not enabled locally", not to this,
+      // and the setup-provider call to action must not replace the field.
       expect(
         screen.queryByTestId(`${baseProps.id}-configure`),
       ).not.toBeInTheDocument();
+      expect(screen.queryByText("Setup Provider")).not.toBeInTheDocument();
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
       // The saved value is kept so lifting the restriction restores it.
       expect(handleOnNewValue).not.toHaveBeenCalled();
     },

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/__tests__/ModelInputComponent.test.tsx
@@ -883,13 +883,18 @@ describe("ModelInputComponent", () => {
       expect(screen.getByRole("combobox")).not.toBeDisabled();
     });
 
-    it("keeps a saved value whose model isn't enabled locally and renders the Configure wrench", async () => {
+    it("keeps a saved value whose provider is not offered at all and flags it as not available", async () => {
       // The backend's update_model_options_in_build_config injects the saved
       // value into options tagged with `not_enabled_locally: true` whenever
-      // it isn't in the user's enabled list. The frontend must:
+      // it isn't in the user's enabled list. Here the saved provider is absent
+      // from /models entirely — it is not offered to this user (not installed,
+      // or its approval was revoked), so there is no provider to configure.
+      // The frontend must:
       //   1. NOT auto-reset the saved value.
-      //   2. Keep the option visible/selectable in the dropdown.
-      //   3. Render the Configure wrench next to the trigger.
+      //   2. Keep naming the saved model in the trigger.
+      //   3. Say the model is not available instead of offering a Configure
+      //      wrench that opens a provider manager the provider is not in
+      //      (LE-1960 restricted messaging).
       mockedUseGetEnabledModels.mockReturnValue({
         data: {
           enabled_models: {
@@ -939,15 +944,39 @@ describe("ModelInputComponent", () => {
         expect(screen.getByText("ibm/granite-3")).toBeInTheDocument();
       });
 
-      // Configure wrench is rendered next to the trigger.
+      // The restriction is explained next to the name; no dead-end wrench.
       expect(
-        screen.getByTestId(`${defaultProps.id}-configure`),
-      ).toBeInTheDocument();
+        screen.getByTestId(`${defaultProps.id}-unavailable`),
+      ).toHaveTextContent("Not available");
+      expect(
+        screen.queryByTestId(`${defaultProps.id}-configure`),
+      ).not.toBeInTheDocument();
     });
 
-    it("opens the provider manager when the Configure wrench is clicked", async () => {
+    it("renders the Configure wrench for a provider that is offered but not yet configured", async () => {
+      // The saved provider IS in /models, awaiting credentials: that is the
+      // shape the Configure wrench exists for, and it opens the provider
+      // manager. Another provider is configured but has no enabled model, so
+      // there is nothing for the auto-select to swap the saved value for.
+      mockedUseGetModelProviders.mockReturnValue({
+        data: [
+          {
+            provider: "OpenAI",
+            is_enabled: false,
+            is_configured: true,
+            models: [{ model_name: "gpt-4", metadata: {} }],
+          },
+          {
+            provider: "IBM watsonx.ai",
+            is_enabled: false,
+            is_configured: false,
+            models: [{ model_name: "ibm/granite-3", metadata: {} }],
+          },
+        ],
+        isLoading: false,
+      });
       mockedUseGetEnabledModels.mockReturnValue({
-        data: { enabled_models: { OpenAI: { "gpt-4": true } } },
+        data: { enabled_models: { OpenAI: { "gpt-4": false } } },
         isLoading: false,
       });
 
@@ -976,7 +1005,9 @@ describe("ModelInputComponent", () => {
       renderWithQueryClient(
         <ModelInputComponent
           {...defaultProps}
-          options={optionsWithSticky}
+          options={optionsWithSticky.filter(
+            (option) => option.provider === "IBM watsonx.ai",
+          )}
           value={savedValue}
           handleOnNewValue={handleOnNewValue}
         />,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -69,7 +69,12 @@ const ModelTrigger = ({
   // administrator or removed from the catalog). Keep naming it, but say so.
   const isUnavailable = selectedModel?.metadata?.unavailable === true;
 
+  // A selected-but-unavailable model outranks the setup-provider call to
+  // action: replacing it with "Setup Provider" would hide both the saved
+  // selection and the reason it cannot be used (the footer still offers
+  // provider management).
   if (
+    !isUnavailable &&
     isSetupProviderState({
       hasEnabledProviders,
       showEmptyState,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -65,6 +65,9 @@ const ModelTrigger = ({
 
   // Check if we're in empty state mode (showEmptyState=true and no options)
   const isEmptyStateMode = showEmptyState && options.length === 0;
+  // The saved model is no longer offered to this user (restricted by an
+  // administrator or removed from the catalog). Keep naming it, but say so.
+  const isUnavailable = selectedModel?.metadata?.unavailable === true;
 
   if (
     isSetupProviderState({
@@ -157,6 +160,20 @@ const ModelTrigger = ({
                 </div>
               )}
             </span>
+            {!disabled && isUnavailable ? (
+              <span
+                data-testid={`${id}-unavailable`}
+                title={t("model.unavailableTitle")}
+                aria-label={t("model.unavailableTitle")}
+                className="inline-flex shrink-0 items-center gap-1 text-[11px] text-accent-amber-foreground"
+              >
+                <ForwardedIconComponent
+                  name="TriangleAlert"
+                  className="h-3.5 w-3.5"
+                />
+                {t("model.unavailable")}
+              </span>
+            ) : null}
           </span>
           <ForwardedIconComponent
             name={disabled ? "Lock" : "ChevronsUpDown"}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/saved-model-availability.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/saved-model-availability.test.ts
@@ -1,0 +1,109 @@
+import type { ModelProviderWithStatus } from "@/controllers/API/queries/models/use-get-model-providers";
+import type { ModelOption } from "../../types";
+import { isSavedModelUnavailable } from "../saved-model-availability";
+
+const saved: ModelOption = {
+  name: "claude-sonnet-5",
+  icon: "Anthropic",
+  provider: "Anthropic",
+  metadata: { model_type: "llm" },
+};
+
+const anthropic = (
+  overrides: Partial<ModelProviderWithStatus> = {},
+): ModelProviderWithStatus => ({
+  provider: "Anthropic",
+  is_enabled: true,
+  is_configured: true,
+  models: [{ model_name: "claude-sonnet-5", metadata: {} }],
+  ...overrides,
+});
+
+const openai: ModelProviderWithStatus = {
+  provider: "OpenAI",
+  is_enabled: true,
+  is_configured: true,
+  models: [{ model_name: "gpt-4o-mini", metadata: {} }],
+};
+
+const base = {
+  savedValue: saved,
+  providers: [anthropic(), openai],
+  enabledModels: { Anthropic: { "claude-sonnet-5": true } },
+  modelStatusIsReliable: true,
+};
+
+describe("isSavedModelUnavailable", () => {
+  it("is never judged while provider or enabled-model status is still settling", () => {
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        providers: [openai],
+        modelStatusIsReliable: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false while the saved model is still listed by its configured provider", () => {
+    expect(isSavedModelUnavailable(base)).toBe(false);
+  });
+
+  it("is true when the saved provider is no longer offered at all", () => {
+    // A revoked provider disappears from /models entirely for that user.
+    expect(isSavedModelUnavailable({ ...base, providers: [openai] })).toBe(
+      true,
+    );
+  });
+
+  it("is true when a configured provider stopped listing the model and the user's settings never heard of it", () => {
+    // Policy hid the model: it is filtered out of the catalog and out of
+    // enabled_models rather than reported as disabled.
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        providers: [anthropic({ models: [] }), openai],
+        enabledModels: { Anthropic: {}, OpenAI: { "gpt-4o-mini": true } },
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for a model the user deactivated in their own settings", () => {
+    // Deactivation keeps the model in enabled_models with `false`; that is the
+    // existing "swap to a valid model" path, not a restriction.
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        providers: [anthropic({ models: [] }), openai],
+        enabledModels: { Anthropic: { "claude-sonnet-5": false } },
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a disconnected provider, which keeps its configure affordance", () => {
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        providers: [anthropic({ is_configured: false, models: [] })],
+        enabledModels: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("cannot judge a legacy name-only value, an empty provider list, or a missing enabled-models map", () => {
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        savedValue: { ...saved, provider: "" },
+        providers: [openai],
+      }),
+    ).toBe(false);
+    expect(isSavedModelUnavailable({ ...base, providers: [] })).toBe(false);
+    expect(
+      isSavedModelUnavailable({
+        ...base,
+        providers: [openai],
+        enabledModels: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/saved-model-availability.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/__tests__/saved-model-availability.test.ts
@@ -53,6 +53,12 @@ describe("isSavedModelUnavailable", () => {
     expect(isSavedModelUnavailable({ ...base, providers: [openai] })).toBe(
       true,
     );
+    // ...including when no provider is offered to this user at all (an
+    // Enterprise install that starts closed): a settled empty list is a
+    // verdict, not a still-loading gap.
+    expect(
+      isSavedModelUnavailable({ ...base, providers: [], enabledModels: {} }),
+    ).toBe(true);
   });
 
   it("is true when a configured provider stopped listing the model and the user's settings never heard of it", () => {
@@ -89,7 +95,7 @@ describe("isSavedModelUnavailable", () => {
     ).toBe(false);
   });
 
-  it("cannot judge a legacy name-only value, an empty provider list, or a missing enabled-models map", () => {
+  it("cannot judge a legacy name-only value or a missing enabled-models map", () => {
     expect(
       isSavedModelUnavailable({
         ...base,
@@ -97,7 +103,6 @@ describe("isSavedModelUnavailable", () => {
         providers: [openai],
       }),
     ).toBe(false);
-    expect(isSavedModelUnavailable({ ...base, providers: [] })).toBe(false);
     expect(
       isSavedModelUnavailable({
         ...base,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/derive-selected-model.ts
@@ -2,6 +2,7 @@ import type { ModelProviderWithStatus } from "@/controllers/API/queries/models/u
 import type { ModelOption, SelectedModel } from "../types";
 import { matchesModelIdentity } from "./model-option-identity";
 import { recoverModelOption } from "./recover-model-option";
+import { isSavedModelUnavailable } from "./saved-model-availability";
 
 export interface DeriveSelectedModelParams {
   isConnectionMode: boolean;
@@ -19,6 +20,10 @@ export interface DeriveSelectedModelParams {
    * not-enabled-locally trigger.
    */
   providerStatusIsReliable: boolean;
+  /** The user's enabled-models map; lets a restricted model be told apart from a deactivated one. */
+  enabledModels?: Record<string, Record<string, boolean>>;
+  /** Whether `providers` AND `enabledModels` are settled; gates the unavailable branch. */
+  modelStatusIsReliable?: boolean;
 }
 
 /**
@@ -33,6 +38,8 @@ export function deriveSelectedModel({
   flatOptions,
   providers,
   providerStatusIsReliable,
+  enabledModels,
+  modelStatusIsReliable = false,
 }: DeriveSelectedModelParams): SelectedModel | null {
   if (isConnectionMode) {
     return {
@@ -54,6 +61,36 @@ export function deriveSelectedModel({
     matchesModelIdentity(option, saved),
   );
   if (match) return match;
+
+  // A model that is no longer offered at all (restricted by an administrator,
+  // removed from the catalog) keeps naming itself in the trigger, flagged so
+  // the trigger can explain why — showing flatOptions[0] here would present a
+  // model the field is not set to, and "Select a model" would hide the
+  // restriction entirely (LE-1960).
+  if (
+    saved &&
+    isSavedModelUnavailable({
+      savedValue,
+      providers,
+      enabledModels,
+      modelStatusIsReliable,
+    })
+  ) {
+    // Drop a backend-injected `not_enabled_locally` tag: that flag drives the
+    // "configure this provider" wrench, which has nothing to configure here.
+    const { not_enabled_locally: _notEnabledLocally, ...savedMetadata } =
+      saved.metadata ?? {};
+    return {
+      ...(saved.id && { id: saved.id }),
+      name: saved.name,
+      icon: saved.icon || "Bot",
+      provider: saved.provider || "Unknown",
+      metadata: {
+        ...savedMetadata,
+        unavailable: true,
+      },
+    } as SelectedModel;
+  }
 
   if (saved) {
     const savedProviderConfigured = providerStatusIsReliable

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/saved-model-availability.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/saved-model-availability.ts
@@ -39,13 +39,11 @@ export function isSavedModelUnavailable({
   enabledModels,
   modelStatusIsReliable,
 }: SavedModelAvailabilityParams): boolean {
-  if (
-    !modelStatusIsReliable ||
-    !providers ||
-    providers.length === 0 ||
-    enabledModels === undefined
-  ) {
+  if (!modelStatusIsReliable || !providers || enabledModels === undefined) {
     // Nothing can be judged unavailable until both server views have loaded.
+    // A settled, empty provider list is a verdict, not a gap: no provider is
+    // offered to this user at all, so a saved one is unavailable like any
+    // other missing provider.
     return false;
   }
   const saved = recoverModelOption(savedValue);

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/saved-model-availability.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/helpers/saved-model-availability.ts
@@ -1,0 +1,78 @@
+import type { ModelProviderWithStatus } from "@/controllers/API/queries/models/use-get-model-providers";
+import type { ModelOption } from "../types";
+import { recoverModelOption } from "./recover-model-option";
+
+type EnabledModels = Record<string, Record<string, boolean>>;
+
+export interface SavedModelAvailabilityParams {
+  savedValue: ModelOption | undefined;
+  providers: ModelProviderWithStatus[] | undefined;
+  enabledModels: EnabledModels | undefined;
+  /**
+   * Whether both the provider list and the enabled-models map reflect settled
+   * server state. While it is false nothing can be judged unavailable — a
+   * mid-flight fetch must not be read as "the saved model is gone".
+   */
+  modelStatusIsReliable: boolean;
+}
+
+/**
+ * Whether a saved model is no longer offered to this user at all — as opposed
+ * to merely not enabled locally (provider present but unconfigured, or the
+ * model deactivated in the user's own settings).
+ *
+ * Two shapes count as unavailable, and both are what an administrator
+ * restriction looks like from the builder's seat (LE-1960):
+ *
+ * - the saved provider is missing from the provider list entirely — it was
+ *   never offered to this user, or its approval was revoked;
+ * - the saved provider is configured, but its catalog no longer lists the
+ *   model and the user's enabled-models map has never heard of it — a model
+ *   hidden by policy, removed from the catalog, or no longer served live.
+ *
+ * The caller decides what to do with the answer: keep the saved value (never
+ * silently swap it for another model) and explain the state in the trigger.
+ */
+export function isSavedModelUnavailable({
+  savedValue,
+  providers,
+  enabledModels,
+  modelStatusIsReliable,
+}: SavedModelAvailabilityParams): boolean {
+  if (
+    !modelStatusIsReliable ||
+    !providers ||
+    providers.length === 0 ||
+    enabledModels === undefined
+  ) {
+    // Nothing can be judged unavailable until both server views have loaded.
+    return false;
+  }
+  const saved = recoverModelOption(savedValue);
+  if (!saved?.name || !saved.provider) {
+    // Legacy name-only values carry no provider to judge against.
+    return false;
+  }
+
+  const providerInfo = providers.find(
+    (provider) => provider.provider === saved.provider,
+  );
+  if (!providerInfo) {
+    return true;
+  }
+  if (providerInfo.is_configured !== true) {
+    // Unconfigured / disconnected providers keep their existing
+    // "configure the provider" affordance.
+    return false;
+  }
+  const listedInCatalog = (providerInfo.models ?? []).some(
+    (model) => model.model_name === saved.name,
+  );
+  if (listedInCatalog) {
+    return false;
+  }
+  const knownToUserSettings =
+    enabledModels?.[saved.provider] !== undefined &&
+    Object.hasOwn(enabledModels[saved.provider], saved.name);
+  return !knownToUserSettings;
+}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/__tests__/useAutoSelectModel.test.ts
@@ -84,3 +84,51 @@ describe("useAutoSelectModel", () => {
     expect(handleOnNewValue).not.toHaveBeenCalled();
   });
 });
+
+describe("useAutoSelectModel — restricted saved model (LE-1960)", () => {
+  const GRANITE = {
+    name: "granite-4-h-small",
+    provider: "IBM WatsonX",
+    icon: "IBMWatsonx",
+    metadata: {},
+  };
+  const RESTRICTED_PROVIDERS = [
+    { provider: "Anthropic", is_configured: true, is_enabled: true },
+    // Configured, but the saved model is neither listed nor known to the
+    // user's enabled-models map: an administrator hid it.
+    {
+      provider: "IBM WatsonX",
+      is_configured: true,
+      is_enabled: true,
+      models: [],
+    },
+  ] as never;
+
+  it("keeps a saved model that is no longer offered instead of swapping it silently", () => {
+    const handleOnNewValue = renderAutoSelect({
+      flatOptions: [ANTHROPIC, OPENAI],
+      value: [GRANITE],
+      providers: RESTRICTED_PROVIDERS,
+      enabledModels: { Anthropic: { "claude-opus-5": true } },
+    });
+
+    expect(handleOnNewValue).not.toHaveBeenCalled();
+  });
+
+  it("still replaces a model the user merely deactivated", () => {
+    const handleOnNewValue = renderAutoSelect({
+      flatOptions: [ANTHROPIC, OPENAI],
+      value: [GRANITE],
+      providers: RESTRICTED_PROVIDERS,
+      enabledModels: {
+        Anthropic: { "claude-opus-5": true },
+        "IBM WatsonX": { "granite-4-h-small": false },
+      },
+    });
+
+    expect(handleOnNewValue).toHaveBeenCalledTimes(1);
+    expect(handleOnNewValue.mock.calls[0][0].value[0].name).toBe(
+      "claude-opus-5",
+    );
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
 import type { ModelProviderWithStatus } from "@/controllers/API/queries/models/use-get-model-providers";
 import { matchesModelIdentity } from "../helpers/model-option-identity";
+import { isSavedModelUnavailable } from "../helpers/saved-model-availability";
 import type { ModelOption } from "../types";
 
 export interface UseAutoSelectModelParams {
@@ -16,12 +17,17 @@ export interface UseAutoSelectModelParams {
    * fetch must not be read as "the saved model is gone".
    */
   modelStatusIsReliable: boolean;
+  /** The user's enabled-models map; a model absent from it (and from the catalog) is restricted, not stale. */
+  enabledModels?: Record<string, Record<string, boolean>>;
 }
 
 /**
  * Replaces a saved value that went stale — its provider is known but no longer
  * offers the model, whether it was disconnected or the model deactivated. An
- * empty value is left empty (LE-2168). Extracted from ModelInputComponent
+ * empty value is left empty (LE-2168). A model that is no longer offered at
+ * all — restricted by an administrator or removed from the catalog — is left
+ * in place too, so the restriction stays visible instead of being papered
+ * over by a silent swap (LE-1960). Extracted from ModelInputComponent
  * (LE-1736 W24).
  */
 export function useAutoSelectModel({
@@ -31,6 +37,7 @@ export function useAutoSelectModel({
   isConnectionMode,
   providers,
   modelStatusIsReliable,
+  enabledModels,
 }: UseAutoSelectModelParams): void {
   useEffect(() => {
     if (
@@ -53,7 +60,13 @@ export function useAutoSelectModel({
       // disconnected or the model deactivated; an unknown one we cannot judge.
       if (!inOptions && saved.provider) {
         isSavedValueStale =
-          providers?.some((p) => p.provider === saved.provider) ?? false;
+          (providers?.some((p) => p.provider === saved.provider) ?? false) &&
+          !isSavedModelUnavailable({
+            savedValue: saved,
+            providers,
+            enabledModels,
+            modelStatusIsReliable,
+          });
       }
     }
 
@@ -79,5 +92,6 @@ export function useAutoSelectModel({
     isConnectionMode,
     providers,
     modelStatusIsReliable,
+    enabledModels,
   ]);
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -222,6 +222,8 @@ export default function ModelInputComponent({
         flatOptions,
         providers: providersData,
         providerStatusIsReliable,
+        enabledModels: enabledModelsData?.enabled_models,
+        modelStatusIsReliable,
       }),
     [
       value,
@@ -230,6 +232,8 @@ export default function ModelInputComponent({
       externalOptions,
       providersData,
       providerStatusIsReliable,
+      enabledModelsData,
+      modelStatusIsReliable,
     ],
   );
 
@@ -240,6 +244,7 @@ export default function ModelInputComponent({
     isConnectionMode,
     providers: providersData,
     modelStatusIsReliable,
+    enabledModels: enabledModelsData?.enabled_models,
   });
 
   /**

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -1736,6 +1736,8 @@
   "node.incompatibleWith": "Incompatible with",
   "model.configureProvider": "Configure this model's provider",
   "model.notEnabledTitle": "This model isn't enabled for your user. Click to configure its provider.",
+  "model.unavailable": "Not available",
+  "model.unavailableTitle": "This model is not available: it may have been restricted by an administrator or removed from the catalog. Select another model or ask an administrator to enable it.",
   "multiselect.textPrefix": "Text:",
   "knowledge.columnNameDescription": "Name of the column in the source DataFrame",
   "knowledge.columnEmbeddingDescription": "Create embeddings for this column",

--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -857,13 +857,32 @@ class ErrorMessage(Message):
     """A message class specifically for error messages with predefined error-specific attributes."""
 
     @staticmethod
+    def _coded_exception_message(exception: BaseException) -> str | None:
+        """Return the human-readable message of an exception that also carries a ``code``.
+
+        Reason-coded errors (for example ``ModelProviderPolicyError`` with
+        ``code="policy_blocked"``) raise with a message meant for the person
+        reading the error panel. Rendering only ``Code: policy_blocked`` --
+        prefixed by the Python class name -- told builders nothing about what
+        was blocked or who to ask.
+        """
+        args = getattr(exception, "args", ())
+        if args and isinstance(args[0], str) and args[0].strip():
+            return args[0].strip()
+        return None
+
+    @staticmethod
     def _format_markdown_reason(exception: BaseException) -> str:
         """Format the error reason with markdown formatting."""
         reason = f"**{exception.__class__.__name__}**\n"
         if hasattr(exception, "body") and isinstance(exception.body, dict) and "message" in exception.body:
             reason += f" - **{exception.body.get('message')}**\n"
         elif hasattr(exception, "code"):
-            reason += f" - **Code: {exception.code}**\n"
+            message = ErrorMessage._coded_exception_message(exception)
+            if message:
+                reason = f"**{message}**\n - **Code: {exception.code}**\n"
+            else:
+                reason += f" - **Code: {exception.code}**\n"
         elif hasattr(exception, "args") and exception.args:
             reason += f" - **Details: {exception.args[0]}**\n"
         elif isinstance(exception, ValidationError):
@@ -880,7 +899,8 @@ class ErrorMessage(Message):
         elif hasattr(exception, "_message"):
             reason = f"{exception._message()}\n" if callable(exception._message) else f"{exception._message}\n"  # noqa: SLF001
         elif hasattr(exception, "code"):
-            reason = f"Code: {exception.code}\n"
+            message = ErrorMessage._coded_exception_message(exception)
+            reason = f"{message}\n" if message else f"Code: {exception.code}\n"
         elif hasattr(exception, "args") and exception.args:
             reason = f"{exception.args[0]}\n"
         elif isinstance(exception, ValidationError):

--- a/src/lfx/src/lfx/services/model_provider_policy/base.py
+++ b/src/lfx/src/lfx/services/model_provider_policy/base.py
@@ -135,11 +135,17 @@ class ModelProviderPolicyError(PermissionError):
         self.provider_id = provider_id
         self.purpose = purpose
         self.model_name = model_name
-        message = (
-            "The requested model is not available"
-            if model_name is not None
-            else "The requested model provider is not available"
-        )
+        # The message is what builders read in the Playground error panel
+        # (rendered by ``ErrorMessage``), so name the blocked model and point
+        # at the governance owner instead of exposing only a reason code.
+        if model_name is not None:
+            message = (
+                f"The requested model is not available: {model_name!r} ({provider_id}) "
+                "is blocked by the current model provider policy. "
+                "Ask an administrator to enable it."
+            )
+        else:
+            message = "The requested model provider is not available"
         super().__init__(message)
 
 

--- a/src/lfx/tests/unit/schema/test_message_content_blocks.py
+++ b/src/lfx/tests/unit/schema/test_message_content_blocks.py
@@ -496,6 +496,30 @@ class TestBackwardsCompatibility:
         error_contents = [c for c in error_blocks[0].contents if isinstance(c, ErrorContent)]
         assert len(error_contents) == 1
 
+    def test_error_message_renders_reason_coded_exception_message(self):
+        """A reason-coded error shows its human message, not just the class name and code."""
+        from lfx.services.model_provider_policy import ModelProviderPolicyError, ModelProviderPolicyPurpose
+
+        exc = ModelProviderPolicyError("anthropic", ModelProviderPolicyPurpose.USE, model_name="claude-sonnet-5")
+        err_msg = ErrorMessage(exception=exc)
+
+        assert err_msg.text == str(exc) + "\n"
+        [error_block] = [block for block in err_msg.content_blocks if isinstance(block, ContentBlock)]
+        [error_content] = [content for content in error_block.contents if isinstance(content, ErrorContent)]
+        assert error_content.reason == f"**{exc}**\n - **Code: policy_blocked**\n"
+        assert "ModelProviderPolicyError" not in error_content.reason
+
+    def test_error_message_keeps_code_only_rendering_for_messageless_coded_errors(self):
+        class CodedError(Exception):
+            code = "rate_limited"
+
+        err_msg = ErrorMessage(exception=CodedError())
+
+        assert err_msg.text == "Code: rate_limited\n"
+        [error_block] = [block for block in err_msg.content_blocks if isinstance(block, ContentBlock)]
+        [error_content] = [content for content in error_block.contents if isinstance(content, ErrorContent)]
+        assert error_content.reason == "**CodedError**\n - **Code: rate_limited**\n"
+
     def test_error_message_can_omit_active_exception_traceback(self):
         """Public/delegated errors keep a generic reason without the caught traceback."""
         sensitive_detail = "owner-provider-secret"

--- a/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
+++ b/src/lfx/tests/unit/services/model_provider_policy/test_policy.py
@@ -1124,7 +1124,10 @@ def test_require_model_raises_generic_reason_coded_error():
     assert exc_info.value.code == "policy_blocked"
     assert exc_info.value.provider_id == "anthropic"
     assert exc_info.value.model_name == "claude-blocked"
-    assert str(exc_info.value) == "The requested model is not available"
+    assert str(exc_info.value) == (
+        "The requested model is not available: 'claude-blocked' (anthropic) is blocked by the "
+        "current model provider policy. Ask an administrator to enable it."
+    )
 
 
 def test_require_model_still_reports_denied_provider_without_model_detail():


### PR DESCRIPTION
## Summary

Builder-side half of the model provider governance QA findings (LE-1960 AC "show restricted messaging when a previously-selected model belongs to a now-blocked provider"; Enterprise QA BUG-02 / BUG-03). The Enterprise admin-side fixes are in the companion WatsonOrchestrate/IBM-Langflow PR.

### What was wrong

- **BUG-02** — when an administrator hid a model after it was selected (model allowlist, or the whole provider revoked), the Language Model field read **"Select a model"** — or named the first model of some other provider — with no hint that a policy removed it, and with other models enabled `useAutoSelectModel` silently **swapped the saved value** for one of them on the next load.
- **BUG-03** — running the flow showed `ModelProviderPolicyError Code: policy_blocked` in the Playground: the Python class name and a reason code, nothing about which model was blocked or who to ask, even though the error already carries a human message.

### What changes

**Frontend — `ModelInputComponent`**
- New pure helper `isSavedModelUnavailable` distinguishes *restricted / no longer offered* from *not enabled locally* and *deactivated*: the saved provider is absent from `/models` entirely, **or** it is configured but neither its catalog nor the user's `enabled_models` map knows the model. Nothing is judged until both server views have settled, and a disconnected provider / a model the user deactivated themselves keep today's behaviour.
- `deriveSelectedModel` keeps naming the saved model and flags it `metadata.unavailable` instead of falling back to `flatOptions[0]`; `ModelTrigger` renders a **"Not available"** marker (`<id>-unavailable`) whose title aligns with the runtime error copy. A backend-injected `not_enabled_locally` tag is dropped on that branch so the configure wrench — which has nothing to configure — does not render.
- `useAutoSelectModel` no longer replaces a restricted model, so lifting the restriction restores the selection.
- Two legacy tests modelled "not enabled locally" with a provider that is absent from `/models`; under the new rule that shape is "not offered at all" and now reads as *Not available*. They were updated, and a new positive wrench test uses the shape the wrench exists for (provider present, awaiting credentials).

**Backend — lfx**
- `ModelProviderPolicyError` for a blocked **model** now reads `The requested model is not available: 'claude-sonnet-5' (anthropic) is blocked by the current model provider policy. Ask an administrator to enable it.` The provider-level message is unchanged (it is pinned by a number of MCP flow-builder tests and surfaced via the voice-mode socket).
- `ErrorMessage` renders the human message of a reason-coded exception (`**message**` + `Code: …`) instead of the class name and `Code: …` alone, for both the markdown reason and the plain text. Coded exceptions without a message keep the previous rendering.

## Test plan

- [x] `jest` — `modelInputComponent/**` (13 suites, 136 tests incl. new `saved-model-availability.test.ts`, `ModelInputComponent.restricted-model.test.tsx`, 2 new `useAutoSelectModel` cases), `modals/modelProviderModal`, `parameterRenderComponent/__tests__/aria-labelledby` — all green; biome clean on the touched files.
- [x] lfx — `tests/unit/schema/test_message_content_blocks.py` (+2 new), `tests/unit/services/model_provider_policy/test_policy.py` — 116 passed in an lfx-only venv.
- [x] backend — `tests/unit/test_build_error_session_id.py`, `tests/unit/api/v1/test_voice_mode_flow_authz.py` — 11 passed.
- [ ] Manual: with Enterprise governance (or OSS `blocked_model_keys`), select a model, block it, reload the flow → field still names the model with the "Not available" marker, value not overwritten; run → Playground shows the model-named message instead of `ModelProviderPolicyError Code: policy_blocked`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Saved models that are removed, restricted, or no longer offered remain selected and are clearly marked as unavailable.
  - Added warning details explaining when a model is restricted by an administrator or removed from the catalog.
  - Available alternatives are no longer selected automatically when a saved model is administratively restricted.

- **Bug Fixes**
  - Improved handling of unavailable model providers and user-disabled models.
  - Error messages now include clearer details about blocked models and providers, including guidance to request administrator enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->