### PR TITLE
fix(security): backport public MCP execution hardening

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -51,6 +51,7 @@ from langflow.api.utils.mcp import (
 from langflow.api.v1.auth_helpers import handle_auth_settings_update
 from langflow.api.v1.mcp import ResponseNoOp
 from langflow.api.v1.mcp_utils import (
+    authenticated_caller_ctx,
     current_request_variables_ctx,
     current_user_ctx,
     handle_call_tool,
@@ -106,6 +107,7 @@ async def verify_project_auth(
     # Mirror the service.py auth entrypoints: reset request-local credential metadata at entry so a
     # later branch (e.g. the composer-token fast path) never inherits stale context from a prior call.
     clear_current_auth_context()
+    authenticated_caller_ctx.set(None)
     # Defensive invariant: drop any stale external access ceiling so it can't carry into MCP project auth.
     clear_current_external_access_context()
 
@@ -130,6 +132,7 @@ async def verify_project_auth(
             if project.user_id:
                 project_user = await db.get(User, project.user_id)
                 if project_user:
+                    authenticated_caller_ctx.set(project_user.id)
                     return project_user
             raise HTTPException(status_code=404, detail="Project owner not found")
 
@@ -190,6 +193,7 @@ async def verify_project_auth(
         if not project_access:
             raise HTTPException(status_code=404, detail="Project not found")
 
+        authenticated_caller_ctx.set(user.id)
         return user
 
     # Legacy AUTO_LOGIN projects without explicit auth settings retain the
@@ -218,6 +222,7 @@ async def _superuser_fallback(db: AsyncSession, settings_service) -> User:
     if result:
         logger.warning(AUTO_LOGIN_WARNING)
         set_current_auth_context(AuthCredentialContext(method=AUTH_METHOD_AUTO_LOGIN))
+        authenticated_caller_ctx.set(result.id)
         return result
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -235,6 +240,7 @@ async def verify_project_auth_conditional(
     - MCP Composer enabled + API key auth: Only allow API keys
     - All other cases: Use standard MCP auth (JWT + API keys)
     """
+    authenticated_caller_ctx.set(None)
     async with session_scope() as session:
         # Get project to check auth settings
         project = (await session.exec(select(Folder).where(Folder.id == project_id))).first()
@@ -279,6 +285,7 @@ async def verify_project_auth_conditional(
         if not project_access:
             raise HTTPException(status_code=404, detail="Project not found")
 
+        authenticated_caller_ctx.set(user.id)
         return user
 
 

--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -7,20 +7,27 @@ import asyncio
 import base64
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
+from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 from urllib.parse import quote, unquote, urlparse
-from uuid import UUID, uuid4
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
 
 from lfx.base.mcp.constants import MAX_MCP_TOOL_NAME_LENGTH
 from lfx.base.mcp.util import get_flow_snake_case, get_unique_name, sanitize_mcp_name
 from lfx.log.logger import logger
-from lfx.utils.flow_validation import CustomComponentValidationError
+from lfx.utils.flow_validation import (
+    CustomComponentValidationError,
+    prepare_public_flow_build,
+    validate_public_flow_no_code_execution,
+)
 from lfx.utils.helpers import build_content_type_from_extension
 from mcp import types
 from sqlmodel import select
 
+from langflow.api.utils.core import strip_secret_field_values
+from langflow.api.utils.flow_utils import compute_virtual_flow_id, scope_session_to_namespace
 from langflow.api.v1.endpoints import simple_run_flow
 from langflow.api.v1.run_validation import HITL_UNSUPPORTED_DETAIL, flow_requires_hitl
 from langflow.api.v1.schemas import SimplifiedAPIRequest
@@ -29,7 +36,7 @@ from langflow.schema.message import Message
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.database.models import Flow
 from langflow.services.database.models.file.model import File as UserFile
-from langflow.services.database.models.user.model import User
+from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import get_settings_service, get_storage_service, session_scope
 
 T = TypeVar("T")
@@ -39,6 +46,47 @@ MCP_SERVERS_FILE = "_mcp_servers"
 
 # Create context variables
 current_user_ctx: ContextVar[User] = ContextVar("current_user_ctx")
+
+authenticated_caller_ctx: ContextVar[UUID | None] = ContextVar("authenticated_caller_ctx", default=None)
+
+
+def _public_mcp_execution_user() -> UserRead:
+    """Return a stable, non-persisted identity for anonymous MCP execution."""
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    return UserRead(
+        id=uuid5(NAMESPACE_URL, "urn:langflow:principal:anonymous-public"),
+        username="anonymous-public",
+        profile_image=None,
+        store_api_key=None,
+        is_active=True,
+        is_superuser=False,
+        create_at=epoch,
+        updated_at=epoch,
+        last_login_at=None,
+        optins=None,
+    )
+
+
+def _public_mcp_session_namespace(server: Any, project_id: UUID, flow_id: UUID) -> str:
+    """Return a per-MCP-connection namespace for anonymous session IDs."""
+    mcp_session = getattr(getattr(server, "request_context", None), "session", None)
+    connection_id = getattr(mcp_session, "session_id", None)
+    if not connection_id:
+        # The SSE session object is stable for the life of a connection even on
+        # SDK versions that do not expose a public session identifier.
+        connection_id = str(id(mcp_session)) if mcp_session is not None else str(uuid4())
+    identifier = f"mcp:{project_id}:{connection_id}"
+    return str(compute_virtual_flow_id(identifier, flow_id, principal_type="client"))
+
+
+async def _prepare_public_mcp_execution_flow(flow: Flow) -> Flow:
+    """Apply the shared anonymous-flow policy to a detached MCP execution graph."""
+    validate_public_flow_no_code_execution(flow.data)
+    prepared_data = await prepare_public_flow_build(flow.data)
+    sanitized_data = strip_secret_field_values(prepared_data if prepared_data is not None else flow.data)
+    return flow.model_copy(update={"data": sanitized_data}, deep=True)
+
+
 # Carries per-request variables injected via HTTP headers (e.g., X-Langflow-Global-Var-*)
 current_request_variables_ctx: ContextVar[dict[str, str] | None] = ContextVar(
     "current_request_variables_ctx", default=None
@@ -304,6 +352,18 @@ async def handle_call_tool(
         if flow_requires_hitl(flow.data or {}):
             raise RuntimeError(HITL_UNSUPPORTED_DETAIL)
 
+        is_public_project_call = project_id is not None and authenticated_caller_ctx.get() is None
+        execution_flow = flow
+        execution_user = current_user
+        if is_public_project_call:
+            try:
+                execution_flow = await _prepare_public_mcp_execution_flow(flow)
+            except CustomComponentValidationError as exc:
+                await logger.awarning(f"Public MCP tool call blocked for flow {flow.id}: {exc!s}")
+                msg = "This flow cannot be executed through a public MCP project."
+                raise RuntimeError(msg) from exc
+            execution_user = _public_mcp_execution_user()
+
         # Process inputs
         processed_inputs = dict(arguments)
 
@@ -314,8 +374,11 @@ async def handle_call_tool(
             )
 
         session_id = processed_inputs.pop("session_id", None) or str(uuid4())
+        if is_public_project_call:
+            namespace = _public_mcp_session_namespace(server, project_id, flow.id)
+            session_id = scope_session_to_namespace(session_id, namespace) or namespace
         input_value = processed_inputs.pop("input_value", "")
-        tweaks = get_flow_input_tweaks(flow, processed_inputs) if processed_inputs else None
+        tweaks = get_flow_input_tweaks(execution_flow, processed_inputs) if processed_inputs else None
         input_request = SimplifiedAPIRequest(
             input_value=input_value,
             session_id=session_id,
@@ -347,10 +410,10 @@ async def handle_call_tool(
             try:
                 try:
                     result = await simple_run_flow(
-                        flow=flow,
+                        flow=execution_flow,
                         input_request=input_request,
                         stream=False,
-                        api_key_user=current_user,
+                        api_key_user=execution_user,
                         context=exec_context,
                     )
                     # Process all outputs and messages, ensuring no duplicates

--- a/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects_auto_login_guard.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException, status
-from langflow.api.v1.mcp_projects import verify_project_auth
+from langflow.api.v1.mcp_projects import authenticated_caller_ctx, verify_project_auth
 from langflow.services.auth.constants import AUTO_LOGIN_ERROR
 
 MODULE = "langflow.api.v1.mcp_projects"
@@ -29,11 +29,11 @@ def _settings(*, auto_login: bool, skip_auth: bool, superuser: str = "admin") ->
     )
 
 
-def _db_yielding(project) -> MagicMock:
+def _db_yielding(project, *, user=None) -> MagicMock:
     """Build the ``db`` session 1.11.x passes into ``verify_project_auth`` directly."""
     db = MagicMock()
     db.exec = AsyncMock(return_value=SimpleNamespace(first=lambda: project))
-    db.get = AsyncMock(return_value=None)
+    db.get = AsyncMock(return_value=user)
     return db
 
 
@@ -123,3 +123,67 @@ async def test_verify_project_auth_rejects_presented_key_from_another_owner():
         await verify_project_auth(db, project.id, query_param=None, header_param="someone-elses-key")
 
     assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_public_project_keeps_caller_anonymous():
+    """A public project executes as its owner without authenticating the anonymous caller as that owner."""
+    owner = SimpleNamespace(id=uuid4(), username="owner")
+    project = SimpleNamespace(id=uuid4(), user_id=owner.id, auth_settings={"auth_type": "none"})
+    token = authenticated_caller_ctx.set(uuid4())
+    try:
+        with patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=False)):
+            result = await verify_project_auth(
+                _db_yielding(project, user=owner), project.id, query_param=None, header_param=None
+            )
+
+        assert authenticated_caller_ctx.get() is None
+    finally:
+        authenticated_caller_ctx.reset(token)
+
+    assert result is owner
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("auth_type", ["apikey", "oauth"])
+async def test_verify_project_auth_records_presented_api_key_caller(auth_type):
+    """API-key and OAuth project entrypoints record the credential's principal."""
+    owner = SimpleNamespace(id=uuid4(), username="owner")
+    project = SimpleNamespace(id=uuid4(), user_id=owner.id, auth_settings={"auth_type": auth_type})
+    api_key_result = SimpleNamespace(user=owner)
+    token = authenticated_caller_ctx.set(None)
+    try:
+        with (
+            patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=False)),
+            patch(f"{MODULE}.authenticate_api_key", new=AsyncMock(return_value=api_key_result)),
+            patch(f"{MODULE}.AuthCredentialContext.from_api_key_result", return_value=MagicMock()),
+        ):
+            result = await verify_project_auth(
+                _db_yielding(project), project.id, query_param=None, header_param="generated-key"
+            )
+
+        assert authenticated_caller_ctx.get() == owner.id
+    finally:
+        authenticated_caller_ctx.reset(token)
+
+    assert result is owner
+
+
+@pytest.mark.anyio
+async def test_verify_project_auth_records_auto_login_caller_and_resets_stale_context():
+    """AUTO_LOGIN records the fallback principal after clearing stale request context."""
+    project = SimpleNamespace(id=uuid4(), user_id=uuid4(), auth_settings=None)
+    superuser = SimpleNamespace(id=uuid4(), username="admin")
+    token = authenticated_caller_ctx.set(uuid4())
+    try:
+        with (
+            patch(f"{MODULE}.get_settings_service", return_value=_settings(auto_login=True, skip_auth=True)),
+            patch(f"{MODULE}.get_user_by_username", new=AsyncMock(return_value=superuser)),
+        ):
+            result = await verify_project_auth(_db_yielding(project), project.id, query_param=None, header_param=None)
+
+        assert authenticated_caller_ctx.get() == superuser.id
+    finally:
+        authenticated_caller_ctx.reset(token)
+
+    assert result is superuser

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import pytest
 from langflow.api.utils.core import extract_global_variables_from_headers
@@ -389,19 +390,40 @@ def _build_fake_server() -> SimpleNamespace:
     )
 
 
-async def _invoke_handle_call_tool(monkeypatch, arguments: dict) -> AsyncMock:
-    """Run handle_call_tool with all external deps stubbed; return the simple_run_flow mock."""
+async def _invoke_handle_call_tool(
+    monkeypatch,
+    arguments: dict,
+    *,
+    authenticated_caller="user-1",
+    project_id=None,
+    flow_data=None,
+) -> AsyncMock:
+    """Run handle_call_tool with all external deps stubbed; return the simple_run_flow mock.
+
+    ``authenticated_caller`` is the principal that presented a credential, which the auth
+    dependency establishes before the handler runs. It is not the same as the principal the
+    flow executes as: a project with ``auth_type="none"`` executes as its owner for an
+    anonymous caller, so the handler cannot read ownership off the execution principal.
+    """
     # ``user_id`` matches the current user (see ``current_user_ctx`` below) so the
     # owner-override path in ``ensure_flow_permission`` is exercised; ``workspace_id``
     # is read by the same guard. ``data`` feeds the HITL support gate.
     flow = SimpleNamespace(
-        id="flow-id-1",
+        id=uuid4(),
         name="my_flow",
-        folder_id=None,
+        folder_id=project_id,
         user_id="user-1",
         workspace_id=None,
-        data={"nodes": [], "edges": []},
+        data=flow_data or {"nodes": [], "edges": []},
     )
+
+    def model_copy(*, update, deep):
+        assert deep is True
+        copied = vars(flow).copy()
+        copied.update(update)
+        return SimpleNamespace(**copied)
+
+    flow.model_copy = model_copy
 
     async def fake_get_flow_snake_case(*_args, **_kwargs):
         return flow
@@ -416,16 +438,70 @@ async def _invoke_handle_call_tool(monkeypatch, arguments: dict) -> AsyncMock:
     mcp_utils.get_mcp_config().enable_progress_notifications = False
 
     token = mcp_utils.current_user_ctx.set(SimpleNamespace(id="user-1"))
+    caller_token = mcp_utils.authenticated_caller_ctx.set(authenticated_caller)
     try:
         await mcp_utils.handle_call_tool(
             name="my_flow",
             arguments=arguments,
             server=_build_fake_server(),
+            project_id=project_id,
         )
     finally:
+        mcp_utils.authenticated_caller_ctx.reset(caller_token)
         mcp_utils.current_user_ctx.reset(token)
 
     return simple_run_flow_mock
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_applies_public_policy_and_scopes_session(monkeypatch):
+    project_id = uuid4()
+    prepared_data = {"nodes": [{"prepared": True}], "edges": []}
+    sanitized_data = {"nodes": [{"sanitized": True}], "edges": []}
+    validate = MagicMock()
+    prepare = AsyncMock(return_value=prepared_data)
+    strip = MagicMock(return_value=sanitized_data)
+    monkeypatch.setattr(mcp_utils, "validate_public_flow_no_code_execution", validate)
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", prepare)
+    monkeypatch.setattr(mcp_utils, "strip_secret_field_values", strip)
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello", "session_id": "owner-private"},
+        authenticated_caller=None,
+        project_id=project_id,
+    )
+
+    validate.assert_called_once()
+    prepare.assert_awaited_once()
+    strip.assert_called_once_with(prepared_data)
+    forwarded_flow = simple_run_flow_mock.await_args.kwargs["flow"]
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    forwarded_user = simple_run_flow_mock.await_args.kwargs["api_key_user"]
+    assert forwarded_flow.data == sanitized_data
+    assert forwarded_request.session_id != "owner-private"
+    assert forwarded_request.session_id.endswith(":owner-private")
+    assert forwarded_user.id == uuid5(NAMESPACE_URL, "urn:langflow:principal:anonymous-public")
+    assert forwarded_user.is_superuser is False
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_preserves_authenticated_mcp_session(monkeypatch):
+    prepare = AsyncMock()
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", prepare)
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello", "session_id": "user-thread"},
+        authenticated_caller="user-1",
+        project_id=uuid4(),
+    )
+
+    prepare.assert_not_awaited()
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    forwarded_user = simple_run_flow_mock.await_args.kwargs["api_key_user"]
+    assert forwarded_request.session_id == "user-thread"
+    assert forwarded_user.id == "user-1"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -397,6 +397,7 @@ async def _invoke_handle_call_tool(
     authenticated_caller="user-1",
     project_id=None,
     flow_data=None,
+    expected_error: str | None = None,
 ) -> AsyncMock:
     """Run handle_call_tool with all external deps stubbed; return the simple_run_flow mock.
 
@@ -440,12 +441,21 @@ async def _invoke_handle_call_tool(
     token = mcp_utils.current_user_ctx.set(SimpleNamespace(id="user-1"))
     caller_token = mcp_utils.authenticated_caller_ctx.set(authenticated_caller)
     try:
-        await mcp_utils.handle_call_tool(
-            name="my_flow",
-            arguments=arguments,
-            server=_build_fake_server(),
-            project_id=project_id,
-        )
+        if expected_error is None:
+            await mcp_utils.handle_call_tool(
+                name="my_flow",
+                arguments=arguments,
+                server=_build_fake_server(),
+                project_id=project_id,
+            )
+        else:
+            with pytest.raises(RuntimeError, match=expected_error):
+                await mcp_utils.handle_call_tool(
+                    name="my_flow",
+                    arguments=arguments,
+                    server=_build_fake_server(),
+                    project_id=project_id,
+                )
     finally:
         mcp_utils.authenticated_caller_ctx.reset(caller_token)
         mcp_utils.current_user_ctx.reset(token)
@@ -453,7 +463,6 @@ async def _invoke_handle_call_tool(
     return simple_run_flow_mock
 
 
-@pytest.mark.asyncio
 async def test_handle_call_tool_applies_public_policy_and_scopes_session(monkeypatch):
     project_id = uuid4()
     prepared_data = {"nodes": [{"prepared": True}], "edges": []}
@@ -485,7 +494,44 @@ async def test_handle_call_tool_applies_public_policy_and_scopes_session(monkeyp
     assert forwarded_user.is_superuser is False
 
 
-@pytest.mark.asyncio
+async def test_handle_call_tool_rejects_public_flow_validation_failure(monkeypatch):
+    validate = MagicMock(side_effect=mcp_utils.CustomComponentValidationError("custom code is not allowed"))
+    prepare = AsyncMock()
+    monkeypatch.setattr(mcp_utils, "validate_public_flow_no_code_execution", validate)
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", prepare)
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+        authenticated_caller=None,
+        project_id=uuid4(),
+        expected_error="cannot be executed through a public MCP project",
+    )
+
+    validate.assert_called_once()
+    prepare.assert_not_awaited()
+    simple_run_flow_mock.assert_not_awaited()
+
+
+async def test_handle_call_tool_rejects_public_flow_prepare_failure(monkeypatch):
+    validate = MagicMock()
+    prepare = AsyncMock(side_effect=mcp_utils.CustomComponentValidationError("invalid public flow"))
+    monkeypatch.setattr(mcp_utils, "validate_public_flow_no_code_execution", validate)
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", prepare)
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+        authenticated_caller=None,
+        project_id=uuid4(),
+        expected_error="cannot be executed through a public MCP project",
+    )
+
+    validate.assert_called_once()
+    prepare.assert_awaited_once()
+    simple_run_flow_mock.assert_not_awaited()
+
+
 async def test_handle_call_tool_preserves_authenticated_mcp_session(monkeypatch):
     prepare = AsyncMock()
     monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", prepare)

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -390,6 +390,22 @@ def _build_fake_server() -> SimpleNamespace:
     )
 
 
+def test_public_mcp_session_namespace_is_stable_and_isolated():
+    """Namespaces are stable per connection and isolated by connection, project, and flow."""
+    project_id = uuid4()
+    flow_id = uuid4()
+    server = SimpleNamespace(request_context=SimpleNamespace(session=SimpleNamespace(session_id="connection-a")))
+
+    namespace = mcp_utils._public_mcp_session_namespace(server, project_id, flow_id)
+
+    assert mcp_utils._public_mcp_session_namespace(server, project_id, flow_id) == namespace
+    assert mcp_utils._public_mcp_session_namespace(server, uuid4(), flow_id) != namespace
+    assert mcp_utils._public_mcp_session_namespace(server, project_id, uuid4()) != namespace
+
+    other_server = SimpleNamespace(request_context=SimpleNamespace(session=SimpleNamespace(session_id="connection-b")))
+    assert mcp_utils._public_mcp_session_namespace(other_server, project_id, flow_id) != namespace
+
+
 async def _invoke_handle_call_tool(
     monkeypatch,
     arguments: dict,


### PR DESCRIPTION
## Summary

Backports #14706 to `release-1.11.5` with the release branch's older authentication plumbing.

- apply the shared anonymous-flow validation, trusted-code preparation, and secret scrubbing to public MCP project calls
- scope caller-provided session IDs to the MCP connection and flow
- execute anonymous calls with a stable non-persisted public principal
- preserve authenticated MCP project behavior

## Validation

- 23 focused MCP utility tests passed
- Ruff checks passed
- pre-commit hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for executing publicly shared MCP projects without requiring an authenticated user.
  * Public executions now use isolated sessions and anonymous identity handling.
  * Authenticated executions consistently preserve the caller’s identity and project context.

* **Security Enhancements**
  * Public project runs use sanitized flow copies with secrets removed.
  * Code-execution policies are validated before public flows run.
  * Session and execution data are scoped to prevent cross-connection interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->