### PR TITLE
fix(frontend): disable legacy Store tags bootstrap

### DIFF
--- a/src/frontend/src/pages/AppInitPage/__tests__/app-init-page-store-query.test.tsx
+++ b/src/frontend/src/pages/AppInitPage/__tests__/app-init-page-store-query.test.tsx
@@ -1,0 +1,116 @@
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { AuthContext } from "@/contexts/authContext";
+
+const mockUseGetTagsQuery = jest.fn();
+const mockRefreshStars = jest.fn();
+const mockRefreshDiscordCount = jest.fn();
+const mockRefetchExamples = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useGetAuthSession: () => ({ data: undefined, isFetched: true }),
+  useGetAutoLogin: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/controllers/API/queries/config/use-get-config", () => ({
+  useGetConfig: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/controllers/API/queries/flows/use-get-basic-examples", () => ({
+  useGetBasicExamplesQuery: () => ({
+    isFetched: true,
+    refetch: mockRefetchExamples,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/folders/use-get-folders", () => ({
+  useGetFoldersQuery: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/store", () => ({
+  useGetTagsQuery: (options: unknown) => mockUseGetTagsQuery(options),
+}));
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useGetGlobalVariables: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/version", () => ({
+  useGetVersionQuery: jest.fn(),
+}));
+
+jest.mock("@/customization/hooks/use-custom-primary-loading", () => ({
+  useCustomPrimaryLoading: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      autoLogin: true,
+      isAuthenticated: true,
+      setIsAuthenticated: jest.fn(),
+      setIsAdmin: jest.fn(),
+    }),
+}));
+
+jest.mock("@/stores/darkStore", () => ({
+  useDarkStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      refreshStars: mockRefreshStars,
+      refreshDiscordCount: mockRefreshDiscordCount,
+    }),
+}));
+
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ isLoading: false }),
+}));
+
+jest.mock("@/customization/components/custom-loading-page", () => ({
+  CustomLoadingPage: () => <div data-testid="custom-loading" />,
+}));
+
+jest.mock("../../LoadingPage", () => ({
+  LoadingPage: () => <div data-testid="loading" />,
+}));
+
+import { AppInitPage } from "../index";
+
+const AuthWrapper = ({ children }: { children: ReactNode }) => (
+  <AuthContext.Provider
+    value={
+      {
+        accessToken: null,
+        apiKey: null,
+        authenticationErrorCount: 0,
+        clearAuthSession: jest.fn(),
+        getUser: jest.fn(),
+        login: jest.fn(),
+        setApiKey: jest.fn(),
+        setUserData: jest.fn(),
+        storeApiKey: jest.fn(),
+        userData: null,
+      } as React.ContextType<typeof AuthContext>
+    }
+  >
+    {children}
+  </AuthContext.Provider>
+);
+
+describe("AppInitPage Store bootstrap", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps the legacy Store tags query disabled in the OSS frontend", () => {
+    render(<AppInitPage />, { wrapper: AuthWrapper });
+
+    expect(mockUseGetTagsQuery).toHaveBeenCalledWith({ enabled: false });
+  });
+});

--- a/src/frontend/src/pages/AppInitPage/index.tsx
+++ b/src/frontend/src/pages/AppInitPage/index.tsx
@@ -12,6 +12,7 @@ import { useGetTagsQuery } from "@/controllers/API/queries/store";
 import { useGetGlobalVariables } from "@/controllers/API/queries/variables";
 import { useGetVersionQuery } from "@/controllers/API/queries/version";
 import { CustomLoadingPage } from "@/customization/components/custom-loading-page";
+import { ENABLE_LANGFLOW_STORE } from "@/customization/feature-flags";
 import { useCustomPrimaryLoading } from "@/customization/hooks/use-custom-primary-loading";
 import useAuthStore from "@/stores/authStore";
 import { useDarkStore } from "@/stores/darkStore";
@@ -48,7 +49,9 @@ export function AppInitPage() {
     enabled: isFetched && isAuthReady,
   });
   useGetGlobalVariables({ enabled: isFetched && isAuthReady });
-  useGetTagsQuery({ enabled: isFetched && isAuthReady });
+  useGetTagsQuery({
+    enabled: ENABLE_LANGFLOW_STORE && isFetched && isAuthReady,
+  });
   useGetFoldersQuery({ enabled: isFetched && isAuthReady });
   const { isFetched: isExamplesFetched, refetch: refetchExamples } =
     useGetBasicExamplesQuery();


### PR DESCRIPTION
## Summary
- gate legacy Store tag loading behind `ENABLE_LANGFLOW_STORE`
- prevent ordinary frontend bootstraps from calling the external Store while the OSS feature is disabled
- add a focused regression test for the disabled query

## Test plan
- `npm test -- --runInBand src/pages/AppInitPage/__tests__/app-init-page-session-ready.test.tsx src/pages/AppInitPage/__tests__/app-init-page-store-query.test.tsx`
- `npx @biomejs/biome check src/pages/AppInitPage/index.tsx src/pages/AppInitPage/__tests__/app-init-page-store-query.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary Store tag requests when the Store feature is disabled.
  * Improved app initialization behavior for configurations where the Store is unavailable.

* **Tests**
  * Added coverage to verify that Store tag loading is disabled in the OSS frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->