### PR TITLE
docs: alloy replaces promtail

### DIFF
--- a/deploy/observability/grafana-loki/README.md
+++ b/deploy/observability/grafana-loki/README.md
@@ -28,7 +28,7 @@ Alloy scrapes a directory of `*.log` files, so `LANGFLOW_LOG_FILE` must point at
 
 In JSON mode the file is a single JSON stream: application logs and third-party stdlib loggers (`uvicorn`, `sqlalchemy`, `httpx`, `langchain`) are all rendered as JSON and run through PII redaction, so the `stage.json` parse stage and the **Stdlib intercept routing** panel work against it directly. This stack scrapes a file, so `LANGFLOW_LOG_FILE` is required. If you instead run Langflow as a container, you can drop the file and scrape its stdout by swapping Alloy's `loki.source.file` target for [`loki.source.docker`](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.docker/).
 
-See [Logs and observability](/docs/Develop/observability-grafana-loki.mdx) for the full list of environment variables (per-logger overrides, extra PII redaction keys, trace correlation, etc.).
+See [Logs and observability](../../../docs/docs/Develop/observability-grafana-loki.mdx) for the full list of environment variables (per-logger overrides, extra PII redaction keys, trace correlation, etc.).
 
 ## Run
 

--- a/deploy/observability/grafana-loki/README.md
+++ b/deploy/observability/grafana-loki/README.md
@@ -2,12 +2,14 @@
 
 Reference stack that ingests Langflow's structured JSON logs into [Loki](https://grafana.com/oss/loki/) and visualizes them with a pre-provisioned Grafana dashboard.
 
-Use this as a starting point. The compose file, Promtail config, and dashboard JSON are independent of the rest of `deploy/` and can be lifted into any environment.
+Use this as a starting point. The compose file, Alloy config, dashboard JSON, and legacy Promtail configuration are independent of the rest of `deploy/` and can be lifted into any environment.
+
+[Grafana Alloy](https://grafana.com/oss/alloy/) replaced [Promtail](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/), which reached end of life on March 2, 2026.
 
 ## What you get
 
 - **Loki 3.2** on `:3100`
-- **Promtail 3.2** scraping a directory of Langflow log files
+- **Alloy 1.18** scraping a directory of Langflow log files
 - **Grafana 11.3** on `:3000` with the Loki datasource and the `Langflow Logs` dashboard already provisioned
 
 ## Prerequisites on the Langflow side
@@ -22,26 +24,18 @@ LANGFLOW_VERSION=1.10.0
 LANGFLOW_ENVIRONMENT=production
 ```
 
-Promtail scrapes a directory of `*.log` files, so `LANGFLOW_LOG_FILE` must point at a file inside
-the directory you expose to Promtail as `LANGFLOW_LOG_DIR` (see [Run](#run)). Set both to the same
-directory, otherwise Promtail watches an empty folder and the dashboard stays blank. Use an
-absolute path: `LANGFLOW_LOG_FILE` is resolved against Langflow's working directory, not this one.
+Alloy scrapes a directory of `*.log` files, so `LANGFLOW_LOG_FILE` must point at a file inside the directory you expose to Alloy as `LANGFLOW_LOG_DIR` (see [Run](#run)). Set both to the same directory, otherwise Alloy watches an empty folder and the dashboard stays blank. Use an absolute path: `LANGFLOW_LOG_FILE` is resolved against Langflow's working directory, not this one.
 
-In JSON mode the file is a single JSON stream: application logs and third-party stdlib loggers
-(`uvicorn`, `sqlalchemy`, `httpx`, `langchain`) are all rendered as JSON and run through PII
-redaction, so the `json` parse stage and the **Stdlib intercept routing** panel work against it
-directly. This stack scrapes a file, so `LANGFLOW_LOG_FILE` is required. If you instead run
-Langflow as a container, you can drop the file and scrape its stdout by swapping Promtail's
-`static_configs` file target for `docker_sd_configs` (same JSON, same labels).
+In JSON mode the file is a single JSON stream: application logs and third-party stdlib loggers (`uvicorn`, `sqlalchemy`, `httpx`, `langchain`) are all rendered as JSON and run through PII redaction, so the `stage.json` parse stage and the **Stdlib intercept routing** panel work against it directly. This stack scrapes a file, so `LANGFLOW_LOG_FILE` is required. If you instead run Langflow as a container, you can drop the file and scrape its stdout by swapping Alloy's `loki.source.file` target for [`loki.source.docker`](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.docker/).
 
-See [Logs and observability](../../../docs/docs/Develop/observability-grafana-loki.mdx) for the full list of environment variables (per-logger overrides, extra PII redaction keys, trace correlation, etc.).
+See [Logs and observability](/docs/Develop/observability-grafana-loki.mdx) for the full list of environment variables (per-logger overrides, extra PII redaction keys, trace correlation, etc.).
 
 ## Run
 
 From this directory:
 
 ```bash
-# Point Promtail at the directory that holds the file you set in
+# Point Alloy at the directory that holds the file you set in
 # LANGFLOW_LOG_FILE above. Must be the same directory. Defaults to the
 # bundled ./logs (used by the quick smoke test below).
 export LANGFLOW_LOG_DIR=/absolute/path/to/langflow/logs
@@ -59,8 +53,7 @@ docker compose down -v
 
 ### Quick smoke test (no Langflow required)
 
-To verify the stack end to end without running Langflow, write a sample record into the bundled
-`./logs` directory and query Loki directly:
+To verify the stack end to end without running Langflow, write a sample record into the bundled `./logs` directory and query Loki directly:
 
 ```bash
 mkdir -p logs
@@ -68,7 +61,7 @@ echo '{"event":"smoke test","level":"info","logger":"langflow.api.run","timestam
 
 docker compose up -d
 
-# Give Promtail a few seconds to tail the file, then confirm the line reached Loki:
+# Give Alloy a few seconds to tail the file, then confirm the line reached Loki:
 sleep 5
 curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query={job="langflow"}' | grep -q "smoke test" && echo "OK: log reached Loki"
 ```
@@ -87,6 +80,6 @@ curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query
 
 ## Notes
 
-- Promtail only promotes `level`, `service`, `environment`, `version`, `logger` to labels. High-cardinality fields (`user_id`, `flow_id`, `trace_id`) stay in the log body — query them with `| json` in LogQL.
-- Replace Promtail with [Grafana Alloy](https://grafana.com/oss/alloy/) if you already standardize on it; the JSON parse stage maps 1:1.
+- Alloy only promotes `level`, `service`, `environment`, `version`, `logger` to labels. High-cardinality fields (`user_id`, `flow_id`, `trace_id`) stay in the log body — query them with `| json` in LogQL.
+- A legacy Promtail config remains at [`promtail/config.yml`](./promtail/config.yml) for reference. Promtail reached end of life on March 2, 2026 and is not started by compose. Grafana documents a [Promtail-to-Alloy conversion](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/).
 - If your runtime ships logs through a different transport (Fluent Bit, Vector, OTLP), only the scrape side changes — the dashboard and label schema stay the same.

--- a/deploy/observability/grafana-loki/alloy/config.alloy
+++ b/deploy/observability/grafana-loki/alloy/config.alloy
@@ -1,0 +1,48 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+local.file_match "langflow" {
+  path_targets = [
+    {
+      __path__ = "/var/log/langflow/*.log",
+      job      = "langflow",
+    },
+  ]
+}
+
+loki.source.file "langflow" {
+  targets    = local.file_match.langflow.targets
+  forward_to = [loki.process.langflow.receiver]
+}
+
+loki.process "langflow" {
+  stage.json {
+    expressions = {
+      level       = "level",
+      service     = "service",
+      environment = "environment",
+      version     = "version",
+      logger      = "logger",
+    }
+  }
+
+  stage.labels {
+    values = {
+      level       = "",
+      service     = "",
+      environment = "",
+      version     = "",
+      logger      = "",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/deploy/observability/grafana-loki/docker-compose.yml
+++ b/deploy/observability/grafana-loki/docker-compose.yml
@@ -11,15 +11,21 @@ services:
       timeout: 3s
       retries: 20
 
-  promtail:
-    image: grafana/promtail:3.2.0
-    container_name: lf-promtail
+  alloy:
+    image: grafana/alloy:v1.18.1
+    container_name: lf-alloy
     volumes:
-      - ./promtail/config.yml:/etc/promtail/config.yml
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
       # Mount the directory that holds your langflow JSON log file.
       # Override LANGFLOW_LOG_DIR to point at your real log location.
       - ${LANGFLOW_LOG_DIR:-./logs}:/var/log/langflow:ro
-    command: -config.file=/etc/promtail/config.yml
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    ports:
+      - "12345:12345"
     depends_on:
       loki:
         condition: service_healthy

--- a/deploy/observability/grafana-loki/docker-compose.yml
+++ b/deploy/observability/grafana-loki/docker-compose.yml
@@ -21,11 +21,9 @@ services:
       - ${LANGFLOW_LOG_DIR:-./logs}:/var/log/langflow:ro
     command:
       - run
-      - --server.http.listen-addr=0.0.0.0:12345
+      - --server.http.listen-addr=127.0.0.1:12345
       - --storage.path=/var/lib/alloy/data
       - /etc/alloy/config.alloy
-    ports:
-      - "12345:12345"
     depends_on:
       loki:
         condition: service_healthy

--- a/deploy/observability/grafana-loki/promtail/config.yml
+++ b/deploy/observability/grafana-loki/promtail/config.yml
@@ -1,3 +1,7 @@
+# LEGACY. Promtail reached end of life on 2026-03-02 and is not used by this stack.
+# The compose file runs Grafana Alloy instead.
+# For more on converting this file, see the Grafana documentation: https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/
+
 server:
   http_listen_port: 9080
   grpc_listen_port: 0

--- a/docs/docs/Develop/observability-grafana-loki.mdx
+++ b/docs/docs/Develop/observability-grafana-loki.mdx
@@ -3,14 +3,15 @@ title: Grafana Loki
 slug: /observability-grafana-loki
 ---
 
-
-This demonstration scrapes Langflow log files with [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/), and then sends JSON logs to [Grafana Loki](https://grafana.com/oss/loki/) to be viewed in a Grafana dashboard.
+This demonstration scrapes Langflow log files with [Grafana Alloy](https://grafana.com/oss/alloy/), and then sends JSON logs to [Grafana Loki](https://grafana.com/oss/loki/) to be viewed in a Grafana dashboard.
 
 It is _not_ OpenTelemetry.
 For traces, metrics, and OTLP logs to Grafana Cloud or an OpenTelemetry Collector, see [OpenTelemetry](./observability-opentelemetry.mdx).
 
 This page demonstrates how to connect Langflow to the [reference Grafana stack](https://github.com/langflow-ai/langflow/tree/main/deploy/observability/grafana-loki) shipped with the Langflow repository.
 For more information, see the [README](https://github.com/langflow-ai/langflow/tree/main/deploy/observability/grafana-loki).
+
+Grafana Alloy replaced [Promtail](https://grafana.com/docs/alloy/latest/set-up/migrate/from-promtail/), which reached end of life on March 2, 2026.
 
 To consume structured Langflow logs with other ingestion providers, see [Logs](/logging).
 
@@ -35,9 +36,9 @@ To consume structured Langflow logs with other ingestion providers, see [Logs](/
 
    Setting `LANGFLOW_LOG_ENV=container` switches structlog's terminal processor to [`JSONRenderer`](https://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer), so every line written to stdout is a JSON object containing the event message, level, timestamp, logger name, exception structure, and service metadata. For more information, see [Logs](/logging).
 
-   The shipped Promtail configuration scrapes `*.log` files from a directory rather than stdout. `LANGFLOW_LOG_FILE` must point at a file inside the directory that Promtail watches. Set `LANGFLOW_LOG_DIR` to that same directory so Langflow creates the file in the right place.
+   The shipped Alloy configuration scrapes `*.log` files from a directory rather than stdout. `LANGFLOW_LOG_FILE` must point at a file inside the directory that Alloy watches. Set `LANGFLOW_LOG_DIR` to that same directory so Langflow creates the file in the right place.
 
-3. Start the reference Loki + Promtail + Grafana stack from the repository:
+3. Start the reference Loki + Alloy + Grafana stack from the repository:
 
    ```bash
    cd deploy/observability/grafana-loki


### PR DESCRIPTION
[Promtail is end of life (EOL) as of March 2, 2026. ](https://grafana.com/docs/loki/latest/send-data/promtail/)

Update the Grafana Loki stack example and docs to use the recommended Alloy instead of Promtail.