### PR TITLE
fix(agent): let structured output hold more than one record

### DIFF
--- a/src/lfx/src/lfx/components/models_and_agents/structured_output/prompt_fallback_invoker.py
+++ b/src/lfx/src/lfx/components/models_and_agents/structured_output/prompt_fallback_invoker.py
@@ -16,6 +16,8 @@ _MISSING_SCHEMA_HINT = "Try setting an output schema"
 def parse_and_validate_fallback_content(
     content: str,
     output_model: type[BaseModel] | None,
+    *,
+    envelope_key: str | None = None,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Extract JSON from free text and validate it against output_model.
 
@@ -29,6 +31,11 @@ def parse_and_validate_fallback_content(
     parsed = extract_json_from_text(content)
     if parsed is None:
         return {"content": content, "error": _MISSING_SCHEMA_HINT}
+
+    # The prompt asks for a list container, but models answer with a bare record or a
+    # bare array just as often. Accept every shape rather than failing validation.
+    if envelope_key and isinstance(parsed, dict) and isinstance(parsed.get(envelope_key), list):
+        parsed = parsed[envelope_key]
 
     if output_model is None:
         if isinstance(parsed, dict):

--- a/src/lfx/src/lfx/components/models_and_agents/structured_output/structured_output_orchestrator.py
+++ b/src/lfx/src/lfx/components/models_and_agents/structured_output/structured_output_orchestrator.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from pydantic import BaseModel
+from pydantic import Field, create_model
+
 from lfx.components.models_and_agents.structured_output.prompt_fallback_invoker import (
     parse_and_validate_fallback_content,
 )
@@ -22,6 +24,28 @@ from lfx.components.models_and_agents.structured_output.schema_preprocessing imp
 from lfx.helpers.base_model import build_model_from_schema
 from lfx.log.logger import logger
 from lfx.schema.data import Data
+
+LIST_FIELD_NAME = "objects"
+
+
+def _wrap_in_list_container(record_model: type[BaseModel]) -> type[BaseModel]:
+    """Wrap the record model in a list container, as the Structured Output component does.
+
+    The schema table describes ONE record. Handing that model straight to the provider
+    declares every field as a scalar, so a request like "list the South American countries"
+    can only come back with one -- which is what the provider correctly did, while the
+    default format instructions asked it to capture every instance (LE-2392).
+    """
+    return create_model(
+        "OutputModel",
+        __doc__="A list of extracted records.",
+        **{
+            LIST_FIELD_NAME: (
+                list[record_model],  # type: ignore[valid-type]
+                Field(description="Every record that matches the schema.", min_length=1),
+            )
+        },
+    )
 
 
 async def orchestrate_structured_output(
@@ -46,7 +70,8 @@ async def orchestrate_structured_output(
         )
         return Data(data={"content": input_value})
 
-    output_model = build_model_from_schema(preprocess_schema(output_schema))
+    record_model = build_model_from_schema(preprocess_schema(output_schema))
+    output_model = _wrap_in_list_container(record_model)
 
     fallback_reason = "llm_lacks_with_structured_output"
     if prefer_native and _supports_native_structured_output(llm):
@@ -79,7 +104,7 @@ async def orchestrate_structured_output(
     )
     augmented_prompt = _build_augmented_system_prompt(system_prompt, format_instructions, output_model)
     raw_content = await run_prompt_fallback(augmented_prompt)
-    parsed = parse_and_validate_fallback_content(raw_content, output_model)
+    parsed = parse_and_validate_fallback_content(raw_content, record_model, envelope_key=LIST_FIELD_NAME)
     return _wrap_payload(parsed)
 
 
@@ -109,6 +134,10 @@ def _build_augmented_system_prompt(
 
 def _wrap_payload(payload: dict[str, Any] | list[Any]) -> Data:
     if isinstance(payload, dict):
+        # Unwrap the list container so the records, not the envelope, drive the shape.
+        records = payload.get(LIST_FIELD_NAME)
+        if isinstance(records, list):
+            return _wrap_payload(records)
         return Data(data=payload)
     if len(payload) == 1 and isinstance(payload[0], dict):
         return Data(data=payload[0])

--- a/src/lfx/src/lfx/components/models_and_agents/structured_output/structured_output_orchestrator.py
+++ b/src/lfx/src/lfx/components/models_and_agents/structured_output/structured_output_orchestrator.py
@@ -28,7 +28,15 @@ from lfx.schema.data import Data
 LIST_FIELD_NAME = "objects"
 
 
-def _wrap_in_list_container(record_model: type[BaseModel]) -> type[BaseModel]:
+def _get_list_field_name(record_model: type[BaseModel]) -> str:
+    """Return an envelope field name that cannot collide with the record schema."""
+    field_name = LIST_FIELD_NAME
+    while field_name in record_model.model_fields:
+        field_name += "_"
+    return field_name
+
+
+def _wrap_in_list_container(record_model: type[BaseModel], list_field_name: str) -> type[BaseModel]:
     """Wrap the record model in a list container, as the Structured Output component does.
 
     The schema table describes ONE record. Handing that model straight to the provider
@@ -40,7 +48,7 @@ def _wrap_in_list_container(record_model: type[BaseModel]) -> type[BaseModel]:
         "OutputModel",
         __doc__="A list of extracted records.",
         **{
-            LIST_FIELD_NAME: (
+            list_field_name: (
                 list[record_model],  # type: ignore[valid-type]
                 Field(description="Every record that matches the schema.", min_length=1),
             )
@@ -71,7 +79,8 @@ async def orchestrate_structured_output(
         return Data(data={"content": input_value})
 
     record_model = build_model_from_schema(preprocess_schema(output_schema))
-    output_model = _wrap_in_list_container(record_model)
+    list_field_name = _get_list_field_name(record_model)
+    output_model = _wrap_in_list_container(record_model, list_field_name)
 
     fallback_reason = "llm_lacks_with_structured_output"
     if prefer_native and _supports_native_structured_output(llm):
@@ -96,7 +105,7 @@ async def orchestrate_structured_output(
             )
             fallback_reason = "native_raised_not_implemented"
         else:
-            return _wrap_payload(payload)
+            return _wrap_payload(payload, envelope_key=list_field_name)
 
     await logger.adebug(
         "structured_output.fallback_invoked",
@@ -104,8 +113,8 @@ async def orchestrate_structured_output(
     )
     augmented_prompt = _build_augmented_system_prompt(system_prompt, format_instructions, output_model)
     raw_content = await run_prompt_fallback(augmented_prompt)
-    parsed = parse_and_validate_fallback_content(raw_content, record_model, envelope_key=LIST_FIELD_NAME)
-    return _wrap_payload(parsed)
+    parsed = parse_and_validate_fallback_content(raw_content, record_model, envelope_key=list_field_name)
+    return _wrap_payload(parsed, envelope_key=list_field_name)
 
 
 def _supports_native_structured_output(llm: Any) -> bool:
@@ -132,12 +141,12 @@ def _build_augmented_system_prompt(
     return "\n\n".join(parts)
 
 
-def _wrap_payload(payload: dict[str, Any] | list[Any]) -> Data:
+def _wrap_payload(payload: dict[str, Any] | list[Any], *, envelope_key: str = LIST_FIELD_NAME) -> Data:
     if isinstance(payload, dict):
         # Unwrap the list container so the records, not the envelope, drive the shape.
-        records = payload.get(LIST_FIELD_NAME)
+        records = payload.get(envelope_key)
         if isinstance(records, list):
-            return _wrap_payload(records)
+            return _wrap_payload(records, envelope_key=envelope_key)
         return Data(data=payload)
     if len(payload) == 1 and isinstance(payload[0], dict):
         return Data(data=payload[0])

--- a/src/lfx/tests/unit/components/models_and_agents/structured_output/test_structured_output_list_shape.py
+++ b/src/lfx/tests/unit/components/models_and_agents/structured_output/test_structured_output_list_shape.py
@@ -1,0 +1,158 @@
+"""LE-2392: the Agent's structured output must be able to hold more than one record.
+
+The Agent and the standalone Structured Output component read the SAME schema table
+but built different models from it:
+
+    Structured Output   ->  {objects: [ {country, capital}, ... ]}   a list
+    Agent.json_response ->  {country, capital}                       exactly one
+
+So asking an agent for "a list of South American countries and their capitals"
+returned the whole list as text and a single record as structured output. The model
+was not truncating: the schema it received declared ``country`` as a string, not an
+array, so one record is all it could express. The Agent's own default
+``format_instructions`` meanwhile tell it to "Extract ALL relevant instances that
+match the schema", which the schema then forbids.
+
+The reported schema is used verbatim below: two ``str`` fields with ``multiple``
+false, which is what the editor writes by default.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from lfx.components.models_and_agents.structured_output.structured_output_orchestrator import (
+    orchestrate_structured_output,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+# Verbatim from the flow that reproduced the report.
+REPORTED_SCHEMA = [
+    {"name": "country", "description": "description of field", "type": "str", "multiple": "False"},
+    {"name": "capital", "description": "description of field", "type": "str", "multiple": "False"},
+]
+
+COUNTRIES = [
+    {"country": "Argentina", "capital": "Buenos Aires"},
+    {"country": "Brasil", "capital": "Brasilia"},
+    {"country": "Chile", "capital": "Santiago"},
+    {"country": "Peru", "capital": "Lima"},
+]
+
+
+class _ListAwareLLM:
+    """Fills whatever model it is handed, the way a capable provider would.
+
+    If the schema can hold many records it returns many; if it can hold only one it
+    returns one. That is what makes this test measure the SCHEMA rather than the stub.
+    """
+
+    def __init__(self) -> None:
+        self.received_schema: dict[str, Any] | None = None
+
+    def with_structured_output(self, model_cls: type[BaseModel]):
+        outer = self
+
+        class _Runnable:
+            async def ainvoke(self, _messages: Any) -> Any:
+                outer.received_schema = model_cls.model_json_schema()
+                fields = model_cls.model_fields
+                if len(fields) == 1:
+                    (only_name, only_field) = next(iter(fields.items()))
+                    annotation = str(only_field.annotation)
+                    if annotation.startswith(("list", "typing.List")):
+                        return model_cls(**{only_name: COUNTRIES})
+                return model_cls(**COUNTRIES[0])
+
+        return _Runnable()
+
+
+async def _run(llm, *, prefer_native: bool):
+    async def _fallback(_prompt: str) -> str:
+        import json
+
+        return json.dumps(COUNTRIES)
+
+    return await orchestrate_structured_output(
+        llm=llm,
+        output_schema=REPORTED_SCHEMA,
+        system_prompt="",
+        format_instructions="",
+        input_value="list the South American countries and their capitals",
+        run_prompt_fallback=_fallback,
+        prefer_native=prefer_native,
+    )
+
+
+def _records(data: dict) -> list[dict]:
+    """Every record the payload carries, whichever shape it uses."""
+    for key in ("results", "objects"):
+        if isinstance(data.get(key), list):
+            return data[key]
+    return [data]
+
+
+@pytest.mark.asyncio
+async def test_native_path_can_return_more_than_one_record():
+    llm = _ListAwareLLM()
+
+    data = await _run(llm, prefer_native=True)
+
+    records = _records(data.data)
+    assert len(records) == len(COUNTRIES), f"structured output collapsed to {len(records)} record(s): {data.data}"
+    assert {r["country"] for r in records} == {c["country"] for c in COUNTRIES}
+
+
+@pytest.mark.asyncio
+async def test_the_schema_handed_to_the_provider_accepts_a_list():
+    """The provider must be OFFERED a shape that can hold many; otherwise one is correct."""
+    llm = _ListAwareLLM()
+
+    await _run(llm, prefer_native=True)
+
+    schema = llm.received_schema
+    assert schema is not None
+    array_props = [name for name, prop in schema.get("properties", {}).items() if prop.get("type") == "array"]
+    assert array_props, f"no array property offered to the provider: {list(schema.get('properties', {}))}"
+
+
+@pytest.mark.asyncio
+async def test_fallback_path_keeps_every_record():
+    """The prompt fallback (agent with tools) must not drop records either."""
+
+    class _NoNative:
+        pass
+
+    data = await _run(_NoNative(), prefer_native=False)
+
+    records = _records(data.data)
+    assert len(records) == len(COUNTRIES), f"fallback collapsed to {len(records)} record(s): {data.data}"
+
+
+@pytest.mark.asyncio
+async def test_a_single_record_keeps_its_flat_shape():
+    """Back-compat: one record must still surface flat, not nested under a list key.
+
+    Existing flows read fields straight off the payload; wrapping them would break
+    every downstream component that already consumes this output.
+    """
+
+    class _SingleRecordLLM:
+        def with_structured_output(self, model_cls: type[BaseModel]):
+            class _Runnable:
+                async def ainvoke(self, _messages: Any) -> Any:
+                    fields = model_cls.model_fields
+                    if len(fields) == 1:
+                        (only_name, _) = next(iter(fields.items()))
+                        return model_cls(**{only_name: [COUNTRIES[0]]})
+                    return model_cls(**COUNTRIES[0])
+
+            return _Runnable()
+
+    data = await _run(_SingleRecordLLM(), prefer_native=True)
+
+    assert data.data.get("country") == "Argentina", f"single record was nested: {data.data}"
+    assert data.data.get("capital") == "Buenos Aires"

--- a/src/lfx/tests/unit/components/models_and_agents/structured_output/test_structured_output_list_shape.py
+++ b/src/lfx/tests/unit/components/models_and_agents/structured_output/test_structured_output_list_shape.py
@@ -133,6 +133,28 @@ async def test_fallback_path_keeps_every_record():
 
 
 @pytest.mark.asyncio
+async def test_fallback_preserves_a_record_field_named_objects():
+    """A user field named ``objects`` must not be mistaken for the list envelope."""
+
+    async def _fallback(_prompt: str) -> str:
+        return '{"objects": ["alpha", "beta"]}'
+
+    data = await orchestrate_structured_output(
+        llm=object(),
+        output_schema=[
+            {"name": "objects", "description": "record values", "type": "str", "multiple": True},
+        ],
+        system_prompt="",
+        format_instructions="",
+        input_value="return the values",
+        run_prompt_fallback=_fallback,
+        prefer_native=False,
+    )
+
+    assert data.data == {"objects": ["alpha", "beta"]}
+
+
+@pytest.mark.asyncio
 async def test_a_single_record_keeps_its_flat_shape():
     """Back-compat: one record must still surface flat, not nested under a list key.
 


### PR DESCRIPTION
An agent asked for "a list of South American countries and their capitals" returned all twelve as text and exactly **one** as structured output.

## Not truncation — the schema could not hold a second record

The Agent and the standalone **Structured Output** component read the *same* schema table and built different models from it:

| component | model handed to the provider |
|---|---|
| Structured Output | `{ objects: array[{country, capital}] }` — a list |
| `Agent.json_response` | `{ country: string, capital: string }` — one record |

`structured_output.py:159` wraps the record model in a list container; the orchestrator did not. So the provider received `"country": {"type": "string"}` and returning Argentina alone was the *correct* response to the schema it was given.

The Agent also contradicted itself: its default `format_instructions` tell the model to *"Extract ALL relevant instances that match the schema — if multiple patterns exist, capture them all"*, which the schema then forbade.

## Fix

`json_response` now wraps the record model the same way the standalone component does. The record model is kept separately for validation, and the prompt fallback accepts the envelope, a bare record, or a bare array — models answer with all three.

**Back-compat is preserved.** `_wrap_payload` already unwraps a single-item list, so one record still surfaces flat and downstream components reading fields off the payload are unaffected. Several records surface under `results`, the key this seam already used — not `objects`, to avoid changing the Agent's existing contract.

## Verified on the reporter's own flow

Same flow id, a server sharing that database, a real model, and the schema exactly as saved (two `str` fields, `multiple: "False"`):

```
POST /api/v1/run/{flow_id}   "me de uma lista dos paises sulamericanos e suas capitais"

before   1 country    ['Argentina']
after   12 countries  ['Argentina', 'Bolívia', 'Brasil', 'Chile', 'Colômbia',
                       'Equador', 'Guiana', 'Paraguai', 'Peru', 'Suriname',
                       'Uruguai', 'Venezuela']
```

Before/after captured on the same instance, restarted with and without the change, so the only variable is the code.

## Tests

4 new, **two of which fail against the current code**:

- the native path returns every record
- the schema actually offered to the provider exposes an array — the assertion that measures the *cause*, not the stub
- the prompt fallback keeps every record
- the single-record control still surfaces flat (back-compat)

The stub fills whatever model it is handed rather than a fixed payload, so it reports the schema's capability instead of confirming the test's own expectation.

Suites: 60 structured-output, 237 `models_and_agents`, 33 standalone-component — all pass. Ruff clean.

## Noticed while investigating, not fixed here

With the **schema left empty**, `json_response` short-circuits and returns `{"content": "<the user's input>"}` — echoing the prompt back as though it were the answer, in 0.1s with no model call. The standalone component refuses this outright (`"Output schema cannot be empty"`). Same divergence, different symptom; worth its own ticket rather than widening this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured output handling for lists of records.
  * Preserved multiple records across native and fallback processing paths.
  * Maintained flat output shape for single-record responses.
  * Added support for configured list envelopes in fallback responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->