### PR TITLE
fix(frontend): keep a file removal over a stale refresh

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
+++ b/src/frontend/src/CustomNodes/helpers/__tests__/mutate-template.test.ts
@@ -335,6 +335,60 @@ describe("mutateTemplate", () => {
     );
   });
 
+  it("keeps a file removed while the refresh was in flight", async () => {
+    const bothFiles = {
+      value: ["first", "second"],
+      file_path: ["folder/first.txt", "folder/second.txt"],
+    };
+    const oneFile = {
+      value: ["first"],
+      file_path: ["folder/first.txt"],
+    };
+    const node = {
+      template: {
+        code: { value: "original source" },
+        path: { ...bothFiles },
+      },
+      outputs: [],
+    } as unknown as APIClassType;
+    const setNodeClass = jest.fn();
+    // The user removes the second file while the selection refresh is in
+    // flight, so the store holds one file when the two-file response lands.
+    const mutateAsync = jest.fn().mockImplementation(async () => {
+      setStoreNodeTemplate("file-node", {
+        code: { value: "original source" },
+        path: { ...oneFile },
+      });
+      return {
+        template: {
+          code: { value: "original source" },
+          path: { ...bothFiles },
+        },
+        outputs: [],
+      } as unknown as APIClassType;
+    });
+    setStoreNodeTemplate("file-node", node.template);
+
+    await mutateTemplate(
+      bothFiles.value,
+      "file-node",
+      node,
+      setNodeClass,
+      { mutateAsync } as never,
+      jest.fn(),
+      "path",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(setNodeClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: expect.objectContaining({
+          path: expect.objectContaining(oneFile),
+        }),
+      }),
+    );
+  });
+
   it("applies a backend-driven value change the user did not touch", async () => {
     const node = {
       template: {

--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -29,13 +29,22 @@ const getNodeCode = (nodeId: string): unknown => {
 // user flipped meanwhile - the field vanishes off the node with no feedback.
 const USER_OWNED_FIELD_FLAGS = ["advanced", "api_editable"] as const;
 
+// A field can carry its value across more than one attribute: a file input
+// stores the selection as names in `value` and as the paths the node actually
+// reads in `file_path`. Guarding `value` alone lets a stale response restore
+// `file_path`, and the file input reconciles back to it - the file the user
+// just removed reappears.
+const VALUE_ATTRIBUTES = ["value", "file_path"] as const;
+
+type AppliedFieldValues = Record<string, unknown>;
+
 // The field values the last applied response wrote, per node. A store value
 // that no longer matches this baseline was changed locally, which is what makes
 // an older in-flight response stale for that field. Comparing against the
 // baseline rather than the request snapshot keeps concurrent refreshes working:
 // several mount refreshes share one snapshot, so the first response to land
 // would otherwise look like a local edit and suppress the others.
-const lastAppliedValues = new Map<string, Record<string, unknown>>();
+const lastAppliedValues = new Map<string, Record<string, AppliedFieldValues>>();
 const LAST_APPLIED_PRUNE_THRESHOLD = 100;
 
 const rememberAppliedValues = (
@@ -48,10 +57,15 @@ const rememberAppliedValues = (
       if (!liveIds.has(id)) lastAppliedValues.delete(id);
     }
   }
-  const values: Record<string, unknown> = {};
+  const values: Record<string, AppliedFieldValues> = {};
   for (const [fieldName, field] of Object.entries(template)) {
     if (typeof field === "object" && field !== null) {
-      values[fieldName] = cloneDeep(field.value);
+      const applied: AppliedFieldValues = {};
+      for (const attribute of VALUE_ATTRIBUTES) {
+        if (attribute in field)
+          applied[attribute] = cloneDeep(field[attribute]);
+      }
+      values[fieldName] = applied;
     }
   }
   lastAppliedValues.set(nodeId, values);
@@ -59,10 +73,10 @@ const rememberAppliedValues = (
 
 // LE-2272: a response answers for the field values that were current when the
 // request left. Anything the user edited meanwhile (a tool action's slug,
-// description or approval_actions; any field typed while a refresh is in
-// flight) is newer than the response, so the local value wins. When the user
-// did not touch the field, the backend value still applies - a legitimate
-// refresh that recomputes a value is unaffected.
+// description or approval_actions; a file removed from a file input; any field
+// typed while a refresh is in flight) is newer than the response, so the local
+// value wins. When the user did not touch the field, the backend value still
+// applies - a legitimate refresh that recomputes a value is unaffected.
 const keepUserEdits = (
   nodeId: string,
   requestedTemplate: APITemplateType | undefined,
@@ -91,12 +105,20 @@ const keepUserEdits = (
         incomingField[flag] = currentField[flag];
       }
     }
-    const appliedValue =
-      baseline && fieldName in baseline
-        ? baseline[fieldName]
-        : requestedField.value;
-    if (!isEqual(currentField.value, appliedValue)) {
-      incomingField.value = cloneDeep(currentField.value);
+    const appliedField = baseline?.[fieldName];
+    const editedLocally = VALUE_ATTRIBUTES.some((attribute) => {
+      const appliedValue =
+        appliedField && attribute in appliedField
+          ? appliedField[attribute]
+          : requestedField[attribute];
+      return !isEqual(currentField[attribute], appliedValue);
+    });
+    if (editedLocally) {
+      for (const attribute of VALUE_ATTRIBUTES) {
+        if (attribute in currentField) {
+          incomingField[attribute] = cloneDeep(currentField[attribute]);
+        }
+      }
     }
   }
   return merged;

--- a/src/frontend/tests/core/unit/fileUploadComponent.spec.ts
+++ b/src/frontend/tests/core/unit/fileUploadComponent.spec.ts
@@ -899,10 +899,27 @@ test(
 
     await page.getByTestId(`remove-file-button-${file2}`).click();
 
-    await page.getByTestId("dropdown-output-file").click();
-    await page
-      .getByTestId("dropdown-item-output-file-file path")
-      .click({ force: true });
+    // Removing a file kicks off a backend outputs refresh: with two files the
+    // component exposes a single "Files" output, with one it exposes "Raw
+    // Content" + "File Path". Opening the dropdown before that refresh lands
+    // shows the stale two-file options, and when it does land the output field
+    // remounts (its React key is the selected output name), silently closing
+    // the popover. Wait for the refreshed outputs and re-open the dropdown if a
+    // late refresh closed it.
+    const outputDropdown = page.getByTestId("dropdown-output-file");
+    const filePathOption = page.getByTestId(
+      "dropdown-item-output-file-file path",
+    );
+    await expect(outputDropdown).toContainText("Raw Content", {
+      timeout: 30000,
+    });
+    await expect(async () => {
+      if ((await outputDropdown.getAttribute("aria-expanded")) !== "true") {
+        await outputDropdown.click();
+      }
+      await expect(filePathOption).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30000, intervals: [500] });
+    await filePathOption.click({ force: true });
     await page.getByTestId("button_run_read file").click();
     await expect(page.getByText("Built successfully")).toBeVisible({
       timeout: 30000,


### PR DESCRIPTION
Removing a file from a file input right after selecting files could resurrect it, and that same race is what made `fileUploadComponent.spec.ts › should be able to use text input for file paths` flaky on both Linux and Windows in the [nightly run 32914399959](https://github.com/langflow-ai/langflow/actions/runs/32914399959).

## Root cause

`keepUserEdits` in `mutate-template.ts` guarded only `field.value`, but a file input carries its selection across **two** attributes: `value` holds the file names and `file_path` the paths the node actually reads (`selectedFiles` is derived from `file_path`).

When the selection refresh is still in flight while the user removes a file, the response restores `file_path` to the pre-removal paths while the local `value` is kept. The field is then internally inconsistent — one name, two paths — so:

- the backend recomputes `update_outputs` from the stale `file_path` and returns `Files` instead of `Raw Content` + `File Path`;
- the file input's reconciliation effect re-adds the removed file from `file_path`.

Captured live (route logging on `/api/v1/custom_component/update`, failing run):

```
[7187ms] removing file2
[7195ms] REQ  value=[file1,file2] fp=[file1,file2]      <- selection refresh, sent before the removal
[7252ms] RES  value=[file1,file2] ... outputs=["Files"] <- lands after it, restores file_path
[7536ms] REQ  value=[file1]       fp=[file1,file2]      <- inconsistent field
[7602ms] RES  outputs=["Files"]                         <- outputs computed from the stale paths
[8273ms] REQ  value=[file1,file2] fp=[file1,file2]      <- removed file is back
```

## Fix

Treat `value` and `file_path` as one unit in `keepUserEdits`: a field counts as locally edited when **either** diverges from the last applied response, and then both are kept from the store. Behaviour for every other field is unchanged (`file_path` is absent there).

## E2E stabilization

The CI trace also shows a second, test-side timing problem in the same spot. Removing a file kicks off the outputs refresh; with two files the component exposes a single `Files` output, with one file it exposes `Raw Content` + `File Path`. The test opened the output dropdown before the refresh landed, so the popover listed the stale two-file options — and when the refresh landed, the output field remounted (its React key is the selected output name) and the popover was silently destroyed, so `dropdown-item-output-file-file path` never appeared:

```
[7292ms] clicking dropdown trigger -> expanded=true  label=Files       filePathItem=0
[9145ms] refresh lands            -> expanded=false label=Raw Content  filePathItem=0
```

The spec now waits for the refreshed outputs and re-opens the dropdown if a late refresh closed it.

## Validation

- Reproduced the CI failure locally by replaying the CI response ordering with `page.route` (trace pulled from `blob-report-Linux-50-of-70`); the popover goes `expanded=true → false` exactly as in CI.
- New unit test `keeps a file removed while the refresh was in flight` fails on `main` (`file_path` comes back as both files) and passes with the fix.
- `should be able to use text input for file paths`: 3/5 passing before the fix, 5/5 after; the instrumented copy went 2/4 → 4/4.
- Full frontend Jest suite: 638 suites / 6809 tests passing.
- Regression e2e: `fileUploadComponent.spec.ts` (full file), `sliderComponent.spec.ts`, `dropdownComponent.spec.ts`, `refresh-dropdown-list.spec.ts` — all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved locally selected files and other field values when refreshed template data arrives.
  * Prevented removed files from reappearing after an in-progress refresh completes.
  * Improved file-output selection behavior after removing a file and refreshing available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->