### PR TITLE
fix(frontend): refetch flow list when upload lands mid first load

### DIFF
--- a/src/frontend/src/controllers/API/helpers/__tests__/refetch-queries-fresh.test.ts
+++ b/src/frontend/src/controllers/API/helpers/__tests__/refetch-queries-fresh.test.ts
@@ -1,0 +1,99 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { refetchQueriesFresh } from "../query-cache";
+
+const FOLDER_KEY = ["useGetFolder", "folder-1", { page: 1 }];
+const FILTERS = { queryKey: ["useGetFolder", "folder-1"] };
+
+const flushTimers = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("refetchQueriesFresh", () => {
+  it("should refetch with the post-mutation rows when the first load is still in flight", async () => {
+    const queryClient = new QueryClient();
+    const rows = ["existing-flow"];
+    let calls = 0;
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: FOLDER_KEY,
+      queryFn: () => {
+        calls++;
+        const snapshot = [...rows];
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(snapshot), 30),
+        );
+      },
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await flushTimers(5);
+    rows.push("uploaded-flow");
+    await refetchQueriesFresh(queryClient, FILTERS);
+
+    expect(calls).toBe(2);
+    expect(queryClient.getQueryData(FOLDER_KEY)).toEqual([
+      "existing-flow",
+      "uploaded-flow",
+    ]);
+
+    unsubscribe();
+    queryClient.clear();
+  });
+
+  it("should still refetch when no request is in flight", async () => {
+    const queryClient = new QueryClient();
+    const rows = ["existing-flow"];
+    let calls = 0;
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: FOLDER_KEY,
+      queryFn: () => {
+        calls++;
+        return Promise.resolve([...rows]);
+      },
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await flushTimers(5);
+    expect(calls).toBe(1);
+
+    rows.push("uploaded-flow");
+    await refetchQueriesFresh(queryClient, FILTERS);
+
+    expect(calls).toBe(2);
+    expect(queryClient.getQueryData(FOLDER_KEY)).toEqual([
+      "existing-flow",
+      "uploaded-flow",
+    ]);
+
+    unsubscribe();
+    queryClient.clear();
+  });
+
+  it("should resolve when a cold in-flight request fails", async () => {
+    const queryClient = new QueryClient();
+    let calls = 0;
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey: FOLDER_KEY,
+      retry: false,
+      queryFn: () => {
+        calls++;
+        return calls === 1
+          ? new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("boom")), 30),
+            )
+          : Promise.resolve(["uploaded-flow"]);
+      },
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    await flushTimers(5);
+    await refetchQueriesFresh(queryClient, FILTERS);
+
+    expect(calls).toBe(2);
+    expect(queryClient.getQueryData(FOLDER_KEY)).toEqual(["uploaded-flow"]);
+
+    unsubscribe();
+    queryClient.clear();
+  });
+});

--- a/src/frontend/src/controllers/API/helpers/query-cache.ts
+++ b/src/frontend/src/controllers/API/helpers/query-cache.ts
@@ -1,4 +1,8 @@
-import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import type {
+  QueryClient,
+  QueryFilters,
+  QueryKey,
+} from "@tanstack/react-query";
 
 /**
  * Returns true only when an exact cache entry is a settled, successful
@@ -26,4 +30,35 @@ export const getSettledSuccessfulQueryData = <T>(
     return undefined;
   }
   return queryClient.getQueryData<T>(queryKey);
+};
+
+/**
+ * Refetches matching queries, including ones still loading their first page.
+ *
+ * `Query.fetch` only cancels and restarts an in-flight request when the query
+ * already holds data. While `data` is still `undefined` it returns the
+ * in-flight promise instead, so a refetch fired from a mutation resolves with
+ * the response of a request that was issued *before* the mutation ran — the
+ * newly created row never reaches the cache and nothing refetches afterwards.
+ * Awaiting that cold fetch first turns the dedupe back into a real refetch.
+ */
+export const refetchQueriesFresh = async (
+  queryClient: QueryClient,
+  filters: QueryFilters,
+): Promise<void> => {
+  const coldFetches = queryClient
+    .getQueryCache()
+    .findAll(filters)
+    .filter(
+      (query) =>
+        query.state.fetchStatus === "fetching" &&
+        query.state.data === undefined,
+    )
+    .map((query) => query.promise?.catch(() => undefined));
+
+  if (coldFetches.length > 0) {
+    await Promise.all(coldFetches);
+  }
+
+  await queryClient.refetchQueries(filters);
 };

--- a/src/frontend/src/controllers/API/queries/flows/__tests__/use-post-add-flow.test.ts
+++ b/src/frontend/src/controllers/API/queries/flows/__tests__/use-post-add-flow.test.ts
@@ -5,6 +5,7 @@ const mockApiPost = jest.fn();
 const mockQueryClient = {
   refetchQueries: jest.fn(),
   invalidateQueries: jest.fn(),
+  getQueryCache: jest.fn(() => ({ findAll: jest.fn(() => []) })),
 };
 
 jest.mock("@/stores/foldersStore", () => ({
@@ -30,7 +31,7 @@ jest.mock("@/controllers/API/services/request-processor", () => ({
     mutate: jest.fn((_key: any, fn: any, options: any) => ({
       mutate: async (payload: any) => {
         const result = await fn(payload);
-        options?.onSettled?.(result);
+        await options?.onSettled?.(result);
         return result;
       },
     })),
@@ -90,5 +91,36 @@ describe("usePostAddFlow", () => {
       expect.stringContaining("/api/v1/flows/"),
       expect.objectContaining({ locked: null }),
     );
+  });
+
+  it("refetches the created flow's project list", async () => {
+    mockApiPost.mockResolvedValue({
+      data: { id: "new-flow", folder_id: "folder" },
+    });
+
+    const mutation = usePostAddFlow();
+
+    await mutation.mutate({
+      name: "Flow",
+      description: "Desc",
+      data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+      is_component: false,
+      folder_id: "folder",
+      endpoint_name: undefined,
+      icon: undefined,
+      gradient: undefined,
+      tags: [],
+      mcp_enabled: true,
+    });
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetFolder", "folder"],
+    });
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: [
+        "useGetRefreshFlowsQuery",
+        { get_all: true, header_flows: true },
+      ],
+    });
   });
 });

--- a/src/frontend/src/controllers/API/queries/flows/use-post-add-flow.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-post-add-flow.ts
@@ -1,5 +1,6 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { ReactFlowJsonObject } from "@xyflow/react";
+import { refetchQueriesFresh } from "@/controllers/API/helpers/query-cache";
 import { useFolderStore } from "@/stores/foldersStore";
 import type { useMutationFunctionType } from "@/types/api";
 import { api } from "../../api";
@@ -49,16 +50,20 @@ export const usePostAddFlow: useMutationFunctionType<
     postAddFlowFn,
     {
       ...options,
+      // Fire-and-forget on purpose: TanStack dispatches the mutation's
+      // "success" only after this callback settles, so awaiting the refetches
+      // would hold up every caller of `addFlow` — including the navigation to
+      // the flow that was just created.
       onSettled: (response) => {
         if (response) {
-          queryClient.refetchQueries({
+          void refetchQueriesFresh(queryClient, {
             queryKey: [
               "useGetRefreshFlowsQuery",
               { get_all: true, header_flows: true },
             ],
           });
 
-          queryClient.refetchQueries({
+          void refetchQueriesFresh(queryClient, {
             queryKey: ["useGetFolder", response.folder_id ?? myCollectionId],
           });
         }

--- a/src/frontend/tests/extended/features/outdated-actions.spec.ts
+++ b/src/frontend/tests/extended/features/outdated-actions.spec.ts
@@ -90,13 +90,12 @@ test(
 
     await page.getByRole("button", { name: "Update Components" }).click();
 
-    await expect(page.getByTestId("update-button")).toHaveCount(0, {
-      timeout: 5000,
-    });
+    // No explicit timeout: each component update is a validate/code round
+    // trip, so five of them blow a hardcoded 5s budget on Windows CI. The
+    // platform-aware expect timeout in playwright.config.ts is the right one.
+    await expect(page.getByTestId("update-button")).toHaveCount(0);
 
-    await expect(page.getByTestId("review-button")).toHaveCount(0, {
-      timeout: 5000,
-    });
+    await expect(page.getByTestId("review-button")).toHaveCount(0);
   },
 );
 
@@ -170,22 +169,15 @@ test(
 
     await page.getByRole("button", { name: "Update Component" }).click();
 
-    await expect(page.getByTestId("update-button")).toHaveCount(0, {
-      timeout: 5000,
-    });
+    await expect(page.getByTestId("update-button")).toHaveCount(0);
 
     await expect(page.getByTestId("review-button")).toHaveCount(
       outdatedBreakingComponents - 1,
-      {
-        timeout: 5000,
-      },
     );
 
-    await expect(page.getByText(/\d+ components? needs? updates?/)).toBeVisible(
-      {
-        timeout: 5000,
-      },
-    );
+    await expect(
+      page.getByText(/\d+ components? needs? updates?/),
+    ).toBeVisible();
 
     expect(await page.getByTestId("update-all-button")).toHaveText(
       "Review All",

--- a/src/frontend/tests/extended/regression/general-bugs-upload-during-cold-flow-list.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-upload-during-cold-flow-list.spec.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "fs";
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../../utils/constants/timeouts";
+import { openFlowsList } from "../../utils/flow/open-flows-list";
+
+const PROJECT_PAGE_PATTERN = /\/api\/v1\/projects\/[^/?]+\?/;
+const FIRST_PAGE_DELAY_MS = 6000;
+
+test(
+  "uploaded flow must appear when the project list is still loading its first page",
+  { tag: ["@release"] },
+  async ({ page }) => {
+    /* Reproduces the Windows-CI failure of outdated-actions.spec.ts.
+     *
+     * `useGetFolder` paginates the project page. Upload a flow while that
+     * query is still loading its FIRST page and its `data` is undefined, so
+     * TanStack's cancelRefetch fast path does not apply: the refetch fired by
+     * the create mutation resolves with the request that was already in
+     * flight — the one issued before the upload. The new card never renders,
+     * and nothing refetches afterwards.
+     *
+     * Holding back that first response reproduces on any OS what a slow
+     * Windows runner produces by accident. */
+
+    // Without a seeded project the page renders the welcome screen and never
+    // issues the paginated request this test has to catch mid-flight.
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    // The response must be fetched BEFORE the upload and delivered after it.
+    // Delaying the request instead would let the server answer with a snapshot
+    // that already contains the new flow, and the race would never show.
+    let firstPageHeld = false;
+    await page.route(
+      (url) => PROJECT_PAGE_PATTERN.test(url.toString()),
+      async (route) => {
+        if (firstPageHeld) {
+          await route.continue();
+          return;
+        }
+        firstPageHeld = true;
+        const response = await route.fetch();
+        const body = await response.body();
+        await new Promise((resolve) =>
+          setTimeout(resolve, FIRST_PAGE_DELAY_MS),
+        );
+        await route.fulfill({ response, body });
+      },
+    );
+
+    const firstPageRequest = page.waitForRequest(
+      (request) => PROJECT_PAGE_PATTERN.test(request.url()),
+      { timeout: TIMEOUTS.standard },
+    );
+
+    const dropTarget = await openFlowsList(page);
+
+    // The drop only reproduces the bug while that first page is unanswered.
+    await firstPageRequest;
+
+    const flowName = `Cold List Upload ${Date.now()}`;
+    const jsonContent = JSON.stringify({
+      ...JSON.parse(readFileSync("tests/assets/outdated_flow.json", "utf-8")),
+      name: flowName,
+    });
+
+    const dataTransfer = await page.evaluateHandle((data) => {
+      const dt = new DataTransfer();
+      dt.items.add(
+        new File([data], "outdated_flow.json", { type: "application/json" }),
+      );
+      return dt;
+    }, jsonContent);
+
+    const flowCreated = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().endsWith("/api/v1/flows/") &&
+        response.status() === 201,
+      { timeout: TIMEOUTS.standard },
+    );
+
+    await dropTarget.dispatchEvent("drop", { dataTransfer });
+    await flowCreated;
+
+    await expect(
+      page.getByTestId("list-card").filter({ hasText: flowName }),
+    ).toBeVisible({ timeout: TIMEOUTS.standard });
+  },
+);


### PR DESCRIPTION
A flow created while the flows list is still loading its first page never shows up. The list keeps rendering the pre-upload snapshot until you navigate away or reload.

This is the root cause of the `outdated-actions.spec.ts` failure on the Windows nightly ([run 33138564041, shard 63](https://github.com/langflow-ai/langflow/actions/runs/33138564041/job/98744893617)).

## Root cause

`usePostAddFlow.onSettled` refetches `["useGetFolder", folderId]`. `Query.fetch` only cancels and restarts an in-flight request when the query already holds data:

```js
if (this.state.fetchStatus !== "idle" && ...) {
  if (this.state.data !== undefined && fetchOptions?.cancelRefetch) {
    this.cancel({ silent: true });        // cancel + restart
  } else if (this.#retryer) {
    return this.#retryer.promise;         // dedupe — returns the stale in-flight fetch
  }
}
```

On a first load `data` is `undefined`, so the refetch silently resolves with the request that was issued **before** the flow was created. No second request is ever made, and the query is not left stale, so nothing refetches afterwards.

The CI trace confirms it — the paginated project request starts at `03:32:23.440` and takes 872 ms, the create lands at `03:32:24.069`, and no further `GET /api/v1/projects/{id}?page=…` is ever issued:

```
03:32:23.440 GET  /api/v1/projects/a83cf36f-…?id=…&page=1&size=12   200  872ms
03:32:24.069 POST /api/v1/flows/                                    201  217ms
03:32:24.347 GET  /api/v1/flows/?get_all=true&header_flows=true     200   73ms
(nothing else for the remaining 30s)
```

On Linux/macOS that first page answers in tens of milliseconds and never overlaps the upload, which is why this only ever failed on Windows runners.

## Fix

`refetchQueriesFresh` (in `controllers/API/helpers/query-cache.ts`) awaits any matching cold in-flight fetch before refetching, turning the dedupe back into a real refetch. `usePostAddFlow` uses it for both the folder query and the header-flows query.

The call stays **fire-and-forget**. TanStack dispatches the mutation's `success` only after `onSettled` settles, so awaiting the refetches would delay every `addFlow` caller — including the navigation to the flow that was just created. That regression showed up as a bootstrap failure while developing this and is why the `void` is deliberate.

## Verification

Reproduced deterministically on macOS by holding back the first project page response — the same condition a slow Windows runner creates by accident.

| | without fix | with fix |
|---|---|---|
| `general-bugs-upload-during-cold-flow-list.spec.ts` (new) | fails — card never appears | passes |
| `outdated-actions.spec.ts` | — | both tests pass |
| `general-bugs-move-flow-from-folder.spec.ts` | — | passes |
| `refetch-queries-fresh.test.ts` (new, real `QueryClient`) | 2/3 fail | 3/3 pass |
| `jest src/controllers/API` | — | 70 suites / 475 tests pass |

## Also in this PR

`outdated-actions.spec.ts` had hardcoded `timeout: 5000` assertions after "Update Components". Five component updates are five `validate/code` round trips, which blows that budget on Windows — that was the second (flaky) failure in the same job. Removing the explicit timeout lets the platform-aware `expect.timeout` from `playwright.config.ts` (15 s on Windows) apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow and folder list refreshes after creating a flow, preventing stale results when data is still loading.
  * Fixed an issue where uploaded flows could fail to appear in project lists during slow initial loading.
* **Tests**
  * Added coverage for refreshed query results and cold-request failures.
  * Added regression coverage for flow uploads during delayed list loading.
  * Updated outdated-component checks to use standard timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->