### PR TITLE
chore: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm ci
 
       - name: Set up Java (Semeru)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: "semeru"
           java-version: "21"


### PR DESCRIPTION
## Summary

Upgrade the Mend workflow from actions/setup-java v5 to v6.0.0.

## Validation

Reviewed the workflow-only diff and verified no setup-java reference older than v6 remains in active workflow YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated security scanning workflow to use the latest Java setup action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->