### PR TITLE
fix(a11y): associate form errors with their fields instead of toast-only announcements

### DIFF
--- a/src/frontend/src/components/core/GlobalVariableModal/GlobalVariableModal.tsx
+++ b/src/frontend/src/components/core/GlobalVariableModal/GlobalVariableModal.tsx
@@ -68,6 +68,12 @@ export default function GlobalVariableModal({
   const [availableFields, setAvailableFields] = useState<string[]>([]);
   useGetTypes({ checkCache: true, enabled: !!globalVariables });
 
+  // The component stays mounted behind its trigger, so a rejection from a
+  // previous session would otherwise re-announce (role="alert") on reopen.
+  useEffect(() => {
+    if (open) setServerError(null);
+  }, [open]);
+
   useEffect(() => {
     if (initialData) {
       setKey(initialData.name ?? "");

--- a/src/frontend/src/components/core/GlobalVariableModal/GlobalVariableModal.tsx
+++ b/src/frontend/src/components/core/GlobalVariableModal/GlobalVariableModal.tsx
@@ -57,6 +57,10 @@ export default function GlobalVariableModal({
       ? [myOpen, mySetOpen]
       : useState(false);
   const setErrorData = useAlertStore((state) => state.setErrorData);
+  // Server-side rejection (duplicate name, invalid provider key…), mirrored
+  // inline so the error is programmatically associated with the fields
+  // (WCAG 3.3.1) instead of living only in the transient toast.
+  const [serverError, setServerError] = useState<string | null>(null);
   const componentFields = useTypesStore((state) => state.ComponentFields);
   const { upsertGlobalVariable, updateGlobalVariable } =
     useGlobalVariableUpsert();
@@ -122,16 +126,17 @@ export default function GlobalVariableModal({
         action?: "created" | "updated";
       };
       const didUpdate = responseError?.action === "updated";
+      const message =
+        responseError?.response?.data?.detail ??
+        (didUpdate
+          ? t("globalVars.modal.errorUnexpectedUpdate")
+          : t("globalVars.modal.errorUnexpectedCreate"));
+      setServerError(message);
       setErrorData({
         title: didUpdate
           ? t("globalVars.modal.errorUpdating")
           : t("globalVars.modal.errorCreating"),
-        list: [
-          responseError?.response?.data?.detail ??
-            (didUpdate
-              ? t("globalVars.modal.errorUnexpectedUpdate")
-              : t("globalVars.modal.errorUnexpectedCreate")),
-        ],
+        list: [message],
       });
     }
   }
@@ -182,6 +187,7 @@ export default function GlobalVariableModal({
             responseError?.response?.data?.detail ??
             t("globalVars.modal.errorUnexpectedUpdate");
 
+          setServerError(errorMessage);
           setErrorData({
             title: isModelProviderVariable
               ? t("globalVars.modal.invalidApiKey")
@@ -249,8 +255,15 @@ export default function GlobalVariableModal({
             <Input
               id="global-variable-name"
               value={key}
-              onChange={(e) => setKey(e.target.value)}
+              onChange={(e) => {
+                setKey(e.target.value);
+                setServerError(null);
+              }}
               placeholder={t("globalVars.modal.namePlaceholder")}
+              aria-invalid={Boolean(serverError)}
+              aria-describedby={
+                serverError ? "global-variable-error" : undefined
+              }
             />
           </div>
 
@@ -266,10 +279,19 @@ export default function GlobalVariableModal({
               password
               id="global-variable-value-credential"
               value={value}
-              onChange={(e) => setValue(e)}
+              onChange={(e) => {
+                setValue(e);
+                setServerError(null);
+              }}
               placeholder={t("globalVars.modal.valuePlaceholder")}
               nodeStyle
               ariaLabelledBy="global-variable-value-credential-label"
+              inputProps={{
+                "aria-invalid": Boolean(serverError) || undefined,
+                "aria-describedby": serverError
+                  ? "global-variable-error"
+                  : undefined,
+              }}
             />
           </TabsContent>
           <TabsContent value="Generic" className="m-0 space-y-2" tabIndex={-1}>
@@ -279,8 +301,15 @@ export default function GlobalVariableModal({
             <Input
               id="global-variable-value-generic"
               value={value}
-              onChange={(e) => setValue(e.target.value)}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setServerError(null);
+              }}
               placeholder={t("globalVars.modal.valuePlaceholder")}
+              aria-invalid={Boolean(serverError)}
+              aria-describedby={
+                serverError ? "global-variable-error" : undefined
+              }
             />
           </TabsContent>
 
@@ -303,6 +332,16 @@ export default function GlobalVariableModal({
               {t("globalVars.modal.applyToFieldsHint")}
             </div>
           </div>
+
+          {serverError && (
+            <p
+              id="global-variable-error"
+              role="alert"
+              className="field-invalid static"
+            >
+              {serverError}
+            </p>
+          )}
         </Tabs>
       </BaseModal.Content>
       <BaseModal.Footer

--- a/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/dbProviderInputComponent/index.tsx
@@ -51,6 +51,10 @@ interface DBProviderInputProps {
    * visible label rather than a generic string.
    */
   ariaLabelledBy?: string;
+  /** Id of the error text describing this field (aria-describedby, WCAG 3.3.1). */
+  ariaDescribedBy?: string;
+  /** Marks the combobox trigger invalid when the field failed validation. */
+  ariaInvalid?: boolean;
   onValueChange: (
     backendType: AvailableDBProviderId,
     backendConfig: Record<string, DBProviderConfigValue>,
@@ -120,6 +124,8 @@ export function DBProviderInput({
   disabled,
   "aria-label": ariaLabel,
   ariaLabelledBy,
+  ariaDescribedBy,
+  ariaInvalid,
   onValueChange,
 }: DBProviderInputProps) {
   const { t } = useTranslation();
@@ -199,6 +205,8 @@ export function DBProviderInput({
           // one is ever emitted — otherwise the aria-label is dead weight.
           aria-label={!ariaLabelledBy ? ariaLabel : undefined}
           aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={ariaInvalid || undefined}
           data-testid={id}
           className={cn(
             "dropdown-component-false-outline py-2",

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -208,6 +208,9 @@ const CustomInputPopover = ({
   hasRefreshButton,
   inspectionPanel,
   ariaLabelledBy,
+  inputProps = undefined as
+    | React.InputHTMLAttributes<HTMLInputElement>
+    | undefined,
   nodeId = undefined as string | undefined,
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -353,6 +356,7 @@ const CustomInputPopover = ({
 
           {(!selectedOption?.length && !selectedOptions?.length) || disabled ? (
             <input
+              {...inputProps}
               autoComplete={getSuppressedAutoComplete(!!password)}
               {...PASSWORD_MANAGER_IGNORE_PROPS}
               onFocus={() => setIsFocused(true)}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
@@ -270,6 +270,7 @@ export default function InputComponent({
               options={options}
               disabledOptions={disabledOptions}
               optionsPlaceholder={optionsPlaceholder}
+              inputProps={inputProps}
               nodeStyle={nodeStyle}
               popoverWidth={popoverWidth}
               commandWidth={commandWidth}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -33,6 +33,8 @@ interface ModelTriggerProps {
   showEmptyState?: boolean;
   "aria-label"?: string;
   ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
+  ariaInvalid?: boolean;
 }
 
 const ModelTrigger = ({
@@ -48,6 +50,8 @@ const ModelTrigger = ({
   showEmptyState = false,
   "aria-label": ariaLabel,
   ariaLabelledBy,
+  ariaDescribedBy,
+  ariaInvalid,
 }: ModelTriggerProps) => {
   const { t } = useTranslation();
   const renderSelectedIcon = () => {
@@ -136,6 +140,8 @@ const ModelTrigger = ({
           aria-expanded={open}
           aria-label={!ariaLabelledBy ? ariaLabel : undefined}
           aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={ariaInvalid || undefined}
           data-testid={id}
           className={cn(
             "dropdown-component-false-outline py-2",

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx
@@ -112,6 +112,7 @@ const ModelTrigger = ({
             ? `${setupProviderTextId} ${ariaLabelledBy}`
             : undefined
         }
+        aria-describedby={ariaDescribedBy}
       >
         <ForwardedIconComponent
           name="BrainCircuit"

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -76,6 +76,8 @@ export default function ModelInputComponent({
   modelType: modelTypeProp,
   "aria-label": ariaLabel,
   ariaLabelledBy,
+  ariaDescribedBy,
+  ariaInvalid,
 }: BaseInputProps<ModelOption[] | undefined> &
   ModelInputComponentType): JSX.Element | null {
   const { t } = useTranslation();
@@ -424,6 +426,8 @@ export default function ModelInputComponent({
               showEmptyState={showEmptyState}
               aria-label={ariaLabel}
               ariaLabelledBy={ariaLabelledBy}
+              ariaDescribedBy={ariaDescribedBy}
+              ariaInvalid={ariaInvalid}
             />
           </div>
           {showConfigureAffordance && (

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/types.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/types.ts
@@ -25,4 +25,8 @@ export interface ModelInputComponentType {
   modelType?: "llm" | "embeddings";
   /** Accessible name for the combobox trigger (WCAG 4.1.2). */
   "aria-label"?: string;
+  /** Id of the error text describing this field (aria-describedby, WCAG 3.3.1). */
+  ariaDescribedBy?: string;
+  /** Marks the combobox trigger invalid when the field failed validation. */
+  ariaInvalid?: boolean;
 }

--- a/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
@@ -68,18 +68,27 @@ jest.mock("@/components/ui/input", () => ({
     "data-testid": dataTestId,
     placeholder,
     disabled,
+    id,
+    "aria-invalid": ariaInvalid,
+    "aria-describedby": ariaDescribedby,
   }: {
     value?: string;
     onChange?: (event: { target: { value: string } }) => void;
     "data-testid"?: string;
     placeholder?: string;
     disabled?: boolean;
+    id?: string;
+    "aria-invalid"?: boolean;
+    "aria-describedby"?: string;
   }) => (
     <input
       value={value}
       placeholder={placeholder}
       data-testid={dataTestId}
       disabled={disabled}
+      id={id}
+      aria-invalid={ariaInvalid}
+      aria-describedby={ariaDescribedby}
       onChange={(event) =>
         onChange?.({ target: { value: event.target.value } })
       }
@@ -96,14 +105,23 @@ jest.mock("@/components/ui/textarea", () => ({
     value,
     onChange,
     "data-testid": dataTestId,
+    id,
+    "aria-invalid": ariaInvalid,
+    "aria-describedby": ariaDescribedby,
   }: {
     value?: string;
     onChange?: (event: { target: { value: string } }) => void;
     "data-testid"?: string;
+    id?: string;
+    "aria-invalid"?: boolean;
+    "aria-describedby"?: string;
   }) => (
     <textarea
       value={value}
       data-testid={dataTestId}
+      id={id}
+      aria-invalid={ariaInvalid}
+      aria-describedby={ariaDescribedby}
       onChange={(event) =>
         onChange?.({ target: { value: event.target.value } })
       }
@@ -310,5 +328,55 @@ describe("AddMcpServerModal", () => {
     // The create (add) flow must never fire during an edit — that is what
     // produced the duplicate server.
     expect(mockAddMCPServer).not.toHaveBeenCalled();
+  });
+
+  it("associates the invalid-JSON error with the JSON textarea", async () => {
+    const user = userEvent.setup();
+    render(<AddMcpServerModal open={true} setOpen={jest.fn()} />);
+
+    await user.type(screen.getByTestId("json-input"), "{{not valid json");
+    await user.click(screen.getByTestId("add-mcp-server-button"));
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveAttribute("id", "mcp-server-form-error");
+    const textarea = screen.getByTestId("json-input");
+    expect(textarea).toHaveAttribute("aria-invalid", "true");
+    expect(textarea).toHaveAttribute(
+      "aria-describedby",
+      "mcp-server-form-error",
+    );
+  });
+
+  it("marks the empty required STDIO field invalid and points it at the banner", async () => {
+    const user = userEvent.setup();
+    const initialData: MCPServerType = {
+      name: "my-server",
+      command: "uvx",
+      args: [],
+    };
+    render(
+      <AddMcpServerModal
+        open={true}
+        setOpen={jest.fn()}
+        initialData={initialData}
+      />,
+    );
+
+    await user.clear(screen.getByTestId("stdio-command-input"));
+    await user.click(screen.getByTestId("add-mcp-server-button"));
+
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveAttribute("id", "mcp-server-form-error");
+    const command = screen.getByTestId("stdio-command-input");
+    expect(command).toHaveAttribute("aria-invalid", "true");
+    expect(command).toHaveAttribute(
+      "aria-describedby",
+      "mcp-server-form-error",
+    );
+    // The filled (locked) name field is not blamed for the error.
+    expect(screen.getByTestId("stdio-name-input")).not.toHaveAttribute(
+      "aria-invalid",
+    );
+    expect(mockPatchMCPServer).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -108,6 +108,23 @@ export default function AddMcpServerModal({
   );
   const [jsonValue, setJsonValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Input ids the current error concerns, so the banner is programmatically
+  // associated with the offending fields (WCAG 3.3.1) — empty for form-level
+  // errors that have no single field (duplicate keys, server failures).
+  const [errorFields, setErrorFields] = useState<string[]>([]);
+
+  const raiseError = (message: string, fields: string[] = []) => {
+    setError(message);
+    setErrorFields(fields);
+  };
+  const clearError = () => {
+    setError(null);
+    setErrorFields([]);
+  };
+  const fieldErrorProps = (id: string) =>
+    errorFields.includes(id)
+      ? { "aria-invalid": true, "aria-describedby": "mcp-server-form-error" }
+      : {};
   const { mutateAsync: addMCPServer, isPending: isAddPending } =
     useAddMCPServer();
   const { mutateAsync: patchMCPServer, isPending: isPatchPending } =
@@ -120,7 +137,7 @@ export default function AddMcpServerModal({
 
   const changeType = (type: string) => {
     setType(type);
-    setError(null);
+    clearError();
     setJsonValue("");
     setStdioName("");
     setStdioCommand("");
@@ -155,7 +172,7 @@ export default function AddMcpServerModal({
   useEffect(() => {
     if (open) {
       setType(initialData ? (initialData.command ? "STDIO" : "HTTP") : "JSON");
-      setError(null);
+      clearError();
       setJsonValue("");
       setStdioName(initialData?.name || "");
       setStdioCommand(initialData?.command || "");
@@ -169,10 +186,16 @@ export default function AddMcpServerModal({
   }, [open]);
 
   async function submitForm() {
-    setError(null);
+    clearError();
     if (type === "STDIO") {
       if (!stdioName.trim() || !stdioCommand.trim()) {
-        setError(t("mcp.modal.errorNameCommandRequired"));
+        raiseError(
+          t("mcp.modal.errorNameCommandRequired"),
+          [
+            !stdioName.trim() && "mcp-stdio-name",
+            !stdioCommand.trim() && "mcp-stdio-command",
+          ].filter((id): id is string => Boolean(id)),
+        );
         return;
       }
       if (stdioEnv.some((item) => item.error)) {
@@ -217,7 +240,7 @@ export default function AddMcpServerModal({
         setStdioCommand("");
         setStdioArgs([""]);
         setStdioEnv([{ key: "", value: "", id: nanoid(), error: false }]);
-        setError(null);
+        clearError();
       } catch (err: unknown) {
         setError(
           err instanceof Error ? err.message : t("mcp.modal.errorFailedAdd"),
@@ -227,7 +250,13 @@ export default function AddMcpServerModal({
     }
     if (type === "HTTP") {
       if (!httpName.trim() || !httpUrl.trim()) {
-        setError(t("mcp.modal.errorNameUrlRequired"));
+        raiseError(
+          t("mcp.modal.errorNameUrlRequired"),
+          [
+            !httpName.trim() && "mcp-http-name",
+            !httpUrl.trim() && "mcp-http-url",
+          ].filter((id): id is string => Boolean(id)),
+        );
         return;
       }
       if (httpEnv.some((item) => item.error)) {
@@ -279,7 +308,7 @@ export default function AddMcpServerModal({
         setHttpUrl("");
         setHttpEnv([{ key: "", value: "", id: nanoid(), error: false }]);
         setHttpHeaders([{ key: "", value: "", id: nanoid(), error: false }]);
-        setError(null);
+        clearError();
       } catch (err: unknown) {
         setError(
           err instanceof Error ? err.message : t("mcp.modal.errorFailedAdd"),
@@ -299,13 +328,14 @@ export default function AddMcpServerModal({
         ]).slice(0, MAX_MCP_SERVER_NAME_LENGTH),
       }));
     } catch (e: unknown) {
-      setError(
+      raiseError(
         e instanceof Error ? e.message : t("mcp.modal.errorNoServerFound"),
+        ["mcp-json-input"],
       );
       return;
     }
     if (servers.length === 0) {
-      setError(t("mcp.modal.errorNoServerFound"));
+      raiseError(t("mcp.modal.errorNoServerFound"), ["mcp-json-input"]);
       return;
     }
     try {
@@ -324,7 +354,7 @@ export default function AddMcpServerModal({
       onSuccess?.(servers.map((server) => server.name)[0]);
       setOpen(false);
       setJsonValue("");
-      setError(null);
+      clearError();
     } catch (err: unknown) {
       setError(
         err instanceof Error
@@ -421,6 +451,7 @@ export default function AddMcpServerModal({
             >
               {error && (
                 <div
+                  id="mcp-server-form-error"
                   role="alert"
                   className="mb-4 rounded-md bg-destructive/10 px-4 py-2 text-xs font-medium text-destructive"
                 >
@@ -442,6 +473,7 @@ export default function AddMcpServerModal({
                 </Label>
                 <Textarea
                   id="mcp-json-input"
+                  {...fieldErrorProps("mcp-json-input")}
                   value={jsonValue}
                   data-testid="json-input"
                   onChange={(e) => setJsonValue(e.target.value)}
@@ -466,6 +498,7 @@ export default function AddMcpServerModal({
                     </Label>
                     <Input
                       id="mcp-stdio-name"
+                      {...fieldErrorProps("mcp-stdio-name")}
                       value={stdioName}
                       onChange={(e) => setStdioName(e.target.value)}
                       placeholder={t("mcp.modal.placeholderServerName")}
@@ -483,6 +516,7 @@ export default function AddMcpServerModal({
                     </Label>
                     <Input
                       id="mcp-stdio-command"
+                      {...fieldErrorProps("mcp-stdio-command")}
                       value={stdioCommand}
                       onChange={(e) => setStdioCommand(e.target.value)}
                       placeholder={t("mcp.modal.placeholderCommand")}
@@ -549,6 +583,7 @@ export default function AddMcpServerModal({
                     </Label>
                     <Input
                       id="mcp-http-name"
+                      {...fieldErrorProps("mcp-http-name")}
                       value={httpName}
                       onChange={(e) => setHttpName(e.target.value)}
                       placeholder={t("mcp.modal.placeholderHttpName")}
@@ -566,6 +601,7 @@ export default function AddMcpServerModal({
                     </Label>
                     <Input
                       id="mcp-http-url"
+                      {...fieldErrorProps("mcp-http-url")}
                       value={httpUrl}
                       onChange={(e) => setHttpUrl(e.target.value)}
                       placeholder={t("mcp.modal.placeholderHttpUrl")}

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -130,9 +130,17 @@ export function StepConfiguration({
             data-testid="kb-source-name-input"
             disabled={isAddSourcesMode}
             className={validationErrors.sourceName ? "border-destructive" : ""}
+            aria-invalid={Boolean(validationErrors.sourceName)}
+            aria-describedby={
+              validationErrors.sourceName ? "kb-source-name-error" : undefined
+            }
           />
           {validationErrors.sourceName && (
-            <span className="text-xs text-destructive">
+            <span
+              id="kb-source-name-error"
+              className="text-xs text-destructive"
+              role="alert"
+            >
               {validationErrors.sourceName}
             </span>
           )}
@@ -167,6 +175,12 @@ export function StepConfiguration({
             >
               <ModelInputComponent
                 id="kb-embedding-model"
+                ariaInvalid={Boolean(validationErrors.embeddingModel)}
+                ariaDescribedBy={
+                  validationErrors.embeddingModel
+                    ? "kb-embedding-model-error"
+                    : undefined
+                }
                 value={selectedEmbeddingModel}
                 editNode={false}
                 disabled={false}
@@ -206,6 +220,10 @@ export function StepConfiguration({
           >
             <DBProviderInput
               id="kb-db-provider"
+              ariaInvalid={Boolean(validationErrors.backend)}
+              ariaDescribedBy={
+                validationErrors.backend ? "kb-backend-error" : undefined
+              }
               value={backendType}
               globalVariables={globalVariables}
               disabled={isAddSourcesMode}
@@ -287,6 +305,9 @@ export function StepConfiguration({
                       <Button
                         variant="outline"
                         data-testid="kb-browse-btn"
+                        aria-describedby={
+                          validationErrors.files ? "kb-files-error" : undefined
+                        }
                         className={cn(
                           "w-full justify-between focus-visible:outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                           validationErrors.files && "border-destructive",
@@ -336,7 +357,11 @@ export function StepConfiguration({
                   </DropdownMenu>
 
                   {validationErrors.files && (
-                    <span className="text-xs text-destructive">
+                    <span
+                      id="kb-files-error"
+                      className="text-xs text-destructive"
+                      role="alert"
+                    >
                       {validationErrors.files}
                     </span>
                   )}
@@ -527,6 +552,7 @@ export function StepConfiguration({
                 <span
                   className="text-xs text-destructive"
                   data-testid="kb-run-metadata-form-error"
+                  role="alert"
                 >
                   {validationErrors.metadata}
                 </span>

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -130,7 +130,10 @@ const ProviderConfigurationForm = ({
   return (
     <div className="flex flex-col gap-1 px-4 pt-4">
       <div className="flex flex-row gap-1 min-w-[300px]">
-        <span className="text-[13px] font-semibold mr-auto">
+        <span
+          id="provider-single-variable-label"
+          className="text-[13px] font-semibold mr-auto"
+        >
           {isSingleVariableProvider ? (
             <>
               {providerVariables[0].variable_name}
@@ -181,11 +184,21 @@ const ProviderConfigurationForm = ({
             const isConfigured = isVariableConfigured(variable.variable_key);
             const hasNewValue = variableValues[variable.variable_key]?.trim();
             const isEditing = editingSecret[variable.variable_key];
+            const inputId = `provider-variable-${variable.variable_key}`;
+            // Single-variable providers render their only label as the form
+            // heading, so the control is named via aria-labelledby instead.
+            const labelId = isSingleVariableProvider
+              ? "provider-single-variable-label"
+              : `provider-variable-label-${variable.variable_key}`;
 
             return (
               <div key={variable.variable_key} className="flex flex-col gap-1">
                 {!isSingleVariableProvider && (
-                  <label className="text-[12px] font-medium text-muted-foreground">
+                  <label
+                    id={labelId}
+                    htmlFor={inputId}
+                    className="text-[12px] font-medium text-muted-foreground"
+                  >
                     {variable.variable_name}
                     {variable.required && (
                       <span className="text-destructive ml-1">*</span>
@@ -197,6 +210,7 @@ const ProviderConfigurationForm = ({
                   <div className="relative">
                     <MultiselectComponent
                       id={variable.variable_key}
+                      ariaLabelledBy={labelId}
                       editNode={false}
                       disabled={isSaving || isDeleting}
                       value={
@@ -260,6 +274,16 @@ const ProviderConfigurationForm = ({
                 ) : (
                   // Render input for text/secret variables
                   <Input
+                    id={inputId}
+                    aria-labelledby={
+                      isSingleVariableProvider ? labelId : undefined
+                    }
+                    aria-invalid={validationState === "invalid" || undefined}
+                    aria-describedby={
+                      validationState === "invalid" && validationError
+                        ? "provider-validation-error"
+                        : undefined
+                    }
                     data-testid={`provider-variable-input-${variable.variable_key}`}
                     placeholder={getPlaceholder(
                       variable.variable_name,
@@ -331,6 +355,15 @@ const ProviderConfigurationForm = ({
               </div>
             );
           })}
+          {validationState === "invalid" && validationError && (
+            <p
+              id="provider-validation-error"
+              role="alert"
+              className="field-invalid static"
+            >
+              {validationError}
+            </p>
+          )}
           {/* Save button */}
           <div className="flex justify-end mt-2 gap-2">
             {selectedProvider.is_enabled && (

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -196,7 +196,13 @@ const ProviderConfigurationForm = ({
                 {!isSingleVariableProvider && (
                   <label
                     id={labelId}
-                    htmlFor={inputId}
+                    // The options branch renders a multiselect with no id —
+                    // only the text-input branch has a target for htmlFor.
+                    htmlFor={
+                      variable.options && variable.options.length > 0
+                        ? undefined
+                        : inputId
+                    }
                     className="text-[12px] font-medium text-muted-foreground"
                   >
                     {variable.variable_name}
@@ -278,7 +284,10 @@ const ProviderConfigurationForm = ({
                     aria-labelledby={
                       isSingleVariableProvider ? labelId : undefined
                     }
-                    aria-invalid={validationState === "invalid" || undefined}
+                    aria-invalid={
+                      (validationState === "invalid" && variable.required) ||
+                      undefined
+                    }
                     aria-describedby={
                       validationState === "invalid" && validationError
                         ? "provider-validation-error"

--- a/src/frontend/src/modals/secretKeyModal/components/__tests__/FormKeyRender.test.tsx
+++ b/src/frontend/src/modals/secretKeyModal/components/__tests__/FormKeyRender.test.tsx
@@ -82,7 +82,7 @@ describe("FormKeyRender", () => {
     expect(screen.getByText(PRESET_YEAR)).toBeInTheDocument();
   });
 
-  it("associates a server error with the name input", () => {
+  it("describes the name input with the form-level server error", () => {
     render(
       <FormKeyRender {...makeProps({ serverError: "Something went wrong" })} />,
     );
@@ -90,14 +90,17 @@ describe("FormKeyRender", () => {
     expect(error).toHaveAttribute("role", "alert");
     expect(error).toHaveAttribute("id", "api-key-form-error");
     const input = screen.getByPlaceholderText("Enter key name");
-    expect(input).toHaveAttribute("aria-invalid", "true");
+    // The failure is the create action's, not the field's — described, not
+    // marked invalid.
     expect(input).toHaveAttribute("aria-describedby", "api-key-form-error");
+    expect(input).not.toHaveAttribute("aria-invalid");
   });
 
-  it("does not mark the name input invalid without a server error", () => {
+  it("renders no error wiring without a server error", () => {
     render(<FormKeyRender {...makeProps()} />);
     const input = screen.getByPlaceholderText("Enter key name");
-    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(input).not.toHaveAttribute("aria-invalid");
     expect(input).not.toHaveAttribute("aria-describedby");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/modals/secretKeyModal/components/__tests__/FormKeyRender.test.tsx
+++ b/src/frontend/src/modals/secretKeyModal/components/__tests__/FormKeyRender.test.tsx
@@ -81,4 +81,23 @@ describe("FormKeyRender", () => {
     expect(screen.getByText(PRESET_WEEK)).toBeInTheDocument();
     expect(screen.getByText(PRESET_YEAR)).toBeInTheDocument();
   });
+
+  it("associates a server error with the name input", () => {
+    render(
+      <FormKeyRender {...makeProps({ serverError: "Something went wrong" })} />,
+    );
+    const error = screen.getByText("Something went wrong");
+    expect(error).toHaveAttribute("role", "alert");
+    expect(error).toHaveAttribute("id", "api-key-form-error");
+    const input = screen.getByPlaceholderText("Enter key name");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "api-key-form-error");
+  });
+
+  it("does not mark the name input invalid without a server error", () => {
+    render(<FormKeyRender {...makeProps()} />);
+    const input = screen.getByPlaceholderText("Enter key name");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
 });

--- a/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
+++ b/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
@@ -96,21 +96,10 @@ export const FormKeyRender = ({
                 setApiKeyName(value);
               }}
               placeholder={modalProps?.inputPlaceholder}
-              aria-invalid={Boolean(serverError)}
               aria-describedby={serverError ? "api-key-form-error" : undefined}
             />
           </Form.Control>
         </div>
-
-        {serverError && (
-          <p
-            id="api-key-form-error"
-            role="alert"
-            className="field-invalid static mt-2"
-          >
-            {serverError}
-          </p>
-        )}
       </Form.Field>
 
       <Form.Field name="expires_at">
@@ -176,6 +165,21 @@ export const FormKeyRender = ({
           })}
         </div>
       </Form.Field>
+
+      {/*
+        Key creation fails as a whole (server error), so the message lives at
+        form level next to the action instead of blaming the name field —
+        the input still references it via aria-describedby.
+      */}
+      {serverError && (
+        <p
+          id="api-key-form-error"
+          role="alert"
+          className="field-invalid static"
+        >
+          {serverError}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
+++ b/src/frontend/src/modals/secretKeyModal/components/form-key-render.tsx
@@ -63,6 +63,7 @@ export const FormKeyRender = ({
   setApiKeyName,
   expiresAt,
   setExpiresAt,
+  serverError,
 }: {
   modalProps: ModalConfigProps | undefined;
   apiKeyName: string;
@@ -70,6 +71,7 @@ export const FormKeyRender = ({
   setApiKeyName: (value: string) => void;
   expiresAt: string;
   setExpiresAt: (value: string) => void;
+  serverError?: string | null;
 }) => {
   const { t } = useTranslation();
   const [calendarOpen, setCalendarOpen] = useState(false);
@@ -94,9 +96,21 @@ export const FormKeyRender = ({
                 setApiKeyName(value);
               }}
               placeholder={modalProps?.inputPlaceholder}
+              aria-invalid={Boolean(serverError)}
+              aria-describedby={serverError ? "api-key-form-error" : undefined}
             />
           </Form.Control>
         </div>
+
+        {serverError && (
+          <p
+            id="api-key-form-error"
+            role="alert"
+            className="field-invalid static mt-2"
+          >
+            {serverError}
+          </p>
+        )}
       </Form.Field>
 
       <Form.Field name="expires_at">

--- a/src/frontend/src/modals/secretKeyModal/index.tsx
+++ b/src/frontend/src/modals/secretKeyModal/index.tsx
@@ -177,7 +177,10 @@ export default function SecretKeyModal({
               setServerError(null);
             }}
             expiresAt={expiresAt}
-            setExpiresAt={setExpiresAt}
+            setExpiresAt={(value) => {
+              setExpiresAt(value);
+              setServerError(null);
+            }}
             serverError={serverError}
           />
         )}

--- a/src/frontend/src/modals/secretKeyModal/index.tsx
+++ b/src/frontend/src/modals/secretKeyModal/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { extractApiErrorMessage } from "@/controllers/API/helpers/extract-api-error-message";
 import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useGenerateToken } from "@/customization/hooks/use-custom-generate-token";
 import { createApiKey } from "../../controllers/API";
@@ -39,6 +40,9 @@ export default function SecretKeyModal({
   const [expiresAt, setExpiresAt] = useState<string>("");
   const [renderKey, setRenderKey] = useState(false);
   const [textCopied, setTextCopied] = useState(true);
+  // Key-creation failure, surfaced inline and associated with the name field
+  // (WCAG 3.3.1) — it was previously swallowed entirely.
+  const [serverError, setServerError] = useState<string | null>(null);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const generateToken = useGenerateToken();
@@ -57,6 +61,7 @@ export default function SecretKeyModal({
     setApiKeyName("");
     setApiKeyValue("");
     setExpiresAt("");
+    setServerError(null);
   }
 
   const handleCopyClick = async () => {
@@ -85,7 +90,14 @@ export default function SecretKeyModal({
       .then((res) => {
         setApiKeyValue(res["api_key"]);
       })
-      .catch((err) => {});
+      .catch((err) => {
+        // Return to the form view instead of showing an empty "generated key"
+        // screen, and tell the user what went wrong.
+        setRenderKey(false);
+        setServerError(
+          extractApiErrorMessage(err, t("errors.errorGeneratingApiKey")),
+        );
+      });
   }
 
   async function handleSubmitForm() {
@@ -156,9 +168,13 @@ export default function SecretKeyModal({
             modalProps={modalConfigProps}
             apiKeyName={apiKeyName}
             inputRef={inputRef}
-            setApiKeyName={setApiKeyName}
+            setApiKeyName={(value) => {
+              setApiKeyName(value);
+              setServerError(null);
+            }}
             expiresAt={expiresAt}
             setExpiresAt={setExpiresAt}
+            serverError={serverError}
           />
         )}
       </BaseModal.Content>

--- a/src/frontend/src/modals/secretKeyModal/index.tsx
+++ b/src/frontend/src/modals/secretKeyModal/index.tsx
@@ -92,10 +92,14 @@ export default function SecretKeyModal({
       })
       .catch((err) => {
         // Return to the form view instead of showing an empty "generated key"
-        // screen, and tell the user what went wrong.
+        // screen, and tell the user what went wrong. Raw 5xx detail ("Internal
+        // Server Error") is no help — prefer the translated message there.
         setRenderKey(false);
+        const status = err?.response?.status;
         setServerError(
-          extractApiErrorMessage(err, t("errors.errorGeneratingApiKey")),
+          typeof status === "number" && status >= 500
+            ? t("errors.errorGeneratingApiKey")
+            : extractApiErrorMessage(err, t("errors.errorGeneratingApiKey")),
         );
       });
   }

--- a/src/frontend/src/pages/LoginPage/__tests__/LoginPage.a11y.test.tsx
+++ b/src/frontend/src/pages/LoginPage/__tests__/LoginPage.a11y.test.tsx
@@ -146,6 +146,42 @@ describe("LoginPage accessibility", () => {
     ).toBeInTheDocument();
   });
 
+  it("associates_server_rejection_with_both_credential_fields", async () => {
+    mockLoginMutate.mockImplementation((_user, options) => {
+      options.onError({
+        response: { data: { detail: "Incorrect username or password." } },
+      });
+    });
+    const { container } = renderLoginPage();
+
+    fireEvent.change(screen.getByPlaceholderText("Username"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Password"), {
+      target: { value: "wrong-password" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+
+    const message =
+      "Incorrect username or password. Check your username and password, then try again.";
+    const inline = await screen.findByText(message);
+    expect(inline).toHaveAttribute("role", "alert");
+    expect(inline).toHaveAttribute("id", "login-form-error");
+
+    const username = screen.getByPlaceholderText("Username");
+    const password = screen.getByPlaceholderText("Password");
+    expect(username).toHaveAttribute("aria-invalid", "true");
+    expect(username).toHaveAttribute("aria-describedby", "login-form-error");
+    expect(password).toHaveAttribute("aria-invalid", "true");
+    expect(password).toHaveAttribute("aria-describedby", "login-form-error");
+
+    // Editing either field clears the stale error and the invalid state.
+    fireEvent.change(username, { target: { value: "alice2" } });
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+    expect(username).toHaveAttribute("aria-invalid", "false");
+    expect(password).not.toHaveAttribute("aria-invalid");
+  });
+
   it("adds_actionable_suggestion_to_server_login_errors", () => {
     mockLoginMutate.mockImplementation((_user, options) => {
       options.onError({

--- a/src/frontend/src/pages/LoginPage/index.tsx
+++ b/src/frontend/src/pages/LoginPage/index.tsx
@@ -34,6 +34,10 @@ export default function LoginPage(): JSX.Element {
   const [inputState, setInputState] =
     useState<loginInputStateType>(CONTROL_LOGIN_STATE);
   const [submitAttempted, setSubmitAttempted] = useState(false);
+  // Server-side rejection (e.g. wrong credentials), mirrored inline so the
+  // error is programmatically associated with the credential fields
+  // (WCAG 3.3.1) instead of living only in the transient toast.
+  const [serverError, setServerError] = useState<string | null>(null);
 
   const { password, username } = inputState;
 
@@ -49,6 +53,7 @@ export default function LoginPage(): JSX.Element {
     target: { name, value },
   }: inputHandlerEventType): void {
     setInputState((prev) => ({ ...prev, [name]: value }));
+    setServerError(null);
   }
 
   const { mutate } = useLoginUser();
@@ -67,20 +72,19 @@ export default function LoginPage(): JSX.Element {
         queryClient.clear();
       },
       onError: (error) => {
+        const message = appendErrorSuggestion(
+          extractApiErrorMessage(
+            error as Parameters<typeof extractApiErrorMessage>[0],
+            t("errors.signin"),
+          ),
+          t("errors.signinSuggestion", {
+            defaultValue: "Check your username and password, then try again.",
+          }),
+        );
+        setServerError(message);
         setErrorData({
           title: t("errors.signin"),
-          list: [
-            appendErrorSuggestion(
-              extractApiErrorMessage(
-                error as Parameters<typeof extractApiErrorMessage>[0],
-                t("errors.signin"),
-              ),
-              t("errors.signinSuggestion", {
-                defaultValue:
-                  "Check your username and password, then try again.",
-              }),
-            ),
-          ],
+          list: [message],
         });
       },
     });
@@ -159,9 +163,14 @@ export default function LoginPage(): JSX.Element {
                     className="h-11 w-full rounded-lg bg-muted"
                     required
                     aria-describedby={
-                      usernameError ? "login-username-error" : undefined
+                      [
+                        usernameError && "login-username-error",
+                        serverError && "login-form-error",
+                      ]
+                        .filter(Boolean)
+                        .join(" ") || undefined
                     }
-                    aria-invalid={Boolean(usernameError)}
+                    aria-invalid={Boolean(usernameError || serverError)}
                     placeholder={t("auth.usernamePlaceholder")}
                   />
 
@@ -201,10 +210,15 @@ export default function LoginPage(): JSX.Element {
                     id="login-password"
                     inputProps={{
                       autoComplete: "current-password",
-                      "aria-describedby": passwordError
-                        ? "login-password-error"
-                        : undefined,
-                      "aria-invalid": Boolean(passwordError) || undefined,
+                      "aria-describedby":
+                        [
+                          passwordError && "login-password-error",
+                          serverError && "login-form-error",
+                        ]
+                          .filter(Boolean)
+                          .join(" ") || undefined,
+                      "aria-invalid":
+                        Boolean(passwordError || serverError) || undefined,
                     }}
                     placeholder={t("auth.passwordPlaceholder")}
                     className="h-11 w-full rounded-lg bg-muted"
@@ -220,6 +234,16 @@ export default function LoginPage(): JSX.Element {
                     </p>
                   )}
                 </Form.Field>
+
+                {serverError && (
+                  <p
+                    id="login-form-error"
+                    role="alert"
+                    className="field-invalid static"
+                  >
+                    {serverError}
+                  </p>
+                )}
 
                 <Form.Submit asChild>
                   <Button className="h-11 w-full rounded-lg" type="submit">

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/__tests__/PasswordForm.a11y.test.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/__tests__/PasswordForm.a11y.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import PasswordFormComponent from "../index";
+
+// Deliberately does NOT mock @radix-ui/react-form. Radix's own valueMissing →
+// aria-describedby wiring cannot be exercised under jsdom (the slot props
+// never materialize there), so that path is covered by the browser-side
+// harness capture (evidence/3.3.1-form-errors, password-form--value-missing).
+// What jsdom CAN pin: the serverError node's association contract and the
+// fields' accessible names.
+
+const renderForm = (serverError: string | null = null) =>
+  render(
+    <PasswordFormComponent
+      currentPassword=""
+      password=""
+      cnfPassword=""
+      handleInput={jest.fn()}
+      handlePatchPassword={jest.fn()}
+      serverError={serverError}
+    />,
+  );
+
+const getInputs = () => [
+  screen.getByPlaceholderText("Current Password"),
+  screen.getByPlaceholderText("Password"),
+  screen.getByPlaceholderText("Confirm Password"),
+];
+
+describe("PasswordForm accessibility", () => {
+  it("associates_a_server_error_with_all_three_fields", () => {
+    renderForm("Passwords do not match");
+
+    const error = screen.getByText("Passwords do not match");
+    expect(error).toHaveAttribute("role", "alert");
+    expect(error).toHaveAttribute("id", "password-form-error");
+
+    for (const input of getInputs()) {
+      expect(input).toHaveAttribute("aria-invalid", "true");
+      expect(input).toHaveAttribute("aria-describedby", "password-form-error");
+    }
+  });
+
+  it("emits_no_aria_error_keys_without_a_server_error", () => {
+    // Companion to the clobber fix: without a server error the DOM must be
+    // clean of error wiring. The clobber itself (a present-but-undefined
+    // aria-describedby key overriding Radix's Slot-provided value) is only
+    // observable in a real browser — see the harness capture noted above.
+    renderForm(null);
+
+    for (const input of getInputs()) {
+      expect(input).not.toHaveAttribute("aria-invalid");
+      expect(input).not.toHaveAttribute("aria-describedby");
+    }
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("names_the_placeholder_only_fields", () => {
+    renderForm(null);
+
+    expect(
+      screen.getByLabelText("Current Password", { selector: "input" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Password", { selector: "input" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Confirm Password", { selector: "input" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
@@ -18,6 +18,8 @@ type PasswordFormComponentProps = {
   cnfPassword: string;
   handleInput: (event: inputHandlerEventType) => void;
   handlePatchPassword: () => void;
+  /** Mismatch or server rejection, rendered inline and associated with the fields (WCAG 3.3.1). */
+  serverError?: string | null;
 };
 const PasswordFormComponent = ({
   currentPassword,
@@ -25,8 +27,13 @@ const PasswordFormComponent = ({
   cnfPassword,
   handleInput,
   handlePatchPassword,
+  serverError,
 }: PasswordFormComponentProps) => {
   const { t } = useTranslation();
+  const errorAriaProps = {
+    "aria-invalid": serverError ? true : undefined,
+    "aria-describedby": serverError ? "password-form-error" : undefined,
+  };
   return (
     <>
       <Form.Root
@@ -57,6 +64,10 @@ const PasswordFormComponent = ({
                   isForm
                   password={true}
                   required
+                  inputProps={{
+                    "aria-label": t("settings.currentPasswordPlaceholder"),
+                    ...errorAriaProps,
+                  }}
                   placeholder={t("settings.currentPasswordPlaceholder")}
                   className="w-full"
                 />
@@ -74,6 +85,10 @@ const PasswordFormComponent = ({
                   isForm
                   password={true}
                   required
+                  inputProps={{
+                    "aria-label": t("settings.passwordPlaceholder"),
+                    ...errorAriaProps,
+                  }}
                   placeholder={t("settings.passwordPlaceholder")}
                   className="w-full"
                 />
@@ -93,6 +108,10 @@ const PasswordFormComponent = ({
                   isForm
                   password={true}
                   required
+                  inputProps={{
+                    "aria-label": t("settings.confirmPasswordPlaceholder"),
+                    ...errorAriaProps,
+                  }}
                   placeholder={t("settings.confirmPasswordPlaceholder")}
                   className="w-full"
                 />
@@ -102,6 +121,15 @@ const PasswordFormComponent = ({
                 </Form.Message>
               </Form.Field>
             </div>
+            {serverError && (
+              <p
+                id="password-form-error"
+                role="alert"
+                className="field-invalid static mt-3"
+              >
+                {serverError}
+              </p>
+            )}
           </CardContent>
           <CardFooter className="border-t px-6 py-4">
             <Form.Submit asChild>

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/PasswordForm/index.tsx
@@ -30,10 +30,15 @@ const PasswordFormComponent = ({
   serverError,
 }: PasswordFormComponentProps) => {
   const { t } = useTranslation();
-  const errorAriaProps = {
-    "aria-invalid": serverError ? true : undefined,
-    "aria-describedby": serverError ? "password-form-error" : undefined,
-  };
+  // Built conditionally: spreading present-but-undefined aria keys would
+  // clobber the aria-describedby Radix Form.Control wires to its
+  // valueMissing messages (Slot merge lets child keys win even at undefined).
+  const errorAriaProps = serverError
+    ? {
+        "aria-invalid": true,
+        "aria-describedby": "password-form-error",
+      }
+    : {};
   return (
     <>
       <Form.Root

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -106,12 +106,10 @@ export const GeneralPage = () => {
             setSuccessData({ title: t("success.changesSaved") });
           },
           onError: (error) => {
-            // biome-ignore lint/suspicious/noExplicitAny: legacy
-            const detail = (error as any)?.response?.data?.detail;
-            setPasswordFormError(detail ?? t("errors.saveChanges"));
             setErrorData({
               title: t("errors.saveChanges"),
-              list: [detail],
+              // biome-ignore lint/suspicious/noExplicitAny: legacy
+              list: [(error as any)?.response?.data?.detail],
             });
           },
         },

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -33,6 +33,12 @@ export const GeneralPage = () => {
   const [inputState, setInputState] = useState<patchUserInputStateType>(
     CONTROL_PATCH_USER_STATE,
   );
+  // Password change rejection (mismatch or server error), mirrored inline so
+  // the error is programmatically associated with the password fields
+  // (WCAG 3.3.1) instead of living only in the transient toast.
+  const [passwordFormError, setPasswordFormError] = useState<string | null>(
+    null,
+  );
 
   const { t } = useTranslation();
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
@@ -51,6 +57,7 @@ export const GeneralPage = () => {
 
   const handlePatchPassword = () => {
     if (password !== cnfPassword) {
+      setPasswordFormError(t("errors.passwordMismatch"));
       setErrorData({
         title: t("errors.changePassword"),
         list: [t("errors.passwordMismatch")],
@@ -72,10 +79,12 @@ export const GeneralPage = () => {
             setSuccessData({ title: t("success.changesSaved") });
           },
           onError: (error) => {
+            // biome-ignore lint/suspicious/noExplicitAny: legacy
+            const detail = (error as any)?.response?.data?.detail;
+            setPasswordFormError(detail ?? t("errors.saveChanges"));
             setErrorData({
               title: t("errors.saveChanges"),
-              // biome-ignore lint/suspicious/noExplicitAny: legacy
-              list: [(error as any)?.response?.data?.detail],
+              list: [detail],
             });
           },
         },
@@ -97,10 +106,12 @@ export const GeneralPage = () => {
             setSuccessData({ title: t("success.changesSaved") });
           },
           onError: (error) => {
+            // biome-ignore lint/suspicious/noExplicitAny: legacy
+            const detail = (error as any)?.response?.data?.detail;
+            setPasswordFormError(detail ?? t("errors.saveChanges"));
             setErrorData({
               title: t("errors.saveChanges"),
-              // biome-ignore lint/suspicious/noExplicitAny: legacy
-              list: [(error as any)?.response?.data?.detail],
+              list: [detail],
             });
           },
         },
@@ -141,6 +152,9 @@ export const GeneralPage = () => {
     target: { name, value },
   }: inputHandlerEventType): void {
     setInputState((prev) => ({ ...prev, [name]: value }));
+    if (["currentPassword", "password", "cnfPassword"].includes(name)) {
+      setPasswordFormError(null);
+    }
   }
 
   return (
@@ -167,6 +181,7 @@ export const GeneralPage = () => {
             cnfPassword={cnfPassword}
             handleInput={handleInput}
             handlePatchPassword={handlePatchPassword}
+            serverError={passwordFormError}
           />
         )}
       </div>

--- a/src/frontend/src/pages/SignUpPage/__tests__/SignUpPage.a11y.test.tsx
+++ b/src/frontend/src/pages/SignUpPage/__tests__/SignUpPage.a11y.test.tsx
@@ -212,4 +212,39 @@ describe("SignUpPage accessibility", () => {
       ],
     });
   });
+
+  it("associates_server_rejection_with_the_username_field", async () => {
+    mockAddUserMutate.mockImplementation((_user, options) => {
+      options.onError({
+        response: { data: { detail: "This username is unavailable." } },
+      });
+    });
+    const { container } = renderSignUpPage();
+
+    fireEvent.change(screen.getByPlaceholderText("Username"), {
+      target: { value: "taken" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Password"), {
+      target: { value: "same-password" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Confirm your password"), {
+      target: { value: "same-password" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+
+    const message =
+      "This username is unavailable. Use a different username or contact an administrator if you already have an account.";
+    const inline = await screen.findByText(message);
+    expect(inline).toHaveAttribute("role", "alert");
+    expect(inline).toHaveAttribute("id", "signup-form-error");
+
+    const username = screen.getByPlaceholderText("Username");
+    expect(username).toHaveAttribute("aria-invalid", "true");
+    expect(username).toHaveAttribute("aria-describedby", "signup-form-error");
+
+    // Editing the username clears the stale error and the invalid state.
+    fireEvent.change(username, { target: { value: "taken2" } });
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+    expect(username).toHaveAttribute("aria-invalid", "false");
+  });
 });

--- a/src/frontend/src/pages/SignUpPage/index.tsx
+++ b/src/frontend/src/pages/SignUpPage/index.tsx
@@ -32,6 +32,10 @@ export default function SignUp(): JSX.Element {
     useState<signUpInputStateType>(CONTROL_INPUT_STATE);
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
+  // Server-side rejection (e.g. username taken), mirrored inline so the error
+  // is programmatically associated with the username field (WCAG 3.3.1)
+  // instead of living only in the transient toast.
+  const [serverError, setServerError] = useState<string | null>(null);
 
   const { t } = useTranslation();
   useDocumentTitle(t("auth.signupButton"));
@@ -47,6 +51,7 @@ export default function SignUp(): JSX.Element {
     target: { name, value },
   }: inputHandlerEventType): void {
     setInputState((prev) => ({ ...prev, [name]: value }));
+    setServerError(null);
   }
 
   function handleSignup(): void {
@@ -65,20 +70,20 @@ export default function SignUp(): JSX.Element {
         navigate("/login");
       },
       onError: (error) => {
+        const message = appendErrorSuggestion(
+          extractApiErrorMessage(
+            error as Parameters<typeof extractApiErrorMessage>[0],
+            t("errors.signup"),
+          ),
+          t("errors.signupSuggestion", {
+            defaultValue:
+              "Use a different username or contact an administrator if you already have an account.",
+          }),
+        );
+        setServerError(message);
         setErrorData({
           title: t("errors.signup"),
-          list: [
-            appendErrorSuggestion(
-              extractApiErrorMessage(
-                error as Parameters<typeof extractApiErrorMessage>[0],
-                t("errors.signup"),
-              ),
-              t("errors.signupSuggestion", {
-                defaultValue:
-                  "Use a different username or contact an administrator if you already have an account.",
-              }),
-            ),
-          ],
+          list: [message],
         });
       },
     });
@@ -180,9 +185,14 @@ export default function SignUp(): JSX.Element {
                   className="h-11 w-full rounded-lg bg-muted"
                   required
                   aria-describedby={
-                    usernameError ? "signup-username-error" : undefined
+                    [
+                      usernameError && "signup-username-error",
+                      serverError && "signup-form-error",
+                    ]
+                      .filter(Boolean)
+                      .join(" ") || undefined
                   }
-                  aria-invalid={Boolean(usernameError)}
+                  aria-invalid={Boolean(usernameError || serverError)}
                   placeholder={t("auth.usernamePlaceholder")}
                 />
 
@@ -307,6 +317,16 @@ export default function SignUp(): JSX.Element {
                   </p>
                 )}
               </Form.Field>
+
+              {serverError && (
+                <p
+                  id="signup-form-error"
+                  role="alert"
+                  className="field-invalid static"
+                >
+                  {serverError}
+                </p>
+              )}
 
               <Form.Submit asChild>
                 <Button type="submit" className="h-11 w-full rounded-lg">

--- a/src/frontend/tests/a11y/auth-pages.a11y.spec.ts
+++ b/src/frontend/tests/a11y/auth-pages.a11y.spec.ts
@@ -107,11 +107,14 @@ async function driveLoginErrorToast(page: LangflowPage) {
   await page.getByLabel(/^Password/).fill("wrong-password");
   await page.getByRole("button", { name: /sign in/i }).click();
   await expect(page.getByText("Error signing in")).toBeVisible();
+  // The rejection surfaces twice by design: the toast announcement and the
+  // inline error associated with the credential fields (WCAG 3.3.1).
   await expect(
     page.getByText(
       "Incorrect username or password. Check your username and password, then try again.",
     ),
-  ).toBeVisible();
+  ).toHaveCount(2);
+  await expect(page.locator("#login-form-error")).toBeVisible();
 }
 
 async function driveSignupEmpty(page: LangflowPage) {
@@ -151,11 +154,13 @@ async function driveSignupErrorToast(page: LangflowPage) {
   await page.getByLabel(/^Confirm your password/).fill("same-password");
   await page.getByRole("button", { name: /sign up/i }).click();
   await expect(page.getByText("Error signing up")).toBeVisible();
+  // Toast + inline error associated with the username field (WCAG 3.3.1).
   await expect(
     page.getByText(
       "This username is unavailable. Use a different username or contact an administrator if you already have an account.",
     ),
-  ).toBeVisible();
+  ).toHaveCount(2);
+  await expect(page.locator("#signup-form-error")).toBeVisible();
 }
 
 async function driveAdminLoginEmpty(page: LangflowPage) {


### PR DESCRIPTION
When a form submission fails in Langflow, the error either flashes by in a bottom-corner toast, hides in a hover tooltip, or — for API-key creation — disappears entirely. A screen-reader user hears an announcement (at best) but lands back on a field that still reports itself as perfectly valid, with no way to find out what went wrong or where. That fails WCAG 1.3.1 (Info & Relationships), 3.3.1 (Error Identification) and 3.3.3 (Error Suggestion).

The auth forms already have the right pattern for client-side required-field errors: `aria-invalid` on the input, `aria-describedby` pointing at inline `role="alert"` text. This PR rolls that same pattern into every server-rejection and validation path:

- **Login / Sign-up** — a rejected submission now renders the error (with its correction suggestion) inline in the form card and marks the credential fields invalid; editing a field clears it. The toast stays.
- **Global variables** — duplicate-name / invalid-key rejections surface inline and mark the name and value inputs.
- **API keys** — a failed creation previously showed the "generated key" screen with an empty key and *no message at all* (the promise rejection was swallowed). It now returns to the form and explains the failure at form level, next to the actions (the name input references the message via `aria-describedby`; raw 5xx detail is replaced with a translated message).
- **MCP server** — the existing error banner gains an id, and the inputs that caused it (empty required fields, the invalid-JSON textarea) point at it via `aria-describedby`.
- **Model providers** — key fields get real label association (single-variable providers had a completely unlabeled key input) and the X-icon tooltip error gains visible inline text tied to the inputs.
- **Knowledge base create** — the name/files/metadata error spans get ids + `role="alert"`, and the name input plus the embedding-model / DB-provider comboboxes reference their error text.
- **Change password** — mismatch and server errors render inline, and the three placeholder-only fields gain accessible names. An adversarial review round then caught and fixed two bugs in the first revision: a duplicated edit had routed profile-picture failures into the password card's error, and the always-present (undefined-valued) aria keys clobbered the `aria-describedby` Radix `Form.Control` wires to its valueMissing messages through Slot merging — both verified fixed in-browser (screenshots below).

Small plumbing to make this possible: `CustomInputPopover` now forwards `inputProps`, and `ModelInputComponent`/`DBProviderInput` accept `ariaDescribedBy`/`ariaInvalid` on their combobox triggers.

**Verification** — live-driven on the dev stack before and after (aria dumps + screenshots per form; the before dumps show `aria-invalid="false"`/absent and zero `aria-describedby` everywhere). 497 Jest tests across the 48 touched suites pass, including new regression tests for the login/sign-up rejection path, the MCP field↔banner association, the API-key inline error, and a PasswordForm suite that runs against the real Radix form (no mock). A second review round also scoped provider `aria-invalid` to required fields only, cleared stale modal errors on reopen, and removed a dangling `htmlFor` on options-backed provider variables. TypeScript introduces no new errors (remaining ones in touched files predate this change on `release-1.12.0`).

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/login--rejected-before.png" alt="Login rejection shown only as a bottom-corner toast; fields untouched" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/login--rejected-after.png" alt="Login rejection also rendered inline between the password field and the submit button" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/api-key--create-rejected-before.png" alt="API key creation failure showing no error message anywhere" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/api-key--create-rejected-after.png" alt="API key creation failure explained at form level above the modal actions" width="100%"></td>
</tr>
</table>

<details><summary>More screenshots (sign-up, global variables, model providers)</summary>

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/signup--rejected-before.png" alt="Sign-up rejection shown only as a toast" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/signup--rejected-after.png" alt="Sign-up rejection rendered inline above the submit button" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/global-variable--create-rejected-before.png" alt="Duplicate variable name error shown only as a toast outside the modal" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/global-variable--create-rejected-after.png" alt="Duplicate variable name error rendered inline inside the modal" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/model-provider--invalid-key-before.png" alt="Invalid provider key indicated only by an X icon with a hover tooltip" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/model-provider--invalid-key-after.png" alt="Invalid provider key error shown as visible inline text under the fields, with aria-invalid scoped to the required key field" width="100%"></td>
</tr>
</table>

Change password (both states are new with this PR — errors were previously toast-only and the Radix valueMissing wiring is preserved):

<table>
<tr><td width="50%"><b>Empty submit (Radix valueMissing)</b></td><td width="50%"><b>Mismatch (inline server-style error)</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/password-form--value-missing.png" alt="Each empty password field described by its own Radix valueMissing message" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/a11y-form-error-semantics/password-form--mismatch.png" alt="Passwords-do-not-match error rendered inline and associated with all three password fields" width="100%"></td>
</tr>
</table>

</details>

Jira: [LE-2280](https://datastax.jira.com/browse/LE-2280)


[LE-2280]: https://datastax.jira.com/browse/LE-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ