### PR TITLE
fix: re-parent exported spans whose parent was dropped

### DIFF
--- a/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
+++ b/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
@@ -80,12 +80,12 @@ def test_application_and_llm_spans_together_export_only_the_application_span(exp
     assert SENTINEL not in str([dict(s.attributes or {}) for s in finished])
 
 
-def test_child_of_a_dropped_span_is_still_exported_and_orphaned(exporter_and_provider):
-    """Pins a known consequence rather than asserting it is desirable.
+def test_child_of_a_dropped_span_is_promoted_to_a_root(exporter_and_provider):
+    """A sub-flow run from inside an agent component, with nothing exported above it.
 
-    An application span nested inside a dropped LLM span (a sub-flow run from inside an agent
-    component) still reaches the APM, but its parent does not, so the trace renders with a
-    gap. Documented in ApplicationOnlySpanProcessor.
+    The dropped LLM span was its only ancestor, so there is nothing left to hang it from and
+    it becomes a root. Previously it kept pointing at the dropped parent and arrived at the
+    APM referencing a span that never showed up.
     """
     from opentelemetry.trace import use_span
 
@@ -98,9 +98,70 @@ def test_child_of_a_dropped_span_is_still_exported_and_orphaned(exporter_and_pro
     provider.force_flush()
     finished = exporter.get_finished_spans()
     assert [s.name for s in finished] == ["flow.execute"]
-    exported_ids = {s.context.span_id for s in finished}
-    assert finished[0].parent is not None
-    assert finished[0].parent.span_id not in exported_ids, "parent should be absent, not silently re-parented"
+    assert finished[0].parent is None, "should be a root, not pointing at a span that was never exported"
+
+
+def test_child_of_a_dropped_span_is_reparented_to_its_nearest_exported_ancestor(exporter_and_provider):
+    """The case that actually renders as a tree: an exported ancestor exists above the drop.
+
+    request -> openai.chat (dropped) -> flow.execute. The middle span never reaches the APM,
+    so flow.execute has to attach to the request or the trace has a hole in it.
+    """
+    from opentelemetry.trace import use_span
+
+    exporter, provider = exporter_and_provider
+    request = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("POST /api/v1/run")
+    with use_span(request, end_on_exit=False):
+        llm_span = provider.get_tracer("opentelemetry.instrumentation.openai").start_span("openai.chat")
+        with use_span(llm_span, end_on_exit=False):
+            provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+        llm_span.end()
+    request.end()
+
+    provider.force_flush()
+    by_name = {s.name: s for s in exporter.get_finished_spans()}
+    assert sorted(by_name) == ["POST /api/v1/run", "flow.execute"]
+    assert by_name["flow.execute"].parent is not None
+    assert by_name["flow.execute"].parent.span_id == by_name["POST /api/v1/run"].context.span_id
+    # Same trace throughout: this moves a span within its tree, it does not relocate it.
+    assert by_name["flow.execute"].context.trace_id == by_name["POST /api/v1/run"].context.trace_id
+
+
+def test_a_span_under_two_dropped_levels_still_finds_the_exported_ancestor(exporter_and_provider):
+    """The walk has to continue past the first dropped parent, not stop at it."""
+    from opentelemetry.trace import use_span
+
+    exporter, provider = exporter_and_provider
+    request = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("POST /api/v1/run")
+    with use_span(request, end_on_exit=False):
+        outer = provider.get_tracer("opentelemetry.instrumentation.openai").start_span("openai.chat")
+        with use_span(outer, end_on_exit=False):
+            inner = provider.get_tracer("opentelemetry.instrumentation.requests").start_span("HTTP POST")
+            with use_span(inner, end_on_exit=False):
+                provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+            inner.end()
+        outer.end()
+    request.end()
+
+    provider.force_flush()
+    by_name = {s.name: s for s in exporter.get_finished_spans()}
+    assert sorted(by_name) == ["POST /api/v1/run", "flow.execute"]
+    assert by_name["flow.execute"].parent.span_id == by_name["POST /api/v1/run"].context.span_id
+
+
+def test_a_real_parent_is_left_alone(exporter_and_provider):
+    """The control. Nothing was dropped, so nothing should be rewritten."""
+    from opentelemetry.trace import use_span
+
+    exporter, provider = exporter_and_provider
+    request = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("POST /api/v1/run")
+    with use_span(request, end_on_exit=False):
+        provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+    request.end()
+
+    provider.force_flush()
+    by_name = {s.name: s for s in exporter.get_finished_spans()}
+    assert by_name["flow.execute"].parent.span_id == by_name["POST /api/v1/run"].context.span_id
 
 
 @pytest.mark.parametrize(
@@ -166,3 +227,62 @@ def test_llm_tracer_name_is_not_allowlisted():
     """The vendor integrations use the bare "langflow" tracer name; ours must differ."""
     assert "langflow" not in APPLICATION_INSTRUMENTATION_SCOPES
     assert APPLICATION_TRACER_NAME in APPLICATION_INSTRUMENTATION_SCOPES
+
+
+def test_a_remote_parent_is_never_rewritten():
+    """The safety case. An unknown parent is not evidence of a drop.
+
+    A parent from another process is absent from this processor's map for the same reason a
+    dropped one is: it was never seen at on_start. Treating absence as a drop would detach
+    every distributed trace from its caller and re-root it here, replacing a correct
+    cross-process link with an invented local one.
+    """
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+
+    remote = SpanContext(
+        trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+        span_id=0x1122334455667788,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    context = otel_trace.set_span_in_context(NonRecordingSpan(remote))
+    provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute", context=context).end()
+
+    provider.force_flush()
+    exported = exporter.get_finished_spans()
+    assert len(exported) == 1
+    assert exported[0].parent is not None, "a remote parent must survive; it is not an orphan"
+    assert exported[0].parent.span_id == remote.span_id
+    provider.shutdown()
+
+
+def test_the_lineage_map_does_not_grow_across_runs():
+    """Entries are removed as spans end, including the dropped ones.
+
+    The map is the only state this processor keeps, so an entry that outlives its span is a
+    leak in a long-running server.
+    """
+    from opentelemetry.trace import use_span
+
+    exporter = InMemorySpanExporter()
+    processor = ApplicationOnlySpanProcessor(exporter)
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+
+    for _ in range(25):
+        request = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("POST /api/v1/run")
+        with use_span(request, end_on_exit=False):
+            llm = provider.get_tracer("opentelemetry.instrumentation.openai").start_span("openai.chat")
+            with use_span(llm, end_on_exit=False):
+                provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+            llm.end()
+        request.end()
+
+    provider.force_flush()
+    assert processor._lineage == {}, f"{len(processor._lineage)} entries left behind"
+    provider.shutdown()

--- a/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
+++ b/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
@@ -261,6 +261,36 @@ def test_a_remote_parent_is_never_rewritten():
     provider.shutdown()
 
 
+def test_a_remote_parent_above_a_dropped_span_is_preserved():
+    """A dropped local span must not sever an incoming distributed trace."""
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, use_span
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(ApplicationOnlySpanProcessor(exporter))
+
+    remote = SpanContext(
+        trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+        span_id=0x1122334455667788,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    context = otel_trace.set_span_in_context(NonRecordingSpan(remote))
+    dropped = provider.get_tracer("opentelemetry.instrumentation.openai").start_span("openai.chat", context=context)
+    with use_span(dropped, end_on_exit=False):
+        provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute").end()
+    dropped.end()
+
+    provider.force_flush()
+    exported = exporter.get_finished_spans()
+    assert len(exported) == 1
+    assert exported[0].parent is not None
+    assert exported[0].parent.span_id == remote.span_id
+    assert exported[0].context.trace_id == remote.trace_id
+    provider.shutdown()
+
+
 def test_the_lineage_map_does_not_grow_across_runs():
     """Entries are removed as spans end, including the dropped ones.
 

--- a/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
+++ b/src/backend/tests/unit/services/telemetry/test_application_span_filter.py
@@ -286,3 +286,40 @@ def test_the_lineage_map_does_not_grow_across_runs():
     provider.force_flush()
     assert processor._lineage == {}, f"{len(processor._lineage)} entries left behind"
     provider.shutdown()
+
+
+def test_a_failure_while_reparenting_does_not_break_the_run():
+    """Telemetry must not raise into the code that ended the span.
+
+    The SDK does not catch exceptions from a span processor: it lets them out of
+    ``Span.end()`` and into the caller. Re-parenting reaches into SDK internals, so if a
+    future release changes them, the failure has to stay inside the processor. The span is
+    still exported, with whatever parent it already had.
+
+    Corrupts the processor's own lineage map rather than patching the SDK, so the failure is
+    raised by the real code path under test.
+    """
+    from opentelemetry.trace import use_span
+
+    exporter = InMemorySpanExporter()
+    processor = ApplicationOnlySpanProcessor(exporter)
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+
+    request = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("POST /api/v1/run")
+    with use_span(request, end_on_exit=False):
+        llm = provider.get_tracer("opentelemetry.instrumentation.openai").start_span("openai.chat")
+        with use_span(llm, end_on_exit=False):
+            child = provider.get_tracer(APPLICATION_TRACER_NAME).start_span("flow.execute")
+            # The walk unpacks each entry as (exported, parent_id, context). A short tuple
+            # raises there, which is what a changed SDK looks like from inside this code.
+            # It has to be falsy in position 0 too, or the caller returns before the walk.
+            processor._lineage[llm.get_span_context().span_id] = (False,)
+            child.end()  # must not raise
+        llm.end()
+    request.end()
+
+    provider.force_flush()
+    exported = [s for s in exporter.get_finished_spans() if s.name == "flow.execute"]
+    assert len(exported) == 1, "the span must still be exported when re-parenting fails"
+    provider.shutdown()

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from opentelemetry.sdk._logs import LoggerProvider
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.trace import Link, Span
+    from opentelemetry.trace import Link, Span, SpanContext
 
 # The tracer name Langflow's own application spans are emitted under. Deliberately not
 # "langflow": the LLM tracer integrations already take a tracer under that name, and their
@@ -445,12 +445,12 @@ if _OTEL_AVAILABLE:
             # Resolved once, at construction, so the set cannot change under a running
             # process and leave two spans of the same scope treated differently.
             self._scopes = exported_span_scopes()
-            # span_id -> (will be exported, parent span id, own span context). Written in
+            # span_id -> (will be exported, parent span context, own span context). Written in
             # on_start, read when a child ends, removed when the span itself ends. Children
             # end before their parents, so a parent is still present when its child looks it
             # up. No lock: dict get and set are atomic here, and a lost race costs one
             # re-parenting, leaving the span exactly as it was exported before this existed.
-            self._lineage: dict[int, tuple[bool, int | None, Any]] = {}
+            self._lineage: dict[int, tuple[bool, SpanContext | None, SpanContext]] = {}
             self._lineage_capped = False
             self._reparent_failed = False
 
@@ -489,8 +489,7 @@ if _OTEL_AVAILABLE:
                 return
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
             context = span.get_span_context()
-            parent_id = span.parent.span_id if span.parent else None
-            self._lineage[context.span_id] = (scope in self._scopes, parent_id, context)
+            self._lineage[context.span_id] = (scope in self._scopes, span.parent, context)
 
         def _exported_ancestor(self, parent_id):
             """The nearest ancestor that will be exported.
@@ -511,7 +510,9 @@ if _OTEL_AVAILABLE:
                 exported, next_parent, context = entry
                 if exported:
                     return context
-                current = next_parent
+                if next_parent is not None and next_parent.is_remote:
+                    return next_parent
+                current = next_parent.span_id if next_parent is not None else None
             return None
 
         def _reparent_over_dropped_ancestors(self, span) -> None:

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -401,6 +401,9 @@ except ImportError:
 
 
 if _OTEL_AVAILABLE:
+    # Distinct from None, which means "no exported ancestor, promote to root". This one means
+    # the chain left what this process saw, so the honest answer is to change nothing.
+    _UNKNOWN_ANCESTOR = object()
 
     class ApplicationOnlySpanProcessor(BatchSpanProcessor):
         """Exports only spans that describe the application, dropping everything else.
@@ -413,13 +416,28 @@ if _OTEL_AVAILABLE:
         Drops are logged once per scope at debug level; they are the expected case for LLM
         instrumentation, and logging every one would be noise.
 
-        Known consequence: an exported span whose parent was dropped arrives at the APM with a
-        parent that never shows up, so the trace renders with a gap. That follows from the
-        requirement of zero component spans in the APM, and it cannot be repaired here because
-        a child ends before its parent, so there is no way to know at the child's on_end that
-        the parent will be dropped. Scrubbing attributes instead of dropping would keep the
-        tree intact, but the requirement is no component spans, not merely no content.
+        A span whose parent is dropped is re-parented to its nearest exported ancestor, or
+        promoted to a root when it has none, so the trace still renders as a tree.
+
+        This is knowable at the child's on_end even though the child ends before its parent,
+        because the drop depends only on the instrumentation scope, which is fixed when the
+        span starts. ``on_start`` fires for every span, dropped ones included, so recording
+        scope and parentage there answers at the child's on_end what will happen to a parent
+        that has not ended yet.
+
+        Only rewrites when the parent is known to be dropped. A parent that is absent from the
+        map is left alone: that is a remote parent from another process, or one evicted by the
+        cap below, and neither is an orphan this can fix. Rewriting on a guess would invent a
+        relationship, which is worse than the gap.
+
+        Scrubbing attributes instead of dropping would also keep the tree intact, but the
+        requirement is no component spans, not merely no content.
         """
+
+        # Bounds the lineage map against spans that start and never end. Entries are removed
+        # as spans end, so a healthy process sits far below this; hitting it means something
+        # is leaking, and the cost of that is losing re-parenting, not memory.
+        _MAX_TRACKED_SPANS = 10_000
 
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
@@ -427,17 +445,82 @@ if _OTEL_AVAILABLE:
             # Resolved once, at construction, so the set cannot change under a running
             # process and leave two spans of the same scope treated differently.
             self._scopes = exported_span_scopes()
+            # span_id -> (will be exported, parent span id, own span context). Written in
+            # on_start, read when a child ends, removed when the span itself ends. Children
+            # end before their parents, so a parent is still present when its child looks it
+            # up. No lock: dict get and set are atomic here, and a lost race costs one
+            # re-parenting, leaving the span exactly as it was exported before this existed.
+            self._lineage: dict[int, tuple[bool, int | None, Any]] = {}
+            self._lineage_capped = False
+
+        def on_start(self, span, parent_context=None) -> None:
+            super().on_start(span, parent_context)
+            if len(self._lineage) >= self._MAX_TRACKED_SPANS:
+                if not self._lineage_capped:
+                    self._lineage_capped = True
+                    logger.debug(
+                        f"Tracking more than {self._MAX_TRACKED_SPANS} in-flight spans; "
+                        "not re-parenting children of dropped spans beyond this point."
+                    )
+                return
+            scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
+            context = span.get_span_context()
+            parent_id = span.parent.span_id if span.parent else None
+            self._lineage[context.span_id] = (scope in self._scopes, parent_id, context)
+
+        def _exported_ancestor(self, parent_id):
+            """The nearest ancestor that will be exported.
+
+            Returns its span context, or None when the chain reaches a root through dropped
+            spans only, or ``_UNKNOWN_ANCESTOR`` when the chain leaves what this process
+            recorded and the answer is genuinely not known.
+            """
+            seen: set[int] = set()
+            current = parent_id
+            while current is not None:
+                if current in seen:  # pragma: no cover - defensive, ids are unique
+                    return _UNKNOWN_ANCESTOR
+                seen.add(current)
+                entry = self._lineage.get(current)
+                if entry is None:
+                    return _UNKNOWN_ANCESTOR
+                exported, next_parent, context = entry
+                if exported:
+                    return context
+                current = next_parent
+            return None
+
+        def _reparent_over_dropped_ancestors(self, span) -> None:
+            parent = span.parent
+            if parent is None:
+                return
+            entry = self._lineage.get(parent.span_id)
+            if entry is None or entry[0]:
+                # Unknown parent, or one that is being exported. Either way, leave it.
+                return
+            ancestor = self._exported_ancestor(parent.span_id)
+            if ancestor is _UNKNOWN_ANCESTOR:
+                return
+            # Same trace either way, so this moves the span within its tree rather than
+            # relocating it. None promotes it to a root, which is what it effectively is once
+            # everything above it is dropped.
+            span._parent = ancestor  # noqa: SLF001
 
         def on_end(self, span) -> None:
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
-            if scope in self._scopes:
-                _redact_url_attributes(span)
-                _redact_db_path_attributes(span)
-                super().on_end(span)
-                return
-            if scope not in self._dropped_scopes:
-                self._dropped_scopes.add(scope)
-                logger.debug(f"Not exporting spans from {scope!r}; only application telemetry is sent to the APM.")
+            try:
+                if scope in self._scopes:
+                    self._reparent_over_dropped_ancestors(span)
+                    _redact_url_attributes(span)
+                    _redact_db_path_attributes(span)
+                    super().on_end(span)
+                    return
+                if scope not in self._dropped_scopes:
+                    self._dropped_scopes.add(scope)
+                    logger.debug(f"Not exporting spans from {scope!r}; only application telemetry is sent to the APM.")
+            finally:
+                # After the export, and after any child has had the chance to read it.
+                self._lineage.pop(span.get_span_context().span_id, None)
 
     class ApplicationOnlyMetricExporter(MetricExporter):
         """Pushes only the service's own metrics, dropping every other instrumentation scope.

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -452,6 +452,30 @@ if _OTEL_AVAILABLE:
             # re-parenting, leaving the span exactly as it was exported before this existed.
             self._lineage: dict[int, tuple[bool, int | None, Any]] = {}
             self._lineage_capped = False
+            self._reparent_failed = False
+
+        def _reparent_safely(self, span) -> None:
+            """Re-parent, but never at the cost of the run.
+
+            ``span._parent`` reaches into the SDK's internals, and the SDK does not catch
+            exceptions raised by a span processor: it lets them out of ``Span.end()`` and into
+            whatever application code ended the span. So a future OpenTelemetry release that
+            renames that attribute would not merely stop the trace rendering nicely, it would
+            raise inside a flow run. Telemetry is not allowed to do that.
+
+            Logged once rather than per span, since the cause is process-wide when it happens
+            at all, and the span is exported either way with the parent it already had.
+            """
+            try:
+                self._reparent_over_dropped_ancestors(span)
+            except Exception:  # noqa: BLE001
+                if not self._reparent_failed:
+                    self._reparent_failed = True
+                    logger.debug(
+                        "Could not re-parent a span over its dropped ancestors; "
+                        "exporting it unchanged. This is a no-op for the run itself.",
+                        exc_info=True,
+                    )
 
         def on_start(self, span, parent_context=None) -> None:
             super().on_start(span, parent_context)
@@ -510,7 +534,7 @@ if _OTEL_AVAILABLE:
             scope = span.instrumentation_scope.name if span.instrumentation_scope else ""
             try:
                 if scope in self._scopes:
-                    self._reparent_over_dropped_ancestors(span)
+                    self._reparent_safely(span)
                     _redact_url_attributes(span)
                     _redact_db_path_attributes(span)
                     super().on_end(span)


### PR DESCRIPTION
A span nested inside a dropped LLM span reached the APM pointing at a parent that never arrived, so the trace rendered with a hole in it. It now attaches to its nearest exported ancestor, or becomes a root when it has none.

## The claim this overturns

`ApplicationOnlySpanProcessor` said:

> it cannot be repaired here because a child ends before its parent, so there is no way to know at the child's on_end that the parent will be dropped

That holds only if the parent's fate is decided when it ends. It is not. The drop depends solely on the instrumentation scope, which is fixed when the span starts, and `on_start` fires for every span including dropped ones. Recording scope and parentage there answers the question at the child's `on_end`, while the parent is still open.

Probed before writing anything:

```
ON_START  openai.chat   scope=...instrumentation.openai   id=fcd5...  parent=None
ON_START  flow.execute  scope=langflow.application        id=a09b...  parent=fcd5...
ON_END    flow.execute
ON_END    openai.chat
```

## The part worth reviewing

**An unknown parent is not evidence of a drop.** A parent from another process is missing from the map for exactly the same reason a dropped one is: never seen at `on_start`. If absence meant "dropped", every distributed trace would be detached from its caller and re-rooted here, swapping a correct cross-process link for an invented local one. That is a worse failure than the gap this fixes, so the code distinguishes "unknown, change nothing" from "no exported ancestor, promote to root" with an explicit sentinel, and `test_a_remote_parent_is_never_rewritten` fails if that distinction is removed.

The lineage map is the only state the processor keeps. Entries are removed as spans end (children end before parents, so a parent is still present when its child looks it up) and the map is capped so a span that starts and never ends costs re-parenting rather than memory.

## Verification

Every assertion mutation checked:

| mutation | result |
|---|---|
| re-parenting removed | 3 failed |
| unknown parent treated as an orphan | `test_a_remote_parent_is_never_rewritten` failed |
| map cleanup removed | failed, `75 entries left behind` |

Suites: 22 in the filter file, 197 langflow telemetry, 30 lfx observability, ruff clean.

The test that pinned the orphaning as a known consequence is replaced, since the consequence is gone.

## Why now

Verifying the Instana work showed an orphan is not only cosmetic there. Instana builds its Calls views from entry spans, so a trace with no exported parent is retrievable by id but does not surface by browsing. Data in the backend that cannot be found by looking is the same operator cost either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved telemetry trace relationships when intermediate spans are excluded.
  - Exported child spans now connect to the nearest eligible ancestor or trace root.
  - Preserved existing parent relationships when ancestry is unavailable.
  - Ensured telemetry lineage state is cleared after spans complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->