### PR TITLE
feat(bundles): add Volcengine Ark bundle component

### DIFF
--- a/docs/docs/Components/bundles-volcengine.mdx
+++ b/docs/docs/Components/bundles-volcengine.mdx
@@ -1,0 +1,46 @@
+---
+title: Volcengine Ark
+slug: /bundles-volcengine
+---
+
+import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
+import PartialLfxBundlesInstall from '@site/docs/_partial-bundle-lfx-bundles-install.mdx';
+
+<PartialLfxBundlesInstall />
+
+<Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
+
+This page describes the components that are available in the **Volcengine Ark** bundle.
+
+Volcengine Ark serves ByteDance's Doubao models over an OpenAI-compatible API. For more information, see the [Volcengine Ark documentation](https://www.volcengine.com/docs/82379/1099455).
+
+## Volcengine Ark text generation
+
+The **Volcengine Ark** component generates text using ByteDance's Doubao models.
+
+It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
+
+Use the **Language Model** output when you want to use a Doubao model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Transform** component.
+
+For more information, see [Language model components](/components-models).
+
+:::important
+Ark only resolves fully versioned model IDs. The short names shown in the Volcengine console, such as `doubao-seed-2.1-pro`, return `InvalidEndpointOrModel.NotFound`. Use the dated IDs offered in the **Model Name** list, for example `doubao-seed-2-1-pro-260628`. The only unversioned ID that resolves is `doubao-seed-evolving`.
+:::
+
+### Volcengine Ark text generation parameters
+
+<PartialParams />
+
+| Name | Type | Description |
+|------|------|-------------|
+| max_tokens | Integer | Input parameter. Maximum number of tokens to generate. Set to `0` for unlimited. Range: `0-128000`. |
+| model_kwargs | Dictionary | Input parameter. Additional keyword arguments for the model. |
+| json_mode | Boolean | Input parameter. If `true`, outputs JSON regardless of passing a schema. |
+| model_name | String | Input parameter. The Volcengine Ark model to use. Default: `doubao-seed-2-1-pro-260628`. |
+| api_base | String | Input parameter. Base URL for API requests. Default: `https://ark.cn-beijing.volces.com/api/v3`. |
+| api_key | SecretString | Input parameter. Your Volcengine Ark API key for authentication. |
+| temperature | Float | Input parameter. Controls randomness in responses. Range: `[0.0, 2.0]`. Default: `1.0`. |
+| reasoning_effort | String | Input parameter. Depth of thinking. Support is per-model: the Doubao entries accept `none` through `max`, where `none` and `minimal` both switch thinking off. Leave empty to use the model default. |
+| seed | Integer | Input parameter. Number initialized for random number generation. Use the same seed integer for more reproducible results, and use a different seed number for more random results. |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -563,6 +563,7 @@ module.exports = {
             "Components/bundles-vectara",
             "Components/bundles-vertexai",
             "Components/bundles-vllm",
+            "Components/bundles-volcengine",
             "Components/bundles-weaviate",
             "Components/bundles-wikipedia",
             "Components/bundles-xai",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ Documentation = "https://docs.langflow.org"
 
 [project.optional-dependencies]
 bundles = [
-    "lfx-bundles[all-no-torch]>=1.1.16,<2.0",
+    "lfx-bundles[all-no-torch]>=1.1.17,<2.0",
     "lfx-arxiv>=0.1.0,<1.0.0",
     "lfx-confluent>=0.1.0,<1.0.0",
     "lfx-duckduckgo>=0.1.0,<1.0.0",

--- a/scripts/ci/release_inventory_contract.json
+++ b/scripts/ci/release_inventory_contract.json
@@ -297,6 +297,7 @@
         "vectara",
         "vertexai",
         "vlmrun",
+        "volcengine",
         "weaviate",
         "wikipedia",
         "wolframalpha",

--- a/src/backend/tests/unit/components/languagemodels/test_volcengine.py
+++ b/src/backend/tests/unit/components/languagemodels/test_volcengine.py
@@ -1,0 +1,123 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("lfx_bundles")
+
+from lfx.custom.custom_component.component import Component
+from lfx.custom.utils import build_custom_component_template
+from lfx_bundles.volcengine.volcengine import (
+    VOLCENGINE_MODELS,
+    VolcengineModelComponent,
+)
+
+
+def test_volcengine_initialization():
+    component = VolcengineModelComponent()
+    assert component.display_name == "Volcengine Ark"
+    assert component.icon == "Volcengine"
+
+
+def test_volcengine_template():
+    volcengine = VolcengineModelComponent()
+    component = Component(_code=volcengine._code)
+    frontend_node, _ = build_custom_component_template(component)
+
+    assert isinstance(frontend_node, dict)
+    assert "template" in frontend_node
+    input_names = [input_["name"] for input_ in frontend_node["template"].values() if isinstance(input_, dict)]
+
+    expected_inputs = [
+        "max_tokens",
+        "model_kwargs",
+        "json_mode",
+        "model_name",
+        "api_base",
+        "api_key",
+        "temperature",
+        "reasoning_effort",
+        "seed",
+    ]
+
+    for input_name in expected_inputs:
+        assert input_name in input_names
+
+
+def test_volcengine_model_ids_are_fully_versioned():
+    """Ark 404s on the console's short names, so no bare family name may ship.
+
+    doubao-seed-evolving is the one unversioned alias that resolves.
+    """
+    for model_id in VOLCENGINE_MODELS:
+        if model_id == "doubao-seed-evolving":
+            continue
+        suffix = model_id.rsplit("-", 1)[-1]
+        assert suffix.isdigit(), f"{model_id} is missing a dated version suffix"
+        assert "." not in model_id, f"{model_id} looks like a console short name"
+
+
+def test_get_models_drops_internal_entries():
+    """/models is a dirty superset: prefix matching alone leaves dev/test builds."""
+    component = VolcengineModelComponent()
+    component.api_key = "test-key-not-real"
+    component.api_base = "https://ark.cn-beijing.volces.com/api/v3"
+
+    payload = {
+        "data": [
+            {"id": "doubao-seed-2-1-pro-260628"},
+            {"id": "doubao-seed-1-6-flash-dev-test"},
+            {"id": "doubao-seed-2-0-mini-mtp-train-test"},
+            {"id": "doubao-seed-evolving"},
+            {"id": "test-v1"},
+            {"id": "ddd-1.0.0"},
+        ]
+    }
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "lfx_bundles.volcengine.volcengine.ssrf_safe_httpx_get",
+            lambda *_args, **_kwargs: response,
+        )
+        models = component.get_models()
+
+    assert models == ["doubao-seed-2-1-pro-260628", "doubao-seed-evolving"]
+
+
+def test_get_models_falls_back_without_api_key():
+    component = VolcengineModelComponent()
+    component.api_key = ""
+    assert component.get_models() == VOLCENGINE_MODELS
+
+
+@pytest.fixture
+def mock_chat_openai(mocker):
+    return mocker.patch("langchain_openai.ChatOpenAI")
+
+
+def test_reasoning_effort_is_passed_through(mock_chat_openai):
+    """Ark grades thinking via reasoning_effort; unset must not send the key.
+
+    It goes in as a first-class ChatOpenAI field, not via model_kwargs, which warns.
+    """
+    component = VolcengineModelComponent()
+    component.api_key = "test-key-not-real"
+    component.api_base = "https://ark.cn-beijing.volces.com/api/v3"
+    component.model_name = VOLCENGINE_MODELS[0]
+    component.max_tokens = 100
+    component.temperature = 1.0
+    component.seed = 1
+    component.json_mode = False
+    component.model_kwargs = {}
+
+    component.reasoning_effort = "high"
+    component.build_model()
+    kwargs = mock_chat_openai.call_args.kwargs
+    assert kwargs["reasoning_effort"] == "high"
+    assert "reasoning_effort" not in kwargs["model_kwargs"]
+
+    component.reasoning_effort = ""
+    component.build_model()
+    assert "reasoning_effort" not in mock_chat_openai.call_args.kwargs

--- a/src/backend/tests/unit/components/languagemodels/test_volcengine.py
+++ b/src/backend/tests/unit/components/languagemodels/test_volcengine.py
@@ -86,6 +86,38 @@ def test_get_models_drops_internal_entries():
     assert models == ["doubao-seed-2-1-pro-260628", "doubao-seed-evolving"]
 
 
+@pytest.mark.parametrize(
+    ("payload", "side_effect"),
+    [
+        (None, ValueError("Expecting value: line 1 column 1 (char 0)")),
+        (["not", "a", "dict"], None),
+        ({"data": [{"name": "missing-id-field"}]}, None),
+        ({"data": None}, None),
+    ],
+)
+def test_get_models_survives_bad_payloads(payload, side_effect):
+    """A 200 can still carry unparseable or oddly shaped JSON; refresh must not break."""
+    component = VolcengineModelComponent()
+    component.api_key = "test-key-not-real"
+    component.api_base = "https://ark.cn-beijing.volces.com/api/v3"
+
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    if side_effect is not None:
+        response.json.side_effect = side_effect
+    else:
+        response.json.return_value = payload
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "lfx_bundles.volcengine.volcengine.ssrf_safe_httpx_get",
+            lambda *_args, **_kwargs: response,
+        )
+        models = component.get_models()
+
+    assert models == VOLCENGINE_MODELS
+
+
 def test_get_models_falls_back_without_api_key():
     component = VolcengineModelComponent()
     component.api_key = ""

--- a/src/backend/tests/unit/components/test_bundle_ssrf_wiring.py
+++ b/src/backend/tests/unit/components/test_bundle_ssrf_wiring.py
@@ -53,6 +53,7 @@ GUARDED_MODULES: dict[str, set[str]] = {
     "litellm/litellm_proxy.py": {"ssrf_safe_httpx_get", "ssrf_protected_openai_clients_for_url"},
     "lmstudio/lmstudioembeddings.py": {"ssrf_safe_async_get", "validate_url_for_ssrf_or_raise"},
     "lmstudio/lmstudiomodel.py": {"ssrf_safe_async_get", "ssrf_protected_openai_clients_for_url"},
+    "volcengine/volcengine.py": {"ssrf_safe_httpx_get", "ssrf_protected_openai_clients_for_url"},
     "xai/xai.py": {"ssrf_safe_httpx_get", "ssrf_protected_openai_clients_for_url"},
 }
 

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-bundles"
-version = "1.1.16"
+version = "1.1.17"
 description = "Langflow's long-tail provider bundles as a single manifest-less metapackage (the langchain-community model)."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -94,6 +94,7 @@ upstash = ["upstash-vector==0.6.0", "langchain-community>=0.4.1,<1.0.0"]
 vectara = ["langchain-community>=0.4.1,<1.0.0"]
 vertexai = ["langchain-google-vertexai>=3.2.0"]
 vlmrun = ["vlmrun[all]>=0.2.0"]
+volcengine = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0", "requests>=2.32.0"]
 weaviate = ["weaviate-client>=4.10.2,<5.0.0", "langchain-weaviate>=0.0.6"]
 wikipedia = ["wikipedia==1.4.0", "langchain-community>=0.4.1,<1.0.0"]
 wolframalpha = ["wolframalpha==5.1.3", "langchain-community>=0.4.1,<1.0.0"]
@@ -164,6 +165,7 @@ all = [
     "lfx-bundles[vectara]",
     "lfx-bundles[vertexai]",
     "lfx-bundles[vlmrun]",
+    "lfx-bundles[volcengine]",
     "lfx-bundles[weaviate]",
     "lfx-bundles[wikipedia]",
     "lfx-bundles[wolframalpha]",
@@ -233,6 +235,7 @@ all-no-torch = [
     "lfx-bundles[vectara]",
     "lfx-bundles[vertexai]",
     "lfx-bundles[vlmrun]",
+    "lfx-bundles[volcengine]",
     "lfx-bundles[weaviate]",
     "lfx-bundles[wikipedia]",
     "lfx-bundles[wolframalpha]",

--- a/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/__init__.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/__init__.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.utils.lazy_import import import_mod
+
+if TYPE_CHECKING:
+    from .volcengine import VolcengineModelComponent
+
+_dynamic_imports = {
+    "VolcengineModelComponent": "volcengine",
+}
+
+__all__ = [
+    "VolcengineModelComponent",
+]
+
+
+def __getattr__(attr_name: str) -> Any:
+    """Lazily import volcengine components on attribute access."""
+    if attr_name not in _dynamic_imports:
+        msg = f"module '{__name__}' has no attribute '{attr_name}'"
+        raise AttributeError(msg)
+    try:
+        result = import_mod(attr_name, _dynamic_imports[attr_name], __spec__.parent)
+    except (ModuleNotFoundError, ImportError, AttributeError) as e:
+        msg = f"Could not import '{attr_name}' from '{__name__}': {e}"
+        raise AttributeError(msg) from e
+    globals()[attr_name] = result
+    return result
+
+
+def __dir__() -> list[str]:
+    return list(__all__)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/volcengine.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/volcengine.py
@@ -123,12 +123,21 @@ class VolcengineModelComponent(LCModelComponent):
             response = ssrf_safe_httpx_get(url, headers=headers, timeout=10)
             response.raise_for_status()
             model_list = response.json()
-            listed = [model["id"] for model in model_list.get("data", [])]
+            if not isinstance(model_list, dict):
+                msg = f"expected a JSON object, got {type(model_list).__name__}"
+                raise TypeError(msg)
+            data = model_list.get("data") or []
+            listed = [model["id"] for model in data if isinstance(model, dict) and "id" in model]
         except SSRFProtectionError as e:
             self.status = f"SSRF Protection: {e}"
             return VOLCENGINE_MODELS
         except httpx.HTTPError as e:
             self.status = f"Error fetching models: {e}"
+            return VOLCENGINE_MODELS
+        except (TypeError, ValueError) as e:
+            # A 200 can still carry unparseable or unexpectedly shaped JSON; keep the
+            # picker working instead of letting it break the refresh.
+            self.status = f"Unexpected model list payload: {e}"
             return VOLCENGINE_MODELS
         else:
             # Keep the catalogue usable: see VOLCENGINE_SUPPORTED_MODELS above.

--- a/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/volcengine.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/volcengine/volcengine.py
@@ -1,0 +1,190 @@
+import httpx
+from lfx.base.models.model import LCModelComponent
+from lfx.field_typing import LanguageModel
+from lfx.field_typing.range_spec import RangeSpec
+from lfx.inputs.inputs import BoolInput, DictInput, DropdownInput, IntInput, SecretStrInput, SliderInput, StrInput
+from lfx.utils.ssrf_httpx import ssrf_protected_openai_clients_for_url, ssrf_safe_httpx_get
+from lfx.utils.ssrf_protection import SSRFProtectionError
+from pydantic.v1 import SecretStr
+from typing_extensions import override
+
+# Ark only resolves fully versioned model IDs. The console's short names
+# (e.g. "doubao-seed-2.1-pro") return InvalidEndpointOrModel.NotFound, and
+# "doubao-seed-evolving" is the sole unversioned alias that resolves. Each ID
+# below was verified against POST /api/v3/chat/completions on 2026-08-27.
+VOLCENGINE_MODELS = [
+    "doubao-seed-2-1-pro-260628",
+    "doubao-seed-2-1-turbo-260628",
+    "doubao-seed-2-0-pro-260215",
+    "doubao-seed-2-0-lite-260428",
+    "doubao-seed-2-0-mini-260428",
+    "doubao-seed-2-0-code-preview-260215",
+    "doubao-seed-1-8-251228",
+    "doubao-seed-1-6-251015",
+    "doubao-seed-1-6-flash-250828",
+    "doubao-seed-1-6-vision-250815",
+    "doubao-seed-character-260628",
+    "doubao-seed-evolving",
+]
+
+# GET /models is a dirty superset: it returned 523 entries on 2026-08-27, most of
+# them internal or unreleased, and being listed does not imply the model is
+# callable — doubao-seed-1-6-thinking-250715 appears there but 404s on chat.
+# Filtering by the "doubao-seed-" prefix alone still leaves 72 entries including
+# doubao-seed-1-6-flash-dev-test and doubao-seed-2-0-mini-mtp-train-test, so the
+# live list is intersected with the verified IDs above and only ever narrows it.
+VOLCENGINE_SUPPORTED_MODELS = frozenset(VOLCENGINE_MODELS)
+
+
+class VolcengineModelComponent(LCModelComponent):
+    display_name = "Volcengine Ark"
+    description = "Generate text using ByteDance Doubao models on Volcengine Ark."
+    icon = "Volcengine"
+
+    inputs = [
+        *LCModelComponent.get_base_inputs(),
+        IntInput(
+            name="max_tokens",
+            display_name="Max Tokens",
+            advanced=True,
+            info="Maximum number of tokens to generate. Set to 0 for unlimited.",
+            range_spec=RangeSpec(min=0, max=128000),
+        ),
+        DictInput(
+            name="model_kwargs",
+            display_name="Model Kwargs",
+            advanced=True,
+            info="Additional keyword arguments to pass to the model.",
+        ),
+        BoolInput(
+            name="json_mode",
+            display_name="JSON Mode",
+            advanced=True,
+            info="If True, it will output JSON regardless of passing a schema.",
+        ),
+        DropdownInput(
+            name="model_name",
+            display_name="Model Name",
+            info="Volcengine Ark model to use. IDs need their full version suffix.",
+            options=VOLCENGINE_MODELS,
+            value=VOLCENGINE_MODELS[0],
+            refresh_button=True,
+        ),
+        StrInput(
+            name="api_base",
+            display_name="Volcengine Ark API Base",
+            advanced=True,
+            info="Base URL for API requests. Defaults to https://ark.cn-beijing.volces.com/api/v3",
+            value="https://ark.cn-beijing.volces.com/api/v3",
+        ),
+        SecretStrInput(
+            name="api_key",
+            display_name="Volcengine Ark API Key",
+            info="The Volcengine Ark API Key",
+            advanced=False,
+            required=True,
+        ),
+        SliderInput(
+            name="temperature",
+            display_name="Temperature",
+            info="Controls randomness in responses",
+            value=1.0,
+            range_spec=RangeSpec(min=0, max=2, step=0.01),
+            advanced=True,
+        ),
+        DropdownInput(
+            name="reasoning_effort",
+            display_name="Reasoning Effort",
+            info=(
+                "Depth of thinking. Support is per-model: the Doubao entries take none through max, "
+                "where none and minimal both switch thinking off. Leave empty to use the model default."
+            ),
+            options=["", "none", "minimal", "low", "medium", "high", "xhigh", "max"],
+            value="",
+            advanced=True,
+        ),
+        IntInput(
+            name="seed",
+            display_name="Seed",
+            info="The seed controls the reproducibility of the job.",
+            advanced=True,
+            value=1,
+        ),
+    ]
+
+    def get_models(self) -> list[str]:
+        if not self.api_key:
+            return VOLCENGINE_MODELS
+
+        url = f"{self.api_base}/models"
+        headers = {"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"}
+
+        try:
+            response = ssrf_safe_httpx_get(url, headers=headers, timeout=10)
+            response.raise_for_status()
+            model_list = response.json()
+            listed = [model["id"] for model in model_list.get("data", [])]
+        except SSRFProtectionError as e:
+            self.status = f"SSRF Protection: {e}"
+            return VOLCENGINE_MODELS
+        except httpx.HTTPError as e:
+            self.status = f"Error fetching models: {e}"
+            return VOLCENGINE_MODELS
+        else:
+            # Keep the catalogue usable: see VOLCENGINE_SUPPORTED_MODELS above.
+            filtered = [m for m in VOLCENGINE_MODELS if m in set(listed) & VOLCENGINE_SUPPORTED_MODELS]
+            return filtered or VOLCENGINE_MODELS
+
+    @override
+    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):
+        if field_name in {"api_key", "api_base", "model_name"}:
+            models = self.get_models()
+            build_config["model_name"]["options"] = models
+        return build_config
+
+    def build_model(self) -> LanguageModel:
+        try:
+            from langchain_openai import ChatOpenAI
+        except ImportError as e:
+            msg = "langchain-openai not installed. Please install with `pip install langchain-openai`"
+            raise ImportError(msg) from e
+
+        api_key = SecretStr(self.api_key).get_secret_value() if self.api_key else None
+        ssrf_client_kwargs = ssrf_protected_openai_clients_for_url(self.api_base)
+
+        # reasoning_effort is a first-class ChatOpenAI field, so pass it directly
+        # rather than through model_kwargs (which warns). Ark rejects
+        # thinking.type=disabled sent alongside a graded effort, so the effort is
+        # the only thinking control exposed here.
+        extra_kwargs = {"reasoning_effort": self.reasoning_effort} if self.reasoning_effort else {}
+
+        output = ChatOpenAI(
+            model=self.model_name,
+            temperature=self.temperature if self.temperature is not None else 0.1,
+            max_tokens=self.max_tokens or None,
+            model_kwargs=self.model_kwargs or {},
+            base_url=self.api_base,
+            api_key=api_key,
+            streaming=self.stream if hasattr(self, "stream") else False,
+            seed=self.seed,
+            **extra_kwargs,
+            **ssrf_client_kwargs,
+        )
+
+        if self.json_mode:
+            output = output.bind(response_format={"type": "json_object"})
+
+        return output
+
+    def _get_exception_message(self, e: Exception):
+        """Get message from Volcengine Ark API exception."""
+        try:
+            from openai import BadRequestError
+
+            if isinstance(e, BadRequestError):
+                message = e.body.get("message")
+                if message:
+                    return message
+        except ImportError:
+            pass
+        return None

--- a/src/frontend/src/icons/Volcengine/VolcengineIcon.jsx
+++ b/src/frontend/src/icons/Volcengine/VolcengineIcon.jsx
@@ -1,0 +1,17 @@
+const VolcengineSVG = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 48 48"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M24 4 6 14v20l18 10 18-10V14L24 4Zm0 4.6 13.9 7.7L24 24 10.1 16.3 24 8.6ZM9.4 19.1 22.4 26v11.3L9.4 30.1V19.1Zm16.2 18.2V26l13-6.9v11L25.6 37.3Z"
+      fill={props.isDark ? "#4d7cff" : "#1664ff"}
+    />
+  </svg>
+);
+
+export default VolcengineSVG;

--- a/src/frontend/src/icons/Volcengine/index.tsx
+++ b/src/frontend/src/icons/Volcengine/index.tsx
@@ -1,0 +1,10 @@
+import type React from "react";
+import { forwardRef } from "react";
+import VolcengineSVG from "./VolcengineIcon";
+
+export const VolcengineIcon = forwardRef<
+  SVGSVGElement,
+  React.PropsWithChildren<{}>
+>((props, ref) => {
+  return <VolcengineSVG ref={ref} {...props} />;
+});

--- a/src/frontend/src/icons/lazyIconImports.ts
+++ b/src/frontend/src/icons/lazyIconImports.ts
@@ -520,6 +520,10 @@ export const lazyIconsMapping = {
     import("@/icons/vectorstores").then((mod) => ({
       default: mod.VectorStoresIcon,
     })),
+  Volcengine: () =>
+    import("@/icons/Volcengine").then((mod) => ({
+      default: mod.VolcengineIcon,
+    })),
   Windsurf: () =>
     import("@/icons/Windsurf").then((mod) => ({ default: mod.WindsurfIcon })),
   Wolfram: () =>

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -525,6 +525,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "vLLM", name: "vllm", icon: "vLLM" },
   { display_name: "Weaviate", name: "weaviate", icon: "Weaviate" },
   { display_name: "Vertex AI", name: "vertexai", icon: "VertexAI" },
+  { display_name: "Volcengine Ark", name: "volcengine", icon: "Volcengine" },
   { display_name: "Wikipedia", name: "wikipedia", icon: "Wikipedia" },
   {
     display_name: "WolframAlpha",

--- a/src/lfx/src/lfx/extension/migration/migration_table.json
+++ b/src/lfx/src/lfx/extension/migration/migration_table.json
@@ -4955,6 +4955,11 @@
       "bare_class_name": "MrscraperRunManualScraper",
       "target": "ext:mrscraper:MrscraperRunManualScraper@official",
       "added_in": "1.12.0"
+    },
+    {
+      "bare_class_name": "VolcengineModelComponent",
+      "target": "ext:volcengine:VolcengineModelComponent@official",
+      "added_in": "1.12.0"
     }
   ],
   "ambiguous_bare_names": [

--- a/uv.lock
+++ b/uv.lock
@@ -9393,7 +9393,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-bundles"
-version = "1.1.16"
+version = "1.1.17"
 source = { editable = "src/bundles/lfx-bundles" }
 dependencies = [
     { name = "lfx" },
@@ -9752,6 +9752,11 @@ vertexai = [
 vlmrun = [
     { name = "vlmrun", extra = ["all"] },
 ]
+volcengine = [
+    { name = "langchain-openai" },
+    { name = "openai" },
+    { name = "requests" },
+]
 weaviate = [
     { name = "langchain-weaviate" },
     { name = "weaviate-client" },
@@ -9847,6 +9852,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'novita'", specifier = ">=1.1.6" },
     { name = "langchain-openai", marker = "extra == 'openrouter'", specifier = ">=1.1.6" },
     { name = "langchain-openai", marker = "extra == 'orcarouter'", specifier = ">=1.1.6" },
+    { name = "langchain-openai", marker = "extra == 'volcengine'", specifier = ">=1.1.6" },
     { name = "langchain-openai", marker = "extra == 'xai'", specifier = ">=1.1.6" },
     { name = "langchain-perplexity", marker = "extra == 'perplexity'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-pinecone", marker = "python_full_version < '3.14' and extra == 'pinecone'", specifier = "~=0.2.13" },
@@ -9978,6 +9984,8 @@ requires-dist = [
     { name = "lfx-bundles", extras = ["vertexai"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["vlmrun"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["vlmrun"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
+    { name = "lfx-bundles", extras = ["volcengine"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
+    { name = "lfx-bundles", extras = ["volcengine"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["weaviate"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["weaviate"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["wikipedia"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
@@ -10003,6 +10011,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'deepseek'", specifier = ">=1.68.2,<3.0.0" },
     { name = "openai", marker = "extra == 'litellm'", specifier = ">=1.68.2,<3.0.0" },
     { name = "openai", marker = "extra == 'lmstudio'", specifier = ">=1.68.2,<3.0.0" },
+    { name = "openai", marker = "extra == 'volcengine'", specifier = ">=1.68.2,<3.0.0" },
     { name = "openai", marker = "extra == 'xai'", specifier = ">=1.68.2,<3.0.0" },
     { name = "opendsstar", marker = "(python_full_version >= '3.11' and python_full_version < '3.14' and platform_machine != 'x86_64' and extra == 'codeagents') or (python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'codeagents')", specifier = "==1.0.26" },
     { name = "opensearch-py", marker = "extra == 'elastic'", specifier = "==2.8.0" },
@@ -10018,6 +10027,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'icosacomputing'", specifier = ">=2.32.0" },
     { name = "requests", marker = "extra == 'notion'", specifier = ">=2.32.0" },
     { name = "requests", marker = "extra == 'novita'", specifier = ">=2.32.0" },
+    { name = "requests", marker = "extra == 'volcengine'", specifier = ">=2.32.0" },
     { name = "requests", marker = "extra == 'xai'", specifier = ">=2.32.0" },
     { name = "scrapegraph-py", marker = "extra == 'scrapegraph'", specifier = ">=1.12.0" },
     { name = "smolagents", marker = "extra == 'codeagents'", specifier = ">=1.8.0" },
@@ -10033,7 +10043,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "mrscraper", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "orcarouter", "perplexity", "pgvector", "pinecone", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
+provides-extras = ["agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "mrscraper", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "orcarouter", "perplexity", "pgvector", "pinecone", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "volcengine", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
 
 [[package]]
 name = "lfx-cohere"


### PR DESCRIPTION
## Summary

Adds a **Volcengine Ark** bundle so Langflow can drive ByteDance's Doubao models. Ark exposes an OpenAI-compatible `/chat/completions` endpoint, so the component builds a `ChatOpenAI` through this repo's SSRF-guarded client helpers (`ssrf_protected_openai_clients_for_url`, `ssrf_safe_httpx_get`) rather than pulling in a new SDK.

Structure follows #14549 (OrcaRouter): bundle package + extra, release inventory entry, migration-table entry, icon, docs page, and sidebar entry. No `src/lfx/components/volcengine` shim — that layer is the deprecation path being removed at M4, and #14549 didn't add one either.

### Model discovery is filtered, deliberately

`GET /models` is a dirty superset. When checked it returned **523 entries**, most internal or unreleased, and being listed does **not** mean the model is callable — `doubao-seed-1-6-thinking-250715` appears there but returns `404 InvalidEndpointOrModel.NotFound` on chat.

Filtering by the `doubao-seed-` prefix alone still left **72** entries, including `doubao-seed-1-6-flash-dev-test`, `doubao-seed-2-0-lite-code-test-1` and `doubao-seed-2-0-mini-mtp-train-test`. So the live list is intersected with the verified IDs and only ever narrows the catalogue. Against the real API this yields exactly the 12 shipped models.

Happy to switch to a plain static list if you'd prefer not to call `/models` at all — the allowlist is already the source of truth either way.

### Model IDs need full version suffixes

The console's short names 404: `doubao-seed-2.1-pro` → `404`, `doubao-seed-2-1-pro-260628` → `200`. `doubao-seed-evolving` is the only unversioned alias that resolves. `test_volcengine_model_ids_are_fully_versioned` guards this so a bare family name can't ship.

### reasoning_effort

Exposed as an advanced input and passed as a **first-class `ChatOpenAI` field** — routing it through `model_kwargs` works but emits `Parameters {'reasoning_effort'} should be specified explicitly`. Ark rejects `thinking.type=disabled` sent alongside a graded effort, so the effort is the only thinking control offered. Measured on `doubao-seed-2-1-pro-260628`: `low` → 61 reasoning tokens, `high` → 107, while `none`/`minimal` both return 0 and switch thinking off.

## How to test

1. Get an Ark API key from the [Volcengine console](https://console.volcengine.com/ark).
2. Add the **Volcengine Ark** component to a flow, paste the key, leave **Volcengine Ark API Base** at its default.
3. Click refresh on **Model Name** — the list should show exactly the 12 Doubao models, with none of Ark's `-dev-test` / `-mtp-train-test` builds.
4. Run the flow and confirm a response. Optionally set **Reasoning Effort** to `high` and confirm reasoning tokens appear in usage.

**Tests:** `src/backend/tests/unit/components/languagemodels/test_volcengine.py` — 6 cases covering init, template inputs, ID versioning, discovery filtering, the no-API-key fallback, and `reasoning_effort` passthrough. **6 passed.** `ruff check` and `ruff format --check` are clean, and the local pre-commit hooks pass (`extension-migration-append-only`, `extension-migration-bare-names`, `bundle-api-changelog`, `component-env-writes`, `logged-exception-text`, `extension-router-trust`).

I mutation-checked the two behavioural tests: replacing the allowlist intersection with prefix matching fails `test_get_models_drops_internal_entries`, and always sending `reasoning_effort` fails `test_reasoning_effort_is_passed_through`.

**Real end-to-end** through the shipped `build_model()` against the live API: text returned `pong` (usage 52 in / 31 out, `reasoning: 29`), live discovery returned the 12 models above, and `reasoning_effort="high"` answered a quadratic correctly.

One gap to flag: I couldn't run biome locally (frontend `node_modules` isn't installed in my environment), so the 4 frontend files are hand-matched to the existing `DeepSeek` icon pattern — brackets balance and the icon name is consistent across `lazyIconImports.ts`, `styleUtils.ts`, the exported `VolcengineIcon`, and the Python `icon` attribute. Please let CI's biome check be the arbiter there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Volcengine Ark support for ByteDance Doubao language models.
  * Added model selection, configurable generation parameters, JSON mode, reasoning controls, and dynamic model discovery.
  * Added Volcengine Ark to the bundle sidebar with a dedicated icon.
* **Documentation**
  * Added setup and configuration documentation, including model ID requirements.
* **Bug Fixes**
  * Improved model discovery fallback when live model information is unavailable.
* **Maintenance**
  * Updated bundle packaging and migration support for the new integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->