### PR TITLE
fix: omit empty optional Composio inputs

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -1,4 +1,4 @@
-"""Tests for SafeLangchainProvider schema sanitization (issues #12894/#12895).
+"""Tests for SafeLangchainProvider schema and argument hardening.
 
 Composio's ``_substitute_file_uploads_recursively`` and
 ``pydantic_model_from_param_schema`` raw-subscript ``properties[name]["type"]``,
@@ -6,14 +6,24 @@ so any tool whose ``input_parameters`` schema has a property without an explicit
 ``"type"`` (Gmail/Calendar actions hit this) raises ``KeyError: 'type'`` at
 execute time. ``_sanitize_schema`` injects a sensible ``type`` for every node so
 those raw subscripts succeed.
+
+Optional nested action inputs can also arrive as Pydantic models whose leaves
+are empty strings. The provider omits those empty optional containers before
+Composio validation while preserving required and meaningful values (#14715).
 """
+
+from types import SimpleNamespace
 
 import pytest
 
 composio = pytest.importorskip("composio", reason="composio extra not installed in this env")
 pytest.importorskip("composio_langchain", reason="composio extra not installed in this env")
 
-from lfx.base.composio.safe_provider import SafeLangchainProvider, _sanitize_schema  # noqa: E402
+from lfx.base.composio.safe_provider import (  # noqa: E402
+    SafeLangchainProvider,
+    _omit_empty_optional_containers,
+    _sanitize_schema,
+)
 
 
 class TestSanitizeSchema:
@@ -170,6 +180,84 @@ class TestSafeLangchainProviderRegression:
         model = pydantic_model_from_param_schema(schema)
         # Defaulted type is "string", which maps to ``str`` in Composio's type table.
         assert "payload" in model.model_fields
+
+
+class TestOptionalContainerNormalization:
+    """Empty optional objects should not become invalid Composio action input."""
+
+    attachment_schema = {
+        "type": "object",
+        "properties": {
+            "attachment": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "data": {"type": "string"},
+                },
+            }
+        },
+    }
+
+    def test_empty_optional_attachment_is_omitted(self):
+        arguments = {"to": "recipient@example.com", "attachment": {"name": "", "data": ""}}
+
+        result = _omit_empty_optional_containers(arguments, self.attachment_schema)
+
+        assert result == {"to": "recipient@example.com"}
+        assert arguments["attachment"] == {"name": "", "data": ""}
+
+    def test_nonempty_attachment_is_preserved(self):
+        arguments = {"attachment": {"name": "report.pdf", "data": "base64-data"}}
+
+        result = _omit_empty_optional_containers(arguments, self.attachment_schema)
+
+        assert result == arguments
+
+    def test_required_empty_attachment_is_preserved_for_validation(self):
+        schema = {**self.attachment_schema, "required": ["attachment"]}
+        arguments = {"attachment": {"name": "", "data": ""}}
+
+        result = _omit_empty_optional_containers(arguments, schema)
+
+        assert result == arguments
+
+    def test_valid_falsy_values_keep_optional_object(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "retry_count": {"type": "integer"},
+                    },
+                }
+            },
+        }
+        arguments = {"options": {"enabled": False, "retry_count": 0}}
+
+        result = _omit_empty_optional_containers(arguments, schema)
+
+        assert result == arguments
+
+    def test_provider_omits_empty_pydantic_attachment_before_execute(self):
+        captured = {}
+
+        def execute_tool(slug, arguments):
+            captured.update(slug=slug, arguments=arguments)
+            return {"ok": True}
+
+        tool = SimpleNamespace(
+            slug="GMAIL_CREATE_EMAIL_DRAFT",
+            description="Create a Gmail draft",
+            input_parameters={"title": "GmailDraftInput", **self.attachment_schema},
+        )
+
+        wrapped = SafeLangchainProvider().wrap_tool(tool, execute_tool)
+        result = wrapped.invoke({"attachment": {"name": "", "data": ""}})
+
+        assert result == {"ok": True}
+        assert captured == {"slug": "GMAIL_CREATE_EMAIL_DRAFT", "arguments": {}}
 
 
 class TestNoOpOnAlreadyTypedSchemas:

--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -15,6 +15,7 @@ Composio validation while preserving required and meaningful values (#14715).
 from types import SimpleNamespace
 
 import pytest
+from pydantic import BaseModel
 
 composio = pytest.importorskip("composio", reason="composio extra not installed in this env")
 pytest.importorskip("composio_langchain", reason="composio extra not installed in this env")
@@ -258,6 +259,29 @@ class TestOptionalContainerNormalization:
 
         assert result == {"ok": True}
         assert captured == {"slug": "GMAIL_CREATE_EMAIL_DRAFT", "arguments": {}}
+
+    def test_pydantic_list_item_drops_nested_empty_attachment(self):
+        class Attachment(BaseModel):
+            name: str
+            data: str
+
+        class Draft(BaseModel):
+            subject: str
+            attachment: Attachment
+
+        draft_schema = {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string"},
+                "attachment": self.attachment_schema["properties"]["attachment"],
+            },
+        }
+        schema = {"type": "object", "properties": {"drafts": {"type": "array", "items": draft_schema}}}
+        draft = Draft(subject="test", attachment=Attachment(name="", data=""))
+
+        result = _omit_empty_optional_containers({"drafts": [draft]}, schema)
+
+        assert result == {"drafts": [{"subject": "test"}]}
 
 
 class TestNoOpOnAlreadyTypedSchemas:

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -1,4 +1,4 @@
-"""Schema-hardening wrapper around composio_langchain.LangchainProvider.
+"""Schema and argument hardening for composio_langchain.LangchainProvider.
 
 Composio's runtime file-substitution helpers (composio.core.models._files) and
 its Pydantic schema builder (composio.utils.shared.pydantic_model_from_param_schema)
@@ -12,12 +12,19 @@ We sanitize ``tool.input_parameters`` in-place at wrap time, and also patch
 both the FileHelper file-substitution helpers and the pydantic schema builder
 so the agent path, the direct ``execute_action`` path, and the legacy
 ``tools.get`` path all see a schema with a ``"type"`` for every node.
+
+The LangChain wrapper can also materialize omitted optional objects as nested
+Pydantic models containing only empty strings. We omit those empty containers
+before Composio validates action input, without changing required or meaningful
+values.
 """
 
 from __future__ import annotations
 
 import keyword
 from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
 
 try:
     import composio_langchain.provider as _composio_lc_provider
@@ -99,6 +106,60 @@ def _sanitize_schema(schema: Any) -> None:
                 _sanitize_schema(sub)
 
 
+def _is_effectively_empty(value: Any) -> bool:
+    """Return whether a nested value contains no meaningful user input."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, BaseModel):
+        return _is_effectively_empty(value.model_dump())
+    if isinstance(value, dict):
+        return all(_is_effectively_empty(item) for item in value.values())
+    if isinstance(value, list):
+        return all(_is_effectively_empty(item) for item in value)
+    return False
+
+
+def _omit_empty_optional_containers(arguments: Any, schema: Any) -> Any:
+    """Copy arguments while omitting optional objects and arrays with no input.
+
+    Some tool calls materialize an omitted optional object as a mapping whose
+    leaves are empty strings. Composio then validates that mapping as a supplied
+    value, so actions such as Gmail draft/send reject an otherwise valid call.
+    Required containers and meaningful falsy values (``False`` and ``0``) are
+    preserved so downstream validation and action semantics remain unchanged.
+    """
+    if not isinstance(arguments, dict) or not isinstance(schema, dict):
+        return arguments
+
+    required = set(schema.get("required") or [])
+    properties = schema.get("properties") or {}
+    cleaned_arguments = {}
+
+    for name, value in arguments.items():
+        property_schema = properties.get(name, {}) if isinstance(properties, dict) else {}
+        if isinstance(value, dict):
+            cleaned_value = _omit_empty_optional_containers(value, property_schema)
+        elif isinstance(value, list):
+            item_schema = property_schema.get("items", {}) if isinstance(property_schema, dict) else {}
+            cleaned_value = [
+                _omit_empty_optional_containers(item, item_schema) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            cleaned_value = value
+
+        if (
+            name not in required
+            and isinstance(cleaned_value, (dict, list, BaseModel))
+            and _is_effectively_empty(cleaned_value)
+        ):
+            continue
+        cleaned_arguments[name] = cleaned_value
+
+    return cleaned_arguments
+
+
 if _COMPOSIO_AVAILABLE:
 
     class SafeLangchainProvider(LangchainProvider, name="langchain"):
@@ -106,7 +167,12 @@ if _COMPOSIO_AVAILABLE:
 
         def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
             _sanitize_schema(tool.input_parameters)
-            return super().wrap_tool(tool=tool, execute_tool=execute_tool)
+
+            def safe_execute_tool(slug: str, arguments: dict[str, Any]) -> Any:
+                cleaned_arguments = _omit_empty_optional_containers(arguments, tool.input_parameters)
+                return execute_tool(slug, cleaned_arguments)
+
+            return super().wrap_tool(tool=tool, execute_tool=safe_execute_tool)
 
 
 def _extract_schema_arg(args: tuple, kwargs: dict, positional_index: int, keyword: str) -> Any:

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -130,7 +130,11 @@ def _omit_empty_optional_containers(arguments: Any, schema: Any) -> Any:
     Required containers and meaningful falsy values (``False`` and ``0``) are
     preserved so downstream validation and action semantics remain unchanged.
     """
-    if not isinstance(arguments, dict) or not isinstance(schema, dict):
+    if not isinstance(schema, dict):
+        return arguments
+    if isinstance(arguments, BaseModel):
+        arguments = arguments.model_dump()
+    if not isinstance(arguments, dict):
         return arguments
 
     required = set(schema.get("required") or [])
@@ -139,12 +143,13 @@ def _omit_empty_optional_containers(arguments: Any, schema: Any) -> Any:
 
     for name, value in arguments.items():
         property_schema = properties.get(name, {}) if isinstance(properties, dict) else {}
-        if isinstance(value, dict):
+        if isinstance(value, (dict, BaseModel)):
             cleaned_value = _omit_empty_optional_containers(value, property_schema)
         elif isinstance(value, list):
             item_schema = property_schema.get("items", {}) if isinstance(property_schema, dict) else {}
             cleaned_value = [
-                _omit_empty_optional_containers(item, item_schema) if isinstance(item, dict) else item for item in value
+                _omit_empty_optional_containers(item, item_schema) if isinstance(item, (dict, BaseModel)) else item
+                for item in value
             ]
         else:
             cleaned_value = value


### PR DESCRIPTION
## Summary

- omit optional Composio object/array arguments when their nested values contain no meaningful input
- preserve required containers, non-empty attachments, and meaningful falsy values such as `false` and `0`
- cover the real `StructuredTool` callback path where nested inputs arrive as Pydantic models

This prevents Gmail draft/send actions from receiving `attachment: {name: "", data: ""}` when no attachment was requested.

Fixes #14715

## Tests

- `pytest src/backend/tests/unit/components/bundles/composio/test_safe_provider.py --confcutdir=src/backend/tests/unit/components/bundles/composio -q` (22 passed)
- `ruff check src/lfx/src/lfx/base/composio/safe_provider.py src/backend/tests/unit/components/bundles/composio/test_safe_provider.py`
- `python -m compileall -q src/lfx/src/lfx/base/composio/safe_provider.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional nested tool inputs when their values are empty, preventing unnecessary validation failures.
  * Preserved required input containers and meaningful values such as `false` and `0`.
  * Ensured provided non-empty nested attachments continue to work as expected.

* **Tests**
  * Added coverage for empty, required, non-empty, and falsy nested input scenarios, including end-to-end tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->