### PR TITLE
fix: fail closed on primary API key read errors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2211,7 +2211,7 @@
         "filename": "src/backend/tests/unit/services/variable/test_service.py",
         "hashed_secret": "30abc0a833efea23496b4d226fffa2f90c0855c0",
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 54,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-25T19:38:23Z"
+  "generated_at": "2026-08-26T21:21:13Z"
 }

--- a/src/backend/base/langflow/services/variable/kubernetes.py
+++ b/src/backend/base/langflow/services/variable/kubernetes.py
@@ -5,6 +5,7 @@ import os
 from typing import TYPE_CHECKING
 
 from lfx.log.logger import logger
+from lfx.services.variable import VariableNotFoundError
 from typing_extensions import override
 
 from langflow.services.auth import utils as auth_utils
@@ -67,7 +68,7 @@ class KubernetesSecretService(VariableService, Service):
         variables = self.kubernetes_secrets.get_secret(name=secret_name)
         if not variables:
             msg = f"user_id {user_id} variable not found."
-            raise ValueError(msg)
+            raise VariableNotFoundError(msg)
 
         if name in variables:
             return name, variables[name]
@@ -75,7 +76,7 @@ class KubernetesSecretService(VariableService, Service):
         if credential_name in variables:
             return credential_name, variables[credential_name]
         msg = f"user_id {user_id} variable name {name} not found."
-        raise ValueError(msg)
+        raise VariableNotFoundError(msg)
 
     @override
     async def get_variable(self, user_id: UUID | str, name: str, field: str, session: AsyncSession) -> str:

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from lfx.log.logger import logger
 from lfx.services.authorization.base import ResourceVisibilityScope
 from lfx.services.settings.constants import AGENTIC_VARIABLES
+from lfx.services.variable import VariableNotFoundError
 from sqlmodel import col, select
 
 from langflow.services.auth import utils as auth_utils
@@ -164,7 +165,7 @@ class DatabaseVariableService(VariableService, Service):
 
         if not variable or not variable.value:
             msg = f"{name} variable not found."
-            raise ValueError(msg)
+            raise VariableNotFoundError(msg)
 
         return variable
 
@@ -179,7 +180,7 @@ class DatabaseVariableService(VariableService, Service):
         # credential = session.query(Variable).filter(Variable.user_id == user_id, Variable.name == name).first()
         try:
             variable = await self.get_variable_object(user_id, name, session)
-        except ValueError as owned_lookup_error:
+        except VariableNotFoundError as owned_lookup_error:
             # Runtime resolution may use an explicitly shared variable, but it
             # must never broaden administrative get/update/delete lookups. An
             # owned variable wins on name collisions; otherwise require one

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -19,6 +19,7 @@ from lfx.services.model_provider_policy import (
     ModelProviderPolicySnapshot,
 )
 from lfx.services.settings.constants import VARIABLES_TO_GET_FROM_ENVIRONMENT
+from lfx.services.variable import VariableNotFoundError
 from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
@@ -242,7 +243,7 @@ async def test_get_variable__valueerror(service, session: AsyncSession):
     name = "name"
     field = ""
 
-    with pytest.raises(ValueError, match=f"{name} variable not found."):
+    with pytest.raises(VariableNotFoundError, match=f"{name} variable not found."):
         await service.get_variable(user_id, name, field, session=session)
 
 
@@ -317,7 +318,7 @@ async def test_get_variable_fails_closed_for_domain_only_runtime_scope(service, 
 
     with (
         patch("langflow.services.deps.get_authorization_service", return_value=authz),
-        pytest.raises(ValueError, match="DOMAIN_ONLY_TOKEN variable not found"),
+        pytest.raises(VariableNotFoundError, match="DOMAIN_ONLY_TOKEN variable not found"),
     ):
         await service.get_variable(actor_id, "DOMAIN_ONLY_TOKEN", "", session=session)
 

--- a/src/backend/tests/unit/test_credential_resolution.py
+++ b/src/backend/tests/unit/test_credential_resolution.py
@@ -2,9 +2,9 @@
 
 Bug: Desktop Global Variable OPENAI_API_KEY not injected at runtime.
 When api_key parameter is None (Agent component default), get_api_key_for_provider
-only attempts DB lookup but has no os.getenv() fallback and no error handling
-for ValueError from get_variable(). This causes failures in Desktop where the
-env var is not set and the DB lookup is the only path.
+attempts a DB lookup before falling back to os.getenv(). A missing DB variable
+must use that fallback, while unexpected lookup failures must propagate instead
+of silently downgrading to an environment credential.
 """
 
 from unittest.mock import patch
@@ -18,8 +18,8 @@ class TestGetApiKeyForProviderDbFallback:
 
     @patch("lfx.base.models.unified_models.credentials.get_model_provider_variable_mapping")
     @patch("lfx.base.models.unified_models.credentials.run_until_complete")
-    def test_should_fallback_to_env_when_db_lookup_raises_value_error(self, mock_run, mock_mapping, monkeypatch):
-        """When variable_service.get_variable raises ValueError (variable not found in DB).
+    def test_should_fallback_to_env_when_db_lookup_finds_no_variable(self, mock_run, mock_mapping, monkeypatch):
+        """When the async database lookup finds no variable.
 
         get_api_key_for_provider should fall back to os.getenv() instead of returning None.
         """
@@ -27,7 +27,7 @@ class TestGetApiKeyForProviderDbFallback:
 
         user_id = str(uuid4())
         mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
-        mock_run.side_effect = ValueError("OPENAI_API_KEY variable not found.")
+        mock_run.return_value = None
 
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-env-key")
 

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from lfx.log.logger import logger
 from lfx.services.deps import get_variable_service, session_scope
+from lfx.services.variable import VariableNotFoundError
 from lfx.services.variable.request_scope import is_env_fallback_disabled
 from lfx.utils.async_helpers import run_until_complete
 from lfx.utils.env_var_security import safe_getenv
@@ -111,7 +112,7 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
                             field="",
                             session=session,
                         )
-                    except ValueError:
+                    except VariableNotFoundError:
                         return None
 
             value = run_until_complete(_get_by_var_name())
@@ -174,7 +175,7 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
                         field="",
                         session=session,
                     )
-                except ValueError:
+                except VariableNotFoundError:
                     return None
 
         api_key = run_until_complete(_get_variable())

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -177,10 +177,7 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
                 except ValueError:
                     return None
 
-        try:
-            api_key = run_until_complete(_get_variable())
-        except (ValueError, Exception):  # noqa: BLE001
-            api_key = None
+        api_key = run_until_complete(_get_variable())
 
     api_key = secret_value_to_str(api_key, strip=True)
     if api_key:

--- a/src/lfx/src/lfx/services/variable/__init__.py
+++ b/src/lfx/src/lfx/services/variable/__init__.py
@@ -1,5 +1,6 @@
 """Variable service for lfx package."""
 
+from .exceptions import VariableNotFoundError
 from .service import VariableService
 
-__all__ = ["VariableService"]
+__all__ = ["VariableNotFoundError", "VariableService"]

--- a/src/lfx/src/lfx/services/variable/exceptions.py
+++ b/src/lfx/src/lfx/services/variable/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions raised by variable services."""
+
+
+class VariableNotFoundError(ValueError):
+    """Raised when a requested variable does not exist."""

--- a/src/lfx/tests/unit/base/models/test_credentials_api_key_fail_closed.py
+++ b/src/lfx/tests/unit/base/models/test_credentials_api_key_fail_closed.py
@@ -1,10 +1,12 @@
 """Fail-closed tests for database-backed primary API key resolution."""
 
+import re
 from contextlib import asynccontextmanager
 from uuid import UUID
 
 import pytest
 from lfx.base.models.unified_models import credentials
+from lfx.services.variable import VariableNotFoundError
 
 _USER_ID = UUID("11111111-1111-1111-1111-111111111111")
 
@@ -18,17 +20,50 @@ async def _session_scope():
     yield object()
 
 
-class _PoolExhaustedVariableService:
+class _FailingVariableService:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
     async def get_variable(self, **_kwargs):
-        raise DatabasePoolTimeoutError
+        raise self.error
+
+
+def _configure_lookup(monkeypatch, error: Exception) -> None:
+    monkeypatch.setattr(credentials, "get_provider_secret_variable_key", lambda _provider: "OPENAI_API_KEY")
+    monkeypatch.setattr(credentials, "get_provider_all_variables", lambda _provider: [])
+    monkeypatch.setattr(credentials, "get_variable_service", lambda: _FailingVariableService(error))
+    monkeypatch.setattr(credentials, "session_scope", _session_scope)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")  # pragma: allowlist secret
 
 
 def test_api_key_read_error_does_not_fall_back_to_env(monkeypatch):
     """An unexpected DB error must propagate instead of silently resolving the process-wide env key."""
-    monkeypatch.setattr(credentials, "get_provider_secret_variable_key", lambda _provider: "OPENAI_API_KEY")
-    monkeypatch.setattr(credentials, "get_variable_service", _PoolExhaustedVariableService)
-    monkeypatch.setattr(credentials, "session_scope", _session_scope)
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")  # pragma: allowlist secret
+    _configure_lookup(monkeypatch, DatabasePoolTimeoutError())
 
     with pytest.raises(DatabasePoolTimeoutError):
         credentials.get_api_key_for_provider(_USER_ID, "OpenAI")
+
+
+@pytest.mark.parametrize("api_key", [None, "OPENAI_API_KEY"], ids=["primary", "named"])
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Could not decrypt credential variable 'OPENAI_API_KEY'.",
+        "Multiple shared variables named 'OPENAI_API_KEY' are visible.",
+    ],
+    ids=["decrypt-failure", "ambiguous-shares"],
+)
+def test_api_key_value_error_does_not_fall_back_to_env(monkeypatch, api_key, error_message):
+    """A non-missing ValueError must propagate instead of resolving the process-wide env key."""
+    _configure_lookup(monkeypatch, ValueError(error_message))
+
+    with pytest.raises(ValueError, match=re.escape(error_message)):
+        credentials.get_api_key_for_provider(_USER_ID, "OpenAI", api_key)
+
+
+@pytest.mark.parametrize("api_key", [None, "OPENAI_API_KEY"], ids=["primary", "named"])
+def test_api_key_not_found_still_falls_back_to_env(monkeypatch, api_key):
+    """A missing database variable must preserve the documented environment fallback."""
+    _configure_lookup(monkeypatch, VariableNotFoundError("OPENAI_API_KEY variable not found."))
+
+    assert credentials.get_api_key_for_provider(_USER_ID, "OpenAI", api_key) == "sk-from-env"

--- a/src/lfx/tests/unit/base/models/test_credentials_api_key_fail_closed.py
+++ b/src/lfx/tests/unit/base/models/test_credentials_api_key_fail_closed.py
@@ -1,0 +1,34 @@
+"""Fail-closed tests for database-backed primary API key resolution."""
+
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+import pytest
+from lfx.base.models.unified_models import credentials
+
+_USER_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+class DatabasePoolTimeoutError(Exception):
+    """Model the timeout raised while acquiring a database connection."""
+
+
+@asynccontextmanager
+async def _session_scope():
+    yield object()
+
+
+class _PoolExhaustedVariableService:
+    async def get_variable(self, **_kwargs):
+        raise DatabasePoolTimeoutError
+
+
+def test_api_key_read_error_does_not_fall_back_to_env(monkeypatch):
+    """An unexpected DB error must propagate instead of silently resolving the process-wide env key."""
+    monkeypatch.setattr(credentials, "get_provider_secret_variable_key", lambda _provider: "OPENAI_API_KEY")
+    monkeypatch.setattr(credentials, "get_variable_service", _PoolExhaustedVariableService)
+    monkeypatch.setattr(credentials, "session_scope", _session_scope)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")  # pragma: allowlist secret
+
+    with pytest.raises(DatabasePoolTimeoutError):
+        credentials.get_api_key_for_provider(_USER_ID, "OpenAI")


### PR DESCRIPTION
Follow-up to #14783, closing the second occurrence of the same fail-open pattern flagged in that PR's review.

## Problem

`get_api_key_for_provider` wrapped its DB read in a broad catch:

```python
try:
    api_key = run_until_complete(_get_variable())
except (ValueError, Exception):  # noqa: BLE001
    api_key = None
```

The inner `_get_variable` already returns `None` for the expected variable-not-found case (`except ValueError`), so this outer handler only ever swallowed **unexpected** infrastructure errors — e.g. a connection-pool acquisition timeout. Swallowing them silently switches the resolved credential from the user's per-user encrypted DB variable to the process-wide `.env` key, violating the "DB must win over .env" invariant documented at the top of this function. In multi-tenant deploys that means a transient DB hiccup can quietly bill a request to the server-wide shared key (or a stale/revoked one).

## Fix

Remove the outer broad catch so unexpected errors propagate (same shape as #14783). The not-found → env fallback path is unchanged, and `_resolve_var_name`'s sibling `run_until_complete` call already propagated, so the two DB read paths in this function now behave consistently.

## Test plan

- [x] New RED-first test `src/lfx/tests/unit/base/models/test_credentials_api_key_fail_closed.py`: raises a pool-timeout error from `get_variable` with `OPENAI_API_KEY` present in the environment, and asserts the error propagates out of `get_api_key_for_provider` instead of the env key being returned. Fails with `DID NOT RAISE` before the fix, passes after.
- [x] `tests/unit/base/models/` in isolated lfx venv: 406 passed
- [x] Other `get_api_key_for_provider` consumers (`tests/unit/components/agentics/test_llm_setup.py`, `tests/unit/cli/test_serve_app.py`): 96 passed
- [x] ruff format + check clean

The test lives in its own file (rather than #14783's `test_credentials_fail_closed.py`) so the two PRs merge independently in either order without an add/add conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Primary API key lookup errors are now surfaced instead of being treated as missing credentials.
  * Prevents fallback to environment-based API keys when the credential database is unavailable or times out.

* **Tests**
  * Added coverage verifying that database timeout errors propagate correctly during API key resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->