### PR TITLE
fix(observability): keep Langflow's metrics off a provider it did not choose

### DIFF
--- a/src/backend/base/langflow/services/telemetry/opentelemetry.py
+++ b/src/backend/base/langflow/services/telemetry/opentelemetry.py
@@ -18,7 +18,7 @@ from lfx.observability import (
     bootstrap_application_telemetry,
 )
 from opentelemetry import metrics
-from opentelemetry.metrics import CallbackOptions, Observation
+from opentelemetry.metrics import CallbackOptions, NoOpMeterProvider, Observation
 from opentelemetry.metrics._internal.instrument import Counter, Histogram, UpDownCounter
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
@@ -231,10 +231,19 @@ class OpenTelemetry(metaclass=ThreadSafeSingletonMetaUsingWeakref):
         self._tracer_provider = telemetry.tracer_provider
         self._logger_provider = telemetry.logger_provider
 
-        # meter_provider is None when nothing is exported and Prometheus is off (the default):
-        # the bootstrap declines to install a reader-less provider. Fall back to the global API
-        # proxy so the custom metrics still register on a no-op meter rather than crashing here.
-        self.meter = (self._meter_provider or metrics.get_meter_provider()).get_meter(langflow_meter_name)
+        # meter_provider is None when nothing is exported and Prometheus is off, which is the
+        # default. Fall back to an explicit no-op provider, NOT to the global API provider.
+        #
+        # The global one at this moment is a proxy, and a proxy meter is not a no-op: its
+        # instruments resolve lazily onto whichever real MeterProvider is registered later. An
+        # LLM tracing SDK that registers one on the first flow run would therefore adopt every
+        # metric recorded here, labels included, and ship it to the vendor's endpoint. The
+        # allowlist that draws this boundary for our own exporter cannot help, because this
+        # path never reaches that exporter.
+        #
+        # A no-op provider says what the configuration actually means: nothing was asked for,
+        # so nothing is recorded, and nothing can be adopted afterwards.
+        self.meter = (self._meter_provider or NoOpMeterProvider()).get_meter(langflow_meter_name)
 
         for name, metric in self._metrics_registry.items():
             if name != metric.name:

--- a/src/backend/base/langflow/services/telemetry/opentelemetry.py
+++ b/src/backend/base/langflow/services/telemetry/opentelemetry.py
@@ -17,8 +17,7 @@ from lfx.observability import (
     ApplicationTelemetry,
     bootstrap_application_telemetry,
 )
-from opentelemetry import metrics
-from opentelemetry.metrics import CallbackOptions, NoOpMeterProvider, Observation
+from opentelemetry.metrics import CallbackOptions, Meter, NoOpMeterProvider, Observation
 from opentelemetry.metrics._internal.instrument import Counter, Histogram, UpDownCounter
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
@@ -77,9 +76,13 @@ class ObservableGaugeWrapper:
     instead it uses a callback function to get the value, we need to create a wrapper class.
     """
 
-    def __init__(self, name: str, description: str, unit: str):
+    def __init__(self, name: str, description: str, unit: str, meter: Meter):
         self._values: dict[tuple[tuple[str, str], ...], float] = {}
-        self._meter = metrics.get_meter(langflow_meter_name)
+        # The meter is passed in rather than fetched from the global API for the same reason
+        # the counters use self.meter: a global proxy meter is not a no-op, so a gauge built
+        # on one would report its flow_id-labelled values to whichever MeterProvider an LLM
+        # tracing SDK registers later.
+        self._meter = meter
         self._gauge = self._meter.create_observable_gauge(
             name=name, description=description, unit=unit, callbacks=[self._callback]
         )
@@ -270,6 +273,7 @@ class OpenTelemetry(metaclass=ThreadSafeSingletonMetaUsingWeakref):
                 name=metric.name,
                 description=metric.description,
                 unit=metric.unit,
+                meter=self.meter,
             )
         if metric.type == MetricType.UP_DOWN_COUNTER:
             return self.meter.create_up_down_counter(

--- a/src/backend/tests/unit/services/telemetry/test_metrics_stay_with_the_operator.py
+++ b/src/backend/tests/unit/services/telemetry/test_metrics_stay_with_the_operator.py
@@ -1,0 +1,101 @@
+"""Langflow's own metrics must not follow a provider someone else registers later.
+
+In the default deployment shape — no OTLP endpoint, Prometheus off — the bootstrap declines to
+install a MeterProvider. The service then has to record its metrics somewhere, and the obvious
+somewhere is the global API provider.
+
+That is a trap. The global provider at that moment is a *proxy*, and a proxy meter is not a
+no-op: its instruments resolve lazily onto whichever real MeterProvider is registered
+afterwards. An LLM tracing SDK that registers one on the first flow run therefore adopts every
+metric Langflow records, labels included, and ships it to the vendor's endpoint.
+
+The allowlist that draws this boundary for the OTLP exporter cannot help: it is applied to the
+exporter Langflow owns, and this path never goes through it.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from langflow.services.telemetry.opentelemetry import OpenTelemetry
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+
+def _recorded_by_a_late_provider(record) -> list[str]:
+    """Register a real provider AFTER the service, the way a tracing SDK does, and see what lands."""
+    reader = InMemoryMetricReader()
+    metrics.set_meter_provider(MeterProvider(metric_readers=[reader]))
+    record()
+    data = reader.get_metrics_data()
+    return [
+        metric.name
+        for rm in (data.resource_metrics if data else [])
+        for sm in rm.scope_metrics
+        for metric in sm.metrics
+    ]
+
+
+def test_metrics_do_not_follow_a_provider_registered_after_startup():
+    """The regression. Nothing Langflow records may reach a provider it did not choose."""
+    service = OpenTelemetry(prometheus_enabled=False)
+
+    landed = _recorded_by_a_late_provider(
+        lambda: service.increment_counter("num_files_uploaded", labels={"flow_id": "probe-flow"}, value=3)
+    )
+
+    assert landed == [], f"Langflow metrics reached a provider registered by someone else: {landed}"
+
+
+def test_recording_a_metric_still_works_when_nothing_is_configured():
+    """The control. The fix must make the metric go nowhere, not make recording raise.
+
+    Without this, returning a broken meter would pass the test above for the wrong reason and
+    take the whole service down on the first upload.
+    """
+    service = OpenTelemetry(prometheus_enabled=False)
+
+    service.increment_counter("num_files_uploaded", labels={"flow_id": "probe-flow"}, value=1)
+
+
+CONFIGURED_PROBE = """
+from langflow.services.telemetry.opentelemetry import OpenTelemetry
+
+service = OpenTelemetry(prometheus_enabled=True)
+print("PROBE_RESULT " + repr({
+    "owns_provider": service._meter_provider is not None,
+    "meter_type": type(service.meter).__name__,
+}))
+"""
+
+
+def test_a_configured_provider_still_receives_the_metrics():
+    """The other control, and the one that stops this fix going too far.
+
+    Silencing the unconfigured case is only correct if the configured case is untouched. With
+    Prometheus on, the bootstrap installs a provider Langflow owns, and the metrics belong on
+    it. A fix that made every meter a no-op would pass the first test and quietly delete the
+    feature.
+
+    Runs in a subprocess: ``set_meter_provider`` is one-shot, and the tests above deliberately
+    register a provider, so in-process this would assert against whichever ran first.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OTEL_")}
+    with tempfile.TemporaryDirectory() as tmp:
+        probe = Path(tmp) / "probe.py"
+        probe.write_text(CONFIGURED_PROBE, encoding="utf-8")
+        completed = subprocess.run(  # noqa: S603
+            [sys.executable, str(probe)], env=env, capture_output=True, text=True, timeout=300, check=False
+        )
+    assert completed.returncode == 0, completed.stderr
+    line = next(ln for ln in completed.stdout.splitlines() if ln.startswith("PROBE_RESULT "))
+    result = ast.literal_eval(line.removeprefix("PROBE_RESULT "))
+
+    assert result["owns_provider"], "the bootstrap should own a provider when Prometheus is on"
+    assert result["meter_type"] != "NoOpMeter", "a configured deployment must still record"

--- a/src/backend/tests/unit/services/telemetry/test_metrics_stay_with_the_operator.py
+++ b/src/backend/tests/unit/services/telemetry/test_metrics_stay_with_the_operator.py
@@ -23,6 +23,7 @@ import tempfile
 from pathlib import Path
 
 from langflow.services.telemetry.opentelemetry import OpenTelemetry
+from lfx.observability_llm_metrics import LLMProviderMetricsCallbackHandler
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
@@ -43,12 +44,27 @@ def _recorded_by_a_late_provider(record) -> list[str]:
 
 
 def test_metrics_do_not_follow_a_provider_registered_after_startup():
-    """The regression. Nothing Langflow records may reach a provider it did not choose."""
-    service = OpenTelemetry(prometheus_enabled=False)
+    """The regression. Nothing Langflow records may reach a provider it did not choose.
 
-    landed = _recorded_by_a_late_provider(
-        lambda: service.increment_counter("num_files_uploaded", labels={"flow_id": "probe-flow"}, value=3)
-    )
+    Every path that builds an instrument is exercised in this one test on purpose:
+    ``set_meter_provider`` is one-shot, so a second test calling it would keep the provider
+    this one registered and assert against a reader nothing was ever wired to. One
+    registration, every recorder.
+
+    The three paths reached the global API separately, so fixing one left the others leaking:
+    the counters and histograms take the service's own meter, the observable gauges built
+    their own, and the LLM provider metrics live in lfx and build a third.
+    """
+    service = OpenTelemetry(prometheus_enabled=False)
+    llm_metrics = LLMProviderMetricsCallbackHandler()
+
+    def record_from_every_path() -> None:
+        service.increment_counter("num_files_uploaded", labels={"flow_id": "probe-flow"}, value=3)
+        service.update_gauge("file_uploads", value=4242.0, labels={"flow_id": "probe-flow"})
+        llm_metrics._duration.record(1.5, {"gen_ai.system": "openai", "gen_ai.request.model": "probe"})
+        llm_metrics._errors.add(1, {"error.type": "ProbeError"})
+
+    landed = _recorded_by_a_late_provider(record_from_every_path)
 
     assert landed == [], f"Langflow metrics reached a provider registered by someone else: {landed}"
 
@@ -66,11 +82,15 @@ def test_recording_a_metric_still_works_when_nothing_is_configured():
 
 CONFIGURED_PROBE = """
 from langflow.services.telemetry.opentelemetry import OpenTelemetry
+from lfx.observability_llm_metrics import get_llm_provider_metrics_handler
 
 service = OpenTelemetry(prometheus_enabled=True)
+handler = get_llm_provider_metrics_handler()
 print("PROBE_RESULT " + repr({
     "owns_provider": service._meter_provider is not None,
     "meter_type": type(service.meter).__name__,
+    "gauge_meter_type": type(service._metrics["file_uploads"]._meter).__name__,
+    "llm_instrument_type": type(handler._duration).__name__,
 }))
 """
 
@@ -99,3 +119,5 @@ def test_a_configured_provider_still_receives_the_metrics():
 
     assert result["owns_provider"], "the bootstrap should own a provider when Prometheus is on"
     assert result["meter_type"] != "NoOpMeter", "a configured deployment must still record"
+    assert result["gauge_meter_type"] != "NoOpMeter", "the gauges must record too, not just the counters"
+    assert result["llm_instrument_type"] != "NoOpHistogram", "the LLM provider metrics must record too"

--- a/src/lfx/src/lfx/observability.py
+++ b/src/lfx/src/lfx/observability.py
@@ -83,6 +83,11 @@ APPLICATION_TRACER_NAME = "langflow.observability"
 # event-loop lag sampler below; langflow's own counters and gauges are additional.
 APPLICATION_METER_NAME = "langflow"
 
+# The meter provider the bootstrap installed, remembered so the code that records metrics can
+# bind to it directly. Set by :func:`bootstrap_application_telemetry`; stays None when nothing
+# is configured, which is the default. See :func:`application_meter`.
+_application_meter_provider: MeterProvider | None = None
+
 DEFAULT_SERVICE_NAME = "langflow"
 
 # The surface a flow run arrived through, recorded as the flow span's ``protocol`` attribute so
@@ -1077,6 +1082,8 @@ def bootstrap_application_telemetry(*, prometheus_enabled: bool = False) -> Appl
         return ApplicationTelemetry()
 
     meter_provider, owns_meter_provider = _install_meter_provider(prometheus_enabled=prometheus_enabled)
+    global _application_meter_provider  # noqa: PLW0603 - process-wide, like the OTel provider globals
+    _application_meter_provider = meter_provider
     if meter_provider is not None:
         _instrument_process_metrics(meter_provider)
     tracer_provider = _configure_tracer_provider_from_environment()
@@ -1087,6 +1094,26 @@ def bootstrap_application_telemetry(*, prometheus_enabled: bool = False) -> Appl
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
     )
+
+
+def application_meter():
+    """Return the meter Langflow's own metrics record on, or None without OpenTelemetry.
+
+    Never ``metrics.get_meter``. With nothing configured the bootstrap installs no provider,
+    and the global API hands back a proxy meter, which is not a no-op: its instruments resolve
+    lazily onto whichever MeterProvider is registered next. An LLM tracing SDK that installs
+    one on the first flow run would therefore adopt every metric recorded here, labels
+    included, and ship it to the vendor's endpoint. The export allowlist that draws this
+    boundary for our own exporter cannot help, because that path never reaches our exporter.
+
+    A no-op meter says what the configuration actually means: nothing was asked for, so
+    nothing is recorded, and nothing can be adopted afterwards.
+    """
+    if not _OTEL_AVAILABLE:
+        return None
+    from opentelemetry.metrics import NoOpMeterProvider
+
+    return (_application_meter_provider or NoOpMeterProvider()).get_meter(APPLICATION_METER_NAME)
 
 
 def instrument_database(engine: object) -> None:

--- a/src/lfx/src/lfx/observability_llm_metrics.py
+++ b/src/lfx/src/lfx/observability_llm_metrics.py
@@ -6,13 +6,15 @@ provider API keys that ride in request URLs cannot leak the way they did through
 path (removed from the export allowlist in :mod:`lfx.observability`).
 
 The instruments are created from the allowlisted "langflow" meter, so they export through the
-same application-only filter as the rest of the runtime's own metrics. When no provider is
-installed yet ``metrics.get_meter`` hands back a proxy meter that records nowhere until the
-bootstrap installs the real one, so creating the handler early is safe under ``lfx serve``.
+same application-only filter as the rest of the runtime's own metrics. That meter comes from
+:func:`lfx.observability.application_meter`, never from the global API: with nothing configured
+the API hands back a proxy meter, and a proxy meter is not a no-op. Its instruments resolve onto
+whichever MeterProvider is registered next, so an LLM tracing SDK installing one on the first
+flow run would adopt this provider and model data and ship it to the vendor's endpoint.
 
 OpenTelemetry is an optional lfx extra (``lfx[otel]``). When it is absent there is no meter to
-record on, so :func:`get_llm_provider_metrics_handler` returns None and the callback is simply
-not attached, keeping bare lfx importable.
+record on, ``application_meter`` returns None, so :func:`get_llm_provider_metrics_handler`
+returns None and the callback is simply not attached, keeping bare lfx importable.
 """
 
 from __future__ import annotations
@@ -25,14 +27,7 @@ from typing import TYPE_CHECKING, Any
 from langchain_core.callbacks import BaseCallbackHandler
 
 from lfx.base.models.llm_callback_utils import detect_provider_from_model, extract_llm_model_name
-from lfx.observability import APPLICATION_METER_NAME
-
-try:
-    from opentelemetry import metrics
-
-    _OTEL_AVAILABLE = True
-except ImportError:
-    _OTEL_AVAILABLE = False
+from lfx.observability import application_meter
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -55,7 +50,7 @@ class LLMProviderMetricsCallbackHandler(BaseCallbackHandler):
 
     def __init__(self) -> None:
         super().__init__()
-        meter = metrics.get_meter(APPLICATION_METER_NAME)
+        meter = application_meter()
         # gen_ai.client.operation.duration is the OTel GenAI semconv metric; on failure it carries
         # error.type, recorded on both the success and error paths so failed-call latency is visible.
         self._duration = meter.create_histogram(
@@ -141,7 +136,12 @@ def get_llm_provider_metrics_handler() -> LLMProviderMetricsCallbackHandler | No
 
     run_ids are unique UUIDs, so one lazily-created shared instance safely serves every flow.
     lru_cache gives the thread-safe lazy singleton in one line.
+
+    Called from component execution, so the bootstrap has always run by this point and the
+    instruments bind to the provider it installed. Constructing the handler before the
+    bootstrap would bind them to a no-op meter for the life of the process, which is the
+    trade for never binding them to a provider the operator did not choose.
     """
-    if not _OTEL_AVAILABLE:
+    if application_meter() is None:
         return None
     return LLMProviderMetricsCallbackHandler()

--- a/src/lfx/tests/unit/observability/test_llm_provider_metrics.py
+++ b/src/lfx/tests/unit/observability/test_llm_provider_metrics.py
@@ -15,16 +15,24 @@ _HAS_OTEL = importlib.util.find_spec("opentelemetry") is not None
 pytestmark = pytest.mark.skipif(not _HAS_OTEL, reason="requires the lfx[otel] extra")
 
 _ALLOWED_KEYS = {"gen_ai.provider.name", "gen_ai.request.model", "error.type"}
+_LLM_METRIC_NAMES = {"gen_ai.client.operation.duration", "langflow.llm.provider.errors"}
 
 
 @pytest.fixture(scope="module")
 def reader():
-    """Install a real meter provider once before any handler reads the global meter.
+    """Install a real meter provider, then bootstrap the way a real startup does.
+
+    The bootstrap is what binds the handler's instruments: it adopts an SDK provider that is
+    already installed (the ``opentelemetry-instrument`` case) and remembers it, and the handler
+    records on that rather than on the global API. Without the bootstrap call the handler gets a
+    no-op meter on purpose, so that a provider an LLM tracing SDK registers later can never
+    adopt these metrics.
 
     The global meter provider can only be set once per process (the SDK refuses to override),
     so this is module-scoped. Each test constructs a fresh handler and uses distinct run_ids;
     the reader is cumulative, so assertions read the point matching what the test just recorded.
     """
+    from lfx.observability import bootstrap_application_telemetry
     from opentelemetry import metrics
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import InMemoryMetricReader
@@ -32,6 +40,8 @@ def reader():
     in_memory = InMemoryMetricReader()
     provider = MeterProvider(metric_readers=[in_memory])
     metrics.set_meter_provider(provider)
+    telemetry = bootstrap_application_telemetry(prometheus_enabled=False)
+    assert telemetry.meter_provider is provider, "the bootstrap should adopt an already-installed provider"
     yield in_memory
     provider.shutdown()
 
@@ -124,7 +134,13 @@ def test_no_leak_and_bounded_cardinality(reader):
     h.on_chat_model_start({}, [[HumanMessage("y")]], run_id=rid2, invocation_params={"model_name": "claude-3-5-sonnet"})
     h.on_llm_error(RuntimeError("boom https://api.openai.com/v1/chat?key=sk-SECRET-LEAK"), run_id=rid2)
 
-    for metric_points in _all_data_points(reader).values():
+    # Only this module's two metrics: the bootstrap also instruments process CPU, memory and GC
+    # on the same provider, and those legitimately carry keys of their own ("type", "generation").
+    points = _all_data_points(reader)
+    llm_metrics = {name: pts for name, pts in points.items() if name in _LLM_METRIC_NAMES}
+    assert set(llm_metrics) == _LLM_METRIC_NAMES, f"expected both LLM metrics, got {sorted(points)}"
+
+    for metric_points in llm_metrics.values():
         for dp in metric_points:
             for key, value in dict(dp.attributes).items():
                 assert key in _ALLOWED_KEYS, f"unexpected attribute key: {key}"


### PR DESCRIPTION
Langflow's own metrics could be adopted by a metrics provider an LLM tracing SDK installs, and shipped to that vendor's endpoint. Reported by Rafael Gil on 10 August and measured then on both #14357 and its merge-base, so it is not a regression from the span fix.

## The bug

In the default deployment shape (no OTLP endpoint, Prometheus off) the bootstrap declines to install a `MeterProvider`, and the code fell back to the global API provider with this comment:

```python
# ... Fall back to the global API
# proxy so the custom metrics still register on a no-op meter rather than crashing here.
```

**A proxy meter is not a no-op.** Its instruments resolve lazily onto whichever real `MeterProvider` is registered afterwards. An LLM tracing SDK that registers one on the first flow run therefore adopts every metric Langflow records, `flow_id` labels included, and ships it to the vendor's endpoint. `APPLICATION_METRIC_SCOPES` exists to draw exactly this boundary, but it is applied to our own exporter and this path never reaches it.

That wrong comment is what made the leak invisible on reading, so it is replaced with what actually happens.

## Three paths, not one

The first commit fixed the service's own meter. Probing the rest of the runtime turned up two more places that built instruments from the global API and kept leaking. In the default shape, with a provider registered afterwards:

```
REACHED THE VENDOR PROVIDER:
  file_uploads                      [scope=langflow]  attrs={'flow_id': 'probe-flow-id'}
  gen_ai.client.operation.duration  [scope=langflow]  attrs={'gen_ai.system': 'openai', 'gen_ai.request.model': 'gpt-probe'}
  langflow.llm.provider.errors      [scope=langflow]  attrs={'error.type': 'ProbeError'}
```

- **counters and histograms** take the telemetry service's meter, now an explicit `NoOpMeterProvider` when nothing is configured
- **observable gauges** built their own meter, so `file_uploads` leaked its `flow_id` values. `ObservableGaugeWrapper` now takes the meter the service already resolved
- **LLM provider metrics** live in lfx and took a third meter. They now go through a new `application_meter()`, which returns the bootstrapped provider's meter or a no-op one

After the fix the same probe reports nothing reaching the late provider.

## The runtime metrics were never at risk

Worth stating because it was raised on the report and was unmeasured until now. The same probe confirms it:

```
bootstrap meter_provider: None
system metrics instrumented: False
```

Process CPU, memory, threads, file descriptors and GC are only instrumented when a provider exists, and `start_event_loop_lag_monitor` returns None without one. The four `langflow_db_pool_*` gauges are the same shape: `instrument_db_pool` returns early when the meter provider is None. All of them take the provider explicitly rather than the global, so none of them had the proxy problem.

## Tests

The regression test records from all three paths in one test on purpose. `set_meter_provider` is one-shot, so a second test calling it would keep this one's provider and assert against a reader nothing was ever wired to.

Two controls, because this fix has two ways to be wrong:

- recording still **works** rather than raising. A broken meter would pass the regression test and take the service down on the first upload.
- a **configured** deployment is untouched, gauges and LLM metrics included. Making every meter a no-op would pass the regression test and quietly delete the feature. Runs in a subprocess, since the regression test has already used the one-shot global.

Mutation checked, each direction caught by the right test:

| reverted | fails with |
|---|---|
| gauge back to the global meter | `metrics reached a provider registered by someone else: ['file_uploads', ...]` |
| `application_meter` back to the global API | same, with the two `gen_ai`/`llm` metrics |
| `application_meter` always no-op | `the LLM provider metrics must record too` |

202 backend telemetry tests and 128 lfx observability tests pass.

## One behaviour change worth knowing

The LLM metrics handler binds its instruments when it is first constructed, which happens during component execution, always after the bootstrap. Constructing it *before* the bootstrap now binds it to a no-op meter for the life of the process instead of being backfilled by the proxy. That is the trade for never binding to a provider the operator did not choose. It moved one test fixture, which now bootstraps the way a real startup does.
