### PR TITLE
fix: stop the InterceptHandler logging cycle that OOMs with LANGFLOW_LOG_FILE set

### DIFF
--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from gunicorn import glogging
 from gunicorn.app.base import BaseApplication
-from lfx.log.logger import InterceptHandler
+from lfx.log.logger import InterceptHandler, structlog_routes_to_stdlib
 from uvicorn.workers import UvicornWorker
 
 
@@ -55,18 +55,31 @@ class LangflowUvicornWorker(UvicornWorker):
 class Logger(glogging.Logger):
     """Implements and overrides the gunicorn logging interface.
 
-    This class inherits from the standard gunicorn logger and overrides it by
-    replacing the handlers with `InterceptHandler` in order to route the
-    gunicorn logs to loguru.
+    This class inherits from the standard gunicorn logger and overrides it so
+    the gunicorn logs join the structlog stream the rest of the process emits.
+
+    How they join it depends on what ``lfx.log.logger.configure`` selected. With
+    no log file, structlog writes to the stream directly, so an
+    ``InterceptHandler`` on each gunicorn logger routes the records into it.
+    With a log file, structlog is backed by ``structlog.stdlib.LoggerFactory``
+    and resolves ``gunicorn.error`` back to this very stdlib logger: an
+    ``InterceptHandler`` here would hand each record back to itself and cycle,
+    doubling the rendered payload every lap until the process runs out of
+    memory. In that mode the records propagate to the root file handler
+    instead, which renders foreign records through the same processor chain.
     """
 
     def __init__(self, cfg) -> None:
         super().__init__(cfg)
-        logging.getLogger("gunicorn.error").setLevel(logging.WARNING)
-        logging.getLogger("gunicorn.access").setLevel(logging.WARNING)
-
-        logging.getLogger("gunicorn.error").handlers = [InterceptHandler()]
-        logging.getLogger("gunicorn.access").handlers = [InterceptHandler()]
+        routes_to_stdlib = structlog_routes_to_stdlib()
+        for name in ("gunicorn.error", "gunicorn.access"):
+            gunicorn_logger = logging.getLogger(name)
+            gunicorn_logger.setLevel(logging.WARNING)
+            if routes_to_stdlib:
+                gunicorn_logger.handlers = []
+                gunicorn_logger.propagate = True
+            else:
+                gunicorn_logger.handlers = [InterceptHandler()]
 
     def error(self, msg, *args, **kwargs):
         """Override error method to filter out SIGSEGV messages."""

--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -72,14 +72,25 @@ class Logger(glogging.Logger):
     def __init__(self, cfg) -> None:
         super().__init__(cfg)
         routes_to_stdlib = structlog_routes_to_stdlib()
+        # The handlers configure() installed on the root logger for file mode: a
+        # RotatingFileHandler carrying the ProcessorFormatter that renders foreign
+        # stdlib records through the same processor chain as application logs.
+        root_handlers = [h for h in logging.root.handlers if not isinstance(h, InterceptHandler)]
         for name in ("gunicorn.error", "gunicorn.access"):
             gunicorn_logger = logging.getLogger(name)
             gunicorn_logger.setLevel(logging.WARNING)
-            if routes_to_stdlib:
+            if not routes_to_stdlib:
+                gunicorn_logger.handlers = [InterceptHandler()]
+            elif root_handlers:
+                # Hand these loggers the file handler directly rather than relying on
+                # propagation: UvicornWorker.__init__ copies whatever sits here onto
+                # uvicorn.error / uvicorn.access and sets propagate = False, so a
+                # propagate-only wiring would drop every uvicorn record.
+                gunicorn_logger.handlers = list(root_handlers)
+                gunicorn_logger.propagate = False
+            else:
                 gunicorn_logger.handlers = []
                 gunicorn_logger.propagate = True
-            else:
-                gunicorn_logger.handlers = [InterceptHandler()]
 
     def error(self, msg, *args, **kwargs):
         """Override error method to filter out SIGSEGV messages."""

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -32,6 +32,7 @@ from lfx.log.logger import (
     log_buffer,
     setup_gunicorn_logger,
     setup_uvicorn_logger,
+    structlog_routes_to_stdlib,
 )
 from loguru import logger as loguru_logger
 
@@ -592,6 +593,25 @@ class TestInterceptHandlerReentrancy:
         contents = log_file.read_text()
         assert "boom" in contents
         assert len(contents) < 10_000
+
+
+class TestStructlogRoutesToStdlib:
+    """Tests for the predicate that reports whether structlog writes back to stdlib."""
+
+    def teardown_method(self):
+        structlog.reset_defaults()
+
+    def test_true_when_a_log_file_is_configured(self, tmp_path):
+        """A log file selects structlog.stdlib.LoggerFactory, which can cycle."""
+        configure(log_level="ERROR", log_file=tmp_path / "langflow.log", cache=False)
+
+        assert structlog_routes_to_stdlib() is True
+
+    def test_false_without_a_log_file(self):
+        """Without a log file the print factory writes to the stream directly."""
+        configure(log_level="ERROR", cache=False)
+
+        assert structlog_routes_to_stdlib() is False
 
 
 class TestSetupFunctions:

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -503,6 +503,7 @@ class TestInterceptHandlerReentrancy:
 
     @staticmethod
     def _record(name="gunicorn.error", msg="boom"):
+        """Build an ERROR record named after a logger that server.py intercepts."""
         return logging.LogRecord(
             name=name,
             level=logging.ERROR,
@@ -523,6 +524,7 @@ class TestInterceptHandlerReentrancy:
             """Stands in for a structlog logger backed by structlog.stdlib.LoggerFactory."""
 
             def error(self, message, **_kwargs):
+                """Dispatch, then route the record back into the handler."""
                 dispatched.append(message)
                 handler.emit(record)
 
@@ -562,6 +564,7 @@ class TestInterceptHandlerReentrancy:
         emit_cap = 8
 
         def counting_emit(handler_self, record):
+            """Track emit depth and stop the cycle before it can exhaust memory."""
             depth["current"] += 1
             depth["max"] = max(depth["max"], depth["current"])
             try:

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -481,6 +481,119 @@ class TestInterceptHandler:
         self.mock_logger.info.assert_called_once_with("Message with string and 42")
 
 
+class TestInterceptHandlerReentrancy:
+    """Regression tests for the ``InterceptHandler.emit()`` re-entrancy guard.
+
+    With a log file configured, ``configure()`` selects
+    ``structlog.stdlib.LoggerFactory``, so the structlog logger ``emit``
+    resolves from ``record.name`` writes back out to the stdlib logger of the
+    same name. When that logger is handled by an ``InterceptHandler`` (as
+    ``langflow.server.Logger`` sets up for ``gunicorn.error`` and
+    ``gunicorn.access``), the record cycles back into ``emit``, and each lap
+    re-renders the previous lap's payload into the next event.
+    """
+
+    def teardown_method(self):
+        structlog.reset_defaults()
+        logging.root.handlers = [h for h in logging.root.handlers if not isinstance(h, InterceptHandler)]
+        gunicorn_logger = logging.getLogger("gunicorn.error")
+        gunicorn_logger.handlers = []
+        gunicorn_logger.setLevel(logging.NOTSET)
+
+    @staticmethod
+    def _record(name="gunicorn.error", msg="boom"):
+        return logging.LogRecord(
+            name=name,
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_emit_drops_a_record_that_re_enters_on_the_same_thread(self):
+        """A record routed back into emit() by its own structlog logger is dropped."""
+        handler = InterceptHandler()
+        record = self._record()
+        dispatched = []
+
+        class ReentrantLogger:
+            """Stands in for a structlog logger backed by structlog.stdlib.LoggerFactory."""
+
+            def error(self, message, **_kwargs):
+                dispatched.append(message)
+                handler.emit(record)
+
+        with patch("structlog.get_logger", return_value=ReentrantLogger()):
+            handler.emit(record)
+
+        assert dispatched == ["boom"]
+
+    def test_guard_is_released_after_a_successful_emit(self):
+        """Two sequential emits both dispatch: the guard is not sticky."""
+        handler = InterceptHandler()
+        mock_logger = Mock()
+
+        with patch("structlog.get_logger", return_value=mock_logger):
+            handler.emit(self._record())
+            handler.emit(self._record())
+
+        assert mock_logger.error.call_count == 2
+
+    def test_guard_is_released_when_emit_raises(self):
+        """A failing emit routes to handleError and still clears the guard."""
+        handler = InterceptHandler()
+        mock_logger = Mock()
+        mock_logger.error.side_effect = [RuntimeError("render failed"), None]
+
+        with patch("structlog.get_logger", return_value=mock_logger), patch.object(handler, "handleError") as handle:
+            handler.emit(self._record())
+            handler.emit(self._record())
+
+        assert handle.call_count == 1
+        assert mock_logger.error.call_count == 2
+
+    def test_intercepted_logger_with_log_file_terminates(self, tmp_path, monkeypatch):
+        """The gunicorn.error + log_file combination logs once and terminates."""
+        depth = {"current": 0, "max": 0}
+        original_emit = InterceptHandler.emit
+        emit_cap = 8
+
+        def counting_emit(handler_self, record):
+            depth["current"] += 1
+            depth["max"] = max(depth["max"], depth["current"])
+            try:
+                # Hard stop so a regression cannot exhaust CI memory: without the
+                # guard the payload doubles per lap.
+                if depth["current"] > emit_cap:
+                    return None
+                return original_emit(handler_self, record)
+            finally:
+                depth["current"] -= 1
+
+        monkeypatch.setattr(InterceptHandler, "emit", counting_emit)
+
+        log_file = tmp_path / "langflow.log"
+        configure(log_level="ERROR", log_file=log_file, cache=False)
+
+        # Exactly what langflow.server.Logger.__init__ does for gunicorn.
+        gunicorn_logger = logging.getLogger("gunicorn.error")
+        gunicorn_logger.setLevel(logging.WARNING)
+        gunicorn_logger.handlers = [InterceptHandler()]
+
+        gunicorn_logger.error("boom")
+
+        for handler in logging.root.handlers:
+            handler.flush()
+
+        # One lap of interception, and the re-entrant lap the guard drops.
+        assert depth["max"] <= 2
+        contents = log_file.read_text()
+        assert "boom" in contents
+        assert len(contents) < 10_000
+
+
 class TestSetupFunctions:
     """Test suite for setup_uvicorn_logger() and setup_gunicorn_logger()."""
 

--- a/src/backend/tests/unit/test_server_logger.py
+++ b/src/backend/tests/unit/test_server_logger.py
@@ -15,6 +15,7 @@ from langflow.server import Logger
 from lfx.log.logger import InterceptHandler, configure
 
 GUNICORN_LOGGERS = ("gunicorn.error", "gunicorn.access")
+UVICORN_LOGGERS = ("uvicorn.error", "uvicorn.access")
 
 
 @pytest.fixture(autouse=True)
@@ -23,7 +24,7 @@ def _restore_logging_state():
     original_root_handlers = list(logging.root.handlers)
     original_gunicorn_state = {
         name: (list(logging.getLogger(name).handlers), logging.getLogger(name).level, logging.getLogger(name).propagate)
-        for name in GUNICORN_LOGGERS
+        for name in GUNICORN_LOGGERS + UVICORN_LOGGERS
     }
 
     yield
@@ -49,16 +50,62 @@ def test_intercepts_when_structlog_writes_to_the_stream():
         assert isinstance(handlers[0], InterceptHandler)
 
 
-def test_propagates_instead_of_intercepting_when_a_log_file_is_configured(tmp_path):
-    """With a log file the records go to the root file handler, not back through structlog."""
+def test_uses_the_root_file_handler_when_a_log_file_is_configured(tmp_path):
+    """With a log file the records go to the file handler, not back through structlog."""
     configure(log_level="ERROR", log_file=tmp_path / "langflow.log", cache=False)
+    root_handlers = list(logging.root.handlers)
 
     Logger(Config())
 
     for name in GUNICORN_LOGGERS:
         gunicorn_logger = logging.getLogger(name)
-        assert gunicorn_logger.handlers == []
-        assert gunicorn_logger.propagate is True
+        assert gunicorn_logger.handlers == root_handlers
+        assert not any(isinstance(handler, InterceptHandler) for handler in gunicorn_logger.handlers)
+        # UvicornWorker sets propagate = False on its copy, so the handler has to be
+        # attached here rather than reached by propagation.
+        assert gunicorn_logger.propagate is False
+
+
+def test_uvicorn_loggers_inherit_a_terminating_handler(tmp_path, monkeypatch):
+    """The handlers UvicornWorker copies onto the uvicorn loggers cannot cycle.
+
+    ``UvicornWorker.__init__`` assigns ``gunicorn.error``'s handler list to
+    ``uvicorn.error`` and sets ``propagate = False``. An ``InterceptHandler``
+    reaching the uvicorn loggers that way is what turned a single uvicorn error
+    line into an out-of-memory kill.
+    """
+    emitted = []
+    original_emit = InterceptHandler.emit
+    emit_cap = 8
+
+    def counting_emit(handler_self, record):
+        emitted.append(record.name)
+        if len(emitted) > emit_cap:
+            return None
+        return original_emit(handler_self, record)
+
+    monkeypatch.setattr(InterceptHandler, "emit", counting_emit)
+
+    log_file = tmp_path / "langflow.log"
+    configure(log_level="ERROR", log_file=log_file, cache=False)
+    gunicorn_logger = Logger(Config())
+
+    # Exactly what UvicornWorker.__init__ does with the gunicorn logger's handlers.
+    for name, source in (("uvicorn.error", gunicorn_logger.error_log), ("uvicorn.access", gunicorn_logger.access_log)):
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers = source.handlers
+        uvicorn_logger.setLevel(source.level)
+        uvicorn_logger.propagate = False
+
+    logging.getLogger("uvicorn.error").error("worker failed")
+
+    for handler in logging.getLogger("uvicorn.error").handlers:
+        handler.flush()
+
+    assert emitted == []
+    contents = log_file.read_text()
+    assert "worker failed" in contents
+    assert len(contents.splitlines()) == 1
 
 
 def test_gunicorn_error_reaches_the_log_file_exactly_once(tmp_path, monkeypatch):

--- a/src/backend/tests/unit/test_server_logger.py
+++ b/src/backend/tests/unit/test_server_logger.py
@@ -1,0 +1,92 @@
+"""Tests for the gunicorn logging wiring in ``langflow.server``.
+
+``Logger`` used to attach an ``InterceptHandler`` to ``gunicorn.error`` and
+``gunicorn.access`` unconditionally. With a log file configured, structlog
+resolves those names back to the same stdlib loggers, so every intercepted
+record was handed straight back to the handler that intercepted it.
+"""
+
+import logging
+
+import pytest
+import structlog
+from gunicorn.config import Config
+from langflow.server import Logger
+from lfx.log.logger import InterceptHandler, configure
+
+GUNICORN_LOGGERS = ("gunicorn.error", "gunicorn.access")
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """Put back the process-wide logging state these tests rewire."""
+    original_root_handlers = list(logging.root.handlers)
+    original_gunicorn_state = {
+        name: (list(logging.getLogger(name).handlers), logging.getLogger(name).level, logging.getLogger(name).propagate)
+        for name in GUNICORN_LOGGERS
+    }
+
+    yield
+
+    structlog.reset_defaults()
+    logging.root.handlers = original_root_handlers
+    for name, (handlers, level, propagate) in original_gunicorn_state.items():
+        gunicorn_logger = logging.getLogger(name)
+        gunicorn_logger.handlers = handlers
+        gunicorn_logger.setLevel(level)
+        gunicorn_logger.propagate = propagate
+
+
+def test_intercepts_when_structlog_writes_to_the_stream():
+    """Without a log file the print factory cannot cycle, so interception stands."""
+    configure(log_level="ERROR", cache=False)
+
+    Logger(Config())
+
+    for name in GUNICORN_LOGGERS:
+        handlers = logging.getLogger(name).handlers
+        assert len(handlers) == 1
+        assert isinstance(handlers[0], InterceptHandler)
+
+
+def test_propagates_instead_of_intercepting_when_a_log_file_is_configured(tmp_path):
+    """With a log file the records go to the root file handler, not back through structlog."""
+    configure(log_level="ERROR", log_file=tmp_path / "langflow.log", cache=False)
+
+    Logger(Config())
+
+    for name in GUNICORN_LOGGERS:
+        gunicorn_logger = logging.getLogger(name)
+        assert gunicorn_logger.handlers == []
+        assert gunicorn_logger.propagate is True
+
+
+def test_gunicorn_error_reaches_the_log_file_exactly_once(tmp_path, monkeypatch):
+    """One gunicorn error line lands in the file, at its original size."""
+    emitted = []
+    original_emit = InterceptHandler.emit
+    emit_cap = 8
+
+    def counting_emit(handler_self, record):
+        emitted.append(record.name)
+        # Hard stop so a regression cannot exhaust CI memory: each lap of the
+        # cycle renders the previous lap's payload into the next event.
+        if len(emitted) > emit_cap:
+            return None
+        return original_emit(handler_self, record)
+
+    monkeypatch.setattr(InterceptHandler, "emit", counting_emit)
+
+    log_file = tmp_path / "langflow.log"
+    configure(log_level="ERROR", log_file=log_file, cache=False)
+    Logger(Config())
+
+    logging.getLogger("gunicorn.error").error("worker timeout")
+
+    for handler in logging.root.handlers:
+        handler.flush()
+
+    assert emitted == []
+    contents = log_file.read_text()
+    assert "worker timeout" in contents
+    assert len(contents.splitlines()) == 1

--- a/src/backend/tests/unit/test_server_logger.py
+++ b/src/backend/tests/unit/test_server_logger.py
@@ -6,7 +6,10 @@ resolves those names back to the same stdlib loggers, so every intercepted
 record was handed straight back to the handler that intercepted it.
 """
 
+import contextlib
+import importlib
 import logging
+import logging.handlers
 
 import pytest
 import structlog
@@ -20,22 +23,54 @@ UVICORN_LOGGERS = ("uvicorn.error", "uvicorn.access")
 
 @pytest.fixture(autouse=True)
 def _restore_logging_state():
-    """Put back the process-wide logging state these tests rewire."""
-    original_root_handlers = list(logging.root.handlers)
-    original_gunicorn_state = {
-        name: (list(logging.getLogger(name).handlers), logging.getLogger(name).level, logging.getLogger(name).propagate)
+    """Put back the process-wide logging state these tests rewire.
+
+    ``configure(log_file=...)`` adds a ``RotatingFileHandler`` to the root logger,
+    raises the root level and parks the handler in ``lfx.log.logger._file_handler``.
+    Left behind, that handler holds an open file inside a since-deleted tmp_path and
+    whatever test the xdist worker picks up next logs into it. Mirrors the module
+    fixture in ``test_logger.py``.
+    """
+    # ``import lfx.log.logger as ...`` would bind the logger object ``lfx.log``
+    # re-exports under that name, not the module.
+    lfx_log = importlib.import_module("lfx.log.logger")
+
+    orig_structlog_config = dict(structlog.get_config())
+    orig_root_handlers = logging.root.handlers[:]
+    orig_root_level = logging.root.level
+    orig_file_handler = lfx_log._file_handler
+    orig_logger_state = {
+        name: (logging.getLogger(name).handlers[:], logging.getLogger(name).level, logging.getLogger(name).propagate)
         for name in GUNICORN_LOGGERS + UVICORN_LOGGERS
     }
 
-    yield
+    try:
+        yield
+    finally:
+        structlog.configure(**orig_structlog_config)
 
-    structlog.reset_defaults()
-    logging.root.handlers = original_root_handlers
-    for name, (handlers, level, propagate) in original_gunicorn_state.items():
-        gunicorn_logger = logging.getLogger(name)
-        gunicorn_logger.handlers = handlers
-        gunicorn_logger.setLevel(level)
-        gunicorn_logger.propagate = propagate
+        # Drop handlers these tests added, closing file handlers so they stop
+        # pointing into deleted temp dirs. If configure() replaced the lfx-managed
+        # file handler, setup_log_file() already closed the original, so it must
+        # not be reinstalled.
+        for handler in logging.root.handlers[:]:
+            if handler not in orig_root_handlers:
+                logging.root.removeHandler(handler)
+                if isinstance(handler, logging.handlers.RotatingFileHandler):
+                    with contextlib.suppress(OSError, ValueError):
+                        handler.close()
+        restored_handlers = orig_root_handlers
+        if lfx_log._file_handler is not orig_file_handler:
+            restored_handlers = [h for h in orig_root_handlers if h is not orig_file_handler]
+            lfx_log._file_handler = None
+        logging.root.handlers[:] = restored_handlers
+        logging.root.setLevel(orig_root_level)
+
+        for name, (handlers, level, propagate) in orig_logger_state.items():
+            named_logger = logging.getLogger(name)
+            named_logger.handlers = handlers
+            named_logger.setLevel(level)
+            named_logger.propagate = propagate
 
 
 def test_intercepts_when_structlog_writes_to_the_stream():
@@ -79,6 +114,7 @@ def test_uvicorn_loggers_inherit_a_terminating_handler(tmp_path, monkeypatch):
     emit_cap = 8
 
     def counting_emit(handler_self, record):
+        """Record every interception and cap the laps a regression could run."""
         emitted.append(record.name)
         if len(emitted) > emit_cap:
             return None
@@ -115,6 +151,7 @@ def test_gunicorn_error_reaches_the_log_file_exactly_once(tmp_path, monkeypatch)
     emit_cap = 8
 
     def counting_emit(handler_self, record):
+        """Record every interception and cap the laps a regression could run."""
         emitted.append(record.name)
         # Hard stop so a regression cannot exhaust CI memory: each lap of the
         # cycle renders the previous lap's payload into the next event.

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -11,7 +11,7 @@ from collections import deque
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from threading import Lock, Semaphore
+from threading import Lock, Semaphore, local
 from typing import Any, TypedDict
 
 import orjson
@@ -1314,9 +1314,29 @@ class InterceptHandler(logging.Handler):
     sqlalchemy, langchain, uvicorn) survive into the JSON output. Without
     this, errors raised inside third-party libraries log a one-line message
     with no stack trace.
+
+    ``emit`` is guarded against re-entry on the same thread. Whenever a log
+    file is configured, ``configure`` installs ``structlog.stdlib.LoggerFactory``,
+    so the structlog logger this handler resolves from ``record.name`` writes
+    straight back out to the stdlib logger of that same name. If that logger
+    is itself handled by an ``InterceptHandler`` -- which ``Logger.__init__``
+    in ``langflow.server`` does unconditionally for ``gunicorn.error`` and
+    ``gunicorn.access`` -- the record re-enters here and cycles. Each lap
+    renders the previous lap's already-rendered payload into the next event,
+    so the message doubles in size per lap and resident memory follows it;
+    a container is exhausted long before the interpreter's recursion limit
+    would fire. Dropping the re-entrant record is the correct outcome for a
+    logging handler: instrumentation must never take down the process it
+    instruments, and the record still reaches the root handlers on the lap
+    that caused the re-entry.
     """
 
+    _reentrancy = local()
+
     def emit(self, record: logging.LogRecord) -> None:
+        if getattr(self._reentrancy, "active", False):
+            return
+        self._reentrancy.active = True
         # Mirrors the stdlib Handler.emit safety net: a malformed third-party
         # log call (e.g. mismatched %-format args) must not propagate up and
         # crash the request path. Anything that raises here is routed to
@@ -1338,6 +1358,8 @@ class InterceptHandler(logging.Handler):
             getattr(structlog_logger, method_name)(record.getMessage(), **kwargs)
         except Exception:  # noqa: BLE001 - logging must never break the caller
             self.handleError(record)
+        finally:
+            self._reentrancy.active = False
 
 
 def _install_stdlib_intercept(numeric_level: int) -> None:

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -1362,6 +1362,24 @@ class InterceptHandler(logging.Handler):
             self._reentrancy.active = False
 
 
+def structlog_routes_to_stdlib() -> bool:
+    """Report whether structlog is configured to write back out to stdlib logging.
+
+    ``configure`` installs ``structlog.stdlib.LoggerFactory`` whenever a log file
+    is configured, which makes every structlog call resolve to the stdlib logger
+    of the same name. Callers that are about to attach an ``InterceptHandler`` to
+    a *named* stdlib logger need to know this: interception in that direction
+    closes a cycle, because the handler routes the record to a structlog logger
+    that writes it straight back to the logger it came from.
+
+    Returns:
+        ``True`` when the configured structlog logger factory is a
+        ``structlog.stdlib.LoggerFactory``, ``False`` otherwise (the print
+        factory writes to the stream directly and cannot cycle).
+    """
+    return isinstance(structlog.get_config().get("logger_factory"), structlog.stdlib.LoggerFactory)
+
+
 def _install_stdlib_intercept(numeric_level: int) -> None:
     """Install (or refresh) the InterceptHandler on the stdlib root logger.
 


### PR DESCRIPTION
Fixes #14776

## Summary

With `LANGFLOW_LOG_FILE` set, a single log record can cycle between the stdlib logging tree and structlog until the process runs out of memory. In a container that is an OOM kill from one ERROR line.

## Root cause

Two halves, both present on `release-1.12.0`:

1. `lfx/log/logger.py`: `configure()` selects `structlog.stdlib.LoggerFactory` whenever a log file is configured, so `structlog.get_logger(name)` resolves to the stdlib logger of that same name.
2. `langflow/server.py`: `Logger.__init__` attaches an `InterceptHandler` to `gunicorn.error` and `gunicorn.access` unconditionally.

A record on `gunicorn.error` reaches `InterceptHandler.emit`, which hands it to a structlog logger named `gunicorn.error`, which writes back out to the stdlib logger whose handler is that same `InterceptHandler`. Each lap renders the previous lap's already-rendered payload into the next event, so the message doubles in size per lap. Memory is exhausted well before the recursion limit fires, and `emit`'s `except Exception -> handleError` swallows the `RecursionError` if it ever does.

`UvicornWorker.__init__` widens the blast radius: it assigns `gunicorn.error`'s handler list to `uvicorn.error` (and `gunicorn.access`'s to `uvicorn.access`) and sets `propagate = False`, so the same handler instance ends up on the uvicorn loggers in every worker. Ordinary component code emitting on `uvicorn.error` triggers it. In that mode those records also never reach the log file at all: `propagate` is off and the only handler is the looping one.

`configure()` already declines to install the root intercept in this mode (`if json_mode and not log_file`), but the gunicorn path bypasses that check.

## Fix

1. `InterceptHandler.emit` gets a thread-local re-entrancy guard: a record arriving while the same thread is already inside `emit` is dropped. A logging handler must never take down the process it instruments, and the record still reaches the root handlers on the lap that caused the re-entry.
2. `Logger.__init__` no longer intercepts when structlog is backed by the stdlib factory. The new `structlog_routes_to_stdlib()` helper reports which mode is active; with no log file the previous behaviour is unchanged.
3. In log-file mode the gunicorn loggers take the root file handler directly rather than relying on propagation, because `UvicornWorker` copies that handler list onto the uvicorn loggers with `propagate = False`. Those uvicorn records now land in the log file instead of being lost to the cycle.

Either of the first two changes alone stops the OOM. Both are included because the handler should be safe regardless of who installs it.

## Tests

- `src/backend/tests/unit/test_logger.py`: re-entrant record dropped, guard released after a successful emit and after `handleError`, `structlog_routes_to_stdlib()` tracking `configure()`, and an integration test wiring `gunicorn.error` the way `server.py` does.
- `src/backend/tests/unit/test_server_logger.py` (new): both wiring modes, an end-to-end check that one gunicorn error line lands in the log file as exactly one line, and a test that replicates `UvicornWorker`'s handler copy and asserts the uvicorn loggers inherit a terminating handler.

Every new test was run against the unpatched code first: reverting either half fails the corresponding tests. The recursion tests carry an emit-depth cap so a future regression fails an assert instead of exhausting CI memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability by preventing recursive logging loops.
  * Ensured Gunicorn and Uvicorn messages are routed correctly and recorded only once.
  * Improved log-file handling and reduced the risk of missing or duplicated entries.

* **Tests**
  * Added coverage for logging configuration, re-entrancy protection, exception cleanup, and file-output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->