### PR TITLE
fix(security): encrypt background request overrides (LE-2381)

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -90,6 +90,10 @@ from langflow.services.auth.utils import get_current_user_for_workflow
 from langflow.services.authorization import FlowAction, ensure_flow_permission
 from langflow.services.authorization.fetch import deny_to_404_unless_readable
 from langflow.services.authorization.flow_data_override import resolve_flow_data_override
+from langflow.services.background_execution.service import (
+    InvalidRequestOverridesError,
+    RequestOverridesUnavailableError,
+)
 from langflow.services.database.models.flow.model import FlowRead
 from langflow.services.database.models.jobs.model import Job, JobType
 from langflow.services.database.models.user.model import UserRead
@@ -406,6 +410,27 @@ async def submit_background_with_mapping(
             stream_protocol=stream_protocol,
             idempotency_key=getattr(parsed, "idempotency_key", None),
         )
+    except InvalidRequestOverridesError as err:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "Invalid request overrides",
+                "code": "INVALID_REQUEST_OVERRIDES",
+                "message": "globals and tweaks must contain JSON-compatible values.",
+                "field": err.field,
+                "flow_id": parsed.flow_id,
+            },
+        ) from err
+    except RequestOverridesUnavailableError as err:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "error": "Service unavailable",
+                "code": "REQUEST_OVERRIDES_UNAVAILABLE",
+                "message": "Background request overrides are temporarily unavailable. Please try again.",
+                "flow_id": parsed.flow_id,
+            },
+        ) from err
     except WorkflowServiceUnavailableError as err:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -1146,12 +1171,23 @@ async def resume_workflow(
     # Snapshot the card id before the continuation runs: it may reach another pause and
     # overwrite job metadata, and this decision must never stamp that later card.
     card_message_id = (job.job_metadata or {}).get("card_message_id")
-    accepted = await service.resume_job(
-        parsed_job_id,
-        current_user,
-        request_id=request.request_id,
-        decision=request.decision or {},
-    )
+    try:
+        accepted = await service.resume_job(
+            parsed_job_id,
+            current_user,
+            request_id=request.request_id,
+            decision=request.decision or {},
+        )
+    except RequestOverridesUnavailableError as err:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "error": "Service unavailable",
+                "code": "REQUEST_OVERRIDES_UNAVAILABLE",
+                "message": "Background request overrides are temporarily unavailable. Please try again.",
+                "job_id": job_id,
+            },
+        ) from err
     if not accepted:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -382,9 +382,13 @@ class BackgroundExecutionService(Service):
         seen.add(value_id)
         try:
             if isinstance(value, dict):
-                if not all(isinstance(key, str) for key in value):
-                    raise InvalidRequestOverridesError(field)
-                for nested in value.values():
+                for key, nested in value.items():
+                    if not isinstance(key, str):
+                        raise InvalidRequestOverridesError(field)
+                    try:
+                        key.encode("utf-8")
+                    except UnicodeEncodeError:
+                        raise InvalidRequestOverridesError(field) from None
                     cls._validate_json_value(nested, field=field, seen=seen, depth=depth + 1)
             else:
                 for nested in value:
@@ -431,7 +435,7 @@ class BackgroundExecutionService(Service):
                     separators=(",", ":"),
                     sort_keys=True,
                 ).encode()
-            except (RecursionError, TypeError, UnicodeError, ValueError) as exc:
+            except (RecursionError, TypeError, UnicodeError, ValueError, OverflowError) as exc:
                 logger.warning(
                     "Background request override serialization failed",
                     job_id=str(job_id),
@@ -440,6 +444,15 @@ class BackgroundExecutionService(Service):
                     error_type=type(exc).__name__,
                 )
                 raise InvalidRequestOverridesError(_REQUEST_OVERRIDES_CONTAINER_FIELD) from None
+            except Exception as exc:  # noqa: BLE001 -- resource/server failures remain retryable
+                logger.error(
+                    "Background request override serialization unavailable",
+                    job_id=str(job_id),
+                    flow_id=str(flow_id),
+                    stage="serialize",
+                    error_type=type(exc).__name__,
+                )
+                raise RequestOverridesUnavailableError from None
             try:
                 ciphertext = get_fernet(self.settings_service).encrypt(plaintext).decode("ascii")
             except Exception as exc:  # noqa: BLE001 -- every crypto/config failure becomes the same safe error

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -22,6 +22,7 @@ import json
 import math
 import os
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -66,15 +67,29 @@ _REQUEST_OVERRIDES_KEY = "request_overrides"
 _REQUEST_OVERRIDES_FORMAT = "fernet-json-v1"
 _REQUEST_OVERRIDES_VERSION = 1
 _REQUEST_OVERRIDE_FIELDS = frozenset({"globals", "tweaks"})
+_REQUEST_OVERRIDES_CONTAINER_FIELD = "overrides"
 _REQUEST_OVERRIDES_ERROR = {"type": "request_overrides_unavailable"}
 _MAX_OVERRIDE_JSON_DEPTH = 64
+_MAX_OVERRIDE_INTEGER_BITS = 14_000
 
 
 class RequestOverridesUnavailableError(RuntimeError):
-    """Fail-closed signal for a background request whose overrides cannot be restored."""
+    """Retryable signal for request overrides blocked by unavailable cryptographic state."""
 
     def __init__(self) -> None:
         super().__init__("Background request overrides are unavailable.")
+
+
+class RequestOverridesCorruptedError(RequestOverridesUnavailableError):
+    """Fail-closed signal for an authenticated or structurally malformed persisted envelope."""
+
+
+class InvalidRequestOverridesError(ValueError):
+    """Caller-supplied request overrides do not match the supported JSON grammar."""
+
+    def __init__(self, field: str) -> None:
+        self.field = field
+        super().__init__(f"Invalid request override field: {field}")
 
 
 class BackgroundExecutionService(Service):
@@ -328,33 +343,52 @@ class BackgroundExecutionService(Service):
         return redacted
 
     @classmethod
-    def _validate_json_value(cls, value: Any, *, seen: set[int] | None = None, depth: int = 0) -> None:
+    def _validate_json_value(
+        cls,
+        value: Any,
+        *,
+        field: str,
+        seen: set[int] | None = None,
+        depth: int = 0,
+    ) -> None:
         """Validate the deliberately narrow JSON value grammar used by overrides."""
         if depth > _MAX_OVERRIDE_JSON_DEPTH:
-            raise RequestOverridesUnavailableError
-        if value is None or isinstance(value, (str, bool, int)):
+            raise InvalidRequestOverridesError(field)
+        if value is None or isinstance(value, bool):
+            return
+        if isinstance(value, str):
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError:
+                raise InvalidRequestOverridesError(field) from None
+            return
+        if isinstance(value, int):
+            # Bound decimal conversion below Python's default 4,300-digit
+            # protection so behavior is stable on every supported interpreter.
+            if value.bit_length() > _MAX_OVERRIDE_INTEGER_BITS:
+                raise InvalidRequestOverridesError(field)
             return
         if isinstance(value, float):
             if not math.isfinite(value):
-                raise RequestOverridesUnavailableError
+                raise InvalidRequestOverridesError(field)
             return
         if not isinstance(value, (dict, list)):
-            raise RequestOverridesUnavailableError
+            raise InvalidRequestOverridesError(field)
         if seen is None:
             seen = set()
         value_id = id(value)
         if value_id in seen:
-            raise RequestOverridesUnavailableError
+            raise InvalidRequestOverridesError(field)
         seen.add(value_id)
         try:
             if isinstance(value, dict):
                 if not all(isinstance(key, str) for key in value):
-                    raise RequestOverridesUnavailableError
+                    raise InvalidRequestOverridesError(field)
                 for nested in value.values():
-                    cls._validate_json_value(nested, seen=seen, depth=depth + 1)
+                    cls._validate_json_value(nested, field=field, seen=seen, depth=depth + 1)
             else:
                 for nested in value:
-                    cls._validate_json_value(nested, seen=seen, depth=depth + 1)
+                    cls._validate_json_value(nested, field=field, seen=seen, depth=depth + 1)
         finally:
             seen.remove(value_id)
 
@@ -362,12 +396,12 @@ class BackgroundExecutionService(Service):
     def _validated_overrides(cls, value: Any) -> dict[str, dict[str, Any]]:
         """Return validated globals/tweaks only, rejecting all other envelope shapes."""
         if not isinstance(value, dict) or not set(value).issubset(_REQUEST_OVERRIDE_FIELDS):
-            raise RequestOverridesUnavailableError
+            raise InvalidRequestOverridesError(_REQUEST_OVERRIDES_CONTAINER_FIELD)
         overrides: dict[str, dict[str, Any]] = {}
         for key, nested in value.items():
             if not isinstance(nested, dict):
-                raise RequestOverridesUnavailableError
-            cls._validate_json_value(nested)
+                raise InvalidRequestOverridesError(key)
+            cls._validate_json_value(nested, field=key)
             overrides[key] = nested
         return overrides
 
@@ -397,10 +431,25 @@ class BackgroundExecutionService(Service):
                     separators=(",", ":"),
                     sort_keys=True,
                 ).encode()
+            except (RecursionError, TypeError, UnicodeError, ValueError) as exc:
+                logger.warning(
+                    "Background request override serialization failed",
+                    job_id=str(job_id),
+                    flow_id=str(flow_id),
+                    stage="serialize",
+                    error_type=type(exc).__name__,
+                )
+                raise InvalidRequestOverridesError(_REQUEST_OVERRIDES_CONTAINER_FIELD) from None
+            try:
                 ciphertext = get_fernet(self.settings_service).encrypt(plaintext).decode("ascii")
-            except RequestOverridesUnavailableError:
-                raise
-            except Exception:  # noqa: BLE001 -- every crypto/config failure must become the same safe error
+            except Exception as exc:  # noqa: BLE001 -- every crypto/config failure becomes the same safe error
+                logger.error(
+                    "Background request override encryption failed",
+                    job_id=str(job_id),
+                    flow_id=str(flow_id),
+                    stage="encrypt",
+                    error_type=type(exc).__name__,
+                )
                 raise RequestOverridesUnavailableError from None
             metadata[_REQUEST_OVERRIDES_FORMAT_KEY] = _REQUEST_OVERRIDES_FORMAT
             metadata[_REQUEST_OVERRIDES_KEY] = ciphertext
@@ -415,28 +464,65 @@ class BackgroundExecutionService(Service):
             # key. Plaintext values are rejected separately by reconstruction.
             return {}
         if not has_marker or not has_ciphertext or metadata[_REQUEST_OVERRIDES_FORMAT_KEY] != _REQUEST_OVERRIDES_FORMAT:
-            raise RequestOverridesUnavailableError
+            raise RequestOverridesCorruptedError
         ciphertext = metadata[_REQUEST_OVERRIDES_KEY]
         if not isinstance(ciphertext, str) or not ciphertext:
-            raise RequestOverridesUnavailableError
+            raise RequestOverridesCorruptedError
 
         from langflow.services.auth.utils import get_fernet_for_decryption
 
         try:
             plaintext = get_fernet_for_decryption(self.settings_service).decrypt(ciphertext.encode("ascii"))
+        except Exception as exc:  # noqa: BLE001 -- Fernet auth failure cannot distinguish bad key from tampering
+            logger.error(
+                "Background request override decryption failed",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="decrypt",
+                error_type=type(exc).__name__,
+            )
+            raise RequestOverridesUnavailableError from None
+
+        try:
             envelope = json.loads(plaintext)
             if not isinstance(envelope, dict) or set(envelope) != {"version", "job_id", "flow_id", "overrides"}:
-                raise RequestOverridesUnavailableError
+                raise RequestOverridesCorruptedError
             if type(envelope["version"]) is not int or envelope["version"] != _REQUEST_OVERRIDES_VERSION:
-                raise RequestOverridesUnavailableError
+                raise RequestOverridesCorruptedError
             if envelope["job_id"] != str(job.job_id) or envelope["flow_id"] != str(job.flow_id):
-                raise RequestOverridesUnavailableError
-            overrides = self._validated_overrides(envelope["overrides"])
+                raise RequestOverridesCorruptedError
+            try:
+                overrides = self._validated_overrides(envelope["overrides"])
+            except InvalidRequestOverridesError:
+                raise RequestOverridesCorruptedError from None
             if not overrides:
-                raise RequestOverridesUnavailableError
-        except RequestOverridesUnavailableError:
+                raise RequestOverridesCorruptedError
+        except RequestOverridesCorruptedError as exc:
+            logger.error(
+                "Background request override envelope validation failed",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="validate",
+                error_type=type(exc).__name__,
+            )
             raise
-        except Exception:  # noqa: BLE001 -- never expose crypto/parser distinctions to the caller
+        except (RecursionError, TypeError, UnicodeError, ValueError, OverflowError) as exc:
+            logger.error(
+                "Background request override parsing failed",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="parse",
+                error_type=type(exc).__name__,
+            )
+            raise RequestOverridesCorruptedError from None
+        except Exception as exc:  # noqa: BLE001 -- resource/server failures remain retryable
+            logger.error(
+                "Background request override parsing unavailable",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="parse",
+                error_type=type(exc).__name__,
+            )
             raise RequestOverridesUnavailableError from None
         else:
             return overrides
@@ -702,12 +788,38 @@ class BackgroundExecutionService(Service):
         # sweep would fail worker_lost. The runner's execute_with_status performs
         # the real QUEUED->IN_PROGRESS flip once it actually starts emitting.
         for job in await self._queued_workflow_jobs():
-            if not await job_service.claim_queued_lease(job.job_id, owner=self._owner, lease_ttl_s=lease_ttl):
+            lease_heartbeat = datetime.now(timezone.utc).isoformat()
+            if not await job_service.claim_queued_lease(
+                job.job_id,
+                owner=self._owner,
+                lease_ttl_s=lease_ttl,
+                heartbeat_at=lease_heartbeat,
+            ):
                 continue
             try:
                 request_dict = self._reconstruct_request(job)
-            except RequestOverridesUnavailableError:
-                await self._fail_request_overrides_unavailable(job.job_id, job_service)
+            except RequestOverridesCorruptedError:
+                await job_service.fail_queued_job(
+                    job.job_id,
+                    owner=self._owner,
+                    heartbeat_at=lease_heartbeat,
+                    error=dict(_REQUEST_OVERRIDES_ERROR),
+                    event_type="run_failed",
+                )
+                continue
+            except RequestOverridesUnavailableError as exc:
+                await logger.aerror(
+                    "Background request overrides unavailable during startup recovery",
+                    job_id=str(job.job_id),
+                    flow_id=str(job.flow_id),
+                    stage="startup_restore",
+                    error_type=type(exc).__name__,
+                )
+                await job_service.release_queued_lease(
+                    job.job_id,
+                    owner=self._owner,
+                    heartbeat_at=lease_heartbeat,
+                )
                 continue
             user = self._user_stub(job.user_id)
             with contextlib.suppress(Exception):
@@ -751,13 +863,6 @@ class BackgroundExecutionService(Service):
             result = await session.exec(stmt)
             return list(result.all())
 
-    @staticmethod
-    async def _fail_request_overrides_unavailable(job_id: UUID, job_service) -> None:
-        """Terminalize a queued job whose authenticated overrides cannot be restored."""
-        await job_service.update_job_status(job_id, JobStatus.FAILED, finished_timestamp=True)
-        await job_service.set_error(job_id, dict(_REQUEST_OVERRIDES_ERROR))
-        await job_service.append_event(job_id, "run_failed", dict(_REQUEST_OVERRIDES_ERROR))
-
     def _reconstruct_request(self, job: Job) -> dict[str, Any]:
         """Rebuild the request dict for a re-enqueued QUEUED job.
 
@@ -784,7 +889,7 @@ class BackgroundExecutionService(Service):
         for key in _REQUEST_OVERRIDE_FIELDS.intersection(request):
             value = request.pop(key)
             if not isinstance(value, dict) or value:
-                raise RequestOverridesUnavailableError
+                raise RequestOverridesCorruptedError
         return {**request, **self._decrypt_request_overrides(job, meta)}
 
     @staticmethod

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -485,7 +485,28 @@ class BackgroundExecutionService(Service):
         from langflow.services.auth.utils import get_fernet_for_decryption
 
         try:
-            plaintext = get_fernet_for_decryption(self.settings_service).decrypt(ciphertext.encode("ascii"))
+            encoded_ciphertext = ciphertext.encode("ascii")
+        except UnicodeEncodeError as exc:
+            logger.error(
+                "Background request override ciphertext validation failed",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="validate",
+                error_type=type(exc).__name__,
+            )
+            raise RequestOverridesCorruptedError from None
+        except Exception as exc:  # noqa: BLE001 -- resource/server failures remain retryable
+            logger.error(
+                "Background request override ciphertext encoding unavailable",
+                job_id=str(job.job_id),
+                flow_id=str(job.flow_id),
+                stage="encode",
+                error_type=type(exc).__name__,
+            )
+            raise RequestOverridesUnavailableError from None
+
+        try:
+            plaintext = get_fernet_for_decryption(self.settings_service).decrypt(encoded_ciphertext)
         except Exception as exc:  # noqa: BLE001 -- Fernet auth failure cannot distinguish bad key from tampering
             logger.error(
                 "Background request override decryption failed",

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -379,7 +379,7 @@ class BackgroundExecutionService(Service):
         # The API models default both fields to {}, so treat empty mappings as no
         # override rather than encrypting an envelope for every ordinary run.
         overrides = {key: value for key, value in supplied_overrides.items() if value}
-        ciphertext: str | None = None
+        metadata: dict[str, Any] = {"request": self._redact_request(request)}
         if overrides:
             from langflow.services.auth.utils import get_fernet
 
@@ -402,26 +402,21 @@ class BackgroundExecutionService(Service):
                 raise
             except Exception:  # noqa: BLE001 -- every crypto/config failure must become the same safe error
                 raise RequestOverridesUnavailableError from None
-        return {
-            "request": self._redact_request(request),
-            _REQUEST_OVERRIDES_FORMAT_KEY: _REQUEST_OVERRIDES_FORMAT,
-            _REQUEST_OVERRIDES_KEY: ciphertext,
-        }
+            metadata[_REQUEST_OVERRIDES_FORMAT_KEY] = _REQUEST_OVERRIDES_FORMAT
+            metadata[_REQUEST_OVERRIDES_KEY] = ciphertext
+        return metadata
 
     def _decrypt_request_overrides(self, job: Job, metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
         """Authenticate, decrypt, bind, and validate a job's override envelope."""
-        marker = metadata.get(_REQUEST_OVERRIDES_FORMAT_KEY)
-        if marker is None:
-            # Safe legacy rows never carried overrides. A legacy plaintext override
-            # must not bypass the encrypted format merely because it predates the marker.
-            if _REQUEST_OVERRIDES_KEY in metadata:
-                raise RequestOverridesUnavailableError
+        has_marker = _REQUEST_OVERRIDES_FORMAT_KEY in metadata
+        has_ciphertext = _REQUEST_OVERRIDES_KEY in metadata
+        if not has_marker and not has_ciphertext:
+            # New no-override rows and safe legacy rows intentionally carry neither
+            # key. Plaintext values are rejected separately by reconstruction.
             return {}
-        if marker != _REQUEST_OVERRIDES_FORMAT or _REQUEST_OVERRIDES_KEY not in metadata:
+        if not has_marker or not has_ciphertext or metadata[_REQUEST_OVERRIDES_FORMAT_KEY] != _REQUEST_OVERRIDES_FORMAT:
             raise RequestOverridesUnavailableError
         ciphertext = metadata[_REQUEST_OVERRIDES_KEY]
-        if ciphertext is None:
-            return {}
         if not isinstance(ciphertext, str) or not ciphertext:
             raise RequestOverridesUnavailableError
 
@@ -783,10 +778,13 @@ class BackgroundExecutionService(Service):
                 "session_id": meta.get("session_id"),
                 "input_value": meta.get("input_value", ""),
             }
-        # No plaintext override is accepted, including on old rows: otherwise a
-        # missing marker would silently downgrade the authenticated format.
-        if _REQUEST_OVERRIDE_FIELDS.intersection(request):
-            raise RequestOverridesUnavailableError
+        # Pre-fix v2 requests always included empty override defaults. They carry
+        # no value and are safe to normalize away; every other plaintext shape
+        # remains a fail-closed downgrade attempt.
+        for key in _REQUEST_OVERRIDE_FIELDS.intersection(request):
+            value = request.pop(key)
+            if not isinstance(value, dict) or value:
+                raise RequestOverridesUnavailableError
         return {**request, **self._decrypt_request_overrides(job, meta)}
 
     @staticmethod

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -280,19 +280,19 @@ class BackgroundExecutionService(Service):
             if existing is not None:
                 return existing
             raise
-        # Persist the submit request on the job row so a QUEUED job that survives
-        # a restart is re-enqueued with its ORIGINAL inputs (input_value, tweaks,
-        # etc.), not a reconstructed default. The worker / startup sweep read it
-        # back via ``_reconstruct_request``.
+        # Persist replay-safe request fields on the job row so a QUEUED job that
+        # survives a restart keeps its original input, files, partial-run ids,
+        # and protocol instead of falling back to reconstructed defaults. The
+        # worker / startup sweep reads them via ``_reconstruct_request``.
         #
-        # Request-level ``globals`` are REDACTED from the persisted copy: they can
-        # carry inline secrets (API keys), and storing them plaintext in the
+        # Request-level ``globals`` and ``tweaks`` are REDACTED from the persisted
+        # copy: both can carry inline secrets (API keys), and storing them plaintext in the
         # durable ``job`` table (JSONB on Postgres) widens the blast radius of any
         # DB read (backup, ops access, a SQL-injection elsewhere) beyond the
-        # live-only handling globals get on the sync path. Tradeoff: a background
-        # re-enqueue after a restart drops inline globals — reference STORED global
-        # variables by name for background runs rather than passing secrets inline.
-        # The live in-memory run below still uses the full ``request``.
+        # live-only handling these overrides get on the sync path. Tradeoff: a
+        # background re-enqueue after a restart drops inline globals and tweaks —
+        # store durable values on the flow or in named variables instead. The live
+        # in-memory run below still uses the full ``request``.
         await job_service.update_job_metadata(job_id, {"request": self._redact_request(request)})
         # After create_job so an idempotent retry returns the existing job instead of
         # cancelling it; the new job is QUEUED, so the suspended-only query skips it.
@@ -307,17 +307,17 @@ class BackgroundExecutionService(Service):
 
     @staticmethod
     def _redact_request(request: dict[str, Any]) -> dict[str, Any]:
-        """Return a copy of ``request`` with secret-bearing ``globals`` removed.
+        """Return a copy of ``request`` with secret-bearing overrides removed.
 
         Returns a shallow copy so the caller's dict (used for the live run) is not
-        mutated. Only ``globals`` is dropped; everything else round-trips for a
-        faithful replay. See ``submit`` for the durable-plaintext rationale and
-        the inline-globals tradeoff.
+        mutated. ``globals`` and ``tweaks`` are dropped; everything else round-trips
+        for replay. See ``submit`` for the durable-plaintext rationale and tradeoff.
         """
-        if "globals" not in request:
+        if "globals" not in request and "tweaks" not in request:
             return request
         redacted = dict(request)
         redacted.pop("globals", None)
+        redacted.pop("tweaks", None)
         return redacted
 
     @staticmethod
@@ -626,11 +626,12 @@ class BackgroundExecutionService(Service):
     def _reconstruct_request(job: Job) -> dict[str, Any]:
         """Rebuild the request dict for a re-enqueued QUEUED job.
 
-        ``submit`` persists the original request body under
-        ``job_metadata["request"]`` so re-enqueue replays the ORIGINAL inputs
-        (input_value, tweaks, globals, files, partial-run ids, ...). Falls back
-        to a minimal default only for legacy rows written before the request was
-        persisted, so a pre-existing QUEUED job still re-runs rather than blocks.
+        ``submit`` persists replay-safe request fields under
+        ``job_metadata["request"]`` so re-enqueue keeps the original input, files,
+        partial-run ids, and protocol. Secret-bearing globals and tweaks stay
+        live-only. Falls back to a minimal default only for legacy rows written
+        before the request was persisted, so a pre-existing QUEUED job still
+        re-runs rather than blocks.
         """
         meta = job.job_metadata or {}
         persisted = meta.get("request")

--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import math
 import os
 import tempfile
 from pathlib import Path
@@ -60,6 +61,20 @@ if TYPE_CHECKING:
 # process-local live bus) so a reattach to a finished job replays and returns
 # instead of tailing a bus that will never produce another frame.
 _TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.TIMED_OUT})
+_REQUEST_OVERRIDES_FORMAT_KEY = "request_overrides_format"
+_REQUEST_OVERRIDES_KEY = "request_overrides"
+_REQUEST_OVERRIDES_FORMAT = "fernet-json-v1"
+_REQUEST_OVERRIDES_VERSION = 1
+_REQUEST_OVERRIDE_FIELDS = frozenset({"globals", "tweaks"})
+_REQUEST_OVERRIDES_ERROR = {"type": "request_overrides_unavailable"}
+_MAX_OVERRIDE_JSON_DEPTH = 64
+
+
+class RequestOverridesUnavailableError(RuntimeError):
+    """Fail-closed signal for a background request whose overrides cannot be restored."""
+
+    def __init__(self) -> None:
+        super().__init__("Background request overrides are unavailable.")
 
 
 class BackgroundExecutionService(Service):
@@ -260,6 +275,11 @@ class BackgroundExecutionService(Service):
         job_service = get_job_service()
         job_id = uuid4()
         dedupe_key = request.get("idempotency_key")
+        # Construct and encrypt the durable payload BEFORE creating the row. The
+        # QUEUED insert then commits the marker, plaintext-safe request, and
+        # authenticated override envelope together; no worker can claim a row in
+        # the old create-then-patch gap.
+        initial_metadata = self._persisted_request_metadata(job_id=job_id, flow_id=flow_id, request=request)
         try:
             await job_service.create_job(
                 job_id=job_id,
@@ -270,6 +290,7 @@ class BackgroundExecutionService(Service):
                 # status/stop/resume isolate on it. user_id stays the SID so the worker's
                 # _user_stub(job.user_id) still fetches the SID-owned flow on re-enqueue.
                 end_user_id=request.get("end_user_id"),
+                initial_metadata=initial_metadata,
             )
         except DuplicateJobError:
             # Idempotent retry: a non-terminal job already exists for this key,
@@ -280,20 +301,6 @@ class BackgroundExecutionService(Service):
             if existing is not None:
                 return existing
             raise
-        # Persist replay-safe request fields on the job row so a QUEUED job that
-        # survives a restart keeps its original input, files, partial-run ids,
-        # and protocol instead of falling back to reconstructed defaults. The
-        # worker / startup sweep reads them via ``_reconstruct_request``.
-        #
-        # Request-level ``globals`` and ``tweaks`` are REDACTED from the persisted
-        # copy: both can carry inline secrets (API keys), and storing them plaintext in the
-        # durable ``job`` table (JSONB on Postgres) widens the blast radius of any
-        # DB read (backup, ops access, a SQL-injection elsewhere) beyond the
-        # live-only handling these overrides get on the sync path. Tradeoff: a
-        # background re-enqueue after a restart drops inline globals and tweaks —
-        # store durable values on the flow or in named variables instead. The live
-        # in-memory run below still uses the full ``request``.
-        await job_service.update_job_metadata(job_id, {"request": self._redact_request(request)})
         # After create_job so an idempotent retry returns the existing job instead of
         # cancelling it; the new job is QUEUED, so the suspended-only query skips it.
         await self.supersede_suspended_runs(flow_id=flow_id, user_id=user.id, session_id=request.get("session_id"))
@@ -310,8 +317,8 @@ class BackgroundExecutionService(Service):
         """Return a copy of ``request`` with secret-bearing overrides removed.
 
         Returns a shallow copy so the caller's dict (used for the live run) is not
-        mutated. ``globals`` and ``tweaks`` are dropped; everything else round-trips
-        for replay. See ``submit`` for the durable-plaintext rationale and tradeoff.
+        mutated. ``globals`` and ``tweaks`` are dropped from this plaintext blob;
+        an authenticated encrypted envelope carries them for durable replay.
         """
         if "globals" not in request and "tweaks" not in request:
             return request
@@ -319,6 +326,125 @@ class BackgroundExecutionService(Service):
         redacted.pop("globals", None)
         redacted.pop("tweaks", None)
         return redacted
+
+    @classmethod
+    def _validate_json_value(cls, value: Any, *, seen: set[int] | None = None, depth: int = 0) -> None:
+        """Validate the deliberately narrow JSON value grammar used by overrides."""
+        if depth > _MAX_OVERRIDE_JSON_DEPTH:
+            raise RequestOverridesUnavailableError
+        if value is None or isinstance(value, (str, bool, int)):
+            return
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise RequestOverridesUnavailableError
+            return
+        if not isinstance(value, (dict, list)):
+            raise RequestOverridesUnavailableError
+        if seen is None:
+            seen = set()
+        value_id = id(value)
+        if value_id in seen:
+            raise RequestOverridesUnavailableError
+        seen.add(value_id)
+        try:
+            if isinstance(value, dict):
+                if not all(isinstance(key, str) for key in value):
+                    raise RequestOverridesUnavailableError
+                for nested in value.values():
+                    cls._validate_json_value(nested, seen=seen, depth=depth + 1)
+            else:
+                for nested in value:
+                    cls._validate_json_value(nested, seen=seen, depth=depth + 1)
+        finally:
+            seen.remove(value_id)
+
+    @classmethod
+    def _validated_overrides(cls, value: Any) -> dict[str, dict[str, Any]]:
+        """Return validated globals/tweaks only, rejecting all other envelope shapes."""
+        if not isinstance(value, dict) or not set(value).issubset(_REQUEST_OVERRIDE_FIELDS):
+            raise RequestOverridesUnavailableError
+        overrides: dict[str, dict[str, Any]] = {}
+        for key, nested in value.items():
+            if not isinstance(nested, dict):
+                raise RequestOverridesUnavailableError
+            cls._validate_json_value(nested)
+            overrides[key] = nested
+        return overrides
+
+    def _persisted_request_metadata(self, *, job_id: UUID, flow_id: UUID, request: dict[str, Any]) -> dict[str, Any]:
+        """Build the atomic metadata payload for a background workflow row."""
+        supplied_overrides = self._validated_overrides(
+            {key: request[key] for key in _REQUEST_OVERRIDE_FIELDS if key in request}
+        )
+        # The API models default both fields to {}, so treat empty mappings as no
+        # override rather than encrypting an envelope for every ordinary run.
+        overrides = {key: value for key, value in supplied_overrides.items() if value}
+        ciphertext: str | None = None
+        if overrides:
+            from langflow.services.auth.utils import get_fernet
+
+            envelope = {
+                "version": _REQUEST_OVERRIDES_VERSION,
+                "job_id": str(job_id),
+                "flow_id": str(flow_id),
+                "overrides": overrides,
+            }
+            try:
+                plaintext = json.dumps(
+                    envelope,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode()
+                ciphertext = get_fernet(self.settings_service).encrypt(plaintext).decode("ascii")
+            except RequestOverridesUnavailableError:
+                raise
+            except Exception:  # noqa: BLE001 -- every crypto/config failure must become the same safe error
+                raise RequestOverridesUnavailableError from None
+        return {
+            "request": self._redact_request(request),
+            _REQUEST_OVERRIDES_FORMAT_KEY: _REQUEST_OVERRIDES_FORMAT,
+            _REQUEST_OVERRIDES_KEY: ciphertext,
+        }
+
+    def _decrypt_request_overrides(self, job: Job, metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        """Authenticate, decrypt, bind, and validate a job's override envelope."""
+        marker = metadata.get(_REQUEST_OVERRIDES_FORMAT_KEY)
+        if marker is None:
+            # Safe legacy rows never carried overrides. A legacy plaintext override
+            # must not bypass the encrypted format merely because it predates the marker.
+            if _REQUEST_OVERRIDES_KEY in metadata:
+                raise RequestOverridesUnavailableError
+            return {}
+        if marker != _REQUEST_OVERRIDES_FORMAT or _REQUEST_OVERRIDES_KEY not in metadata:
+            raise RequestOverridesUnavailableError
+        ciphertext = metadata[_REQUEST_OVERRIDES_KEY]
+        if ciphertext is None:
+            return {}
+        if not isinstance(ciphertext, str) or not ciphertext:
+            raise RequestOverridesUnavailableError
+
+        from langflow.services.auth.utils import get_fernet_for_decryption
+
+        try:
+            plaintext = get_fernet_for_decryption(self.settings_service).decrypt(ciphertext.encode("ascii"))
+            envelope = json.loads(plaintext)
+            if not isinstance(envelope, dict) or set(envelope) != {"version", "job_id", "flow_id", "overrides"}:
+                raise RequestOverridesUnavailableError
+            if type(envelope["version"]) is not int or envelope["version"] != _REQUEST_OVERRIDES_VERSION:
+                raise RequestOverridesUnavailableError
+            if envelope["job_id"] != str(job.job_id) or envelope["flow_id"] != str(job.flow_id):
+                raise RequestOverridesUnavailableError
+            overrides = self._validated_overrides(envelope["overrides"])
+            if not overrides:
+                raise RequestOverridesUnavailableError
+        except RequestOverridesUnavailableError:
+            raise
+        except Exception:  # noqa: BLE001 -- never expose crypto/parser distinctions to the caller
+            raise RequestOverridesUnavailableError from None
+        else:
+            return overrides
 
     @staticmethod
     async def _existing_job_for_dedupe(dedupe_key: str | None, user_id: UUID | None) -> UUID | None:
@@ -486,6 +612,10 @@ class BackgroundExecutionService(Service):
         pending = (job.job_metadata or {}).get("pending_request_id")
         if pending is not None and request_id != pending:
             return False
+        # Decrypt and validate before the single-flight claim or signal write. A
+        # key-rotation/configuration error must leave the pause and decision seam
+        # untouched so the caller can retry after restoring the key.
+        request = self._reconstruct_request(job)
         # Win the single-flight flip BEFORE writing the RESUME signal, so exactly one
         # RESUME row exists per suspend and a loser never strands a stray decision.
         if not await job_service.claim_suspended_for_resume(job_id, owner=self._owner):
@@ -495,7 +625,7 @@ class BackgroundExecutionService(Service):
             await self._enqueue(
                 job_id=job_id,
                 flow_id=job.flow_id,
-                request=self._reconstruct_request(job),
+                request=request,
                 user=self._user_stub(job.user_id),
             )
         except Exception:
@@ -579,7 +709,11 @@ class BackgroundExecutionService(Service):
         for job in await self._queued_workflow_jobs():
             if not await job_service.claim_queued_lease(job.job_id, owner=self._owner, lease_ttl_s=lease_ttl):
                 continue
-            request_dict = self._reconstruct_request(job)
+            try:
+                request_dict = self._reconstruct_request(job)
+            except RequestOverridesUnavailableError:
+                await self._fail_request_overrides_unavailable(job.job_id, job_service)
+                continue
             user = self._user_stub(job.user_id)
             with contextlib.suppress(Exception):
                 await self._enqueue(
@@ -623,27 +757,37 @@ class BackgroundExecutionService(Service):
             return list(result.all())
 
     @staticmethod
-    def _reconstruct_request(job: Job) -> dict[str, Any]:
+    async def _fail_request_overrides_unavailable(job_id: UUID, job_service) -> None:
+        """Terminalize a queued job whose authenticated overrides cannot be restored."""
+        await job_service.update_job_status(job_id, JobStatus.FAILED, finished_timestamp=True)
+        await job_service.set_error(job_id, dict(_REQUEST_OVERRIDES_ERROR))
+        await job_service.append_event(job_id, "run_failed", dict(_REQUEST_OVERRIDES_ERROR))
+
+    def _reconstruct_request(self, job: Job) -> dict[str, Any]:
         """Rebuild the request dict for a re-enqueued QUEUED job.
 
-        ``submit`` persists replay-safe request fields under
-        ``job_metadata["request"]`` so re-enqueue keeps the original input, files,
-        partial-run ids, and protocol. Secret-bearing globals and tweaks stay
-        live-only. Falls back to a minimal default only for legacy rows written
-        before the request was persisted, so a pre-existing QUEUED job still
-        re-runs rather than blocks.
+        ``submit`` persists replay-safe fields under ``job_metadata["request"]``
+        and globals/tweaks in an authenticated Fernet envelope beside it. Legacy
+        rows with no overrides keep their old fallback; legacy plaintext overrides
+        and malformed encrypted rows fail closed.
         """
         meta = job.job_metadata or {}
         persisted = meta.get("request")
         if isinstance(persisted, dict) and persisted:
-            return persisted
-        return {
-            "flow_id": str(job.flow_id),
-            "mode": "background",
-            "stream_protocol": meta.get("stream_protocol", "langflow"),
-            "session_id": meta.get("session_id"),
-            "input_value": meta.get("input_value", ""),
-        }
+            request = dict(persisted)
+        else:
+            request = {
+                "flow_id": str(job.flow_id),
+                "mode": "background",
+                "stream_protocol": meta.get("stream_protocol", "langflow"),
+                "session_id": meta.get("session_id"),
+                "input_value": meta.get("input_value", ""),
+            }
+        # No plaintext override is accepted, including on old rows: otherwise a
+        # missing marker would silently downgrade the authenticated format.
+        if _REQUEST_OVERRIDE_FIELDS.intersection(request):
+            raise RequestOverridesUnavailableError
+        return {**request, **self._decrypt_request_overrides(job, meta)}
 
     @staticmethod
     def _user_stub(user_id: UUID | None) -> UserRead | None:

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -688,46 +688,67 @@ class JobService(Service):
         error: dict,
         event_type: str,
     ) -> bool:
-        """Atomically terminalize this owner's QUEUED claim with its durable event."""
+        """Atomically terminalize this owner's QUEUED claim with its durable event.
+
+        The entire status-CAS + event transaction is retried after a per-job
+        sequence collision or transient SQLite writer lock. Rolling back before
+        each retry leaves the job QUEUED under the exact original lease, so a
+        retry either commits both records or safely loses to a newer claim.
+        """
         from sqlmodel import update
 
         owner_expr = col(Job.job_metadata)["owner"].as_string()
         hb_expr = col(Job.job_metadata)["heartbeat_at"].as_string()
-        async with session_scope() as session:
-            job = await session.get(Job, job_id)
-            if job is None or job.status != JobStatus.QUEUED:
-                return False
-            metadata = job.job_metadata or {}
-            if metadata.get("owner") != owner or metadata.get("heartbeat_at") != heartbeat_at:
-                return False
-            stmt = (
-                update(Job)
-                .where(
-                    Job.job_id == job_id,
-                    Job.status == JobStatus.QUEUED,
-                    owner_expr == owner,
-                    hb_expr == heartbeat_at,
-                )
-                .values(
-                    status=JobStatus.FAILED,
-                    error=dict(error),
-                    finished_timestamp=datetime.now(timezone.utc),
-                )
-            )
-            result = await session.exec(stmt)  # type: ignore[call-overload]
-            if result.rowcount != 1:
-                return False
-            current_max = (await session.exec(select(func.max(JobEvent.seq)).where(JobEvent.job_id == job_id))).one()
-            session.add(
-                JobEvent(
-                    job_id=job_id,
-                    seq=(current_max or 0) + 1,
-                    event_type=event_type,
-                    payload=dict(error),
-                )
-            )
-            await session.flush()
-            return True
+        last_exc: Exception | None = None
+        for attempt in range(_APPEND_EVENT_MAX_RETRIES):
+            try:
+                async with session_scope() as session:
+                    job = await session.get(Job, job_id)
+                    if job is None or job.status != JobStatus.QUEUED:
+                        return False
+                    metadata = job.job_metadata or {}
+                    if metadata.get("owner") != owner or metadata.get("heartbeat_at") != heartbeat_at:
+                        return False
+                    stmt = (
+                        update(Job)
+                        .where(
+                            Job.job_id == job_id,
+                            Job.status == JobStatus.QUEUED,
+                            owner_expr == owner,
+                            hb_expr == heartbeat_at,
+                        )
+                        .values(
+                            status=JobStatus.FAILED,
+                            error=dict(error),
+                            finished_timestamp=datetime.now(timezone.utc),
+                        )
+                    )
+                    result = await session.exec(stmt)  # type: ignore[call-overload]
+                    if result.rowcount != 1:
+                        return False
+                    current_max = (
+                        await session.exec(select(func.max(JobEvent.seq)).where(JobEvent.job_id == job_id))
+                    ).one()
+                    session.add(
+                        JobEvent(
+                            job_id=job_id,
+                            seq=(current_max or 0) + 1,
+                            event_type=event_type,
+                            payload=dict(error),
+                        )
+                    )
+                    await session.flush()
+                    return True
+            except IntegrityError as exc:
+                last_exc = exc
+            except OperationalError as exc:
+                if "lock" not in str(exc).lower() and "busy" not in str(exc).lower():
+                    raise
+                last_exc = exc
+            await asyncio.sleep(min(0.05, 0.002 * (attempt + 1)))
+
+        msg = f"fail_queued_job exhausted {_APPEND_EVENT_MAX_RETRIES} retries for job {job_id} (event seq contention)"
+        raise RuntimeError(msg) from last_exc
 
     async def claim_suspended_for_resume(self, job_id: UUID, *, owner: str | None = None) -> bool:
         """Atomically flip SUSPENDED->IN_PROGRESS for resume; True iff this caller won.

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -125,6 +125,7 @@ class JobService(Service):
         user_id: UUID | None = None,
         dedupe_key: str | None = None,
         end_user_id: str | None = None,
+        initial_metadata: dict | None = None,
     ) -> Job:
         """Create a new job record with QUEUED status.
 
@@ -142,6 +143,10 @@ class JobService(Service):
                 ``job_metadata['end_user_id']`` (no schema change) — ``user_id`` stays the
                 executing service account so re-enqueue/resume can still fetch the SID-owned
                 flow, while status/stop/resume isolate on this end-user key. See F8.
+            initial_metadata: Metadata that must be committed atomically with the QUEUED
+                row. The background workflow facade uses this for its replay request and
+                encrypted override envelope so a worker can never claim a partially
+                initialized job.
 
         Returns:
             Created Job object
@@ -179,6 +184,9 @@ class JobService(Service):
                     msg = f"A non-retryable job with dedupe_key={dedupe_key!r} already exists"
                     raise DuplicateJobError(msg)
 
+            metadata = dict(initial_metadata or {})
+            if end_user_id:
+                metadata["end_user_id"] = end_user_id
             job = Job(
                 job_id=job_id,
                 flow_id=flow_id,
@@ -188,9 +196,8 @@ class JobService(Service):
                 asset_type=asset_type,
                 user_id=user_id,
                 dedupe_key=dedupe_key,
-                # Two things stamped atomically with the insert, for the same reason: a later
-                # shallow update_job_metadata (e.g. submit's persisted request) preserves what
-                # is already on the row.
+                # Job-owned context is stamped atomically with the insert. A later shallow
+                # update_job_metadata preserves what is already on the row.
                 #
                 # The end user, so serving rows carry who the run was for.
                 #
@@ -201,7 +208,7 @@ class JobService(Service):
                 #
                 # Still None when neither applies, so non-serving untraced rows stay
                 # byte-identical to what they were.
-                job_metadata=inject_trace_carrier({"end_user_id": end_user_id} if end_user_id else None) or None,
+                job_metadata=inject_trace_carrier(metadata) or None,
             )
             session.add(job)
             await session.flush()

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -593,7 +593,14 @@ class JobService(Service):
             await session.flush()
             return result.rowcount == 1
 
-    async def claim_queued_lease(self, job_id: UUID, *, owner: str, lease_ttl_s: float) -> bool:
+    async def claim_queued_lease(
+        self,
+        job_id: UUID,
+        *,
+        owner: str,
+        lease_ttl_s: float,
+        heartbeat_at: str | None = None,
+    ) -> bool:
         """Lease-claim a QUEUED row WITHOUT flipping its status. Returns True if won.
 
         Single-flight ownership for the default re-enqueue path that, unlike
@@ -608,12 +615,14 @@ class JobService(Service):
         The claim succeeds only when the row is QUEUED and its current lease is
         absent or stale, and the conditional UPDATE matches the EXACT prior
         ``heartbeat_at`` we read, so two workers racing the same stale row see
-        only one ``rowcount == 1``. Portable across SQLite and Postgres.
+        only one ``rowcount == 1``. A caller-supplied ``heartbeat_at`` becomes
+        the claim token for a later guarded release or terminalization. Portable
+        across SQLite and Postgres.
         """
         from sqlmodel import update
 
         hb_expr = col(Job.job_metadata)["heartbeat_at"].as_string()
-        now = datetime.now(timezone.utc).isoformat()
+        claim_heartbeat = heartbeat_at or datetime.now(timezone.utc).isoformat()
         async with session_scope() as session:
             job = await session.get(Job, job_id)
             if job is None or job.status != JobStatus.QUEUED:
@@ -623,7 +632,7 @@ class JobService(Service):
             # A fresh lease means another worker already owns this claim window.
             if not self.is_lease_stale(job, lease_ttl_s=lease_ttl_s):
                 return False
-            merged = {**meta, "owner": owner, "heartbeat_at": now}
+            merged = {**meta, "owner": owner, "heartbeat_at": claim_heartbeat}
             # Guard on the exact prior heartbeat so a concurrent claimer that
             # already stamped its own loses the conditional UPDATE.
             guard = hb_expr.is_(None) if prior_hb is None else hb_expr == prior_hb
@@ -635,6 +644,90 @@ class JobService(Service):
             result = await session.exec(stmt)  # type: ignore[call-overload]
             await session.flush()
             return result.rowcount == 1
+
+    async def release_queued_lease(self, job_id: UUID, *, owner: str, heartbeat_at: str) -> bool:
+        """Release this owner's QUEUED lease without clearing a newer claim.
+
+        The status, owner, and exact heartbeat guards make the whole-metadata
+        replacement safe across SQLite and Postgres: a worker that has replaced
+        or refreshed this lease cannot have its claim erased by a stale recovery.
+        """
+        from sqlmodel import update
+
+        owner_expr = col(Job.job_metadata)["owner"].as_string()
+        hb_expr = col(Job.job_metadata)["heartbeat_at"].as_string()
+        async with session_scope() as session:
+            job = await session.get(Job, job_id)
+            if job is None or job.status != JobStatus.QUEUED:
+                return False
+            metadata = dict(job.job_metadata or {})
+            if metadata.get("owner") != owner or metadata.get("heartbeat_at") != heartbeat_at:
+                return False
+            metadata.pop("owner", None)
+            metadata.pop("heartbeat_at", None)
+            stmt = (
+                update(Job)
+                .where(
+                    Job.job_id == job_id,
+                    Job.status == JobStatus.QUEUED,
+                    owner_expr == owner,
+                    hb_expr == heartbeat_at,
+                )
+                .values(job_metadata=metadata or None)
+            )
+            result = await session.exec(stmt)  # type: ignore[call-overload]
+            await session.flush()
+            return result.rowcount == 1
+
+    async def fail_queued_job(
+        self,
+        job_id: UUID,
+        *,
+        owner: str,
+        heartbeat_at: str,
+        error: dict,
+        event_type: str,
+    ) -> bool:
+        """Atomically terminalize this owner's QUEUED claim with its durable event."""
+        from sqlmodel import update
+
+        owner_expr = col(Job.job_metadata)["owner"].as_string()
+        hb_expr = col(Job.job_metadata)["heartbeat_at"].as_string()
+        async with session_scope() as session:
+            job = await session.get(Job, job_id)
+            if job is None or job.status != JobStatus.QUEUED:
+                return False
+            metadata = job.job_metadata or {}
+            if metadata.get("owner") != owner or metadata.get("heartbeat_at") != heartbeat_at:
+                return False
+            stmt = (
+                update(Job)
+                .where(
+                    Job.job_id == job_id,
+                    Job.status == JobStatus.QUEUED,
+                    owner_expr == owner,
+                    hb_expr == heartbeat_at,
+                )
+                .values(
+                    status=JobStatus.FAILED,
+                    error=dict(error),
+                    finished_timestamp=datetime.now(timezone.utc),
+                )
+            )
+            result = await session.exec(stmt)  # type: ignore[call-overload]
+            if result.rowcount != 1:
+                return False
+            current_max = (await session.exec(select(func.max(JobEvent.seq)).where(JobEvent.job_id == job_id))).one()
+            session.add(
+                JobEvent(
+                    job_id=job_id,
+                    seq=(current_max or 0) + 1,
+                    event_type=event_type,
+                    payload=dict(error),
+                )
+            )
+            await session.flush()
+            return True
 
     async def claim_suspended_for_resume(self, job_id: UUID, *, owner: str | None = None) -> bool:
         """Atomically flip SUSPENDED->IN_PROGRESS for resume; True iff this caller won.

--- a/src/backend/tests/unit/api/v2/test_resume_route.py
+++ b/src/backend/tests/unit/api/v2/test_resume_route.py
@@ -63,6 +63,35 @@ async def test_resume_stale_request_id_409(client, created_api_key, suspended_jo
     assert resp.status_code == 409
 
 
+async def test_resume_crypto_unavailable_returns_503_and_preserves_suspension(
+    client,
+    created_api_key,
+    suspended_job,
+):
+    """Unreadable encrypted overrides fail before resume claims or decision writes."""
+    async with session_scope() as session:
+        job = await session.get(Job, suspended_job)
+        job.job_metadata = {
+            **(job.job_metadata or {}),
+            "request_overrides_format": "fernet-json-v1",
+            "request_overrides": "authenticated-token-unavailable",
+        }
+        session.add(job)
+        await session.flush()
+
+    body = {"request_id": "req-1", "decision": {"action_id": "approve"}}
+    resp = await client.post(f"api/v2/workflows/{suspended_job}/resume", json=body, headers=_headers(created_api_key))
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json()["detail"]["code"] == "REQUEST_OVERRIDES_UNAVAILABLE"
+    async with session_scope() as session:
+        job = await session.get(Job, suspended_job)
+        assert job.status == JobStatus.SUSPENDED
+    from langflow.services.deps import get_job_service
+
+    assert await get_job_service().unconsumed_signals(suspended_job) == []
+
+
 async def test_resume_unknown_job_404(client, created_api_key):
     body = {"request_id": "req-1", "decision": {}}
     resp = await client.post(f"api/v2/workflows/{uuid4()}/resume", json=body, headers=_headers(created_api_key))

--- a/src/backend/tests/unit/api/v2/test_workflow_facade.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_facade.py
@@ -153,6 +153,41 @@ class TestBackgroundSubmitContract:
         assert response.json()["detail"]["code"] == "REQUEST_OVERRIDES_UNAVAILABLE"
         assert await get_job_service().get_jobs_by_flow_id(chatbot_flow, created_api_key.user_id) == []
 
+    async def test_serialization_resource_unavailable_returns_503_without_creating_job(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        chatbot_flow,
+        monkeypatch,
+    ):
+        """A transient serializer resource failure is a structured retryable server error."""
+        from types import SimpleNamespace
+
+        from langflow.services.background_execution import service as background_service
+        from langflow.services.deps import get_job_service
+
+        body = _body(chatbot_flow, mode="background")
+        body["tweaks"] = {"ChatInput-x": {"input_value": "retry-later"}}
+        encoded_body = json.dumps(body)
+
+        def _unavailable_dumps(*_args, **_kwargs):
+            raise MemoryError
+
+        monkeypatch.setattr(
+            background_service,
+            "json",
+            SimpleNamespace(dumps=_unavailable_dumps, loads=json.loads),
+        )
+        response = await client.post(
+            "api/v2/workflows",
+            content=encoded_body,
+            headers={"x-api-key": created_api_key.api_key, "content-type": "application/json"},
+        )
+
+        assert response.status_code == 503, response.text
+        assert response.json()["detail"]["code"] == "REQUEST_OVERRIDES_UNAVAILABLE"
+        assert await get_job_service().get_jobs_by_flow_id(chatbot_flow, created_api_key.user_id) == []
+
 
 class TestStatusDurableResultError:
     """GET status reads durable result/error written by the runner, additively."""

--- a/src/backend/tests/unit/api/v2/test_workflow_facade.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_facade.py
@@ -104,6 +104,55 @@ class TestBackgroundSubmitContract:
         # New additive link: re-attach events URL must point at the job.
         assert result["links"]["events"] == f"/api/v2/workflows/{result['job_id']}/events"
 
+    async def test_invalid_override_grammar_returns_422_without_creating_job(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        chatbot_flow,
+    ):
+        """Non-finite caller data is a structured validation error, not a server fault."""
+        from langflow.services.deps import get_job_service
+
+        body = _body(chatbot_flow, mode="background")
+        body["tweaks"] = {"ChatInput-x": {"temperature": float("nan")}}
+        response = await client.post(
+            "api/v2/workflows",
+            content=json.dumps(body),
+            headers={"x-api-key": created_api_key.api_key, "content-type": "application/json"},
+        )
+
+        assert response.status_code == 422, response.text
+        detail = response.json()["detail"]
+        assert detail["code"] == "INVALID_REQUEST_OVERRIDES"
+        assert detail["field"] == "tweaks"
+        assert await get_job_service().get_jobs_by_flow_id(chatbot_flow, created_api_key.user_id) == []
+
+    async def test_crypto_unavailable_returns_503_without_creating_job(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        chatbot_flow,
+        monkeypatch,
+    ):
+        """A temporarily unavailable encryption key is retryable and never creates a job."""
+        from langflow.services.deps import get_job_service
+
+        def _unavailable_fernet(_settings_service):
+            raise RuntimeError
+
+        monkeypatch.setattr("langflow.services.auth.utils.get_fernet", _unavailable_fernet)
+        body = _body(chatbot_flow, mode="background")
+        body["tweaks"] = {"ChatInput-x": {"input_value": "retry-later"}}
+        response = await client.post(
+            "api/v2/workflows",
+            json=body,
+            headers={"x-api-key": created_api_key.api_key},
+        )
+
+        assert response.status_code == 503, response.text
+        assert response.json()["detail"]["code"] == "REQUEST_OVERRIDES_UNAVAILABLE"
+        assert await get_job_service().get_jobs_by_flow_id(chatbot_flow, created_api_key.user_id) == []
+
 
 class TestStatusDurableResultError:
     """GET status reads durable result/error written by the runner, additively."""

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -357,6 +357,106 @@ async def test_submit_writes_request_and_encrypted_overrides_atomically(real_ser
     assert "secret-atomic" not in json.dumps(job.job_metadata)
 
 
+@pytest.mark.parametrize(
+    ("field", "invalid_case"),
+    [
+        ("tweaks", "nan"),
+        ("tweaks", "infinity"),
+        ("tweaks", "non-string-key"),
+        ("tweaks", "unsupported-value"),
+        ("tweaks", "cycle"),
+        ("tweaks", "too-deep"),
+        ("tweaks", "top-level-shape"),
+        ("globals", "top-level-shape"),
+    ],
+)
+async def test_submit_rejects_invalid_override_grammar_before_creating_job(
+    real_services_job_service,
+    field,
+    invalid_case,
+):
+    """Caller validation failures identify the field and never persist a job."""
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        InvalidRequestOverridesError,
+    )
+    from langflow.services.deps import get_settings_service
+
+    if invalid_case == "nan":
+        invalid_value = {"Node-x": {"value": float("nan")}}
+    elif invalid_case == "infinity":
+        invalid_value = {"Node-x": {"value": float("inf")}}
+    elif invalid_case == "non-string-key":
+        invalid_value = {"Node-x": {1: "value"}}
+    elif invalid_case == "unsupported-value":
+        invalid_value = {"Node-x": {"value": object()}}
+    elif invalid_case == "cycle":
+        cyclic: dict = {}
+        cyclic["self"] = cyclic
+        invalid_value = {"Node-x": cyclic}
+    elif invalid_case == "too-deep":
+        nested: object = "leaf"
+        for _ in range(66):
+            nested = [nested]
+        invalid_value = {"Node-x": {"value": nested}}
+    else:
+        invalid_value = ["not-a-mapping"]
+
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    service = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "invalid-overrides",
+        field: invalid_value,
+    }
+
+    with pytest.raises(InvalidRequestOverridesError) as exc_info:
+        await service.submit(flow_id=flow_id, request=request, user=_StubUser(user_id))
+
+    assert exc_info.value.field == field
+    assert await job_service.get_jobs_by_flow_id(flow_id, user_id) == []
+
+
+async def test_submit_crypto_unavailable_creates_no_job(real_services_job_service, monkeypatch):
+    """Server-side encryption failure is retryable and precedes durable creation."""
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        RequestOverridesUnavailableError,
+    )
+    from langflow.services.deps import get_settings_service
+
+    def _unavailable_fernet(_settings_service):
+        raise RuntimeError
+
+    monkeypatch.setattr("langflow.services.auth.utils.get_fernet", _unavailable_fernet)
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    service = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "crypto-unavailable",
+        "tweaks": {"Node-x": {"api_key": "never-persisted"}},  # pragma: allowlist secret
+    }
+
+    with pytest.raises(RequestOverridesUnavailableError):
+        await service.submit(flow_id=flow_id, request=request, user=_StubUser(user_id))
+
+    assert await job_service.get_jobs_by_flow_id(flow_id, user_id) == []
+
+
 async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_services_job_service):
     """A job-id-only handoff and a fresh startup both replay the original overrides."""
     import asyncio
@@ -414,13 +514,11 @@ async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_ser
     assert recovered.status == JobStatus.COMPLETED
 
 
-@pytest.mark.parametrize("damage", ["missing", "null", "tampered", "wrong-key"])
+@pytest.mark.parametrize("damage", ["missing", "null"])
 async def test_startup_terminalizes_unavailable_encrypted_overrides(real_services_job_service, damage):
-    """A damaged envelope cannot downgrade into a run without its original overrides."""
-    from cryptography.fernet import Fernet
+    """Malformed marker/ciphertext pairs terminalize without running downgraded."""
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
-    from pydantic import SecretStr
 
     job_service = real_services_job_service
     backend = _RecordingBackend()
@@ -450,20 +548,11 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
         metadata.pop("request_overrides")
     elif damage == "null":
         metadata["request_overrides"] = None
-    elif damage == "tampered":
-        token = metadata["request_overrides"]
-        metadata["request_overrides"] = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
     await job_service.update_job_metadata(job_id, metadata, replace=True)
 
     ran: list[dict] = []
-    recovery_settings = settings_service
-    if damage == "wrong-key":
-        wrong_auth = settings_service.auth_settings.model_copy(
-            update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
-        )
-        recovery_settings = SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth)
     restart = BackgroundExecutionService(
-        settings_service=recovery_settings,
+        settings_service=settings_service,
         frame_source_factory=_capture_request_factory(ran),
     )
     await restart.sweep_orphans_on_startup()
@@ -478,6 +567,140 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
     assert [(event.event_type, event.payload) for event in events] == [
         ("run_failed", {"type": "request_overrides_unavailable"})
     ]
+
+
+@pytest.mark.parametrize("failure", ["wrong-key", "auth-failure"])
+async def test_startup_keeps_ambiguous_crypto_failures_queued_and_replays_after_recovery(
+    real_services_job_service,
+    failure,
+):
+    """Unreadable Fernet tokens remain retryable because key loss and tampering are indistinguishable."""
+    import asyncio
+
+    from cryptography.fernet import Fernet
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+    from pydantic import SecretStr
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    backend = _RecordingBackend()
+    flow_id, user_id = uuid4(), uuid4()
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": f"recover-{failure}",
+        "tweaks": {"Node-x": {"api_key": "recoverable-secret"}},  # pragma: allowlist secret
+    }
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_echo_input_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(flow_id=flow_id, request=request, user=_StubUser(user_id))
+    original = await job_service.get_job_by_job_id(job_id)
+    original_metadata = dict(original.job_metadata)
+
+    recovery_settings = settings_service
+    if failure == "wrong-key":
+        wrong_auth = settings_service.auth_settings.model_copy(
+            update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
+        )
+        recovery_settings = SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth)
+    else:
+        damaged = dict(original_metadata)
+        token = damaged["request_overrides"]
+        damaged["request_overrides"] = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
+        await job_service.update_job_metadata(job_id, damaged, replace=True)
+
+    ran: list[dict] = []
+    unavailable = BackgroundExecutionService(
+        settings_service=recovery_settings,
+        frame_source_factory=_capture_request_factory(ran),
+    )
+    await unavailable.sweep_orphans_on_startup()
+    await unavailable.stop()
+
+    queued = await job_service.get_job_by_job_id(job_id)
+    assert ran == []
+    assert queued.status == JobStatus.QUEUED
+    assert queued.error is None
+    assert (queued.job_metadata or {}).get("owner") is None
+    assert (queued.job_metadata or {}).get("heartbeat_at") is None
+    assert await job_service.read_events(job_id, after_seq=0) == []
+
+    if failure == "auth-failure":
+        await job_service.update_job_metadata(job_id, original_metadata, replace=True)
+
+    captured: list[dict] = []
+    restored = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_capture_request_factory(captured),
+    )
+    await restored.start()
+    try:
+        await restored.sweep_orphans_on_startup()
+        for _ in range(100):
+            replayed = await job_service.get_job_by_job_id(job_id)
+            if replayed.status == JobStatus.COMPLETED:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await restored.stop()
+
+    assert replayed.status == JobStatus.COMPLETED
+    assert captured.count(request) == 1
+
+
+async def test_startup_terminalizes_authenticated_malformed_override_payload(real_services_job_service):
+    """Authenticated payload corruption is distinct from ambiguous Fernet authentication failure."""
+    from langflow.services.auth.utils import get_fernet
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    flow_id, user_id = uuid4(), uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "input_value": "authenticated-corruption",
+            "tweaks": {"Node-x": {"api_key": "corrupt-secret"}},  # pragma: allowlist secret
+        },
+        user=_StubUser(user_id),
+    )
+    job = await job_service.get_job_by_job_id(job_id)
+    metadata = dict(job.job_metadata)
+    malformed = {
+        "version": 1,
+        "job_id": str(job_id),
+        "flow_id": str(flow_id),
+        "overrides": {"tweaks": ["not-a-mapping"]},
+    }
+    metadata["request_overrides"] = get_fernet(settings_service).encrypt(json.dumps(malformed).encode()).decode()
+    await job_service.update_job_metadata(job_id, metadata, replace=True)
+
+    ran: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_capture_request_factory(ran),
+    )
+    await restart.sweep_orphans_on_startup()
+    await restart.stop()
+
+    failed = await job_service.get_job_by_job_id(job_id)
+    assert ran == []
+    assert failed.status == JobStatus.FAILED
+    assert failed.error == {"type": "request_overrides_unavailable"}
 
 
 async def test_wrong_key_cross_job_and_null_envelopes_fail_closed(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -11,6 +11,7 @@ and the orphan sweep on BOTH engines.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -204,13 +205,37 @@ def _echo_input_factory(*, request, **_kwargs):
     return _source
 
 
+class _RecordingBackend:
+    """Scaled-backend stand-in that records durable job ids without running them."""
+
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, job_id: str) -> None:
+        self.enqueued.append(job_id)
+
+
+def _capture_request_factory(captured: list[dict]):
+    """Record the request a fresh worker hydrates without persisting its secrets."""
+
+    def _factory(*, request, **_kwargs):
+        captured.append(request)
+
+        async def _source(**_kw):
+            yield _frame("end", {})
+
+        return _source
+
+    return _factory
+
+
 async def test_submit_persists_request_for_faithful_requeue(real_services_job_service):
     """``submit`` persists only replay-safe request fields on job_metadata.request.
 
     The startup sweep needs the original non-secret inputs, but caller tweaks may
-    contain credentials and must remain live-only. Proven on both real SQLite and
-    real Postgres. The executor is stopped right after submit so no run interferes
-    with reading the persisted row.
+    contain credentials and must live outside the plaintext request in an encrypted
+    envelope. Proven on both real SQLite and real Postgres. The executor is stopped
+    right after submit so no run interferes with reading the persisted row.
     """
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
@@ -244,6 +269,10 @@ async def test_submit_persists_request_for_faithful_requeue(real_services_job_se
         "input_value": original_input,
         "session_id": "thread-restart",
     }
+    assert job.job_metadata.get("request_overrides_format") == "fernet-json-v1"
+    assert isinstance(job.job_metadata.get("request_overrides"), str)
+    hydrated = svc._reconstruct_request(job)
+    assert hydrated == request
     # Redaction must not mutate the live request passed to the in-memory run.
     assert request["tweaks"] == {"ChatInput-x": {"foo": "bar"}}
 
@@ -253,8 +282,8 @@ async def test_submit_redacts_inline_overrides_from_persisted_request(real_servi
 
     Both request shapes can carry API keys. Storing either plaintext in the durable
     ``job`` table widens the blast radius of any DB read (backup, ops access, a
-    SQL-injection elsewhere). The persisted replay request must omit both; the live
-    in-memory run still has them. Real SQLite and Postgres.
+    SQL-injection elsewhere). The persisted plaintext request must omit both while
+    authenticated decryption restores them for replay. Real SQLite and Postgres.
     """
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
@@ -284,9 +313,276 @@ async def test_submit_redacts_inline_overrides_from_persisted_request(real_servi
     assert "globals" not in persisted, "inline globals persisted plaintext on the job row"
     assert "tweaks" not in persisted, "inline tweaks persisted plaintext on the job row"
     assert secret not in json.dumps(job.job_metadata), "inline secret leaked into job_metadata"
+    assert svc._reconstruct_request(job) == request
     # The caller's original request dict is not mutated as a side effect.
     assert request["globals"] == {"OPENAI_API_KEY": secret}
     assert request["tweaks"] == {"LanguageModelComponent-x": {"api_key": secret}}
+
+
+async def test_submit_writes_request_and_encrypted_overrides_atomically(real_services_job_service, monkeypatch):
+    """Submit must not expose a QUEUED row before its durable replay payload exists."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    backend = _RecordingBackend()
+    flow_id = uuid4()
+
+    async def _unexpected_metadata_update(*_args, **_kwargs):
+        pytest.fail("submit persisted replay metadata in a second transaction")
+
+    monkeypatch.setattr(job_service, "update_job_metadata", _unexpected_metadata_update)
+    svc = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=backend,
+    )
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "atomic",
+        "tweaks": {"LanguageModelComponent-x": {"api_key": "secret-atomic"}},  # pragma: allowlist secret
+    }
+    job_id = await svc.submit(flow_id=flow_id, request=request, user=_StubUser(uuid4()))
+
+    assert backend.enqueued == [str(job_id)]
+    job = await job_service.get_job_by_job_id(job_id)
+    assert job.job_metadata.get("request") == {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "atomic",
+    }
+    assert "secret-atomic" not in json.dumps(job.job_metadata)
+
+
+async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_services_job_service):
+    """A job-id-only handoff and a fresh startup both replay the original overrides."""
+    import asyncio
+
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    backend = _RecordingBackend()
+    flow_id = uuid4()
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "restart-with-overrides",
+        "globals": {"MODEL_API_KEY": "restart-secret"},  # pragma: allowlist secret
+        "tweaks": {  # pragma: allowlist secret
+            "LanguageModelComponent-x": {  # pragma: allowlist secret
+                "api_key": "restart-secret",  # pragma: allowlist secret
+                "temperature": 0.2,
+            }
+        },
+    }
+    submitter = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(flow_id=flow_id, request=request, user=_StubUser(uuid4()))
+    assert backend.enqueued == [str(job_id)]
+
+    job = await job_service.get_job_by_job_id(job_id)
+    # This is the worker/scaled hydration seam: only the queued job id crosses the bus.
+    assert submitter._reconstruct_request(job) == request
+
+    captured: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_capture_request_factory(captured),
+    )
+    await restart.start()
+    try:
+        await restart.sweep_orphans_on_startup()
+        for _ in range(100):
+            recovered = await job_service.get_job_by_job_id(job_id)
+            if recovered.status == JobStatus.COMPLETED:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await restart.stop()
+
+    assert captured == [request]
+    assert recovered.status == JobStatus.COMPLETED
+
+
+@pytest.mark.parametrize("damage", ["missing", "tampered"])
+async def test_startup_terminalizes_unavailable_encrypted_overrides(real_services_job_service, damage):
+    """A damaged envelope cannot downgrade into a run without its original overrides."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    backend = _RecordingBackend()
+    flow_id = uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "input_value": "must-not-run",
+            "tweaks": {  # pragma: allowlist secret
+                "LanguageModelComponent-x": {"api_key": "tamper-secret"}  # pragma: allowlist secret
+            },
+        },
+        user=_StubUser(uuid4()),
+    )
+    job = await job_service.get_job_by_job_id(job_id)
+    metadata = dict(job.job_metadata)
+    if damage == "missing":
+        metadata.pop("request_overrides")
+    else:
+        token = metadata["request_overrides"]
+        metadata["request_overrides"] = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
+    await job_service.update_job_metadata(job_id, metadata, replace=True)
+
+    ran: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_capture_request_factory(ran),
+    )
+    await restart.sweep_orphans_on_startup()
+    await restart.stop()
+
+    failed = await job_service.get_job_by_job_id(job_id)
+    assert ran == []
+    assert failed.status == JobStatus.FAILED
+    assert failed.error == {"type": "request_overrides_unavailable"}
+    assert "tamper-secret" not in json.dumps(failed.error)
+    events = await job_service.read_events(job_id, after_seq=0)
+    assert [(event.event_type, event.payload) for event in events] == [
+        ("run_failed", {"type": "request_overrides_unavailable"})
+    ]
+
+
+async def test_wrong_key_and_cross_job_envelopes_fail_closed(real_services_job_service):
+    """Ciphertext is tied to both the installation key and its job/flow identity."""
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        RequestOverridesUnavailableError,
+    )
+    from langflow.services.deps import get_settings_service
+    from pydantic import SecretStr
+
+    job_service = real_services_job_service
+    backend = _RecordingBackend()
+    settings_service = get_settings_service()
+    flow_id = uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_echo_input_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "input_value": "bound",
+            "tweaks": {"Node-x": {"api_key": "bound-secret"}},  # pragma: allowlist secret
+        },
+        user=_StubUser(uuid4()),
+    )
+    job = await job_service.get_job_by_job_id(job_id)
+
+    wrong_auth = settings_service.auth_settings.model_copy(
+        update={  # pragma: allowlist secret
+            "SECRET_KEY": SecretStr("wrong-key-material-that-is-at-least-32-bytes")
+        }
+    )
+    wrong_key_service = BackgroundExecutionService(
+        settings_service=SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth),
+        frame_source_factory=_echo_input_factory,
+    )
+    with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
+        wrong_key_service._reconstruct_request(job)
+
+    other_job_id = uuid4()
+    await job_service.create_job(
+        job_id=other_job_id,
+        flow_id=uuid4(),
+        user_id=uuid4(),
+        initial_metadata=job.job_metadata,
+    )
+    other_job = await job_service.get_job_by_job_id(other_job_id)
+    with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
+        submitter._reconstruct_request(other_job)
+
+
+async def test_no_overrides_and_safe_legacy_rows_remain_replayable(real_services_job_service):
+    """New empty envelopes and old rows without overrides preserve compatibility."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    backend = _RecordingBackend()
+    flow_id = uuid4()
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "no-overrides",
+    }
+    svc = BackgroundExecutionService(
+        settings_service=get_settings_service(), frame_source_factory=_echo_input_factory, backend=backend
+    )
+    job_id = await svc.submit(flow_id=flow_id, request=request, user=_StubUser(uuid4()))
+    job = await job_service.get_job_by_job_id(job_id)
+    assert job.job_metadata.get("request_overrides_format") == "fernet-json-v1"
+    assert job.job_metadata.get("request_overrides") is None
+    assert svc._reconstruct_request(job) == request
+
+    legacy_id = uuid4()
+    await job_service.create_job(
+        job_id=legacy_id,
+        flow_id=flow_id,
+        user_id=uuid4(),
+        initial_metadata={"request": request},
+    )
+    legacy = await job_service.get_job_by_job_id(legacy_id)
+    assert svc._reconstruct_request(legacy) == request
+
+
+async def test_legacy_plaintext_overrides_are_not_replayed(real_services_job_service):
+    """A pre-fix plaintext override row cannot bypass the encrypted envelope contract."""
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        RequestOverridesUnavailableError,
+    )
+    from langflow.services.deps import get_settings_service
+
+    flow_id = uuid4()
+    job_id = uuid4()
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "legacy",
+        "tweaks": {"Node-x": {"api_key": "legacy-plaintext-secret"}},  # pragma: allowlist secret
+    }
+    await real_services_job_service.create_job(
+        job_id=job_id,
+        flow_id=flow_id,
+        user_id=uuid4(),
+        initial_metadata={"request": request},
+    )
+    svc = BackgroundExecutionService(settings_service=get_settings_service(), frame_source_factory=_echo_input_factory)
+    job = await real_services_job_service.get_job_by_job_id(job_id)
+    with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
+        svc._reconstruct_request(job)
 
 
 async def test_requeued_queued_job_replays_original_input(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -614,6 +614,7 @@ async def test_fail_queued_job_retries_event_sequence_collision_atomically(real_
         error={"type": "request_overrides_unavailable"},
         event_type="run_failed",
     )
+    monkeypatch.setattr(jobs_service_module, "JobEvent", JobEvent)
 
     assert failed is True
     assert calls == 2
@@ -909,7 +910,7 @@ async def test_startup_terminalizes_non_ascii_override_ciphertext(real_services_
     await restart.stop()
 
     failed = await job_service.get_job_by_job_id(job_id)
-    assert ran == []
+    assert all(captured.get("flow_id") != str(flow_id) for captured in ran)
     assert failed.status == JobStatus.FAILED
     assert failed.error == {"type": "request_overrides_unavailable"}
     assert [(event.event_type, event.payload) for event in await job_service.read_events(job_id, after_seq=0)] == [

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -414,7 +414,7 @@ async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_ser
     assert recovered.status == JobStatus.COMPLETED
 
 
-@pytest.mark.parametrize("damage", ["missing", "tampered", "wrong-key"])
+@pytest.mark.parametrize("damage", ["missing", "null", "tampered", "wrong-key"])
 async def test_startup_terminalizes_unavailable_encrypted_overrides(real_services_job_service, damage):
     """A damaged envelope cannot downgrade into a run without its original overrides."""
     from cryptography.fernet import Fernet
@@ -448,6 +448,8 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
     metadata = dict(job.job_metadata)
     if damage == "missing":
         metadata.pop("request_overrides")
+    elif damage == "null":
+        metadata["request_overrides"] = None
     elif damage == "tampered":
         token = metadata["request_overrides"]
         metadata["request_overrides"] = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
@@ -478,8 +480,8 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
     ]
 
 
-async def test_wrong_key_and_cross_job_envelopes_fail_closed(real_services_job_service):
-    """Ciphertext is tied to both the installation key and its job/flow identity."""
+async def test_wrong_key_cross_job_and_null_envelopes_fail_closed(real_services_job_service):
+    """Worker hydration rejects wrong-key, cross-job, and nulled ciphertext."""
     from cryptography.fernet import Fernet
     from langflow.services.background_execution.service import (
         BackgroundExecutionService,
@@ -531,6 +533,13 @@ async def test_wrong_key_and_cross_job_envelopes_fail_closed(real_services_job_s
     with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
         submitter._reconstruct_request(other_job)
 
+    null_metadata = dict(job.job_metadata)
+    null_metadata["request_overrides"] = None
+    await job_service.update_job_metadata(job_id, null_metadata, replace=True)
+    null_job = await job_service.get_job_by_job_id(job_id)
+    with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
+        submitter._reconstruct_request(null_job)
+
 
 async def test_no_overrides_and_safe_legacy_rows_remain_replayable(real_services_job_service):
     """New empty envelopes and old rows without overrides preserve compatibility."""
@@ -554,20 +563,63 @@ async def test_no_overrides_and_safe_legacy_rows_remain_replayable(real_services
     )
     job_id = await svc.submit(flow_id=flow_id, request=request, user=_StubUser(uuid4()))
     job = await job_service.get_job_by_job_id(job_id)
-    assert job.job_metadata.get("request_overrides_format") == "fernet-json-v1"
-    assert job.job_metadata.get("request_overrides") is None
+    assert "request_overrides_format" not in job.job_metadata
+    assert "request_overrides" not in job.job_metadata
     safe_request = {key: value for key, value in request.items() if key not in {"globals", "tweaks"}}
     assert svc._reconstruct_request(job) == safe_request
 
     legacy_id = uuid4()
+    legacy_request = {**safe_request, "globals": {}, "tweaks": {}}
     await job_service.create_job(
         job_id=legacy_id,
         flow_id=flow_id,
         user_id=uuid4(),
-        initial_metadata={"request": safe_request},
+        initial_metadata={"request": legacy_request},
     )
     legacy = await job_service.get_job_by_job_id(legacy_id)
     assert svc._reconstruct_request(legacy) == safe_request
+
+
+async def test_legacy_empty_overrides_restart_safely(real_services_job_service):
+    """A queued pre-fix v2 row with empty override defaults remains recoverable."""
+    import asyncio
+
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    flow_id, job_id = uuid4(), uuid4()
+    safe_request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "legacy-empty-restart",
+    }
+    await job_service.create_job(
+        job_id=job_id,
+        flow_id=flow_id,
+        user_id=uuid4(),
+        initial_metadata={"request": {**safe_request, "globals": {}, "tweaks": {}}},
+    )
+
+    captured: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_capture_request_factory(captured),
+    )
+    await restart.start()
+    try:
+        await restart.sweep_orphans_on_startup()
+        for _ in range(100):
+            recovered = await job_service.get_job_by_job_id(job_id)
+            if recovered.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await restart.stop()
+
+    assert captured.count(safe_request) == 1
+    assert recovered.status == JobStatus.COMPLETED
 
 
 async def test_legacy_plaintext_overrides_are_not_replayed(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -457,6 +457,25 @@ async def test_submit_crypto_unavailable_creates_no_job(real_services_job_servic
     assert await job_service.get_jobs_by_flow_id(flow_id, user_id) == []
 
 
+async def test_release_queued_lease_never_clears_a_new_owner(real_services_job_service):
+    """A stale startup recovery cannot release a lease another worker has replaced."""
+    from datetime import datetime, timezone
+
+    job_service = real_services_job_service
+    job_id = uuid4()
+    await job_service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+    assert await job_service.claim_queued_lease(job_id, owner="old-owner", lease_ttl_s=0)
+    new_heartbeat = datetime.now(timezone.utc).isoformat()
+    await job_service.update_job_metadata(job_id, {"owner": "new-owner", "heartbeat_at": new_heartbeat})
+
+    released = await job_service.release_queued_lease(job_id, owner="old-owner")
+
+    assert released is False
+    job = await job_service.get_job_by_job_id(job_id)
+    assert (job.job_metadata or {}).get("owner") == "new-owner"
+    assert (job.job_metadata or {}).get("heartbeat_at") == new_heartbeat
+
+
 async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_services_job_service):
     """A job-id-only handoff and a fresh startup both replay the original overrides."""
     import asyncio

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -571,6 +571,61 @@ async def test_fail_queued_job_never_terminalizes_a_replaced_claim(real_services
     await job_service.update_job_status(job_id, JobStatus.CANCELLED, finished_timestamp=True)
 
 
+async def test_fail_queued_job_retries_event_sequence_collision_atomically(real_services_job_service, monkeypatch):
+    """A colliding event insert rolls back the status CAS before retrying the whole transaction."""
+    from datetime import datetime, timezone
+
+    from langflow.services.database.models.jobs.model import JobEvent
+    from langflow.services.jobs import service as jobs_service_module
+    from sqlalchemy.exc import IntegrityError
+
+    job_service = real_services_job_service
+    job_id = uuid4()
+    await job_service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+    heartbeat = datetime.now(timezone.utc).isoformat()
+    assert await job_service.claim_queued_lease(
+        job_id,
+        owner="recovery-owner",
+        lease_ttl_s=0,
+        heartbeat_at=heartbeat,
+    )
+    await job_service.append_event(job_id, "queued", {})
+
+    calls = 0
+
+    class _CollidingJobEvent:
+        job_id = JobEvent.job_id
+        seq = JobEvent.seq
+
+        def __new__(cls, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                collision = "forced event sequence collision"
+                raise IntegrityError(collision, None, RuntimeError())
+            return JobEvent(*args, **kwargs)
+
+    monkeypatch.setattr(jobs_service_module, "JobEvent", _CollidingJobEvent)
+
+    failed = await job_service.fail_queued_job(
+        job_id,
+        owner="recovery-owner",
+        heartbeat_at=heartbeat,
+        error={"type": "request_overrides_unavailable"},
+        event_type="run_failed",
+    )
+
+    assert failed is True
+    assert calls == 2
+    job = await job_service.get_job_by_job_id(job_id)
+    assert job.status == JobStatus.FAILED
+    assert job.error == {"type": "request_overrides_unavailable"}
+    assert [(event.seq, event.event_type) for event in await job_service.read_events(job_id, after_seq=0)] == [
+        (1, "queued"),
+        (2, "run_failed"),
+    ]
+
+
 async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_services_job_service):
     """A job-id-only handoff and a fresh startup both replay the original overrides."""
     import asyncio
@@ -815,6 +870,51 @@ async def test_startup_terminalizes_authenticated_malformed_override_payload(rea
     assert ran == []
     assert failed.status == JobStatus.FAILED
     assert failed.error == {"type": "request_overrides_unavailable"}
+
+
+async def test_startup_terminalizes_non_ascii_override_ciphertext(real_services_job_service):
+    """A non-ASCII Fernet token is structural corruption, not an ambiguous authentication failure."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    flow_id, user_id = uuid4(), uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "tweaks": {"Node-x": {"value": "never-run"}},
+        },
+        user=_StubUser(user_id),
+    )
+    job = await job_service.get_job_by_job_id(job_id)
+    metadata = dict(job.job_metadata)
+    metadata["request_overrides"] = "not-a-fernet-token-\N{SNOWMAN}"
+    await job_service.update_job_metadata(job_id, metadata, replace=True)
+
+    ran: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_capture_request_factory(ran),
+    )
+    await restart.sweep_orphans_on_startup()
+    await restart.stop()
+
+    failed = await job_service.get_job_by_job_id(job_id)
+    assert ran == []
+    assert failed.status == JobStatus.FAILED
+    assert failed.error == {"type": "request_overrides_unavailable"}
+    assert [(event.event_type, event.payload) for event in await job_service.read_events(job_id, after_seq=0)] == [
+        ("run_failed", {"type": "request_overrides_unavailable"})
+    ]
 
 
 async def test_startup_terminalizes_authenticated_unparseable_override_payload(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -408,21 +408,26 @@ async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_ser
     finally:
         await restart.stop()
 
-    assert captured == [request]
+    # The shared real-services DB may contain other QUEUED fixtures; this target
+    # must still hydrate exactly once with its full authenticated request.
+    assert captured.count(request) == 1
     assert recovered.status == JobStatus.COMPLETED
 
 
-@pytest.mark.parametrize("damage", ["missing", "tampered"])
+@pytest.mark.parametrize("damage", ["missing", "tampered", "wrong-key"])
 async def test_startup_terminalizes_unavailable_encrypted_overrides(real_services_job_service, damage):
     """A damaged envelope cannot downgrade into a run without its original overrides."""
+    from cryptography.fernet import Fernet
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
+    from pydantic import SecretStr
 
     job_service = real_services_job_service
     backend = _RecordingBackend()
     flow_id = uuid4()
+    settings_service = get_settings_service()
     submitter = BackgroundExecutionService(
-        settings_service=get_settings_service(),
+        settings_service=settings_service,
         frame_source_factory=_echo_input_factory,
         backend=backend,
     )
@@ -443,14 +448,20 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
     metadata = dict(job.job_metadata)
     if damage == "missing":
         metadata.pop("request_overrides")
-    else:
+    elif damage == "tampered":
         token = metadata["request_overrides"]
         metadata["request_overrides"] = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
     await job_service.update_job_metadata(job_id, metadata, replace=True)
 
     ran: list[dict] = []
+    recovery_settings = settings_service
+    if damage == "wrong-key":
+        wrong_auth = settings_service.auth_settings.model_copy(
+            update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
+        )
+        recovery_settings = SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth)
     restart = BackgroundExecutionService(
-        settings_service=get_settings_service(),
+        settings_service=recovery_settings,
         frame_source_factory=_capture_request_factory(ran),
     )
     await restart.sweep_orphans_on_startup()
@@ -469,6 +480,7 @@ async def test_startup_terminalizes_unavailable_encrypted_overrides(real_service
 
 async def test_wrong_key_and_cross_job_envelopes_fail_closed(real_services_job_service):
     """Ciphertext is tied to both the installation key and its job/flow identity."""
+    from cryptography.fernet import Fernet
     from langflow.services.background_execution.service import (
         BackgroundExecutionService,
         RequestOverridesUnavailableError,
@@ -499,9 +511,7 @@ async def test_wrong_key_and_cross_job_envelopes_fail_closed(real_services_job_s
     job = await job_service.get_job_by_job_id(job_id)
 
     wrong_auth = settings_service.auth_settings.model_copy(
-        update={  # pragma: allowlist secret
-            "SECRET_KEY": SecretStr("wrong-key-material-that-is-at-least-32-bytes")
-        }
+        update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
     )
     wrong_key_service = BackgroundExecutionService(
         settings_service=SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth),
@@ -535,6 +545,9 @@ async def test_no_overrides_and_safe_legacy_rows_remain_replayable(real_services
         "mode": "background",
         "stream_protocol": "langflow",
         "input_value": "no-overrides",
+        # API model defaults: these must not create an envelope for an ordinary run.
+        "globals": {},
+        "tweaks": {},
     }
     svc = BackgroundExecutionService(
         settings_service=get_settings_service(), frame_source_factory=_echo_input_factory, backend=backend
@@ -543,17 +556,18 @@ async def test_no_overrides_and_safe_legacy_rows_remain_replayable(real_services
     job = await job_service.get_job_by_job_id(job_id)
     assert job.job_metadata.get("request_overrides_format") == "fernet-json-v1"
     assert job.job_metadata.get("request_overrides") is None
-    assert svc._reconstruct_request(job) == request
+    safe_request = {key: value for key, value in request.items() if key not in {"globals", "tweaks"}}
+    assert svc._reconstruct_request(job) == safe_request
 
     legacy_id = uuid4()
     await job_service.create_job(
         job_id=legacy_id,
         flow_id=flow_id,
         user_id=uuid4(),
-        initial_metadata={"request": request},
+        initial_metadata={"request": safe_request},
     )
     legacy = await job_service.get_job_by_job_id(legacy_id)
-    assert svc._reconstruct_request(legacy) == request
+    assert svc._reconstruct_request(legacy) == safe_request
 
 
 async def test_legacy_plaintext_overrides_are_not_replayed(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -822,6 +822,54 @@ async def test_startup_terminalizes_authenticated_unparseable_override_payload(r
     ]
 
 
+async def test_startup_releases_lease_for_transient_authenticated_parser_failure(
+    real_services_job_service, monkeypatch
+):
+    """Transient parser resource failures keep an authenticated job queued for retry."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    flow_id, user_id = uuid4(), uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "tweaks": {"Node-x": {"value": "retry-after-resource-recovery"}},
+        },
+        user=_StubUser(user_id),
+    )
+    monkeypatch.setattr(
+        "langflow.services.background_execution.service.json.loads",
+        lambda _plaintext: (_ for _ in ()).throw(MemoryError),
+    )
+
+    ran: list[dict] = []
+    restart = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_capture_request_factory(ran),
+    )
+    await restart.sweep_orphans_on_startup()
+    await restart.stop()
+
+    queued = await job_service.get_job_by_job_id(job_id)
+    assert ran == []
+    assert queued.status == JobStatus.QUEUED
+    assert queued.error is None
+    assert queued.finished_timestamp is None
+    assert (queued.job_metadata or {}).get("owner") is None
+    assert (queued.job_metadata or {}).get("heartbeat_at") is None
+    assert await job_service.read_events(job_id, after_seq=0) == []
+
+
 async def test_wrong_key_cross_job_and_null_envelopes_fail_closed(real_services_job_service):
     """Worker hydration rejects wrong-key, cross-job, and nulled ciphertext."""
     from cryptography.fernet import Fernet

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -366,6 +366,8 @@ async def test_submit_writes_request_and_encrypted_overrides_atomically(real_ser
         ("tweaks", "unsupported-value"),
         ("tweaks", "cycle"),
         ("tweaks", "too-deep"),
+        ("tweaks", "lone-surrogate"),
+        ("tweaks", "oversized-integer"),
         ("tweaks", "top-level-shape"),
         ("globals", "top-level-shape"),
     ],
@@ -399,6 +401,10 @@ async def test_submit_rejects_invalid_override_grammar_before_creating_job(
         for _ in range(66):
             nested = [nested]
         invalid_value = {"Node-x": {"value": nested}}
+    elif invalid_case == "lone-surrogate":
+        invalid_value = {"Node-x": {"value": "\ud800"}}
+    elif invalid_case == "oversized-integer":
+        invalid_value = {"Node-x": {"value": 10**5000}}
     else:
         invalid_value = ["not-a-mapping"]
 
@@ -457,23 +463,70 @@ async def test_submit_crypto_unavailable_creates_no_job(real_services_job_servic
     assert await job_service.get_jobs_by_flow_id(flow_id, user_id) == []
 
 
-async def test_release_queued_lease_never_clears_a_new_owner(real_services_job_service):
-    """A stale startup recovery cannot release a lease another worker has replaced."""
+@pytest.mark.parametrize("new_owner", ["old-owner", "new-owner"])
+async def test_release_queued_lease_never_clears_an_updated_claim(real_services_job_service, new_owner):
+    """A stale recovery cannot release a claim whose owner or heartbeat advanced."""
     from datetime import datetime, timezone
 
     job_service = real_services_job_service
     job_id = uuid4()
     await job_service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
-    assert await job_service.claim_queued_lease(job_id, owner="old-owner", lease_ttl_s=0)
+    old_heartbeat = datetime.now(timezone.utc).isoformat()
+    assert await job_service.claim_queued_lease(
+        job_id,
+        owner="old-owner",
+        lease_ttl_s=0,
+        heartbeat_at=old_heartbeat,
+    )
     new_heartbeat = datetime.now(timezone.utc).isoformat()
-    await job_service.update_job_metadata(job_id, {"owner": "new-owner", "heartbeat_at": new_heartbeat})
+    await job_service.update_job_metadata(job_id, {"owner": new_owner, "heartbeat_at": new_heartbeat})
 
-    released = await job_service.release_queued_lease(job_id, owner="old-owner")
+    released = await job_service.release_queued_lease(
+        job_id,
+        owner="old-owner",
+        heartbeat_at=old_heartbeat,
+    )
 
     assert released is False
     job = await job_service.get_job_by_job_id(job_id)
+    assert (job.job_metadata or {}).get("owner") == new_owner
+    assert (job.job_metadata or {}).get("heartbeat_at") == new_heartbeat
+    await job_service.update_job_status(job_id, JobStatus.CANCELLED, finished_timestamp=True)
+
+
+async def test_fail_queued_job_never_terminalizes_a_replaced_claim(real_services_job_service):
+    """A stale recovery cannot fail a QUEUED row after another owner replaces its claim."""
+    from datetime import datetime, timezone
+
+    job_service = real_services_job_service
+    job_id = uuid4()
+    await job_service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+    old_heartbeat = datetime.now(timezone.utc).isoformat()
+    assert await job_service.claim_queued_lease(
+        job_id,
+        owner="old-owner",
+        lease_ttl_s=0,
+        heartbeat_at=old_heartbeat,
+    )
+    new_heartbeat = datetime.now(timezone.utc).isoformat()
+    await job_service.update_job_metadata(job_id, {"owner": "new-owner", "heartbeat_at": new_heartbeat})
+
+    failed = await job_service.fail_queued_job(
+        job_id,
+        owner="old-owner",
+        heartbeat_at=old_heartbeat,
+        error={"type": "request_overrides_unavailable"},
+        event_type="run_failed",
+    )
+
+    assert failed is False
+    job = await job_service.get_job_by_job_id(job_id)
+    assert job.status == JobStatus.QUEUED
+    assert job.error is None
     assert (job.job_metadata or {}).get("owner") == "new-owner"
     assert (job.job_metadata or {}).get("heartbeat_at") == new_heartbeat
+    assert await job_service.read_events(job_id, after_seq=0) == []
+    await job_service.update_job_status(job_id, JobStatus.CANCELLED, finished_timestamp=True)
 
 
 async def test_restart_and_scaled_hydration_restore_encrypted_overrides(real_services_job_service):
@@ -720,6 +773,53 @@ async def test_startup_terminalizes_authenticated_malformed_override_payload(rea
     assert ran == []
     assert failed.status == JobStatus.FAILED
     assert failed.error == {"type": "request_overrides_unavailable"}
+
+
+async def test_startup_terminalizes_authenticated_unparseable_override_payload(real_services_job_service):
+    """Authenticated JSON parser-limit failures cannot abort the startup sweep or retain its lease."""
+    from langflow.services.auth.utils import get_fernet
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    flow_id, job_id = uuid4(), uuid4()
+    plaintext = (
+        '{"version":1,"job_id":"'
+        + str(job_id)
+        + '","flow_id":"'
+        + str(flow_id)
+        + '","overrides":{"tweaks":{"Node-x":{"value":'
+        + "9" * 5000
+        + "}}}}"
+    )
+    ciphertext = get_fernet(settings_service).encrypt(plaintext.encode()).decode()
+    await job_service.create_job(
+        job_id=job_id,
+        flow_id=flow_id,
+        user_id=uuid4(),
+        initial_metadata={
+            "request": {
+                "flow_id": str(flow_id),
+                "mode": "background",
+                "stream_protocol": "langflow",
+            },
+            "request_overrides_format": "fernet-json-v1",
+            "request_overrides": ciphertext,
+        },
+    )
+
+    restart = BackgroundExecutionService(settings_service=settings_service, frame_source_factory=_echo_input_factory)
+    await restart.sweep_orphans_on_startup()
+    await restart.stop()
+
+    failed = await job_service.get_job_by_job_id(job_id)
+    assert failed.status == JobStatus.FAILED
+    assert failed.error == {"type": "request_overrides_unavailable"}
+    assert failed.finished_timestamp is not None
+    assert [(event.event_type, event.payload) for event in await job_service.read_events(job_id, after_seq=0)] == [
+        ("run_failed", {"type": "request_overrides_unavailable"})
+    ]
 
 
 async def test_wrong_key_cross_job_and_null_envelopes_fail_closed(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -205,11 +205,12 @@ def _echo_input_factory(*, request, **_kwargs):
 
 
 async def test_submit_persists_request_for_faithful_requeue(real_services_job_service):
-    """``submit`` persists the request body on the job row (job_metadata.request).
+    """``submit`` persists only replay-safe request fields on job_metadata.request.
 
-    This is the durable record the startup sweep reads to replay original inputs.
-    Proven on both real SQLite and real Postgres. The executor is stopped right
-    after submit so no run interferes with reading the persisted row.
+    The startup sweep needs the original non-secret inputs, but caller tweaks may
+    contain credentials and must remain live-only. Proven on both real SQLite and
+    real Postgres. The executor is stopped right after submit so no run interferes
+    with reading the persisted row.
     """
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
@@ -236,21 +237,24 @@ async def test_submit_persists_request_for_faithful_requeue(real_services_job_se
     job = await job_service.get_job_by_job_id(job_id)
     assert job.job_metadata is not None
     persisted = job.job_metadata.get("request")
-    # The whole request round-trips, not just input_value.
-    assert persisted == request
+    assert persisted == {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": original_input,
+        "session_id": "thread-restart",
+    }
+    # Redaction must not mutate the live request passed to the in-memory run.
+    assert request["tweaks"] == {"ChatInput-x": {"foo": "bar"}}
 
 
-async def test_submit_redacts_inline_globals_from_persisted_request(real_services_job_service):
-    """Inline ``globals`` (request-level secrets) must NOT land plaintext on the row.
+async def test_submit_redacts_inline_overrides_from_persisted_request(real_services_job_service):
+    """Inline ``globals`` and ``tweaks`` must NOT land plaintext on the row.
 
-    ``submit`` persists the request body for faithful replay, but request-level
-    ``globals`` can carry inline secrets (API keys). Storing them plaintext in the
-    durable ``job`` table widens the blast radius of any DB read (backup, ops
-    access, SQL-injection elsewhere). The persisted replay request must omit
-    ``globals``; the live in-memory run still has them. Tradeoff: a background
-    re-enqueue after a restart drops inline globals — reference stored global
-    variables by name for background runs instead of passing secrets inline.
-    Real SQLite and Postgres.
+    Both request shapes can carry API keys. Storing either plaintext in the durable
+    ``job`` table widens the blast radius of any DB read (backup, ops access, a
+    SQL-injection elsewhere). The persisted replay request must omit both; the live
+    in-memory run still has them. Real SQLite and Postgres.
     """
     from langflow.services.background_execution.service import BackgroundExecutionService
     from langflow.services.deps import get_settings_service
@@ -269,17 +273,20 @@ async def test_submit_redacts_inline_globals_from_persisted_request(real_service
         "stream_protocol": "langflow",
         "input_value": "hi",
         "globals": {"OPENAI_API_KEY": secret},
+        "tweaks": {"LanguageModelComponent-x": {"api_key": secret}},
     }
     job_id = await svc.submit(flow_id=flow_id, request=request, user=_StubUser(uuid4()))
     await svc.stop()
 
     job = await job_service.get_job_by_job_id(job_id)
     persisted = job.job_metadata.get("request") or {}
-    # The secret must not appear anywhere in the persisted request blob.
+    # Neither secret-bearing override shape may appear in the persisted blob.
     assert "globals" not in persisted, "inline globals persisted plaintext on the job row"
+    assert "tweaks" not in persisted, "inline tweaks persisted plaintext on the job row"
     assert secret not in json.dumps(job.job_metadata), "inline secret leaked into job_metadata"
     # The caller's original request dict is not mutated as a side effect.
     assert request["globals"] == {"OPENAI_API_KEY": secret}
+    assert request["tweaks"] == {"LanguageModelComponent-x": {"api_key": secret}}
 
 
 async def test_requeued_queued_job_replays_original_input(real_services_job_service):

--- a/src/backend/tests/unit/background_execution/test_facade_real_services.py
+++ b/src/backend/tests/unit/background_execution/test_facade_real_services.py
@@ -367,6 +367,7 @@ async def test_submit_writes_request_and_encrypted_overrides_atomically(real_ser
         ("tweaks", "cycle"),
         ("tweaks", "too-deep"),
         ("tweaks", "lone-surrogate"),
+        ("tweaks", "lone-surrogate-key"),
         ("tweaks", "oversized-integer"),
         ("tweaks", "top-level-shape"),
         ("globals", "top-level-shape"),
@@ -403,6 +404,8 @@ async def test_submit_rejects_invalid_override_grammar_before_creating_job(
         invalid_value = {"Node-x": {"value": nested}}
     elif invalid_case == "lone-surrogate":
         invalid_value = {"Node-x": {"value": "\ud800"}}
+    elif invalid_case == "lone-surrogate-key":
+        invalid_value = {"Node-x": {"\ud800": "value"}}
     elif invalid_case == "oversized-integer":
         invalid_value = {"Node-x": {"value": 10**5000}}
     else:
@@ -455,6 +458,45 @@ async def test_submit_crypto_unavailable_creates_no_job(real_services_job_servic
         "stream_protocol": "langflow",
         "input_value": "crypto-unavailable",
         "tweaks": {"Node-x": {"api_key": "never-persisted"}},  # pragma: allowlist secret
+    }
+
+    with pytest.raises(RequestOverridesUnavailableError):
+        await service.submit(flow_id=flow_id, request=request, user=_StubUser(user_id))
+
+    assert await job_service.get_jobs_by_flow_id(flow_id, user_id) == []
+
+
+async def test_submit_serialization_resource_unavailable_creates_no_job(real_services_job_service, monkeypatch):
+    """Transient JSON serialization resource failures use the retryable server error."""
+    from types import SimpleNamespace
+
+    from langflow.services.background_execution import service as background_service
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        RequestOverridesUnavailableError,
+    )
+    from langflow.services.deps import get_settings_service
+
+    def _unavailable_dumps(*_args, **_kwargs):
+        raise MemoryError
+
+    monkeypatch.setattr(
+        background_service,
+        "json",
+        SimpleNamespace(dumps=_unavailable_dumps, loads=json.loads),
+    )
+    job_service = real_services_job_service
+    flow_id, user_id = uuid4(), uuid4()
+    service = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_echo_input_factory,
+        backend=_RecordingBackend(),
+    )
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "tweaks": {"Node-x": {"value": "retry-after-resource-recovery"}},
     }
 
     with pytest.raises(RequestOverridesUnavailableError):

--- a/src/backend/tests/unit/background_execution/test_resume.py
+++ b/src/backend/tests/unit/background_execution/test_resume.py
@@ -174,10 +174,12 @@ async def test_stale_request_id_is_rejected(real_services_job_service) -> None:
 
 @pytest.mark.real_services
 @pytest.mark.no_blockbuster
+@pytest.mark.parametrize("damage", ["wrong-key", "null-token"])
 async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_decision(
     real_services_job_service,
+    damage,
 ) -> None:
-    """A wrong decryption key leaves the paused run and its decision seam untouched."""
+    """Unavailable ciphertext leaves the paused run and its decision seam untouched."""
     from cryptography.fernet import Fernet
     from langflow.services.background_execution.service import (
         BackgroundExecutionService,
@@ -209,11 +211,20 @@ async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_deci
     await job_service.update_job_metadata(job_id, {"pending_request_id": "req-encrypted"})
     await job_service.update_job_status(job_id, JobStatus.SUSPENDED)
 
-    wrong_auth = settings_service.auth_settings.model_copy(
-        update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
-    )
+    resume_settings = settings_service
+    if damage == "wrong-key":
+        wrong_auth = settings_service.auth_settings.model_copy(
+            update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
+        )
+        resume_settings = SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth)
+    else:
+        job = await job_service.get_job_by_job_id(job_id)
+        null_metadata = dict(job.job_metadata)
+        null_metadata["request_overrides"] = None
+        await job_service.update_job_metadata(job_id, null_metadata, replace=True)
+
     resume_service = BackgroundExecutionService(
-        settings_service=SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth),
+        settings_service=resume_settings,
         frame_source_factory=_noop_factory,
     )
     with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
@@ -282,6 +293,55 @@ async def test_resume_rehydrates_original_encrypted_overrides(real_services_job_
         # The factory is called synchronously while building the re-enqueued
         # runner, before the executor starts consuming the resume checkpoint.
         assert captured == [request]
+    finally:
+        await resume_service.stop()
+
+
+@pytest.mark.real_services
+@pytest.mark.no_blockbuster
+async def test_resume_accepts_legacy_empty_overrides(real_services_job_service) -> None:
+    """A suspended pre-fix v2 row drops empty override defaults and resumes safely."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    user_id, flow_id, job_id = uuid4(), uuid4(), uuid4()
+    safe_request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "legacy-empty-resume",
+    }
+    await job_service.create_job(
+        job_id=job_id,
+        flow_id=flow_id,
+        user_id=user_id,
+        initial_metadata={
+            "request": {**safe_request, "globals": {}, "tweaks": {}},
+            "pending_request_id": "req-legacy-empty",
+        },
+    )
+    await job_service.update_job_status(job_id, JobStatus.SUSPENDED)
+
+    captured: list[dict] = []
+
+    def _capture_factory(*, request, **_kwargs):
+        captured.append(request)
+        return _noop_factory()
+
+    resume_service = BackgroundExecutionService(
+        settings_service=get_settings_service(),
+        frame_source_factory=_capture_factory,
+    )
+    try:
+        accepted = await resume_service.resume_job(
+            job_id,
+            _StubUser(user_id),
+            request_id="req-legacy-empty",
+            decision={"choice": "approve"},
+        )
+        assert accepted is True
+        assert captured == [safe_request]
     finally:
         await resume_service.stop()
 

--- a/src/backend/tests/unit/background_execution/test_resume.py
+++ b/src/backend/tests/unit/background_execution/test_resume.py
@@ -8,6 +8,7 @@ non-SUSPENDED resumes are rejected before any signal/re-enqueue.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -39,6 +40,14 @@ def _noop_factory(**_kwargs):
 class _StubUser:
     def __init__(self, user_id):
         self.id = user_id
+
+
+class _RecordingBackend:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, job_id: str) -> None:
+        self.enqueued.append(job_id)
 
 
 def _runner(job_service, job_id, source):
@@ -161,6 +170,69 @@ async def test_stale_request_id_is_rejected(real_services_job_service) -> None:
     assert not [s for s in signals if s.signal_type == SignalType.RESUME]  # no signal written for a stale id
     job = await job_service.get_job_by_job_id(job_id)
     assert job.status == JobStatus.SUSPENDED  # untouched
+
+
+@pytest.mark.real_services
+@pytest.mark.no_blockbuster
+async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_decision(
+    real_services_job_service,
+) -> None:
+    """A wrong decryption key leaves the paused run and its decision seam untouched."""
+    from langflow.services.background_execution.service import (
+        BackgroundExecutionService,
+        RequestOverridesUnavailableError,
+    )
+    from langflow.services.deps import get_settings_service
+    from pydantic import SecretStr
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    backend = _RecordingBackend()
+    user_id, flow_id = uuid4(), uuid4()
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_noop_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(
+        flow_id=flow_id,
+        request={
+            "flow_id": str(flow_id),
+            "mode": "background",
+            "stream_protocol": "langflow",
+            "input_value": "pause",
+            "tweaks": {"Node-x": {"api_key": "resume-secret"}},  # pragma: allowlist secret
+        },
+        user=_StubUser(user_id),
+    )
+    await job_service.update_job_metadata(job_id, {"pending_request_id": "req-encrypted"})
+    await job_service.update_job_status(job_id, JobStatus.SUSPENDED)
+
+    wrong_auth = settings_service.auth_settings.model_copy(
+        update={  # pragma: allowlist secret
+            "SECRET_KEY": SecretStr("different-key-material-that-is-at-least-32-bytes")
+        }
+    )
+    resume_service = BackgroundExecutionService(
+        settings_service=SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth),
+        frame_source_factory=_noop_factory,
+    )
+    with pytest.raises(RequestOverridesUnavailableError, match="Background request overrides are unavailable"):
+        await resume_service.resume_job(
+            job_id,
+            _StubUser(user_id),
+            request_id="req-encrypted",
+            decision={  # pragma: allowlist secret
+                "choice": "approve",
+                "secret": "decision-must-not-be-written",  # pragma: allowlist secret
+            },
+        )
+
+    job = await job_service.get_job_by_job_id(job_id)
+    assert job.status == JobStatus.SUSPENDED
+    assert (job.job_metadata or {}).get("pending_request_id") == "req-encrypted"
+    assert await job_service.unconsumed_signals(job_id) == []
+    assert "decision-must-not-be-written" not in json.dumps(job.job_metadata)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/backend/tests/unit/background_execution/test_resume.py
+++ b/src/backend/tests/unit/background_execution/test_resume.py
@@ -178,6 +178,7 @@ async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_deci
     real_services_job_service,
 ) -> None:
     """A wrong decryption key leaves the paused run and its decision seam untouched."""
+    from cryptography.fernet import Fernet
     from langflow.services.background_execution.service import (
         BackgroundExecutionService,
         RequestOverridesUnavailableError,
@@ -209,9 +210,7 @@ async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_deci
     await job_service.update_job_status(job_id, JobStatus.SUSPENDED)
 
     wrong_auth = settings_service.auth_settings.model_copy(
-        update={  # pragma: allowlist secret
-            "SECRET_KEY": SecretStr("different-key-material-that-is-at-least-32-bytes")
-        }
+        update={"SECRET_KEY": SecretStr(Fernet.generate_key().decode())}
     )
     resume_service = BackgroundExecutionService(
         settings_service=SimpleNamespace(settings=settings_service.settings, auth_settings=wrong_auth),
@@ -233,6 +232,58 @@ async def test_resume_checks_encrypted_overrides_before_claiming_or_writing_deci
     assert (job.job_metadata or {}).get("pending_request_id") == "req-encrypted"
     assert await job_service.unconsumed_signals(job_id) == []
     assert "decision-must-not-be-written" not in json.dumps(job.job_metadata)
+
+
+@pytest.mark.real_services
+@pytest.mark.no_blockbuster
+async def test_resume_rehydrates_original_encrypted_overrides(real_services_job_service) -> None:
+    """A successful HITL resume receives the same overrides as the initial run."""
+    from langflow.services.background_execution.service import BackgroundExecutionService
+    from langflow.services.deps import get_settings_service
+
+    job_service = real_services_job_service
+    settings_service = get_settings_service()
+    backend = _RecordingBackend()
+    user_id, flow_id = uuid4(), uuid4()
+    request = {
+        "flow_id": str(flow_id),
+        "mode": "background",
+        "stream_protocol": "langflow",
+        "input_value": "resume-with-overrides",
+        "tweaks": {"Node-x": {"api_key": "resume-replay-secret"}},  # pragma: allowlist secret
+    }
+    submitter = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_noop_factory,
+        backend=backend,
+    )
+    job_id = await submitter.submit(flow_id=flow_id, request=request, user=_StubUser(user_id))
+    await job_service.update_job_metadata(job_id, {"pending_request_id": "req-replay"})
+    await job_service.update_job_status(job_id, JobStatus.SUSPENDED)
+
+    captured: list[dict] = []
+
+    def _capture_factory(*, request, **_kwargs):
+        captured.append(request)
+        return _noop_factory()
+
+    resume_service = BackgroundExecutionService(
+        settings_service=settings_service,
+        frame_source_factory=_capture_factory,
+    )
+    try:
+        accepted = await resume_service.resume_job(
+            job_id,
+            _StubUser(user_id),
+            request_id="req-replay",
+            decision={"choice": "approve"},
+        )
+        assert accepted is True
+        # The factory is called synchronously while building the re-enqueued
+        # runner, before the executor starts consuming the resume checkpoint.
+        assert captured == [request]
+    finally:
+        await resume_service.stop()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- keep request `globals` and `tweaks` out of plaintext background-job metadata
- persist a versioned, authenticated Fernet envelope bound to the job and flow so restart and resume preserve the exact request
- keep ambiguous key/authentication failures queued and retryable, while authenticated or structural corruption fails closed without executing
- return structured 422 responses for invalid caller overrides and structured 503 responses for temporary crypto/restore failures
- create queued jobs atomically with complete metadata and guard lease release/terminalization by the exact owner and heartbeat claim

## Upgrade note

Before upgrading, drain, cancel, or resubmit pre-fix `QUEUED` workflow jobs whose persisted request contains non-empty plaintext `tweaks`. Those legacy values were not authenticated, so the new recovery path deliberately does not trust or re-encrypt them and fails those rows closed. Legacy rows with only empty `globals`/`tweaks` remain replayable. Ambiguous Fernet authentication or key failures leave the job `QUEUED` for retry after the key is restored.

## Validation

- background execution and resume: 61 passed; 61 PostgreSQL variants skipped because `LANGFLOW_TEST_DATABASE_URI` is not configured
- API background and resume routes: 33 passed
- JobService liveness: 9 passed
- focused corruption and event-collision regressions: 2 passed; 2 PostgreSQL variants skipped locally
- Ruff, formatting, pre-commit hooks, diff check, and secret scan passed
- independent code, database/concurrency, and security reviews approved the final head

[LE-2381](https://datastax.jira.com/browse/LE-2381)


[LE-2381]: https://datastax.jira.com/browse/LE-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background workflow requests now securely preserve and restore global settings and tweak overrides across retries, restarts, and scaled deployments.
  * Job metadata is saved atomically when a job is created.

* **Bug Fixes**
  * Invalid, damaged, or unavailable request overrides now fail safely without executing the workflow.
  * Resume operations preserve suspended jobs when required overrides cannot be restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
