### PR TITLE
test(frontend): classify assistant mock model

### DIFF
--- a/src/frontend/tests/utils/mock-assistant.ts
+++ b/src/frontend/tests/utils/mock-assistant.ts
@@ -78,7 +78,12 @@ export async function mockAssistant(
           icon: "OpenAI",
           is_configured: true,
           is_enabled: true,
-          models: [{ metadata: {}, model_name: "gpt-4o-mini" }],
+          models: [
+            {
+              metadata: { model_type: "llm" },
+              model_name: "gpt-4o-mini",
+            },
+          ],
           provider: "OpenAI",
         },
       ]);


### PR DESCRIPTION
## Summary

The assistant Playwright fixture advertises `gpt-4o-mini` in the typed enabled-model response, but its mocked model catalog leaves `metadata` empty. Since the assistant now filters the catalog to `model_type: "llm"`, six assistant-panel tests render “No Model Provider Configured.”

This classifies the mocked model as an LLM so the two mocked endpoints agree with the production contract.

## Validation

- Biome and pre-commit hooks passed
- the affected Playwright specs compile and list all six regression consumers
- independent TypeScript review approved the contract/minimality of the change

Unblocks the shared-base Playwright failures observed on [#14829](https://github.com/langflow-ai/langflow/pull/14829).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated assistant model catalog test data to correctly identify the mock model as an LLM.
  * Improved test coverage alignment with model metadata displayed by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->