### PR TITLE
test(frontend): stabilize sidebar affordance regression

### DIFF
--- a/src/frontend/tests/core/regression/sidebarRowAffordances.spec.ts
+++ b/src/frontend/tests/core/regression/sidebarRowAffordances.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "../../fixtures";
-import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { openBlankFlow } from "../../utils/flow/open-blank-flow";
 
 /**
  * LE-2311: the sidebar row's label wrapper is a flex item with the default
@@ -21,17 +21,13 @@ test(
   { tag: ["@release", "@components", "@workspace"] },
   async ({ page }) => {
     await page.setViewportSize({ width: 1470, height: 704 });
-    await awaitBootstrapTest(page);
-
-    await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 30000,
-    });
+    await openBlankFlow(page);
 
     await page.getByTestId("sidebar-search-input").fill("embed");
-    await page.waitForSelector('[data-testid="icon-GripVertical"]', {
-      timeout: 30000,
-    });
+    const longRow = page.getByTestId(
+      "amazon_amazon bedrock embeddings_draggable",
+    );
+    await expect(longRow).toBeVisible({ timeout: 30000 });
 
     const overflowing = await page.evaluate(() => {
       const rows = Array.from(
@@ -62,9 +58,6 @@ test(
 
     // The `+` is hidden until hover by design; on an affected row it never
     // appears at all because the whole action container is off the row.
-    const longRow = page.getByTestId(
-      "amazon_amazon bedrock embeddings_draggable",
-    );
     await longRow.hover();
 
     const addButton = longRow.getByTestId(


### PR DESCRIPTION
This pull request refactors the sidebar row affordance regression test to improve reliability and readability by replacing manual flow setup steps with a reusable utility function.

**Test reliability and code reuse:**
* Replaced the manual flow setup sequence in `sidebarRowAffordances.spec.ts` with the `openBlankFlow` utility function to streamline test initialization and reduce duplication. [[1]](diffhunk://#diff-adbaf8b338a4e452d396bcb1e6484c71732fe90700c381bde455e8113c36bb28L2-R2) [[2]](diffhunk://#diff-adbaf8b338a4e452d396bcb1e6484c71732fe90700c381bde455e8113c36bb28L24-R30)

**Test readability:**
* Moved the definition of the `longRow` test element closer to its usage and clarified its role in the test. [[1]](diffhunk://#diff-adbaf8b338a4e452d396bcb1e6484c71732fe90700c381bde455e8113c36bb28L24-R30) [[2]](diffhunk://#diff-adbaf8b338a4e452d396bcb1e6484c71732fe90700c381bde455e8113c36bb28L65-L67)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sidebar regression coverage to use the current blank-flow setup.
  * Simplified row visibility and interaction checks for long component names.
  * Improved reuse of sidebar row locators during hover and add-button validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->