### PR TITLE
fix(observability): attribute Azure deployments to Azure, not OpenAI

### DIFF
--- a/src/lfx/src/lfx/base/models/llm_callback_utils.py
+++ b/src/lfx/src/lfx/base/models/llm_callback_utils.py
@@ -40,6 +40,17 @@ def detect_provider_from_model(model_name: str | None) -> str | None:
 
     model_lower = model_name.lower()
 
+    # Azure first, and the order is the whole point. Detection is substring matching, and an
+    # Azure deployment is conventionally named after the model it serves ("azure-gpt-4",
+    # "gpt-4-azure"), so such a name matches both branches. Checking "gpt" first attributed
+    # every realistically-named Azure deployment to OpenAI, which reads as an OpenAI outage
+    # when Azure is down and misattributes per-provider cost and latency for anyone on Azure.
+    #
+    # Azure is who serves the call, so it wins over the model's own vendor. That also covers
+    # the non-OpenAI models Azure serves, such as "azure-claude".
+    if "azure" in model_lower:
+        return "azure"
+
     # Pattern-based detection works across different LangChain integrations
     if "gpt" in model_lower or "o1" in model_lower or model_lower.startswith("text-"):
         return "openai"
@@ -55,7 +66,4 @@ def detect_provider_from_model(model_name: str | None) -> str | None:
         return "cohere"
     if "titan" in model_lower or "nova" in model_lower:
         return "amazon"
-    if "azure" in model_lower:
-        return "azure"
-
     return None

--- a/src/lfx/tests/unit/base/models/test_detect_provider_from_model.py
+++ b/src/lfx/tests/unit/base/models/test_detect_provider_from_model.py
@@ -1,0 +1,60 @@
+"""Provider attribution for the ``gen_ai.provider.name`` metric attribute.
+
+This decides which provider an operator sees against outbound LLM latency and errors, so
+getting it wrong is not cosmetic: an Azure outage reads as an OpenAI outage, and per-provider
+cost and latency attribution is wrong for every deployment on Azure.
+
+Detection is substring matching over the model name, which makes order significant. Azure
+deployments are conventionally named after the model they serve (``azure-gpt-4``,
+``gpt-4-azure``), so a name carries both hints and whichever branch runs first wins.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lfx.base.models.llm_callback_utils import detect_provider_from_model
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        # Azure deployments carrying the served model's name. These are the realistic ones:
+        # the portal defaults a deployment name to the model, and teams prefix or suffix it.
+        ("azure-gpt-4", "azure"),
+        ("azure-gpt-35-turbo", "azure"),
+        ("gpt-4-azure", "azure"),
+        ("AZURE-GPT-4", "azure"),
+        # Azure serves more than OpenAI models.
+        ("azure-claude", "azure"),
+        ("my-azure-deployment", "azure"),
+    ],
+)
+def test_azure_wins_over_the_model_it_serves(model_name, expected):
+    """The regression. Azure is who serves the call; the model name is not the provider."""
+    assert detect_provider_from_model(model_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("gpt-4", "openai"),
+        ("gpt-4o-mini", "openai"),
+        ("text-davinci-003", "openai"),
+        ("claude-3-5-sonnet", "anthropic"),
+        ("gemini-1.5-pro", "google"),
+        ("llama-3.1-70b", "meta"),
+        ("mistral-large", "mistral"),
+        ("mixtral-8x7b", "mistral"),
+        ("command-r-plus", "cohere"),
+        ("amazon.titan-text-express-v1", "amazon"),
+    ],
+)
+def test_direct_providers_are_unchanged(model_name, expected):
+    """The control. Reordering must not move anything that was already right."""
+    assert detect_provider_from_model(model_name) == expected
+
+
+@pytest.mark.parametrize("model_name", [None, "", "some-internal-model"])
+def test_an_unknown_model_is_none_rather_than_a_guess(model_name):
+    """None becomes ``unknown`` at the call site, which is honest. A wrong provider is not."""
+    assert detect_provider_from_model(model_name) is None


### PR DESCRIPTION
Provider detection is substring matching over the model name, and `"gpt"` was checked before `"azure"`. An Azure deployment is conventionally named after the model it serves, so the name carries both hints and whichever branch runs first wins.

Measured on `release-1.12.0` before the fix:

```
azure-gpt-4          -> openai      (should be azure)
azure-gpt-35-turbo   -> openai      (should be azure)
gpt-4-azure          -> openai      (should be azure)
azure-claude         -> anthropic   (should be azure)
my-azure-deployment  -> azure       (only correct because it has no model hint)
```

## Why it matters

This feeds `gen_ai.provider.name` on the outbound LLM latency and error metrics. So today an Azure outage shows up as an OpenAI outage, and per-provider cost and latency attribution is wrong for anyone running on Azure. It is not a display detail; it is the attribution an operator alerts on.

## The fix

Move the `azure` branch above the model-vendor branches. Azure is who serves the call, so it wins over the model's own vendor, which also covers the non-OpenAI models Azure serves.

## Tests

The function had none. Added:

- the Azure cases above
- **the direct providers as a control** (`gpt-4`, `claude-3-5-sonnet`, `gemini-1.5-pro`, `llama-3.1-70b`, `mistral-large`, `command-r-plus`, `titan`), so the reordering is shown not to move anything that was already correct
- unknown and empty names, which stay `None` rather than becoming a guess

Red before green: five azure cases failed, fourteen controls passed. After: 19 pass. Both callers' suites green (49 native-callback, 424 model tests).

## Relationship to #14233

The same fix is in #14233, buried in ~4,000 lines across 37 files, most of which has already landed by other routes (`observability_doctor.py` is on the branch already). That is why it is still conflicted and untouched since 23 July. This is the fix on its own, so it can land clean; #14233 is better abandoned than rebased.

## Noted, not changed

`"o1" in model_lower` is a loose substring match that would claim any model name containing `o1`. Out of scope here, but worth a look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider detection for Azure deployments, including deployments using OpenAI or other model names.
  - Preserved correct identification for directly mapped providers.
  - Unknown or empty model names are now handled consistently.

- **Tests**
  - Added coverage for Azure precedence and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->