### PR TITLE
fix(mcp): honor API exposure in tool schemas

### DIFF
--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -681,7 +681,60 @@ def _get_flow_input_nodes(flow: Flow) -> list[Vertex]:
 
 
 def _is_mcp_input_field(field_data: Any) -> bool:
-    return isinstance(field_data, dict) and field_data.get("show", False) and not field_data.get("advanced", False)
+    return (
+        isinstance(field_data, dict)
+        and field_data.get("show", False)
+        and not field_data.get("advanced", False)
+        and field_data.get("api_editable") is True
+    )
+
+
+_JSON_SCHEMA_TYPE_BY_FIELD_TYPE = {
+    "str": "string",
+    "string": "string",
+    "int": "integer",
+    "integer": "integer",
+    "float": "number",
+    "number": "number",
+    "slider": "number",
+    "bool": "boolean",
+    "boolean": "boolean",
+    "dict": "object",
+    "NestedDict": "object",
+    "table": "object",
+    "duration": "object",
+    "auth": "object",
+    "mcp": "object",
+    "data_display": "object",
+    "object": "object",
+    "sortableList": "array",
+    "actionPicker": "array",
+    "tools": "array",
+    "model": "array",
+    "array": "array",
+    "connect": "string",
+    "file": "string",
+    "prompt": "string",
+    "mustache": "string",
+    "code": "string",
+    "other": "string",
+    "link": "string",
+    "tab": "string",
+    "query": "string",
+    "knowledge_backend": "string",
+}
+
+
+def _json_schema_type_for_field(field_data: dict[str, Any]) -> dict[str, Any]:
+    field_type = field_data.get("type", "string")
+    json_schema_type = _JSON_SCHEMA_TYPE_BY_FIELD_TYPE.get(field_type)
+    if json_schema_type is None:
+        logger.warning(f"Unknown field type: {field_type} defaulting to string")
+        json_schema_type = "string"
+
+    if field_data.get("list") is True:
+        return {"type": "array", "items": {"type": json_schema_type}}
+    return {"type": json_schema_type}
 
 
 def get_flow_input_tweaks(flow: Flow, inputs: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -710,24 +763,10 @@ def json_schema_from_flow(flow: Flow) -> dict:
 
         for field_name, field_data in template.items():
             if _is_mcp_input_field(field_data):
-                field_type = field_data.get("type", "string")
                 properties[field_name] = {
-                    "type": field_type,
+                    **_json_schema_type_for_field(field_data),
                     "description": field_data.get("info", f"Input for {field_name}"),
                 }
-                # Update field_type in properties after determining the JSON Schema type
-                if field_type == "str":
-                    field_type = "string"
-                elif field_type == "int":
-                    field_type = "integer"
-                elif field_type == "float":
-                    field_type = "number"
-                elif field_type == "bool":
-                    field_type = "boolean"
-                else:
-                    logger.warning(f"Unknown field type: {field_type} defaulting to string")
-                    field_type = "string"
-                properties[field_name]["type"] = field_type
 
                 if field_data.get("required", False):
                     required.append(field_name)

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -701,16 +701,11 @@ _JSON_SCHEMA_TYPE_BY_FIELD_TYPE = {
     "boolean": "boolean",
     "dict": "object",
     "NestedDict": "object",
-    "table": "object",
     "duration": "object",
     "auth": "object",
     "mcp": "object",
     "data_display": "object",
     "object": "object",
-    "sortableList": "array",
-    "actionPicker": "array",
-    "tools": "array",
-    "model": "array",
     "array": "array",
     "connect": "string",
     "file": "string",
@@ -724,15 +719,27 @@ _JSON_SCHEMA_TYPE_BY_FIELD_TYPE = {
     "knowledge_backend": "string",
 }
 
+_JSON_SCHEMA_ARRAY_ITEM_TYPE_BY_FIELD_TYPE = {
+    "sortableList": "object",
+    "actionPicker": "string",
+    "table": "object",
+    "tools": "object",
+    "model": "object",
+}
+
 
 def _json_schema_type_for_field(field_data: dict[str, Any]) -> dict[str, Any]:
     field_type = field_data.get("type", "string")
+    array_item_type = _JSON_SCHEMA_ARRAY_ITEM_TYPE_BY_FIELD_TYPE.get(field_type)
+    if array_item_type is not None:
+        return {"type": "array", "items": {"type": array_item_type}}
+
     json_schema_type = _JSON_SCHEMA_TYPE_BY_FIELD_TYPE.get(field_type)
     if json_schema_type is None:
         logger.warning(f"Unknown field type: {field_type} defaulting to string")
         json_schema_type = "string"
 
-    if field_data.get("list") is True:
+    if field_data.get("list") is True or field_data.get("is_list") is True:
         return {"type": "array", "items": {"type": json_schema_type}}
     return {"type": json_schema_type}
 

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -911,6 +911,34 @@ def test_json_schema_from_flow_maps_structured_and_list_field_types(monkeypatch)
                         "api_editable": True,
                         "type": "sortableList",
                     },
+                    "rows": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "table",
+                        "list": True,
+                    },
+                    "actions": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "actionPicker",
+                        "list": True,
+                    },
+                    "tools": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "tools",
+                        "is_list": True,
+                    },
+                    "models": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "model",
+                        "list": False,
+                    },
                     "tags": {
                         "show": True,
                         "advanced": False,
@@ -939,6 +967,15 @@ def test_json_schema_from_flow_maps_structured_and_list_field_types(monkeypatch)
     assert properties["metadata"]["type"] == "object"
     assert properties["nested"]["type"] == "object"
     assert properties["steps"]["type"] == "array"
+    assert properties["steps"]["items"] == {"type": "object"}
+    assert properties["rows"]["type"] == "array"
+    assert properties["rows"]["items"] == {"type": "object"}
+    assert properties["actions"]["type"] == "array"
+    assert properties["actions"]["items"] == {"type": "string"}
+    assert properties["tools"]["type"] == "array"
+    assert properties["tools"]["items"] == {"type": "object"}
+    assert properties["models"]["type"] == "array"
+    assert properties["models"]["items"] == {"type": "object"}
     assert properties["tags"]["type"] == "array"
     assert properties["tags"]["items"] == {"type": "string"}
 

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -705,24 +705,24 @@ async def test_handle_call_tool_forwards_only_advertised_input_fields(monkeypatc
                     is_input=True,
                     template={
                         "input_value": {"show": True, "advanced": False},
-                        "backend_token": {"show": True, "advanced": False},
-                        "enabled": {"show": True, "advanced": False},
-                        "hidden": {"show": False, "advanced": False},
-                        "advanced": {"show": True, "advanced": True},
+                        "backend_token": {"show": True, "advanced": False, "api_editable": True},
+                        "enabled": {"show": True, "advanced": False, "api_editable": True},
+                        "hidden": {"show": False, "advanced": False, "api_editable": True},
+                        "advanced": {"show": True, "advanced": True, "api_editable": True},
                     },
                 ),
                 _FakeNode(
                     "input-b",
                     is_input=True,
                     template={
-                        "backend_token": {"show": True, "advanced": False},
-                        "backend_url": {"show": True, "advanced": False},
+                        "backend_token": {"show": True, "advanced": False, "api_editable": True},
+                        "backend_url": {"show": True, "advanced": False, "api_editable": True},
                     },
                 ),
                 _FakeNode(
                     "downstream",
                     is_input=False,
-                    template={"backend_url": {"show": True, "advanced": False}},
+                    template={"backend_url": {"show": True, "advanced": False, "api_editable": True}},
                 ),
             ]
 
@@ -802,6 +802,7 @@ def test_json_schema_from_flow_preserves_flow_defined_session_id(monkeypatch):
                     "session_id": {
                         "show": True,
                         "advanced": False,
+                        "api_editable": True,
                         "type": "str",
                         "info": custom_session_id_property["description"],
                         "required": True,

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -830,6 +830,118 @@ def test_json_schema_from_flow_preserves_flow_defined_session_id(monkeypatch):
     assert "session_id" in schema["required"]
 
 
+def test_json_schema_from_flow_only_advertises_api_exposed_fields(monkeypatch):
+    """MCP tools/list must honor each input field's API exposure toggle."""
+
+    class _FakeNode:
+        is_input = True
+        data = {
+            "node": {
+                "template": {
+                    "exposed": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "str",
+                        "required": True,
+                    },
+                    "not_exposed": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": False,
+                        "type": "str",
+                        "required": True,
+                    },
+                    "legacy_without_exposure_flag": {
+                        "show": True,
+                        "advanced": False,
+                        "type": "str",
+                    },
+                    "off_node": {
+                        "show": True,
+                        "advanced": True,
+                        "api_editable": True,
+                        "type": "str",
+                    },
+                }
+            }
+        }
+
+    class _FakeGraph:
+        vertices = [_FakeNode()]
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+    schema = flow_helpers.json_schema_from_flow(SimpleNamespace(data={"nodes": [], "edges": []}))
+
+    assert set(schema["properties"]) == {"exposed", "session_id"}
+    assert schema["required"] == ["exposed"]
+
+
+def test_json_schema_from_flow_maps_structured_and_list_field_types(monkeypatch):
+    """MCP input schemas must describe the JSON values accepted by exposed fields."""
+
+    class _FakeNode:
+        is_input = True
+        data = {
+            "node": {
+                "template": {
+                    "metadata": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "dict",
+                    },
+                    "nested": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "NestedDict",
+                    },
+                    "steps": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "sortableList",
+                    },
+                    "tags": {
+                        "show": True,
+                        "advanced": False,
+                        "api_editable": True,
+                        "type": "str",
+                        "list": True,
+                    },
+                }
+            }
+        }
+
+    class _FakeGraph:
+        vertices = [_FakeNode()]
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+    schema = flow_helpers.json_schema_from_flow(SimpleNamespace(data={"nodes": [], "edges": []}))
+    properties = schema["properties"]
+
+    assert properties["metadata"]["type"] == "object"
+    assert properties["nested"]["type"] == "object"
+    assert properties["steps"]["type"] == "array"
+    assert properties["tags"]["type"] == "array"
+    assert properties["tags"]["items"] == {"type": "string"}
+
+
 @pytest.mark.asyncio
 async def test_handle_call_tool_blocks_hitl_flow(monkeypatch):
     """A HITL flow invoked as an MCP tool must raise so the MCP result is isError, pointing to the v2 API."""


### PR DESCRIPTION
## Summary
- honor the per-field API exposure toggle when advertising and forwarding MCP flow inputs
- emit JSON Schema object and array shapes for structured, list, table, tool, model, and action-picker fields
- add regressions for exposure filtering, call-time filtering, and non-primitive field schemas

## Testing
- `uv run pytest src/backend/tests/unit/api/v1/test_mcp_utils.py src/backend/tests/unit/api/v1/test_mcp_failure_reporting.py src/backend/tests/unit/api/v1/test_a2a.py -q` (145 passed, 1 skipped)
- `uv run ruff check src/backend/base/langflow/helpers/flow.py src/backend/tests/unit/api/v1/test_mcp_utils.py`
- pre-commit hooks passed on all three commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP schemas now support structured, list-based, and specialized array input types with more accurate JSON Schema representations.
  * Optional session identifiers continue to be included when applicable.

* **Bug Fixes**
  * MCP inputs are now exposed only when explicitly API-editable, visible, and non-advanced.
  * Unrecognized field types now safely default to string schemas with a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->