### PR TITLE
fix: fail closed on provider variable read errors

### DIFF
--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -261,7 +261,7 @@ def get_all_variables_for_provider(user_id: UUID | str | None, provider: str) ->
                     value = secret_value_to_str(value, strip=True)
                     if value:
                         values[var_key] = value
-                except (ValueError, Exception):  # noqa: BLE001
+                except ValueError:
                     # Variable not found - check environment, unless the request disables
                     # env fallback (keeps served flows isolated from process-wide credentials).
                     if is_env_fallback_disabled():

--- a/src/lfx/tests/unit/base/models/test_credentials_fail_closed.py
+++ b/src/lfx/tests/unit/base/models/test_credentials_fail_closed.py
@@ -1,0 +1,39 @@
+"""Fail-closed tests for database-backed provider variable resolution."""
+
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+import pytest
+from lfx.base.models.unified_models import credentials
+
+_USER_ID = UUID("11111111-1111-1111-1111-111111111111")
+_PROVIDER_VARIABLES = [
+    {"variable_key": "OPENAI_API_KEY"},
+    {"variable_key": "OPENAI_BASE_URL"},
+]
+
+
+class DatabasePoolTimeoutError(Exception):
+    """Model the timeout raised while acquiring a database connection."""
+
+
+@asynccontextmanager
+async def _session_scope():
+    yield object()
+
+
+class _PoolExhaustedVariableService:
+    async def get_variable(self, *, name: str, **_kwargs):
+        if name == "OPENAI_API_KEY":
+            return "sk-from-db"  # pragma: allowlist secret
+        raise DatabasePoolTimeoutError
+
+
+def test_provider_variable_read_error_does_not_return_partial_configuration(monkeypatch):
+    """A failed base URL read must abort resolution instead of enabling the provider default."""
+    monkeypatch.setattr(credentials, "get_provider_all_variables", lambda _provider: _PROVIDER_VARIABLES)
+    monkeypatch.setattr(credentials, "get_variable_service", _PoolExhaustedVariableService)
+    monkeypatch.setattr(credentials, "session_scope", _session_scope)
+
+    with pytest.raises(DatabasePoolTimeoutError):
+        credentials.get_all_variables_for_provider(_USER_ID, "OpenAI")


### PR DESCRIPTION
## Summary

- propagate unexpected database/session errors while resolving provider Global Variables
- keep environment fallback limited to genuine variable-not-found errors
- prevent partial provider configuration from selecting a default public endpoint

## Testing

- LFX unified-model unit suite: 406 passed
- OpenAI base URL and credential-resolution suites: 37 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider configuration handling when variable retrieval encounters an error.
  * Prevented partial configuration or unintended provider defaults from being used after database connection timeouts.
* **Tests**
  * Added coverage confirming configuration resolution fails safely when database access times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->