### PR TITLE
ci: stabilize nightly Windows Playwright shards

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -372,6 +372,21 @@ jobs:
       - name: Install Python Dependencies
         run: uv sync --extra audio
 
+      # The backend spawns `uvx --with mcp~=1.28 mcp-proxy ...` for the
+      # project MCP server as soon as the UI asks for tool counts
+      # (GET /api/v2/mcp/servers?action_count=true). On a cold uv cache that
+      # first invocation resolves and downloads mcp-proxy mid-test, which on
+      # Windows runners stalls the API for 20-30s until the stdio connect
+      # times out. Warm the environment during setup instead. The --with
+      # constraint must match mcp_sdk_constraint_args() (lfx.base.mcp.uvx)
+      # or uvx builds a different cached environment than the backend uses.
+      - name: Pre-warm uvx mcp-proxy (Windows)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        timeout-minutes: 5
+        shell: bash
+        run: uvx --with 'mcp~=1.28' mcp-proxy --help > /dev/null
+
       - name: Execute Playwright Tests
         timeout-minutes: 18
         shell: bash

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
   workers: 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   timeout: 5 * 60 * 1000, // 5 minutes
+  expect: {
+    // Windows CI runners are markedly slower than Linux; assertions that poll
+    // the backend (toHaveCount after a delete, toBeVisible after a fetch)
+    // routinely blow the 5s default there.
+    timeout: process.platform === "win32" ? 15_000 : 5_000,
+  },
   // reporter: [
   //   ["html", { open: "never", outputFolder: "playwright-report/test-results" }],
   // ],
@@ -41,7 +47,9 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: `http://localhost:${PORT || 3000}/`,
 
-    actionTimeout: 20000,
+    // Also the default for page.waitForResponse/waitForSelector calls that
+    // pass no explicit timeout. Windows CI needs the extra headroom.
+    actionTimeout: process.platform === "win32" ? 40_000 : 20_000,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
     contextOptions: {
@@ -140,7 +148,10 @@ export default defineConfig({
       stderr: "pipe",
 
       reuseExistingServer: true,
-      timeout: 120 * 750,
+      // Windows CI runners can spend 60s+ on imports plus the Alembic
+      // migration chain against the fresh SQLite DB before the port opens;
+      // 90s boots are routinely lost there.
+      timeout: process.platform === "win32" ? 240_000 : 90_000,
     },
     {
       command: "npm start",

--- a/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
+++ b/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
 import {
   closeParametersPanel,
   openParametersPanel,
@@ -57,10 +58,10 @@ test(
     // default contract of the inputs list).
     await expect(
       page.getByTestId("inspector-param-add_current_date_tool"),
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible({ timeout: TIMEOUTS.standard });
     await expect(
       page.getByTestId("inspector-param-add_calculator_tool"),
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible({ timeout: TIMEOUTS.standard });
 
     // Flip the Calculator field visible on canvas so we can assert the toggle
     // is active and can be switched off and on (S3).
@@ -75,7 +76,7 @@ test(
     const calculatorToggle = page.getByTestId(
       "toggle_bool_add_calculator_tool",
     );
-    await expect(calculatorToggle).toBeVisible({ timeout: 10000 });
+    await expect(calculatorToggle).toBeVisible({ timeout: TIMEOUTS.standard });
     await expect(calculatorToggle).toBeChecked();
 
     // S3 — user disables the toggle.
@@ -97,7 +98,9 @@ test(
     // The placeholders must be present inside the Agent Instructions textarea
     // so the dynamic injection has a discoverable effect out of the box.
     const instructionsTextarea = page.getByTestId("textarea_str_system_prompt");
-    await expect(instructionsTextarea).toBeVisible({ timeout: 10000 });
+    await expect(instructionsTextarea).toBeVisible({
+      timeout: TIMEOUTS.standard,
+    });
 
     // <textarea> stores content in its `value`, not textContent.
     const promptText = await instructionsTextarea.inputValue();

--- a/src/frontend/tests/extended/features/lock-flow.spec.ts
+++ b/src/frontend/tests/extended/features/lock-flow.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { TEXTS } from "../../utils/constants/texts";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
 import { openStarterProject } from "../../utils/flow/open-starter-project";
 import { waitForFlowEditorReady } from "../../utils/flow/wait-for-flow-editor-ready";
 import { lockFlow, unlockFlow } from "../../utils/lock-flow";
@@ -44,17 +45,9 @@ test(
     await tryDeleteEdge(page);
 
     // Delete edges one by one (when unlocked, should work)
-    await page.locator(".react-flow__edge").nth(0).click();
-    await page.keyboard.press("Backspace");
-    await expect(page.locator(".react-flow__edge")).toHaveCount(2);
-
-    await page.locator(".react-flow__edge").nth(0).click();
-    await page.keyboard.press("Backspace");
-    await expect(page.locator(".react-flow__edge")).toHaveCount(1);
-
-    await page.locator(".react-flow__edge").nth(0).click();
-    await page.keyboard.press("Backspace");
-    await expect(page.locator(".react-flow__edge")).toHaveCount(0);
+    await deleteFirstEdge(page, 2);
+    await deleteFirstEdge(page, 1);
+    await deleteFirstEdge(page, 0);
 
     await tryConnectNodes(page);
 
@@ -115,6 +108,20 @@ async function tryConnectNodes(page: Page) {
     await expect(page.locator(".react-flow__edge")).toHaveCount(0);
   }
   await unlockFlow(page);
+}
+
+async function deleteFirstEdge(page: Page, expectedRemaining: number) {
+  const edges = page.locator(".react-flow__edge");
+  const selectedEdges = page.locator(".react-flow__edge.selected");
+  // A bezier edge's bounding-box center is not always on its stroke, so a
+  // single click can miss the edge and select nothing — Backspace then
+  // silently deletes nothing. Re-click until an edge is actually selected.
+  await expect(async () => {
+    await edges.nth(0).click();
+    await expect(selectedEdges).not.toHaveCount(0, { timeout: 1000 });
+  }).toPass({ timeout: TIMEOUTS.standard });
+  await page.keyboard.press("Backspace");
+  await expect(edges).toHaveCount(expectedRemaining);
 }
 
 async function tryDeleteEdge(page: Page) {

--- a/src/frontend/tests/extended/features/outdated-actions.spec.ts
+++ b/src/frontend/tests/extended/features/outdated-actions.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { expect, test } from "../../fixtures";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
 import { openFlowsList } from "../../utils/flow/open-flows-list";
 
 test.describe.configure({ mode: "serial" });
@@ -192,6 +193,10 @@ test(
 
     await openFlowsList(page);
 
-    expect(await page.getByText("Backup").count()).toBeGreaterThan(0);
+    // The backup flow row renders after the list refetch settles; a bare
+    // count() snapshot races it on slow runners.
+    await expect(page.getByText("Backup").first()).toBeVisible({
+      timeout: TIMEOUTS.medium,
+    });
   },
 );

--- a/src/frontend/tests/extended/regression/generalBugs-shard-11.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-11.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "../../fixtures";
 import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
+import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 import { skipIfComponentUnavailable } from "../../utils/skip-if-component-unavailable";
 import { zoomOut } from "../../utils/zoom-out";
@@ -46,46 +48,36 @@ test(
 
     await page.getByTestId("blank-flow").click();
 
-    //first component
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("url");
-    await page.waitForSelector('[data-testid="data_sourceURL"]', {
-      timeout: 1000,
-    });
-
     await zoomOut(page, 3);
 
-    await page
-      .getByTestId("data_sourceURL")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 100 },
-      });
+    //first component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("tool calling agent");
-    await page.waitForSelector(
-      '[data-testid="langchain_utilitiesTool Calling Agent"]',
-      {
-        timeout: 1000,
-      },
-    );
+    await addComponentFromSidebar(page, {
+      search: "url",
+      testId: "data_sourceURL",
+      position: { x: 100, y: 100 },
+    });
 
-    await page
-      .getByTestId("langchain_utilitiesTool Calling Agent")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 300, y: 300 },
-      });
+    await addComponentFromSidebar(page, {
+      search: "tool calling agent",
+      testId: "langchain_utilitiesTool Calling Agent",
+      position: { x: 300, y: 300 },
+    });
 
     await adjustScreenView(page);
 
     await page.getByTestId("title-URL").first().click();
+    await expect(page.getByTestId("tool-mode-button")).toBeVisible({
+      timeout: TIMEOUTS.short,
+    });
     await page.getByTestId("tool-mode-button").click();
 
     //connection
     const urlOutput = await page
       .getByTestId("handle-urlcomponent-shownode-toolset-right")
       .first();
+
+    await expect(urlOutput).toBeVisible({ timeout: TIMEOUTS.short });
 
     await urlOutput.hover();
     await page.mouse.down();
@@ -95,6 +87,8 @@ test(
     await toolCallingAgentInput.hover();
     await page.mouse.up();
 
-    expect(await page.locator(".react-flow__edge-interaction").count()).toBe(2);
+    await expect(page.locator(".react-flow__edge-interaction")).toHaveCount(2, {
+      timeout: TIMEOUTS.short,
+    });
   },
 );

--- a/src/frontend/tests/utils/flow/select-starter-template.ts
+++ b/src/frontend/tests/utils/flow/select-starter-template.ts
@@ -65,6 +65,10 @@ export async function selectStarterTemplate(
       (response) =>
         response.request().method() === "POST" &&
         new URL(response.url()).pathname === "/api/v1/flows/",
+      // Creating a starter flow does real backend work (template hydration,
+      // folder wiring) and can outlive the default action timeout on slow
+      // Windows CI runners.
+      { timeout: TIMEOUTS.long },
     ),
     template.click(),
   ]);


### PR DESCRIPTION
Every nightly since Aug 20 has had 1–2 Windows Playwright shards fail on attempt 1 (runs 32316625398, 32432045876, 32539736510, 32607420251, 32676146801). The failures are non-blocking (`continue-on-error`), but they are recurring and diagnosable, with three distinct causes:

1. **Backend boot timeout (shard 24, Aug 24).** The `webServer` timeout is 90s; the server log shows the backend spending ~49s on imports before the Alembic migration chain even starts on the fresh SQLite DB. The boot was killed mid-migration.
2. **A 20–30s mid-test backend stall from MCP stdio.** The failing shards' server logs show `MCPStdioClient._connect_to_server` timing out for the auto-registered `lf-starter_project` server. The UI's background `GET /api/v2/mcp/servers?action_count=true` makes the backend spawn `cmd /c uvx --with mcp~=1.28 mcp-proxy ...`; on a cold uv cache that first invocation resolves and downloads mcp-proxy mid-test, stalling the API until the stdio connect times out. This lines up with `POST /api/v1/flows/` blowing its 20s wait in `selectStarterTemplate` (shard 50, twice).
3. **Timeouts calibrated for Linux runners.** 5s default `expect`, 20s `actionTimeout`, and per-spec 10s waits are routinely exceeded on Windows runners, plus two genuinely racy assertions (`lock-flow` edge delete, `outdated-actions` bare `count()`).

## Changes

- **`playwright.config.ts`** — Windows-conditional headroom: `actionTimeout` 20s → 40s, default `expect` timeout 5s → 15s, backend `webServer` boot timeout 90s → 240s. Linux values unchanged.
- **`typescript_test.yml`** — pre-warm `uvx --with 'mcp~=1.28' mcp-proxy` during Windows shard setup so the first in-test stdio connect doesn't download anything. The `--with` constraint mirrors `mcp_sdk_constraint_args()` so the warmed uvx environment is the one the backend actually spawns.
- **`select-starter-template.ts`** — explicit `TIMEOUTS.long` on the flow-create `waitForResponse` (failed twice on shard 50).
- **`agentDefaultToolsComponent.spec.ts`** — raw `timeout: 10000` → `TIMEOUTS.standard`, per the timeouts.ts convention.
- **`lock-flow.spec.ts`** (failed twice, shard 61) — edge deletion now re-clicks until an edge is actually `.selected` before pressing Backspace; a bezier edge's bbox center isn't always on its stroke, so a single click can miss and Backspace silently deletes nothing.
- **`outdated-actions.spec.ts`** — replace the non-waiting `expect(await ...count()).toBeGreaterThan(0)` with a waiting `toBeVisible`.

## Test plan

- [x] `npx playwright test` locally on the three touched specs (lock-flow, outdated-actions, agentDefaultToolsComponent) — all pass
- [x] `npx playwright test --list` compiles all touched specs
- [x] `biome check` clean on touched frontend files
- [x] Workflow YAML parses; `uvx --with 'mcp~=1.28' mcp-proxy --help` verified locally (exit 0)
- [ ] Observe the next few nightlies' Windows shards

## Main-only addition

This PR additionally ports `generalBugs-shard-11.spec.ts` verbatim from release-1.12.0 (the `addComponentFromSidebar` rewrite), which fixes the Aug 21 shard-70 failure — that spec's 1s `waitForSelector` calls only still exist on main. After both PRs merge, all touched files are byte-identical across the two branches.

Twin PR for release-1.12.0: #14726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of automated workflows on Windows, including longer waits for slower startup and backend operations.
  - Reduced intermittent failures when adding components, editing flows, deleting connections, and validating outdated actions.

- **Tests**
  - Standardized timing and retry behavior across UI and regression checks.
  - Added Windows-specific environment preparation to improve Playwright test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->