### PR TITLE
fix(frontend): preserve dependency callback types

### DIFF
--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-file.ts
@@ -26,11 +26,11 @@ export const useDeleteFileV2: useMutationFunctionType<IDeleteFile, void> = (
     ["useDeleteFileV2"],
     deleteFileFn,
     {
-      onSettled: (data, error, variables, context) => {
+      onSettled: (...args) => {
         queryClient.invalidateQueries({
           queryKey: ["useGetFilesV2"],
         });
-        options?.onSettled?.(data, error, variables, context);
+        options?.onSettled?.(...args);
       },
       ...options,
     },

--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-file.ts
@@ -8,21 +8,23 @@ interface IDeleteFile {
   id: string;
 }
 
-export const useDeleteFileV2: useMutationFunctionType<IDeleteFile, void> = (
-  params,
-  options?,
-) => {
+export const useDeleteFileV2: useMutationFunctionType<
+  IDeleteFile,
+  void,
+  unknown,
+  Error
+> = (params, options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  const deleteFileFn = async (): Promise<any> => {
-    const response = await api.delete<any>(
+  const deleteFileFn = async (): Promise<unknown> => {
+    const response = await api.delete<unknown>(
       `${getURL("FILE_MANAGEMENT", { id: params.id }, true)}`,
     );
 
     return response.data;
   };
 
-  const mutation: UseMutationResult<any, any, void> = mutate(
+  const mutation: UseMutationResult<unknown, Error, void> = mutate(
     ["useDeleteFileV2"],
     deleteFileFn,
     {

--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-files.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-files.ts
@@ -29,11 +29,11 @@ export const useDeleteFilesV2: useMutationFunctionType<
     ["useDeleteFilesV2"],
     deleteFileFn,
     {
-      onSettled: (data, error, variables, context) => {
+      onSettled: (...args) => {
         queryClient.invalidateQueries({
           queryKey: ["useGetFilesV2"],
         });
-        options?.onSettled?.(data, error, variables, context);
+        options?.onSettled?.(...args);
       },
       ...options,
     },

--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-files.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-files.ts
@@ -10,12 +10,14 @@ interface IDeleteFiles {
 
 export const useDeleteFilesV2: useMutationFunctionType<
   undefined,
-  IDeleteFiles
+  IDeleteFiles,
+  unknown,
+  Error
 > = (options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  const deleteFileFn = async (params): Promise<any> => {
-    const response = await api.delete<any>(
+  const deleteFileFn = async (params: IDeleteFiles): Promise<unknown> => {
+    const response = await api.delete<unknown>(
       `${getURL("FILE_MANAGEMENT", { mode: "batch/" }, true)}`,
       {
         data: params.ids,
@@ -25,7 +27,7 @@ export const useDeleteFilesV2: useMutationFunctionType<
     return response.data;
   };
 
-  const mutation: UseMutationResult<any, any, IDeleteFiles> = mutate(
+  const mutation: UseMutationResult<unknown, Error, IDeleteFiles> = mutate(
     ["useDeleteFilesV2"],
     deleteFileFn,
     {

--- a/src/frontend/src/controllers/API/queries/file-management/use-duplicate-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-duplicate-file.ts
@@ -51,11 +51,11 @@ export const useDuplicateFileV2: useMutationFunctionType<
     ["useDuplicateFileV2"],
     duplicateFileFn,
     {
-      onSettled: (data, error, variables, context) => {
+      onSettled: (...args) => {
         queryClient.invalidateQueries({
           queryKey: ["useGetFilesV2"],
         });
-        options?.onSettled?.(data, error, variables, context);
+        options?.onSettled?.(...args);
       },
       ...options,
     },

--- a/src/frontend/src/controllers/API/queries/file-management/use-duplicate-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-duplicate-file.ts
@@ -1,6 +1,7 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import { getFetchCredentials } from "@/customization/utils/get-fetch-credentials";
 import type { useMutationFunctionType } from "@/types/api";
+import type { FileType } from "@/types/file_management";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -13,11 +14,13 @@ interface DuplicateFileQueryParams {
 
 export const useDuplicateFileV2: useMutationFunctionType<
   DuplicateFileQueryParams,
-  void
+  void,
+  FileType,
+  Error
 > = (params, options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  const duplicateFileFn = async (): Promise<any> => {
+  const duplicateFileFn = async (): Promise<FileType> => {
     // First download the file
     const response = await fetch(
       `${getURL("FILE_MANAGEMENT", { id: params.id }, true)}`,
@@ -39,7 +42,7 @@ export const useDuplicateFileV2: useMutationFunctionType<
     const formData = new FormData();
     formData.append("file", file);
 
-    const uploadResponse = await api.post<any>(
+    const uploadResponse = await api.post<FileType>(
       `${getURL("FILE_MANAGEMENT", {}, true)}/`,
       formData,
     );
@@ -47,7 +50,7 @@ export const useDuplicateFileV2: useMutationFunctionType<
     return uploadResponse.data;
   };
 
-  const mutation: UseMutationResult<any, any, void> = mutate(
+  const mutation: UseMutationResult<FileType, Error, void> = mutate(
     ["useDuplicateFileV2"],
     duplicateFileFn,
     {

--- a/src/frontend/src/controllers/API/queries/file-management/use-put-rename-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-put-rename-file.ts
@@ -31,11 +31,11 @@ export const usePostRenameFileV2: useMutationFunctionType<
         return res;
       },
       {
-        onSettled: (data, error, variables, context) => {
+        onSettled: (...args) => {
           queryClient.invalidateQueries({
             queryKey: ["useGetFilesV2"],
           });
-          options?.onSettled?.(data, error, variables, context);
+          options?.onSettled?.(...args);
         },
         ...options,
       },

--- a/src/frontend/src/controllers/API/queries/file-management/use-put-rename-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-put-rename-file.ts
@@ -11,19 +11,23 @@ interface IPostRenameFile {
 
 export const usePostRenameFileV2: useMutationFunctionType<
   undefined,
-  IPostRenameFile
+  IPostRenameFile,
+  IPostRenameFile,
+  Error
 > = (options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  const postRenameFileFn = async (payload: IPostRenameFile): Promise<any> => {
-    const response = await api.put<any>(
+  const postRenameFileFn = async (
+    payload: IPostRenameFile,
+  ): Promise<IPostRenameFile> => {
+    const response = await api.put<IPostRenameFile>(
       `${getURL("FILE_MANAGEMENT", { id: payload.id }, true)}?name=${encodeURI(payload.name)}`,
     );
 
     return response.data;
   };
 
-  const mutation: UseMutationResult<IPostRenameFile, any, IPostRenameFile> =
+  const mutation: UseMutationResult<IPostRenameFile, Error, IPostRenameFile> =
     mutate(
       ["usePostRenameFileV2"],
       async (payload: IPostRenameFile) => {

--- a/src/frontend/src/controllers/API/queries/messages/use-delete-messages.ts
+++ b/src/frontend/src/controllers/API/queries/messages/use-delete-messages.ts
@@ -28,11 +28,11 @@ export const useDeleteMessages: useMutationFunctionType<
     DeleteMessagesParams
   > = mutate(["useDeleteMessages"], deleteMessage, {
     ...options,
-    onSettled: (data, error, variables, context) => {
+    onSettled: (...args) => {
       queryClient.invalidateQueries({
         queryKey: ["useGetSessionsFromFlowQuery"],
       });
-      options?.onSettled?.(data, error, variables, context);
+      options?.onSettled?.(...args);
     },
   });
 

--- a/src/frontend/src/controllers/API/queries/messages/use-delete-messages.ts
+++ b/src/frontend/src/controllers/API/queries/messages/use-delete-messages.ts
@@ -10,21 +10,28 @@ interface DeleteMessagesParams {
 
 export const useDeleteMessages: useMutationFunctionType<
   undefined,
-  DeleteMessagesParams
+  DeleteMessagesParams,
+  DeleteMessagesParams,
+  Error
 > = (options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  const deleteMessage = async ({ ids }: DeleteMessagesParams): Promise<any> => {
-    const response = await api.delete(`${getURL("MESSAGES")}`, {
-      data: ids,
-    });
+  const deleteMessage = async ({
+    ids,
+  }: DeleteMessagesParams): Promise<DeleteMessagesParams> => {
+    const response = await api.delete<DeleteMessagesParams>(
+      `${getURL("MESSAGES")}`,
+      {
+        data: ids,
+      },
+    );
 
     return response.data;
   };
 
   const mutation: UseMutationResult<
     DeleteMessagesParams,
-    any,
+    Error,
     DeleteMessagesParams
   > = mutate(["useDeleteMessages"], deleteMessage, {
     ...options,

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/helpers/utils.ts
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/helpers/utils.ts
@@ -1,4 +1,6 @@
-export function base64ToFloat32Array(base64String: string): Float32Array {
+export function base64ToFloat32Array(
+  base64String: string,
+): Float32Array<ArrayBuffer> {
   const binaryString = atob(base64String);
   const pcmData = new Int16Array(binaryString.length / 2);
 

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/hooks/use-bar-controls.ts
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/hooks/use-bar-controls.ts
@@ -8,7 +8,7 @@ export const useBarControls = (
   setSoundDetected?,
 ) => {
   const animationFrameRef = useRef<number | null>(null);
-  const timeDataRef = useRef<Uint8Array | null>(null);
+  const timeDataRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const baseHeightsRef = useRef<number[]>([]);
   const lastRandomizeTimeRef = useRef<number>(0);
   const minHeightRef = useRef<number>(20);

--- a/src/frontend/tests/core/features/deployment-create.spec.ts
+++ b/src/frontend/tests/core/features/deployment-create.spec.ts
@@ -79,12 +79,10 @@ async function goToStepReview(page: Page) {
   // Click version item
   await page.waitForSelector('[data-testid="version-item-fv1"]');
   await page.getByTestId("version-item-fv1-select").click();
-  // After clicking version, a connection panel may appear - skip it if present
-  const skipBtn = page.getByRole("button", { name: /skip/i });
-  const skipVisible = await skipBtn.isVisible().catch(() => false);
-  if (skipVisible) {
-    await skipBtn.click();
-  }
+  // Wait for the async eligibility check before skipping the connection step
+  const skipButton = page.getByTestId("connection-skip");
+  await expect(skipButton).toBeVisible();
+  await skipButton.click();
   // Advance to review
   await page.getByTestId("deployment-stepper-next").click();
   await expect(
@@ -202,12 +200,10 @@ test(
     await page.waitForSelector('[data-testid="version-item-fv1"]');
     await page.getByTestId("version-item-fv1-select").click();
 
-    // Skip connection if prompted
-    const skipBtn = page.getByRole("button", { name: /skip/i });
-    const skipVisible = await skipBtn.isVisible().catch(() => false);
-    if (skipVisible) {
-      await skipBtn.click();
-    }
+    // Wait for the async eligibility check before skipping the connection step
+    const skipButton = page.getByTestId("connection-skip");
+    await expect(skipButton).toBeVisible();
+    await skipButton.click();
 
     // Next should be enabled after version selection
     await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();

--- a/src/frontend/tests/utils/deployment-mocks.ts
+++ b/src/frontend/tests/utils/deployment-mocks.ts
@@ -93,6 +93,14 @@ export const CONFIGS_MOCK = {
   total: 0,
 };
 
+export const ELIGIBLE_FLOW_DATA_MOCK = {
+  nodes: [
+    { id: "chat-input", data: { type: "ChatInput" } },
+    { id: "chat-output", data: { type: "ChatOutput" } },
+  ],
+  edges: [],
+};
+
 export const FLOWS_MOCK = [
   {
     id: "f1",
@@ -101,7 +109,7 @@ export const FLOWS_MOCK = [
     folder_id: "my-collection",
     icon: "Workflow",
     description: "",
-    data: null,
+    data: ELIGIBLE_FLOW_DATA_MOCK,
   },
 ];
 
@@ -116,6 +124,14 @@ export const FLOW_VERSIONS_MOCK = {
       is_current: true,
     },
   ],
+  max_entries: 1,
+};
+
+export const FLOW_VERSION_DETAIL_MOCK = {
+  ...FLOW_VERSIONS_MOCK.entries[0],
+  user_id: "user-1",
+  description: null,
+  data: ELIGIBLE_FLOW_DATA_MOCK,
 };
 
 export const DEPLOY_RESPONSE = {
@@ -303,6 +319,16 @@ export async function setupDeploymentMocks(
   // Flows list — inject the captured folderId so the component's folder filter passes
   await page.route("**/api/v1/flows/**", (route) => {
     const url = route.request().url();
+    const isVersionDetail =
+      /\/api\/v1\/flows\/[^/]+\/versions\/[^/?]+(?:\?.*)?$/.test(url);
+    if (isVersionDetail) {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(FLOW_VERSION_DETAIL_MOCK),
+      });
+      return;
+    }
     if (url.includes("/versions/")) {
       route.fulfill({
         status: 200,


### PR DESCRIPTION
## Summary

- Forward React Query mutation callback arguments across 5.100 and 5.101 signatures.
- Use `ArrayBuffer`-backed audio typed arrays for current TypeScript DOM APIs.
- Keep the source fixes upstream for [Langflow Desktop #154](https://github.com/langflow-ai/langflow-desktop/pull/154).

## Test

- `npm run build`
- Biome format check on all changed files
- `tsc --noEmit` (existing repository errors only; none in changed files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal callback handling for file and message operations without changing visible behavior.
  * Clarified audio data type handling for voice assistant controls.
* **Bug Fixes**
  * Preserved all mutation callback information when operations complete, improving callback reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->