### PR TITLE
feat(lfx): let users customize component trace names

### DIFF
--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -11,8 +11,13 @@ from langflow.services.tracing.service import (
     component_context_var,
     trace_context_var,
 )
+from lfx.custom.custom_component.component import Component
 from lfx.services.settings.base import Settings
 from lfx.services.settings.service import SettingsService
+
+
+class TraceNameOverrideComponent(Component):
+    display_name = "X"
 
 
 class MockTracer(BaseTracer):
@@ -309,6 +314,27 @@ async def test_trace_component(tracing_service, mock_component):
         assert tracer.end_trace_list[0]["logs"] == component_context.logs[trace_name]
 
     # Cleanup
+    await tracing_service.end_tracers({})
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tracers")
+async def test_trace_component_uses_overridden_trace_display_name(tracing_service):
+    """A component's trace_display_name override reaches tracers as the trace name."""
+    run_id = uuid.uuid4()
+    await tracing_service.start_tracers(run_id, "test_run", "test_user", "test_session", "test_project")
+
+    component = TraceNameOverrideComponent(trace_display_name="RAG Query")
+    expected_trace_name = f"RAG Query ({component._id})"
+    async with tracing_service.trace_component(component, component.trace_name, {}, None):
+        await asyncio.sleep(0.1)  # Wait for async queue processing
+        for tracer in trace_context_var.get().tracers.values():
+            assert tracer.add_trace_list[0]["trace_name"] == expected_trace_name
+
+    await asyncio.sleep(0.1)  # Wait for async queue processing
+    for tracer in trace_context_var.get().tracers.values():
+        assert tracer.end_trace_list[0]["trace_name"] == expected_trace_name
+
     await tracing_service.end_tracers({})
 
 

--- a/src/lfx/src/lfx/custom/custom_component/custom_component.py
+++ b/src/lfx/src/lfx/custom/custom_component/custom_component.py
@@ -67,6 +67,8 @@ class CustomComponent(BaseComponent):
     """The name of the component used to styles. Defaults to None."""
     display_name: str | None = None
     """The display name of the component. Defaults to None."""
+    trace_display_name: str | None = None
+    """Optional override for the component name shown in traces. Defaults to None."""
     description: str | None = None
     """The description of the component. Defaults to None."""
     icon: str | None = None
@@ -136,9 +138,28 @@ class CustomComponent(BaseComponent):
         if hasattr(self, "_id") and self._id is None:
             msg = "Component id is not set"
             raise ValueError(msg)
+        name = self._resolve_trace_base_name()
         if hasattr(self, "_id"):
-            return f"{self.display_name} ({self._id})"
-        return f"{self.display_name}"
+            return f"{name} ({self._id})"
+        return f"{name}"
+
+    def _resolve_trace_base_name(self) -> str | None:
+        override = getattr(self, "trace_display_name", None)
+        if override is None:
+            # Component routes constructor kwargs into _attributes, and the class
+            # default above shadows __getattr__, so the kwargs are only visible here.
+            attributes = getattr(self, "_attributes", None)
+            if isinstance(attributes, dict):
+                override = attributes.get("trace_display_name")
+        if isinstance(override, str) and override.strip():
+            return override.strip()
+        vertex = getattr(self, "_vertex", None)
+        if vertex is not None:
+            node_name = getattr(vertex, "display_name", None)
+            vertex_id = getattr(vertex, "id", "") or ""
+            if isinstance(node_name, str) and node_name.strip() and node_name != vertex_id.split("-")[0]:
+                return node_name
+        return self.display_name
 
     def stop(self, output_name: str | None = None) -> None:
         if not output_name and self._vertex and len(self._vertex.outputs) == 1:

--- a/src/lfx/tests/unit/custom/custom_component/test_trace_name.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_trace_name.py
@@ -1,0 +1,96 @@
+"""Regression tests for CustomComponent.trace_name resolution.
+
+Covers the trace_display_name override and UI node-rename propagation
+requested in https://github.com/langflow-ai/langflow/issues/7284.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from lfx.custom.custom_component.component import Component
+from lfx.custom.custom_component.custom_component import CustomComponent
+
+
+class TracedComponent(Component):
+    display_name = "X"
+
+
+def test_default_trace_name_with_id():
+    component = CustomComponent(display_name="X", _id="X-abc123")
+    assert component.trace_name == "X (X-abc123)"
+
+
+def test_default_trace_name_without_id():
+    component = CustomComponent(display_name="X")
+    assert component.trace_name == "X"
+
+
+def test_trace_name_raises_when_id_is_none():
+    component = CustomComponent(display_name="X", _id=None)
+    with pytest.raises(ValueError, match="Component id is not set"):
+        _ = component.trace_name
+
+
+def test_explicit_override_is_used():
+    component = CustomComponent(display_name="X", _id="X-abc123", trace_display_name="RAG Query")
+    assert component.trace_name == "RAG Query (X-abc123)"
+
+
+def test_blank_override_falls_back_to_default():
+    component = CustomComponent(display_name="X", _id="X-abc123", trace_display_name="   ")
+    assert component.trace_name == "X (X-abc123)"
+
+
+def test_non_string_override_falls_back_to_default():
+    component = CustomComponent(display_name="X", _id="X-abc123", trace_display_name=123)
+    assert component.trace_name == "X (X-abc123)"
+
+
+def test_direct_assignment_override():
+    component = TracedComponent()
+    component.trace_display_name = "Direct Name"
+    assert component.trace_name.startswith("Direct Name (")
+
+
+def test_ctor_kwarg_override_resolved_through_component_attributes():
+    component = TracedComponent(trace_display_name="Kwarg Name")
+    assert component.trace_name.startswith("Kwarg Name (")
+
+
+def test_stripped_override_is_normalized():
+    component = CustomComponent(display_name="X", _id="X-abc123", trace_display_name="  RAG Query  ")
+    assert component.trace_name == "RAG Query (X-abc123)"
+
+
+def test_vertex_rename_propagates():
+    component = CustomComponent(display_name="X", _id="abc123-def456")
+    component._vertex = SimpleNamespace(display_name="Renamed Node", id="abc123-def456")
+    assert component.trace_name == "Renamed Node (abc123-def456)"
+
+
+def test_vertex_id_fragment_guard_falls_back_to_class_display_name():
+    component = CustomComponent(display_name="X", _id="b62c8e1e-9999")
+    component._vertex = SimpleNamespace(display_name="b62c8e1e", id="b62c8e1e-9999")
+    assert component.trace_name == "X (b62c8e1e-9999)"
+
+
+def test_vertex_name_equal_to_class_display_name_is_byte_identical():
+    component = CustomComponent(display_name="X", _id="X-abc123")
+    default = component.trace_name
+    component._vertex = SimpleNamespace(display_name="X", id="vertex-999")
+    assert component.trace_name == default
+
+
+def test_explicit_override_wins_over_vertex_rename():
+    component = CustomComponent(display_name="X", _id="abc123-def456")
+    component._vertex = SimpleNamespace(display_name="Renamed Node", id="abc123-def456")
+    component.trace_display_name = "Explicit"
+    assert component.trace_name == "Explicit (abc123-def456)"
+
+
+def test_same_override_yields_unique_trace_names_across_instances():
+    first = CustomComponent(display_name="X", _id="X-id1", trace_display_name="Shared")
+    second = CustomComponent(display_name="X", _id="X-id2", trace_display_name="Shared")
+    assert first.trace_name == "Shared (X-id1)"
+    assert second.trace_name == "Shared (X-id2)"
+    assert first.trace_name != second.trace_name


### PR DESCRIPTION
Fixes #7284

**Problem**

Trace names for components are built from the component class's `display_name` (`trace_name` returns `"{display_name} ({id})"`). Renaming a node in the UI only updates the vertex, so traces sent to Langfuse/LangSmith/etc. keep showing the code-level class name — runs are hard to tell apart when a flow uses several instances of the same component.

**Change**

`CustomComponent.trace_name` now resolves the name part before falling back to the class display name:

1. new optional attribute `trace_display_name` (class attr, instance assignment or constructor kwarg) when set to a non-blank string;
2. otherwise the attached vertex's `display_name`, so renaming a node in the flow editor is reflected in trace names;
3. otherwise the previous behavior.

The `" ({id})"` suffix and the missing-`_id` error are unchanged, so trace names remain unique per node and every tracer that strips the suffix keeps working. The vertex branch ignores synthetic id-fragment display names (nodes saved without one) so payload-built graphs don't regress.

Behavior change worth noting: for flows saved earlier, the stored node display name now wins over the component class's current display_name in trace names; nodes that were never renamed produce byte-identical trace names as before.

Out of scope: a frontend field editor for `trace_display_name` (the attribute is usable from component code today).

**Testing**

- New unit tests: src/lfx/tests/unit/custom/custom_component/test_trace_name.py — default naming, explicit override incl. blank/non-string fallback, UI-rename propagation, id-fragment guard, uniqueness.
- Integration test: src/backend/tests/unit/services/tracing/test_tracing_service.py asserts the overridden name reaches tracers via TracingService.trace_component.
- `uv run --package lfx pytest src/lfx/tests/unit/custom -q` → 209 passed
- `uv run pytest src/backend/tests/unit/services/tracing -q` → 345 passed, 7 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable trace display names for components.
  - Trace names now prioritize explicit overrides, then meaningful vertex or component names.
  - Component ID suffixes are retained when available to help distinguish instances.
  - Invalid or blank custom names safely fall back to the standard naming behavior.

- **Bug Fixes**
  - Corrected component trace start and end events so they consistently use the configured display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->