### PR TITLE
fix(mcp): drop unreachable exception types from the MCP test handler

### DIFF
--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -341,8 +341,9 @@ async def get_servers(
             # Data parsing and access errors
             await logger.aerror(f"Data error for server {server_name}: {e}")
             server_info["error"] = f"Configuration data error: {e}"
-        except (RuntimeError, ProcessLookupError, PermissionError) as e:
-            # Runtime and process-related errors
+        except RuntimeError as e:
+            # Runtime errors. ProcessLookupError and PermissionError are OSError
+            # subclasses and are handled by the OSError branch above.
             await logger.aerror(f"Runtime error for server {server_name}: {e}")
             server_info["error"] = f"Runtime error: {e}"
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
## What

In `src/backend/base/langflow/api/v2/mcp.py`, `_test_single_server` catches `OSError` and then, four handlers later, catches `(RuntimeError, ProcessLookupError, PermissionError)`:

```python
except OSError as e:
    # System-level errors (process execution, file access)
    server_info["error"] = f"System error: {e}"
except (KeyError, TypeError) as e:
    ...
except (RuntimeError, ProcessLookupError, PermissionError) as e:
    # Runtime and process-related errors
    server_info["error"] = f"Runtime error: {e}"
```

`ProcessLookupError` and `PermissionError` are both subclasses of `OSError`, so neither can ever reach the second handler.

```
ProcessLookupError   mro-> ProcessLookupError -> OSError -> Exception -> BaseException
PermissionError      mro-> PermissionError    -> OSError -> Exception -> BaseException
```

Running the chain exactly as written:

```
PermissionError      -> 'System error'
ProcessLookupError   -> 'System error'
RuntimeError         -> 'Runtime error'
```

This is reachable in practice: stdio MCP servers are launched as subprocesses, so a non-executable command or a missing `npx`/`uvx` surfaces as `PermissionError`.

## Fix

Drop the two dead names rather than reorder. The `OSError` branch's own comment already claims "process execution, file access", so it is the intended home for both, and the later mention reads as a leftover. **Behaviour is unchanged** — every exception still lands in exactly the same branch it does today. What changes is that the code no longer claims to route two types it never routes, and a comment records why, so they do not get re-added.

If you would rather the two kept their own "Runtime error:" wording, the alternative is hoisting them into a handler above `except OSError`; say the word and I will switch it.

## Scope

One file, three lines. Targeted at `release-1.12.0` per CONTRIBUTING. Grepped the rest of `src/` for the same shape — no other handler chain lists an `OSError` subclass after a bare `OSError`. `ruff check` and `ruff format --check` clean on the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when checking server availability.
  * Prevented certain operating system errors from being handled by the wrong runtime-error path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->