### PR TITLE
fix(frontend): keep local edits over stale refresh

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
@@ -273,6 +273,108 @@ describe("mutateTemplate", () => {
     );
   });
 
+  it("keeps a tool action edited while the refresh was in flight (LE-2272)", async () => {
+    const preEdit = [
+      {
+        name: "fetch_content",
+        description: "Fetch content from one or more web pages.",
+        approval_actions: [],
+        status: true,
+      },
+    ];
+    const edited = [
+      {
+        name: "web_fetch",
+        description: "custom description",
+        approval_actions: ["approve", "reject"],
+        status: true,
+      },
+    ];
+    const node = {
+      template: {
+        code: { value: "original source" },
+        tools_metadata: { value: preEdit },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    // The editor closes while the request is in flight, so the store already
+    // holds the edits by the time the pre-edit response lands.
+    const mutateAsync = jest.fn().mockImplementation(async () => {
+      setStoreNodeTemplate("url-node", {
+        code: { value: "original source" },
+        tools_metadata: { value: edited },
+      });
+      return {
+        template: {
+          code: { value: "original source" },
+          tools_metadata: { value: preEdit },
+        },
+        outputs: [],
+      } as unknown as APIClassType;
+    });
+    setStoreNodeTemplate("url-node", node.template);
+
+    await mutateTemplate(
+      preEdit,
+      "url-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "tools_metadata",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          tools_metadata: expect.objectContaining({ value: edited }),
+        }),
+      }),
+    );
+  });
+
+  it("applies a backend-driven value change the user did not touch", async () => {
+    const node = {
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        model_name: { value: "gpt-4" },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    const mutateAsync = jest.fn().mockResolvedValue({
+      template: {
+        code: { value: "original source" },
+        agent_llm: { value: "OpenAI" },
+        model_name: { value: "gpt-5" },
+      },
+      outputs: [],
+    } as unknown as APIClassType);
+    setStoreNodeTemplate("agent-node", node.template);
+
+    await mutateTemplate(
+      "OpenAI",
+      "agent-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "agent_llm",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          model_name: expect.objectContaining({ value: "gpt-5" }),
+        }),
+      }),
+    );
+  });
+
   it("applies a backend-driven visibility change the user did not touch", async () => {
     const node = {
       template: {

--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -1,5 +1,5 @@
 import type { UseMutationResult } from "@tanstack/react-query";
-import { cloneDeep, debounce } from "lodash";
+import { cloneDeep, debounce, isEqual } from "lodash";
 import { SAVE_DEBOUNCE_TIME } from "@/constants/constants";
 import useFlowStore from "@/stores/flowStore";
 import type {
@@ -29,7 +29,41 @@ const getNodeCode = (nodeId: string): unknown => {
 // user flipped meanwhile - the field vanishes off the node with no feedback.
 const USER_OWNED_FIELD_FLAGS = ["advanced", "api_editable"] as const;
 
-const keepUserFieldFlags = (
+// The field values the last applied response wrote, per node. A store value
+// that no longer matches this baseline was changed locally, which is what makes
+// an older in-flight response stale for that field. Comparing against the
+// baseline rather than the request snapshot keeps concurrent refreshes working:
+// several mount refreshes share one snapshot, so the first response to land
+// would otherwise look like a local edit and suppress the others.
+const lastAppliedValues = new Map<string, Record<string, unknown>>();
+const LAST_APPLIED_PRUNE_THRESHOLD = 100;
+
+const rememberAppliedValues = (
+  nodeId: string,
+  template: APITemplateType,
+): void => {
+  if (lastAppliedValues.size > LAST_APPLIED_PRUNE_THRESHOLD) {
+    const liveIds = new Set(useFlowStore.getState().nodes.map((n) => n.id));
+    for (const id of lastAppliedValues.keys()) {
+      if (!liveIds.has(id)) lastAppliedValues.delete(id);
+    }
+  }
+  const values: Record<string, unknown> = {};
+  for (const [fieldName, field] of Object.entries(template)) {
+    if (typeof field === "object" && field !== null) {
+      values[fieldName] = cloneDeep(field.value);
+    }
+  }
+  lastAppliedValues.set(nodeId, values);
+};
+
+// LE-2272: a response answers for the field values that were current when the
+// request left. Anything the user edited meanwhile (a tool action's slug,
+// description or approval_actions; any field typed while a refresh is in
+// flight) is newer than the response, so the local value wins. When the user
+// did not touch the field, the backend value still applies - a legitimate
+// refresh that recomputes a value is unaffected.
+const keepUserEdits = (
   nodeId: string,
   requestedTemplate: APITemplateType | undefined,
   incomingTemplate: APITemplateType,
@@ -38,6 +72,7 @@ const keepUserFieldFlags = (
   if (!requestedTemplate || !currentTemplate) return incomingTemplate;
 
   const merged = cloneDeep(incomingTemplate);
+  const baseline = lastAppliedValues.get(nodeId);
   for (const [fieldName, currentField] of Object.entries(currentTemplate)) {
     const requestedField = requestedTemplate[fieldName];
     const incomingField = merged[fieldName];
@@ -55,6 +90,13 @@ const keepUserFieldFlags = (
       if (currentField[flag] !== requestedField[flag]) {
         incomingField[flag] = currentField[flag];
       }
+    }
+    const appliedValue =
+      baseline && fieldName in baseline
+        ? baseline[fieldName]
+        : requestedField.value;
+    if (!isEqual(currentField.value, appliedValue)) {
+      incomingField.value = cloneDeep(currentField.value);
     }
   }
   return merged;
@@ -121,11 +163,12 @@ export const mutateTemplate = async (
               is_refresh: isRefresh ?? false,
             });
             if (newTemplate && !isStaleForNode(nodeId, node)) {
-              newNode.template = keepUserFieldFlags(
+              newNode.template = keepUserEdits(
                 nodeId,
                 node.template,
                 newTemplate.template,
               );
+              rememberAppliedValues(nodeId, newNode.template);
               newNode.outputs = updateHiddenOutputs(
                 newNode.outputs ?? [],
                 newTemplate.outputs ?? [],

--- a/src/frontend/tests/extended/regression/general-bugs-human-input-stale-decisions.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-human-input-stale-decisions.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "../../fixtures";
+import { adjustScreenView } from "../../utils/adjust-screen-view";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+const NEW_ACTION = "Request Changes";
+
+// LE-2278: Human Input fires an on-mount decisions refresh. Its response was
+// applied over a User Action added while it was still in flight, so the chip
+// vanished, the node kept the orphan branch output, and the autosave persisted
+// the reverted value. Same family as LE-2272.
+test(
+  "a custom User Action survives a decisions refresh response that lands late",
+  { tag: ["@release", "@components"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("human input");
+    await page.waitForSelector('[data-testid="flow_controlsHuman Input"]', {
+      timeout: 30000,
+    });
+
+    // Hold the on-mount decisions refresh. Its round trip runs now and only the
+    // delivery waits, so releasing it lands the response immediately - the
+    // window between the user's commit and the field-change request leaving.
+    let alreadyHeld = false;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/api/v1/custom_component/update", async (route) => {
+      const body = route.request().postData() ?? "";
+      if (!alreadyHeld && body.includes('"field":"decisions"')) {
+        alreadyHeld = true;
+        const response = await route.fetch();
+        await gate;
+        await route.fulfill({ response });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.getByTestId("flow_controlsHuman Input").hover();
+    await page.getByTestId("add-component-button-human-input").click();
+    await adjustScreenView(page);
+
+    await page.getByTestId("actionpicker-add-decisions").click();
+    await page.getByTestId("action-add-input").fill(NEW_ACTION);
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId(`action-edit-${NEW_ACTION}`)).toBeVisible({
+      timeout: 30000,
+    });
+
+    release();
+
+    await expect(page.getByTestId(`action-edit-${NEW_ACTION}`)).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByTestId("action-edit-Approve")).toBeVisible();
+    await expect(page.getByTestId("action-edit-Reject")).toBeVisible();
+
+    // The reverted value used to reach the database, leaving chips and branch
+    // outputs inconsistent there too.
+    const flowId = page.url().split("/flow/")[1]?.split("/")[0];
+    await expect
+      .poll(
+        async () => {
+          const response = await page.request.get(
+            `http://localhost:7860/api/v1/flows/${flowId}`,
+          );
+          const flow = await response.json();
+          const node = flow?.data?.nodes?.find((candidate) =>
+            candidate?.id?.toLowerCase().includes("humaninput"),
+          );
+          if (!node) return null;
+          return {
+            decisions: node.data?.node?.template?.decisions?.value ?? null,
+            outputs: (node.data?.node?.outputs ?? []).map((o) => o.name),
+          };
+        },
+        { timeout: 30000 },
+      )
+      .toEqual({
+        decisions: ["Approve", "Reject", NEW_ACTION],
+        outputs: ["branch_approve", "branch_reject", "branch_request_changes"],
+      });
+  },
+);

--- a/src/frontend/tests/extended/regression/general-bugs-tool-action-stale-update.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-tool-action-stale-update.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "../../fixtures";
+import { adjustScreenView } from "../../utils/adjust-screen-view";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+const NEW_SLUG = "web_fetch";
+const NEW_DESCRIPTION = "LE2272 distinctive description";
+
+// LE-2272: the tool actions editor applies its edits to the node only on close.
+// A custom_component/update response issued before those edits but landing after
+// them used to be applied wholesale, reverting the slug, the description and
+// approval_actions — and the autosave then persisted the loss.
+test(
+  "tool action edits survive a custom_component/update response that lands late",
+  { tag: ["@release", "@components"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("url");
+    await page.waitForSelector('[data-testid="data_sourceURL"]', {
+      timeout: 30000,
+    });
+    await page.getByTestId("data_sourceURL").hover();
+    await page.getByTestId("add-component-button-url").click();
+    await adjustScreenView(page);
+
+    // Hold the pre-edit tools_metadata refresh and release it only once the
+    // editor has closed, so its response is stale by the time it is applied.
+    let alreadyHeld = false;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route("**/api/v1/custom_component/update", async (route) => {
+      const body = route.request().postData() ?? "";
+      if (!alreadyHeld && body.includes('"field":"tools_metadata"')) {
+        alreadyHeld = true;
+        await gate;
+      }
+      await route.continue();
+    });
+
+    await page.getByTestId("title-URL").first().click();
+    await page.keyboard.press("ControlOrMeta+Shift+m");
+    await page.waitForSelector('[data-testid="button_open_actions"]', {
+      timeout: 30000,
+    });
+
+    await page.getByTestId("button_open_actions").click();
+    await expect(page.getByText("FETCH_CONTENT").first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    await page
+      .locator('.ag-center-cols-container .ag-row [col-id="description"]')
+      .first()
+      .click({ force: true });
+    await expect(page.getByTestId("input_update_name")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await page.getByTestId("input_update_name").fill(NEW_SLUG);
+    await page.getByTestId("input_update_description").fill(NEW_DESCRIPTION);
+
+    const toggle = page.getByTestId("requires-approval-toggle").first();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+    // The switch renders instantly but persists onto the row after its slide
+    // transition, so give that timer room before closing the editor.
+    await page.waitForTimeout(600);
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("input_update_name")).toBeHidden({
+      timeout: 30000,
+    });
+
+    release();
+    await page.waitForTimeout(4000);
+
+    await page.getByTestId("button_open_actions").click();
+    await expect(page.getByText("WEB_FETCH").first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText(NEW_DESCRIPTION).first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(
+      page.getByTestId("requires-approval-toggle").first(),
+    ).toHaveAttribute("aria-checked", "true");
+    await page.keyboard.press("Escape");
+
+    // The reverted node used to reach the database through the debounced autosave.
+    const flowId = page.url().split("/flow/")[1]?.split("/")[0];
+    await expect
+      .poll(
+        async () => {
+          const response = await page.request.get(
+            `http://localhost:7860/api/v1/flows/${flowId}`,
+          );
+          const flow = await response.json();
+          const node = flow?.data?.nodes?.find((candidate) =>
+            candidate?.id?.toLowerCase().includes("url"),
+          );
+          return node?.data?.node?.template?.tools_metadata?.value?.[0] ?? null;
+        },
+        { timeout: 30000 },
+      )
+      .toMatchObject({
+        name: NEW_SLUG,
+        description: NEW_DESCRIPTION,
+        approval_actions: ["approve", "reject"],
+      });
+  },
+);


### PR DESCRIPTION
Two bug reports, one root cause: a `POST /api/v1/custom_component/update` response computed from a template older than the user's local edit was applied over that edit. No error, no toast, no conflict indication — and the debounced autosave persisted the loss.

Fixes LE-2272. Fixes LE-2278.

## The two surfaces

**LE-2272 — Tool Mode actions.** The actions editor applies its edits to the node **only on close**. A response in flight at that moment reverted the action slug, the description and `approval_actions`. Reproduced live (URL component, response held with `page.route`):

```
8.11s ESC              local state = web_fetch / ["approve","reject"] / new desc
8.27s RES stale update fetch_content / [] / default desc    <- clobbers the node
8.52s REQ update       field_value = EDITED, template = PRE-EDIT
8.58s RES update       fetch_content / []
9.56s PATCH flow       fetch_content / []                   <- loss persisted
```

**LE-2278 — Human Input User Choices.** The node fires an on-mount `decisions` refresh. Released in the window between the user's add and the field-change request leaving, it reverted the chip:

```
4.64s chip committed    local state = ["Approve","Reject","Request Changes"]
4.68s RES stale update  ["Approve","Reject"] / 2 branch outputs   <- clobbers
4.95s REQ update        field_value = EDITED, template = REVERTED
5.01s RES update        decisions ["Approve","Reject"] BUT outputs include branch_request_changes
5.99s PATCH flow        reverted value + orphan third branch      <- mixed state persisted
```

In both traces the same second-order effect appears: once the store is clobbered, the *next* request is built from it, so it carries the edits in `field_value` but the stale data in `template` — and the backend answers from the template it was given. That also settles LE-2278's open question about "which write path splits them": nothing splits them on the frontend. `update_outputs` honours `field_value` (three branches) while the template echo follows the stale `template` (two choices), in one and the same response.

The `last_updated` guard in `use-post-template-value.ts` does not cover either case — it only discards a response older than the last *applied* one, and on a freshly mounted node nothing has been applied yet.

`approval_actions` is what gates human-in-the-loop approval (`component_tool.py::update_tools_metadata` → `hitl.py`), so losing it silently means an action the user marked as requiring approval runs without approval.

## The fix

`keepUserFieldFlags` → `keepUserEdits` in `mutate-template.ts`, now also preserving a field's `value` when the store diverged.

The baseline is the non-obvious part. Comparing against the **request snapshot** is wrong: several mount refreshes share one snapshot, so the first response to land would look like a local edit and suppress every concurrent one. The baseline is therefore `lastAppliedValues` — the values the last *applied* response wrote. Divergence from that is a genuine local edit and the user wins; untouched fields still take the backend value, so legitimate refreshes are unaffected.

This is the third and fourth instance of this clobber race, after #14726/#14736 (`isStaleForNode` for `code`, `keepUserFieldFlags` for `advanced`/`api_editable`).

## Tests

- `mutate-template.test.ts`: the LE-2272 case (verified RED without the fix — 1 of 9 failing), plus a counter-test that a backend value change the user did not touch is still applied.
- `general-bugs-tool-action-stale-update.spec.ts`: holds the pre-edit `tools_metadata` refresh and releases it after the editor closes; asserts the reopened editor **and** the persisted flow. RED without the fix, green with it; both ticket variants (stale response landing before and after the reopen) pass.
- `general-bugs-human-input-stale-decisions.spec.ts`: pre-fetches the on-mount `decisions` response and delivers it on release, so the window is hit without depending on RTT; asserts the chips and the persisted `decisions` + `outputs` together, which is what catches the mixed state. RED 3/3 on `release-1.12.0`, green 3/3 with the fix.
- No regressions: 174 jest tests in `src/CustomNodes`; `dropdownComponent`, `tabComponent`, `linkComponent`, `agentDefaultToolsComponent`, `refresh-dropdown-list` E2E all pass.

## Out of scope

`RequiresApprovalToggle` persists onto the row 200 ms after the click (deliberately, so the ag-grid cell does not remount mid-animation). Toggling and closing the editor inside that window loses the toggle — a separate, smaller bug; the E2E spec waits it out.
