### PR TITLE
feat: add project_type and project_config to projects

### DIFF
--- a/src/backend/base/langflow/alembic/versions/b8e1c47d3f56_add_project_type_to_folder.py
+++ b/src/backend/base/langflow/alembic/versions/b8e1c47d3f56_add_project_type_to_folder.py
@@ -1,0 +1,45 @@
+"""add project_type and project_config to folder
+
+Revision ID: b8e1c47d3f56
+Revises: a3f8b1c9d7e2
+Create Date: 2026-08-21 10:00:00.000000
+
+Phase: EXPAND
+
+``project_type`` is deliberately ``sa.Text``, matching the model's ``Column(Text)``, and not
+``sa.Enum``. A DB enum would need an ``ALTER TYPE ... ADD VALUE`` migration for every new
+project type, which is the cost ``deployment_type_enum`` already pays. The set of valid values
+is enforced in the application by ``folder.utils.validate_project_type``, not by the database.
+
+No data pass. Every existing row takes the server default.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "b8e1c47d3f56"  # pragma: allowlist secret
+down_revision: str | None = "a3f8b1c9d7e2"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    with op.batch_alter_table("folder", schema=None) as batch_op:
+        if not migration.column_exists(table_name="folder", column_name="project_type", conn=conn):
+            batch_op.add_column(sa.Column("project_type", sa.Text(), server_default=sa.text("'flows'"), nullable=False))
+        if not migration.column_exists(table_name="folder", column_name="project_config", conn=conn):
+            batch_op.add_column(sa.Column("project_config", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    with op.batch_alter_table("folder", schema=None) as batch_op:
+        if migration.column_exists(table_name="folder", column_name="project_config", conn=conn):
+            batch_op.drop_column("project_config")
+        if migration.column_exists(table_name="folder", column_name="project_type", conn=conn):
+            batch_op.drop_column("project_type")

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -616,7 +616,16 @@ async def _apply_project_update(
     if project.description is not None:
         existing_project.description = project.description
 
-    if project.project_type is not None:
+    # An omitted project_type means "leave it alone". An explicit null is a value the caller
+    # asked for, and the column is NOT NULL, so it cannot be honoured. Answering 200 for a
+    # request that changed nothing is the same silent no-op this endpoint already avoids
+    # elsewhere, and `validate_project_type` already refuses every other invalid value.
+    if "project_type" in project.model_fields_set:
+        if project.project_type is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="project_type must not be null.",
+            )
         existing_project.project_type = validate_project_type(project.project_type)
 
     # project_config uses model_fields_set, not a None check: clearing the config and leaving

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -72,6 +72,7 @@ from langflow.services.database.models.folder.model import (
     FolderUpdate,
 )
 from langflow.services.database.models.folder.pagination_model import FolderWithPaginatedFlows
+from langflow.services.database.models.folder.utils import validate_project_type
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_service, get_settings_service
 from langflow.services.schema import ServiceType
@@ -117,6 +118,7 @@ async def _new_project(
     side effects operate on the owning user, not just their id.
     """
     new_project = Folder.model_validate(project, from_attributes=True)
+    new_project.project_type = validate_project_type(new_project.project_type)
     new_project.user_id = current_user.id
     # Apply the stable id: an explicit ``project_id`` (PUT upsert) overrides the uuid4 default.
     if project_id is not None:
@@ -614,6 +616,14 @@ async def _apply_project_update(
     if project.description is not None:
         existing_project.description = project.description
 
+    if project.project_type is not None:
+        existing_project.project_type = validate_project_type(project.project_type)
+
+    # project_config uses model_fields_set, not a None check: clearing the config and leaving
+    # it untouched are different requests, and a None check cannot tell them apart.
+    if "project_config" in project.model_fields_set:
+        existing_project.project_config = project.project_config
+
     if project.parent_id is not None:
         # Validate the supplied parent references a folder owned by the project owner, so
         # shared-project writes cannot create cross-owner folder hierarchies.
@@ -769,9 +779,11 @@ def _folder_create_to_update(project: FolderCreate) -> FolderUpdate:
     mapped because ``_apply_project_update`` recomputes them from the project's current DB
     contents; ``parent_id`` is not part of ``FolderCreate``.
     """
-    # exclude_unset carries only fields explicitly set on the body; include restricts to the three
+    # exclude_unset carries only fields explicitly set on the body; include restricts to the
     # fields FolderUpdate shares with FolderCreate (flows/components/parent_id handled per docstring).
-    data = project.model_dump(include={"name", "description", "auth_settings"}, exclude_unset=True)
+    data = project.model_dump(
+        include={"name", "description", "auth_settings", "project_type", "project_config"}, exclude_unset=True
+    )
     return FolderUpdate(**data)
 
 

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import Text, UniqueConstraint
+from sqlalchemy import Text, UniqueConstraint, text
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 from langflow.services.database.models.deployment.model import Deployment
@@ -16,6 +16,20 @@ class FolderBase(SQLModel):
         default=None,
         sa_column=Column(JSON, nullable=True),
         description="Authentication settings for the folder/project",
+    )
+    project_type: str = Field(
+        default="flows",
+        sa_column=Column(Text, nullable=False, server_default=text("'flows'")),
+        description=(
+            "Which project type this folder is. Per row: a child folder does not inherit its "
+            "parent's type. Stored as text rather than a DB enum so registering a new project "
+            "type never needs an ALTER TYPE migration."
+        ),
+    )
+    project_config: dict | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description="Values for the project type's form fields. Not encrypted; must hold no secrets.",
     )
 
 
@@ -69,3 +83,7 @@ class FolderUpdate(SQLModel):
     components: list[UUID] = Field(default_factory=list)
     flows: list[UUID] = Field(default_factory=list)
     auth_settings: dict | None = None
+    # FolderUpdate subclasses SQLModel, not FolderBase, so new FolderBase fields do not
+    # reach it. Adding them here is required for PATCH and for the PUT upsert body.
+    project_type: str | None = None
+    project_config: dict | None = None

--- a/src/backend/base/langflow/services/database/models/folder/utils.py
+++ b/src/backend/base/langflow/services/database/models/folder/utils.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from fastapi import HTTPException
 from sqlmodel import and_, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -9,6 +10,35 @@ from langflow.services.database.models.flow.model import Flow
 
 from .constants import DEFAULT_FOLDER_DESCRIPTION, DEFAULT_FOLDER_NAME
 from .model import Folder
+
+DEFAULT_PROJECT_TYPE = "flows"
+
+# The set of valid project types belongs to the registry that lands with the lfx project-type
+# work, not to this module. Until that registry exists this tuple stands in for it, so the
+# public API cannot persist a value nothing will ever recognise. Replacing this with
+# ``from lfx.projects import registered_project_types`` is a one-line swap, on purpose.
+_REGISTERED_PROJECT_TYPES = (DEFAULT_PROJECT_TYPE, "agent-harness")
+
+
+def registered_project_types() -> tuple[str, ...]:
+    """Return the project types a folder may be set to."""
+    return _REGISTERED_PROJECT_TYPES
+
+
+def validate_project_type(value: str | None) -> str:
+    """Return a valid project type, or raise 422.
+
+    ``None`` means the caller did not ask for a type, so it takes the default. An empty
+    string is a value the caller did ask for, and it is not a valid one.
+    """
+    if value is None:
+        return DEFAULT_PROJECT_TYPE
+    if value not in registered_project_types():
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown project_type {value!r}. Valid types: {', '.join(registered_project_types())}.",
+        )
+    return value
 
 
 async def create_default_folder_if_it_doesnt_exist(session: AsyncSession, user_id: UUID):

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -2564,3 +2564,114 @@ async def test_upsert_project_update_rejects_flows_list(client: AsyncClient, log
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
     assert "flows_list" in response.json()["detail"]
+
+
+async def test_create_project_defaults_project_type_to_flows(client: AsyncClient, logged_in_headers, basic_case):
+    """A project created without a project_type is a plain flows project."""
+    response = await client.post("api/v1/projects/", json=basic_case, headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    assert response.json()["project_type"] == "flows"
+
+
+async def test_create_project_persists_explicit_project_type(client: AsyncClient, logged_in_headers):
+    """POST carries project_type and project_config through to the stored row."""
+    body = {
+        "name": "harness_on_create",
+        "description": "",
+        "project_type": "agent-harness",
+        "project_config": {"Instructions": "be careful"},
+    }
+    create_response = await client.post("api/v1/projects/", json=body, headers=logged_in_headers)
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    assert create_response.json()["project_type"] == "agent-harness"
+
+    # Re-read rather than trusting the create response, so this asserts persistence.
+    project_id = create_response.json()["id"]
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.status_code == status.HTTP_200_OK, read_response.text
+    assert read_response.json()["project_type"] == "agent-harness"
+
+
+async def test_patch_project_updates_project_type(client: AsyncClient, logged_in_headers):
+    """PATCH re-types an existing project."""
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": "patch_retype", "description": ""},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"api/v1/projects/{project_id}",
+        json={"project_type": "agent-harness", "project_config": {"Model": "openai/gpt-4o"}},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["project_type"] == "agent-harness"
+    assert response.json()["project_config"] == {"Model": "openai/gpt-4o"}
+
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.status_code == status.HTTP_200_OK, read_response.text
+    assert read_response.json()["project_type"] == "agent-harness"
+
+
+async def test_upsert_project_updates_project_type(client: AsyncClient, logged_in_headers):
+    """PUT re-types an existing project.
+
+    This is the case that catches the silent drop: ``_folder_create_to_update`` restricts the
+    PUT body to an explicit include set, so a project_type missing from that set is accepted,
+    discarded, and still answered with 200.
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": "put_retype", "description": ""},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    response = await client.put(
+        f"api/v1/projects/{project_id}",
+        json={"name": "put_retype", "description": "", "project_type": "agent-harness"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["project_type"] == "agent-harness"
+
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.status_code == status.HTTP_200_OK, read_response.text
+    assert read_response.json()["project_type"] == "agent-harness"
+
+
+@pytest.mark.parametrize("bad_type", ["totally-not-a-real-type", ""])
+async def test_project_type_rejects_unknown_values(client: AsyncClient, logged_in_headers, bad_type):
+    """An unregistered project_type is refused on both create and update.
+
+    The empty string is the case a NOT NULL column does not catch on its own.
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": f"reject_{bad_type or 'empty'}", "description": "", "project_type": bad_type},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, create_response.text
+
+    ok_response = await client.post(
+        "api/v1/projects/",
+        json={"name": f"reject_patch_{bad_type or 'empty'}", "description": ""},
+        headers=logged_in_headers,
+    )
+    assert ok_response.status_code == status.HTTP_201_CREATED, ok_response.text
+    project_id = ok_response.json()["id"]
+
+    patch_response = await client.patch(
+        f"api/v1/projects/{project_id}",
+        json={"project_type": bad_type},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, patch_response.text
+
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.json()["project_type"] == "flows"

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -2585,12 +2585,14 @@ async def test_create_project_persists_explicit_project_type(client: AsyncClient
     create_response = await client.post("api/v1/projects/", json=body, headers=logged_in_headers)
     assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
     assert create_response.json()["project_type"] == "agent-harness"
+    assert create_response.json()["project_config"] == {"Instructions": "be careful"}
 
     # Re-read rather than trusting the create response, so this asserts persistence.
     project_id = create_response.json()["id"]
     read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert read_response.status_code == status.HTTP_200_OK, read_response.text
     assert read_response.json()["project_type"] == "agent-harness"
+    assert read_response.json()["project_config"] == {"Instructions": "be careful"}
 
 
 async def test_patch_project_updates_project_type(client: AsyncClient, logged_in_headers):
@@ -2615,6 +2617,39 @@ async def test_patch_project_updates_project_type(client: AsyncClient, logged_in
     read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert read_response.status_code == status.HTTP_200_OK, read_response.text
     assert read_response.json()["project_type"] == "agent-harness"
+    assert read_response.json()["project_config"] == {"Model": "openai/gpt-4o"}
+
+
+async def test_patch_project_clears_project_config_with_explicit_null(client: AsyncClient, logged_in_headers):
+    """Sending null clears project_config; omitting it leaves the stored value alone.
+
+    This is the whole reason the apply block reads ``model_fields_set`` instead of checking for
+    None. A None check cannot tell "clear this" from "do not touch this".
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": "clear_config", "description": "", "project_config": {"Model": "openai/gpt-4o"}},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    # Omitting project_config must not disturb it.
+    untouched = await client.patch(
+        f"api/v1/projects/{project_id}", json={"description": "touched"}, headers=logged_in_headers
+    )
+    assert untouched.status_code == status.HTTP_200_OK, untouched.text
+    assert untouched.json()["project_config"] == {"Model": "openai/gpt-4o"}
+
+    # Sending null must clear it.
+    cleared = await client.patch(
+        f"api/v1/projects/{project_id}", json={"project_config": None}, headers=logged_in_headers
+    )
+    assert cleared.status_code == status.HTTP_200_OK, cleared.text
+    assert cleared.json()["project_config"] is None
+
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.json()["project_config"] is None
 
 
 async def test_upsert_project_updates_project_type(client: AsyncClient, logged_in_headers):
@@ -2634,15 +2669,22 @@ async def test_upsert_project_updates_project_type(client: AsyncClient, logged_i
 
     response = await client.put(
         f"api/v1/projects/{project_id}",
-        json={"name": "put_retype", "description": "", "project_type": "agent-harness"},
+        json={
+            "name": "put_retype",
+            "description": "",
+            "project_type": "agent-harness",
+            "project_config": {"Model": "openai/gpt-4o"},
+        },
         headers=logged_in_headers,
     )
     assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json()["project_type"] == "agent-harness"
+    assert response.json()["project_config"] == {"Model": "openai/gpt-4o"}
 
     read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert read_response.status_code == status.HTTP_200_OK, read_response.text
     assert read_response.json()["project_type"] == "agent-harness"
+    assert read_response.json()["project_config"] == {"Model": "openai/gpt-4o"}
 
 
 @pytest.mark.parametrize("bad_type", ["totally-not-a-real-type", ""])
@@ -2656,7 +2698,7 @@ async def test_project_type_rejects_unknown_values(client: AsyncClient, logged_i
         json={"name": f"reject_{bad_type or 'empty'}", "description": "", "project_type": bad_type},
         headers=logged_in_headers,
     )
-    assert create_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, create_response.text
+    assert create_response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, create_response.text
 
     ok_response = await client.post(
         "api/v1/projects/",
@@ -2671,7 +2713,32 @@ async def test_project_type_rejects_unknown_values(client: AsyncClient, logged_i
         json={"project_type": bad_type},
         headers=logged_in_headers,
     )
-    assert patch_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, patch_response.text
+    assert patch_response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, patch_response.text
 
     read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert read_response.json()["project_type"] == "flows"
+
+
+async def test_patch_project_rejects_explicit_null_project_type(client: AsyncClient, logged_in_headers):
+    """An explicit null is a value the caller asked for, and project_type cannot be null.
+
+    Omitting the field means "leave it alone"; sending null means "set it to null", which the
+    NOT NULL column cannot honour. Ignoring it would answer 200 for a request that did nothing.
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": "null_type", "description": "", "project_type": "agent-harness"},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"api/v1/projects/{project_id}",
+        json={"project_type": None},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, response.text
+
+    read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert read_response.json()["project_type"] == "agent-harness"


### PR DESCRIPTION
Adds two columns to the `folder` table so a project can carry a type and the configuration that type needs. Nothing reads `project_type` yet. This is the first piece of the typed-projects work, and it lands on its own so the column exists before anything depends on it.

## What's here

`project_type`: text, NOT NULL, server default `'flows'`. Text rather than a DB enum, so registering a new type never needs an `ALTER TYPE` migration. That is the cost `deployment_type_enum` already pays, and there is no reason to pay it again.

`project_config`: nullable JSON. Deliberately not folded into `auth_settings`. That column is encrypted on write and read back as plaintext elsewhere, so it is the wrong home for form values; `project_config` is plaintext and must hold no secrets.

Both are wired through PATCH and the PUT upsert.

## Two things worth a reviewer's attention

The include set in `_folder_create_to_update` is easy to miss. A PUT body carrying `project_type` was accepted, silently dropped, and answered with 200. `test_upsert_project_updates_project_type` covers exactly that case; removing the fix makes it fail with `assert 'flows' == 'agent-harness'`.

`validate_project_type` returns 422 for anything unregistered, on create and on update. The valid set is a placeholder tuple in `folder/utils.py` for now. It is meant to be replaced by the project-type registry when that lands, and the swap is one line. Validating now rather than later keeps unrecognised values out of the column before anything reads it, including the empty string, which a NOT NULL column does not catch on its own.

## Known gaps

The placeholder allowlist is not the real validation. The registry that owns the valid set is separate work, and this PR only makes room for it.

Existing rows take the server default. The system folders that are identified by name today (Starter Projects, the assistant folder, the default folder) are untouched and keep working through those name checks; folding them into `project_type` is a much larger migration and is not attempted here.

## Verification

- `test_projects.py` and `alembic/`: 205 passed, 35 skipped
- `test_mcp_projects.py` and `test_initial_setup.py`: 98 passed
- `test_database.py`, `test_flows.py`, export-secret sanitization, authz listing prefilter: 165 passed
- Migration run up and down against a real SQLite database: upgrade gives `project_type TEXT NOT NULL DEFAULT 'flows'` and `project_config JSON NULL`; downgrade removes both and leaves the original column set

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project type support for projects, defaulting to `flows`.
  * Added support for storing optional project configuration.
  * Project type and configuration can be set or updated through project creation, PATCH, and PUT requests.
  * Added support for the `agent-harness` project type.

* **Bug Fixes**
  * Invalid or empty project types now return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->