### PR TITLE
fix(store): stop a Langflow Store outage from breaking the app

### DIFF
--- a/src/backend/base/langflow/api/v1/store.py
+++ b/src/backend/base/langflow/api/v1/store.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from lfx.log.logger import logger
 
@@ -147,6 +148,13 @@ async def get_tags():
         return await get_store_service().get_tags()
     except CustomError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except httpx.TransportError as exc:
+        # The store is a third-party service and the visual editor asks for tags on
+        # every app boot, so an unreachable upstream must not read as a fault of this
+        # server. Tags only decorate a filter, so degrade to none and keep 500 for
+        # failures that ARE ours.
+        await logger.awarning(f"Langflow Store unreachable; serving no tags: {exc}")
+        return []
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/src/backend/tests/unit/api/v1/test_store_tags_outage.py
+++ b/src/backend/tests/unit/api/v1/test_store_tags_outage.py
@@ -1,0 +1,74 @@
+"""A Langflow Store outage must not surface as a server fault.
+
+``GET /api/v1/store/tags`` proxies a third-party service. Every route in
+``store.py`` funnels an unreachable upstream into a bare ``except Exception`` and
+answers ``500``, and the visual editor calls this one on **every** app boot, on
+every route. When ``api.langflow.store`` started serving a certificate for
+``*.<id>.us-east-1.cs.amazonlightsail.com`` instead of its own hostname, that
+turned into a 500 on every page load and wiped the whole Playwright suite, whose
+fixture fails any test that sees an unexpected server error.
+
+The store being down is not this server's fault, and tags are a decorative
+filter list, so an unreachable upstream degrades to an empty list. Anything else
+still reports ``500`` -- a real bug in our own code must stay loud.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+MODULE = "langflow.api.v1.store"
+
+# The exact error the broken certificate produced, verified against the live host.
+SSL_HOSTNAME_MISMATCH = (
+    "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, "
+    "certificate is not valid for 'api.langflow.store'. (_ssl.c:1032)"
+)
+
+
+def _store_service(side_effect):
+    service = AsyncMock()
+    service.get_tags = AsyncMock(side_effect=side_effect)
+    return service
+
+
+@pytest.mark.parametrize(
+    "upstream_error",
+    [
+        httpx.ConnectError(SSL_HOSTNAME_MISMATCH),
+        httpx.ConnectTimeout("timed out"),
+        httpx.ReadTimeout("timed out"),
+        httpx.RemoteProtocolError("peer closed connection"),
+    ],
+    ids=["ssl_hostname_mismatch", "connect_timeout", "read_timeout", "protocol_error"],
+)
+async def test_should_return_no_tags_when_the_store_is_unreachable(
+    client: AsyncClient, logged_in_headers, upstream_error
+):
+    with patch(f"{MODULE}.get_store_service", return_value=_store_service(upstream_error)):
+        response = await client.get("api/v1/store/tags", headers=logged_in_headers)
+
+    assert response.status_code == 200, f"a store outage surfaced as {response.status_code}"
+    assert response.json() == []
+
+
+async def test_should_still_report_an_unexpected_failure_as_a_server_error(client: AsyncClient, logged_in_headers):
+    """A bug in our own code must not be silenced by the outage carve-out."""
+    with patch(f"{MODULE}.get_store_service", return_value=_store_service(TypeError("boom"))):
+        response = await client.get("api/v1/store/tags", headers=logged_in_headers)
+
+    assert response.status_code == 500
+
+
+async def test_should_return_the_tags_when_the_store_is_reachable(client: AsyncClient, logged_in_headers):
+    service = AsyncMock()
+    tag_id = "3f8a1c2e-0d4b-4a6f-9c11-7e5b2d8a0f31"
+    service.get_tags = AsyncMock(return_value=[{"id": tag_id, "name": "Agents"}])
+
+    with patch(f"{MODULE}.get_store_service", return_value=service):
+        response = await client.get("api/v1/store/tags", headers=logged_in_headers)
+
+    assert response.status_code == 200
+    assert response.json() == [{"id": tag_id, "name": "Agents"}]

--- a/src/frontend/src/controllers/API/queries/store/__tests__/use-get-tags.test.tsx
+++ b/src/frontend/src/controllers/API/queries/store/__tests__/use-get-tags.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * The Langflow Store tags query must not run when the store is off.
+ *
+ * `AppInitPage` calls `useGetTagsQuery` on every app boot, on every route, with no
+ * regard for `ENABLE_LANGFLOW_STORE`. The backend proxies it to a third-party host,
+ * so when `api.langflow.store` started serving a certificate for a different
+ * hostname every page load produced a 500 — and the Playwright fixture, which fails
+ * any test that sees an unexpected server error, took the whole suite down with it.
+ *
+ * The store's only consumer (`ShareModal`) already gates itself on `hasStore`, which
+ * is `ENABLE_LANGFLOW_STORE && ...`, so nothing reads these tags while the flag is
+ * off. The request was pure cost and pure risk.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useGetTagsQuery } from "../use-get-tags";
+
+const mockGet = jest.fn();
+jest.mock("../../../api", () => ({
+  api: { get: (...args: unknown[]) => mockGet(...args) },
+}));
+jest.mock("../../../helpers/constants", () => ({
+  getURL: () => "/api/v1/store",
+}));
+jest.mock("@/stores/utilityStore", () => ({
+  useUtilityStore: (selector: (state: unknown) => unknown) =>
+    selector({ setTags: jest.fn() }),
+}));
+
+let storeEnabled = false;
+jest.mock("@/customization/feature-flags", () => ({
+  get ENABLE_LANGFLOW_STORE() {
+    return storeEnabled;
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderTagsQuery() {
+  return renderHook(() => useGetTagsQuery({ enabled: true }), { wrapper });
+}
+
+describe("useGetTagsQuery — store outage must not reach the app", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGet.mockResolvedValue({ data: [] });
+  });
+
+  it("should_not_request_tags_when_the_store_is_disabled", async () => {
+    storeEnabled = false;
+
+    renderTagsQuery();
+
+    await waitFor(() => {
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should_request_tags_when_the_store_is_enabled", async () => {
+    storeEnabled = true;
+
+    renderTagsQuery();
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/api/v1/store/tags");
+    });
+  });
+
+  it("should_keep_honouring_an_explicit_disabled_option", async () => {
+    storeEnabled = true;
+
+    renderHook(() => useGetTagsQuery({ enabled: false }), { wrapper });
+
+    await waitFor(() => {
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/src/controllers/API/queries/store/use-get-tags.ts
+++ b/src/frontend/src/controllers/API/queries/store/use-get-tags.ts
@@ -1,3 +1,4 @@
+import { ENABLE_LANGFLOW_STORE } from "@/customization/feature-flags";
 import { useUtilityStore } from "@/stores/utilityStore";
 import type { useQueryFunctionType } from "@/types/api";
 import { api } from "../../api";
@@ -31,6 +32,8 @@ export const useGetTagsQuery: useQueryFunctionType<
   const queryResult = query(["useGetTagsQuery"], responseFn, {
     refetchOnWindowFocus: false,
     ...options,
+    // Gated here, not at the call site: AppInitPage fires this on every app boot.
+    enabled: (options?.enabled ?? true) && ENABLE_LANGFLOW_STORE,
   });
 
   return queryResult;


### PR DESCRIPTION
A third-party outage is currently taking Langflow's CI down with it, and would do the same to any deployment that keeps the store on.

## What happened

`api.langflow.store` is serving the **default AWS Lightsail certificate** instead of one for its own hostname. Verified directly against the live host, outside CI:

```
subject: CN=*.ri6ls7718h63a.us-east-1.cs.amazonlightsail.com
subjectAltName does not match host name api.langflow.store
```

Every TLS connection to it fails verification, for everyone. That is infrastructure for someone to fix on the store side — **this PR is about why it broke us.**

## Why a store outage broke the whole app

**1. The editor asked for store tags on every boot.** `AppInitPage` calls `useGetTagsQuery` unconditionally, on every route — even though `ENABLE_LANGFLOW_STORE` is `false` and the store's only consumer (`ShareModal`) already gates itself on `hasStore`, which is `ENABLE_LANGFLOW_STORE && …`. Nothing could ever read those tags. The request was pure cost and pure risk.

**2. `GET /api/v1/store/tags` answered `500` for an unreachable upstream.** `store.py` funnels everything into a bare `except Exception` → `500`, so a third-party service being down read as a fault of *this* server.

Together: every page load produced a `500`, and the Playwright fixture fails any test that sees an unexpected server error — so entirely unrelated suites (a11y, api-keys) died with nothing but store SSL errors in the report.

## The fix

**Frontend** — gated inside the hook rather than at the call site, so no future caller can reintroduce it, and an explicit `enabled: false` still wins:

```ts
enabled: (options?.enabled ?? true) && ENABLE_LANGFLOW_STORE,
```

**Backend** — `httpx` surfaces the TLS failure as `ConnectError` (a `TransportError`), confirmed against the live broken host. That degrades to an empty tag list with a warning, since tags only decorate a filter. Errors that are genuinely ours still return `500` and stay loud:

```python
except httpx.TransportError as exc:
    await logger.awarning(f"Langflow Store unreachable; serving no tags: {exc}")
    return []
```

Either fix alone closes the CI wipeout, but they cover different cases: (1) is what a deployment with the store **off** should always have done; (2) is what protects deployments that keep it **on**.

## Tests

| | |
|---|---|
| Backend | 6 new — parametrized over the exact SSL message, connect/read timeouts and a protocol error, plus the must-stay-`500` and happy paths |
| Frontend | 3 new — store off, store on, and an explicit `enabled: false` |
| Verified failing pre-fix | yes, both suites |
| Suites | 21 store backend, 20 frontend; ruff + biome clean on touched files |

## Scope

No component, route, schema or UI string changed. The tag list is the only behaviour affected, and only when the store is off or unreachable.

Worth a follow-up, deliberately **not** in this PR: the other `store.py` routes share the same `except Exception` → `500` shape, so they will report a store outage as our fault too. They just aren't on the boot path, so they don't take CI down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Store tag requests now gracefully return an empty list when the upstream store is unavailable, avoiding an error page.
  * Unexpected failures continue to be reported normally.
  * Store tag retrieval is now correctly disabled when the Langflow Store feature is turned off.
* **Tests**
  * Added coverage for store outages, feature-flag behavior, disabled queries, and successful tag retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->