### PR TITLE
fix(schema): stop coded driver errors collapsing to a bare code

### DIFF
--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -865,11 +865,24 @@ class ErrorMessage(Message):
         reading the error panel. Rendering only ``Code: policy_blocked`` --
         prefixed by the Python class name -- told builders nothing about what
         was blocked or who to ask.
+
+        Driver and SDK errors are coded too, but put nothing in ``args``: a Cassandra
+        ``SyntaxException`` carries the protocol status on ``.code`` and the parser text
+        on ``.message``/``__str__``. Reading only ``args`` made a mistyped table name
+        surface as ``Code: 8192`` while the real cause sat in the logs (LE-2352).
         """
         args = getattr(exception, "args", ())
         if args and isinstance(args[0], str) and args[0].strip():
             return args[0].strip()
-        return None
+
+        # ``.message`` is the SDK convention for the human text; ``__str__`` is the
+        # fallback for drivers that only render it there.
+        message = getattr(exception, "message", None)
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+
+        rendered = str(exception).strip()
+        return rendered or None
 
     @staticmethod
     def _format_markdown_reason(exception: BaseException) -> str:

--- a/src/lfx/tests/unit/schema/test_message_content_blocks.py
+++ b/src/lfx/tests/unit/schema/test_message_content_blocks.py
@@ -520,6 +520,55 @@ class TestBackwardsCompatibility:
         [error_content] = [content for content in error_block.contents if isinstance(content, ErrorContent)]
         assert error_content.reason == "**CodedError**\n - **Code: rate_limited**\n"
 
+    def test_error_message_shows_the_text_of_a_driver_exception_that_carries_a_code(self):
+        """LE-2352: a coded DRIVER error must not collapse to its numeric code.
+
+        ``_coded_exception_message`` only looked at ``args[0]``, which reason-coded
+        Langflow errors populate. A database or SDK exception carries a protocol status
+        on ``.code`` with ``args`` EMPTY and the human text on ``__str__``, so the
+        ``hasattr(exception, "code")`` branch short-circuited past the ``.message`` and
+        ``.detail`` fallbacks below it and rendered a bare code.
+
+        Reproduced against a real Astra database: a Table Name containing ``-`` is
+        invalid CQL, the driver raises ``SyntaxException`` (0x2000 = 8192), and the UI
+        showed only ``Code: 8192`` while the parser message sat in the logs.
+        """
+
+        class DriverError(Exception):
+            """Shaped like cassandra.protocol.SyntaxException: coded, no args."""
+
+            code = 8192
+
+            def __str__(self):
+                return "<Error from server: code=2000 [Syntax error in CQL query] message=\"mismatched input '-'\">"
+
+        exc = DriverError()
+        assert exc.args == (), "the fixture must reproduce the empty-args shape"
+
+        err_msg = ErrorMessage(exception=exc)
+
+        assert "Code: 8192" not in err_msg.text, "the numeric code replaced the message"
+        assert "Syntax error in CQL query" in err_msg.text
+        [error_block] = [block for block in err_msg.content_blocks if isinstance(block, ContentBlock)]
+        [error_content] = [content for content in error_block.contents if isinstance(content, ErrorContent)]
+        assert "Syntax error in CQL query" in error_content.reason
+        assert "Code: 8192" in error_content.reason, "the code is still useful context alongside the message"
+
+    def test_error_message_prefers_an_explicit_message_attribute_over_repr(self):
+        """SDKs that expose ``.message`` should surface it rather than their __str__ noise."""
+
+        class CodedWithMessageError(Exception):
+            code = "invalid_request"
+            message = "Table name must not contain a hyphen."
+
+            def __str__(self):
+                return "<CodedWithMessageError object at 0xdeadbeef>"
+
+        err_msg = ErrorMessage(exception=CodedWithMessageError())
+
+        assert "Table name must not contain a hyphen." in err_msg.text
+        assert "0xdeadbeef" not in err_msg.text
+
     def test_error_message_can_omit_active_exception_traceback(self):
         """Public/delegated errors keep a generic reason without the caught traceback."""
         sensitive_detail = "owner-provider-secret"


### PR DESCRIPTION
Reported by QA on LE-2352: a Cassandra **Table Name** typed with `-` instead of `_` produced only

```
Flow build failed
Code: 8192
```

while the real cause sat in the logs. Flagged there as the same shape as an earlier "code 13" report — so this is **not** Cassandra-specific.

## Root cause

`_coded_exception_message` read only `args[0]`. Reason-coded Langflow errors (`ModelProviderPolicyError`) populate it; **driver and SDK exceptions do not**:

| | `cassandra.protocol.SyntaxException` |
|---|---|
| `.code` | `8192` (`0x2000`, the CQL syntax-error status) |
| `.args` | `()` ← empty |
| `.message` | `line 1:53 mismatched input '-' expecting '('…` |
| `str(exc)` | `<Error from server: code=2000 [Syntax error in CQL query] message="…">` |

The branch is selected by `hasattr(exception, "code")`, so it short-circuited **past** the `.message` and `.detail` fallbacks further down `_format_plain_reason` and rendered the number alone. Every piece of information the builder needed was on the exception object already.

## Fix

Fall back to `.message` (the SDK convention), then to `__str__`. Any coded exception carrying text now surfaces it; one with a code and genuinely no message still renders code-only — the existing test pinning that shape is untouched and still passes.

Both render paths improve together, since `_format_plain_reason` and `_format_markdown_reason` share the helper.

## Verified against a real Astra database

Not a stub. Same flow, same hyphenated table name, an actual Astra serverless DB:

| | UI shows |
|---|---|
| **before** | `Code: 8192` |
| **after** | `line 1:53 mismatched input '-' expecting '(' (... IF NOT EXISTS default_keyspace.cassandra[-]...)` |

The `[-]` marks the offending character in the table name. The markdown path keeps `Code: 8192` as context alongside the message.

**Sequencing note:** reaching the CQL error at all requires the `batch_size` fix from #14795 — which is why QA only saw this *after* validating that PR. That component fix was applied to the working tree for the verification run above and is **not** part of this branch; the diff here is confined to `lfx/schema/message.py`.

## Why this is separate from #14795

Different file, different root cause, and a blast radius covering **every** component rather than one bundle. #14795 is already validated by QA; folding a shared-path change into it would force re-validation of an unrelated area. Any SDK exception with a `.code` and empty `args` was affected — Astra, OpenAI, Anthropic, any driver.

## Tests

2 new, **both failing against the current code**: the driver-shaped exception (coded, empty args, text only in `__str__`), and an SDK-shaped one that exposes `.message` while its `__str__` is object noise. 345 lfx schema tests and 90 backend message tests pass; ruff clean.

## Scope

No component, schema, migration, API or UI change. Only what an already-failing build reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now display clearer, human-readable details for coded driver and SDK errors.
  * Explicit exception messages are preferred over less informative representations.
  * Error codes remain available as contextual information when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->