### PR TITLE
fix(frontend): keep parameter visibility across a component refresh

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
@@ -10,6 +10,12 @@ const setStoreNodeCode = (nodeId: string, code: string) => {
   } as never);
 };
 
+const setStoreNodeTemplate = (nodeId: string, template: object) => {
+  jest.spyOn(useFlowStore, "getState").mockReturnValue({
+    nodes: [{ id: nodeId, data: { node: { template } } }],
+  } as never);
+};
+
 describe("mutateTemplate", () => {
   afterEach(() => {
     jest.useRealTimers();
@@ -168,6 +174,141 @@ describe("mutateTemplate", () => {
     expect(setNodeClass).toHaveBeenCalledWith(
       expect.objectContaining({
         template: expect.objectContaining({ model_name: expect.anything() }),
+      }),
+    );
+  });
+
+  it("keeps a canvas-visibility flip that happened while the refresh was in flight", async () => {
+    const node = {
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        add_calculator_tool: { value: true, advanced: true },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    const mutateAsync = jest.fn().mockImplementation(async () => {
+      // The user adds the parameter to the canvas before the response lands.
+      setStoreNodeTemplate("agent-node", {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        add_calculator_tool: { value: true, advanced: false },
+      });
+      return {
+        template: {
+          code: { value: "original source" },
+          agent_llm: { value: "OpenAI" },
+          add_calculator_tool: { value: true, advanced: true },
+        },
+        outputs: [],
+      } as unknown as APIClassType;
+    });
+    setStoreNodeTemplate("agent-node", node.template);
+
+    await mutateTemplate(
+      "OpenAI",
+      "agent-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "agent_llm",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          add_calculator_tool: expect.objectContaining({ advanced: false }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps an API-exposure flip that happened while the refresh was in flight", async () => {
+    const node = {
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        max_tokens: { value: 100, api_editable: false },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    const mutateAsync = jest.fn().mockImplementation(async () => {
+      setStoreNodeTemplate("agent-node", {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        max_tokens: { value: 100, api_editable: true },
+      });
+      return {
+        template: {
+          code: { value: "original source" },
+          agent_llm: { value: "OpenAI" },
+          max_tokens: { value: 100, api_editable: false },
+        },
+        outputs: [],
+      } as unknown as APIClassType;
+    });
+    setStoreNodeTemplate("agent-node", node.template);
+
+    await mutateTemplate(
+      "OpenAI",
+      "agent-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "agent_llm",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          max_tokens: expect.objectContaining({ api_editable: true }),
+        }),
+      }),
+    );
+  });
+
+  it("applies a backend-driven visibility change the user did not touch", async () => {
+    const node = {
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        api_key: { value: "", advanced: true },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    const mutateAsync = jest.fn().mockResolvedValue({
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        api_key: { value: "", advanced: false },
+      },
+      outputs: [],
+    } as unknown as APIClassType);
+    setStoreNodeTemplate("agent-node", node.template);
+
+    await mutateTemplate(
+      "OpenAI",
+      "agent-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "agent_llm",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          api_key: expect.objectContaining({ advanced: false }),
+        }),
       }),
     );
   });

--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -2,17 +2,62 @@ import type { UseMutationResult } from "@tanstack/react-query";
 import { cloneDeep, debounce } from "lodash";
 import { SAVE_DEBOUNCE_TIME } from "@/constants/constants";
 import useFlowStore from "@/stores/flowStore";
-import type { APIClassType, ResponseErrorDetailAPI } from "@/types/api";
+import type {
+  APIClassType,
+  APITemplateType,
+  ResponseErrorDetailAPI,
+} from "@/types/api";
 import i18n from "../../i18n";
 import { updateHiddenOutputs } from "./update-hidden-outputs";
 
 const debouncedFunctions = new Map<string, ReturnType<typeof debounce>>();
 
-const getNodeCode = (nodeId: string): unknown => {
+const getNodeTemplate = (nodeId: string): APITemplateType | undefined => {
   const currentNode = useFlowStore
     .getState()
     .nodes.find((flowNode) => flowNode.id === nodeId);
-  return currentNode?.data?.node?.template?.code?.value;
+  return currentNode?.data?.node?.template;
+};
+
+const getNodeCode = (nodeId: string): unknown => {
+  return getNodeTemplate(nodeId)?.code?.value;
+};
+
+// Canvas visibility and API exposure are owned by the user through the
+// Parameters panel, never by a refresh. The response carries whatever these
+// were when the request left, so applying it wholesale reverts a flag the
+// user flipped meanwhile - the field vanishes off the node with no feedback.
+const USER_OWNED_FIELD_FLAGS = ["advanced", "api_editable"] as const;
+
+const keepUserFieldFlags = (
+  nodeId: string,
+  requestedTemplate: APITemplateType | undefined,
+  incomingTemplate: APITemplateType,
+): APITemplateType => {
+  const currentTemplate = getNodeTemplate(nodeId);
+  if (!requestedTemplate || !currentTemplate) return incomingTemplate;
+
+  const merged = cloneDeep(incomingTemplate);
+  for (const [fieldName, currentField] of Object.entries(currentTemplate)) {
+    const requestedField = requestedTemplate[fieldName];
+    const incomingField = merged[fieldName];
+    if (
+      typeof currentField !== "object" ||
+      currentField === null ||
+      typeof requestedField !== "object" ||
+      requestedField === null ||
+      typeof incomingField !== "object" ||
+      incomingField === null
+    ) {
+      continue;
+    }
+    for (const flag of USER_OWNED_FIELD_FLAGS) {
+      if (currentField[flag] !== requestedField[flag]) {
+        incomingField[flag] = currentField[flag];
+      }
+    }
+  }
+  return merged;
 };
 
 // A refresh answers for the code that was current when it left, and applying it
@@ -76,7 +121,11 @@ export const mutateTemplate = async (
               is_refresh: isRefresh ?? false,
             });
             if (newTemplate && !isStaleForNode(nodeId, node)) {
-              newNode.template = newTemplate.template;
+              newNode.template = keepUserFieldFlags(
+                nodeId,
+                node.template,
+                newTemplate.template,
+              );
               newNode.outputs = updateHiddenOutputs(
                 newNode.outputs ?? [],
                 newTemplate.outputs ?? [],


### PR DESCRIPTION
The 2026-08-24 nightly lost two Windows shards. One is a real product bug that a timeout bump cannot fix; the rest was already handled by #14726.

Failing run: [Nightly Build 32676146801](https://github.com/langflow-ai/langflow/actions/runs/32676146801) — Windows shards [50/70](https://github.com/langflow-ai/langflow/actions/runs/32676146801/job/97285401254) and 24/70.

## What the nightly actually hit

| # | Symptom | Status |
| --- | --- | --- |
| 1 | Shard 24: `Timed out waiting 90000ms from config.webServer` — backend never opened the port during the Alembic chain | Already fixed by #14726 (Windows webServer timeout → 240s) |
| 2 | Shard 50 attempt 1: `waitForResponse POST /api/v1/flows/` timed out at 20s in `selectStarterTemplate` | Already fixed by #14726 (`TIMEOUTS.long`) |
| 3 | Shard 50 **retry**: `toggle_bool_add_calculator_tool` — `element(s) not found` | **Real bug — fixed here** |

#14726 landed at 2026-08-24 03:48 UTC, after this nightly started (00:22 UTC), so 1 and 2 need no further work. Item 3 is different: #14726 only widened that assertion from 10s to 30s, and the element never renders at all, so the extra 20s would not have saved it.

## The bug

Adding a parameter to the canvas from the Parameters panel **while a component refresh is in flight** silently reverts it. The field disappears from the node, and the panel still shows it as added — no error, no feedback.

`mutateTemplate` captures the node when the request leaves and, on response, does `newNode.template = newTemplate.template` — a full replace. `isStaleForNode` guards only `template.code.value` (added for the #13087-era slider race), so any per-field flag the user flipped mid-flight is lost. The inspector writes exactly two such flags, `advanced` (canvas visibility) and `api_editable` (API exposure), and both are user-owned — a refresh never decides them.

### Evidence from the CI trace

I pulled the shard-50 blob report and read the retry's action trace:

```
t+34.5s  642ms   click inspector-add-add_calculator_tool
t+35.2s   89ms   expect inspector-remove-add_calculator_tool visible   PASS
t+35.3s  153ms   close parameters panel
t+36.0s  639ms   fit_view
t+37.0s 10020ms  expect toggle_bool_add_calculator_tool visible        FAIL
```

Every surrounding action took 20–650ms, so the runner was responsive — this was not slowness. The captured aria snapshot confirms it: the Agent node renders Language Model, Agent Instructions, Tools and Input, with **no Calculator field**, while the panel had already flipped it on.

## Fix

Preserve `advanced` and `api_editable` per field when they changed in the store while the request was in flight; take the backend value otherwise, so a refresh that legitimately shows or hides a field still applies.

## Validation

- **Reproduced on macOS** by holding the Agent's mount-time `POST /api/v1/custom_component/update` until after the toggle: the toggle renders, then vanishes when the response lands. With the fix it stays (`toggle count after refresh landed: 1`).
- 3 new Jest cases in `mutate-template.test.ts`; 2 of them fail on `main` without the fix, and the third guards against over-correcting (a backend-driven visibility change the user did not touch must still apply). Full file: 7/7 green.
- `npx jest src/CustomNodes src/pages/FlowPage/components/InspectionPanel` — 28 suites, 213 tests green.
- Playwright: `agentDefaultToolsComponent`, `sliderComponent`, `dropdownComponent` and the parameter-panel specs green. Three specs in that sweep fail on this machine (`fileUploadComponent`, `general-bugs-component-webhook-api-key-display`, `general-bugs-hidden-input-edges`) — they fail identically with the fix stashed, so they are pre-existing local-env failures, not regressions.
- `npx biome check` clean; no new `tsc` errors in the touched files.

## Note

`main` carries the same `mutateTemplate` code and needs this fix too — happy to open the forward-port once this is reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-selected canvas visibility and API exposure settings when asynchronous template updates are applied.
  * Continued applying backend-driven changes to settings the user has not modified.
  * Improved template updates to merge changes without overwriting user-owned preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->