### PR TITLE
fix(frontend): keep canvas edits made during a save, fix Windows-flaky specs

### DIFF
--- a/src/frontend/src/hooks/flows/__tests__/use-save-flow.test.ts
+++ b/src/frontend/src/hooks/flows/__tests__/use-save-flow.test.ts
@@ -401,4 +401,44 @@ describe("useSaveFlow", () => {
       expect.objectContaining({ id: "flow-1", folder_id: "folder-B" }),
     );
   });
+  it("keeps canvas edits made while the save was in flight", async () => {
+    // The editor's `currentFlow` is the baseline the next autosave diffs
+    // against. Overwriting it with the response of a save that started before
+    // the edit makes that edit look already-persisted, so the follow-up save
+    // is skipped and the work is lost. Reproduced on Windows CI as a published
+    // flow whose edge never reached the backend.
+    let resolveSave: (() => void) | undefined;
+    mockMutate.mockImplementation((payload, options) => {
+      resolveSave = () =>
+        options.onSuccess({
+          ...flowsManagerState.currentFlow,
+          data: payload.data,
+        });
+    });
+
+    const { result } = renderHook(() => useSaveFlow());
+    const inFlight = result.current();
+
+    // The user connects an edge while the request is still open.
+    const newEdges = [{ id: "new-edge" }];
+    flowStoreState.edges = newEdges;
+    flowStoreState.currentFlow = {
+      ...flowStoreState.currentFlow,
+      data: { ...flowStoreState.currentFlow.data, edges: newEdges },
+    };
+
+    resolveSave!();
+    await inFlight;
+
+    expect(mockSetCurrentFlow).not.toHaveBeenCalled();
+    expect(flowStoreState.currentFlow.data.edges).toEqual(newEdges);
+  });
+
+  it("still adopts the saved flow when the canvas did not change", async () => {
+    const { result } = renderHook(() => useSaveFlow());
+
+    await expect(result.current()).resolves.toBeUndefined();
+
+    expect(mockSetCurrentFlow).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/frontend/src/hooks/flows/use-save-flow.ts
+++ b/src/frontend/src/hooks/flows/use-save-flow.ts
@@ -134,7 +134,18 @@ const useSaveFlow = () => {
                   // When saving from the list page (e.g., renaming via settings modal),
                   // setting this would leave stale unprocessed flow data in the store,
                   // causing a crash when the user later navigates to the flow page.
-                  if (useFlowStore.getState().onFlowPage) {
+                  //
+                  // And only when the canvas still holds the graph this request
+                  // carried. `currentFlow` is the baseline the next autosave
+                  // diffs against, so adopting the response of a save that
+                  // started before an edit makes that edit look persisted and
+                  // the follow-up save is skipped — the edit is lost. The
+                  // store swaps these arrays on every change, so identity is
+                  // an exact "nothing moved while we were away" check.
+                  const liveState = useFlowStore.getState();
+                  const graphUnchanged =
+                    liveState.nodes === nodes && liveState.edges === edges;
+                  if (liveState.onFlowPage && graphUnchanged) {
                     setCurrentFlow(updatedFlow);
                   }
                   resolve();

--- a/src/frontend/tests/core/features/stop-building.spec.ts
+++ b/src/frontend/tests/core/features/stop-building.spec.ts
@@ -4,12 +4,12 @@ import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { TEXTS } from "../../utils/constants/texts";
 import { TIMEOUTS } from "../../utils/constants/timeouts";
+import { addComponentFromSidebar } from "../../utils/flow/add-component-from-sidebar";
 import { replaceComponentCode } from "../../utils/flow/replace-component-code";
 import { removeOldApiKeys } from "../../utils/remove-old-api-keys";
 import { updateOldComponents } from "../../utils/update-old-components";
 import { zoomOut } from "../../utils/zoom-out";
 
-// TODO: fix this test
 test(
   "user must be able to stop a building",
   { tag: ["@release", "@workspace", "@api"] },
@@ -21,59 +21,44 @@ test(
 
     //first component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill(TEXTS.searchTextInput);
-
-    await page
-      .getByTestId("input_outputText Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 50, y: 50 },
-      });
+    await addComponentFromSidebar(page, {
+      search: TEXTS.searchTextInput,
+      testId: "input_outputText Input",
+      position: { x: 50, y: 50 },
+    });
 
     await zoomOut(page, 3);
     //second component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill(TEXTS.searchUrl);
-
-    await page
-      .getByTestId("data_sourceURL")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 50, y: 300 },
-      });
+    await addComponentFromSidebar(page, {
+      search: TEXTS.searchUrl,
+      testId: "data_sourceURL",
+      position: { x: 50, y: 300 },
+    });
 
     //third component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("split text");
-
-    await page
-      .getByTestId("processingSplit Text")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 300, y: 500 },
-      });
+    await addComponentFromSidebar(page, {
+      search: "split text",
+      testId: "processingSplit Text",
+      position: { x: 300, y: 500 },
+    });
 
     //fourth component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("data to message");
-
-    await page
-      .getByTestId("processingData to Message")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 500 },
-      });
+    await addComponentFromSidebar(page, {
+      search: "data to message",
+      testId: "processingData to Message",
+      position: { x: 100, y: 500 },
+    });
 
     //fifth component
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill(TEXTS.searchChatOutput);
-
-    await page
-      .getByTestId("input_outputChat Output")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 600, y: 300 },
-      });
+    await addComponentFromSidebar(page, {
+      search: TEXTS.searchChatOutput,
+      testId: "input_outputChat Output",
+      position: { x: 600, y: 300 },
+    });
 
     await updateOldComponents(page);
     await removeOldApiKeys(page);

--- a/src/frontend/tests/extended/features/lock-flow.spec.ts
+++ b/src/frontend/tests/extended/features/lock-flow.spec.ts
@@ -12,6 +12,16 @@ test(
   "user must be able to lock a flow and it must be saved",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
+    // Four lock/unlock round trips, each a settings save plus a full editor
+    // reload, then twenty click-and-assert iterations. That is ~1 minute on
+    // Linux/macOS and lands right on the 5-minute wall on Windows CI, where
+    // every step costs 3-5x as much — the test times out mid-loop rather than
+    // finding anything. Nothing here is Windows-specific except the pace.
+    test.slow(
+      process.platform === "win32",
+      "Windows CI runners are 3-5x slower",
+    );
+
     await openStarterProject(page, TEXTS.templateBasicPrompting);
     const flowId = new URL(page.url()).pathname.match(/\/flow\/([^/]+)/)?.[1];
     if (!flowId) {

--- a/src/frontend/tests/fixtures.ts
+++ b/src/frontend/tests/fixtures.ts
@@ -39,7 +39,11 @@ export type { A11yScanOptions, LangflowPage } from "./utils/types";
 const RUN_A11Y = process.env.RUN_A11Y === "true";
 const RUN_A11Y_ASSERT = process.env.RUN_A11Y_ASSERT === "true";
 const MAX_FLOW_ERROR_DIAGNOSTICS = 20;
-const API_REQUEST_DRAIN_TIMEOUT_MS = 2000;
+// How long teardown waits for in-flight API requests to settle. Windows CI
+// runners routinely need more than 2s to finish the last few requests a test
+// kicked off (an MCP server list, a component template refresh), and the wait
+// only costs that long when something really is still pending.
+const API_REQUEST_DRAIN_TIMEOUT_MS = process.platform === "win32" ? 6000 : 2000;
 const RESPONSE_BODY_READ_TIMEOUT_MS = API_REQUEST_DRAIN_TIMEOUT_MS;
 const RESPONSE_INSPECTION_DRAIN_TIMEOUT_MS = API_REQUEST_DRAIN_TIMEOUT_MS;
 const MAX_PENDING_REQUEST_DIAGNOSTICS = 20;

--- a/src/frontend/tests/utils/flow/add-component-from-sidebar.ts
+++ b/src/frontend/tests/utils/flow/add-component-from-sidebar.ts
@@ -2,6 +2,9 @@ import { expect, type Page } from "@playwright/test";
 import { SELECTORS, TID } from "../constants/testIds";
 import { TIMEOUTS } from "../constants/timeouts";
 
+/** How many times a swallowed drag is re-attempted before failing. */
+const DRAG_ATTEMPTS = 3;
+
 export type AddComponentOpts = {
   /** Search query typed into the sidebar input. */
   search: string;
@@ -86,12 +89,29 @@ export async function addComponentFromSidebar(
 
   const nodes = page.locator(".react-flow__node");
   const previousNodeCount = await nodes.count();
-  await page
-    .getByTestId(testId)
-    .dragTo(page.locator(SELECTORS.reactFlowCanvasXPath), {
+  const canvas = page.locator(SELECTORS.reactFlowCanvasXPath);
+
+  // A drag can be swallowed whole: the HTML5 drag sequence starts on a sidebar
+  // row React is still re-rendering after the search (or a legacy-toggle), the
+  // drop never reaches the canvas, and no node appears — with no error, so the
+  // spec only fails much later on a handle that does not exist. Reproduced on a
+  // CPU-starved renderer; it is what cost Windows CI the Text Input node in
+  // stop-building.spec.ts. Retry, but only when nothing landed at all, so a
+  // slow-but-successful drop is never duplicated into a second node.
+  for (let attempt = 1; attempt <= DRAG_ATTEMPTS; attempt++) {
+    await page.getByTestId(testId).dragTo(canvas, {
       targetPosition: position ?? { x: 200, y: 200 },
     });
-  await expect(nodes).toHaveCount(previousNodeCount + 1, {
-    timeout: TIMEOUTS.standard,
-  });
+    try {
+      await expect(nodes).toHaveCount(previousNodeCount + 1, {
+        timeout: TIMEOUTS.standard,
+      });
+      return;
+    } catch (error) {
+      const landed = (await nodes.count()) !== previousNodeCount;
+      if (attempt === DRAG_ATTEMPTS || landed) {
+        throw error;
+      }
+    }
+  }
 }


### PR DESCRIPTION
The Windows nightly ([run 32792904429](https://github.com/langflow-ai/langflow/actions/runs/32792904429)) failed four specs. One turned out to be a real data-loss bug in the save path; the rest were test-side. Each was reproduced on macOS before being touched.

## An edit made while a save is in flight is silently discarded

`saveFlow` adopts the PATCH response into `useFlowStore.currentFlow`, the baseline the next autosave diffs against. When that response belongs to a request that started *before* the user's edit, adopting it makes the edit look already-persisted, the queued autosave short-circuits on its equality guard, and the change never reaches the backend. Nothing surfaces the loss until the flow is reloaded.

The CI trace shows it exactly: two PATCHes (`nodes 1, edges 0` then `nodes 2, edges 0`), the edge connected right as the second response landed, and then **no third request at all** — the published flow had no edge.

Reproduced on macOS by holding the PATCH response until after the edge was connected. There the damage was larger: the second node *and* the edge were both lost (`nodes 1, edges 0` persisted).

The fix adopts the response only when the canvas still holds the graph that request carried. The store swaps the nodes/edges arrays on every change, so identity is an exact "nothing moved while we were away" check — and when nothing moved, behaviour is unchanged. Covered by two unit tests, one of which fails on `main`.

This affects real users, not just CI: any edit made during the ~300ms autosave window plus request latency could vanish.

## Test-side fixes

| Spec | Cause | Change |
| --- | --- | --- |
| `stop-building` | A sidebar drag can be swallowed whole — the HTML5 drag starts on a row React is still re-rendering after the search, the drop never reaches the canvas, and no node appears. Silently, so the spec failed 40s later on a handle that never existed. Windows lost the Text Input node this way. | `addComponentFromSidebar` retries, **only** when nothing landed at all, so a slow-but-successful drop is never duplicated into a second node. The spec drops its five hand-rolled drags for that verified helper. |
| `lock-flow` | Four lock/unlock round trips plus twenty click-and-assert iterations: ~1 min locally, right on the 5-minute wall on Windows where every step costs 3-5x. | `test.slow()` on win32. Nothing about it is Windows-specific except the pace. |
| `mcp-server-tab` | Teardown's in-flight request drain gives 2s; Windows needs longer to finish the last MCP server list and template refresh. | Drain window scaled on win32. It only costs that long when something really is still pending. |
| `mcp-server-starter-projects` | Failed inside the old `navigateSettingsPages`, which matched on visible text. | **No change needed** — already rewritten onto test ids on this branch. |

Nothing is skipped on Windows; the coverage stays.

## Verification

- Dropped drag reproduced on macOS at 20x CPU throttling (first drag after the legacy toggle drops), green across repeated runs with the retry.
- Save race reproduced and re-verified green against a live backend.
- `stop-building`, all four `shared-playground.a11y`, `mcp-server-tab`, `lock-flow`, `mcp-server-starter-projects` pass locally.
- Full frontend Jest suite: 6806 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented completed saves from overwriting canvas edits made while a save was in progress.
  - Ensured the latest saved flow is reflected when no newer edits were made.

- **Tests**
  - Improved coverage for concurrent editing and save behavior.
  - Increased reliability of component insertion and flow locking tests across platforms.
  - Added platform-specific timing adjustments to reduce flaky test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->