### PR TITLE
fix(frontend): report every alias of a blocked component to the editor

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1892,16 +1892,21 @@ async def custom_component_update(
 
 
 def _blocked_component_types(snapshot) -> list[str]:
-    """Return the component types the editor should treat as policy-blocked.
+    """Return every component type the editor should treat as policy-blocked.
 
-    A blocked key is whatever the administrator entered, which may be an alias
-    rather than the registry's canonical name, so it is resolved the same way
-    the enforcement path resolves it. Both the raw key and its canonical
-    candidates are reported: a node's ``type`` can carry either.
+    The editor compares a node's ``type`` against this set, and a saved node
+    carries whichever identity it was saved under -- ``Prompt`` rather than the
+    registry key ``Prompt Template``. Alias resolution only runs one way, so
+    reporting the administrator's key and its canonical candidates is not
+    enough: blocking the canonical key would leave every node saved under an
+    alias unmatched, and the palette exposes only the canonical key, so that is
+    the one an administrator can find.
 
-    A node whose ``type`` is some *third* alias of a blocked component is not
-    listed and the editor will not name a policy for it. That under-claims
-    rather than over-claims, and the server still refuses the run.
+    ``_resolve_catalog_policy_matches`` decides the write by resolving the node
+    side too and intersecting, so the same rule is applied here in reverse:
+    every alias whose canonical candidates meet the blocked identities is
+    reported. That keeps this answer identical to the one that decides whether
+    the save succeeds, which is the whole point of sending it.
     """
     blocked_keys = getattr(snapshot, "blocked_component_keys", None)
     if not blocked_keys:
@@ -1915,7 +1920,15 @@ def _blocked_component_types(snapshot) -> list[str]:
     except Exception:  # noqa: BLE001
         identity_index = None
     if identity_index is not None:
-        types |= set(identity_index.resolve_many(blocked_keys))
+        blocked_identities = frozenset(identity_index.resolve_many(blocked_keys))
+        types |= blocked_identities
+        types |= {
+            alias
+            for alias, candidates in identity_index.aliases.items()
+            # Any overlap blocks the node server side, including an alias that
+            # is ambiguous across components.
+            if not blocked_identities.isdisjoint(candidates)
+        }
     return sorted(types)
 
 

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -593,10 +593,74 @@ async def test_get_config_names_blocked_components_to_authenticated_callers(
     response = await client.get("api/v1/config", headers=logged_in_headers)
 
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert result["blocked_component_types"] == ["Agent", "ChatOutput"]
+    reported = response.json()["blocked_component_types"]
+    # The keys themselves, plus every alias a saved node could carry for them.
+    assert {"Agent", "ChatOutput"} <= set(reported)
     # Template identities stay withheld: nothing in the editor consumes them.
-    assert "Simple Agent" not in result["blocked_component_types"]
+    assert "Simple Agent" not in reported
+    # An unrelated component contributes nothing.
+    assert "Prompt Template" not in reported
+
+
+async def test_get_config_names_every_alias_of_a_blocked_component(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """A node saved under an alias must match the administrator's canonical key.
+
+    Alias resolution runs alias -> canonical only, so reporting just the
+    blocked key and its canonical candidates leaves a node saved as ``Prompt``
+    unmatched when ``Prompt Template`` is blocked -- and the palette exposes
+    only ``Prompt Template``, so that is the key an administrator can find.
+    Nine shipped starter flows save that component as ``Prompt``.
+    """
+    identity_index = SimpleNamespace(
+        canonical_keys=frozenset({"Prompt Template", "ParserComponent"}),
+        aliases={
+            "Prompt": frozenset({"Prompt Template"}),
+            "PromptComponent": frozenset({"Prompt Template"}),
+            "parser": frozenset({"ParserComponent"}),
+        },
+        resolve_many=lambda keys: frozenset(
+            candidate
+            for key in keys
+            for candidate in (
+                frozenset({key})
+                if key in {"Prompt Template", "ParserComponent"}
+                else {
+                    "Prompt": frozenset({"Prompt Template"}),
+                    "PromptComponent": frozenset({"Prompt Template"}),
+                    "parser": frozenset({"ParserComponent"}),
+                }.get(key, frozenset({key}))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "lfx.utils.flow_validation.get_component_identity_index_for_validation",
+        lambda: identity_index,
+    )
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_catalog_policy_service",
+        lambda: SimpleNamespace(
+            enabled=True,
+            snapshot=SimpleNamespace(
+                blocked_component_keys=frozenset({"Prompt Template"}),
+                blocked_template_keys=frozenset(),
+            ),
+        ),
+    )
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    reported = response.json()["blocked_component_types"]
+    # The alias a saved node actually carries.
+    assert "Prompt" in reported
+    assert "PromptComponent" in reported
+    assert "Prompt Template" in reported
+    # An unrelated component's alias stays out of it.
+    assert "parser" not in reported
 
 
 async def test_get_config_names_no_components_when_only_a_template_is_blocked(


### PR DESCRIPTION
## Problem

Reported by QA while verifying #14681. Confirmed, reproduced, and fixed here.

`/config` reports `blocked_component_types` so the editor can tell whether a policy names the component in front of the user. It reported the administrator's key plus the canonical identities that key resolves to — but alias resolution runs **alias → canonical only**:

```python
def resolve(self, identity: str) -> frozenset[str]:
    if identity in self.canonical_keys:
        return frozenset({identity})     # canonical -> itself, aliases dropped
    return self.aliases.get(identity, frozenset({identity}))
```

So blocking the **canonical** key left every node saved under an alias unmatched. With `Prompt Template` blocked, a node saved as `Prompt` matched nothing, and all three surfaces answered "no": no banner, build preflight passed, autosave never paused. The write was then rejected server-side with a 400 the user never saw, and their edit was silently discarded.

Two things make this the common case rather than a corner:

- **The failing key is the only discoverable one.** `Prompt` is not a registry key; `Prompt Template` is. An administrator browsing the palette or `/api/v1/all` can only find the key that breaks.
- **Shipped starter flows are affected.** I measured the current tree: **9** flows save that component as `Prompt` — including the featured Basic Prompting — plus 4 using `parser` and 1 using `AstraDB`.

This is not the "third alias" under-claim I documented in #14681. `Prompt` is the component's runtime type, and `Prompt Template` is the canonical key the enforcement path resolves it to.

## Fix

`_resolve_catalog_policy_matches` decides the write by resolving the *node* side too and intersecting. This applies the reverse of that rule: every alias whose canonical candidates meet the blocked identities is reported, including an alias ambiguous across components — which the server also blocks, since it uses the same non-empty-intersection test.

The editor's answer now matches the one that decides whether the save succeeds, which is the entire point of sending it.

## Verified live

Against a running server, `PUT /api/v1/policy-bundle` then `GET /api/v1/config`:

| Policy | `blocked_component_types` | node `type: "Prompt"` matches |
| --- | --- | --- |
| `Prompt Template` (canonical) | `['Prompt', 'Prompt Template', 'PromptComponent']` | **yes** (was **no**) |
| `Prompt` (alias) | `['Prompt', 'Prompt Template', 'PromptComponent']` | yes (unchanged) |
| template only | `[]` | n/a — LE-2226 fix intact |
| `ChatOutput` | `['Chat Output', 'ChatOutput']` | no — no cross-component leak |

Row 1 is the bug. Rows 2–4 confirm nothing regressed: the alias case QA used as their counter-proof still works, #14681's template-only fix is untouched, and blocking one component does not name another.

## Test plan

- [x] `pytest src/backend/tests/unit/api/v1/test_endpoints.py -k config` — **21 passed**
- [x] New test reproduces the QA scenario: `Prompt Template` blocked reports `Prompt` and `PromptComponent`, and an unrelated component's alias stays out
- [x] Guard verified non-vacuous — dropping the reverse-alias emission fails exactly that test
- [x] `jest src/CustomNodes src/stores src/hooks/flows src/controllers/API/queries/config` — **48 suites, 706 passed** (frontend needs no change; the membership test was already right, it was being given an incomplete set)
- [x] `ruff check` / `ruff format --check` clean

## Note on the other half of the report

QA also observed the build rejection surfacing as a raw payload toast (`HTTP 400: {"detail":...}`) rather than policy copy. That is a separate, pre-existing error-rendering issue on the build path and is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked component reporting so all relevant aliases are included when a component is restricted.
  * Ensured editor configuration matches server-side component availability rules.
  * Prevented unrelated aliases and blocked template identities from being incorrectly reported as blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->