### PR TITLE
fix(frontend): keep sidebar add and drag affordances inside the row

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx
@@ -185,7 +185,11 @@ export const SidebarDraggableComponent = forwardRef(
               tabIndex={0}
               onKeyDown={handleKeyDown}
               className={cn(
-                "flex flex-1 items-center gap-2 rounded-md outline-none ring-ring focus-visible:ring-1",
+                // `min-w-0` (LE-2311): without it this flex item keeps the
+                // default `min-width: auto` and refuses to shrink below the
+                // component name's intrinsic width, pushing the sibling
+                // add/drag container off the row.
+                "flex min-w-0 flex-1 items-center gap-2 rounded-md outline-none ring-ring focus-visible:ring-1",
                 isUnavailable ? "cursor-not-allowed" : "cursor-grab",
               )}
               draggable={!error && !isUnavailable}

--- a/src/frontend/tests/core/regression/sidebarRowAffordances.spec.ts
+++ b/src/frontend/tests/core/regression/sidebarRowAffordances.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+/**
+ * LE-2311: the sidebar row's label wrapper is a flex item with the default
+ * `min-width: auto`, so it refuses to shrink below its intrinsic content
+ * width. On rows whose name (plus an optional Beta/Legacy badge) is wider
+ * than the row, the sibling action container holding the add (`+`) button and
+ * the drag handle is pushed past the row's right edge and clipped away.
+ *
+ * The row keeps working (double-click, drag, right-click), but neither
+ * affordance is visible, so nothing on the row signals that it can be added
+ * or dragged.
+ *
+ * The search term is chosen so that both a short name and several long ones
+ * are on screen at once: the short row proves the measurement is sound, the
+ * long ones are the regression.
+ */
+test(
+  "sidebar add button and drag handle stay inside the row for long component names",
+  { tag: ["@release", "@components", "@workspace"] },
+  async ({ page }) => {
+    await page.setViewportSize({ width: 1470, height: 704 });
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("blank-flow").click();
+    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
+      timeout: 30000,
+    });
+
+    await page.getByTestId("sidebar-search-input").fill("embed");
+    await page.waitForSelector('[data-testid="icon-GripVertical"]', {
+      timeout: 30000,
+    });
+
+    const overflowing = await page.evaluate(() => {
+      const rows = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-testid$="_draggable"]'),
+      );
+      return rows
+        .map((row) => {
+          const rowBox = row.getBoundingClientRect();
+          const grip = row.querySelector('[data-testid="icon-GripVertical"]');
+          const gripBox = grip?.getBoundingClientRect();
+          return {
+            name:
+              row.querySelector('[data-testid="display-name"]')?.textContent ??
+              row.getAttribute("data-testid"),
+            // Positive means the handle sticks out past the row's right edge.
+            overflow: gripBox ? Math.round(gripBox.right - rowBox.right) : null,
+          };
+        })
+        .filter((r) => r.overflow === null || r.overflow > 0);
+    });
+
+    expect(
+      overflowing,
+      `rows whose drag handle renders outside the row: ${JSON.stringify(
+        overflowing,
+      )}`,
+    ).toEqual([]);
+
+    // The `+` is hidden until hover by design; on an affected row it never
+    // appears at all because the whole action container is off the row.
+    const longRow = page.getByTestId(
+      "amazon_amazon bedrock embeddings_draggable",
+    );
+    await longRow.hover();
+
+    const addButton = longRow.getByTestId(
+      "add-component-button-amazon-bedrock-embeddings",
+    );
+    await expect(addButton).toBeVisible();
+
+    const rowBox = await longRow.boundingBox();
+    const addBox = await addButton.boundingBox();
+    expect(rowBox).not.toBeNull();
+    expect(addBox).not.toBeNull();
+    expect(addBox!.x + addBox!.width).toBeLessThanOrEqual(
+      rowBox!.x + rowBox!.width,
+    );
+
+    await addButton.click();
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);


### PR DESCRIPTION
Fixes LE-2311

## Problem

In the flow sidebar, the action container holding the add (`+`) button and the drag handle (`GripVertical`) is pushed outside the row's visible bounds whenever the row's content is wide enough, so both icons are clipped and never render. The row itself stays interactive — double-click, drag from anywhere, and right-click all keep working — but nothing on the row signals that it can be added or dragged.

Measured live at a 1470×704 viewport, rows are 210px wide and the sidebar clips at `x=263`:

| Row | Drag handle overflow past the row edge |
| --- | --- |
| Amazon Bedrock Embeddings | +75px (handle center x=330) |
| IBM watsonx.ai Embeddings | +62px |
| Azure OpenAI Embeddings | +54px |
| OpenAI Embeddings | +11px |
| Embedding Model (short name) | −7px (fine) |

The ticket counts 89 of 176 rows affected — 81% of Legacy rows, 50% of Beta rows, and 27% of rows with no badge at all.

## Root cause

The inner draggable wrapper in `sidebarDraggableComponent.tsx` is a flex item with the default `min-width: auto` and `overflow: visible`. Its automatic minimum size is therefore its content's min-content width, so it refuses to shrink below the full component name, and the sibling `shrink-0` action container (44px) is laid out past the row's right edge.

The label div nested inside it already has `overflow-hidden`, which is why truncation *looked* like it should work — but that only zeroes that div's own minimum size, not the wrapper's.

The Beta/Legacy badge is an accelerant, not the cause: it adds ~40px, so it trips the overflow at shorter names. 25 components with no badge are affected purely by name length.

## Fix

One class: `min-w-0` on the wrapper, so it can shrink and the name truncates via the existing `truncate` span instead. The action container stays anchored to the right edge of every row, and the badge (`shrink-0`) keeps its full width. The full name is still available through the tooltip that already wraps the label.

## Validation

Reproduced and verified against a live instance (backend 7860 + Vite dev server), not simulated:

- New regression spec `src/frontend/tests/core/regression/sidebarRowAffordances.spec.ts` — measures the drag handle against the row bounds for every visible row, then hovers a long-named row and asserts the `+` is visible, inside the row, and actually adds the node. **Fails before the change** (reports 6 overflowing rows, worst +75px), passes after.
- Full sidebar sweep with Beta and Legacy enabled: 199 rows, **0** overflowing (worst margin −8px, i.e. inside).
- Existing suites green: `componentHoverAdd`, `filterSidebar`, `keyboardComponentSearch`, `right-click-dropdown`, `core-pages.a11y` (zero violations), and 531 jest tests across `flowSidebarComponent`.

Note: the `+` staying `sm:opacity-0` until hover is by design and unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long component names in the flow sidebar now shrink appropriately, keeping drag and add controls visible.
  - Adding a component from a long sidebar row now works as expected.

- **Tests**
  - Added regression coverage to verify sidebar controls remain visible, positioned correctly, and create flow nodes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->