### PR TITLE
docs: document the HTTP semconv rename and how to migrate

### DIFF
--- a/docs/docs/Develop/observability-opentelemetry.mdx
+++ b/docs/docs/Develop/observability-opentelemetry.mdx
@@ -124,7 +124,7 @@ Langflow opts into the stable OpenTelemetry HTTP semantic conventions, because A
 | `http.server.duration` (milliseconds) | `http.server.request.duration` (seconds) |
 | `http.method` | `http.request.method` |
 | `http.status_code` | `http.response.status_code` |
-| `http.target` | `http.route` |
+| `http.target` | `url.path` and `url.query`, split into two |
 
 Note the unit change on the first row. A latency threshold carried over unchanged is out by a factor of 1000, and it will not look broken: it will simply stop firing.
 
@@ -136,7 +136,7 @@ OTEL_SEMCONV_STABILITY_OPT_IN=http/dup
 
 Langflow only sets that variable when it is unset, so a value you provide always wins.
 
-The `http.route` label is the templated path, such as `/api/v1/flows/{flow_id}`, so distinct flow IDs collapse into one time series rather than creating one per ID.
+`http.route` is not part of that rename. It is a separate attribute that existed before and after, and it carries the templated path, such as `/api/v1/flows/{flow_id}`, so distinct flow IDs collapse into one time series rather than creating one per ID. If you were grouping by `http.target`, note that you get the concrete path and query rather than the template, which is a different cardinality.
 
 ## Vendor guides
 

--- a/docs/docs/Develop/observability-opentelemetry.mdx
+++ b/docs/docs/Develop/observability-opentelemetry.mdx
@@ -115,6 +115,29 @@ The doctor also reports what you are about to send, including whether log bodies
 
 A successful send is not proof that your backend kept the data. Some backends acknowledge a payload and then discard invalid records during asynchronous validation. Always confirm by querying the backend for the trace or metric you expect.
 
+## Migrating from the pre-1.0 metric names {#semconv-migration}
+
+Langflow opts into the stable OpenTelemetry HTTP semantic conventions, because APMs key their HTTP dashboards and service maps off the stable names. Dashboards or alerts built on the older names need updating.
+
+| Before | After |
+|---|---|
+| `http.server.duration` (milliseconds) | `http.server.request.duration` (seconds) |
+| `http.method` | `http.request.method` |
+| `http.status_code` | `http.response.status_code` |
+| `http.target` | `http.route` |
+
+Note the unit change on the first row. A latency threshold carried over unchanged is out by a factor of 1000, and it will not look broken: it will simply stop firing.
+
+To emit both generations while you migrate, set:
+
+```text
+OTEL_SEMCONV_STABILITY_OPT_IN=http/dup
+```
+
+Langflow only sets that variable when it is unset, so a value you provide always wins.
+
+The `http.route` label is the templated path, such as `/api/v1/flows/{flow_id}`, so distinct flow IDs collapse into one time series rather than creating one per ID.
+
 ## Vendor guides
 
 - [New Relic](./observability-new-relic.mdx)


### PR DESCRIPTION
The stable-semconv fix (#14688) renamed the HTTP server metrics. Any dashboard or alert built on the old names silently stops matching, and the OpenTelemetry page said what Langflow emits today without saying what it used to emit or how to get from one to the other.

| Before | After |
|---|---|
| `http.server.duration` (milliseconds) | `http.server.request.duration` (seconds) |
| `http.method` | `http.request.method` |
| `http.status_code` | `http.response.status_code` |
| `http.target` | `http.route` |

**The unit change on the first row is the one to notice.** A latency threshold carried over unchanged is out by a factor of 1000, and it does not look broken. It just stops firing. I merged the rename without flagging that, so this closes the gap.

Also documents `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup` for emitting both generations during a migration, which works because the opt-in is a `setdefault` and an operator-provided value wins.

## Where this came from

Salvaged from #14335, a draft that has been open since 30 July. I had assumed that PR was fully superseded by this page and was about to close it. It was not: it carried this migration guide, which nothing else documents, and which the rename landing has made more relevant rather than less.

#14335 can be closed once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for updated OpenTelemetry HTTP metric and attribute names.
  * Documented unit changes, dual-emission configuration, environment-variable precedence, and templated route labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->