### PR TITLE
fix: send string input to OpenAI-compatible embeddings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "lfx-cohere>=0.1.0,<1.0.0",
     "lfx-oracle>=0.1.0,<1.0.0",
     "lfx-vllm>=0.1.0,<1.0.0",
-    "lfx-openai-compatible>=0.1.0,<1.0.0",
+    "lfx-openai-compatible>=0.1.2,<1.0.0",
     "lfx-google>=0.1.0,<1.0.0",
     # langflow-extensions:bundle-deps-end
 ]

--- a/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
+++ b/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
@@ -118,9 +118,9 @@
       "providers": [
         "lfx-openai-compatible"
       ],
-      "requested": ">=0.1.0,<1.0.0",
-      "requirement": "lfx-openai-compatible==0.1.1",
-      "resolved_version": "0.1.1"
+      "requested": ">=0.1.2,<1.0.0",
+      "requirement": "lfx-openai-compatible==0.1.2",
+      "resolved_version": "0.1.2"
     },
     {
       "distribution": "lfx-oracle",
@@ -160,7 +160,7 @@
     "https://pypi.org/simple"
   ],
   "profile": "enterprise-hardened",
-  "profile_digest": "sha256:b3c3e390da6c1749",
+  "profile_digest": "sha256:fa3180625f0dd0b2",
   "providers": [
     "lfx-amazon",
     "lfx-anthropic",

--- a/scripts/ci/bundle_profiles.json
+++ b/scripts/ci/bundle_profiles.json
@@ -127,7 +127,7 @@
         {
           "distribution": "lfx-openai-compatible",
           "extras": [],
-          "version": ">=0.1.0,<1.0.0",
+          "version": ">=0.1.2,<1.0.0",
           "providers": [
             "lfx-openai-compatible"
           ]

--- a/src/bundles/openai-compatible/pyproject.toml
+++ b/src/bundles/openai-compatible/pyproject.toml
@@ -13,15 +13,15 @@ keywords = ["langflow", "lfx", "extension", "bundle", "model-provider", "openai-
 # Runtime deps: lfx supplies both the BUNDLE_API surface and the
 # provider-registry seam this bundle plugs its ``providers[]`` block into. The
 # provider targets any OpenAI-compatible server, so its model/embedding classes
-# (``ChatOpenAI`` / ``OpenAIEmbeddings``) are the langchain-openai classes lfx
-# already ships and resolves lazily -- the bundle does not import them directly,
-# so they are not re-declared here. ``httpx`` backs the SSRF-safe, DNS-pinned
-# live ``/v1/models`` discovery and credential-validation probe.
+# (``ChatOpenAI`` / ``OpenAIEmbeddings``) come from langchain-openai. ``httpx``
+# backs the SSRF-safe, DNS-pinned live ``/v1/models`` discovery and
+# credential-validation probe.
 # The lfx floor is the current major.minor line (the seam ships in 1.11) and is
 # re-synced on ``make patch`` via scripts/ci/sync_bundle_lfx_pin.py; fine-grained
 # BUNDLE_API compatibility is enforced via extension.json's lfx.compat list.
 dependencies = [
     "lfx>=1.12.0.dev0,<2.0.0",
+    "langchain-openai>=1.1.6",
     "httpx>=0.24.0,<1.0.0",
 ]
 

--- a/src/bundles/openai-compatible/pyproject.toml
+++ b/src/bundles/openai-compatible/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-openai-compatible"
-version = "0.1.1"
+version = "0.1.2"
 description = "Generic OpenAI-compatible endpoints (OpenRouter, Together, Groq, self-hosted vLLM/TGI, ...) as a first-class Langflow model provider, packaged as a standalone Extension Bundle."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/openai-compatible/src/lfx_openai_compatible/extension.json
+++ b/src/bundles/openai-compatible/src/lfx_openai_compatible/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.langflow.org/extension/v1.json",
   "id": "lfx-openai-compatible",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "OpenAI Compatible",
   "description": "Generic OpenAI-compatible endpoints (OpenRouter, Together, Groq, self-hosted vLLM/TGI, ...) as a first-class Langflow model provider, packaged as a standalone Extension Bundle.",
   "lfx": {

--- a/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
+++ b/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -46,6 +47,54 @@ def test_bundle_registers_provider_end_to_end():
         assert provider_registry.is_api_key_optional("OpenAI Compatible")
         assert provider_registry.live_discovery_for("OpenAI Compatible") is not None
         assert provider_registry.validator_for("OpenAI Compatible") is not None
+    finally:
+        provider_registry.clear()
+
+
+def test_embeddings_send_string_input_to_compatible_endpoint(monkeypatch):
+    """OpenAI-compatible servers receive text, not OpenAI-only token arrays."""
+    from lfx.base.models import provider_registry, unified_models
+    from lfx.base.models.unified_models import instantiation
+    from lfx.base.models.unified_models.instantiation import get_embeddings
+    from lfx.extension import load_extension
+
+    captured_inputs = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        captured_inputs.append(json.loads(request.content)["input"])
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"embedding": [0.1], "index": 0}],
+                "model": "nomic-embed-text",
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    provider_registry.clear()
+    try:
+        root = Path(__file__).resolve().parents[1] / "src" / "lfx_openai_compatible"
+        result = load_extension(root)
+        assert result.ok, (result.errors, result.warnings)
+
+        monkeypatch.setattr(unified_models, "get_api_key_for_provider", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(
+            unified_models,
+            "get_all_variables_for_provider",
+            lambda *_args, **_kwargs: {"OPENAI_COMPATIBLE_BASE_URL": "http://compatible.example/v1"},
+        )
+
+        with httpx.Client(transport=httpx.MockTransport(handle_request)) as client:
+            monkeypatch.setattr(
+                instantiation,
+                "ssrf_protected_openai_clients_for_url",
+                lambda _url: {"http_client": client},
+            )
+            embeddings = get_embeddings([{"name": "nomic-embed-text", "provider": "OpenAI Compatible", "metadata": {}}])
+            embeddings.embed_query("hello world")
+
+        assert captured_inputs == [["hello world"]]
     finally:
         provider_registry.clear()
 

--- a/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
+++ b/src/bundles/openai-compatible/tests/test_openai_compatible_provider.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -51,26 +52,13 @@ def test_bundle_registers_provider_end_to_end():
         provider_registry.clear()
 
 
-def test_embeddings_send_string_input_to_compatible_endpoint(monkeypatch):
-    """OpenAI-compatible servers receive text, not OpenAI-only token arrays."""
+@contextmanager
+def _openai_compatible_embeddings(monkeypatch, handler):
+    """Yield real OpenAI-compatible embeddings backed by a mock HTTP transport."""
     from lfx.base.models import provider_registry, unified_models
     from lfx.base.models.unified_models import instantiation
     from lfx.base.models.unified_models.instantiation import get_embeddings
     from lfx.extension import load_extension
-
-    captured_inputs = []
-
-    def handle_request(request: httpx.Request) -> httpx.Response:
-        captured_inputs.append(json.loads(request.content)["input"])
-        return httpx.Response(
-            200,
-            json={
-                "data": [{"embedding": [0.1], "index": 0}],
-                "model": "nomic-embed-text",
-                "usage": {"prompt_tokens": 2, "total_tokens": 2},
-            },
-            request=request,
-        )
 
     provider_registry.clear()
     try:
@@ -82,21 +70,92 @@ def test_embeddings_send_string_input_to_compatible_endpoint(monkeypatch):
         monkeypatch.setattr(
             unified_models,
             "get_all_variables_for_provider",
-            lambda *_args, **_kwargs: {"OPENAI_COMPATIBLE_BASE_URL": "http://compatible.example/v1"},
+            lambda *_args, **_kwargs: {"OPENAI_COMPATIBLE_BASE_URL": "https://compatible.example/v1"},
         )
 
-        with httpx.Client(transport=httpx.MockTransport(handle_request)) as client:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
             monkeypatch.setattr(
                 instantiation,
                 "ssrf_protected_openai_clients_for_url",
                 lambda _url: {"http_client": client},
             )
-            embeddings = get_embeddings([{"name": "nomic-embed-text", "provider": "OpenAI Compatible", "metadata": {}}])
-            embeddings.embed_query("hello world")
-
-        assert captured_inputs == [["hello world"]]
+            yield get_embeddings([{"name": "nomic-embed-text", "provider": "OpenAI Compatible", "metadata": {}}])
     finally:
         provider_registry.clear()
+
+
+def test_embeddings_send_string_input_to_compatible_endpoint(monkeypatch):
+    """OpenAI-compatible servers receive text, not OpenAI-only token arrays."""
+    captured_inputs = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        """Capture one successful query request."""
+        captured_inputs.append(json.loads(request.content)["input"])
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"embedding": [0.1], "index": 0}],
+                "model": "nomic-embed-text",
+                "usage": {"prompt_tokens": 2, "total_tokens": 2},
+            },
+            request=request,
+        )
+
+    with _openai_compatible_embeddings(monkeypatch, handle_request) as embeddings:
+        embeddings.embed_query("hello world")
+
+    assert captured_inputs == [["hello world"]]
+
+
+def test_embeddings_preserve_batch_strings_and_empty_input(monkeypatch):
+    """Batch embedding preserves string shape, including an empty boundary value."""
+    captured_inputs = []
+    texts = ["", "first document", "second document"]
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        """Return one embedding for every captured batch item."""
+        request_inputs = json.loads(request.content)["input"]
+        captured_inputs.append(request_inputs)
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"embedding": [0.1, float(index)], "index": index} for index in range(len(request_inputs))],
+                "model": "nomic-embed-text",
+                "usage": {"prompt_tokens": 4, "total_tokens": 4},
+            },
+            request=request,
+        )
+
+    with _openai_compatible_embeddings(monkeypatch, handle_request) as embeddings:
+        result = embeddings.embed_documents(texts)
+
+    assert captured_inputs == [texts]
+    assert len(result) == len(texts)
+
+
+def test_embeddings_propagate_compatible_endpoint_errors(monkeypatch):
+    """A compatible endpoint error remains visible to the flow execution path."""
+    from openai import BadRequestError
+
+    captured_inputs = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        """Reject the request with the endpoint's invalid-input response."""
+        captured_inputs.append(json.loads(request.content)["input"])
+        return httpx.Response(
+            400,
+            json={"error": {"message": "invalid input type", "type": "invalid_request_error"}},
+            request=request,
+        )
+
+    with (
+        _openai_compatible_embeddings(monkeypatch, handle_request) as embeddings,
+        pytest.raises(BadRequestError, match="invalid input type") as exc_info,
+    ):
+        embeddings.embed_query("rejected input")
+
+    assert exc_info.value.status_code == 400
+    assert captured_inputs == [["rejected input"]]
 
 
 def _ok_response(payload: dict | list) -> MagicMock:

--- a/src/lfx/src/lfx/base/models/unified_models/instantiation.py
+++ b/src/lfx/src/lfx/base/models/unified_models/instantiation.py
@@ -700,6 +700,10 @@ def _compose_embedding_kwargs(
 
     kwargs: dict[str, Any] = {}
     connection_url_param: str | None = None
+    if provider == "OpenAI Compatible" and embedding_class_name == "OpenAIEmbeddings":
+        # Non-OpenAI servers expect strings and commonly reject the token-ID
+        # arrays produced by LangChain's client-side context-length handling.
+        kwargs["check_embedding_ctx_length"] = False
     if "model" in param_mapping:
         kwargs[param_mapping["model"]] = model_name
     elif "model_id" in param_mapping:

--- a/uv.lock
+++ b/uv.lock
@@ -10351,7 +10351,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-openai-compatible"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "src/bundles/openai-compatible" }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -10355,12 +10355,14 @@ version = "0.1.1"
 source = { editable = "src/bundles/openai-compatible" }
 dependencies = [
     { name = "httpx" },
+    { name = "langchain-openai" },
     { name = "lfx" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.24.0,<1.0.0" },
+    { name = "langchain-openai", specifier = ">=1.1.6" },
     { name = "lfx", editable = "src/lfx" },
 ]
 


### PR DESCRIPTION
## Summary
- disable LangChain client-side tokenization for OpenAI Compatible embeddings
- send strings accepted by Ollama, LM Studio, and other compatible servers
- declare the bundle's `langchain-openai` runtime dependency
- cover query, batch/empty-input, and endpoint-error behavior at the wire level

## Validation
- 32 OpenAI-compatible bundle tests on Python 3.10 and 3.13
- 74 unified-model tests
- 56 isolated provider-registry tests
- Ruff check and format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for OpenAI-compatible embedding providers by ensuring text inputs are sent in the expected format.
  * Prevented client-side context-length handling from interfering with embedding requests.

* **Tests**
  * Added end-to-end coverage validating embedding requests through the unified embedding pathway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
