### PR TITLE
fix(tools): bind dynamic outputs to invocation copies

### DIFF
--- a/src/lfx/src/lfx/base/tools/component_tool.py
+++ b/src/lfx/src/lfx/base/tools/component_tool.py
@@ -102,6 +102,21 @@ def patch_components_send_message(component: Component):
     return old_send_message
 
 
+def _get_output_method_from_copy(component: Component, output_method: Callable, method_name: str) -> Callable:
+    """Resolve an output method against the per-invocation component copy."""
+    if local_method := getattr(component, method_name, None):
+        return local_method
+
+    # Runtime-generated methods (for example RunFlow's dynamic output
+    # resolvers) are not present on the instance reconstructed by
+    # Component.__deepcopy__. Rebind the captured method function so inputs set
+    # on the isolated copy are also read from that copy during execution.
+    if method_function := getattr(output_method, "__func__", None):
+        return method_function.__get__(component, type(component))
+
+    return output_method
+
+
 def _build_output_function(
     component: Component,
     output_method: Callable,
@@ -125,7 +140,7 @@ def _build_output_function(
         # overlapping calls: the second call recorded the first call's no-op as the method
         # to restore, and restored it once the first call had put the real one back.
         # Suppressing the tool run's own messages is a separate change, tracked on its own.
-        local_method = getattr(comp, method_name, output_method)
+        local_method = _get_output_method_from_copy(comp, output_method, method_name)
         build_started = False
         result = None
         try:
@@ -183,7 +198,7 @@ def _build_output_async_function(
         # tool is invoked concurrently by an agent (GitHub issue #8791)
         comp = deepcopy(component)
         # See _build_output_function: a tool call must not patch send_message anywhere.
-        local_method = getattr(comp, method_name, output_method)
+        local_method = _get_output_method_from_copy(comp, output_method, method_name)
         build_started = False
         result = None
         try:

--- a/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
+++ b/src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py
@@ -9,8 +9,14 @@ import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from types import MethodType
 
-from lfx.base.tools.component_tool import ComponentToolkit, send_message_noop
+from lfx.base.tools.component_tool import (
+    ComponentToolkit,
+    _build_output_async_function,
+    _build_output_function,
+    send_message_noop,
+)
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import DataInput, MessageTextInput
 from lfx.io import Output
@@ -52,6 +58,46 @@ class SlowLabelComponent(Component):
                 "label_after": self.label,
             }
         )
+
+
+class RuntimeOutputComponent(Component):
+    """Component whose declared output can be replaced at runtime."""
+
+    display_name = "Runtime Output"
+    description = "Returns the invocation input."
+    inputs = [MessageTextInput(name="input_value", display_name="Input", value="original", tool_mode=True)]
+    outputs = [Output(display_name="Result", name="result", method="static_output")]
+
+    def static_output(self) -> str:
+        return self.input_value
+
+
+def test_runtime_bound_sync_output_executes_on_component_copy():
+    """Runtime output methods must read inputs from the isolated invocation copy."""
+    component = RuntimeOutputComponent()
+
+    def runtime_output(self) -> str:
+        return self.input_value
+
+    component.runtime_output = MethodType(runtime_output, component)
+    output_function = _build_output_function(component, component.runtime_output)
+
+    assert output_function(input_value="tool input") == "tool input"
+    assert component.input_value == "original"
+
+
+async def test_runtime_bound_async_output_executes_on_component_copy():
+    """Async RunFlow-style resolvers must not fall back to the original component."""
+    component = RuntimeOutputComponent()
+
+    async def runtime_output(self) -> str:
+        return self.input_value
+
+    component.runtime_output = MethodType(runtime_output, component)
+    output_function = _build_output_async_function(component, component.runtime_output)
+
+    assert await output_function(input_value="tool input") == "tool input"
+    assert component.input_value == "original"
 
 
 def test_should_isolate_inputs_when_tool_invoked_concurrently():


### PR DESCRIPTION
## Summary

- rebind runtime-generated component output methods to the isolated per-invocation component copy
- ensure RunFlow tool-mode arguments are read from the same copy they are written to
- add sync and async regression coverage for dynamically bound output methods

## Root cause

`ComponentToolkit` deep-copies a component for every tool invocation, then resolves the output method by name. RunFlow registers its output resolvers dynamically on the original instance, so the copied instance does not contain that method. The fallback therefore remained bound to the original component: tool arguments were written to the copy, while execution read stale/default values from the original.

The fix rebinds the captured bound method's function to the copied component when the runtime-generated method is absent from that copy.

## Tests

- `pytest src/lfx/tests/unit/custom/component/test_concurrent_tool_invocation.py -q` (12 passed)
- `pytest src/lfx/tests/unit/base/tools/test_run_flow.py -q` (1 passed)
- `pytest src/lfx/tests/unit/custom/component/test_tool_dataframe_return.py src/lfx/tests/unit/custom/component/test_tool_name_fallback.py -q` (20 passed)
- `ruff check` and `ruff format --check` for the changed files

Fixes #14791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent tool execution so synchronous and asynchronous operations consistently use isolated invocation state.
  - Fixed runtime-generated output methods to read inputs from the correct execution copy, helping prevent state from leaking between simultaneous invocations.

- **Tests**
  - Added coverage for runtime-bound synchronous and asynchronous output methods during concurrent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->