### PR TITLE
feat: add Magic Hour video and image generation components

### DIFF
--- a/docs/docs/Components/bundles-magic-hour.mdx
+++ b/docs/docs/Components/bundles-magic-hour.mdx
@@ -1,0 +1,95 @@
+---
+title: Magic Hour
+slug: /bundles-magic-hour
+description: Generate videos and images in Langflow with Magic Hour's AI video and image generation API.
+---
+
+import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
+import PartialLfxBundlesInstall from '@site/docs/_partial-bundle-lfx-bundles-install.mdx';
+
+<PartialLfxBundlesInstall />
+
+<Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
+
+This page describes the components that are available in the **Magic Hour** bundle.
+
+[Magic Hour](https://magichour.ai) is an AI video and image generation API. One API key gives access to Sora 2, Veo 3.1, Kling 3.0, Seedance, MiniMax, WAN 2.2 and LTX for video, and GPT-image, Nano Banana Pro, Seedream, Flux and Z-Image for images.
+Get a free API key at [magichour.ai/developer](https://magichour.ai/developer); new accounts receive 400 credits plus 100 credits per day.
+The `wan-2.2`, `ltx-2.3` and `minimax-h3` video models and the `default` image model fit inside the free tier.
+
+For more information, see the [Magic Hour documentation](https://docs.magichour.ai).
+
+## Magic Hour Text to Video
+
+This component generates a video from a text prompt and returns the rendered video URL.
+
+It outputs either a **Result** ([`Data`](/data-types#data)) with `project_id`, `status`, `video_url` and `credits_charged`, or a **Video URL** ([`Message`](/data-types#message)).
+
+### Magic Hour Text to Video parameters
+
+<PartialParams />
+
+| Name | Type | Description |
+|------|------|-------------|
+| api_key | SecretString | Input parameter. Your Magic Hour API key. |
+| prompt | String | Input parameter. The description of the video to generate. |
+| model | Dropdown | Input parameter. The video model. `wan-2.2` (default), `ltx-2.3` and `minimax-h3` are free-tier models at 24 credits per second; `kling-3.0` costs 48, `veo3.1` 96 and `sora-2` 120 credits per second. |
+| duration | Integer | Input parameter. Video length in seconds. Allowed values depend on the model. Default: `5`. |
+| resolution | Dropdown | Input parameter. `480p`, `720p` or `1080p`. Default: `480p`. |
+| aspect_ratio | Dropdown | Input parameter. `16:9`, `9:16` or `1:1`. Default: `16:9`. |
+| audio | Boolean | Input parameter. Generate audio where the model supports it. Default: `false`. |
+| wait_for_completion | Boolean | Input parameter. Poll until the render finishes. If disabled, only the project ID is returned. Default: `true`. |
+| timeout_seconds | Integer | Input parameter. Maximum time to wait for the render. Default: `900`. |
+
+## Magic Hour Image to Video
+
+This component animates a source image into a video.
+The image can be a public `https` URL or a local file path, which the component uploads to Magic Hour automatically.
+
+### Magic Hour Image to Video parameters
+
+<PartialParams />
+
+| Name | Type | Description |
+|------|------|-------------|
+| api_key | SecretString | Input parameter. Your Magic Hour API key. |
+| image | String | Input parameter. A public image URL or a local file path. |
+| prompt | String | Input parameter. A description of the motion or scene. |
+| model | Dropdown | Input parameter. The video model. Default: `wan-2.2`. |
+| duration | Integer | Input parameter. Video length in seconds. Default: `5`. |
+| resolution | Dropdown | Input parameter. `480p`, `720p` or `1080p`. Default: `480p`. |
+| wait_for_completion | Boolean | Input parameter. Poll until the render finishes. Default: `true`. |
+| timeout_seconds | Integer | Input parameter. Maximum time to wait for the render. Default: `900`. |
+
+## Magic Hour Image Generator
+
+This component generates one or more images from a text prompt and returns their URLs.
+
+### Magic Hour Image Generator parameters
+
+<PartialParams />
+
+| Name | Type | Description |
+|------|------|-------------|
+| api_key | SecretString | Input parameter. Your Magic Hour API key. |
+| prompt | String | Input parameter. The description of the image to generate. |
+| model | Dropdown | Input parameter. `default`, `gpt-image-2`, `nano-banana-pro`, `seedream-5-pro`, `flux-2-klein`, `z-image-turbo` or `qwen-edit`. Default: `default`. |
+| image_count | Integer | Input parameter. Number of images to generate. Default: `1`. |
+| aspect_ratio | Dropdown | Input parameter. `1:1`, `16:9`, `9:16`, `4:3` or `3:4`. Default: `1:1`. |
+| wait_for_completion | Boolean | Input parameter. Poll until rendering finishes. Default: `true`. |
+| timeout_seconds | Integer | Input parameter. Maximum time to wait. Default: `300`. |
+
+## Use Magic Hour in a flow
+
+1. Get an API key at [magichour.ai/developer](https://magichour.ai/developer).
+2. In Langflow, add the **Magic Hour Text to Video** component to your flow and enter your API key.
+3. Connect a **Chat Input** component to the **Prompt** field, and connect the **Video URL** output to a **Chat Output** component.
+4. Click **Playground**, describe a scene, and the rendered video URL is returned when the job completes.
+
+All three components expose **Tool Mode**, so an **Agent** can call them to generate media on demand.
+
+## See also
+
+- [Magic Hour API documentation](https://docs.magichour.ai)
+- [Magic Hour LangChain integration](https://github.com/RhythmP28/langchain-magic-hour)

--- a/docs/docs/Lfx/extensions-bundle-list.mdx
+++ b/docs/docs/Lfx/extensions-bundle-list.mdx
@@ -82,6 +82,7 @@ Bare `uv pip install lfx-bundles` registers the provider code only; add a per-pr
 | `langwatch` | `uv pip install "lfx-bundles[langwatch]"` |
 | `litellm` | `uv pip install "lfx-bundles[litellm]"` |
 | [`lmstudio`](/bundles-lmstudio) (LM Studio) | `uv pip install "lfx-bundles[lmstudio]"` |
+| [`magic_hour`](/bundles-magic-hour) (Magic Hour) | `uv pip install "lfx-bundles[magic-hour]"` |
 | [`maritalk`](/bundles-maritalk) (MariTalk) | `uv pip install "lfx-bundles[maritalk]"` |
 | [`mem0`](/bundles-mem0) (Mem0) | `uv pip install "lfx-bundles[mem0]"` |
 | [`milvus`](/bundles-milvus) (Milvus) | `uv pip install "lfx-bundles[milvus]"` |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -531,6 +531,7 @@ module.exports = {
             "Components/bundles-langchain",
             "Components/bundles-lite-llm",
             "Components/bundles-lmstudio",
+            "Components/bundles-magic-hour",
             "Components/bundles-maritalk",
             "Components/bundles-mem0",
             "Components/bundles-milvus",

--- a/scripts/ci/release_inventory_contract.json
+++ b/scripts/ci/release_inventory_contract.json
@@ -265,6 +265,7 @@
         "langwatch",
         "litellm",
         "lmstudio",
+        "magic_hour",
         "maritalk",
         "mem0",
         "milvus",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -60,6 +60,7 @@ jigsawstack = ["jigsawstack==0.2.7"]
 langwatch = []
 litellm = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0"]
 lmstudio = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0", "langchain-nvidia-ai-endpoints~=1.0.0"]
+magic-hour = []
 maritalk = ["langchain-community>=0.4.1,<1.0.0"]
 mem0 = ["mem0ai>=2.0.2,<3.0.0"]
 milvus = ["langchain-milvus~=0.3.2"]
@@ -130,6 +131,7 @@ all = [
     "lfx-bundles[langwatch]",
     "lfx-bundles[litellm]",
     "lfx-bundles[lmstudio]",
+    "lfx-bundles[magic-hour]",
     "lfx-bundles[maritalk]",
     "lfx-bundles[mem0]",
     "lfx-bundles[milvus]",
@@ -198,6 +200,7 @@ all-no-torch = [
     "lfx-bundles[langwatch]",
     "lfx-bundles[litellm]",
     "lfx-bundles[lmstudio]",
+    "lfx-bundles[magic-hour]",
     "lfx-bundles[maritalk]",
     "lfx-bundles[mem0]",
     "lfx-bundles[milvus]",

--- a/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/__init__.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.utils.lazy_import import import_mod
+
+if TYPE_CHECKING:
+    from lfx_bundles.magic_hour.magic_hour_image_generator import MagicHourImageGeneratorComponent
+    from lfx_bundles.magic_hour.magic_hour_image_to_video import MagicHourImageToVideoComponent
+    from lfx_bundles.magic_hour.magic_hour_text_to_video import MagicHourTextToVideoComponent
+
+_dynamic_imports = {
+    "MagicHourImageGeneratorComponent": "magic_hour_image_generator",
+    "MagicHourImageToVideoComponent": "magic_hour_image_to_video",
+    "MagicHourTextToVideoComponent": "magic_hour_text_to_video",
+}
+
+__all__ = [
+    "MagicHourImageGeneratorComponent",
+    "MagicHourImageToVideoComponent",
+    "MagicHourTextToVideoComponent",
+]
+
+
+def __getattr__(attr_name: str) -> Any:
+    """Lazily import magic_hour components on attribute access."""
+    if attr_name not in _dynamic_imports:
+        msg = f"module '{__name__}' has no attribute '{attr_name}'"
+        raise AttributeError(msg)
+    try:
+        result = import_mod(attr_name, _dynamic_imports[attr_name], __spec__.parent)
+    except (ModuleNotFoundError, ImportError, AttributeError) as e:
+        msg = f"Could not import '{attr_name}' from '{__name__}': {e}"
+        raise AttributeError(msg) from e
+    globals()[attr_name] = result
+    return result
+
+
+def __dir__() -> list[str]:
+    return list(__all__)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/_api.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/_api.py
@@ -1,0 +1,116 @@
+"""Thin httpx helpers shared by the Magic Hour components.
+
+Talks to the Magic Hour REST API (https://docs.magichour.ai) directly so the
+bundle needs no third-party SDK beyond ``httpx`` (an lfx core dependency).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+MAGIC_HOUR_API_BASE = "https://api.magichour.ai/v1"
+DEFAULT_TIMEOUT = 60.0
+TERMINAL_STATUSES = {"complete", "error", "canceled"}
+
+
+class MagicHourError(RuntimeError):
+    """Raised when the Magic Hour API returns an error or a job fails."""
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    if not api_key:
+        msg = "A Magic Hour API key is required. Get one at https://magichour.ai/developer."
+        raise MagicHourError(msg)
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if response.is_success:
+        return
+    try:
+        detail = response.json()
+    except ValueError:
+        detail = response.text
+    msg = f"Magic Hour API error {response.status_code}: {detail}"
+    raise MagicHourError(msg)
+
+
+def create_project(api_key: str, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """POST ``/v1/<endpoint>`` and return the ``{id, credits_charged}`` response body."""
+    with httpx.Client(timeout=DEFAULT_TIMEOUT) as client:
+        response = client.post(f"{MAGIC_HOUR_API_BASE}/{endpoint}", json=payload, headers=_headers(api_key))
+    _raise_for_status(response)
+    return response.json()
+
+
+def get_project(api_key: str, kind: str, project_id: str) -> dict[str, Any]:
+    """GET ``/v1/<kind>-projects/{id}``; ``kind`` is ``"video"`` or ``"image"``."""
+    with httpx.Client(timeout=DEFAULT_TIMEOUT) as client:
+        response = client.get(f"{MAGIC_HOUR_API_BASE}/{kind}-projects/{project_id}", headers=_headers(api_key))
+    _raise_for_status(response)
+    return response.json()
+
+
+def wait_for_project(
+    api_key: str,
+    kind: str,
+    project_id: str,
+    *,
+    poll_interval: float = 5.0,
+    timeout: float = 600.0,
+) -> dict[str, Any]:
+    """Poll a project until it reaches a terminal status or ``timeout`` seconds elapse."""
+    deadline = time.monotonic() + timeout
+    while True:
+        project = get_project(api_key, kind, project_id)
+        status = project.get("status")
+        if status in TERMINAL_STATUSES:
+            if status != "complete":
+                error = project.get("error") or {}
+                msg = f"Magic Hour {kind} project {project_id} ended with status '{status}': {error}"
+                raise MagicHourError(msg)
+            return project
+        if time.monotonic() >= deadline:
+            msg = (
+                f"Timed out after {timeout:.0f}s waiting for Magic Hour {kind} project {project_id} (status={status})."
+            )
+            raise MagicHourError(msg)
+        time.sleep(poll_interval)
+
+
+def download_urls(project: dict[str, Any]) -> list[str]:
+    return [item["url"] for item in project.get("downloads", []) if item.get("url")]
+
+
+def upload_local_file(api_key: str, path: str) -> str:
+    """Upload a local image via ``/v1/files/upload-urls`` and return the Magic Hour ``file_path``."""
+    file_path = Path(path)
+    if not file_path.is_file():
+        msg = f"Image file not found: {path}"
+        raise MagicHourError(msg)
+    extension = file_path.suffix.lstrip(".").lower() or "png"
+    response = create_project(api_key, "files/upload-urls", {"items": [{"extension": extension, "type": "image"}]})
+    item = response["items"][0]
+    with httpx.Client(timeout=DEFAULT_TIMEOUT) as client:
+        put = client.put(item["upload_url"], content=file_path.read_bytes())
+    _raise_for_status(put)
+    return item["file_path"]
+
+
+def resolve_image_asset(api_key: str, image: str) -> str:
+    """Return something ``assets.image_file_path`` accepts: a public URL, an ``api-assets/`` path, or an upload."""
+    image = (image or "").strip()
+    if not image:
+        msg = "An image URL or local file path is required."
+        raise MagicHourError(msg)
+    if image.startswith(("http://", "https://", "api-assets/")):
+        return image
+    return upload_local_file(api_key, image)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_image_generator.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_image_generator.py
@@ -1,0 +1,115 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.schema.data import Data
+from lfx.schema.message import Message
+from lfx.template.field.base import Output
+
+from lfx_bundles.magic_hour._api import create_project, download_urls, wait_for_project
+
+IMAGE_MODELS = [
+    "default",
+    "gpt-image-2",
+    "nano-banana-pro",
+    "seedream-5-pro",
+    "flux-2-klein",
+    "z-image-turbo",
+    "qwen-edit",
+]
+IMAGE_ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:3", "3:4"]
+
+
+class MagicHourImageGeneratorComponent(Component):
+    display_name = "Magic Hour Image Generator"
+    description = (
+        "Generate images from a text prompt with Magic Hour (GPT-image, Nano Banana Pro, Seedream, Flux, Z-Image). "
+        "Costs 5 credits per image with the default model. Returns the image URLs."
+    )
+    documentation = "https://docs.magichour.ai"
+    icon = "Clapperboard"
+    name = "MagicHourImageGenerator"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Magic Hour API Key",
+            required=True,
+            info="Your Magic Hour API key (free at https://magichour.ai/developer).",
+        ),
+        MessageTextInput(
+            name="prompt",
+            display_name="Prompt",
+            required=True,
+            info="Describe the image to generate.",
+            tool_mode=True,
+        ),
+        DropdownInput(
+            name="model",
+            display_name="Model",
+            options=IMAGE_MODELS,
+            value="default",
+            info="Image model. 'default' is the cheapest; nano-banana-pro / gpt-image-2 give the highest quality.",
+        ),
+        IntInput(
+            name="image_count",
+            display_name="Image Count",
+            value=1,
+            info="Number of images to generate (1-4).",
+        ),
+        DropdownInput(
+            name="aspect_ratio",
+            display_name="Aspect Ratio",
+            options=IMAGE_ASPECT_RATIOS,
+            value="1:1",
+        ),
+        BoolInput(
+            name="wait_for_completion",
+            display_name="Wait for Completion",
+            value=True,
+            advanced=True,
+            info="Poll until rendering finishes. If off, only the project id is returned.",
+        ),
+        IntInput(
+            name="timeout_seconds",
+            display_name="Timeout (seconds)",
+            value=300,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="generate_images"),
+        Output(display_name="Image URL", name="image_url", method="image_url_message"),
+    ]
+
+    def _build_payload(self) -> dict:
+        return {
+            "name": f"Langflow: {self.prompt[:60]}",
+            "model": self.model,
+            "image_count": int(self.image_count or 1),
+            "aspect_ratio": self.aspect_ratio,
+            "style": {"prompt": self.prompt},
+        }
+
+    def generate_images(self) -> Data:
+        created = create_project(self.api_key, "ai-image-generator", self._build_payload())
+        result = {
+            "project_id": created["id"],
+            "status": "queued",
+            "image_urls": [],
+            "credits_charged": created.get("credits_charged"),
+            "model": self.model,
+        }
+        if self.wait_for_completion:
+            project = wait_for_project(self.api_key, "image", created["id"], timeout=float(self.timeout_seconds or 300))
+            result.update(
+                status=project.get("status"),
+                image_urls=download_urls(project),
+                credits_charged=project.get("credits_charged", result["credits_charged"]),
+            )
+        self.status = result
+        return Data(data=result)
+
+    def image_url_message(self) -> Message:
+        data = self.generate_images()
+        urls = data.data.get("image_urls") or []
+        return Message(text=urls[0] if urls else data.data["project_id"])

--- a/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_image_to_video.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_image_to_video.py
@@ -1,0 +1,113 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.schema.data import Data
+from lfx.schema.message import Message
+from lfx.template.field.base import Output
+
+from lfx_bundles.magic_hour._api import create_project, download_urls, resolve_image_asset, wait_for_project
+from lfx_bundles.magic_hour.magic_hour_text_to_video import VIDEO_MODELS, VIDEO_RESOLUTIONS
+
+
+class MagicHourImageToVideoComponent(Component):
+    display_name = "Magic Hour Image to Video"
+    description = (
+        "Animate an image into a video with Magic Hour. Accepts a public image URL or a local file path "
+        "(uploaded automatically). wan-2.2, ltx-2.3 and minimax-h3 are free-tier models; "
+        "premium models cost 30-120 credits/s. Returns the rendered video URL."
+    )
+    documentation = "https://docs.magichour.ai"
+    icon = "Clapperboard"
+    name = "MagicHourImageToVideo"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Magic Hour API Key",
+            required=True,
+            info="Your Magic Hour API key (free at https://magichour.ai/developer).",
+        ),
+        MessageTextInput(
+            name="image",
+            display_name="Image URL or Path",
+            required=True,
+            info="Public https URL of the source image, or a local file path to upload.",
+            tool_mode=True,
+        ),
+        MessageTextInput(
+            name="prompt",
+            display_name="Prompt",
+            info="Describe the motion or scene for the video.",
+            tool_mode=True,
+        ),
+        DropdownInput(
+            name="model",
+            display_name="Model",
+            options=VIDEO_MODELS,
+            value="wan-2.2",
+            info="Video model. wan-2.2 / ltx-2.3 / minimax-h3 are free-tier (24 credits/s).",
+        ),
+        IntInput(
+            name="duration",
+            display_name="Duration (seconds)",
+            value=5,
+            info="Length of the video in seconds. Allowed values depend on the model.",
+        ),
+        DropdownInput(
+            name="resolution",
+            display_name="Resolution",
+            options=VIDEO_RESOLUTIONS,
+            value="480p",
+        ),
+        BoolInput(
+            name="wait_for_completion",
+            display_name="Wait for Completion",
+            value=True,
+            advanced=True,
+            info="Poll until the render finishes. If off, only the project id is returned.",
+        ),
+        IntInput(
+            name="timeout_seconds",
+            display_name="Timeout (seconds)",
+            value=900,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="generate_video"),
+        Output(display_name="Video URL", name="video_url", method="video_url_message"),
+    ]
+
+    def _build_payload(self) -> dict:
+        return {
+            "name": f"Langflow: {(self.prompt or 'image to video')[:60]}",
+            "model": self.model,
+            "end_seconds": float(self.duration),
+            "resolution": self.resolution,
+            "style": {"prompt": self.prompt or ""},
+            "assets": {"image_file_path": resolve_image_asset(self.api_key, self.image)},
+        }
+
+    def generate_video(self) -> Data:
+        created = create_project(self.api_key, "image-to-video", self._build_payload())
+        result = {
+            "project_id": created["id"],
+            "status": "queued",
+            "video_url": None,
+            "credits_charged": created.get("credits_charged"),
+            "model": self.model,
+        }
+        if self.wait_for_completion:
+            project = wait_for_project(self.api_key, "video", created["id"], timeout=float(self.timeout_seconds or 900))
+            urls = download_urls(project)
+            result.update(
+                status=project.get("status"),
+                video_url=urls[0] if urls else None,
+                credits_charged=project.get("credits_charged", result["credits_charged"]),
+            )
+        self.status = result
+        return Data(data=result)
+
+    def video_url_message(self) -> Message:
+        data = self.generate_video()
+        return Message(text=data.data.get("video_url") or data.data["project_id"])

--- a/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_text_to_video.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/magic_hour_text_to_video.py
@@ -1,0 +1,146 @@
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import BoolInput, DropdownInput, IntInput, MessageTextInput, SecretStrInput
+from lfx.schema.data import Data
+from lfx.schema.message import Message
+from lfx.template.field.base import Output
+
+from lfx_bundles.magic_hour._api import create_project, download_urls, wait_for_project
+
+VIDEO_MODELS = [
+    "wan-2.2",
+    "ltx-2.3",
+    "minimax-h3",
+    "seedance-1.5",
+    "seedance-2.0-mini",
+    "seedance-2.0",
+    "seedance-2.5",
+    "kling-2.6",
+    "kling-3.0",
+    "veo3.1-lite",
+    "veo3.1",
+    "veo3.1-audio",
+    "sora-2",
+]
+VIDEO_RESOLUTIONS = ["480p", "720p", "1080p"]
+ASPECT_RATIOS = ["16:9", "9:16", "1:1"]
+
+
+class MagicHourTextToVideoComponent(Component):
+    display_name = "Magic Hour Text to Video"
+    description = (
+        "Generate a video from a text prompt with Magic Hour (Sora 2, Veo 3.1, Kling 3.0, Seedance, WAN 2.2, ...). "
+        "wan-2.2, ltx-2.3 and minimax-h3 are free-tier models (24 credits/s); "
+        "premium models cost 30-120 credits/s. Returns the rendered video URL."
+    )
+    documentation = "https://docs.magichour.ai"
+    icon = "Clapperboard"
+    name = "MagicHourTextToVideo"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="Magic Hour API Key",
+            required=True,
+            info="Your Magic Hour API key (free at https://magichour.ai/developer).",
+        ),
+        MessageTextInput(
+            name="prompt",
+            display_name="Prompt",
+            required=True,
+            info="Describe the video to generate.",
+            tool_mode=True,
+        ),
+        DropdownInput(
+            name="model",
+            display_name="Model",
+            options=VIDEO_MODELS,
+            value="wan-2.2",
+            info=(
+                "Video model. wan-2.2 / ltx-2.3 / minimax-h3 are free-tier (24 credits/s); "
+                "kling-3.0 is 48 credits/s, veo3.1 96 credits/s, sora-2 120 credits/s (max 720p)."
+            ),
+        ),
+        IntInput(
+            name="duration",
+            display_name="Duration (seconds)",
+            value=5,
+            info="Length of the video in seconds. Allowed values depend on the model (wan-2.2: 3-10 or 15).",
+        ),
+        DropdownInput(
+            name="resolution",
+            display_name="Resolution",
+            options=VIDEO_RESOLUTIONS,
+            value="480p",
+            info="Output resolution. sora-2 and seedance-2.x are limited to 720p.",
+        ),
+        DropdownInput(
+            name="aspect_ratio",
+            display_name="Aspect Ratio",
+            options=ASPECT_RATIOS,
+            value="16:9",
+            advanced=True,
+        ),
+        BoolInput(
+            name="audio",
+            display_name="Generate Audio",
+            value=False,
+            advanced=True,
+            info="Ask the model to generate audio where supported (e.g. veo3.1-audio).",
+        ),
+        BoolInput(
+            name="wait_for_completion",
+            display_name="Wait for Completion",
+            value=True,
+            advanced=True,
+            info="Poll until the render finishes. If off, only the project id is returned.",
+        ),
+        IntInput(
+            name="timeout_seconds",
+            display_name="Timeout (seconds)",
+            value=900,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="generate_video"),
+        Output(display_name="Video URL", name="video_url", method="video_url_message"),
+    ]
+
+    def _build_payload(self) -> dict:
+        return {
+            "name": f"Langflow: {self.prompt[:60]}",
+            "model": self.model,
+            "end_seconds": float(self.duration),
+            "resolution": self.resolution,
+            "aspect_ratio": self.aspect_ratio,
+            "audio": bool(self.audio),
+            "style": {"prompt": self.prompt},
+        }
+
+    def generate_video(self) -> Data:
+        created = create_project(self.api_key, "text-to-video", self._build_payload())
+        result = {
+            "project_id": created["id"],
+            "status": "queued",
+            "video_url": None,
+            "credits_charged": created.get("credits_charged"),
+            "model": self.model,
+        }
+        if self.wait_for_completion:
+            project = wait_for_project(self.api_key, "video", created["id"], timeout=float(self.timeout_seconds or 900))
+            urls = download_urls(project)
+            result.update(
+                status=project.get("status"),
+                video_url=urls[0] if urls else None,
+                credits_charged=project.get("credits_charged", result["credits_charged"]),
+                width=project.get("width"),
+                height=project.get("height"),
+                fps=project.get("fps"),
+            )
+        self.status = result
+        return Data(data=result)
+
+    def video_url_message(self) -> Message:
+        data = self.generate_video()
+        return Message(text=data.data.get("video_url") or data.data["project_id"])

--- a/src/bundles/lfx-bundles/tests/test_magic_hour_components.py
+++ b/src/bundles/lfx-bundles/tests/test_magic_hour_components.py
@@ -1,0 +1,188 @@
+"""Offline unit tests for the Magic Hour bundle (httpx is mocked)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx_bundles.magic_hour._api import MagicHourError, resolve_image_asset, wait_for_project
+from lfx_bundles.magic_hour.magic_hour_image_generator import MagicHourImageGeneratorComponent
+from lfx_bundles.magic_hour.magic_hour_image_to_video import MagicHourImageToVideoComponent
+from lfx_bundles.magic_hour.magic_hour_text_to_video import MagicHourTextToVideoComponent
+
+VIDEO_URL = "https://videos.magichour.ai/out.mp4"
+IMAGE_URL = "https://images.magichour.ai/out.png"
+
+
+def _response(status_code: int, payload):
+    request = httpx.Request("GET", "https://api.magichour.ai/v1/x")
+    return httpx.Response(status_code, json=payload, request=request)
+
+
+def _mock_client(post_payloads=(), get_payloads=()):
+    """Build a patched ``httpx.Client`` whose post/get return the given bodies in order."""
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    client.post.side_effect = [_response(200, p) for p in post_payloads]
+    client.get.side_effect = [_response(200, p) for p in get_payloads]
+    client.put.return_value = _response(200, {})
+    return client
+
+
+@pytest.mark.unit
+class TestMagicHourTextToVideo:
+    def test_generates_video_and_polls_until_complete(self):
+        component = MagicHourTextToVideoComponent(
+            api_key="test-key", prompt="a fox in snow", model="wan-2.2", duration=5, resolution="480p"
+        )
+        client = _mock_client(
+            post_payloads=[{"id": "vid_1", "credits_charged": 120}],
+            get_payloads=[
+                {"id": "vid_1", "status": "rendering", "downloads": []},
+                {
+                    "id": "vid_1",
+                    "status": "complete",
+                    "downloads": [{"url": VIDEO_URL, "expires_at": "2030-01-01"}],
+                    "credits_charged": 120,
+                    "width": 854,
+                    "height": 480,
+                    "fps": 24,
+                },
+            ],
+        )
+        with (
+            patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client),
+            patch("lfx_bundles.magic_hour._api.time.sleep") as sleep,
+        ):
+            result = component.generate_video()
+
+        assert result.data["project_id"] == "vid_1"
+        assert result.data["status"] == "complete"
+        assert result.data["video_url"] == VIDEO_URL
+        assert result.data["credits_charged"] == 120
+        assert sleep.call_count == 1
+
+        _, kwargs = client.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-key"
+        body = kwargs["json"]
+        assert body["model"] == "wan-2.2"
+        assert body["end_seconds"] == 5.0
+        assert body["resolution"] == "480p"
+        assert body["aspect_ratio"] == "16:9"
+        assert body["style"] == {"prompt": "a fox in snow"}
+        assert client.post.call_args[0][0] == "https://api.magichour.ai/v1/text-to-video"
+
+    def test_video_url_message_output(self):
+        component = MagicHourTextToVideoComponent(api_key="k", prompt="p")
+        client = _mock_client(
+            post_payloads=[{"id": "vid_2", "credits_charged": 120}],
+            get_payloads=[{"id": "vid_2", "status": "complete", "downloads": [{"url": VIDEO_URL}]}],
+        )
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            message = component.video_url_message()
+        assert message.text == VIDEO_URL
+
+    def test_no_wait_returns_project_id_only(self):
+        component = MagicHourTextToVideoComponent(api_key="k", prompt="p", wait_for_completion=False)
+        client = _mock_client(post_payloads=[{"id": "vid_3", "credits_charged": 120}])
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            result = component.generate_video()
+        assert result.data == {
+            "project_id": "vid_3",
+            "status": "queued",
+            "video_url": None,
+            "credits_charged": 120,
+            "model": "wan-2.2",
+        }
+        client.get.assert_not_called()
+
+    def test_http_error_raises(self):
+        component = MagicHourTextToVideoComponent(api_key="bad", prompt="p")
+        client = _mock_client()
+        client.post.side_effect = [_response(401, {"message": "Unauthorized"})]
+        with (
+            patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client),
+            pytest.raises(MagicHourError, match="401"),
+        ):
+            component.generate_video()
+
+    def test_failed_render_raises(self):
+        client = _mock_client(get_payloads=[{"id": "vid_4", "status": "error", "error": {"message": "boom"}}])
+        with (
+            patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client),
+            pytest.raises(MagicHourError, match="error"),
+        ):
+            wait_for_project("k", "video", "vid_4")
+
+
+@pytest.mark.unit
+class TestMagicHourImageToVideo:
+    def test_public_url_is_passed_through(self):
+        component = MagicHourImageToVideoComponent(
+            api_key="k", image="https://example.com/cat.png", prompt="make it dance", duration=5
+        )
+        client = _mock_client(
+            post_payloads=[{"id": "vid_5", "credits_charged": 120}],
+            get_payloads=[{"id": "vid_5", "status": "complete", "downloads": [{"url": VIDEO_URL}]}],
+        )
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            result = component.generate_video()
+        assert result.data["video_url"] == VIDEO_URL
+        body = client.post.call_args[1]["json"]
+        assert body["assets"] == {"image_file_path": "https://example.com/cat.png"}
+        assert client.post.call_args[0][0] == "https://api.magichour.ai/v1/image-to-video"
+
+    def test_local_file_is_uploaded(self, tmp_path):
+        image = tmp_path / "cat.png"
+        image.write_bytes(b"\x89PNG")
+        client = _mock_client(
+            post_payloads=[
+                {"items": [{"upload_url": "https://upload.example/abc", "file_path": "api-assets/id/cat.png"}]}
+            ]
+        )
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            file_path = resolve_image_asset("k", str(image))
+        assert file_path == "api-assets/id/cat.png"
+        client.put.assert_called_once()
+        assert client.put.call_args[0][0] == "https://upload.example/abc"
+        assert client.put.call_args[1]["content"] == b"\x89PNG"
+
+    def test_missing_image_raises(self):
+        with pytest.raises(MagicHourError, match="required"):
+            resolve_image_asset("k", "")
+
+
+@pytest.mark.unit
+class TestMagicHourImageGenerator:
+    def test_generates_images(self):
+        component = MagicHourImageGeneratorComponent(
+            api_key="k", prompt="a red bicycle", model="default", image_count=2, aspect_ratio="16:9"
+        )
+        client = _mock_client(
+            post_payloads=[{"id": "img_1", "credits_charged": 10}],
+            get_payloads=[
+                {"id": "img_1", "status": "complete", "downloads": [{"url": IMAGE_URL}, {"url": IMAGE_URL + "?2"}]}
+            ],
+        )
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            result = component.generate_images()
+        assert result.data["image_urls"] == [IMAGE_URL, IMAGE_URL + "?2"]
+        assert result.data["status"] == "complete"
+        body = client.post.call_args[1]["json"]
+        assert body["image_count"] == 2
+        assert body["aspect_ratio"] == "16:9"
+        assert client.post.call_args[0][0] == "https://api.magichour.ai/v1/ai-image-generator"
+
+    def test_image_url_message_output(self):
+        component = MagicHourImageGeneratorComponent(api_key="k", prompt="p")
+        client = _mock_client(
+            post_payloads=[{"id": "img_2", "credits_charged": 5}],
+            get_payloads=[{"id": "img_2", "status": "complete", "downloads": [{"url": IMAGE_URL}]}],
+        )
+        with patch("lfx_bundles.magic_hour._api.httpx.Client", return_value=client):
+            assert component.image_url_message().text == IMAGE_URL

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -481,6 +481,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "LangWatch", name: "langwatch", icon: "Langwatch" },
   { display_name: "LiteLLM", name: "litellm", icon: "LiteLLM" },
   { display_name: "LMStudio", name: "lmstudio", icon: "LMStudio" },
+  { display_name: "Magic Hour", name: "magic_hour", icon: "Clapperboard" },
   { display_name: "MariTalk", name: "maritalk", icon: "Maritalk" },
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },
   { display_name: "Memories", name: "memories", icon: "Cpu" },

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -4915,6 +4915,21 @@
       "legacy_slot": "ext:valkey:ValkeyIndexChatMemory@official-pre-a",
       "target": "ext:valkey:ValkeyIndexChatMemory@official",
       "added_in": "1.11.0"
+    },
+    {
+      "bare_class_name": "MagicHourImageGeneratorComponent",
+      "target": "ext:magic_hour:MagicHourImageGeneratorComponent@official",
+      "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "MagicHourImageToVideoComponent",
+      "target": "ext:magic_hour:MagicHourImageToVideoComponent@official",
+      "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "MagicHourTextToVideoComponent",
+      "target": "ext:magic_hour:MagicHourTextToVideoComponent@official",
+      "added_in": "1.12.0"
     }
   ],
   "ambiguous_bare_names": [


### PR DESCRIPTION
## Summary

Adds a **Magic Hour** bundle (`lfx_bundles/magic_hour`) with three components for AI video and image generation via the [Magic Hour API](https://docs.magichour.ai). One API key gives access to Sora 2, Veo 3.1, Kling 3.0, Seedance, WAN 2.2, LTX and MiniMax for video, and GPT-image, Nano Banana Pro, Seedream, Flux and Z-Image for images. Free API keys (400 credits + 100/day) at https://magichour.ai/developer; the `wan-2.2`, `ltx-2.3`, `minimax-h3` and `default` image models fit inside the free tier.

- `MagicHourTextToVideoComponent` - prompt -> video URL
- `MagicHourImageToVideoComponent` - public image URL or local file path (auto-uploaded through `/v1/files/upload-urls`) -> video URL
- `MagicHourImageGeneratorComponent` - prompt -> image URLs

Each exposes `api_key` (SecretStrInput), `prompt` (MessageTextInput, tool mode), `model` / `resolution` / `aspect_ratio` dropdowns, `duration` / `image_count` ints, an optional `wait_for_completion` flag, and returns `Data` (`project_id`, `status`, `video_url` / `image_urls`, `credits_charged`) plus a `Message` with the URL.

The components call the REST API directly with `httpx` (already an lfx core dependency), so the `magic-hour` extra is empty like `tavily` / `glean`; no new third-party SDK is added.

## Changes

- `src/bundles/lfx-bundles/src/lfx_bundles/magic_hour/` - bundle (`__init__.py`, `_api.py`, three component modules)
- `src/bundles/lfx-bundles/pyproject.toml` - `magic-hour` extra + `all` / `all-no-torch` aggregates
- `src/lfx/src/lfx/extension/migration/migration_table.json` - bare-name entries for the three classes (append-only, `added_in: 1.12.0`)
- `scripts/ci/release_inventory_contract.json` - `magic_hour` in the `python-full` bundle inventory
- `src/frontend/src/utils/styleUtils.ts` - sidebar bundle entry (uses the lucide `Clapperboard` icon)
- `docs/docs/Components/bundles-magic-hour.mdx`, `docs/sidebars.js`, `docs/docs/Lfx/extensions-bundle-list.mdx` - docs
- `src/bundles/lfx-bundles/tests/test_magic_hour_components.py` - offline unit tests (httpx mocked)

## Testing

- `uv run pytest src/bundles/lfx-bundles/tests/test_magic_hour_components.py` - 10 passed
- `uv run pytest src/bundles/lfx-bundles/tests/test_all_no_torch_extra.py scripts/ci/test_release_inventory.py` - 13 passed
- `scripts/migrate/check_bare_names.py` and `check_migration_append_only.py` pass
- `load_lfx_bundles_extensions()` discovers the `magic_hour` bundle with 3 components and no errors
- `ruff format` / `ruff check` clean on the new files

## Related

- Python SDK: https://pypi.org/project/magic_hour/
- LangChain integration: https://github.com/RhythmP28/langchain-magic-hour
- Vercel AI SDK provider: https://github.com/RhythmP28/magic-hour-ai-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Magic Hour integrations for text-to-video, image-to-video, and image generation.
  * Supports configurable models, prompts, media settings, completion polling, timeouts, and downloadable result URLs.
  * Added support for image URLs and local image files.
  * Added Magic Hour to the available bundle catalog and sidebar navigation.

* **Documentation**
  * Added installation guidance, API details, configuration references, supported models, defaults, and usage examples.

* **Bug Fixes**
  * Added clear handling for missing inputs, API failures, failed renders, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->