### PR TITLE
fix(amazon): wire Top K into Bedrock Converse additionalModelRequestFields

### DIFF
--- a/src/bundles/amazon/src/lfx_amazon/components/amazon/amazon_bedrock_converse.py
+++ b/src/bundles/amazon/src/lfx_amazon/components/amazon/amazon_bedrock_converse.py
@@ -153,18 +153,18 @@ class AmazonBedrockConverseComponent(LCModelComponent):
         if hasattr(self, "disable_streaming") and self.disable_streaming:
             init_params["disable_streaming"] = True
 
-        # Handle additional model request fields carefully
-        # Based on the error, inferenceConfig should not be passed as additional fields for some models
+        # top_k is not part of the universal Converse API inferenceConfig, so it is
+        # passed through additional_model_request_fields like other provider-specific fields.
         additional_model_request_fields = {}
+        if hasattr(self, "top_k") and self.top_k is not None:
+            additional_model_request_fields["top_k"] = self.top_k
 
-        # Only add top_k if user explicitly provided additional fields or if needed for specific models
+        # additional_model_fields lets users override or extend provider-specific fields,
+        # including using a different key for providers that don't accept "top_k".
         if hasattr(self, "additional_model_fields") and self.additional_model_fields:
             for field in self.additional_model_fields:
                 if isinstance(field, dict):
                     additional_model_request_fields.update(field)
-
-        # For now, don't automatically add inferenceConfig for top_k to avoid validation errors
-        # Users can manually add it via additional_model_fields if their model supports it
 
         # Only add if we have actual additional fields
         if additional_model_request_fields:

--- a/src/bundles/amazon/tests/test_amazon_bedrock_converse.py
+++ b/src/bundles/amazon/tests/test_amazon_bedrock_converse.py
@@ -1,0 +1,41 @@
+"""Regression test: the Top K input must reach the constructed ChatBedrockConverse model."""
+
+from lfx_amazon.components.amazon.amazon_bedrock_converse import AmazonBedrockConverseComponent
+
+_FAKE_AWS_ACCESS_KEY_ID = "AKIAFAKEFAKEFAKEFAKE"  # pragma: allowlist secret
+_FAKE_AWS_SECRET_ACCESS_KEY = "fake-secret"  # noqa: S105  # pragma: allowlist secret
+
+
+def _component(**overrides) -> AmazonBedrockConverseComponent:
+    component = AmazonBedrockConverseComponent()
+    component.model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    component.aws_access_key_id = _FAKE_AWS_ACCESS_KEY_ID
+    component.aws_secret_access_key = _FAKE_AWS_SECRET_ACCESS_KEY
+    component.region_name = "us-east-1"
+    component.temperature = 0.7
+    component.max_tokens = 4096
+    component.top_p = 0.9
+    component.top_k = 250
+    component.disable_streaming = False
+    component.additional_model_fields = []
+    for name, value in overrides.items():
+        setattr(component, name, value)
+    return component
+
+
+def test_top_k_reaches_additional_model_request_fields():
+    model = _component(top_k=17).build_model()
+
+    assert model.additional_model_request_fields == {"top_k": 17}
+
+
+def test_user_supplied_additional_model_fields_can_override_top_k():
+    model = _component(top_k=17, additional_model_fields=[{"top_k": 99}]).build_model()
+
+    assert model.additional_model_request_fields == {"top_k": 99}
+
+
+def test_top_k_omitted_when_unset():
+    model = _component(top_k=None).build_model()
+
+    assert not model.additional_model_request_fields


### PR DESCRIPTION
## Problem

Fixes #14716. `AmazonBedrockConverseComponent` defines a `top_k`
input, but `build_model()` never reads `self.top_k`. `temperature`,
`max_tokens`, and `top_p` are all wired into `init_params`; `top_k` has no
equivalent line. A user who sets Top K in the UI has that value silently
dropped - no error, just different sampling behavior than what the UI
shows.

Found incidentally while investigating #13033 (Bedrock streaming error) in
the same file. #13033 remains open/unresolved separately and is not
touched by this PR.

## Fix

`top_k` isn't part of the Converse API's universal `inferenceConfig`
(unlike `temperature`/`top_p`/`max_tokens`), so - matching how
`ChatBedrockConverse` (`langchain-aws`, pinned `1.6.3`) actually expects
provider-specific parameters - it now goes into
`additional_model_request_fields` instead of `init_params`. It's added
before the existing `additional_model_fields` override loop, so a user can
still supply a different key via `additional_model_fields` for providers
that don't accept `top_k` under that name.

## Testing

- Added `src/bundles/amazon/tests/test_amazon_bedrock_converse.py`;
  confirmed `test_top_k_reaches_additional_model_request_fields` fails on
  the pre-fix code and all three tests pass post-fix.
- Verified the fix builds a real `ChatBedrockConverse` instance (pinned
  `langchain-aws` 1.6.3) with `additional_model_request_fields = {"top_k":
  ...}` set - no AWS credentials required, since this is local parameter
  construction, not a live Bedrock call.
- `ruff check` / `ruff format --diff` clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Amazon Bedrock Converse requests now automatically include the configured `top_k` value.
  - Custom model fields can override or extend provider-specific settings.
  - The `top_k` setting is omitted when no value is provided.

- **Bug Fixes**
  - Improved consistency when applying model configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->