### PR TITLE
fix(api): preserve v2 sync tweak refusals (LE-2380)

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -33,6 +33,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from fastapi.responses import EventSourceResponse, StreamingResponse
+from lfx.exceptions.tweaks import TweakRefusedError
 from lfx.log.logger import logger
 from lfx.memory.flow_context import derive_message_owner_uuid
 from lfx.schema.workflow import (
@@ -319,6 +320,8 @@ async def run_sync_with_mapping(
                 "timeout_seconds": timeout_seconds,
             },
         ) from None
+    except TweakRefusedError:
+        raise
     except (PydanticValidationError, WorkflowValidationError) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -31,6 +31,26 @@ async def test_refused_tweak_returns_422_on_the_v1_sync_run(client, simple_api_t
     assert detail["fields"] == ["code"]
 
 
+async def test_refused_tweak_returns_422_on_the_v2_sync_run(client, simple_api_test, created_api_key):
+    """The v2 sync error mapper must preserve the app-level refusal response."""
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+    node_id = simple_api_test["data"]["nodes"][0]["id"]
+    payload = {
+        "flow_id": flow_id,
+        "mode": "sync",
+        "input_value": "hello",
+        "tweaks": {node_id: {"code": "import os; os.system('id')"}},
+    }
+
+    response = await client.post("/api/v2/workflows", headers=headers, json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "TWEAKS_REFUSED"
+    assert detail["fields"] == ["code"]
+
+
 async def test_an_allowed_tweak_still_runs_on_the_v1_sync_run(client, simple_api_test, created_api_key):
     """The refusal path must not make ordinary tweaks fail."""
     headers = {"x-api-key": created_api_key.api_key}


### PR DESCRIPTION
## Summary

- preserve `TweakRefusedError` through the v2 sync response-mapping boundary
- return the existing structured 422 refusal response instead of a generic 500
- add an HTTP-level regression test for protected sync tweaks

Jira: https://datastax.jira.com/browse/LE-2380

## Tests

- `test_tweak_refusal_surface.py` (5 passed)
- v2 sync success control (1 passed)
- Ruff, formatting, and pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow runs now return a clear **422 error** when requested tweaks are refused, instead of a generic server error.
  - Refusal responses include the `TWEAKS_REFUSED` code and identify the affected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->