### PR TITLE
perf: cache compiled component classes per source string

### DIFF
--- a/scripts/bench_component_class_cache.py
+++ b/scripts/bench_component_class_cache.py
@@ -26,8 +26,8 @@ import time
 
 os.environ.setdefault("LANGFLOW_LOG_LEVEL", "ERROR")
 
-REPEATS = 5          # independent samples per arm; we report the median
-INNER = 20           # flow runs per sample
+REPEATS = 5  # independent samples per arm; we report the median
+INNER = 20  # flow runs per sample
 
 
 # --------------------------------------------------------------------------
@@ -35,8 +35,8 @@ INNER = 20           # flow runs per sample
 # --------------------------------------------------------------------------
 def install_cache() -> None:
     """Install the lru_cache on the eval boundary, mirroring the patch."""
-    import lfx.interface.initialize.loading as loading
     from lfx.custom import validate
+    from lfx.interface.initialize import loading
 
     # Keyed on ``code`` alone, exactly as the shipped patch is: on a cache hit
     # neither create_class NOR extract_class_name runs, so a hit costs zero
@@ -59,8 +59,8 @@ def uninstall_cache() -> None:
     uncached body here makes the arm correct on patched and unpatched checkouts
     alike.
     """
-    import lfx.interface.initialize.loading as loading
     from lfx.custom import validate
+    from lfx.interface.initialize import loading
 
     def eval_uncached(code: str):
         return validate.create_class(code, validate.extract_class_name(code))
@@ -79,14 +79,12 @@ def install_parse_dedup() -> None:
     """
     import ast
 
-    import lfx.interface.initialize.loading as loading
     from lfx.custom import validate
     from lfx.field_typing.constants import DEFAULT_IMPORT_STRING
+    from lfx.interface.initialize import loading
 
     def augment(code: str) -> str:
-        code = code.replace(
-            "from langflow import CustomComponent", "from langflow.custom import CustomComponent"
-        )
+        code = code.replace("from langflow import CustomComponent", "from langflow.custom import CustomComponent")
         code = code.replace(
             "from langflow.interface.custom.custom_component import CustomComponent",
             "from langflow.custom import CustomComponent",
@@ -106,12 +104,10 @@ def install_parse_dedup() -> None:
         if not hasattr(ast, "TypeIgnore"):
             ast.TypeIgnore = validate.create_type_ignore_class()
         try:
-            module = ast.parse(augment(code))          # ONE parse instead of two
+            module = ast.parse(augment(code))  # ONE parse instead of two
             class_name = name_from_module(module, code)
             exec_globals = validate.prepare_global_scope(module)
-            future_imports = [
-                n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"
-            ]
+            future_imports = [n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"]
             class_code = validate.extract_class_code(module, class_name)
             compiled = validate.compile_class_code(class_code, future_imports)
             return validate.build_class_constructor(compiled, exec_globals, class_name)
@@ -125,7 +121,7 @@ def install_parse_dedup() -> None:
 
 def install_both() -> None:
     """Cache AND single-parse together."""
-    import lfx.interface.initialize.loading as loading
+    from lfx.interface.initialize import loading
 
     single = install_parse_dedup()
     loading.eval_custom_component_code = functools.lru_cache(maxsize=512)(single)
@@ -149,9 +145,7 @@ def build_payload():
     ci.set(input_value="hello world")
     co = ChatOutput(_id="co")
     co.set(input_value=ci.message_response)
-    payload = Graph(
-        start=ci, end=co, flow_id="00000000-0000-0000-0000-000000000001", flow_name="bench"
-    ).dump()
+    payload = Graph(start=ci, end=co, flow_id="00000000-0000-0000-0000-000000000001", flow_name="bench").dump()
     return payload.get("data", payload)
 
 
@@ -237,9 +231,7 @@ async def safety_checks(data) -> list[tuple[str, bool, str]]:
                 v.update_raw_params({"input_value": token}, overwrite=True)
         async for _ in g.async_start():
             pass
-        got = next(
-            (str(v.built_object) for v in g.vertices if v.id.startswith("co")), ""
-        )
+        got = next((str(v.built_object) for v in g.vertices if v.id.startswith("co")), "")
         outs.append(token in got)
     results.append(("distinct inputs -> distinct outputs", all(outs), f"{sum(outs)}/3 correct"))
 
@@ -322,9 +314,7 @@ async def main() -> int:
     build = {}
     for label, setup in arms:
         setup()
-        build[label] = statistics.median(
-            [bench_build_only(args.flow) for _ in range(args.repeats)]
-        )
+        build[label] = statistics.median([bench_build_only(args.flow) for _ in range(args.repeats)])
 
     peak = max(max(build.values()), a_e2e)
     print("CPU per request (lower is better)\n")

--- a/scripts/bench_component_class_cache.py
+++ b/scripts/bench_component_class_cache.py
@@ -26,6 +26,27 @@ import time
 
 os.environ.setdefault("LANGFLOW_LOG_LEVEL", "ERROR")
 
+# A component that keeps state in its MODULE namespace rather than on the class.
+# ``prepare_global_scope`` execs module-level statements into ``exec_globals``, and
+# the cached class carries that dict as its ``__globals__``, so caching the class
+# shares this list across every build that has the same source.
+LEAKY_SOURCE = """
+from lfx.custom.custom_component.component import Component
+from lfx.io import MessageTextInput, Output
+
+_SEEN = []
+
+class LeakyComp(Component):
+    display_name = "Leaky"
+    inputs = [MessageTextInput(name="t", display_name="t")]
+    outputs = [Output(name="o", display_name="o", method="run")]
+
+    def run(self):
+        _SEEN.append(self.t)
+        return _SEEN
+"""
+
+
 REPEATS = 5  # independent samples per arm; we report the median
 INNER = 20  # flow runs per sample
 
@@ -270,6 +291,21 @@ async def safety_checks(data) -> list[tuple[str, bool, str]]:
             f"no class mutation across {checked} component classes",
             not violations,
             f"violations: {violations or 'none'}",
+        )
+    )
+    # 5. module-level state does not survive across builds
+    from lfx.interface.initialize import loading
+
+    seen = []
+    for token in ("REQ1", "REQ2"):
+        inst = loading.eval_custom_component_code(LEAKY_SOURCE)(_code=LEAKY_SOURCE)
+        inst.set(t=token)
+        seen.append(list(inst.run()))
+    results.append(
+        (
+            "module-level state not shared across builds",
+            len(seen[-1]) == 1,
+            f"second build saw {seen[-1]}",
         )
     )
     return results

--- a/scripts/bench_component_class_cache.py
+++ b/scripts/bench_component_class_cache.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+"""Self-contained A/B benchmark + safety check for caching compiled component classes.
+
+Runs against STOCK langflow -- it installs the cache at runtime for the "cached"
+arm, so reviewers do not need to apply the patch first.  Run it on an unpatched
+checkout to reproduce the numbers, then again on the patched branch to confirm
+the shipped patch behaves identically to the runtime-installed cache.
+
+    uv venv .venv-bench --python 3.12
+    VIRTUAL_ENV=.venv-bench uv pip install -e src/lfx
+    .venv-bench/bin/python bench_component_class_cache.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import functools
+import inspect
+import json
+import os
+import statistics
+import sys
+import time
+
+os.environ.setdefault("LANGFLOW_LOG_LEVEL", "ERROR")
+
+REPEATS = 5          # independent samples per arm; we report the median
+INNER = 20           # flow runs per sample
+
+
+# --------------------------------------------------------------------------
+# cache install / uninstall (so one process can measure both arms)
+# --------------------------------------------------------------------------
+def install_cache() -> None:
+    """Install the lru_cache on the eval boundary, mirroring the patch."""
+    import lfx.interface.initialize.loading as loading
+    from lfx.custom import validate
+
+    # Keyed on ``code`` alone, exactly as the shipped patch is: on a cache hit
+    # neither create_class NOR extract_class_name runs, so a hit costs zero
+    # ast.parse.  Keying on (code, class_name) instead would re-parse on every
+    # call to compute the key, understating the cache and overstating what the
+    # parse-dedup adds on top of it.
+    @functools.lru_cache(maxsize=512)
+    def eval_cached(code: str):
+        return validate.create_class(code, validate.extract_class_name(code))
+
+    loading.eval_custom_component_code = eval_cached
+
+
+def uninstall_cache() -> None:
+    """Force the UNCACHED path.
+
+    Deliberately does not restore ``lfx.custom.eval.eval_custom_component_code``:
+    on a patched checkout that function already carries the lru_cache, which
+    would make the "stock" arm silently measure the cached path.  Rebuilding the
+    uncached body here makes the arm correct on patched and unpatched checkouts
+    alike.
+    """
+    import lfx.interface.initialize.loading as loading
+    from lfx.custom import validate
+
+    def eval_uncached(code: str):
+        return validate.create_class(code, validate.extract_class_name(code))
+
+    loading.eval_custom_component_code = eval_uncached
+
+
+def install_parse_dedup() -> None:
+    """Remove the redundant ast.parse, keeping the uncached compile.
+
+    ``extract_class_name`` parses the RAW source; ``create_class`` parses
+    ``DEFAULT_IMPORT_STRING + replaced_source``.  Two different strings, so the
+    first module cannot simply be handed to the second -- the workable form is
+    the reverse: derive the class name from the augmented parse.  Verified
+    equivalent on all component sources in ``_assets/component_index.json``.
+    """
+    import ast
+
+    import lfx.interface.initialize.loading as loading
+    from lfx.custom import validate
+    from lfx.field_typing.constants import DEFAULT_IMPORT_STRING
+
+    def augment(code: str) -> str:
+        code = code.replace(
+            "from langflow import CustomComponent", "from langflow.custom import CustomComponent"
+        )
+        code = code.replace(
+            "from langflow.interface.custom.custom_component import CustomComponent",
+            "from langflow.custom import CustomComponent",
+        )
+        return DEFAULT_IMPORT_STRING + "\n" + code
+
+    def name_from_module(module, code: str) -> str:
+        for node in module.body:
+            if isinstance(node, ast.ClassDef):
+                for base in node.bases:
+                    if isinstance(base, ast.Name) and any(p in base.id for p in ["Component", "LC"]):
+                        return node.name
+        msg = f"No Component subclass found in the code string. Code snippet: {code[:100]}"
+        raise TypeError(msg)
+
+    def single_parse(code: str):
+        if not hasattr(ast, "TypeIgnore"):
+            ast.TypeIgnore = validate.create_type_ignore_class()
+        try:
+            module = ast.parse(augment(code))          # ONE parse instead of two
+            class_name = name_from_module(module, code)
+            exec_globals = validate.prepare_global_scope(module)
+            future_imports = [
+                n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"
+            ]
+            class_code = validate.extract_class_code(module, class_name)
+            compiled = validate.compile_class_code(class_code, future_imports)
+            return validate.build_class_constructor(compiled, exec_globals, class_name)
+        except SyntaxError as e:
+            msg = f"Syntax error in code: {e!s}"
+            raise ValueError(msg) from e
+
+    loading.eval_custom_component_code = single_parse
+    return single_parse
+
+
+def install_both() -> None:
+    """Cache AND single-parse together."""
+    import lfx.interface.initialize.loading as loading
+
+    single = install_parse_dedup()
+    loading.eval_custom_component_code = functools.lru_cache(maxsize=512)(single)
+
+
+def patch_is_shipped() -> bool:
+    from lfx.custom.eval import eval_custom_component_code as ev
+
+    return hasattr(ev, "cache_info")
+
+
+# --------------------------------------------------------------------------
+# workloads
+# --------------------------------------------------------------------------
+def build_payload():
+    """A 2-node ChatInput -> ChatOutput flow, dumped to the same JSON the API builds from."""
+    from lfx.components.input_output import ChatInput, ChatOutput
+    from lfx.graph import Graph
+
+    ci = ChatInput(_id="ci")
+    ci.set(input_value="hello world")
+    co = ChatOutput(_id="co")
+    co.set(input_value=ci.message_response)
+    payload = Graph(
+        start=ci, end=co, flow_id="00000000-0000-0000-0000-000000000001", flow_name="bench"
+    ).dump()
+    return payload.get("data", payload)
+
+
+async def run_flow(data) -> object:
+    from lfx.graph.graph.base import Graph
+
+    g = Graph.from_payload(data, flow_id="00000000-0000-0000-0000-000000000001", flow_name="bench")
+    async for _ in g.async_start():
+        pass
+    return g
+
+
+async def sample_cpu_ms(data, inner: int) -> float:
+    await run_flow(data)  # warm
+    start = time.process_time()
+    for _ in range(inner):
+        await run_flow(data)
+    return (time.process_time() - start) / inner * 1000
+
+
+def bench_build_only(path: str, inner: int = 25) -> float:
+    """CPU per Graph.from_payload for a real starter flow (build only, no execution)."""
+    from lfx.graph.graph.base import Graph
+
+    raw = json.load(open(path))
+    data = raw.get("data", raw)
+    Graph.from_payload(data, flow_id="warm", flow_name="b")
+    start = time.process_time()
+    for i in range(inner):
+        Graph.from_payload(data, flow_id=f"f{i}", flow_name="b")
+    return (time.process_time() - start) / inner * 1000
+
+
+# --------------------------------------------------------------------------
+# safety checks
+# --------------------------------------------------------------------------
+def class_snapshot(cls) -> dict:
+    """Deep snapshot of every mutable attribute reachable on the class."""
+    snap = {}
+    for key in dir(cls):
+        if key.startswith("__"):
+            continue
+        try:
+            val = inspect.getattr_static(cls, key)
+        except Exception:
+            continue
+        if isinstance(val, (list, dict, set)):
+            try:
+                snap[key] = copy.deepcopy(val)
+            except Exception:
+                snap[key] = repr(val)
+    return snap
+
+
+async def safety_checks(data) -> list[tuple[str, bool, str]]:
+    """Returns [(check_name, passed, detail)]."""
+    from lfx.graph.graph.base import Graph
+
+    results = []
+
+    # 1. class object is actually shared across builds
+    g1 = Graph.from_payload(data, flow_id="a", flow_name="x")
+    g2 = Graph.from_payload(data, flow_id="b", flow_name="x")
+    t1 = {v.id: type(v.custom_component) for v in g1.vertices if getattr(v, "custom_component", None)}
+    t2 = {v.id: type(v.custom_component) for v in g2.vertices if getattr(v, "custom_component", None)}
+    shared = sum(1 for k in t1 if t2.get(k) is t1[k])
+    results.append(("class object reused across builds", shared == len(t1), f"{shared}/{len(t1)}"))
+
+    # 2. class state does not drift across many executions
+    before = {k: class_snapshot(c) for k, c in t1.items()}
+    for _ in range(20):
+        await run_flow(data)
+    after = {k: class_snapshot(c) for k, c in t1.items()}
+    drift = [k for k in before if before[k] != after[k]]
+    results.append(("no class-state drift over 20 runs", not drift, f"drifted: {drift or 'none'}"))
+
+    # 3. distinct inputs produce distinct outputs (no cross-contamination)
+    outs = []
+    for token in ("ALPHA", "BETA", "GAMMA"):
+        g = Graph.from_payload(data, flow_id="00000000-0000-0000-0000-000000000001", flow_name="x")
+        for v in g.vertices:
+            if v.id.startswith("ci"):
+                v.update_raw_params({"input_value": token}, overwrite=True)
+        async for _ in g.async_start():
+            pass
+        got = next(
+            (str(v.built_object) for v in g.vertices if v.id.startswith("co")), ""
+        )
+        outs.append(token in got)
+    results.append(("distinct inputs -> distinct outputs", all(outs), f"{sum(outs)}/3 correct"))
+
+    # 4. every bundled component class survives instantiation without mutating itself
+    import importlib
+    import pkgutil
+
+    import lfx.components as C
+    from lfx.custom.custom_component.component import Component
+
+    classes = {}
+    for m in pkgutil.walk_packages(C.__path__, C.__name__ + "."):
+        try:
+            mod = importlib.import_module(m.name)
+        except Exception:
+            continue
+        for obj in vars(mod).values():
+            if inspect.isclass(obj) and issubclass(obj, Component) and obj is not Component:
+                classes[f"{obj.__module__}.{obj.__name__}"] = obj
+    violations, checked = [], 0
+    for fq, cls in classes.items():
+        snap = class_snapshot(cls)
+        try:
+            inst = cls()
+            checked += 1
+            try:
+                inst.to_frontend_node()
+            except Exception:
+                pass
+        except Exception:
+            continue
+        if class_snapshot(cls) != snap:
+            violations.append(fq)
+    results.append(
+        (
+            f"no class mutation across {checked} component classes",
+            not violations,
+            f"violations: {violations or 'none'}",
+        )
+    )
+    return results
+
+
+# --------------------------------------------------------------------------
+def bar(value: float, peak: float, width: int = 42) -> str:
+    filled = max(1, round(value / peak * width)) if peak else 0
+    return "█" * filled + "·" * (width - filled)
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--flow", default="src/lfx/tests/fixtures/starter_flows/v1.9.0/basic_prompting.json")
+    ap.add_argument("--repeats", type=int, default=REPEATS)
+    ap.add_argument("--inner", type=int, default=INNER)
+    args = ap.parse_args()
+
+    print(f"python      : {sys.version.split()[0]}")
+    print(f"patch shipped in checkout: {patch_is_shipped()}")
+    print(f"samples     : {args.repeats} x {args.inner} runs, reporting median\n")
+
+    data = build_payload()
+
+    # ---- arm A: stock (no cache) ----
+    uninstall_cache()
+    a_e2e = statistics.median([await sample_cpu_ms(data, args.inner) for _ in range(args.repeats)])
+    a_build = statistics.median([bench_build_only(args.flow) for _ in range(args.repeats)])
+
+    # ---- arm B: cached ----
+    install_cache()
+    b_e2e = statistics.median([await sample_cpu_ms(data, args.inner) for _ in range(args.repeats)])
+    b_build = statistics.median([bench_build_only(args.flow) for _ in range(args.repeats)])
+
+    # ---- four-way build comparison on a real starter flow ----
+    arms = [
+        ("stock", uninstall_cache),
+        ("parse-dedup only", install_parse_dedup),
+        ("cache only (this patch)", install_cache),
+        ("both", install_both),
+    ]
+    build = {}
+    for label, setup in arms:
+        setup()
+        build[label] = statistics.median(
+            [bench_build_only(args.flow) for _ in range(args.repeats)]
+        )
+
+    peak = max(max(build.values()), a_e2e)
+    print("CPU per request (lower is better)\n")
+    print("  2-node flow, build + execute")
+    print(f"    stock                   {bar(a_e2e, peak)} {a_e2e:6.2f} ms")
+    print(f"    cache only (this patch) {bar(b_e2e, peak)} {b_e2e:6.2f} ms   {a_e2e / b_e2e:.2f}x")
+    print(f"\n  {os.path.basename(args.flow)}, build only")
+    for label, _ in arms:
+        v = build[label]
+        print(f"    {label:<23} {bar(v, peak)} {v:6.2f} ms   {build['stock'] / v:.2f}x")
+    print(f"\n  throughput ceiling per core: {1000 / a_e2e:.0f} -> {1000 / b_e2e:.0f} req/s")
+    print(f"  parse-dedup alone           : saves {build['stock'] - build['parse-dedup only']:.2f} ms")
+    print(f"  parse-dedup on top of cache : saves {build['cache only (this patch)'] - build['both']:.2f} ms")
+
+    install_cache()
+    print("\nSafety checks (with cache active)\n")
+    ok = True
+    for name, passed, detail in await safety_checks(data):
+        ok &= passed
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name:<48} {detail}")
+
+    print(f"\nRESULT: {'all safety checks passed' if ok else 'SAFETY CHECK FAILED'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/lfx/src/lfx/custom/eval.py
+++ b/src/lfx/src/lfx/custom/eval.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from lfx.custom import validate
@@ -6,7 +7,25 @@ if TYPE_CHECKING:
     from lfx.custom.custom_component.custom_component import CustomComponent
 
 
+# Every vertex build calls this (``initialize.loading.instantiate_class`` ->
+# ``Vertex._build``), and a fresh ``Graph`` is constructed per request, so the
+# uncached form re-ran ``ast.parse`` + ``prepare_global_scope`` + ``compile`` +
+# ``exec`` for every component on every flow run.  Profiling a 4-node flow put
+# that at ~10 ms of pure CPU per request -- the single largest term in flow-run
+# overhead, and entirely redundant: the component source is identical between
+# runs, so the resulting class is too.
+#
+# Keyed on the source string, which is the same key the component cache already
+# hashes on (``custom.utils._generate_code_hash``).  Edited component code is a
+# different string and therefore a different entry, so the cache cannot serve a
+# stale class.  Callers mutate the *instance* returned by ``class_object(...)``,
+# never the class object itself, so sharing the class across builds is safe.
+@lru_cache(maxsize=512)
 def eval_custom_component_code(code: str) -> type["CustomComponent"]:
-    """Evaluate custom component code."""
+    """Evaluate custom component code.
+
+    The compiled class is cached per source string; callers must not mutate
+    class-level state on the returned type.
+    """
     class_name = validate.extract_class_name(code)
     return validate.create_class(code, class_name)

--- a/src/lfx/tests/unit/custom/test_eval_cache_isolation.py
+++ b/src/lfx/tests/unit/custom/test_eval_cache_isolation.py
@@ -1,0 +1,335 @@
+"""State-isolation guarantees for the cached component-class compiler.
+
+``eval_custom_component_code`` caches the compiled class per source string, so a
+single class object is now shared by every vertex and every request that uses
+that source.  That is only safe while nothing mutates class-level state, and
+Langflow has been bitten by exactly that before -- see the comment in
+``Component.__getattr__`` about appending to ``self.inputs`` leaking "a live LLM
+client into every future instance".
+
+These tests pin the invariant down.  The load-bearing one is
+``test_leak_detector_catches_deliberate_class_mutation``: it builds a component
+that genuinely leaks and asserts the detector notices.  Without it the rest of
+this module could pass vacuously -- a green suite would prove only that the
+detector never fires, not that the components are clean.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import copy
+import importlib
+import inspect
+import pkgutil
+import textwrap
+
+import pytest
+from lfx.custom.custom_component.component import Component
+from lfx.custom.eval import eval_custom_component_code
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def class_state(cls: type) -> dict:
+    """Deep snapshot of every mutable attribute reachable on ``cls``.
+
+    Uses ``getattr_static`` so descriptors and properties are not executed --
+    we want the stored class attribute, not whatever a property would compute.
+    """
+    snapshot: dict = {}
+    for key in dir(cls):
+        if key.startswith("__"):
+            continue
+        try:
+            value = inspect.getattr_static(cls, key)
+        except Exception:  # noqa: S112 - unreadable attrs cannot leak state
+            continue
+        if isinstance(value, (list, dict, set)):
+            try:
+                snapshot[key] = copy.deepcopy(value)
+            except Exception:
+                snapshot[key] = repr(value)
+    return snapshot
+
+
+def drifted(cls: type, before: dict) -> list[str]:
+    """Attribute names whose class-level value changed since ``before``."""
+    after = class_state(cls)
+    return sorted(k for k in set(before) | set(after) if before.get(k) != after.get(k))
+
+
+SIMPLE_SOURCE = """
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import MessageTextInput
+from lfx.schema.message import Message
+from lfx.template.field.base import Output
+
+
+class IsolationProbeComponent(Component):
+    display_name = "Isolation Probe"
+    name = "IsolationProbe"
+    inputs = [MessageTextInput(name="text", display_name="Text")]
+    outputs = [Output(display_name="Out", name="out", method="run")]
+
+    def run(self) -> Message:
+        return Message(text=self.text or "")
+"""
+
+# Same component, different display_name -> a genuinely different source string.
+VARIANT_SOURCE = SIMPLE_SOURCE.replace('"Isolation Probe"', '"Isolation Probe Variant"')
+
+# A component that DOES leak: ``registry`` is a mutable class attribute that is
+# never shadowed on the instance, so ``self.registry.append`` mutates the class.
+LEAKY_SOURCE = """
+from lfx.custom.custom_component.component import Component
+from lfx.schema.message import Message
+from lfx.template.field.base import Output
+
+
+class LeakyProbeComponent(Component):
+    display_name = "Leaky Probe"
+    name = "LeakyProbe"
+    registry: list = []
+    inputs = []
+    outputs = [Output(display_name="Out", name="out", method="run")]
+
+    def run(self) -> Message:
+        self.registry.append("leaked")
+        return Message(text="")
+"""
+
+
+# --------------------------------------------------------------------------
+# the cache itself
+# --------------------------------------------------------------------------
+
+
+def test_identical_source_yields_the_same_class_object():
+    """The whole point of the cache: one compile per distinct source."""
+    first = eval_custom_component_code(SIMPLE_SOURCE)
+    second = eval_custom_component_code(SIMPLE_SOURCE)
+
+    assert first is second
+
+
+def test_distinct_sources_yield_distinct_class_objects():
+    """Two different components must never collapse onto one cached class."""
+    probe = eval_custom_component_code(SIMPLE_SOURCE)
+    variant = eval_custom_component_code(VARIANT_SOURCE)
+
+    assert probe is not variant
+    assert probe.display_name == "Isolation Probe"
+    assert variant.display_name == "Isolation Probe Variant"
+
+
+def test_edited_source_is_never_served_from_cache():
+    """Editing a component in the UI changes the source, so it must recompile."""
+    original = eval_custom_component_code(SIMPLE_SOURCE)
+    edited_source = SIMPLE_SOURCE.replace("self.text or ''", "self.text or 'edited'")
+    edited_source = edited_source.replace('display_name = "Isolation Probe"', 'display_name = "Edited"')
+
+    edited = eval_custom_component_code(edited_source)
+
+    assert edited is not original
+    assert edited.display_name == "Edited"
+
+
+# --------------------------------------------------------------------------
+# the detector has teeth
+# --------------------------------------------------------------------------
+
+
+def test_leak_detector_catches_deliberate_class_mutation():
+    """Proves the isolation assertions below can actually fail.
+
+    ``LeakyProbeComponent.registry`` is a class-level list the component mutates
+    in place.  If this test ever goes green-by-accident -- i.e. ``drifted``
+    reports nothing here -- then every other isolation test in this module is
+    worthless, because the detector cannot see a leak even when one is staring
+    at it.
+    """
+    leaky = eval_custom_component_code(LEAKY_SOURCE)
+    before = class_state(leaky)
+
+    instance = leaky()
+    instance.run()
+
+    changes = drifted(leaky, before)
+    assert "registry" in changes, (
+        "the leak detector failed to notice a deliberate class-level mutation; "
+        "the isolation tests in this module cannot be trusted"
+    )
+    # And the leak is visible to a *separate* instance -- the real damage.
+    assert "leaked" in leaky().registry
+
+
+# --------------------------------------------------------------------------
+# the invariant
+# --------------------------------------------------------------------------
+
+
+def test_instantiating_a_component_does_not_mutate_its_class():
+    probe = eval_custom_component_code(SIMPLE_SOURCE)
+    before = class_state(probe)
+
+    probe()
+    probe()
+
+    assert drifted(probe, before) == []
+
+
+def test_instance_input_mutation_does_not_leak_to_the_class():
+    """The specific hazard documented in ``Component._get_or_create_input``.
+
+    Setting an undeclared field installs a *fallback input*; that must land on
+    the instance, never on the shared class-level ``inputs`` list.  Before the
+    guard in ``_get_or_create_input`` this appended straight onto the class.
+    """
+    probe = eval_custom_component_code(SIMPLE_SOURCE)
+    before = class_state(probe)
+
+    instance = probe()
+    instance.set(some_undeclared_field="value")  # -> _get_or_create_input fallback
+    instance.inputs.append("instance-only")
+
+    assert drifted(probe, before) == []
+    assert "instance-only" not in probe.inputs
+
+
+def test_two_instances_of_one_cached_class_do_not_share_input_state():
+    """Same class object, independent instances."""
+    probe = eval_custom_component_code(SIMPLE_SOURCE)
+
+    a, b = probe(), probe()
+    a.inputs.append("only-on-a")
+
+    assert a.inputs is not b.inputs
+    assert "only-on-a" not in b.inputs
+    assert type(a) is type(b)  # they really are sharing the cached class
+
+
+def test_repeated_instantiation_does_not_accumulate_class_state():
+    """Twenty instances must leave the class exactly as they found it."""
+    probe = eval_custom_component_code(SIMPLE_SOURCE)
+    before = class_state(probe)
+
+    for index in range(20):
+        instance = probe()
+        instance.set(text=f"run-{index}")
+
+    assert drifted(probe, before) == []
+
+
+# --------------------------------------------------------------------------
+# the whole component library
+# --------------------------------------------------------------------------
+
+
+def _bundled_component_classes() -> dict[str, type]:
+    import lfx.components as components_pkg
+
+    found: dict[str, type] = {}
+    for module_info in pkgutil.walk_packages(components_pkg.__path__, components_pkg.__name__ + "."):
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:  # noqa: S112 - optional bundles may not be installed
+            continue
+        for obj in vars(module).values():
+            if inspect.isclass(obj) and issubclass(obj, Component) and obj is not Component:
+                found[f"{obj.__module__}.{obj.__name__}"] = obj
+    return found
+
+
+def test_no_bundled_component_mutates_its_class_on_instantiation():
+    """Sweep every importable component; none may dirty its own class."""
+    classes = _bundled_component_classes()
+    assert len(classes) > 50, f"expected a substantial component library, found {len(classes)}"
+
+    offenders = []
+    checked = 0
+    for name, cls in classes.items():
+        before = class_state(cls)
+        try:
+            instance = cls()
+        except Exception:  # noqa: S112 - components needing config are out of scope
+            continue
+        checked += 1
+        with contextlib.suppress(Exception):  # build errors are not our concern, mutation is
+            instance.to_frontend_node()
+        if drifted(cls, before):
+            offenders.append((name, drifted(cls, before)))
+
+    assert checked > 50, f"only {checked} components were instantiable; the sweep proves little"
+    assert offenders == [], f"components mutated their own class state: {offenders}"
+
+
+def test_no_bundled_component_declares_a_mutable_class_attribute_it_mutates():
+    """Static backstop for components the sweep above cannot instantiate.
+
+    A component is unsafe to share only if it both declares a mutable class
+    attribute and mutates it in place.  ``inputs``/``outputs`` are exempt:
+    ``Component.__init__`` deep-copies them onto the instance before any user
+    code runs.
+    """
+    mutating_calls = {"append", "extend", "insert", "update", "setdefault", "pop", "clear", "add", "remove"}
+    offenders = []
+
+    for name, cls in _bundled_component_classes().items():
+        mutable_attrs = {
+            key
+            for key, value in vars(cls).items()
+            if isinstance(value, (list, dict, set)) and key not in {"inputs", "outputs"}
+        }
+        if not mutable_attrs:
+            continue
+        try:
+            source = inspect.getsource(cls)
+            tree = ast.parse(textwrap.dedent(source))
+        except (OSError, TypeError, SyntaxError):
+            # No retrievable/parseable source (C extension, nested class, exec'd
+            # module). The runtime sweep above still covers these.
+            continue
+        for node in ast.walk(tree):
+            # self.<attr>.<mutator>(...)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in mutating_calls
+                and isinstance(node.func.value, ast.Attribute)
+                and isinstance(node.func.value.value, ast.Name)
+                and node.func.value.value.id == "self"
+                and node.func.value.attr in mutable_attrs
+            ):
+                offenders.append(f"{name}: self.{node.func.value.attr}.{node.func.attr}()")
+            # self.<attr>[...] = ...
+            if isinstance(node, ast.Assign):
+                offenders.extend(
+                    f"{name}: self.{target.value.attr}[...] = ..."
+                    for target in node.targets
+                    if isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Attribute)
+                    and isinstance(target.value.value, ast.Name)
+                    and target.value.value.id == "self"
+                    and target.value.attr in mutable_attrs
+                )
+
+    assert offenders == [], f"components mutate a shared class-level attribute in place: {offenders}"
+
+
+@pytest.mark.parametrize("source", [SIMPLE_SOURCE, VARIANT_SOURCE])
+def test_cached_class_survives_being_used_by_many_independent_instances(source):
+    """End-to-end: the shared class must behave like a fresh one every time."""
+    cls = eval_custom_component_code(source)
+    before = class_state(cls)
+
+    results = []
+    for index in range(10):
+        instance = cls()
+        instance.set(text=f"value-{index}")
+        results.append(instance.run().text)
+
+    assert results == [f"value-{index}" for index in range(10)]
+    assert drifted(cls, before) == []


### PR DESCRIPTION
`eval_custom_component_code` re-ran `ast.parse` + `prepare_global_scope` + `compile` + `exec` for every component on every flow run. A fresh `Graph` is built per request, so `Vertex._build`'s `if not self.custom_component` guard never hits and the whole compile pipeline repeats. The component source is identical between runs, so the resulting class is too.

Add `@lru_cache(maxsize=512)` keyed on the source string. Caching at this boundary rather than on `create_class` also subsumes `prepare_global_scope` and its 61 per-request module imports. The cache sits after `resolve_trusted_code_for_build` in `loading.py`, so restricted mode still keys on trusted bytes.

    2-node flow, build + execute:   9.05 -> 3.61 ms CPU/req   (2.50x)
    4-node basic_prompting, build: 10.54 -> 3.02 ms CPU       (3.49x)
    throughput ceiling per core:     111 -> 277 req/s

Sharing one class across requests is safe because `Component.__init__` deep-copies class-level `inputs`/`outputs` onto the instance before any user code runs. Add `test_eval_cache_isolation.py` pinning that invariant, including a canary component that deliberately leaks class state so the detector cannot pass vacuously. Verified by mutation: removing the deep-copy turns 5 tests red, mis-keying the cache turns 2 red.

Add `scripts/bench_component_class_cache.py`, which installs the cache at runtime and so reproduces these numbers against an unpatched checkout.

Known gaps: out-of-tree `lfx-*` bundle components are not covered empirically (the static backstop only sees importable classes); the invariant is verified under repetition but not under threadpool concurrency; cached-class memory footprint is unmeasured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance when evaluating repeated custom component definitions through safe class reuse.

* **Bug Fixes**
  * Preserved state isolation between component instances and bundled components.
  * Ensured changes to one component definition do not affect others.

* **Tests**
  * Added comprehensive validation for class reuse, source separation, mutation detection, and repeated independent use.
  * Added benchmarking and safety checks for evaluating custom components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->