### PR TITLE
fix(api): enforce targeted-input policy (LE-2386)

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -600,10 +600,10 @@ async def _generate_flow_events(
             # not be flattened into the generic 500 below.
             #
             # ``start_flow_build`` eagerly refuses targeted inputs and does not
-            # accept tweaks. This branch remains for worker-initiated callers
-            # that pass tweaks directly to ``generate_flow_events``; their HTTP
-            # response is already committed, so refusal is reported as an error
-            # event instead. Enforcement still holds: the tweak is never applied.
+            # accept tweaks. V2 streaming and background callers instead pass
+            # tweaks directly to ``generate_flow_events`` after their response or
+            # job is committed, so refusal is reported as an error event there.
+            # Enforcement still holds: the tweak is never applied.
             raise
         except Exception as exc:
             await log_telemetry(

--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -12,7 +12,7 @@ from lfx.graph.exceptions import GraphPausedException
 from lfx.graph.graph.base import Graph
 from lfx.graph.utils import log_vertex_build
 from lfx.log.logger import logger
-from lfx.processing.process import process_tweaks_on_graph
+from lfx.processing.process import process_tweaks_on_graph, validate_targeted_inputs
 from lfx.schema.legacy_render import project_payload_to_v1
 from lfx.schema.schema import InputValueRequest
 from lfx.utils.file_path_security import LocalFileAccessError
@@ -225,6 +225,11 @@ async def start_flow_build(
     Returns:
         the job_id.
     """
+    # Reject before allocating a queue or starting the background build. Once a
+    # job id has been returned, a policy refusal can only arrive as an event on
+    # an HTTP 200 rather than the documented structured 422.
+    validate_targeted_inputs([inputs] if inputs is not None else None)
+
     job_id = str(uuid.uuid4())
     try:
         _, event_manager = queue_service.create_queue(job_id)

--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -599,11 +599,11 @@ async def _generate_flow_events(
             # A refused tweak is a caller error, not a build failure, so it must
             # not be flattened into the generic 500 below.
             #
-            # Where it surfaces depends on how this ran. Called inline, it
-            # reaches the app-level handler and answers 422. Streaming and
-            # background callers run this in their own task, so the refusal is
-            # reported as an error event on an already-committed HTTP 200
-            # instead. Enforcement holds either way: the tweak is never applied.
+            # ``start_flow_build`` eagerly refuses targeted inputs and does not
+            # accept tweaks. This branch remains for worker-initiated callers
+            # that pass tweaks directly to ``generate_flow_events``; their HTTP
+            # response is already committed, so refusal is reported as an error
+            # event instead. Enforcement still holds: the tweak is never applied.
             raise
         except Exception as exc:
             await log_telemetry(

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from lfx.exceptions.tweaks import TweakRefusedError
 from lfx.graph.graph.base import Graph
 from lfx.graph.utils import log_vertex_build
 from lfx.log.logger import logger
@@ -1163,6 +1164,9 @@ async def build_public_tmp(
         # started through this public build path, preventing unauthenticated
         # callers from reading or cancelling private-flow builds by job_id.
         await queue_service.register_public_job(job_id)
+    except TweakRefusedError:
+        # Let the app-level handler return the documented structured 422.
+        raise
     except CatalogPolicyIdentityUnavailableError as exc:
         await logger.awarning("Public flow component identities are temporarily unavailable")
         raise HTTPException(status_code=503, detail=PUBLIC_CATALOG_POLICY_UNAVAILABLE_MESSAGE) from exc

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1606,6 +1606,9 @@ async def experimental_run_flow(
                 outputs=outputs,
                 stream=stream,
             )
+    except TweakRefusedError:
+        # Let the app-level handler return the documented structured 422.
+        raise
     except Exception as exc:
         await logger.aexception("Advanced-run execution failed for flow %s", flow.id)
         if isinstance(exc, HTTPException):

--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -7,61 +7,20 @@ from lfx.processing.process import apply_tweaks as _lfx_apply_tweaks
 from lfx.processing.process import apply_tweaks_on_vertex as _lfx_apply_tweaks_on_vertex
 from lfx.processing.process import process_tweaks as _lfx_process_tweaks
 from lfx.processing.process import process_tweaks_on_graph as _lfx_process_tweaks_on_graph
+from lfx.processing.process import run_graph_internal as _lfx_run_graph_internal
 from pydantic import BaseModel
 
 from langflow.schema.graph import InputValue, Tweaks
 from langflow.schema.schema import INPUT_FIELD_NAME
-from langflow.services.deps import get_settings_service
 
 if TYPE_CHECKING:
-    from lfx.events.event_manager import EventManager
     from lfx.graph.graph.base import Graph
     from lfx.graph.schema import RunOutputs
-    from lfx.schema.schema import InputValueRequest
 
 
 class Result(BaseModel):
     result: Any
     session_id: str
-
-
-async def run_graph_internal(
-    graph: Graph,
-    flow_id: str,
-    *,
-    stream: bool = False,
-    session_id: str | None = None,
-    inputs: list[InputValueRequest] | None = None,
-    outputs: list[str] | None = None,
-    event_manager: EventManager | None = None,
-) -> tuple[list[RunOutputs], str]:
-    """Run the graph and generate the result."""
-    inputs = inputs or []
-    effective_session_id = session_id or flow_id
-    components = []
-    inputs_list = []
-    types = []
-    for input_value_request in inputs:
-        if input_value_request.input_value is None:
-            await logger.awarning("InputValueRequest input_value cannot be None, defaulting to an empty string.")
-            input_value_request.input_value = ""
-        components.append(input_value_request.components or [])
-        inputs_list.append({INPUT_FIELD_NAME: input_value_request.input_value})
-        types.append(input_value_request.type)
-
-    fallback_to_env_vars = get_settings_service().settings.fallback_to_env_var
-    graph.session_id = effective_session_id
-    run_outputs = await graph.arun(
-        inputs=inputs_list,
-        inputs_components=components,
-        types=types,
-        outputs=outputs or [],
-        stream=stream,
-        session_id=effective_session_id or "",
-        fallback_to_env_vars=fallback_to_env_vars,
-        event_manager=event_manager,
-    )
-    return run_outputs, effective_session_id
 
 
 async def run_graph(
@@ -147,6 +106,7 @@ def validate_input(
 # `is_protected_tweak_field` while this copy kept the older inline checks and a
 # separate "code field" warning. The guards were equivalent, so no request was
 # unguarded, but the drift is why a second copy is not worth keeping.
+run_graph_internal = _lfx_run_graph_internal
 apply_tweaks = _lfx_apply_tweaks
 apply_tweaks_on_vertex = _lfx_apply_tweaks_on_vertex
 process_tweaks = _lfx_process_tweaks

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -99,12 +99,18 @@ async def test_off_refuses_component_targeted_inputs_on_the_v1_build(
     client, simple_api_test, logged_in_headers, monkeypatch
 ):
     """The authenticated build path must refuse before it queues a job."""
-    from langflow.services.deps import get_settings_service
+    from uuid import UUID
+
+    from langflow.services.database.models.jobs.model import Job
+    from langflow.services.deps import get_queue_service, get_settings_service, session_scope
+    from sqlmodel import select
 
     monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", "off")
-    flow_id = simple_api_test["id"]
+    flow_id = UUID(simple_api_test["id"])
     node_id = next(node["id"] for node in simple_api_test["data"]["nodes"] if node["id"].startswith("ChatInput"))
     payload = {"inputs": {"components": [node_id], "input_value": "targeted", "type": "chat"}}
+    queue_service = get_queue_service()
+    active_jobs_before = queue_service.metrics_snapshot()["active_jobs"]
 
     response = await client.post(f"/api/v1/build/{flow_id}/flow", headers=logged_in_headers, json=payload)
 
@@ -112,6 +118,10 @@ async def test_off_refuses_component_targeted_inputs_on_the_v1_build(
     detail = response.json()["detail"]
     assert detail["code"] == "TWEAKS_REFUSED"
     assert detail["fields"] == [node_id]
+    assert queue_service.metrics_snapshot()["active_jobs"] == active_jobs_before
+    async with session_scope() as session:
+        jobs = (await session.exec(select(Job).where(Job.flow_id == flow_id))).all()
+    assert jobs == []
 
 
 async def test_off_refuses_component_targeted_inputs_on_the_v1_public_build(

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -71,6 +71,72 @@ async def test_refused_tweak_returns_422_on_the_v1_advanced_run(client, simple_a
     assert detail["fields"] == ["code"]
 
 
+async def test_off_refuses_component_targeted_inputs_on_the_v1_advanced_run(
+    client, simple_api_test, created_api_key, monkeypatch
+):
+    """The Langflow HTTP path must enforce the LFX targeted-input guard."""
+    from langflow.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", "off")
+    flow_id = simple_api_test["id"]
+    node_id = next(node["id"] for node in simple_api_test["data"]["nodes"] if node["id"].startswith("ChatInput"))
+    payload = {
+        "inputs": [{"components": [node_id], "input_value": "targeted", "type": "chat"}],
+        "outputs": [],
+    }
+
+    response = await client.post(
+        f"/api/v1/run/advanced/{flow_id}", headers={"x-api-key": created_api_key.api_key}, json=payload
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "TWEAKS_REFUSED"
+    assert detail["fields"] == [node_id]
+
+
+@pytest.mark.parametrize("policy", ["permissive", "declared"])
+async def test_non_off_policies_allow_component_targeted_inputs_on_the_v1_advanced_run(
+    client, simple_api_test, created_api_key, monkeypatch, policy
+):
+    """Only ``off`` closes targeted inputs; the other policies remain compatible."""
+    from langflow.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", policy)
+    flow_id = simple_api_test["id"]
+    node_id = next(node["id"] for node in simple_api_test["data"]["nodes"] if node["id"].startswith("ChatInput"))
+    payload = {
+        "inputs": [{"components": [node_id], "input_value": "targeted", "type": "chat"}],
+        "outputs": [],
+    }
+
+    response = await client.post(
+        f"/api/v1/run/advanced/{flow_id}", headers={"x-api-key": created_api_key.api_key}, json=payload
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["session_id"] == flow_id
+
+
+async def test_off_allows_plain_input_and_session_on_the_v1_run(client, simple_api_test, created_api_key, monkeypatch):
+    """``off`` closes node selection without disabling ordinary chat runs."""
+    from langflow.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", "off")
+    flow_id = simple_api_test["id"]
+    payload = {
+        "input_value": "ordinary",
+        "input_type": "chat",
+        "output_type": "text",
+        "session_id": "ordinary-session",
+    }
+
+    response = await client.post(f"/api/v1/run/{flow_id}", headers={"x-api-key": created_api_key.api_key}, json=payload)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["session_id"] == "ordinary-session"
+
+
 async def test_off_does_not_break_a_flow_called_as_a_tool(simple_api_test, active_user):
     """``off`` closes the API surface, it must not stop agents calling flows as tools.
 

--- a/src/backend/tests/unit/api/test_tweak_refusal_surface.py
+++ b/src/backend/tests/unit/api/test_tweak_refusal_surface.py
@@ -95,6 +95,50 @@ async def test_off_refuses_component_targeted_inputs_on_the_v1_advanced_run(
     assert detail["fields"] == [node_id]
 
 
+async def test_off_refuses_component_targeted_inputs_on_the_v1_build(
+    client, simple_api_test, logged_in_headers, monkeypatch
+):
+    """The authenticated build path must refuse before it queues a job."""
+    from langflow.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", "off")
+    flow_id = simple_api_test["id"]
+    node_id = next(node["id"] for node in simple_api_test["data"]["nodes"] if node["id"].startswith("ChatInput"))
+    payload = {"inputs": {"components": [node_id], "input_value": "targeted", "type": "chat"}}
+
+    response = await client.post(f"/api/v1/build/{flow_id}/flow", headers=logged_in_headers, json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "TWEAKS_REFUSED"
+    assert detail["fields"] == [node_id]
+
+
+async def test_off_refuses_component_targeted_inputs_on_the_v1_public_build(
+    client, simple_api_test, logged_in_headers, monkeypatch
+):
+    """The anonymous public build path must return the same structured 422."""
+    from langflow.services.deps import get_settings_service
+
+    monkeypatch.setattr(get_settings_service().settings, "tweaks_policy", "off")
+    flow_id = simple_api_test["id"]
+    node_id = next(node["id"] for node in simple_api_test["data"]["nodes"] if node["id"].startswith("ChatInput"))
+    public_response = await client.patch(
+        f"/api/v1/flows/{flow_id}", json={"access_type": "PUBLIC"}, headers=logged_in_headers
+    )
+    assert public_response.status_code == status.HTTP_200_OK, public_response.text
+    client.cookies.clear()
+    client.cookies.set("client_id", "targeted-input-policy-client")
+    payload = {"inputs": {"components": [node_id], "input_value": "targeted", "type": "chat"}}
+
+    response = await client.post(f"/api/v1/build_public_tmp/{flow_id}/flow", json=payload)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "TWEAKS_REFUSED"
+    assert detail["fields"] == [node_id]
+
+
 @pytest.mark.parametrize("policy", ["permissive", "declared"])
 async def test_non_off_policies_allow_component_targeted_inputs_on_the_v1_advanced_run(
     client, simple_api_test, created_api_key, monkeypatch, policy

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -44,6 +44,20 @@ class Result(BaseModel):
     session_id: str
 
 
+def validate_targeted_inputs(inputs: list[InputValueRequest] | None) -> None:
+    """Refuse caller-selected input components when the tweak policy is off."""
+    from lfx.utils.flow_validation import TWEAK_POLICY_OFF
+
+    if _resolve_tweak_policy() != TWEAK_POLICY_OFF:
+        return
+
+    targeted = sorted({component for request in inputs or [] for component in (request.components or [])})
+    if targeted:
+        from lfx.exceptions.tweaks import TweakRefusedError
+
+        raise TweakRefusedError(targeted, reason="This deployment does not accept component-targeted inputs.")
+
+
 async def run_graph_internal(
     graph: Graph,
     flow_id: str,
@@ -61,14 +75,7 @@ async def run_graph_internal(
     # ``off`` refuses component-targeted inputs as well as tweaks. Both aim a
     # value at a named node, so refusing only tweaks would make the setting
     # tell a half-truth. ``input_value`` and ``session_id`` keep working.
-    from lfx.utils.flow_validation import TWEAK_POLICY_OFF
-
-    if _resolve_tweak_policy() == TWEAK_POLICY_OFF:
-        targeted = sorted({c for r in inputs for c in (r.components or [])})
-        if targeted:
-            from lfx.exceptions.tweaks import TweakRefusedError
-
-            raise TweakRefusedError(targeted, reason="This deployment does not accept component-targeted inputs.")
+    validate_targeted_inputs(inputs)
 
     components = []
     inputs_list = []

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -82,7 +82,7 @@ async def run_graph_internal(
     types = []
     for input_value_request in inputs:
         if input_value_request.input_value is None:
-            logger.warning("InputValueRequest input_value cannot be None, defaulting to an empty string.")
+            await logger.awarning("InputValueRequest input_value cannot be None, defaulting to an empty string.")
             input_value_request.input_value = ""
         components.append(input_value_request.components or [])
         inputs_list.append({INPUT_FIELD_NAME: input_value_request.input_value})


### PR DESCRIPTION
## Summary

- route Langflow execution through the guarded LFX `run_graph_internal`
- reject component-targeted inputs under `LANGFLOW_TWEAKS_POLICY=off` before build-job allocation
- preserve structured 422 responses on advanced, authenticated-build, and public-build routes
- keep permissive/declared targeting and ordinary input/session execution unchanged

Jira: https://datastax.jira.com/browse/LE-2386

## Tests

- HTTP tweak-refusal surface (10 passed)
- end-user scoping HTTP controls (10 passed)
- agentic flow-run controls (22 passed)
- isolated LFX policy/schema controls (35 passed)
- Ruff, formatting, and pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy-refused targeted inputs now return a clear, structured 422 error instead of appearing as successful requests or generic server errors.
  * Error responses identify the targeted input fields that were refused across advanced runs and build operations.
  * Ordinary chat runs with standard inputs continue to work when targeted tweaks are disabled.
  * Targeted inputs remain supported when permissive or declared tweak policies allow them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->