### PR TITLE
fix(deployments): surface wxO create validation errors

### DIFF
--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
@@ -431,6 +431,8 @@ async def create_agent_deployment(
     """Create a provider agent deployment from a prebuilt payload."""
     try:
         return await asyncio.to_thread(clients.agent.create, payload)
+    except ValueError:
+        raise
     except Exception as exc:  # noqa: BLE001
         raise_as_deployment_error(
             exc,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/retry.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/retry.py
@@ -108,6 +108,7 @@ def is_retryable_create_exception(exc: Exception) -> bool:
             InvalidContentError,
             InvalidDeploymentOperationError,
             InvalidDeploymentTypeError,
+            ValueError,
         ),
     )
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -18,6 +18,7 @@ from lfx.services.adapters.deployment.exceptions import (
     DeploymentError,
     DeploymentNotConfiguredError,
     DeploymentNotFoundError,
+    DeploymentServiceError,
     DeploymentSupportError,
     InvalidContentError,
     InvalidDeploymentOperationError,
@@ -264,14 +265,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 deployment_spec=deployment_spec,
                 plan=provider_plan,
             )
-        except (
-            AuthenticationError,
-            ResourceConflictError,
-            InvalidContentError,
-            InvalidDeploymentOperationError,
-            InvalidDeploymentTypeError,
-            DeploymentSupportError,
-        ):
+        except DeploymentServiceError:
             raise
         except (ClientAPIException, HTTPException) as exc:
             raise_as_deployment_error(
@@ -279,6 +273,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 error_prefix=ErrorPrefix.CREATE,
                 log_msg="Unexpected provider error during wxO deployment create",
             )
+        except ValueError as exc:
+            msg = f"{ErrorPrefix.CREATE.value} {exc}"
+            raise InvalidContentError(message=msg, cause=exc) from exc
         except Exception as exc:
             logger.exception("Unexpected error during wxO deployment creation")
             msg = f"{ErrorPrefix.CREATE.value} Please check server logs for details."

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -7612,9 +7612,7 @@ async def test_create_preserves_exception_chain_on_unexpected_error():
             ),
         )
 
-    inner = exc_info.value.__cause__
-    assert isinstance(inner, DeploymentError)
-    assert inner.__cause__ is original_error
+    assert exc_info.value.__cause__ is original_error
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -5170,6 +5170,12 @@ def test_is_retryable_create_exception_domain_exceptions_not_retryable():
     assert is_retryable_create_exception(InvalidDeploymentOperationError()) is False
 
 
+def test_is_retryable_create_exception_value_error_is_not_retryable():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.retry import is_retryable_create_exception
+
+    assert is_retryable_create_exception(ValueError("invalid flow definition")) is False
+
+
 def test_is_retryable_create_exception_generic_exception_is_retryable():
     from langflow.services.adapters.deployment.watsonx_orchestrate.core.retry import is_retryable_create_exception
 
@@ -7291,6 +7297,39 @@ async def test_create_maps_422_to_invalid_content_error():
                 provider_data=_create_provider_spec(),
             ),
         )
+
+
+@pytest.mark.anyio
+async def test_create_maps_value_error_to_invalid_content_without_retry():
+    """Deterministic local create errors are actionable client errors and must not be retried."""
+    error_message = "No 'ChatInput' node found in langflow tool"
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    agent = FakeAgentClient(
+        {"id": "dep-1", "tools": []},
+        create_exception=ValueError(error_message),
+    )
+    clients = FakeWXOClients(
+        agent=agent,
+        tool=FakeToolClient([{"id": "tool-existing-1", "binding": {"langflow": {}}}]),
+        connections=FakeConnectionsClient(existing_app_id="app-existing-1"),
+    )
+    _attach_provider_clients(service, clients)
+
+    with pytest.raises(InvalidContentError, match=error_message):
+        await service.create(
+            user_id="user-1",
+            db=object(),
+            payload=DeploymentCreate(
+                spec=BaseDeploymentData(
+                    name="my_deployment",
+                    description="desc",
+                    type=DeploymentType.AGENT,
+                ),
+                provider_data=_create_provider_spec(),
+            ),
+        )
+
+    assert len(agent.create_calls) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- surface deterministic wxO create failures as specific 422 responses
- preserve existing deployment-domain error mappings
- skip retries for ValueError while retaining the generic 500 path for unexpected faults

## Tests

- 319 passed: test_watsonx_orchestrate.py
- Ruff check and format checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment creation error handling for invalid configuration or content.
  - Deterministic validation failures now return clear invalid-content errors without unnecessary retry attempts.
  - Unexpected deployment failures preserve their original underlying error details for improved troubleshooting.
- **Tests**
  - Added coverage for validation failures, retry behavior, and preservation of underlying deployment errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->