### PR TITLE
feat: carry project type through the zip export

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1445,7 +1445,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_projects.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 2131,
+        "line_number": 2133,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-21T15:00:35Z"
+  "generated_at": "2026-08-21T21:13:38Z"
 }

--- a/src/backend/base/langflow/api/utils/zip_utils.py
+++ b/src/backend/base/langflow/api/utils/zip_utils.py
@@ -14,6 +14,16 @@ from lfx.log.logger import logger
 MAX_ZIP_ENTRIES = 500
 MAX_ENTRY_UNCOMPRESSED_BYTES = 50 * 1024 * 1024  # 50 MB per file
 
+# Reserved zip member carrying project-level metadata (project_type, project_config).
+# Every other ``.json`` entry is a flow, so this name must be skipped when collecting
+# flows or it is imported as a junk flow. Matched on the basename, case-insensitively,
+# so a zip written with a directory prefix still resolves.
+PROJECT_METADATA_FILENAME = "project.json"
+
+
+def _is_project_metadata(filename: str) -> bool:
+    return filename.rsplit("/", 1)[-1].lower() == PROJECT_METADATA_FILENAME
+
 
 @dataclass
 class _ZipExtractionResult:
@@ -21,6 +31,7 @@ class _ZipExtractionResult:
 
     flows: list[dict] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    project_metadata: dict | None = None
 
 
 def _extract_flows_sync(contents: bytes) -> _ZipExtractionResult:
@@ -59,7 +70,16 @@ def _extract_flows_sync(contents: bytes) -> _ZipExtractionResult:
                         f"{len(raw)} exceeds limit of {MAX_ENTRY_UNCOMPRESSED_BYTES} bytes"
                     )
                     continue
-                result.flows.append(orjson.loads(raw))
+                parsed = orjson.loads(raw)
+                if _is_project_metadata(info.filename):
+                    # Project metadata, not a flow. Ignore a non-object payload rather than
+                    # failing the whole import over it.
+                    if isinstance(parsed, dict):
+                        result.project_metadata = parsed
+                    else:
+                        result.warnings.append(f"Ignoring ZIP entry '{info.filename}': expected a JSON object")
+                    continue
+                result.flows.append(parsed)
             except orjson.JSONDecodeError:
                 result.warnings.append(f"Skipping ZIP entry '{info.filename}': invalid JSON")
                 continue
@@ -77,9 +97,20 @@ async def extract_flows_from_zip(contents: bytes) -> list[dict]:
     Raises:
         ValueError: If the ZIP is corrupt or contains more than MAX_ZIP_ENTRIES JSON files.
     """
+    flows, _ = await extract_project_from_zip(contents)
+    return flows
+
+
+async def extract_project_from_zip(contents: bytes) -> tuple[list[dict], dict | None]:
+    """Extract flows and the optional project metadata member from a ZIP file.
+
+    Returns the flows and the parsed ``project.json`` payload, or ``None`` when the archive
+    does not carry one. Archives exported before project metadata existed simply have no such
+    member, so they return ``None`` and import exactly as before.
+    """
     result = await asyncio.to_thread(_extract_flows_sync, contents)
 
     for warning in result.warnings:
         await logger.awarning(warning)
 
-    return result.flows
+    return result.flows, result.project_metadata

--- a/src/backend/base/langflow/api/utils/zip_utils.py
+++ b/src/backend/base/langflow/api/utils/zip_utils.py
@@ -15,14 +15,12 @@ MAX_ZIP_ENTRIES = 500
 MAX_ENTRY_UNCOMPRESSED_BYTES = 50 * 1024 * 1024  # 50 MB per file
 
 # Reserved zip member carrying project-level metadata (project_type, project_config).
-# Every other ``.json`` entry is a flow, so this name must be skipped when collecting
-# flows or it is imported as a junk flow. Matched on the basename, case-insensitively,
-# so a zip written with a directory prefix still resolves.
-PROJECT_METADATA_FILENAME = "project.json"
-
-
-def _is_project_metadata(filename: str) -> bool:
-    return filename.rsplit("/", 1)[-1].lower() == PROJECT_METADATA_FILENAME
+# Deliberately NOT a ``.json`` file. Flows are exported as ``{name}.json``, so a ``.json``
+# metadata member would collide with a flow legitimately named "project", and the collision
+# is silent: the flow and the metadata would both be lost. A non-json extension also makes
+# the member invisible to importers that predate it, because only ``.json`` entries are ever
+# read, so an older deployment ignores it instead of failing the whole upload.
+PROJECT_METADATA_FILENAME = "project.meta"
 
 
 @dataclass
@@ -32,6 +30,37 @@ class _ZipExtractionResult:
     flows: list[dict] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     project_metadata: dict | None = None
+
+
+def _read_project_metadata(zf: zipfile.ZipFile, result: _ZipExtractionResult) -> None:
+    """Read the reserved metadata member, by exact name, if the archive carries one.
+
+    Matched exactly rather than by basename: only the member this exporter writes at the zip
+    root is ours. A same-named file inside a directory belongs to whoever built that archive.
+    """
+    try:
+        info = zf.getinfo(PROJECT_METADATA_FILENAME)
+    except KeyError:
+        return
+    if info.file_size > MAX_ENTRY_UNCOMPRESSED_BYTES:
+        result.warnings.append(
+            f"Skipping ZIP entry '{PROJECT_METADATA_FILENAME}': uncompressed size "
+            f"{info.file_size} exceeds limit of {MAX_ENTRY_UNCOMPRESSED_BYTES} bytes"
+        )
+        return
+    raw = zf.read(PROJECT_METADATA_FILENAME)
+    if len(raw) > MAX_ENTRY_UNCOMPRESSED_BYTES:
+        result.warnings.append(f"Skipping ZIP entry '{PROJECT_METADATA_FILENAME}': actual size exceeds limit")
+        return
+    try:
+        parsed = orjson.loads(raw)
+    except orjson.JSONDecodeError:
+        result.warnings.append(f"Ignoring ZIP entry '{PROJECT_METADATA_FILENAME}': invalid JSON")
+        return
+    if isinstance(parsed, dict):
+        result.project_metadata = parsed
+    else:
+        result.warnings.append(f"Ignoring ZIP entry '{PROJECT_METADATA_FILENAME}': expected a JSON object")
 
 
 def _extract_flows_sync(contents: bytes) -> _ZipExtractionResult:
@@ -49,6 +78,8 @@ def _extract_flows_sync(contents: bytes) -> _ZipExtractionResult:
         raise ValueError(msg) from exc
 
     with zf:
+        _read_project_metadata(zf, result)
+
         json_entries = [info for info in zf.infolist() if info.filename.lower().endswith(".json")]
 
         if len(json_entries) > MAX_ZIP_ENTRIES:
@@ -70,16 +101,7 @@ def _extract_flows_sync(contents: bytes) -> _ZipExtractionResult:
                         f"{len(raw)} exceeds limit of {MAX_ENTRY_UNCOMPRESSED_BYTES} bytes"
                     )
                     continue
-                parsed = orjson.loads(raw)
-                if _is_project_metadata(info.filename):
-                    # Project metadata, not a flow. Ignore a non-object payload rather than
-                    # failing the whole import over it.
-                    if isinstance(parsed, dict):
-                        result.project_metadata = parsed
-                    else:
-                        result.warnings.append(f"Ignoring ZIP entry '{info.filename}': expected a JSON object")
-                    continue
-                result.flows.append(parsed)
+                result.flows.append(orjson.loads(raw))
             except orjson.JSONDecodeError:
                 result.warnings.append(f"Skipping ZIP entry '{info.filename}': invalid JSON")
                 continue

--- a/src/backend/base/langflow/api/v1/projects_files.py
+++ b/src/backend/base/langflow/api/v1/projects_files.py
@@ -23,7 +23,7 @@ from langflow.api.utils import (
     normalize_flow_for_export,
     strip_flow_secrets,
 )
-from langflow.api.utils.zip_utils import extract_flows_from_zip
+from langflow.api.utils.zip_utils import PROJECT_METADATA_FILENAME, extract_project_from_zip
 from langflow.api.v1.flows import create_flows
 from langflow.api.v1.flows_helpers import _sanitize_flow_filename
 from langflow.api.v1.schemas import FlowListCreate
@@ -38,6 +38,7 @@ from langflow.services.database.models.folder.model import (
     Folder,
     FolderCreate,
 )
+from langflow.services.database.models.folder.utils import DEFAULT_PROJECT_TYPE, registered_project_types
 from langflow.services.deps import get_settings_service
 
 
@@ -79,6 +80,21 @@ async def download_project_flows(
         zip_stream = io.BytesIO()
 
         with zipfile.ZipFile(zip_stream, "w") as zip_file:
+            # Project-level metadata rides alongside the flows so a typed project survives a
+            # round trip. Written only when there is something to carry: an untyped project
+            # exports exactly as it did before this member existed. That matters because an
+            # importer that predates it reads every .json entry as a flow, so a zip carrying
+            # this member imports as a junk flow on an older deployment. Absence means the
+            # default type, which is what the importer assumes.
+            if project.project_type != DEFAULT_PROJECT_TYPE or project.project_config is not None:
+                project_metadata = {
+                    "project_type": project.project_type,
+                    "project_config": project.project_config,
+                }
+                zip_file.writestr(
+                    PROJECT_METADATA_FILENAME,
+                    orjson_dumps(project_metadata, sort_keys=True).encode("utf-8"),
+                )
             for flow in normalised_flows:
                 safe_name = _sanitize_flow_filename(str(flow["name"]), str(flow.get("id", "flow")))
                 # Serialise with sorted keys and 2-space indent for stable diffs.
@@ -107,6 +123,23 @@ async def download_project_flows(
         ) from e
 
 
+def _imported_project_type(value: object) -> str:
+    """Resolve the project type from an uploaded payload.
+
+    Unlike the create and update paths, an import does not reject an unknown type. The archive
+    may come from a deployment that has a project type this one does not, and refusing the whole
+    import over it would lose the flows too. Fall back to the default and say so in the log.
+    """
+    if value is None:
+        return DEFAULT_PROJECT_TYPE
+    if not isinstance(value, str) or value not in registered_project_types():
+        logger.warning(
+            "Ignoring unknown project_type %r in uploaded project; importing as %s", value, DEFAULT_PROJECT_TYPE
+        )
+        return DEFAULT_PROJECT_TYPE
+    return value
+
+
 async def upload_project_flows(
     *,
     session: DbSession,
@@ -129,7 +162,7 @@ async def upload_project_flows(
     # Detect ZIP files and extract flow data
     if zipfile.is_zipfile(io.BytesIO(contents)):
         try:
-            flows_data = await extract_flows_from_zip(contents)
+            flows_data, project_metadata = await extract_project_from_zip(contents)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
         if not flows_data:
@@ -143,6 +176,9 @@ async def upload_project_flows(
             "folder_description": "",
             "flows": flows_data,
         }
+        if project_metadata:
+            data["folder_project_type"] = project_metadata.get("project_type")
+            data["folder_project_config"] = project_metadata.get("project_config")
     else:
         try:
             data = orjson.loads(contents)
@@ -169,7 +205,12 @@ async def upload_project_flows(
 
     data["folder_name"] = project_name
 
-    project = FolderCreate(name=data["folder_name"], description=data.get("folder_description", ""))
+    project = FolderCreate(
+        name=data["folder_name"],
+        description=data.get("folder_description", ""),
+        project_type=_imported_project_type(data.get("folder_project_type")),
+        project_config=data.get("folder_project_config"),
+    )
 
     new_project = Folder.model_validate(project, from_attributes=True)
     new_project.id = None

--- a/src/backend/base/langflow/api/v1/projects_files.py
+++ b/src/backend/base/langflow/api/v1/projects_files.py
@@ -81,20 +81,16 @@ async def download_project_flows(
 
         with zipfile.ZipFile(zip_stream, "w") as zip_file:
             # Project-level metadata rides alongside the flows so a typed project survives a
-            # round trip. Written only when there is something to carry: an untyped project
-            # exports exactly as it did before this member existed. That matters because an
-            # importer that predates it reads every .json entry as a flow, so a zip carrying
-            # this member imports as a junk flow on an older deployment. Absence means the
-            # default type, which is what the importer assumes.
-            if project.project_type != DEFAULT_PROJECT_TYPE or project.project_config is not None:
-                project_metadata = {
-                    "project_type": project.project_type,
-                    "project_config": project.project_config,
-                }
-                zip_file.writestr(
-                    PROJECT_METADATA_FILENAME,
-                    orjson_dumps(project_metadata, sort_keys=True).encode("utf-8"),
-                )
+            # round trip. Written unconditionally: the member is not a .json entry, so an
+            # importer that predates it never reads it, and it cannot collide with a flow file.
+            project_metadata = {
+                "project_type": project.project_type,
+                "project_config": project.project_config,
+            }
+            zip_file.writestr(
+                PROJECT_METADATA_FILENAME,
+                orjson_dumps(project_metadata, sort_keys=True).encode("utf-8"),
+            )
             for flow in normalised_flows:
                 safe_name = _sanitize_flow_filename(str(flow["name"]), str(flow.get("id", "flow")))
                 # Serialise with sorted keys and 2-space indent for stable diffs.
@@ -121,6 +117,24 @@ async def download_project_flows(
         raise HTTPException(
             status_code=500, detail="An internal error occurred while downloading project flows."
         ) from e
+
+
+def _imported_project_config(value: object) -> dict | None:
+    """Resolve the project config from an uploaded payload.
+
+    ``FolderCreate.project_config`` is a ``dict | None``, so a scalar or a list reaches pydantic
+    as a validation error that no handler catches and the whole upload answers 500. An uploaded
+    archive is untrusted input, so a wrong shape degrades to no config, matching how an unknown
+    project type degrades to the default.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        logger.warning(
+            "Ignoring project_config of type %s in uploaded project; expected an object", type(value).__name__
+        )
+        return None
+    return value
 
 
 def _imported_project_type(value: object) -> str:
@@ -209,7 +223,7 @@ async def upload_project_flows(
         name=data["folder_name"],
         description=data.get("folder_description", ""),
         project_type=_imported_project_type(data.get("folder_project_type")),
-        project_config=data.get("folder_project_config"),
+        project_config=_imported_project_config(data.get("folder_project_config")),
     )
 
     new_project = Folder.model_validate(project, from_attributes=True)

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -101,7 +101,9 @@ async def test_shared_project_download_filters_flows_by_read_permission():
 
     body = b"".join([chunk async for chunk in response.body_iterator])
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
-        assert archive.namelist() == ["Allowed Flow.json"]
+        # The archive also carries the reserved project metadata member; this test is about
+        # which flows are visible, so compare the flow entries only.
+        assert [n for n in archive.namelist() if n.endswith(".json")] == ["Allowed Flow.json"]
 
     filter_visible.assert_awaited_once()
     assert filter_visible.await_args.kwargs["candidates"] == [allowed_flow, denied_flow]
@@ -2001,9 +2003,9 @@ async def test_download_file_starter_project(client: AsyncClient, logged_in_head
     # Verify zip file contents
     zip_content = response.content
     with zipfile.ZipFile(io.BytesIO(zip_content), "r") as zip_file:
-        file_names = zip_file.namelist()
-        # Should have 3 flow files
-        assert len(file_names) == 3, f"Expected 3 files in zip, got {len(file_names)}: {file_names}"
+        file_names = [n for n in zip_file.namelist() if n.endswith(".json")]
+        # Should have 3 flow files, alongside the reserved project metadata member
+        assert len(file_names) == 3, f"Expected 3 flow files in zip, got {len(file_names)}: {file_names}"
 
         # Verify each basic flow file exists and contains valid JSON
         for i in range(2):
@@ -2101,7 +2103,7 @@ async def test_download_project_sanitizes_windows_path_characters(
     assert response.status_code == status.HTTP_200_OK
 
     with zipfile.ZipFile(io.BytesIO(response.content), "r") as zip_file:
-        file_names = zip_file.namelist()
+        file_names = [n for n in zip_file.namelist() if n.endswith(".json")]
         assert len(file_names) == 1
         assert "/" not in file_names[0]
         assert "\\" not in file_names[0]
@@ -2775,8 +2777,8 @@ async def test_project_type_survives_zip_round_trip(client: AsyncClient, logged_
 
     # The metadata member must be present, and must not be mistaken for a flow.
     with zipfile.ZipFile(io.BytesIO(download_response.content)) as zf:
-        assert "project.json" in zf.namelist()
-        metadata = json.loads(zf.read("project.json"))
+        assert "project.meta" in zf.namelist()
+        metadata = json.loads(zf.read("project.meta"))
     assert metadata["project_type"] == "agent-harness"
     assert metadata["project_config"] == {"Model": "openai/gpt-4o"}
 
@@ -2797,10 +2799,10 @@ async def test_project_type_survives_zip_round_trip(client: AsyncClient, logged_
     assert imported, f"no imported project found in {[p['name'] for p in projects]}"
     assert imported[0]["project_type"] == "agent-harness"
 
-    # project.json must not have been imported as a flow.
+    # The metadata member must not have been imported as a flow.
     imported_detail = (await client.get(f"api/v1/projects/{imported[0]['id']}", headers=logged_in_headers)).json()
     flow_names = [f["name"] for f in imported_detail.get("flows", [])]
-    assert "project" not in flow_names, f"project.json leaked in as a flow: {flow_names}"
+    assert "project" not in flow_names, f"the metadata member leaked in as a flow: {flow_names}"
 
 
 async def test_zip_import_falls_back_on_unknown_project_type(client: AsyncClient, logged_in_headers, json_flow):
@@ -2811,7 +2813,7 @@ async def test_zip_import_falls_back_on_unknown_project_type(client: AsyncClient
     flow_payload = json.loads(json_flow)
     zip_stream = io.BytesIO()
     with zipfile.ZipFile(zip_stream, "w") as zf:
-        zf.writestr("project.json", json.dumps({"project_type": "from-the-future", "project_config": {"a": 1}}))
+        zf.writestr("project.meta", json.dumps({"project_type": "from-the-future", "project_config": {"a": 1}}))
         zf.writestr("a_flow.json", json.dumps({**flow_payload, "name": "future_flow"}))
     zip_stream.seek(0)
 
@@ -2826,3 +2828,73 @@ async def test_zip_import_falls_back_on_unknown_project_type(client: AsyncClient
     imported = [p for p in projects if p["name"].startswith("future")]
     assert imported, f"no imported project found in {[p['name'] for p in projects]}"
     assert imported[0]["project_type"] == "flows"
+
+
+async def test_flow_named_project_survives_the_round_trip(client: AsyncClient, logged_in_headers, json_flow):
+    """A flow called "project" must not be eaten by the reserved metadata member.
+
+    Flows export as ``{name}.json``, so a metadata member named ``project.json`` collides with
+    a flow named "project" and the loss is silent: the import answers 201 having dropped it.
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={"name": "collide_src", "description": "", "project_type": "agent-harness"},
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    for flow_name in ("project", "keeper"):
+        flow_payload = json.loads(json_flow)
+        flow_payload.pop("id", None)  # let the server assign ids; the fixture reuses one
+        flow_response = await client.post(
+            "api/v1/flows/",
+            json={**flow_payload, "name": flow_name, "folder_id": project_id},
+            headers=logged_in_headers,
+        )
+        assert flow_response.status_code == status.HTTP_201_CREATED, flow_response.text
+
+    download_response = await client.get(f"api/v1/projects/download/{project_id}", headers=logged_in_headers)
+    assert download_response.status_code == status.HTTP_200_OK, download_response.text
+
+    names = zipfile.ZipFile(io.BytesIO(download_response.content)).namelist()
+    assert sorted(names) == ["keeper.json", "project.json", "project.meta"], names
+
+    delete_response = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert delete_response.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT), delete_response.text
+
+    upload_response = await client.post(
+        "api/v1/projects/upload/",
+        files={"file": ("collide.zip", download_response.content, "application/zip")},
+        headers=logged_in_headers,
+    )
+    assert upload_response.status_code == status.HTTP_201_CREATED, upload_response.text
+
+    projects = (await client.get("api/v1/projects/", headers=logged_in_headers)).json()
+    imported = [p for p in projects if p["name"].startswith("collide")]
+    assert imported, f"no imported project in {[p['name'] for p in projects]}"
+    assert imported[0]["project_type"] == "agent-harness"
+
+    detail = (await client.get(f"api/v1/projects/{imported[0]['id']}", headers=logged_in_headers)).json()
+    assert sorted(f["name"] for f in detail.get("flows", [])) == ["keeper", "project"]
+
+
+@pytest.mark.parametrize("bad_config", ["junk", 123, ["a"]])
+async def test_zip_import_ignores_malformed_project_config(client, logged_in_headers, json_flow, bad_config):
+    """A wrong-shaped project_config degrades to none; it must not 500 the whole upload."""
+    zip_stream = io.BytesIO()
+    with zipfile.ZipFile(zip_stream, "w") as zf:
+        zf.writestr("project.meta", json.dumps({"project_type": "flows", "project_config": bad_config}))
+        zf.writestr("a_flow.json", json.dumps({**json.loads(json_flow), "name": f"badcfg_{type(bad_config).__name__}"}))
+
+    upload_response = await client.post(
+        "api/v1/projects/upload/",
+        files={"file": ("badcfg.zip", zip_stream.getvalue(), "application/zip")},
+        headers=logged_in_headers,
+    )
+    assert upload_response.status_code == status.HTTP_201_CREATED, upload_response.text
+
+    projects = (await client.get("api/v1/projects/", headers=logged_in_headers)).json()
+    imported = [p for p in projects if p["name"].startswith("badcfg")]
+    assert imported, f"no imported project in {[p['name'] for p in projects]}"
+    assert imported[0]["project_config"] is None

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -2742,3 +2742,87 @@ async def test_patch_project_rejects_explicit_null_project_type(client: AsyncCli
 
     read_response = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert read_response.json()["project_type"] == "agent-harness"
+
+
+async def test_project_type_survives_zip_round_trip(client: AsyncClient, logged_in_headers, json_flow):
+    """A typed project exported as a zip re-imports with its type and config intact.
+
+    The zip carries the type in a reserved ``project.json`` member. Without it the round trip
+    silently downgrades every imported project to the default type.
+    """
+    create_response = await client.post(
+        "api/v1/projects/",
+        json={
+            "name": "roundtrip_source",
+            "description": "",
+            "project_type": "agent-harness",
+            "project_config": {"Model": "openai/gpt-4o"},
+        },
+        headers=logged_in_headers,
+    )
+    assert create_response.status_code == status.HTTP_201_CREATED, create_response.text
+    project_id = create_response.json()["id"]
+
+    flow_response = await client.post(
+        "api/v1/flows/",
+        json={**json.loads(json_flow), "name": "roundtrip_flow", "folder_id": project_id},
+        headers=logged_in_headers,
+    )
+    assert flow_response.status_code == status.HTTP_201_CREATED, flow_response.text
+
+    download_response = await client.get(f"api/v1/projects/download/{project_id}", headers=logged_in_headers)
+    assert download_response.status_code == status.HTTP_200_OK, download_response.text
+
+    # The metadata member must be present, and must not be mistaken for a flow.
+    with zipfile.ZipFile(io.BytesIO(download_response.content)) as zf:
+        assert "project.json" in zf.namelist()
+        metadata = json.loads(zf.read("project.json"))
+    assert metadata["project_type"] == "agent-harness"
+    assert metadata["project_config"] == {"Model": "openai/gpt-4o"}
+
+    # Remove the source project first. Re-importing the same flows into the same account
+    # otherwise collides on flow ids, which is a property of this test, not of the round trip.
+    delete_response = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert delete_response.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT), delete_response.text
+
+    upload_response = await client.post(
+        "api/v1/projects/upload/",
+        files={"file": ("roundtrip.zip", download_response.content, "application/zip")},
+        headers=logged_in_headers,
+    )
+    assert upload_response.status_code == status.HTTP_201_CREATED, upload_response.text
+
+    projects = (await client.get("api/v1/projects/", headers=logged_in_headers)).json()
+    imported = [p for p in projects if p["name"].startswith("roundtrip")]
+    assert imported, f"no imported project found in {[p['name'] for p in projects]}"
+    assert imported[0]["project_type"] == "agent-harness"
+
+    # project.json must not have been imported as a flow.
+    imported_detail = (await client.get(f"api/v1/projects/{imported[0]['id']}", headers=logged_in_headers)).json()
+    flow_names = [f["name"] for f in imported_detail.get("flows", [])]
+    assert "project" not in flow_names, f"project.json leaked in as a flow: {flow_names}"
+
+
+async def test_zip_import_falls_back_on_unknown_project_type(client: AsyncClient, logged_in_headers, json_flow):
+    """An archive naming a project type this deployment does not have still imports.
+
+    Refusing the whole upload would lose the flows too, so the type degrades to the default.
+    """
+    flow_payload = json.loads(json_flow)
+    zip_stream = io.BytesIO()
+    with zipfile.ZipFile(zip_stream, "w") as zf:
+        zf.writestr("project.json", json.dumps({"project_type": "from-the-future", "project_config": {"a": 1}}))
+        zf.writestr("a_flow.json", json.dumps({**flow_payload, "name": "future_flow"}))
+    zip_stream.seek(0)
+
+    upload_response = await client.post(
+        "api/v1/projects/upload/",
+        files={"file": ("future.zip", zip_stream.getvalue(), "application/zip")},
+        headers=logged_in_headers,
+    )
+    assert upload_response.status_code == status.HTTP_201_CREATED, upload_response.text
+
+    projects = (await client.get("api/v1/projects/", headers=logged_in_headers)).json()
+    imported = [p for p in projects if p["name"].startswith("future")]
+    assert imported, f"no imported project found in {[p['name'] for p in projects]}"
+    assert imported[0]["project_type"] == "flows"


### PR DESCRIPTION
Stacked on #14700 and merges after it. The diff here is only the files this PR adds; #14700 carries the columns.

A project's type and config had no way to survive an export. Both download routes emit a zip of per-flow JSON with no project metadata, and the JSON envelope the importer accepts is import-only, so nothing writes it. A typed project exported and re-imported silently came back as a plain one.

## What's here

A reserved `project.meta` member in the zip, carrying `project_type` and `project_config`, read back on import.

## Why `.meta` and not `.json`

This matters, and the first version of this PR got it wrong.

Flows export as `{flow_name}.json`. A metadata member named `project.json` therefore collides with a flow legitimately called "project": the export writes two entries under that name, zipfile permits it, and on import `zf.read()` keys by name so both resolve to the last entry. The flow **and** the project type were lost, and the upload still answered 201. The same over-broad match dropped the flow on the flow-upload path in `flows.py`, and it applied to untyped projects too, because the reader-side skip did not depend on what the exporter had written.

`_extract_flows_sync` only ever collects entries ending in `.json`. A non-json member therefore:

- cannot collide with any flow file,
- is invisible to an importer that predates it, rather than reaching `FlowCreate` and failing the whole upload with an unhandled `ValidationError`,
- needs no basename matching, so the member is read by exact name and a foreign archive carrying `sub/project.meta` is left alone,
- does not consume one of the `MAX_ZIP_ENTRIES` slots, so export and import stay symmetric at the boundary.

Emission is unconditional, because there is no longer anything to protect older importers from.

## Import is lenient on purpose

An unknown `project_type` falls back to the default with a logged warning rather than rejecting the upload; an archive may come from a deployment that has a type this one does not, and refusing would lose the flows too. A non-dict `project_config` degrades the same way — it previously reached `FolderCreate` unvalidated and answered 500 with raw pydantic validation text.

## Verification

- `test_projects.py`, `test_flows.py`, `test_database.py`: 228 passed, 1 skipped
- Collision test is load-bearing: renaming the member back to `project.json` fails it with `['project.json', 'project.json', 'keeper.json']`
- Config guard is load-bearing: removing it fails all three parametrized cases with the raw `ValidationError`
- Three existing download tests now compare `.json` flow entries rather than every archive member, since the archive legitimately carries one more file

CI green here only proves this change against #14700, not against `release-1.12.0`.
