### PR TITLE
fix(a11y): settings actions reachable at 320px, pointer targets at the 24px minimum

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
@@ -336,8 +336,10 @@ export default function InputComponent({
           type="button"
           aria-label={pwdVisible ? "Hide password" : "Show password"}
           aria-pressed={pwdVisible}
+          // w-6 + centering gives the toggle the 24px minimum target width
+          // (WCAG 2.5.8); mr-2.5 keeps the 20px icon where mr-3 put it.
           className={classNames(
-            "mb-px mr-3 p-0",
+            "mb-px mr-2.5 flex w-6 items-center justify-center p-0",
             editNode
               ? "input-component-true-button"
               : "input-component-false-button",

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -62,7 +62,6 @@ const externalLinkIconClasses = {
   icon: "icons-parameters-comp absolute right-3 h-4 w-4 shrink-0",
   editNodeTop: "top-[-1.4rem] h-5",
   normalTop: "top-[-2.1rem] h-7",
-  iconTop: "top-[-1.7rem]",
 };
 
 export default function TextAreaComponent({

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -236,16 +236,21 @@ export default function TextAreaComponent({
             onClick={() => changeWebhookFormat("multiline")}
             aria-label={t("input.expandTextEditor")}
             className={cn(
-              // `before:` pseudo-element pads the touch target out to the
-              // WCAG 2.5.8 minimum (24x24) without resizing the visible
-              // icon or shifting its position. The button is already
-              // `position: absolute` (via externalLinkIconClasses.icon),
-              // which is enough to anchor the pseudo-element.
-              "flex items-center justify-center before:absolute before:-inset-1 before:content-['']",
+              "flex items-center justify-center",
               externalLinkIconClasses.icon,
               editNode
-                ? externalLinkIconClasses.editNodeTop
-                : externalLinkIconClasses.iconTop,
+                ? // `before:` pseudo-element pads the touch target out to the
+                  // WCAG 2.5.8 minimum (24x24) without resizing the compact
+                  // edit-node layout; the button is `position: absolute` (via
+                  // externalLinkIconClasses.icon), which anchors the pseudo.
+                  cn(
+                    externalLinkIconClasses.editNodeTop,
+                    "before:absolute before:-inset-1 before:content-['']",
+                  )
+                : // Real 24x24 box (WCAG 2.5.8) — rect-based checkers don't
+                  // count pseudo-element hit areas. The offsets keep the 16px
+                  // icon exactly where the old right-3/top-[-1.7rem] box put it.
+                  "right-2 top-[-1.95rem] h-6 w-6",
             )}
           >
             {renderIcon()}

--- a/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx
@@ -156,7 +156,15 @@ const ModelProvidersContent = ({
           requiresConfiguration={requiresConfiguration}
         />
 
-        <div className="relative flex min-h-0 flex-1 flex-col">
+        {/* hidden while collapsed: the padded scroller inside has intrinsic
+            width, so it would stick out of the w-0 column and register as
+            clipped content at a 320px viewport (WCAG 1.4.10). */}
+        <div
+          className={cn(
+            "relative flex min-h-0 flex-1 flex-col",
+            !syncedSelectedProvider && "hidden",
+          )}
+        >
           <div className="flex h-full flex-col gap-3 overflow-y-auto px-4 pt-4 pb-6 transition-all duration-300 ease-in-out">
             <CustomModelProvidersEmptyState
               kind="models"

--- a/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
@@ -69,7 +69,9 @@ export default function MCPServersPage() {
 
   return (
     <div className="flex h-full w-full flex-col gap-6">
-      <div className="flex w-full items-start justify-between gap-6">
+      {/* flex-wrap: at narrow viewports (WCAG 1.4.10, 320px) the action
+          button drops below the title instead of clipping off-screen. */}
+      <div className="flex w-full flex-wrap items-start justify-between gap-x-6 gap-y-2">
         <div className="flex flex-col">
           <h2
             className="flex items-center text-lg font-semibold tracking-tight"
@@ -125,9 +127,11 @@ export default function MCPServersPage() {
                     key={server.name}
                     className="flex items-center justify-between rounded-lg px-3 py-2 shadow-sm transition-colors hover:bg-accent"
                   >
-                    <div className="flex items-center gap-2">
+                    {/* min-w-0 + wrap: long unbreakable server names must not
+                        push the row (and its menu button) past the viewport. */}
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
                       <span
-                        className="text-sm font-medium"
+                        className="min-w-0 break-words text-sm font-medium"
                         data-testid={"mcp_server_name_" + index}
                       >
                         {server.name}

--- a/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
@@ -158,7 +158,9 @@ export default function McpClientPage() {
                 // move within the tablist.
                 tabIndex={isSelected ? 0 : -1}
                 className={cn(
-                  "flex h-6 flex-row items-end gap-2 text-nowrap border-b-2 border-b-transparent px-3 py-2 text-[13px] font-medium",
+                  // No fixed height: the icon/text used to overflow the h-6
+                  // box invisibly, and the scrollable tablist would clip it.
+                  "flex flex-row items-end gap-2 text-nowrap border-b-2 border-b-transparent px-3 py-2 text-[13px] font-medium",
                   isSelected
                     ? "border-b-2 border-black dark:border-b-white"
                     : "text-muted-foreground hover:text-foreground",

--- a/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
@@ -135,9 +135,11 @@ export default function McpClientPage() {
         <div
           role="tablist"
           aria-label={t("settings.mcpClient.agentTablistLabel")}
-          // flex-wrap: tab labels are text-nowrap, so at a 320px viewport the
-          // last tab would clip off-screen instead of wrapping (WCAG 1.4.10).
-          className="flex flex-row flex-wrap justify-start border-b border-border"
+          // overflow-x-auto: tab labels are text-nowrap, so at a 320px
+          // viewport the last tab would clip off-screen with no way to reach
+          // it (WCAG 1.4.10); a scrollable strip keeps every tab reachable
+          // without wrapping the underline row.
+          className="flex flex-row justify-start overflow-x-auto border-b border-border"
         >
           {agents.map((agent, index) => {
             const isSelected = selectedAgent === agent.id;

--- a/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
@@ -135,7 +135,9 @@ export default function McpClientPage() {
         <div
           role="tablist"
           aria-label={t("settings.mcpClient.agentTablistLabel")}
-          className="flex flex-row justify-start border-b border-border"
+          // flex-wrap: tab labels are text-nowrap, so at a 320px viewport the
+          // last tab would clip off-screen instead of wrapping (WCAG 1.4.10).
+          className="flex flex-row flex-wrap justify-start border-b border-border"
         >
           {agents.map((agent, index) => {
             const isSelected = selectedAgent === agent.id;

--- a/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/McpClientPage/index.tsx
@@ -160,7 +160,9 @@ export default function McpClientPage() {
                 className={cn(
                   // No fixed height: the icon/text used to overflow the h-6
                   // box invisibly, and the scrollable tablist would clip it.
-                  "flex flex-row items-end gap-2 text-nowrap border-b-2 border-b-transparent px-3 py-2 text-[13px] font-medium",
+                  // Inset focus outline: the tab fills the scroll container's
+                  // padding box, so the global +2px outline would be clipped.
+                  "flex flex-row items-end gap-2 text-nowrap border-b-2 border-b-transparent px-3 py-2 text-[13px] font-medium focus-visible:-outline-offset-2",
                   isSelected
                     ? "border-b-2 border-black dark:border-b-white"
                     : "text-muted-foreground hover:text-foreground",

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/index.tsx
@@ -68,8 +68,10 @@ export default function ShortcutsPage() {
 
   return (
     <div className="flex h-full w-full flex-col gap-6">
-      <div className="flex w-full items-start justify-between gap-6">
-        <div className="flex w-full flex-col">
+      {/* flex-wrap (and no w-full on the title column): at narrow viewports
+          (WCAG 1.4.10, 320px) the Restore button wraps instead of clipping. */}
+      <div className="flex w-full flex-wrap items-start justify-between gap-x-6 gap-y-2">
+        <div className="flex flex-col">
           <h2
             className="flex items-center text-lg font-semibold tracking-tight"
             data-testid="settings_menu_header"

--- a/src/frontend/src/style/ag-theme-shadcn.css
+++ b/src/frontend/src/style/ag-theme-shadcn.css
@@ -22,6 +22,17 @@
   height: 3rem !important;
 }
 
+/* WCAG 2.5.8 — AG-Grid renders the paging buttons as 16x16 icon boxes, too
+   close to the grid's last row for the spacing exception to apply. Grow the
+   hit area to the 24x24 minimum and keep the icon centered. */
+.ag-theme-shadcn .ag-paging-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  min-height: 24px;
+}
+
 .ag-row .ag-cell {
   align-content: center !important;
 }


### PR DESCRIPTION
At a 320 px viewport, four settings pages push content past the right edge with no way to scroll to it — worst on MCP Servers, where the "Add MCP Server" primary action is cut off by 52 px and every row's actions menu by 55 px (WCAG 1.4.10 Reflow). Separately, five controls sit under the 24×24 px pointer-target minimum with no spacing clearance: the AG-Grid pagination buttons on the Files and Messages grids, the login show-password toggle, and the canvas "Expand text editor" button (WCAG 2.5.8 Target Size).

**Reflow — headers wrap instead of clipping**

- **MCP Servers**: the header action wraps below the title, and long unbreakable server names wrap inside the row instead of pushing the row's actions menu off-screen.
- **Shortcuts**: the Restore button wraps below the title.
- **MCP Client**: the agent tablist becomes a horizontally scrollable strip, so every tab stays reachable without wrapping the underline row (the next tab peeks at the edge as a scroll affordance, and keyboard tab navigation scrolls the focused tab into view natively). Two knock-on fixes: the tabs' fixed `h-6` is removed — their content always overflowed that box invisibly, and the scroll container would have clipped it — and the tabs get an inset focus outline (`-outline-offset-2`), since the global +2px outline would be clipped by the same container. Net visual change at desktop: the strip is ~12 px taller because its content height is now real; label-to-underline spacing is unchanged.
- **Model Providers**: the collapsed detail column's padded scroller is `hidden` while the panel is closed, so it no longer overhangs the viewport; the open/close animation is unchanged.

**Target size — real ≥24 px boxes**

- AG-Grid paging buttons: 16×16 → 24×24, icon centered (`ag-theme-shadcn.css`).
- Login show-password toggle: 20 px → 24 px wide; the icon keeps its exact position.
- Canvas "Expand text editor": the previous `before:` pseudo-element hit-area doesn't register on bounding-rect measurements, so the button is now a real 24×24 box with the 16 px icon centered exactly where it was (the compact edit-node variant keeps the pseudo-element approach).

**Verification** — re-measured against the running dev stack with the audit's measuring method: all four settings routes report `scrollWidth = 320` with zero clipped elements on a fresh 320×600 load; show-password measures 24×43, all four paging buttons 24×24, and expand-text-editor 24×24 at 100 % canvas zoom. Desktop layouts are unchanged (screenshots below) except the MCP Client tab strip, which is ~12 px taller as described above; the provider detail panel still opens normally, the Messages paging bar still fits a 320 px viewport with the bigger buttons (measured: all controls within 15–271 px, description not clipped, panel height still 48 px), and the Jest suites for the touched components pass (22 tests).

<table>
<tr><td width="50%"><b>Before — MCP Servers at 320 px</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-servers-320-before.png" alt="Add MCP Server button and row action menus cut off at the right edge of a 320px viewport" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-servers-320-after.png" alt="Add MCP Server button wrapped below the title, all row action menus fully visible" width="100%"></td>
</tr>
</table>

<details><summary>More before/after screenshots (Shortcuts, MCP Client, grid pagination, login, desktop regression)</summary>

<table>
<tr><td width="50%"><b>Before — Shortcuts at 320 px</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/shortcuts-320-before.png" alt="Restore button truncated at the right edge of a 320px viewport" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/shortcuts-320-after.png" alt="Restore button wrapped below the title, fully visible" width="100%"></td>
</tr>
<tr><td width="50%"><b>Before — MCP Client at 320 px</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-client-320-before.png" alt="Claude Code tab label clipped at the right edge of a 320px viewport" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-client-320-after-v3.png" alt="Agent tabs on one line in a scrollable strip, the second tab peeking at the edge" width="100%"></td>
</tr>
<tr><td width="50%"></td><td width="50%"><b>After — strip scrolled to the second tab</b></td></tr>
<tr>
  <td></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-client-320-after-v3-scrolled.png" alt="Tab strip scrolled right, Claude Code tab fully visible" width="100%"></td>
</tr>
<tr><td width="50%"><b>Before — Messages grid pagination (16×16 buttons)</b></td><td width="50%"><b>After (24×24)</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/paging-before.png" alt="Messages grid with 16 by 16 pixel pagination buttons crowded by the last grid row" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/paging-after.png" alt="Messages grid pagination buttons with 24 by 24 pixel hit areas, visually unchanged" width="100%"></td>
</tr>
<tr><td width="50%"><b>After — login (24 px show-password toggle)</b></td><td width="50%"><b>After — MCP Servers desktop, unchanged</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/login-after.png" alt="Login page with the show-password toggle in its usual position inside the password field" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-servers-1280-after.png" alt="MCP Servers settings page at desktop width with the header action on the same line as the title" width="100%"></td>
</tr>
<tr><td width="50%"><b>After — Shortcuts desktop, unchanged</b></td><td width="50%"><b>After — MCP Client desktop, unchanged</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/shortcuts-1280-after.png" alt="Shortcuts settings page at desktop width with the Restore button on the same line as the title" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-reflow-target-size/mcp-client-1280-after-v3.png" alt="MCP Client settings page at desktop width with both agent tabs on one line" width="100%"></td>
</tr>
</table>

</details>

Jira: [LE-2279](https://datastax.jira.com/browse/LE-2279)


[LE-2279]: https://datastax.jira.com/browse/LE-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ