### PR TITLE
fix(security): close model-provider SSRF follow-up gaps

### DIFF
--- a/src/bundles/anthropic/src/lfx_anthropic/anthropic_chat_model.py
+++ b/src/bundles/anthropic/src/lfx_anthropic/anthropic_chat_model.py
@@ -8,6 +8,8 @@ model construction.
 
 from typing import Any
 
+import anthropic
+import httpx
 from langchain_anthropic import ChatAnthropic
 
 
@@ -43,3 +45,15 @@ def _install_thinking_compat() -> type[ChatAnthropic]:
 # those fields without their defaults. Patch the request hook once and keep the
 # already-supported ChatAnthropic model and validator intact.
 ChatAnthropicThinkingCompat = _install_thinking_compat()
+
+
+def install_anthropic_ssrf_clients(
+    model: ChatAnthropic,
+    *,
+    http_client: httpx.Client,
+    http_async_client: httpx.AsyncClient,
+) -> None:
+    """Install validated, DNS-pinned transports into ChatAnthropic's lazy SDK clients."""
+    client_params = model._client_params  # noqa: SLF001
+    model.__dict__["_client"] = anthropic.Anthropic(**client_params, http_client=http_client)
+    model.__dict__["_async_client"] = anthropic.AsyncAnthropic(**client_params, http_client=http_async_client)

--- a/src/bundles/anthropic/src/lfx_anthropic/components/anthropic/anthropic.py
+++ b/src/bundles/anthropic/src/lfx_anthropic/components/anthropic/anthropic.py
@@ -8,7 +8,7 @@ from lfx.base.models.anthropic_constants import (
     TOOL_CALLING_UNSUPPORTED_ANTHROPIC_MODELS,
 )
 from lfx.base.models.model import LCModelComponent
-from lfx.base.models.provider_ssrf import validate_provider_base_url
+from lfx.base.models.provider_ssrf import provider_httpx_clients, validate_provider_base_url
 from lfx.field_typing import LanguageModel
 from lfx.field_typing.range_spec import RangeSpec
 from lfx.io import BoolInput, DropdownInput, IntInput, MessageTextInput, SecretStrInput, SliderInput
@@ -78,14 +78,17 @@ class AnthropicModelComponent(LCModelComponent):
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
         try:
-            from lfx_anthropic.anthropic_chat_model import ChatAnthropicThinkingCompat
+            from lfx_anthropic.anthropic_chat_model import (
+                ChatAnthropicThinkingCompat,
+                install_anthropic_ssrf_clients,
+            )
         except ImportError as e:
             msg = "langchain_anthropic is not installed. Please install it with `pip install langchain_anthropic`."
             raise ImportError(msg) from e
         # base_url is tenant-editable and the SDK sends the operator's stored API key to whatever
-        # host it names. Validate before the try block below, which would otherwise flatten the
-        # SSRF error into a generic "could not connect" message.
-        validate_provider_base_url(self.base_url, default_url=DEFAULT_ANTHROPIC_API_URL)
+        # host it names. Build protected clients before the try block below, which would otherwise
+        # flatten an SSRF error into a generic "could not connect" message.
+        ssrf_clients = provider_httpx_clients(self.base_url, default_url=DEFAULT_ANTHROPIC_API_URL)
         try:
             max_tokens_value = getattr(self, "max_tokens", "")
             max_tokens_value = 4096 if max_tokens_value == "" else int(max_tokens_value)
@@ -98,6 +101,8 @@ class AnthropicModelComponent(LCModelComponent):
                 streaming=self.stream,
                 stream_usage=True,
             )
+            if ssrf_clients:
+                install_anthropic_ssrf_clients(output, **ssrf_clients)
         except ValidationError:
             raise
         except Exception as e:
@@ -107,8 +112,8 @@ class AnthropicModelComponent(LCModelComponent):
         return output
 
     def get_models(self, *, tool_model_enabled: bool | None = None) -> list[str]:
-        # The tool-capability probe below builds a client against base_url and sends the
-        # operator's API key to it, so the same connector SSRF policy applies here.
+        # Reject unsafe custom configuration before the capability probe constructs model objects.
+        # The live model-list request below uses Anthropic's canonical endpoint, not base_url.
         validate_provider_base_url(self.base_url, default_url=DEFAULT_ANTHROPIC_API_URL)
         try:
             import anthropic

--- a/src/bundles/anthropic/tests/test_anthropic_base_url_ssrf.py
+++ b/src/bundles/anthropic/tests/test_anthropic_base_url_ssrf.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from lfx.base.models.anthropic_constants import DEFAULT_ANTHROPIC_API_URL
+from lfx.utils.ssrf_transport import SSRFProtectedSyncTransport, SSRFProtectedTransport
 from lfx_anthropic.components.anthropic.anthropic import AnthropicModelComponent
 
 _FAKE_ANTHROPIC_API_KEY = "sk-ant-not-a-real-key"  # pragma: allowlist secret
@@ -17,6 +18,8 @@ BLOCKED_URLS = [
     "http://10.0.0.5:8000",
     "http://192.168.1.10",
     "http://172.16.0.9",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
 ]
 
 
@@ -70,3 +73,22 @@ class TestAnthropicBaseUrlSSRF:
         component.build_model()
 
         assert mock_chat.call_args.kwargs["anthropic_api_url"] == "http://10.0.0.5:8000"
+
+    def test_should_install_dns_pinned_clients_for_custom_endpoint(self, monkeypatch):
+        monkeypatch.setattr("lfx.utils.ssrf_protection.resolve_hostname", lambda _hostname: ["93.184.216.34"])
+        component = _component("https://anthropic-proxy.example")
+
+        model = component.build_model()
+
+        assert isinstance(model._client._client._transport, SSRFProtectedSyncTransport)
+        assert isinstance(model._async_client._client._transport, SSRFProtectedTransport)
+        assert model._client._client._transport.pinned_ips == {"anthropic-proxy.example": ["93.184.216.34"]}
+        assert model._async_client._client._transport.pinned_ips == {"anthropic-proxy.example": ["93.184.216.34"]}
+
+    def test_should_allow_explicitly_allowlisted_loopback(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "127.0.0.1")
+        component = _component("http://127.0.0.1:8000")
+
+        model = component.build_model()
+
+        assert model.anthropic_api_url == "http://127.0.0.1:8000"

--- a/src/bundles/nextplaid/pyproject.toml
+++ b/src/bundles/nextplaid/pyproject.toml
@@ -14,8 +14,9 @@ keywords = ["langflow", "lfx", "extension", "bundle", "nextplaid", "colbert", "p
 # bundled components import.
 #
 # * ``langchain-plaid`` wraps the NextPlaid server client used by
-#   ``NextPlaidVectorStoreComponent``.  It transitively pulls ``requests``
-#   (>=2.28.0), which ``VllmMultivectorEmbeddings`` also uses.
+#   ``NextPlaidVectorStoreComponent``.
+# * ``httpx`` is used by ``VllmMultivectorEmbeddings`` through LFX's
+#   DNS-pinned provider request helper.
 # * ``pillow`` backs the ColPali image path (``embed_images`` /
 #   ``_data_to_pil``).  It is already an lfx dep, but is listed here so the
 #   bundle keeps building if lfx drops it.
@@ -28,6 +29,7 @@ keywords = ["langflow", "lfx", "extension", "bundle", "nextplaid", "colbert", "p
 dependencies = [
     "lfx>=1.11.0.dev0,<2.0.0",
     "langchain-plaid>=0.1.0,<1.0.0",
+    "httpx>=0.28.1,<1.0.0",
     "pillow>=10.0.0",
 ]
 

--- a/src/bundles/nextplaid/src/lfx_nextplaid/components/nextplaid/vllm_multivector_impl.py
+++ b/src/bundles/nextplaid/src/lfx_nextplaid/components/nextplaid/vllm_multivector_impl.py
@@ -5,9 +5,9 @@ import io
 import time
 from typing import TYPE_CHECKING
 
-import requests
+import httpx
 from langchain_core.embeddings import Embeddings as LCEmbeddings
-from lfx.base.models.provider_ssrf import validate_provider_base_url
+from lfx.base.models.provider_ssrf import provider_safe_httpx_post, validate_provider_base_url
 
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage
@@ -46,8 +46,8 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
         timeout: float = 60.0,
         max_retries: int = 1,
     ) -> None:
-        # url is tenant-editable and every /pooling request below carries api_key in an
-        # Authorization header, so validate once here to cover both request sites.
+        # Reject an unsafe URL at construction, then revalidate and pin every request below so
+        # a hostname cannot rebind after this preflight check.
         validate_provider_base_url(url)
         self.url = url.rstrip("/")
         self.model = model
@@ -87,7 +87,7 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
         last_exc: Exception | None = None
         for attempt in range(max(self.max_retries, 1)):
             try:
-                resp = requests.post(
+                resp = provider_safe_httpx_post(
                     f"{self.url}/pooling",
                     json={"model": self.model, "input": input_data},
                     headers=self._headers,
@@ -101,14 +101,14 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
                 except (KeyError, TypeError) as exc:
                     msg = "vLLM /pooling response has invalid embedding row shape"
                     raise RuntimeError(msg) from exc
-            except requests.HTTPError as exc:
+            except httpx.HTTPStatusError as exc:
                 valid_client_status_codes = 500
                 if exc.response is not None and exc.response.status_code < valid_client_status_codes:
                     raise  # don't retry 4xx — surface immediately
                 last_exc = exc
                 if attempt < self.max_retries - 1:
                     time.sleep(2**attempt)
-            except requests.RequestException as exc:
+            except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt < self.max_retries - 1:
                     time.sleep(2**attempt)
@@ -147,7 +147,7 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
             last_exc: Exception | None = None
             for attempt in range(max(self.max_retries, 1)):
                 try:
-                    resp = requests.post(
+                    resp = provider_safe_httpx_post(
                         f"{self.url}/pooling",
                         json={
                             "model": self.model,
@@ -169,7 +169,7 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
                         msg = "vLLM /pooling image response has invalid embedding row shape"
                         raise RuntimeError(msg) from exc
                     break
-                except requests.HTTPError as exc:
+                except httpx.HTTPStatusError as exc:
                     valid_client_status_codes = 500
                     if exc.response is not None and exc.response.status_code < valid_client_status_codes:
                         msg = f"vLLM {exc.response.status_code}: {exc.response.text}"
@@ -177,7 +177,7 @@ class VllmMultivectorEmbeddings(LCEmbeddings):
                     last_exc = exc
                     if attempt < self.max_retries - 1:
                         time.sleep(2**attempt)
-                except requests.RequestException as exc:
+                except httpx.RequestError as exc:
                     last_exc = exc
                     if attempt < self.max_retries - 1:
                         time.sleep(2**attempt)

--- a/src/bundles/nextplaid/tests/test_nextplaid_component.py
+++ b/src/bundles/nextplaid/tests/test_nextplaid_component.py
@@ -34,7 +34,9 @@ def test_nextplaid_component_template_defaults():
 
 
 def test_vllm_multivector_embeddings_build(monkeypatch):
-    monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "localhost")
+    # Avoid initializing the shared settings service while a temporary environment
+    # allowlist is active; that would leak "localhost" into later deny-policy tests.
+    monkeypatch.setattr("lfx.utils.ssrf_protection.get_allowed_hosts", lambda: ["localhost"])
     component = VllmMultivectorEmbeddingsComponent(
         model_name="answerdotai/answerai-colbert-small-v1",
         api_base="http://localhost:8000",

--- a/src/bundles/nextplaid/tests/test_nextplaid_component.py
+++ b/src/bundles/nextplaid/tests/test_nextplaid_component.py
@@ -33,7 +33,8 @@ def test_nextplaid_component_template_defaults():
     assert node["template"]["nbits"]["value"] == "4"
 
 
-def test_vllm_multivector_embeddings_build():
+def test_vllm_multivector_embeddings_build(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "localhost")
     component = VllmMultivectorEmbeddingsComponent(
         model_name="answerdotai/answerai-colbert-small-v1",
         api_base="http://localhost:8000",
@@ -47,8 +48,9 @@ def test_vllm_multivector_embeddings_build():
     assert embeddings.url == "http://localhost:8000"
 
 
-def test_embeddings_impl_handles_empty_input():
+def test_embeddings_impl_handles_empty_input(monkeypatch):
     """Empty batches short-circuit without touching the network."""
+    monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "localhost")
     impl = VllmMultivectorEmbeddings(url="http://localhost:8000/", model="m")
 
     assert impl.embed_documents([]) == []
@@ -57,11 +59,9 @@ def test_embeddings_impl_handles_empty_input():
     assert impl.url == "http://localhost:8000"
 
 
-def test_embeddings_impl_identity():
-    # The constructor now applies the connector SSRF policy, which resolves the hostname.
-    # "http://h:1" was a placeholder that cannot resolve, so it fails in a network-isolated
-    # runner. Loopback is exempt from the policy by default and needs no DNS, which keeps
-    # this test about identity/hash/repr rather than about URL validation.
+def test_embeddings_impl_identity(monkeypatch):
+    # Keep this test about identity/hash/repr rather than provider URL policy.
+    monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "127.0.0.1")
     a = VllmMultivectorEmbeddings(url="http://127.0.0.1:1", model="m", api_key="k")
     b = VllmMultivectorEmbeddings(url="http://127.0.0.1:1", model="m", api_key="k")
     c = VllmMultivectorEmbeddings(url="http://127.0.0.1:1", model="other", api_key="k")

--- a/src/bundles/nextplaid/tests/test_vllm_multivector_ssrf.py
+++ b/src/bundles/nextplaid/tests/test_vllm_multivector_ssrf.py
@@ -4,9 +4,12 @@ The ``url`` passed to ``VllmMultivectorEmbeddings`` comes from a tenant-editable
 field, and every ``/pooling`` request carries ``api_key`` in an Authorization header.
 """
 
+import socket
 from unittest.mock import patch
 
+import httpcore
 import pytest
+from lfx.utils.ssrf_protection import SSRFProtectionError
 from lfx_nextplaid.components.nextplaid.vllm_multivector_impl import VllmMultivectorEmbeddings
 
 _FAKE_VLLM_API_KEY = "not-a-real-key"  # pragma: allowlist secret
@@ -20,18 +23,21 @@ class TestVllmMultivectorSSRF:
             "http://10.0.0.5:8000",
             "http://192.168.1.10:8000",
             "http://172.16.0.9:8000",
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
         ],
     )
     def test_should_block_internal_endpoint(self, blocked_url):
         """Constructing against an internal host must fail before any request is made."""
-        with patch("requests.post") as mock_post:
+        with patch("lfx_nextplaid.components.nextplaid.vllm_multivector_impl.provider_safe_httpx_post") as mock_post:
             with pytest.raises(ValueError, match="SSRF Protection"):
                 VllmMultivectorEmbeddings(url=blocked_url, model="test-model", api_key=_FAKE_VLLM_API_KEY)
 
             mock_post.assert_not_called()
 
-    def test_should_allow_local_vllm_server(self):
-        """The default local vLLM endpoint keeps working (loopback exemption)."""
+    def test_should_allow_explicitly_allowlisted_local_vllm_server(self, monkeypatch):
+        """A single-tenant operator can explicitly trust its local vLLM server."""
+        monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "localhost")
         embeddings = VllmMultivectorEmbeddings(url="http://localhost:8000", model="test-model")
 
         assert embeddings.url == "http://localhost:8000"
@@ -43,3 +49,77 @@ class TestVllmMultivectorSSRF:
         embeddings = VllmMultivectorEmbeddings(url="http://10.0.0.5:8000", model="test-model")
 
         assert embeddings.url == "http://10.0.0.5:8000"
+
+    def test_should_send_requests_through_the_provider_safe_client(self, monkeypatch):
+        monkeypatch.setattr("lfx.utils.ssrf_protection.resolve_hostname", lambda _hostname: ["93.184.216.34"])
+        embeddings = VllmMultivectorEmbeddings(
+            url="https://vllm.example", model="test-model", api_key=_FAKE_VLLM_API_KEY
+        )
+
+        with patch("lfx_nextplaid.components.nextplaid.vllm_multivector_impl.provider_safe_httpx_post") as mock_post:
+            mock_post.return_value.json.return_value = {"data": [{"index": 0, "data": [[0.1, 0.2]]}]}
+            result = embeddings.embed_query("query")
+
+        assert result == [[0.1, 0.2]]
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == f"Bearer {_FAKE_VLLM_API_KEY}"
+
+    def test_should_pin_the_request_ip_after_revalidation(self):
+        call_count = 0
+        connected_to_ip = None
+
+        def mock_getaddrinfo(_hostname, _port, *_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+
+        def mock_connect_tcp(_self, host, port, **_kwargs):
+            nonlocal connected_to_ip
+            connected_to_ip = host
+            assert port == 8080
+            body = b'{"data":[{"index":0,"data":[[0.1,0.2]]}]}'
+            return httpcore.MockStream(
+                [
+                    b"HTTP/1.1 200 OK\r\n",
+                    b"Content-Type: application/json\r\n",
+                    f"Content-Length: {len(body)}\r\n".encode(),
+                    b"\r\n",
+                    body,
+                ]
+            )
+
+        with (
+            patch("socket.getaddrinfo", side_effect=mock_getaddrinfo),
+            patch.object(httpcore.SyncBackend, "connect_tcp", mock_connect_tcp),
+        ):
+            embeddings = VllmMultivectorEmbeddings(
+                url="http://rebind.example:8080", model="test-model", api_key=_FAKE_VLLM_API_KEY
+            )
+            result = embeddings.embed_query("query")
+
+        assert result == [[0.1, 0.2]]
+        assert call_count == 2
+        assert connected_to_ip == "93.184.216.34"
+
+    def test_should_block_a_rebind_before_sending_the_credential(self):
+        call_count = 0
+
+        def mock_getaddrinfo(_hostname, _port, *_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            address = "93.184.216.34" if call_count == 1 else "127.0.0.1"
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 0))]
+
+        with (
+            patch("socket.getaddrinfo", side_effect=mock_getaddrinfo),
+            patch("httpx.Client.post") as mock_post,
+        ):
+            embeddings = VllmMultivectorEmbeddings(
+                url="http://rebind.example:8080", model="test-model", api_key=_FAKE_VLLM_API_KEY
+            )
+            with pytest.raises(SSRFProtectionError, match="blocked"):
+                embeddings.embed_query("query")
+
+        assert call_count == 2
+        mock_post.assert_not_called()

--- a/src/bundles/openai/tests/test_openai_model_ssrf.py
+++ b/src/bundles/openai/tests/test_openai_model_ssrf.py
@@ -61,27 +61,37 @@ class TestOpenAIModelBaseUrlSSRF:
         mock_chat_openai.assert_not_called()
 
     @patch("lfx_openai.components.openai.openai_chat_model.ChatOpenAI")
-    def test_should_pin_http_clients_for_custom_base_url(self, mock_chat_openai):
+    def test_should_pin_http_clients_for_custom_base_url(self, mock_chat_openai, monkeypatch):
         """An allowed custom endpoint still builds, but through SSRF-protected clients."""
-        component = _component("http://127.0.0.1:1234/v1")
+        monkeypatch.setattr("lfx.utils.ssrf_protection.resolve_hostname", lambda _hostname: ["93.184.216.34"])
+        component = _component("https://provider.example/v1")
 
         component.build_model()
 
         kwargs = mock_chat_openai.call_args.kwargs
-        assert kwargs["base_url"] == "http://127.0.0.1:1234/v1"
+        assert kwargs["base_url"] == "https://provider.example/v1"
         assert "http_client" in kwargs
         assert "http_async_client" in kwargs
 
     @patch("lfx_openai.components.openai.openai_chat_model.ChatOpenAI")
-    def test_should_block_loopback_when_operator_disables_the_exemption(self, mock_chat_openai, monkeypatch):
-        """Multi-tenant operators can close the local-model-server loopback exemption."""
-        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "false")
+    def test_should_block_loopback_by_default(self, mock_chat_openai):
+        """Provider credentials must not reach a server-local listener under defaults."""
         component = _component("http://127.0.0.1:9999/v1")
 
         with pytest.raises(ValueError, match="SSRF Protection"):
             component.build_model()
 
         mock_chat_openai.assert_not_called()
+
+    @patch("lfx_openai.components.openai.openai_chat_model.ChatOpenAI")
+    def test_should_allow_explicitly_allowlisted_loopback(self, mock_chat_openai, monkeypatch):
+        """A single-tenant operator can explicitly trust a local provider host."""
+        monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "127.0.0.1")
+        component = _component("http://127.0.0.1:1234/v1")
+
+        component.build_model()
+
+        assert mock_chat_openai.call_args.kwargs["base_url"] == "http://127.0.0.1:1234/v1"
 
     @patch("lfx_openai.components.openai.openai_chat_model.ChatOpenAI")
     def test_should_leave_default_endpoint_untouched(self, mock_chat_openai):
@@ -161,6 +171,15 @@ class TestOpenAIEmbeddingsBaseUrlSSRF:
         kwargs = mock_embeddings.call_args.kwargs
         assert kwargs["base_url"] is None
         assert "http_client" not in kwargs
+
+    @patch("lfx_openai.components.openai.openai.OpenAIEmbeddings")
+    def test_should_block_loopback_by_default(self, mock_embeddings):
+        component = _embeddings_component("http://127.0.0.1:9999/v1")
+
+        with pytest.raises(ValueError, match="SSRF Protection"):
+            component.build_embeddings()
+
+        mock_embeddings.assert_not_called()
 
 
 @patch("lfx_openai.components.openai.openai_chat_model.ChatOpenAI")

--- a/src/lfx/src/lfx/base/models/provider_ssrf.py
+++ b/src/lfx/src/lfx/base/models/provider_ssrf.py
@@ -9,29 +9,37 @@ and a credential-exfiltration primitive.
 This module is the single seam where those components apply the repository's existing
 connector SSRF policy (``lfx.utils.ssrf_protection`` /
 ``lfx.utils.ssrf_httpx``), so a new provider bundle picks up the guard by importing one
-helper rather than copy-pasting a call site. It adds no policy of its own: the
-``LANGFLOW_SSRF_PROTECTION_ENABLED``, ``LANGFLOW_CONNECTOR_SSRF_VALIDATION_ENABLED``,
-``LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK`` and ``LANGFLOW_SSRF_ALLOWED_HOSTS`` settings
-govern behavior exactly as they do for every other connector.
+helper rather than copy-pasting a call site. Credential-bearing provider URLs intentionally
+use a stricter default than ordinary connectors: literal loopback is blocked unless the
+operator explicitly trusts it through ``LANGFLOW_SSRF_ALLOWED_HOSTS``. The global and
+connector validation kill switches retain their existing behavior.
 
-Scope note: this policy blocks *internal* destinations (cloud metadata, RFC1918, and —
-for operators who close the local-model-server exemption — loopback). It does not, and
-cannot, decide whether an arbitrary *public* host is a legitimate OpenAI-compatible
-provider, so pointing a provider component at an attacker-controlled public endpoint
-still forwards the configured credential. Restricting which hosts a stored provider
-credential may be sent to is a separate, additive control.
+Scope note: this policy blocks *internal* destinations (cloud metadata, RFC1918, and
+loopback). It does not, and cannot, decide whether an arbitrary *public* host is a
+legitimate OpenAI-compatible provider, so pointing a provider component at an
+attacker-controlled public endpoint still forwards the configured credential. Restricting
+which hosts a stored provider credential may be sent to is a separate, additive control.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lfx.utils.ssrf_httpx import (
-    ssrf_protected_openai_clients_for_url,
-    validate_url_for_ssrf_or_raise,
+    ssrf_protected_strict_openai_clients_for_url,
+    ssrf_safe_strict_httpx_post,
+    validate_strict_url_for_ssrf_or_raise,
 )
 
-__all__ = ["openai_compatible_client_kwargs", "validate_provider_base_url"]
+if TYPE_CHECKING:
+    import httpx
+
+__all__ = [
+    "openai_compatible_client_kwargs",
+    "provider_httpx_clients",
+    "provider_safe_httpx_post",
+    "validate_provider_base_url",
+]
 
 
 def _is_provider_default(base_url: str | None, default_url: str | None) -> bool:
@@ -53,10 +61,10 @@ def _is_provider_default(base_url: str | None, default_url: str | None) -> bool:
 def validate_provider_base_url(base_url: str | None, *, default_url: str | None = None) -> None:
     """Apply connector SSRF policy to a tenant-supplied provider base URL.
 
-    Use this for provider SDKs that expose no HTTP-client seam to pin DNS on (e.g.
-    ``ChatAnthropic``) or for plain ``requests``-based clients. Prefer
-    :func:`openai_compatible_client_kwargs` whenever the SDK accepts an httpx client,
-    since that additionally pins the validated IP and disables redirect following.
+    Use this only for configuration or preflight paths that do not later connect to
+    ``base_url``. Credential-bearing network calls must use :func:`provider_httpx_clients`,
+    :func:`provider_safe_httpx_post`, or :func:`openai_compatible_client_kwargs` so the
+    actual connection stays pinned to the validated IP.
 
     Args:
         base_url: The tenant-supplied base URL, or None/empty to use the provider default.
@@ -67,7 +75,21 @@ def validate_provider_base_url(base_url: str | None, *, default_url: str | None 
     """
     if _is_provider_default(base_url, default_url):
         return
-    validate_url_for_ssrf_or_raise(base_url)
+    validate_strict_url_for_ssrf_or_raise(base_url)
+
+
+def provider_httpx_clients(
+    base_url: str | None, *, default_url: str | None = None
+) -> dict[str, httpx.Client | httpx.AsyncClient]:
+    """Return strict, DNS-pinned clients for a credential-bearing provider SDK."""
+    if _is_provider_default(base_url, default_url):
+        return {}
+    return ssrf_protected_strict_openai_clients_for_url(base_url)
+
+
+def provider_safe_httpx_post(url: str, **request_kwargs: Any) -> httpx.Response:
+    """POST to a provider URL with strict validation and connection-time DNS pinning."""
+    return ssrf_safe_strict_httpx_post(url, **request_kwargs)
 
 
 def openai_compatible_client_kwargs(base_url: str | None, *, default_url: str | None = None) -> dict[str, Any]:
@@ -95,4 +117,4 @@ def openai_compatible_client_kwargs(base_url: str | None, *, default_url: str | 
     """
     if _is_provider_default(base_url, default_url):
         return {}
-    return ssrf_protected_openai_clients_for_url(base_url)
+    return provider_httpx_clients(base_url)

--- a/src/lfx/src/lfx/services/settings/groups/security.py
+++ b/src/lfx/src/lfx/services/settings/groups/security.py
@@ -48,8 +48,8 @@ class SecuritySettings(BaseModel):
     components, the separate LANGFLOW_RESTRICT_LOCAL_FILE_ACCESS toggle still governs local-file
     dialects (e.g. sqlite) independently of this flag."""
     connector_ssrf_allow_loopback: bool = True
-    """Whether a literal loopback host (localhost, 127.0.0.0/8, ::1) is allowed for HTTP CONNECTOR
-    and model-provider URLs, even while connector SSRF validation is on.
+    """Whether a literal loopback host (localhost, 127.0.0.0/8, ::1) is allowed for ordinary HTTP
+    CONNECTOR URLs, even while connector SSRF validation is on.
 
     Default True because connectors routinely target a *local* service: Ollama and LM Studio
     default to http://localhost:11434 / http://localhost:1234, and local vector stores bind to
@@ -59,8 +59,10 @@ class SecuritySettings(BaseModel):
     Multi-tenant deployers, where a tenant pointing a connector at the *server's* loopback is an
     SSRF vector, set this to False to block loopback too. Only literal loopback references are
     exempted — a hostname that *resolves* to loopback is still blocked, so DNS-rebinding cannot
-    abuse this. Has no effect on the API Request component (always strict), database URLs, or git
-    URLs, which validate loopback independently."""
+    abuse this. When SSRF validation is enabled, credential-bearing URLs guarded by
+    ``lfx.base.models.provider_ssrf`` use the strict path and require an explicit
+    ``ssrf_allowed_hosts`` entry for loopback. Has no effect on the API Request component,
+    database URLs, or git URLs, which validate loopback independently."""
 
     # API key handling
     disable_track_apikey_usage: bool = False

--- a/src/lfx/src/lfx/utils/ssrf_httpx.py
+++ b/src/lfx/src/lfx/utils/ssrf_httpx.py
@@ -9,9 +9,12 @@ import httpx
 
 from lfx.utils.ssrf_protection import (
     SSRFProtectionError,
+    is_connector_ssrf_validation_enabled,
     is_ssrf_protection_enabled,
     validate_and_resolve_connector_url,
+    validate_and_resolve_url,
     validate_connector_url_for_ssrf,
+    validate_url_for_ssrf,
 )
 from lfx.utils.ssrf_transport import (
     SSRFProtectedSyncTransport,
@@ -32,6 +35,23 @@ def validate_url_for_ssrf_or_raise(url: str) -> None:
     except SSRFProtectionError as e:
         msg = f"SSRF Protection: {e}"
         raise ValueError(msg) from e
+
+
+def validate_strict_url_for_ssrf_or_raise(url: str) -> None:
+    """Validate a credential-bearing provider URL without the connector loopback exemption."""
+    try:
+        if is_connector_ssrf_validation_enabled():
+            validate_url_for_ssrf(url)
+    except SSRFProtectionError as e:
+        msg = f"SSRF Protection: {e}"
+        raise ValueError(msg) from e
+
+
+def _validate_and_resolve_strict_url(url: str) -> tuple[str, list[str]]:
+    """Resolve a credential-bearing provider URL without the connector loopback exemption."""
+    if not is_connector_ssrf_validation_enabled():
+        return url, []
+    return validate_and_resolve_url(url)
 
 
 def _raise_if_following_redirects(request_kwargs: dict[str, Any]) -> None:
@@ -61,14 +81,10 @@ def _sync_client_for_url(url: str, validated_ips: list[str]) -> httpx.Client:
     return httpx.Client()
 
 
-def ssrf_protected_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Return sync/async httpx kwargs that enforce connector SSRF protection for SDK clients."""
-    try:
-        validated_url, validated_ips = validate_and_resolve_connector_url(url)
-    except SSRFProtectionError as e:
-        msg = f"SSRF Protection: {e}"
-        raise ValueError(msg) from e
-
+def _httpx_client_kwargs_for_validated_url(
+    validated_url: str, validated_ips: list[str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build sync and async client kwargs for an already validated URL."""
     if not is_ssrf_protection_enabled():
         return {}, {}
 
@@ -84,15 +100,46 @@ def ssrf_protected_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any]
     return sync_kwargs, async_kwargs
 
 
-def ssrf_protected_openai_clients_for_url(url: str) -> dict[str, httpx.Client | httpx.AsyncClient]:
-    """Return pinned sync and async clients for OpenAI-compatible LangChain components."""
-    sync_kwargs, async_kwargs = ssrf_protected_httpx_client_kwargs_for_url(url)
+def ssrf_protected_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return sync/async httpx kwargs that enforce connector SSRF protection for SDK clients."""
+    try:
+        validated_url, validated_ips = validate_and_resolve_connector_url(url)
+    except SSRFProtectionError as e:
+        msg = f"SSRF Protection: {e}"
+        raise ValueError(msg) from e
+    return _httpx_client_kwargs_for_validated_url(validated_url, validated_ips)
+
+
+def ssrf_protected_strict_httpx_client_kwargs_for_url(url: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return pinned client kwargs while denying provider loopback unless explicitly allowlisted."""
+    try:
+        validated_url, validated_ips = _validate_and_resolve_strict_url(url)
+    except SSRFProtectionError as e:
+        msg = f"SSRF Protection: {e}"
+        raise ValueError(msg) from e
+    return _httpx_client_kwargs_for_validated_url(validated_url, validated_ips)
+
+
+def _openai_clients_from_kwargs(
+    sync_kwargs: dict[str, Any], async_kwargs: dict[str, Any]
+) -> dict[str, httpx.Client | httpx.AsyncClient]:
+    """Build OpenAI-compatible sync and async clients from validated kwargs."""
     if not sync_kwargs and not async_kwargs:
         return {}
     return {
         "http_client": httpx.Client(**sync_kwargs),
         "http_async_client": httpx.AsyncClient(**async_kwargs),
     }
+
+
+def ssrf_protected_openai_clients_for_url(url: str) -> dict[str, httpx.Client | httpx.AsyncClient]:
+    """Return pinned sync and async clients for OpenAI-compatible LangChain components."""
+    return _openai_clients_from_kwargs(*ssrf_protected_httpx_client_kwargs_for_url(url))
+
+
+def ssrf_protected_strict_openai_clients_for_url(url: str) -> dict[str, httpx.Client | httpx.AsyncClient]:
+    """Return pinned clients while denying provider loopback unless explicitly allowlisted."""
+    return _openai_clients_from_kwargs(*ssrf_protected_strict_httpx_client_kwargs_for_url(url))
 
 
 async def ssrf_safe_async_get(url: str, **request_kwargs: Any) -> httpx.Response:
@@ -274,5 +321,13 @@ def ssrf_safe_httpx_post(url: str, **request_kwargs: Any) -> httpx.Response:
     """Perform a synchronous POST with connector SSRF validation and DNS pinning."""
     _raise_if_following_redirects(request_kwargs)
     validated_url, validated_ips = validate_and_resolve_connector_url(url)
+    with _sync_client_for_url(validated_url, validated_ips) as client:
+        return client.post(url=validated_url, **request_kwargs)
+
+
+def ssrf_safe_strict_httpx_post(url: str, **request_kwargs: Any) -> httpx.Response:
+    """POST to a credential-bearing provider URL with strict validation and DNS pinning."""
+    _raise_if_following_redirects(request_kwargs)
+    validated_url, validated_ips = _validate_and_resolve_strict_url(url)
     with _sync_client_for_url(validated_url, validated_ips) as client:
         return client.post(url=validated_url, **request_kwargs)

--- a/src/lfx/src/lfx/utils/ssrf_protection.py
+++ b/src/lfx/src/lfx/utils/ssrf_protection.py
@@ -464,7 +464,7 @@ def is_connector_ssrf_validation_enabled() -> bool:
 
 
 def is_connector_loopback_allowed() -> bool:
-    """Whether a literal loopback host is allowed for CONNECTOR / model-provider URLs.
+    """Whether a literal loopback host is allowed for ordinary CONNECTOR URLs.
 
     Connector and model-provider components routinely target a *local* service — Ollama and
     LM Studio default to ``http://localhost:11434`` / ``http://localhost:1234`` and local vector

--- a/src/lfx/tests/unit/base/models/test_provider_ssrf.py
+++ b/src/lfx/tests/unit/base/models/test_provider_ssrf.py
@@ -2,6 +2,7 @@
 
 import pytest
 from lfx.base.models.provider_ssrf import openai_compatible_client_kwargs, validate_provider_base_url
+from lfx.utils.ssrf_transport import SSRFProtectedSyncTransport, SSRFProtectedTransport
 
 BLOCKED_URLS = [
     "http://169.254.169.254/latest/meta-data",
@@ -9,6 +10,11 @@ BLOCKED_URLS = [
     "http://192.168.1.10/v1",
     "http://172.16.0.9/v1",
     "http://[fd00::1]/v1",
+    "http://localhost:1234/v1",
+    "http://127.0.0.1:1234/v1",
+    "http://127.1:1234/v1",
+    "http://2130706433:1234/v1",
+    "http://[::1]:1234/v1",
 ]
 
 DEFAULT_URL = "https://api.example-provider.com/v1"
@@ -47,6 +53,17 @@ class TestValidateProviderBaseUrl:
         monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "10.0.0.5")
         assert validate_provider_base_url("http://10.0.0.5:8000/v1") is None
 
+    def test_should_not_inherit_the_connector_loopback_exemption(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
+
+        with pytest.raises(ValueError, match="SSRF Protection"):
+            validate_provider_base_url("http://127.0.0.1:1234/v1")
+
+    def test_should_allow_explicitly_allowlisted_loopback(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "127.0.0.1")
+
+        assert validate_provider_base_url("http://127.0.0.1:1234/v1") is None
+
 
 class TestOpenAICompatibleClientKwargs:
     @pytest.mark.parametrize("blocked_url", BLOCKED_URLS)
@@ -61,18 +78,26 @@ class TestOpenAICompatibleClientKwargs:
     def test_should_return_empty_kwargs_for_provider_default(self):
         assert openai_compatible_client_kwargs(DEFAULT_URL, default_url=DEFAULT_URL) == {}
 
-    def test_should_return_pinned_clients_for_allowed_custom_url(self):
-        kwargs = openai_compatible_client_kwargs("http://localhost:1234/v1")
+    def test_should_return_pinned_clients_for_allowed_custom_url(self, monkeypatch):
+        monkeypatch.setattr("lfx.utils.ssrf_protection.resolve_hostname", lambda _hostname: ["93.184.216.34"])
+
+        kwargs = openai_compatible_client_kwargs("https://provider.example/v1")
 
         assert set(kwargs) == {"http_client", "http_async_client"}
         assert kwargs["http_client"].follow_redirects is False
         assert kwargs["http_async_client"].follow_redirects is False
+        assert isinstance(kwargs["http_client"]._transport, SSRFProtectedSyncTransport)
+        assert isinstance(kwargs["http_async_client"]._transport, SSRFProtectedTransport)
+        assert kwargs["http_client"]._transport.pinned_ips == {"provider.example": ["93.184.216.34"]}
+        assert kwargs["http_async_client"]._transport.pinned_ips == {"provider.example": ["93.184.216.34"]}
 
     def test_should_return_empty_kwargs_when_protection_is_disabled(self, monkeypatch):
         monkeypatch.setenv("LANGFLOW_SSRF_PROTECTION_ENABLED", "false")
         assert openai_compatible_client_kwargs("http://10.0.0.5:8000/v1") == {}
 
-    def test_should_block_loopback_when_exemption_is_closed(self, monkeypatch):
-        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "false")
-        with pytest.raises(ValueError, match="SSRF Protection"):
-            openai_compatible_client_kwargs("http://127.0.0.1:1234/v1")
+    def test_should_allow_explicitly_allowlisted_loopback(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_SSRF_ALLOWED_HOSTS", "127.0.0.1")
+
+        kwargs = openai_compatible_client_kwargs("http://127.0.0.1:1234/v1")
+
+        assert set(kwargs) == {"http_client", "http_async_client"}

--- a/uv.lock
+++ b/uv.lock
@@ -9990,6 +9990,7 @@ name = "lfx-nextplaid"
 version = "0.1.0"
 source = { editable = "src/bundles/nextplaid" }
 dependencies = [
+    { name = "httpx" },
     { name = "langchain-plaid" },
     { name = "lfx" },
     { name = "pillow" },
@@ -9997,6 +9998,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-plaid", specifier = ">=0.1.0,<1.0.0" },
     { name = "lfx", editable = "src/lfx" },
     { name = "pillow", specifier = ">=10.0.0" },


### PR DESCRIPTION
## Summary

Backports the PVR0851058 / H1-3938024 follow-up to `release-1.11.5`. This is the release-1.11.5 counterpart to the follow-up on `release-1.12.0`, building on the original backport in #14654.

The original remediation applied the connector SSRF policy to tenant-editable provider URLs, but literal loopback remained allowed by the generic connector default and Anthropic/vLLM still had validate-then-connect DNS-rebinding windows. This closes those residual paths for credential-bearing provider calls.

## Changes

- Add a strict provider URL path that blocks loopback by default while preserving the global/connector validation kill switches.
- Preserve explicitly trusted local provider setups through `LANGFLOW_SSRF_ALLOWED_HOSTS`.
- Install validated, DNS-pinned sync/async clients into custom Anthropic endpoints.
- Route each authenticated vLLM `/pooling` request through strict validation and DNS pinning; automatic redirects remain disabled.
- Keep ordinary connector behavior, canonical OpenAI/Anthropic endpoints, and their defaults unchanged.
- Preserve the release-1.11.5 NextPlaid dependency constraints while adding its direct `httpx` dependency.

## Security boundary

This closes internal/loopback SSRF and DNS-rebinding paths for the affected OpenAI, Anthropic, and NextPlaid vLLM provider calls. An arbitrary public custom endpoint remains a separate credential-destination policy question and is not changed here.

## Validation

- [x] LFX provider/HTTPX suites: **52 passed**
- [x] OpenAI bundle SSRF suite: **18 passed**
- [x] Anthropic bundle SSRF suite: **16 passed**
- [x] NextPlaid vLLM SSRF/component suites: **18 passed**
- [x] Exact loopback canary: blocked before dispatch; listener captured no request
- [x] Pre-commit hooks, `git diff --check`, and `uv lock --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened protection for credential-bearing provider requests against SSRF and DNS-rebinding attacks.
  * Loopback and localhost endpoints are blocked by default and require explicit allowlisting.
  * Added protected HTTP handling for Anthropic, OpenAI-compatible, and vLLM provider requests.
  * Preserved retry behavior while preventing credentials from being sent to unsafe destinations.

* **Documentation**
  * Clarified loopback allowlist behavior and updated HTTP client dependency documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->