### PR TITLE
docs: fix broken cross-directory links and dead anchors

### DIFF
--- a/docs/docs/API-Reference/api-openai-responses.mdx
+++ b/docs/docs/API-Reference/api-openai-responses.mdx
@@ -126,7 +126,7 @@ If you need these in a different format or want a downloadable calendar, let me 
 |--------|----------|-------------|---------|
 | `x-api-key` | Yes | Your Langflow API key for authentication | `"sk-..."` |
 | `Content-Type` | Yes | Specifies the JSON format | `"application/json"` |
-| `X-LANGFLOW-GLOBAL-VAR-*` | No | Global variables for the flow | `"X-LANGFLOW-GLOBAL-VAR-API_KEY: sk-..."` For more, see [Pass global variables to your flows in headers](#global-var). |
+| `X-LANGFLOW-GLOBAL-VAR-*` | No | Global variables for the flow | `"X-LANGFLOW-GLOBAL-VAR-API_KEY: sk-..."` For more, see [Pass global variables to your flows in headers](./api-flows-run#pass-global-variables-in-headers). |
 
 ### Request body
 

--- a/docs/docs/API-Reference/workflow-api-quickstart.mdx
+++ b/docs/docs/API-Reference/workflow-api-quickstart.mdx
@@ -20,7 +20,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import PartialAPISetup from '@site/docs/_partial-api-setup.mdx';
 
-The [Workflow API](./workflow-api) executes Langflow flows over `POST /api/v2/workflows` in three modes.
+The [Workflow API](./workflows-api) executes Langflow flows over `POST /api/v2/workflows` in three modes.
 
 Use the default **`sync`** mode when you want to wait for the full JSON result in one response. Use **`stream`** when you need live Server-Sent Events (SSE) emitted as the flow runs. Use **`background`** when you want to queue a job and then poll or re-attach to its event stream.
 
@@ -81,7 +81,7 @@ Set `"mode": "stream"` to open an SSE stream. Choose the wire format with `strea
 - **`langflow`** (default): Langflow `EventManager` frames for existing Langflow clients.
 - **`agui`**: [AG-UI](https://docs.ag-ui.com/introduction) lifecycle events for compatible clients.
 
-For request examples, event types, and protocol details, see [Execute flow with selected `stream` mode](./workflow-api#execute-flow-with-selected-stream-mode) in the Workflow API reference.
+For request examples, event types, and protocol details, see [Execute flow with selected `stream` mode](./workflows-api#execute-flow-with-selected-stream-mode) in the Workflow API reference.
 
 ### Langflow EventManager (default)
 
@@ -151,9 +151,9 @@ Set `"mode": "background"` to queue a job and receive a `job_id` immediately. Po
 
 While a job is still `queued` or `in_progress`, the poll endpoint returns a job object (`object: "job"`) with `links` for status, events, and stop. When the job completes, the same endpoint returns the full execution response.
 
-To connect to a background run, see [Re-attach to a background run](./workflow-api#re-attach-to-a-background-run).
+To connect to a background run, see [Re-attach to a background run](./workflows-api#re-attach-to-a-background-run).
 
 ## Next steps
 
-* [Workflow API reference](./workflow-api) — request body fields, response schemas, status polling, stop endpoint, tweaks, globals, and error codes.
+* [Workflow API reference](./workflows-api) — request body fields, response schemas, status polling, stop endpoint, tweaks, globals, and error codes.
 * [Flow trigger endpoints](/api-flows-run) — v1 `/run` and `/webhook` endpoints if you are migrating from or comparing with the v1 API.

--- a/docs/docs/API-Reference/workflows-api.mdx
+++ b/docs/docs/API-Reference/workflows-api.mdx
@@ -402,7 +402,7 @@ The `status` values are:
 |--------|-------------|
 | `queued` | Job is queued and waiting to start. |
 | `in_progress` | Job is currently executing. |
-| `suspended` | Job is paused and waiting for human input. See [Human-in-the-Loop](./human-in-the-loop). |
+| `suspended` | Job is paused and waiting for human input. See [Human-in-the-Loop](../Flows/human-in-the-loop). |
 | `completed` | Job completed successfully. |
 | `failed` | Job failed during execution. |
 | `cancelled` | Job was stopped by the client. |

--- a/docs/docs/Agents/a2a-server.mdx
+++ b/docs/docs/Agents/a2a-server.mdx
@@ -19,7 +19,7 @@ Langflow supports the [Agent2Agent (A2A) protocol](https://a2a-protocol.org/). Y
 
 This page describes how to publish a flow as an A2A agent that A2A clients can discover and call.
 
-To call remote A2A agents from inside a flow, see the [**A2A Agent** component](./a2a-agent-component).
+To call remote A2A agents from inside a flow, see the [**A2A Agent** component](../Components/a2a-agent).
 
 ## Prerequisites
 
@@ -814,9 +814,9 @@ If the flow pauses for human input, `message/send` returns a task in the `input-
 
 ## Call a remote A2A agent
 
-The [**A2A Agent** component](./a2a-agent-component) lets a flow call a flow within the same Langflow [project](/concepts-flows#projects), or call out to any remote spec-compliant A2A agent.
+The [**A2A Agent** component](../Components/a2a-agent) lets a flow call a flow within the same Langflow [project](/concepts-flows#projects), or call out to any remote spec-compliant A2A agent.
 
-For more information, see [**A2A Agent** component](./a2a-agent-component).
+For more information, see [**A2A Agent** component](../Components/a2a-agent).
 
 ## A2A environment variables
 

--- a/docs/docs/Agents/agents-tools.mdx
+++ b/docs/docs/Agents/agents-tools.mdx
@@ -59,7 +59,7 @@ However, you might use a fixed value if you're trying to debug an agent's behavi
 
 ## Require approval for agent tools {#require-approval-for-agent-tools}
 
-The **Agent** component can pause before calling a gated tool, create a stateful checkpoint, and then resume after a human decision. This is one way to add [Human-in-the-Loop](./human-in-the-loop) to a flow.
+The **Agent** component can pause before calling a gated tool, create a stateful checkpoint, and then resume after a human decision. This is one way to add [Human-in-the-Loop](../Flows/human-in-the-loop) to a flow.
 
 For example, if your agent drafts Python code and one of its tools commits to Git, enable **Requires approval** on the commit tool only. The flow run will pause when the agent tries to call the commit tool, without adding a branch node on the canvas.
 
@@ -226,7 +226,7 @@ The connected flow returns an answer based on your question.
 
 ## See also
 
-* [Human-in-the-Loop](./human-in-the-loop)
+* [Human-in-the-Loop](../Flows/human-in-the-loop)
 * [Agent components](/components-agents)
 * [Use Langflow as an MCP client](/mcp-client)
 * [Use Langflow as an MCP server](/mcp-server)

--- a/docs/docs/Agents/agents.mdx
+++ b/docs/docs/Agents/agents.mdx
@@ -159,7 +159,7 @@ The **Agent** component has two outputs:
     1. In the **Agent** component, click the output label near the component's output port and select **Structured Response**.
     2. Select the **Agent** component to open the [component inspection panel](/concepts-components#component-inspection-panel), and then click <Icon name="Table" aria-hidden="true"/> **Open table**.
     3. Click <Icon name="Plus" aria-hidden="true"/> **+** to add a row for each field you want to extract. For each row, enter a **Name**, **Type**, and optionally a **Description** and **As List** toggle.
-    4. Connect the **Structured Response** port to a downstream component that accepts [`JSON`](/data-types#json) input, such as a **Parser** or [**Data Operations** component](./operations).
+    4. Connect the **Structured Response** port to a downstream component that accepts [`JSON`](/data-types#json) input, such as a **Parser** or [**Data Operations** component](../Components/operations).
 
     The **Agent** component uses the connected LLM to extract structured data, and the extraction behavior is configured in the **Output Format Instructions** field.
     Modify the prompt in the **Output Format Instructions** field to change extraction behavior.

--- a/docs/docs/Agents/langflow-mcp-client.mdx
+++ b/docs/docs/Agents/langflow-mcp-client.mdx
@@ -28,7 +28,7 @@ To connect Langflow to a coding agent, do the following:
 
 ## See also
 
-* [Build flows with the LFX MCP server](./lfx-mcp)
+* [Build flows with the LFX MCP server](../Lfx/lfx-mcp)
 * [Use Langflow as an MCP client](./mcp-client)
 * [Use Langflow as an MCP server](./mcp-server)
-* [**MCP Tools** component](./mcp-tools)
+* [**MCP Tools** component](../Components/mcp-tools)

--- a/docs/docs/Components/a2a-agent.mdx
+++ b/docs/docs/Components/a2a-agent.mdx
@@ -10,20 +10,20 @@ As of Langflow 1.11.x, A2A support is **off** by default. To enable it, set the 
 LANGFLOW_A2A_ENABLED=true
 ```
 
-`LANGFLOW_A2A_ENABLED` enables Langflow's A2A server endpoints. Set it when you [publish Langflow flows as A2A agents](./a2a-server#publish-a-flow-as-an-a2a-agent), or when you use **Internal** mode to call those published flows. You do **not** need it to call a remote agent in **External** mode.
+`LANGFLOW_A2A_ENABLED` enables Langflow's A2A server endpoints. Set it when you [publish Langflow flows as A2A agents](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent), or when you use **Internal** mode to call those published flows. You do **not** need it to call a remote agent in **External** mode.
 :::
 
 The **A2A Agent** component calls an [Agent2Agent (A2A)](https://a2a-protocol.org/) agent and returns its reply.
 
 Use **Internal** mode to call published A2A agent flows within the same Langflow [project](/concepts-flows#projects), or use **External** mode to call a remote A2A agent by its published URL.
 
-For more information on publishing a Langflow flow, see [Publish a flow as an A2A agent](./a2a-server#publish-a-flow-as-an-a2a-agent).
+For more information on publishing a Langflow flow, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
 
 ## Use Internal mode in a flow
 
 1. Add an **A2A Agent** component to your flow.
 2. In the **A2A Agent** component, set **Mode** to **Internal**.
-3. In **Agent**, select a published A2A agent flow within your Langflow [project](/concepts-flows#projects). The flow must have [**Chat Input** and **Chat Output** components](./chat-input-and-output). For more information, see [Publish a flow as an A2A agent](./a2a-server#publish-a-flow-as-an-a2a-agent).
+3. In **Agent**, select a published A2A agent flow within your Langflow [project](/concepts-flows#projects). The flow must have [**Chat Input** and **Chat Output** components](./chat-input-and-output). For more information, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
 4. Connect a [**Chat Input** component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
 5. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** component](./chat-input-and-output#chat-output).
 
@@ -35,13 +35,13 @@ For more information on publishing a Langflow flow, see [Publish a flow as an A2
 Alternatively, enter the agent's `/.well-known/agent-card.json` card URL in the **Agent URL** field.
 Both options resolve the same agent.
 When the URL returns a card, the component displays a read-only **Agent card** preview.
-4. Optional: If the remote agent requires `x-api-key` authentication, enter the API key in the **API Key** field, or use a [global variable](./configuration-global-variables).
+4. Optional: If the remote agent requires `x-api-key` authentication, enter the API key in the **API Key** field, or use a [global variable](../Develop/configuration-global-variables).
 5. Connect a [**Chat Input** component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
 6. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** component](./chat-input-and-output#chat-output).
 
 ### Local and private agent URLs
 
-Langflow enables [SSRF protection](./api-keys-and-authentication#ssrf-protection) by default.
+Langflow enables [SSRF protection](../Develop/api-keys-and-authentication#ssrf-protection) by default.
 Loopback and private addresses such as `localhost`, `127.0.0.1`, and `::1` are blocked unless you allow them.
 
 If the remote agent URL points at a local or private host, such as another Langflow instance on `http://localhost:7862`, set `LANGFLOW_SSRF_ALLOWED_HOSTS` on the Langflow instance that runs the **A2A Agent** component. The allowlist takes hostnames and not full URLs. For example:
@@ -51,7 +51,7 @@ export LANGFLOW_SSRF_ALLOWED_HOSTS=localhost,127.0.0.1
 ```
 Restart Langflow after changing the variable.
 
-For more information, see [SSRF protection](./api-keys-and-authentication#ssrf-protection).
+For more information, see [SSRF protection](../Develop/api-keys-and-authentication#ssrf-protection).
 
 ## A2A Agent parameters
 
@@ -68,6 +68,6 @@ For more information, see [SSRF protection](./api-keys-and-authentication#ssrf-p
 
 ## See also
 
-* [Use Langflow as an A2A agent](./a2a-server)
-* [SSRF protection](./api-keys-and-authentication#ssrf-protection)
+* [Use Langflow as an A2A agent](../Agents/a2a-server)
+* [SSRF protection](../Develop/api-keys-and-authentication#ssrf-protection)
 * [Agent2Agent protocol](https://a2a-protocol.org/)

--- a/docs/docs/Components/a2a-agent.mdx
+++ b/docs/docs/Components/a2a-agent.mdx
@@ -10,22 +10,22 @@ As of Langflow 1.11.x, A2A support is **off** by default. To enable it, set the 
 LANGFLOW_A2A_ENABLED=true
 ```
 
-`LANGFLOW_A2A_ENABLED` enables Langflow's A2A server endpoints. Set it when you [publish Langflow flows as A2A agents](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent), or when you use **Internal** mode to call those published flows. You do **not** need it to call a remote agent in **External** mode.
+`LANGFLOW_A2A_ENABLED` enables Langflow's A2A server endpoints. Set it when you [publish Langflow Flows as A2A agents](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent), or when you use **Internal** mode to call those published Flows. You do **not** need it to call a remote agent in **External** mode.
 :::
 
 The **A2A Agent** component calls an [Agent2Agent (A2A)](https://a2a-protocol.org/) agent and returns its reply.
 
 Use **Internal** mode to call published A2A agent flows within the same Langflow [project](/concepts-flows#projects), or use **External** mode to call a remote A2A agent by its published URL.
 
-For more information on publishing a Langflow flow, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
+For more information on publishing a Langflow Flow, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
 
 ## Use Internal mode in a flow
 
 1. Add an **A2A Agent** component to your flow.
 2. In the **A2A Agent** component, set **Mode** to **Internal**.
-3. In **Agent**, select a published A2A agent flow within your Langflow [project](/concepts-flows#projects). The flow must have [**Chat Input** and **Chat Output** components](./chat-input-and-output). For more information, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
-4. Connect a [**Chat Input** component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
-5. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** component](./chat-input-and-output#chat-output).
+3. In **Agent**, select a published A2A agent Flow within your Langflow [project](/concepts-flows#projects). The Flow must have [**Chat Input** and **Chat Output** Components](./chat-input-and-output). For more information, see [Publish a flow as an A2A agent](../Agents/a2a-server#publish-a-flow-as-an-a2a-agent).
+4. Connect a [**Chat Input** Component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
+5. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** Component](./chat-input-and-output#chat-output).
 
 ## Use External mode in a flow
 
@@ -36,8 +36,8 @@ Alternatively, enter the agent's `/.well-known/agent-card.json` card URL in the 
 Both options resolve the same agent.
 When the URL returns a card, the component displays a read-only **Agent card** preview.
 4. Optional: If the remote agent requires `x-api-key` authentication, enter the API key in the **API Key** field, or use a [global variable](../Develop/configuration-global-variables).
-5. Connect a [**Chat Input** component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
-6. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** component](./chat-input-and-output#chat-output).
+5. Connect a [**Chat Input** Component](./chat-input-and-output#chat-input) to the **A2A Agent** component's **Message** input.
+6. Connect the **Response** output to the next component in your flow, such as a [**Chat Output** Component](./chat-input-and-output#chat-output).
 
 ### Local and private agent URLs
 

--- a/docs/docs/Components/components-agents.mdx
+++ b/docs/docs/Components/components-agents.mdx
@@ -23,7 +23,7 @@ For examples of flows using the **Agent** component, see the following:
 
 * [Use Langflow as an MCP client](/mcp-client) and [Use Langflow as an MCP server](/mcp-server): Use the **Agent** and [**MCP Tools** component](/mcp-tools) to implement the Model Context Protocol (MCP) in your flows.
 
-* [Require approval for agent tools](./agents-tools#require-approval-for-agent-tools): Gate tool calls with [Human-in-the-Loop](./human-in-the-loop).
+* [Require approval for agent tools](../Agents/agents-tools#require-approval-for-agent-tools): Gate tool calls with [Human-in-the-Loop](../Flows/human-in-the-loop).
 
 ## Agent component {#agent-component}
 
@@ -37,7 +37,7 @@ For more information about using this component, see [Use Langflow agents](/agen
 
 ## See also
 
-* [**A2A Agent** component](./a2a-agent-component)
+* [**A2A Agent** component](./a2a-agent)
 * [**MCP Tools** component](/mcp-tools)
 * [**Message History** component](/message-history)
 * [Store chat memory](/memory#store-chat-memory)

--- a/docs/docs/Components/components-agents.mdx
+++ b/docs/docs/Components/components-agents.mdx
@@ -37,9 +37,9 @@ For more information about using this component, see [Use Langflow agents](/agen
 
 ## See also
 
-* [**A2A Agent** component](./a2a-agent)
+* [**A2A Agent** Component](./a2a-agent)
 * [**MCP Tools** component](/mcp-tools)
 * [**Message History** component](/message-history)
 * [Store chat memory](/memory#store-chat-memory)
 * [Bundles](/components-bundle-components)
-* [Legacy LangChain components](/bundles-langchain#legacy-langchain-components)
+* [Legacy LangChain Components](/bundles-langchain#legacy-langchain-components)

--- a/docs/docs/Components/components-bundles.mdx
+++ b/docs/docs/Components/components-bundles.mdx
@@ -57,7 +57,7 @@ If all else fails, you can always create your own [custom components](/component
 Firecrawl, NextPlaid, Paddle, and Valkey standalone packages. Install the
 supported torch-free full profile with `uv pip install "langflow[bundles]"`.
 
-If you install `lfx` directly or need to add bundles to an existing environment, see [Install LFX with bundle components](../Lfx/lfx-install#install-with-bundle-components).
+If you install `lfx` directly or need to add bundles to an existing environment, see [Install LFX with bundle Components](../Lfx/lfx-install#install-with-bundle-components).
 
 ### Torch opt-in installs {#torch-opt-in}
 

--- a/docs/docs/Components/components-bundles.mdx
+++ b/docs/docs/Components/components-bundles.mdx
@@ -57,7 +57,7 @@ If all else fails, you can always create your own [custom components](/component
 Firecrawl, NextPlaid, Paddle, and Valkey standalone packages. Install the
 supported torch-free full profile with `uv pip install "langflow[bundles]"`.
 
-If you install `lfx` directly or need to add bundles to an existing environment, see [Install LFX with bundle components](./lfx-install#install-with-bundle-components).
+If you install `lfx` directly or need to add bundles to an existing environment, see [Install LFX with bundle components](../Lfx/lfx-install#install-with-bundle-components).
 
 ### Torch opt-in installs {#torch-opt-in}
 

--- a/docs/docs/Components/human-input.mdx
+++ b/docs/docs/Components/human-input.mdx
@@ -54,6 +54,6 @@ For a video example, see the [Langflow 1.11 release blog](https://www.langflow.o
 
 ## See also
 
-- [Human-in-the-Loop](./human-in-the-loop)
+- [Human-in-the-Loop](../Flows/human-in-the-loop)
 - [If-Else](./if-else)
-- [Workflow API (Beta)](./workflow-api)
+- [Workflow API (Beta)](../API-Reference/workflows-api)

--- a/docs/docs/Deployment/deployment-multi-worker.mdx
+++ b/docs/docs/Deployment/deployment-multi-worker.mdx
@@ -254,7 +254,7 @@ To verify that cancellation works across workers, trigger a build with the API t
 
 ## Troubleshoot
 
-See [Troubleshoot multi-worker deployments](./troubleshoot#multi-worker-deployments).
+See [Troubleshoot multi-worker deployments](/troubleshoot#multi-worker-deployments).
 
 ## Configuration reference
 

--- a/docs/docs/Develop/environment-variables.mdx
+++ b/docs/docs/Develop/environment-variables.mdx
@@ -395,11 +395,11 @@ See [Use Langflow as an MCP server](/mcp-server).
 
 ### A2A agents {#a2a}
 
-See [A2A environment variables](./a2a-server#a2a-environment-variables).
+See [A2A environment variables](../Agents/a2a-server#a2a-environment-variables).
 
 ### Multi-worker deployments
 
-For multi-worker tuning—including the Redis job queue and Gunicorn worker settings—see [Deploy Langflow with multiple workers](./deployment-multi-worker).
+For multi-worker tuning—including the Redis job queue and Gunicorn worker settings—see [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker).
 
 ### Monitoring and metrics
 
@@ -417,10 +417,10 @@ The following environment variables set base Langflow server configuration, such
 | `LANGFLOW_DEV` | Boolean | `False` | Whether to run Langflow in development mode (may contain bugs). |
 | `LANGFLOW_OPEN_BROWSER` | Boolean | `False` | Open the system web browser on startup. |
 | `LANGFLOW_HEALTH_CHECK_MAX_RETRIES` | Integer | `5` | Set the maximum number of retries for Langflow's server status health checks. |
-| `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_GUNICORN_PRELOAD` | Boolean | `False` | Enables Gunicorn `preload_app`. Non-Windows only. See [Deploy Langflow with multiple workers](./deployment-multi-worker#recommended-gunicorn-settings). |
-| `LANGFLOW_JOB_QUEUE_TYPE` | String | `asyncio` | Job queue backend. Use `redis` for multi-worker deployments. See [Deploy Langflow with multiple workers](./deployment-multi-worker#configuration-reference). |
+| `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker#recommended-gunicorn-settings). |
+| `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker#recommended-gunicorn-settings). |
+| `LANGFLOW_GUNICORN_PRELOAD` | Boolean | `False` | Enables Gunicorn `preload_app`. Non-Windows only. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker#recommended-gunicorn-settings). |
+| `LANGFLOW_JOB_QUEUE_TYPE` | String | `asyncio` | Job queue backend. Use `redis` for multi-worker deployments. See [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker#configuration-reference). |
 | `LANGFLOW_SSL_CERT_FILE` | String | Not set | Path to the SSL certificate file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_SSL_KEY_FILE` | String | Not set | Path to the SSL key file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_DEACTIVATE_TRACING` | Boolean | `False` | Deactivate tracing functionality. |

--- a/docs/docs/Flows/concepts-playground.mdx
+++ b/docs/docs/Flows/concepts-playground.mdx
@@ -45,7 +45,7 @@ For example, the following agent used a connected `fetch_content` tool to perfor
 
 ### Respond to Human-in-the-Loop prompts
 
-When a flow pauses for human approval from a [**Human Input** component](./human-input) or an [**Agent**](./agents), the **Playground** prompts you to approve or reject the tool call.
+When a flow pauses for human approval from a [**Human Input** component](../Components/human-input) or an [**Agent**](../Agents/agents), the **Playground** prompts you to approve or reject the tool call.
 
 Select an action to resume the run from where it was paused.
 

--- a/docs/docs/Flows/human-in-the-loop.mdx
+++ b/docs/docs/Flows/human-in-the-loop.mdx
@@ -8,18 +8,18 @@ Human-in-the-Loop (HITL) pauses a flow, creates a checkpoint, and waits for a hu
 After you approve or reject the proposed action, the flow run resumes from the checkpoint using the selected branch.
 The previously completed steps are not executed again.
 
-To include a HITL gate in a flow, add a [**Human Input** component](./human-input), or configure your Agent component to [require approval for agent tools](./agents-tools#require-approval-for-agent-tools).
+To include a HITL gate in a flow, add a [**Human Input** component](../Components/human-input), or configure your Agent component to [require approval for agent tools](../Agents/agents-tools#require-approval-for-agent-tools).
 
 For example, imagine you're building an agent that drafts Python code, and one of its tools can commit code to Git.
 
 The **Human Input** component pauses the flow where you place the component, and creates one output branch per configured **User Action**.
 Place the component after the code generation steps, where a human selects an **Approve** or **Reject** user action.
 If a human selects **Approve**, the flow continues to the commit step, and if a human selects **Reject**, the flow sends the draft back for revision.
-For more information, see the [**Human Input** component](./human-input).
+For more information, see the [**Human Input** component](../Components/human-input).
 
 The **Agent** tool approval enables **Requires approval** on the Git commit tool _only_.
 The run pauses when the agent tries to call that tool, but doesn't add a branch.
-For more information, see [Require approval for agent tools](./agents-tools#require-approval-for-agent-tools).
+For more information, see [Require approval for agent tools](../Agents/agents-tools#require-approval-for-agent-tools).
 
 ## Use HITL in a flow
 
@@ -27,5 +27,5 @@ For a video example, see the [Langflow 1.11 release blog](https://www.langflow.o
 
 ## See also
 
-- [Human Input component](./human-input)
-- [Agents](./components-agents)
+- [Human Input component](../Components/human-input)
+- [Agents](../Components/components-agents)

--- a/docs/docs/Lfx/extensions-bundle-list.mdx
+++ b/docs/docs/Lfx/extensions-bundle-list.mdx
@@ -28,18 +28,18 @@ using `uv pip install "langflow[bundles]"`.
 | [`datastax`](/bundles-datastax) (DataStax) | `uv pip install lfx-datastax` |
 | [`docling`](/bundles-docling) (Docling) | `uv pip install lfx-docling` |
 | [`duckduckgo`](/bundles-duckduckgo) (DuckDuckGo) | `uv pip install lfx-duckduckgo` |
-| [`empiriolabs`](./bundles-empiriolabs) (EmpirioLabs) | `uv pip install lfx-empiriolabs` |
+| [`empiriolabs`](../Components/bundles-empiriolabs) (EmpirioLabs) | `uv pip install lfx-empiriolabs` |
 | [`exa`](/bundles-exa) (Exa) | `uv pip install lfx-exa` |
 | [`firecrawl`](/bundles-firecrawl) (Firecrawl) | `uv pip install lfx-firecrawl` |
 | [`google`](/bundles-google) (Google components) | `uv pip install lfx-google` |
 | [`ibm`](/bundles-ibm) (IBM) | `uv pip install lfx-ibm` |
-| [`nextplaid`](./bundles-nextplaid) (NextPlaid) | `uv pip install lfx-nextplaid` |
+| [`nextplaid`](../Components/bundles-nextplaid) (NextPlaid) | `uv pip install lfx-nextplaid` |
 | [`ollama`](/bundles-ollama) (Ollama) | `uv pip install lfx-ollama` |
 | [`openai`](/bundles-openai) (OpenAI) | `uv pip install lfx-openai` |
-| [`openai-compatible`](./bundles-openai-compatible) (OpenAI Compatible) | `uv pip install lfx-openai-compatible` |
-| [`oracle`](./bundles-oracle) (Oracle) | `uv pip install lfx-oracle` |
-| [`paddle`](./bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
-| [`valkey`](./bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
+| [`openai-compatible`](../Components/bundles-openai-compatible) (OpenAI Compatible) | `uv pip install lfx-openai-compatible` |
+| [`oracle`](../Components/bundles-oracle) (Oracle) | `uv pip install lfx-oracle` |
+| [`paddle`](../Components/bundles-paddle) (Paddle) | `uv pip install lfx-paddle` |
+| [`valkey`](../Components/bundles-valkey) (Valkey) | `uv pip install lfx-valkey` |
 | [`vllm`](/bundles-vllm) (vLLM) | `uv pip install lfx-vllm` |
 
 ## Long-tail bundles (`lfx-bundles`)

--- a/docs/docs/Lfx/extensions-errors.mdx
+++ b/docs/docs/Lfx/extensions-errors.mdx
@@ -13,10 +13,10 @@ error[inline-bundle-name-invalid]: Inline bundle directory 'Notion' does not mat
   see:      https://docs.langflow.org/extensions/errors
 ```
 
-Before launching Langflow, run [`lfx extension validate`](../extensions-quickstart) to catch manifest and bundle issues.
+Before launching Langflow, run [`lfx extension validate`](./extensions-quickstart) to catch manifest and bundle issues.
 
 ## See also
 
-- [Extensions overview](../extensions-overview)
-- [Build your first extension](../extensions-quickstart)
-- [Manifest reference](../extensions-manifest)
+- [Extensions overview](./extensions-overview)
+- [Build your first extension](./extensions-quickstart)
+- [Manifest reference](./extensions-manifest)

--- a/docs/docs/Lfx/extensions-manifest.mdx
+++ b/docs/docs/Lfx/extensions-manifest.mdx
@@ -178,7 +178,7 @@ The loader prefers an `extension.json` when both exist. The Pydantic validator i
 
 ## Error codes raised against this manifest
 
-The loader and validator both emit typed errors keyed by the manifest field that triggered them. The full reference is on the [Extension error codes](./extensions/errors) page; the codes most relevant when authoring a manifest are:
+The loader and validator both emit typed errors keyed by the manifest field that triggered them. The full reference is on the [Extension error codes](/extensions/errors) page; the codes most relevant when authoring a manifest are:
 
 | Code | Cause |
 | --- | --- |
@@ -199,4 +199,4 @@ Run `lfx extension validate <path>` to see every error as a structured object wi
 - [Extensions overview](./extensions-overview)
 - [Build your first extension](./extensions-quickstart)
 - [About LFX](./lfx-overview)
-- [Extension error codes](./extensions/errors)
+- [Extension error codes](/extensions/errors)

--- a/docs/docs/Lfx/lfx-compatibility.mdx
+++ b/docs/docs/Lfx/lfx-compatibility.mdx
@@ -119,4 +119,4 @@ It does **not** install graduated standalone packages such as `lfx-openai` or `l
 Use `uv pip install "langflow[bundles]"` to add the reviewed `lfx-bundles[all-no-torch]` profile plus the opt-in arXiv, DuckDuckGo, EmpirioLabs, Exa, Firecrawl, NextPlaid, Paddle, and Valkey standalone packages while keeping the full Langflow application torch-free.
 For a slimmer image, install only the provider packages a deployment actually executes, for example `uv pip install lfx lfx-openai "lfx-bundles[qdrant]"`.
 There is intentionally no `lfx[all]` extra. Install `lfx-bundles` explicitly for long-tail providers, or install only the provider extras you need to avoid the full torch-inclusive `[all]` set.
-Some components require a [torch opt-in install](./components-bundle-components#torch-opt-in).
+Some components require a [torch opt-in install](/components-bundle-components#torch-opt-in).

--- a/docs/docs/Lfx/lfx-mcp.mdx
+++ b/docs/docs/Lfx/lfx-mcp.mdx
@@ -14,17 +14,17 @@ The server calls the Langflow REST API, so flows that the agent creates appear i
 
 `lfx-mcp` differs from these other MCP options:
 
-* [Use Langflow as an MCP server](./mcp-server): Expose existing flows as tools that clients can call.
-* [Use Langflow as an MCP client](./mcp-client): Call MCP servers from components on the canvas.
+* [Use Langflow as an MCP server](../Agents/mcp-server): Expose existing flows as tools that clients can call.
+* [Use Langflow as an MCP client](../Agents/mcp-client): Call MCP servers from components on the canvas.
 
 For Bob (IBM) and Claude Code, you can also use the guided setup in Langflow under **Settings** → <Icon name="Terminal" aria-hidden="true" /> **Langflow MCP Client**.
-For more information, see [Langflow MCP Client for coding agents](./langflow-mcp-client).
+For more information, see [Langflow MCP Client for coding agents](../Agents/langflow-mcp-client).
 
 ## Prerequisites
 
 * A running Langflow instance
-* A [Langflow API key](./api-keys-and-authentication)
-* An LLM provider API key available in Langflow, typically as a [global variable](./configuration-global-variables)
+* A [Langflow API key](../Develop/api-keys-and-authentication)
+* An LLM provider API key available in Langflow, typically as a [global variable](../Develop/configuration-global-variables)
 * [`uv`](https://docs.astral.sh/uv/getting-started/installation/), or `lfx` installed with `uv pip install lfx`
 * [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or another MCP client that supports stdio servers
 
@@ -161,8 +161,8 @@ To connect an agent and create a flow on your Langflow server, follow these step
 
 ## See also
 
-* [Langflow MCP Client for coding agents](./langflow-mcp-client)
-* [Use Langflow as an MCP server](./mcp-server)
-* [Use Langflow as an MCP client](./mcp-client)
+* [Langflow MCP Client for coding agents](../Agents/langflow-mcp-client)
+* [Use Langflow as an MCP server](../Agents/mcp-server)
+* [Use Langflow as an MCP client](../Agents/mcp-client)
 * [About LFX](./lfx-overview)
 * [Install LFX](./lfx-install)

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -189,13 +189,13 @@ If Langflow fails to start with a `get_body_field` error after installing versio
     Missing-provider errors use the same install guidance.
     Graduated providers such as OpenAI, Anthropic, Cohere, and Exa remain part of the default Langflow installation through their standalone `lfx-*` packages.
 
-    For the complete package list and provider-specific commands, see [Extension bundle list](./extensions-bundle-list).
+    For the complete package list and provider-specific commands, see [Extension bundle list](../Lfx/extensions-bundle-list).
 
 - PyTorch components are opt-in by default
 
     **CUGA**, **Code Agents**, and **Docling** local conversion are excluded from the default `uv pip install langflow` installation because they require PyTorch.
 
-    To install these components, see [Torch opt-in installs](./components-bundle-components#torch-opt-in).
+    To install these components, see [Torch opt-in installs](/components-bundle-components#torch-opt-in).
 
 - Workflow API request schema (Beta)
 
@@ -248,13 +248,13 @@ If Langflow fails to start with a `get_body_field` error after installing versio
     Human-in-the-Loop (HITL) pauses an agent when the agent calls a tool and creates a stateful checkpoint.
     After a human responds by approving, rejecting, or editing the request, the agent resumes from the checkpoint.
 
-    For more information, see [Human-in-the-Loop](./human-in-the-loop).
+    For more information, see [Human-in-the-Loop](../Flows/human-in-the-loop).
 
 - Agent2Agent (A2A) protocol support
 
     Publish a flow as an A2A agent so other agents can discover and call it, and call remote A2A agents from inside a flow with the **A2A Agent** component.
 
-    For more information, see [Use Langflow as an A2A server](./a2a-server) and the [**A2A Agent** component](./a2a-agent-component).
+    For more information, see [Use Langflow as an A2A server](../Agents/a2a-server) and the [**A2A Agent** component](../Components/a2a-agent).
 
 - AG-UI compatible streaming for the Workflow API
 
@@ -267,13 +267,13 @@ If Langflow fails to start with a `get_body_field` error after installing versio
     Point Langflow's model provider at any OpenAI-compatible endpoint, and Langflow discovers models live from the `/v1/models` endpoint.
     These models can power flows, Langflow Assistant, and any component that uses Langflow’s global model providers.
 
-    For more information, see [OpenAI Compatible](./bundles-openai-compatible).
+    For more information, see [OpenAI Compatible](../Components/bundles-openai-compatible).
 
 - Unified **Data Operations** component
 
-    **Text Operations**, **JSON Operations**, and **Table Operations** are consolidated into a single [**Data Operations** component](./operations).
+    **Text Operations**, **JSON Operations**, and **Table Operations** are consolidated into a single [**Data Operations** component](../Components/operations).
     Saved flows that use the separate components continue to work.
-    For more information, see the [**Data Operations** component](./operations).
+    For more information, see the [**Data Operations** component](../Components/operations).
 
 - IBM watsonx Orchestrate: Python 3.14 compatibility
 
@@ -299,25 +299,25 @@ If Langflow fails to start with a `get_body_field` error after installing versio
 
     The **NextPlaid** vector store, backed by a running [NextPlaid](https://github.com/meetdoshi90/next-plaid) server, stores each document as a matrix of token embeddings, and the **vLLM Multivector Embeddings** component generates the token-level multi-vector embeddings required by NextPlaid.
 
-    For more information, see [NextPlaid bundle](./bundles-nextplaid).
+    For more information, see [NextPlaid bundle](../Components/bundles-nextplaid).
 
 - PaddleOCR bundle
 
     The **Paddle** bundle (`lfx-paddle`) adds a **PaddleOCR** component that calls the PaddleOCR AI Studio Job API for layout-aware document parsing into Markdown.
 
-    For more information, see [Paddle bundle](./bundles-paddle).
+    For more information, see [Paddle bundle](../Components/bundles-paddle).
 
 - Oracle Extension bundle
 
     The **Oracle** bundle adds Oracle Database integration for vector search, document loading, and embeddings.
 
-    For more information, see [Oracle bundle](./bundles-oracle).
+    For more information, see [Oracle bundle](../Components/bundles-oracle).
 
 - Valkey bundle
 
     The **Valkey** bundle adds a vector store and chat memory components for [Valkey](https://valkey.io/), an open-source Redis fork.
 
-    For more information, see [Valkey bundle](./bundles-valkey).
+    For more information, see [Valkey bundle](../Components/bundles-valkey).
 
 - LFX is now engine-only
 
@@ -331,7 +331,7 @@ If Langflow fails to start with a `get_body_field` error after installing versio
     Graduated providers, such as OpenAI, Anthropic, Cohere, and Exa, ship as individual packages and are installed separately with `uv pip install lfx-<provider>`.
 
     The `lfx-bundles` long tail is opt-in for both `lfx` and `langflow` installations.
-    For more information, see [Extensions overview](./extensions-overview).
+    For more information, see [Extensions overview](../Lfx/extensions-overview).
 
 ## 1.10.x
 

--- a/docs/docs/Support/troubleshooting.mdx
+++ b/docs/docs/Support/troubleshooting.mdx
@@ -508,7 +508,7 @@ uv run langflow migration --fix
 `langflow migration --fix` is destructive.
 Use a dedicated database for Langflow application data.
 Repair mode repeatedly downgrades and re-applies Langflow's schema revisions, which can delete Langflow data, and it might fail to converge when non-Langflow tables such as `langchain_pg_*` vector store tables share the same database.
-For more information, see [Database migrations](./database-migrations).
+For more information, see [Database migrations](../Develop/database-migrations).
 :::
 
 If the migration fix doesn't resolve the issue, clear the cache by deleting the contents of your Langflow cache folder.
@@ -724,7 +724,7 @@ To resolve this issue:
 - Ensure `LANGFLOW_JOB_QUEUE_TYPE=redis` is set on **all** workers, not just some. Mixed-mode deployments (some workers using `asyncio`, others using `redis`) are not supported.
 - Verify all workers can reach the same Redis instance.
 
-For setup instructions, see [Deploy Langflow with multiple workers](./deployment-multi-worker).
+For setup instructions, see [Deploy Langflow with multiple workers](../Deployment/deployment-multi-worker).
 
 ### Redis connection refused or auth errors
 
@@ -781,7 +781,7 @@ If Langflow feels slow on an Intel Mac:
 2. Use API-based providers for embeddings and completions instead of local models.
 3. Consider upgrading to Apple Silicon for better performance with ML features.
 
-For more information, see [Workarounds for Intel Mac users](./macos-support-matrix.mdx#workarounds-for-intel-mac-users).
+For more information, see [Workarounds for Intel Mac users](./macos-support-matrix#installation-recommendations).
 
 ## See also
 

--- a/docs/docs/_partial-bundle-lfx-bundles-install.mdx
+++ b/docs/docs/_partial-bundle-lfx-bundles-install.mdx
@@ -8,5 +8,5 @@ uv pip install "lfx-bundles[<bundle>]"
 Replace `<bundle>` with this page's provider name, for example `qdrant`.
 For a torch-free full Langflow install, run `uv pip install "langflow[bundles]"`.
 For standalone LFX with every long-tail provider, including torch-based providers, run `uv pip install "lfx[bundles]"`.
-See the [Bundle list](./extensions-bundle-list) for the exact extra name.
+See the [Bundle list](/extensions-bundle-list) for the exact extra name.
 :::

--- a/docs/docs/_partial-extension-bundle-install.mdx
+++ b/docs/docs/_partial-extension-bundle-install.mdx
@@ -4,7 +4,7 @@
 
 If your flows use bundle components, install the required packages in the same virtual environment.
 
-Some components require an additional [torch opt-in installation](./components-bundle-components#torch-opt-in).
+Some components require an additional [torch opt-in installation](/components-bundle-components#torch-opt-in).
 
 _Long-tail bundles_ are third-party provider integrations like vector stores or model providers that ship together in the `lfx-bundles` package.
 
@@ -37,7 +37,7 @@ For example:
 uv pip install lfx-openai
 ```
 
-For the complete bundle-to-package mapping, see the [Bundle list](./extensions-bundle-list).
+For the complete bundle-to-package mapping, see the [Bundle list](/extensions-bundle-list).
 
 Bundle discovery happens at startup. Restart Langflow or your LFX server after installing.
 

--- a/docs/docs/_partial-lfx-component-categories.mdx
+++ b/docs/docs/_partial-lfx-component-categories.mdx
@@ -10,7 +10,7 @@ LFX loads all component categories by default. Use environment variables to rest
 Category names are case-insensitive. The virtual keyword `core` in the allowlist or blocklist expands to all core component categories.
 
 Component category names don't always match the labels displayed in the Langflow visual editor.
-To view the component categories, see [Bundle list](./extensions-bundle-list).
+To view the component categories, see [Bundle list](/extensions-bundle-list).
 
 To restrict components to specific categories:
 

--- a/docs/docs/_partial-lfx-run-serve-prereqs.mdx
+++ b/docs/docs/_partial-lfx-run-serve-prereqs.mdx
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-- [Install LFX](./lfx-install)
+- [Install LFX](/lfx-install)
 - A flow JSON file. Download the Simple Agent starter flow from the repository:
 
   ```bash
@@ -20,15 +20,15 @@ component-not-found-with-hint: DuckDuckGoSearchComponent not found.
 Hint: try ext:duckduckgo:DuckDuckGoSearchComponent@official
 ```
 
-Use the bundle name from the hint to find the pip package in the [Bundle list](./extensions-bundle-list).
+Use the bundle name from the hint to find the pip package in the [Bundle list](/extensions-bundle-list).
 
-For more information, see [Install LFX with bundle components](./lfx-install#install-with-bundle-components).
+For more information, see [Install LFX with bundle components](/lfx-install#install-with-bundle-components).
 
 ### Generate requirements.txt
 
 Extension packages cover component code. Some flows still need additional Python packages at runtime (third-party SDKs imported by those components).
 
-To list them from a flow JSON file, use [`lfx requirements`](./flow-devops-sdk#generate-requirementstxt-for-flows):
+To list them from a flow JSON file, use [`lfx requirements`](/flow-devops-sdk#generate-requirementstxt-for-flows):
 
 ```bash
 lfx requirements simple-agent-flow.json


### PR DESCRIPTION
## Problem

`docs/docs` contains ~90 links that reference pages by name as if they were in the same directory, e.g.:

- `API-Reference/workflow-api-quickstart.mdx` links `./workflow-api` — the page is `workflows-api.mdx` (renamed at some point)
- several Agents/Components pages link `./human-in-the-loop`, `./a2a-server`, `./deployment-multi-worker`, ... which live in *other* directories (`Flows/`, `Agents/`, `Deployment/`)

Also `_partial-*.mdx` snippets are included from pages in different directories, so relative links inside them resolve differently per includer — they need root-absolute slugs.

## Fix

- Repointed every broken link to the actual page path (extensionless, docusaurus-style)
- `_partial-*` links converted to root-absolute slugs (`/lfx-install`, `/extensions-bundle-list`, `/components-bundle-components`, `/flow-devos-sdk`, `/extensions/errors`)
- Two dead anchors repointed: `#global-var` → `api-flows-run#pass-global-variables-in-headers`; `macos-support-matrix#workarounds-for-intel-mac-users` → `#installation-recommendations`
- `versioned_docs/` snapshots left untouched

Verified with a repo-wide link audit (relative-target existence + heading-anchor checks, including docusaurus `{#custom-id}` headings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected documentation links across API, Agents, Components, Flows, LFX, Deployment, and Support pages.
  * Updated references for workflows, human-in-the-loop guidance, A2A agents, MCP, bundles, troubleshooting, and environment configuration.
  * Improved navigation to related guides, installation instructions, release notes, and component references.
  * No product behavior or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->