### PR TITLE
fix(api): preserve tweak refusal reasons (LE-2387)

### DIFF
--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -27,8 +27,12 @@ async def test_refused_tweak_returns_422_on_the_v1_sync_run(client, simple_api_t
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
     detail = response.json()["detail"]
-    assert detail["code"] == "TWEAKS_REFUSED"
-    assert detail["fields"] == ["code"]
+    assert detail == {
+        "error": "Refused tweaks",
+        "code": "TWEAKS_REFUSED",
+        "message": "The field is protected and keeps the value set by the flow author.",
+        "fields": ["code"],
+    }
 
 
 async def test_an_allowed_tweak_still_runs_on_the_v1_sync_run(client, simple_api_test, created_api_key):

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -207,13 +207,15 @@ def apply_tweaks(
     # bypass: two copies of a security predicate that drifted apart. In the
     # two-pass callers this list is already empty by the time we get here, so the
     # skip below only matters to direct callers of this function.
-    refused = _refused_tweak_names(
-        template_data,
-        node.get("data", {}).get("type"),
-        node_tweaks,
-        policy=policy,
-        flow_declares_allowlist=flow_declares_allowlist,
-        exempt_keys=exempt_keys,
+    refused = list(
+        _refused_tweak_reasons(
+            template_data,
+            node.get("data", {}).get("type"),
+            node_tweaks,
+            policy=policy,
+            flow_declares_allowlist=flow_declares_allowlist,
+            exempt_keys=exempt_keys,
+        )
     )
     refused_names = frozenset(refused)
 
@@ -256,7 +258,7 @@ def apply_tweaks(
     return refused
 
 
-def _refused_tweak_names(
+def _refused_tweak_reasons(
     template_data: dict[str, Any],
     component_type: str | None,
     node_tweaks: dict[str, Any],
@@ -264,8 +266,8 @@ def _refused_tweak_names(
     policy: str,
     flow_declares_allowlist: bool,
     exempt_keys: frozenset[str] = frozenset(),
-) -> list[str]:
-    """Return the names this node would refuse. Mutates nothing.
+) -> dict[str, str]:
+    """Return each refused field with its caller-facing reason. Mutates nothing.
 
     Refusal has to be decided for the whole request before anything is applied.
     Applying as we go and raising at the end leaves the accepted half written,
@@ -274,14 +276,14 @@ def _refused_tweak_names(
     """
     from lfx.utils.flow_validation import is_protected_tweak_field, is_tweak_refused_by_policy
 
-    refused: list[str] = []
+    refused: dict[str, str] = {}
     for tweak_name in node_tweaks:
         field = template_data.get(tweak_name)
         if not isinstance(field, dict):
             continue
         if is_protected_tweak_field(component_type, tweak_name, field.get("type", "")):
             logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
+            refused[tweak_name] = _PROTECTED_TWEAK_REASON
             continue
         if tweak_name not in exempt_keys and is_tweak_refused_by_policy(
             policy,
@@ -289,7 +291,7 @@ def _refused_tweak_names(
             field_is_api_editable=field.get("api_editable") is True,
         ):
             logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
-            refused.append(tweak_name)
+            refused[tweak_name] = _policy_refusal_reason(policy)
     return refused
 
 
@@ -327,15 +329,27 @@ def _effective_policy(*, caller_supplied: bool) -> str:
     return _resolve_tweak_policy()
 
 
-def _refusal_reason(policy: str, *, flow_declares_allowlist: bool) -> str:
-    """Return a caller-facing explanation for a refusal."""
-    from lfx.utils.flow_validation import TWEAK_POLICY_DECLARED, TWEAK_POLICY_OFF
+_PROTECTED_TWEAK_REASON = "The field is protected and keeps the value set by the flow author."
+_DECLARED_TWEAK_REASON = (
+    "This flow declares which fields the API may set. Only fields marked editable via API accept a tweak."
+)
+_OFF_TWEAK_REASON = "This deployment does not accept tweaks."
+_REFUSAL_REASON_ORDER = (_PROTECTED_TWEAK_REASON, _DECLARED_TWEAK_REASON, _OFF_TWEAK_REASON)
+
+
+def _policy_refusal_reason(policy: str) -> str:
+    """Return the caller-facing explanation for a policy-layer refusal."""
+    from lfx.utils.flow_validation import TWEAK_POLICY_OFF
 
     if policy == TWEAK_POLICY_OFF:
-        return "This deployment does not accept tweaks."
-    if policy == TWEAK_POLICY_DECLARED and flow_declares_allowlist:
-        return "This flow declares which fields the API may set. Only fields marked editable via API accept a tweak."
-    return "The field is protected and keeps the value set by the flow author."
+        return _OFF_TWEAK_REASON
+    return _DECLARED_TWEAK_REASON
+
+
+def _combined_refusal_reason(refused: list[tuple[str, str]]) -> str:
+    """Combine the generic reasons present in a request in stable priority order."""
+    present_reasons = {reason for _, reason in refused}
+    return " ".join(reason for reason in _REFUSAL_REASON_ORDER if reason in present_reasons)
 
 
 def apply_tweaks_on_vertex(
@@ -369,12 +383,14 @@ def apply_tweaks_on_vertex(
     # Same single-predicate rule as ``apply_tweaks``: this function applies, it
     # does not re-decide. Two copies of the floor are what let the graph path
     # accept tweaks the sync path refused in the first place.
-    refused = _refused_tweak_names(
-        template_data,
-        vertex.data.get("type"),
-        node_tweaks,
-        policy=policy,
-        flow_declares_allowlist=flow_declares_allowlist,
+    refused = list(
+        _refused_tweak_reasons(
+            template_data,
+            vertex.data.get("type"),
+            node_tweaks,
+            policy=policy,
+            flow_declares_allowlist=flow_declares_allowlist,
+        )
     )
     refused_names = frozenset(refused)
 
@@ -456,7 +472,7 @@ def process_tweaks(
 
     policy = _effective_policy(caller_supplied=caller_supplied)
     flow_declares_allowlist = flow_declares_api_editable(nodes)
-    refused: list[str] = []
+    refused: list[tuple[str, str]] = []
 
     all_nodes_tweaks = {}
     pending: list[tuple[dict[str, Any], dict[str, Any]]] = []
@@ -474,18 +490,20 @@ def process_tweaks(
         template_data = node.get("data", {}).get("node", {}).get("template")
         if not isinstance(template_data, dict):
             continue
-        refused += _refused_tweak_names(
-            template_data,
-            node.get("data", {}).get("type"),
-            node_tweaks,
-            policy=policy,
-            flow_declares_allowlist=flow_declares_allowlist,
-            exempt_keys=exempt_keys,
+        refused.extend(
+            _refused_tweak_reasons(
+                template_data,
+                node.get("data", {}).get("type"),
+                node_tweaks,
+                policy=policy,
+                flow_declares_allowlist=flow_declares_allowlist,
+                exempt_keys=exempt_keys,
+            ).items()
         )
 
     if refused:
-        reason = _refusal_reason(policy, flow_declares_allowlist=flow_declares_allowlist)
-        raise TweakRefusedError(sorted(set(refused)), reason=reason)
+        refused_fields = sorted({field_name for field_name, _ in refused})
+        raise TweakRefusedError(refused_fields, reason=_combined_refusal_reason(refused))
 
     for node, node_tweaks in pending:
         apply_tweaks(
@@ -522,7 +540,7 @@ def process_tweaks_on_graph(graph: Graph, tweaks: dict[str, dict[str, Any]], *, 
     flow_declares_allowlist = flow_declares_api_editable(
         [{"data": v.data} for v in graph.vertices if isinstance(v, Vertex) and isinstance(v.data, dict)]
     )
-    refused: list[str] = []
+    refused: list[tuple[str, str]] = []
 
     pending: list[tuple[Vertex, dict[str, Any]]] = []
     for vertex in graph.vertices:
@@ -539,17 +557,19 @@ def process_tweaks_on_graph(graph: Graph, tweaks: dict[str, dict[str, Any]], *, 
         template_data = vertex.data.get("node", {}).get("template", {})
         if not isinstance(template_data, dict):
             continue
-        refused += _refused_tweak_names(
-            template_data,
-            vertex.data.get("type"),
-            node_tweaks,
-            policy=policy,
-            flow_declares_allowlist=flow_declares_allowlist,
+        refused.extend(
+            _refused_tweak_reasons(
+                template_data,
+                vertex.data.get("type"),
+                node_tweaks,
+                policy=policy,
+                flow_declares_allowlist=flow_declares_allowlist,
+            ).items()
         )
 
     if refused:
-        reason = _refusal_reason(policy, flow_declares_allowlist=flow_declares_allowlist)
-        raise TweakRefusedError(sorted(set(refused)), reason=reason)
+        refused_fields = sorted({field_name for field_name, _ in refused})
+        raise TweakRefusedError(refused_fields, reason=_combined_refusal_reason(refused))
 
     for vertex, node_tweaks in pending:
         apply_tweaks_on_vertex(

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -195,35 +195,31 @@ def apply_tweaks(
     exempt keys.
     """
     exempt_keys = exempt_keys or frozenset()
-    refused: list[str] = []
     template_data = node.get("data", {}).get("node", {}).get("template")
 
     if not isinstance(template_data, dict):
         logger.warning(f"Template data for node {node.get('id')} should be a dictionary")
-        return refused
+        return []
 
     # One function decides refusals, this one only applies them. Re-deriving the
     # floor and the policy here is exactly the shape that produced the original
     # bypass: two copies of a security predicate that drifted apart. In the
     # two-pass callers this list is already empty by the time we get here, so the
     # skip below only matters to direct callers of this function.
-    refused = list(
-        _refused_tweak_reasons(
-            template_data,
-            node.get("data", {}).get("type"),
-            node_tweaks,
-            policy=policy,
-            flow_declares_allowlist=flow_declares_allowlist,
-            exempt_keys=exempt_keys,
-        )
+    refused = _refused_tweak_reasons(
+        template_data,
+        node.get("data", {}).get("type"),
+        node_tweaks,
+        policy=policy,
+        flow_declares_allowlist=flow_declares_allowlist,
+        exempt_keys=exempt_keys,
     )
-    refused_names = frozenset(refused)
 
     for tweak_name, tweak_value in node_tweaks.items():
         field = template_data.get(tweak_name)
         if not isinstance(field, dict):
             continue
-        if tweak_name in refused_names:
+        if tweak_name in refused:
             continue
         field_type = field.get("type", "")
         if field_type == "NestedDict":
@@ -255,7 +251,7 @@ def apply_tweaks(
             if "load_from_db" in template_data[tweak_name]:
                 template_data[tweak_name]["load_from_db"] = False
 
-    return refused
+    return list(refused)
 
 
 def _refused_tweak_reasons(
@@ -274,24 +270,26 @@ def _refused_tweak_reasons(
     and the graph the run paths hand us is cached and reused, so that half
     survives into later runs that send no tweaks at all.
     """
-    from lfx.utils.flow_validation import is_protected_tweak_field, is_tweak_refused_by_policy
-
     refused: dict[str, str] = {}
     for tweak_name in node_tweaks:
         field = template_data.get(tweak_name)
         if not isinstance(field, dict):
             continue
-        if is_protected_tweak_field(component_type, tweak_name, field.get("type", "")):
-            logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
-            refused[tweak_name] = _PROTECTED_TWEAK_REASON
-            continue
-        if tweak_name not in exempt_keys and is_tweak_refused_by_policy(
+        reason = _tweak_refusal_reason(
+            component_type,
+            tweak_name,
+            field.get("type", ""),
             policy,
             flow_declares_allowlist=flow_declares_allowlist,
             field_is_api_editable=field.get("api_editable") is True,
-        ):
-            logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
-            refused[tweak_name] = _policy_refusal_reason(policy)
+            policy_exempt=tweak_name in exempt_keys,
+        )
+        if reason is not None:
+            if reason == _PROTECTED_TWEAK_REASON:
+                logger.warning(f"Security: refusing to override protected field {tweak_name!r} via tweaks.")
+            else:
+                logger.warning(f"Policy {policy!r}: refusing to override field {tweak_name!r} via tweaks.")
+            refused[tweak_name] = reason
     return refused
 
 
@@ -337,13 +335,42 @@ _OFF_TWEAK_REASON = "This deployment does not accept tweaks."
 _REFUSAL_REASON_ORDER = (_PROTECTED_TWEAK_REASON, _DECLARED_TWEAK_REASON, _OFF_TWEAK_REASON)
 
 
-def _policy_refusal_reason(policy: str) -> str:
-    """Return the caller-facing explanation for a policy-layer refusal."""
-    from lfx.utils.flow_validation import TWEAK_POLICY_OFF
+def _tweak_refusal_reason(
+    component_type: str | None,
+    field_name: str,
+    field_type: str,
+    policy: str,
+    *,
+    flow_declares_allowlist: bool,
+    field_is_api_editable: bool,
+    policy_exempt: bool,
+) -> str | None:
+    """Return the single caller-facing reason for refusing a field, if any.
 
-    if policy == TWEAK_POLICY_OFF:
+    Under ``off``, the policy alone refuses every caller-supplied field. Keep
+    that response uniform so probing one field at a time cannot reveal which
+    fields are also protected by the deployment floor. In the other modes the
+    floor takes precedence, which is the distinction LE-2387 needs under
+    ``declared``.
+    """
+    from lfx.utils.flow_validation import (
+        TWEAK_POLICY_OFF,
+        is_protected_tweak_field,
+        is_tweak_refused_by_policy,
+    )
+
+    refused_by_policy = not policy_exempt and is_tweak_refused_by_policy(
+        policy,
+        flow_declares_allowlist=flow_declares_allowlist,
+        field_is_api_editable=field_is_api_editable,
+    )
+    if refused_by_policy and policy == TWEAK_POLICY_OFF:
         return _OFF_TWEAK_REASON
-    return _DECLARED_TWEAK_REASON
+    if is_protected_tweak_field(component_type, field_name, field_type):
+        return _PROTECTED_TWEAK_REASON
+    if refused_by_policy:
+        return _DECLARED_TWEAK_REASON
+    return None
 
 
 def _combined_refusal_reason(refused: list[tuple[str, str]]) -> str:
@@ -372,27 +399,23 @@ def apply_tweaks_on_vertex(
     component at runtime, which is the bug the two former private copies of this
     function existed to work around.
     """
-    refused: list[str] = []
     template_data = vertex.data.get("node", {}).get("template", {})
     if not isinstance(template_data, dict):
         # No usable template means nothing can be validated, so nothing is
         # applied. Refusing here instead would turn a malformed node into a
         # caller-facing error the caller cannot act on.
-        return refused
+        return []
 
     # Same single-predicate rule as ``apply_tweaks``: this function applies, it
     # does not re-decide. Two copies of the floor are what let the graph path
     # accept tweaks the sync path refused in the first place.
-    refused = list(
-        _refused_tweak_reasons(
-            template_data,
-            vertex.data.get("type"),
-            node_tweaks,
-            policy=policy,
-            flow_declares_allowlist=flow_declares_allowlist,
-        )
+    refused = _refused_tweak_reasons(
+        template_data,
+        vertex.data.get("type"),
+        node_tweaks,
+        policy=policy,
+        flow_declares_allowlist=flow_declares_allowlist,
     )
-    refused_names = frozenset(refused)
 
     accepted: dict[str, Any] = {}
     for tweak_name, tweak_value in node_tweaks.items():
@@ -403,7 +426,7 @@ def apply_tweaks_on_vertex(
         # caller who sends a tweak for a component the flow no longer has.
         if not isinstance(field, dict):
             continue
-        if tweak_name in refused_names:
+        if tweak_name in refused:
             continue
 
         accepted[tweak_name] = tweak_value
@@ -425,7 +448,7 @@ def apply_tweaks_on_vertex(
     if accepted:
         vertex.update_raw_params(accepted, overwrite=True)
 
-    return refused
+    return list(refused)
 
 
 def process_tweaks(

--- a/src/lfx/tests/unit/test_tweaks_policy.py
+++ b/src/lfx/tests/unit/test_tweaks_policy.py
@@ -12,7 +12,7 @@ refuse every request, including one that sends no tweaks at all.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from lfx.exceptions.tweaks import TweakRefusedError
@@ -394,6 +394,20 @@ class _FakeVertex:
             self.raw_params.update(params)
 
 
+def _built_vertex(vertex_id: str, template: dict, node_type: str | None = None):
+    """Return a minimal object accepted by the built-graph tweak path."""
+    from lfx.graph.vertex.base import Vertex
+
+    vertex = MagicMock(spec=Vertex)
+    vertex.id = vertex_id
+    vertex.data = {"node": {"template": template}}
+    if node_type is not None:
+        vertex.data["type"] = node_type
+    vertex.params = {}
+    vertex.load_from_db_fields = []
+    return vertex
+
+
 def test_graph_path_refuses_a_sandbox_field_the_old_filter_allowed():
     """`global_imports` is sandbox-widening and was previously applied here.
 
@@ -435,6 +449,63 @@ def test_graph_path_applies_and_persists_an_allowed_tweak():
     assert refused == []
     assert vertex.raw_params == {"a": "new"}
     assert vertex.params["a"] == "new"
+
+
+@pytest.mark.parametrize(
+    ("policy", "template", "node_type", "tweaks", "expected_fields", "expected_reason"),
+    [
+        (
+            "permissive",
+            {"database_url": {"value": "stored", "type": "str"}},
+            "SQLComponent",
+            {"database_url": "postgresql://attacker/db"},
+            ["database_url"],
+            PROTECTED_TWEAK_REASON,
+        ),
+        (
+            "off",
+            {
+                "a": {"value": "old", "type": "str"},
+                "b": {"value": "old", "type": "str"},
+            },
+            None,
+            {"b": "new-b", "a": "new-a"},
+            ["a", "b"],
+            OFF_TWEAK_REASON,
+        ),
+        (
+            "declared",
+            {
+                "allowed": {"value": "old", "type": "str", "api_editable": True},
+                "ordinary": {"value": "old", "type": "str"},
+                "database_url": {"value": "stored", "type": "str", "api_editable": True},
+            },
+            "SQLComponent",
+            {"ordinary": "new", "database_url": "postgresql://attacker/db"},
+            ["database_url", "ordinary"],
+            f"{PROTECTED_TWEAK_REASON} {DECLARED_TWEAK_REASON}",
+        ),
+    ],
+)
+def test_graph_path_reports_stable_refusal_reasons(
+    policy, template, node_type, tweaks, expected_fields, expected_reason
+):
+    """The built-graph path must preserve reasons, deduplicate them, and order them stably."""
+    from lfx.processing.process import process_tweaks_on_graph
+
+    vertex = _built_vertex("v1", template, node_type)
+
+    class _G:
+        vertices = [vertex]
+
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value=policy),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks_on_graph(_G(), {"v1": tweaks})
+
+    assert exc.value.refused == expected_fields
+    assert exc.value.reason == expected_reason
 
 
 # --- atomicity ------------------------------------------------------------

--- a/src/lfx/tests/unit/test_tweaks_policy.py
+++ b/src/lfx/tests/unit/test_tweaks_policy.py
@@ -12,10 +12,12 @@ refuse every request, including one that sends no tweaks at all.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 from lfx.exceptions.tweaks import TweakRefusedError
+from lfx.graph.vertex.base import Vertex
 from lfx.processing.process import apply_tweaks, process_tweaks
 from lfx.utils.flow_validation import flow_declares_api_editable
 
@@ -161,8 +163,16 @@ def test_process_tweaks_raises_naming_every_refused_key():
     assert exc.value.refused == ["a", "b"]
 
 
-@pytest.mark.parametrize("policy", ["permissive", "declared", "off"])
-def test_process_tweaks_reports_protected_reason_under_every_policy(policy):
+@pytest.mark.parametrize(
+    ("policy", "expected_reason"),
+    [
+        ("permissive", PROTECTED_TWEAK_REASON),
+        ("declared", PROTECTED_TWEAK_REASON),
+        ("off", OFF_TWEAK_REASON),
+    ],
+)
+def test_process_tweaks_reports_the_causal_refusal_reason(policy, expected_reason):
+    """Off is uniform; otherwise the protected-field floor is the cause."""
     graph = _graph(
         [
             _node(
@@ -179,7 +189,7 @@ def test_process_tweaks_reports_protected_reason_under_every_policy(policy):
         process_tweaks(graph, {"n": {"database_url": "postgresql://attacker/db"}})
 
     assert exc.value.refused == ["database_url"]
-    assert exc.value.reason == PROTECTED_TWEAK_REASON
+    assert exc.value.reason == expected_reason
 
 
 @pytest.mark.parametrize(
@@ -228,6 +238,35 @@ def test_process_tweaks_reports_protected_and_policy_reasons_together():
         process_tweaks(graph, {"n": {"ordinary": "new", "database_url": "postgresql://attacker/db"}})
 
     assert exc.value.refused == ["database_url", "ordinary"]
+    assert exc.value.reason == f"{PROTECTED_TWEAK_REASON} {DECLARED_TWEAK_REASON}"
+
+
+def test_process_tweaks_deduplicates_a_flat_key_refused_by_two_rules():
+    """A flat tweak can target multiple nodes but names each refused key once."""
+    graph = _graph(
+        [
+            _node(
+                {"query": {"value": "SELECT 1", "type": "str"}},
+                node_type="SQLComponent",
+                node_id="sql",
+            ),
+            _node(
+                {
+                    "allowed": {"value": "old", "type": "str", "api_editable": True},
+                    "query": {"value": "old", "type": "str"},
+                },
+                node_id="ordinary",
+            ),
+        ]
+    )
+
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value="declared"),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks(graph, {"query": "attacker"})
+
+    assert exc.value.refused == ["query"]
     assert exc.value.reason == f"{PROTECTED_TWEAK_REASON} {DECLARED_TWEAK_REASON}"
 
 
@@ -373,7 +412,7 @@ def test_graph_path_exempts_runtime_generated_tweaks():
 # the literal key "code", so it accepted tweaks the sync mode refused.
 
 
-class _FakeVertex:
+class _FakeVertex(Vertex):
     """Minimal stand-in for a built Vertex.
 
     A real Graph is not needed to prove which tweaks the graph-level path
@@ -382,7 +421,7 @@ class _FakeVertex:
 
     def __init__(self, vertex_id: str, template: dict, node_type: str | None = None) -> None:
         self.id = vertex_id
-        self.data = {"node": {"template": template}}
+        self.data: dict[str, Any] = {"node": {"template": template}}
         if node_type is not None:
             self.data["type"] = node_type
         self.params: dict = {}
@@ -396,16 +435,7 @@ class _FakeVertex:
 
 def _built_vertex(vertex_id: str, template: dict, node_type: str | None = None):
     """Return a minimal object accepted by the built-graph tweak path."""
-    from lfx.graph.vertex.base import Vertex
-
-    vertex = MagicMock(spec=Vertex)
-    vertex.id = vertex_id
-    vertex.data = {"node": {"template": template}}
-    if node_type is not None:
-        vertex.data["type"] = node_type
-    vertex.params = {}
-    vertex.load_from_db_fields = []
-    return vertex
+    return _FakeVertex(vertex_id, template, node_type)
 
 
 def test_graph_path_refuses_a_sandbox_field_the_old_filter_allowed():

--- a/src/lfx/tests/unit/test_tweaks_policy.py
+++ b/src/lfx/tests/unit/test_tweaks_policy.py
@@ -19,6 +19,12 @@ from lfx.exceptions.tweaks import TweakRefusedError
 from lfx.processing.process import apply_tweaks, process_tweaks
 from lfx.utils.flow_validation import flow_declares_api_editable
 
+PROTECTED_TWEAK_REASON = "The field is protected and keeps the value set by the flow author."
+DECLARED_TWEAK_REASON = (
+    "This flow declares which fields the API may set. Only fields marked editable via API accept a tweak."
+)
+OFF_TWEAK_REASON = "This deployment does not accept tweaks."
+
 
 def _node(template: dict, *, node_type: str | None = None, node_id: str = "n") -> dict:
     data: dict = {"node": {"template": template}}
@@ -153,6 +159,76 @@ def test_process_tweaks_raises_naming_every_refused_key():
     ):
         process_tweaks(graph, {"n1": {"a": "x"}, "n2": {"b": "y"}})
     assert exc.value.refused == ["a", "b"]
+
+
+@pytest.mark.parametrize("policy", ["permissive", "declared", "off"])
+def test_process_tweaks_reports_protected_reason_under_every_policy(policy):
+    graph = _graph(
+        [
+            _node(
+                {"database_url": {"value": "stored", "type": "str", "api_editable": True}},
+                node_type="SQLComponent",
+            )
+        ]
+    )
+
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value=policy),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks(graph, {"n": {"database_url": "postgresql://attacker/db"}})
+
+    assert exc.value.refused == ["database_url"]
+    assert exc.value.reason == PROTECTED_TWEAK_REASON
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_reason"),
+    [("declared", DECLARED_TWEAK_REASON), ("off", OFF_TWEAK_REASON)],
+)
+def test_process_tweaks_reports_policy_reason_for_ordinary_field(policy, expected_reason):
+    graph = _graph(
+        [
+            _node(
+                {
+                    "allowed": {"value": "old", "type": "str", "api_editable": True},
+                    "ordinary": {"value": "old", "type": "str"},
+                }
+            )
+        ]
+    )
+
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value=policy),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks(graph, {"n": {"ordinary": "new"}})
+
+    assert exc.value.refused == ["ordinary"]
+    assert exc.value.reason == expected_reason
+
+
+def test_process_tweaks_reports_protected_and_policy_reasons_together():
+    graph = _graph(
+        [
+            _node(
+                {
+                    "database_url": {"value": "stored", "type": "str", "api_editable": True},
+                    "ordinary": {"value": "old", "type": "str"},
+                },
+                node_type="SQLComponent",
+            )
+        ]
+    )
+
+    with (
+        patch("lfx.processing.process._resolve_tweak_policy", return_value="declared"),
+        pytest.raises(TweakRefusedError) as exc,
+    ):
+        process_tweaks(graph, {"n": {"ordinary": "new", "database_url": "postgresql://attacker/db"}})
+
+    assert exc.value.refused == ["database_url", "ordinary"]
+    assert exc.value.reason == f"{PROTECTED_TWEAK_REASON} {DECLARED_TWEAK_REASON}"
 
 
 def test_process_tweaks_does_not_refuse_the_injected_stream_key():


### PR DESCRIPTION
## Summary

- retain the reason attached to each refused tweak at the rule-decision point
- report protected-field, declared-policy, and disabled-policy refusals accurately
- combine mixed refusal reasons in a stable order without exposing submitted values or policy internals

Jira: https://datastax.jira.com/browse/LE-2387

## Tests

- LFX tweak-policy and process tests (43 passed)
- backend refusal-surface tests (4 passed)
- Ruff, formatting, and pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tweak refusal responses with clear, caller-facing reasons for each refused field.
  * Refusal messages now combine multiple applicable policy reasons consistently.
  * Synchronous-run errors now return complete structured 422 response details, including the error, code, message, and refused fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->