### PR TITLE
fix(release): keep wheels within Docker image profile

### DIFF
--- a/scripts/ci/install_release_wheels.py
+++ b/scripts/ci/install_release_wheels.py
@@ -135,10 +135,6 @@ def install_release_wheels(
         target_profile = _installed_distribution_names(python) | CORE_DISTRIBUTIONS
         skipped = [wheel for wheel in wheels if wheel.name not in target_profile]
         wheels = [wheel for wheel in wheels if wheel.name in target_profile]
-        missing = REQUIRED_DISTRIBUTIONS[mode] - {wheel.name for wheel in wheels}
-        if missing:
-            msg = f"Target environment is missing required {mode} distributions: {', '.join(sorted(missing))}"
-            raise ValueError(msg)
         if skipped:
             print("Skipping release wheels outside the target image profile:")
             for wheel in skipped:

--- a/scripts/ci/install_release_wheels.py
+++ b/scripts/ci/install_release_wheels.py
@@ -21,6 +21,7 @@ from email.parser import BytesParser
 from pathlib import Path
 
 BASE_DISTRIBUTIONS = frozenset({"langflow-base", "langflow-sdk", "lfx"})
+CORE_DISTRIBUTIONS = BASE_DISTRIBUTIONS | {"langflow"}
 REQUIRED_DISTRIBUTIONS = {
     "base": frozenset({"langflow-base", "lfx"}),
     "main": frozenset({"langflow", "langflow-base", "lfx"}),
@@ -131,9 +132,9 @@ def install_release_wheels(
 
     wheels = _select_wheels(artifacts_dir, mode)
     if mode == "main":
-        installed_names = _installed_distribution_names(python)
-        skipped = [wheel for wheel in wheels if wheel.name not in installed_names]
-        wheels = [wheel for wheel in wheels if wheel.name in installed_names]
+        target_profile = _installed_distribution_names(python) | CORE_DISTRIBUTIONS
+        skipped = [wheel for wheel in wheels if wheel.name not in target_profile]
+        wheels = [wheel for wheel in wheels if wheel.name in target_profile]
         missing = REQUIRED_DISTRIBUTIONS[mode] - {wheel.name for wheel in wheels}
         if missing:
             msg = f"Target environment is missing required {mode} distributions: {', '.join(sorted(missing))}"

--- a/scripts/ci/install_release_wheels.py
+++ b/scripts/ci/install_release_wheels.py
@@ -83,6 +83,20 @@ def _select_wheels(artifacts_dir: Path, mode: str) -> list[Wheel]:
     return sorted(by_name.values(), key=lambda wheel: wheel.name)
 
 
+def _installed_distribution_names(python: Path) -> frozenset[str]:
+    command = (
+        "import importlib.metadata as metadata, json; "
+        "names = {dist.metadata.get('Name') for dist in metadata.distributions()}; "
+        "print(json.dumps(sorted(name for name in names if name)))"
+    )
+    output = subprocess.check_output([python, "-I", "-c", command], text=True)  # noqa: S603
+    names = json.loads(output)
+    if not isinstance(names, list) or not all(isinstance(name, str) for name in names):
+        msg = f"Expected installed distribution names as a JSON string list, got {names!r}"
+        raise ValueError(msg)
+    return frozenset(_canonicalize_name(name) for name in names)
+
+
 def _restore_frontend(python: Path, frontend_source: Path) -> None:
     command = (
         "from importlib.util import find_spec; "
@@ -116,6 +130,19 @@ def install_release_wheels(
         return
 
     wheels = _select_wheels(artifacts_dir, mode)
+    if mode == "main":
+        installed_names = _installed_distribution_names(python)
+        skipped = [wheel for wheel in wheels if wheel.name not in installed_names]
+        wheels = [wheel for wheel in wheels if wheel.name in installed_names]
+        missing = REQUIRED_DISTRIBUTIONS[mode] - {wheel.name for wheel in wheels}
+        if missing:
+            msg = f"Target environment is missing required {mode} distributions: {', '.join(sorted(missing))}"
+            raise ValueError(msg)
+        if skipped:
+            print("Skipping release wheels outside the target image profile:")
+            for wheel in skipped:
+                print(f"  {wheel.name}=={wheel.version} ({wheel.path})")
+
     expected_versions = {wheel.name: wheel.version for wheel in wheels}
     uv = _find_uv()
     print("Installing release wheels:")

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -56,6 +56,16 @@ def test_missing_required_wheel_fails_closed(tmp_path: Path) -> None:
         _select_wheels(tmp_path, "main")
 
 
+def test_duplicate_release_wheels_fail_closed(tmp_path: Path) -> None:
+    _write_wheel(tmp_path, "langflow", "1.11.0rc4")
+    _write_wheel(tmp_path, "langflow", "1.11.0rc5")
+    _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "lfx", "1.11.0rc5")
+
+    with pytest.raises(ValueError, match="Duplicate release wheels for langflow"):
+        _select_wheels(tmp_path, "main")
+
+
 def test_install_release_wheels_installs_only_target_profile_and_checks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -124,6 +134,35 @@ def test_install_release_wheels_fails_when_target_profile_omits_required_distrib
     )
 
     with pytest.raises(ValueError, match="Target environment is missing required main distributions: langflow"):
+        install_release_wheels(tmp_path, tmp_path / "venv" / "bin" / "python", "main")
+
+
+def test_install_release_wheels_rejects_malformed_target_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_wheel(tmp_path, "langflow", "1.11.0rc5")
+    _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "lfx", "1.11.0rc5")
+    monkeypatch.setattr(
+        "scripts.ci.install_release_wheels.subprocess.check_output",
+        lambda *_args, **_kwargs: json.dumps({"langflow": "1.11.0rc5"}),
+    )
+
+    with pytest.raises(ValueError, match="Expected installed distribution names as a JSON string list"):
+        install_release_wheels(tmp_path, tmp_path / "venv" / "bin" / "python", "main")
+
+
+def test_install_release_wheels_requires_uv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_wheel(tmp_path, "langflow", "1.11.0rc5")
+    _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "lfx", "1.11.0rc5")
+    monkeypatch.setattr(
+        "scripts.ci.install_release_wheels.subprocess.check_output",
+        lambda *_args, **_kwargs: json.dumps(["langflow", "langflow-base", "lfx"]),
+    )
+    monkeypatch.setattr("scripts.ci.install_release_wheels.shutil.which", lambda _name: None)
+
+    with pytest.raises(FileNotFoundError, match="uv is required"):
         install_release_wheels(tmp_path, tmp_path / "venv" / "bin" / "python", "main")
 
 

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -126,21 +126,6 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
     assert check_command == [str(uv), "pip", "check", "--python", str(python)]
 
 
-def test_install_release_wheels_fails_when_target_profile_omits_required_distribution(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _write_wheel(tmp_path, "langflow", "1.11.0rc5")
-    _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
-    _write_wheel(tmp_path, "lfx", "1.11.0rc5")
-    monkeypatch.setattr(
-        "scripts.ci.install_release_wheels.subprocess.check_output",
-        lambda *_args, **_kwargs: json.dumps(["langflow-base", "lfx"]),
-    )
-
-    with pytest.raises(ValueError, match="Target environment is missing required main distributions: langflow"):
-        install_release_wheels(tmp_path, tmp_path / "venv" / "bin" / "python", "main")
-
-
 def test_install_release_wheels_rejects_malformed_target_profile(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -19,7 +19,7 @@ def _write_wheel(directory: Path, name: str, version: str) -> None:
         archive.writestr(metadata_path, f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n")
 
 
-def test_main_installs_every_release_artifact(tmp_path: Path) -> None:
+def test_main_selects_every_release_artifact(tmp_path: Path) -> None:
     _write_wheel(tmp_path, "langflow", "1.11.0rc5")
     _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
     _write_wheel(tmp_path, "lfx", "1.11.0rc5")
@@ -67,19 +67,22 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
     python = tmp_path / "venv" / "bin" / "python"
     uv = tmp_path / "bin" / "uv"
     commands: list[tuple[list[object], bool]] = []
+    profile_commands: list[list[object]] = []
 
     def record_run(command: list[object], *, check: bool) -> None:
         commands.append((command, check))
 
+    def installed_profile(command: list[object], **_kwargs: object) -> str:
+        profile_commands.append(command)
+        return json.dumps(["langflow", "langflow-base", "lfx", "lfx-firecrawl"])
+
     monkeypatch.setattr("scripts.ci.install_release_wheels._find_uv", lambda: str(uv))
     monkeypatch.setattr("scripts.ci.install_release_wheels.subprocess.run", record_run)
-    monkeypatch.setattr(
-        "scripts.ci.install_release_wheels.subprocess.check_output",
-        lambda *_args, **_kwargs: json.dumps(["langflow", "langflow-base", "lfx", "lfx-firecrawl"]),
-    )
+    monkeypatch.setattr("scripts.ci.install_release_wheels.subprocess.check_output", installed_profile)
 
     install_release_wheels(tmp_path, python, "main")
 
+    assert profile_commands[0][:3] == [python, "-I", "-c"]
     assert len(commands) == 3
     assert all(check for _, check in commands)
     install_command, verify_command, check_command = (command for command, _ in commands)
@@ -104,8 +107,24 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
         "langflow": "1.11.0rc5",
         "langflow-base": "0.11.0rc5",
         "lfx": "1.11.0rc5",
+        "lfx-firecrawl": "0.1.1",
     }
     assert check_command == [str(uv), "pip", "check", "--python", str(python)]
+
+
+def test_install_release_wheels_fails_when_target_profile_omits_required_distribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_wheel(tmp_path, "langflow", "1.11.0rc5")
+    _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "lfx", "1.11.0rc5")
+    monkeypatch.setattr(
+        "scripts.ci.install_release_wheels.subprocess.check_output",
+        lambda *_args, **_kwargs: json.dumps(["langflow-base", "lfx"]),
+    )
+
+    with pytest.raises(ValueError, match="Target environment is missing required main distributions: langflow"):
+        install_release_wheels(tmp_path, tmp_path / "venv" / "bin" / "python", "main")
 
 
 def test_install_release_wheels_without_artifacts_is_a_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 import json
 import zipfile
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
 from scripts.ci.install_release_wheels import _restore_frontend, _select_wheels, install_release_wheels
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _write_wheel(directory: Path, name: str, version: str) -> None:
@@ -59,10 +56,14 @@ def test_missing_required_wheel_fails_closed(tmp_path: Path) -> None:
         _select_wheels(tmp_path, "main")
 
 
-def test_install_release_wheels_installs_verifies_and_checks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_release_wheels_installs_only_target_profile_and_checks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _write_wheel(tmp_path, "langflow", "1.11.0rc5")
     _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
     _write_wheel(tmp_path, "lfx", "1.11.0rc5")
+    _write_wheel(tmp_path, "lfx-firecrawl", "0.1.1")
+    _write_wheel(tmp_path, "lfx-duckduckgo", "0.1.3")
     python = tmp_path / "venv" / "bin" / "python"
     uv = tmp_path / "bin" / "uv"
     commands: list[tuple[list[object], bool]] = []
@@ -72,6 +73,10 @@ def test_install_release_wheels_installs_verifies_and_checks(tmp_path: Path, mon
 
     monkeypatch.setattr("scripts.ci.install_release_wheels._find_uv", lambda: str(uv))
     monkeypatch.setattr("scripts.ci.install_release_wheels.subprocess.run", record_run)
+    monkeypatch.setattr(
+        "scripts.ci.install_release_wheels.subprocess.check_output",
+        lambda *_args, **_kwargs: json.dumps(["langflow", "langflow-base", "lfx", "lfx-firecrawl"]),
+    )
 
     install_release_wheels(tmp_path, python, "main")
 
@@ -87,7 +92,12 @@ def test_install_release_wheels_installs_verifies_and_checks(tmp_path: Path, mon
         "--no-deps",
         "--force-reinstall",
     ]
-    assert {str(path) for path in install_command[7:]} == {str(path) for path in tmp_path.glob("*.whl")}
+    assert {Path(str(path)).name for path in install_command[7:]} == {
+        "langflow-1.11.0rc5-py3-none-any.whl",
+        "langflow_base-0.11.0rc5-py3-none-any.whl",
+        "lfx-1.11.0rc5-py3-none-any.whl",
+        "lfx_firecrawl-0.1.1-py3-none-any.whl",
+    }
     assert verify_command[:2] == [python, "-c"]
     assert "assert actual == expected" in str(verify_command[2])
     assert json.loads(str(verify_command[3])) == {

--- a/scripts/ci/test_install_release_wheels.py
+++ b/scripts/ci/test_install_release_wheels.py
@@ -40,6 +40,7 @@ def test_main_selects_every_release_artifact(tmp_path: Path) -> None:
 def test_base_excludes_main_and_bundle_wheels(tmp_path: Path) -> None:
     _write_wheel(tmp_path, "langflow", "1.11.0rc5")
     _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "langflow-sdk", "0.3.0rc5")
     _write_wheel(tmp_path, "lfx", "1.11.0rc5")
     _write_wheel(tmp_path, "langflow-sdk", "0.3.0rc5")
     _write_wheel(tmp_path, "lfx-arxiv", "0.1.3rc5")
@@ -71,6 +72,7 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
 ) -> None:
     _write_wheel(tmp_path, "langflow", "1.11.0rc5")
     _write_wheel(tmp_path, "langflow-base", "0.11.0rc5")
+    _write_wheel(tmp_path, "langflow-sdk", "0.3.0rc5")
     _write_wheel(tmp_path, "lfx", "1.11.0rc5")
     _write_wheel(tmp_path, "lfx-firecrawl", "0.1.1")
     _write_wheel(tmp_path, "lfx-duckduckgo", "0.1.3")
@@ -108,6 +110,7 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
     assert {Path(str(path)).name for path in install_command[7:]} == {
         "langflow-1.11.0rc5-py3-none-any.whl",
         "langflow_base-0.11.0rc5-py3-none-any.whl",
+        "langflow_sdk-0.3.0rc5-py3-none-any.whl",
         "lfx-1.11.0rc5-py3-none-any.whl",
         "lfx_firecrawl-0.1.1-py3-none-any.whl",
     }
@@ -116,6 +119,7 @@ def test_install_release_wheels_installs_only_target_profile_and_checks(
     assert json.loads(str(verify_command[3])) == {
         "langflow": "1.11.0rc5",
         "langflow-base": "0.11.0rc5",
+        "langflow-sdk": "0.3.0rc5",
         "lfx": "1.11.0rc5",
         "lfx-firecrawl": "0.1.1",
     }


### PR DESCRIPTION
Fixes the v1.12.0 release Docker build by reinstalling only wheels in the resolved image profile while always retaining core release artifacts. The expanded bundles image continues to receive all bundle wheels after its full-profile sync. Validation: 28 targeted release tests passed, focused installer coverage is 82%, Ruff passed, and repository hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release installations now select only wheels matching the installed image profile, along with required core components.
  * Skipped wheels are logged for improved installation visibility.
  * Installation safeguards now handle duplicate wheels, invalid profile data, and missing tooling more reliably.

* **Tests**
  * Expanded coverage for SDK and plugin wheel selection.
  * Added validation that installed wheels match the selected profile exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->