### PR TITLE
fix(frontend): show final file extension (LE-2391)

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
@@ -36,6 +36,15 @@ interface FilesTabProps {
   isShiftPressed: boolean;
 }
 
+const getFileExtension = (path: string) => {
+  const fileName = path.split("/").pop() ?? "";
+  const extensionStart = fileName.lastIndexOf(".");
+  if (extensionStart <= 0 || extensionStart === fileName.length - 1) {
+    return undefined;
+  }
+  return fileName.slice(extensionStart + 1).toLowerCase();
+};
+
 const FilesTab = ({
   quickFilterText,
   setQuickFilterText,
@@ -167,7 +176,7 @@ const FilesTab = ({
       cellClass:
         "cursor-text select-text group-[.no-select-cells]:cursor-default group-[.no-select-cells]:select-none",
       cellRenderer: (params) => {
-        const type = params.data.path.split(".")[1]?.toLowerCase();
+        const type = getFileExtension(params.data.path);
         return (
           <div className="flex items-center gap-4 font-medium">
             {params.data.progress !== undefined &&
@@ -229,7 +238,7 @@ const FilesTab = ({
       filter: "agTextColumnFilter",
       editable: false,
       valueFormatter: (params) => {
-        return params.value.split(".")[1]?.toUpperCase();
+        return getFileExtension(params.value)?.toUpperCase();
       },
       cellClass:
         "text-muted-foreground cursor-text select-text group-[.no-select-cells]:cursor-default group-[.no-select-cells]:select-none",

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/__tests__/FilesTab.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/__tests__/FilesTab.test.tsx
@@ -1,12 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ColDef } from "ag-grid-community";
 import React from "react";
 import type { FileType } from "@/types/file_management";
 
 // ── Heavy / external dependency mocks ────────────────────────────────────────
 
 interface MockTableProps {
+  columnDefs?: ColDef<FileType>[];
   rowData?: FileType[];
   quickFilterText?: string;
   onSelectionChanged?: (event: {
@@ -220,6 +222,23 @@ describe("FilesTab", () => {
       expect(rows).toHaveLength(2);
       expect(rows[0]).toHaveTextContent("newer");
       expect(rows[1]).toHaveTextContent("older");
+    });
+
+    it.each([
+      ["files/recording.21.mov", "MOV"],
+      ["archives.v1/report.pdf", "PDF"],
+      ["files/README", undefined],
+    ])("formats the final file extension from %s", (path, expected) => {
+      render(<FilesTab {...defaultProps} />, { wrapper: createWrapper() });
+      const typeColumn = mockLatestTableProps.columnDefs?.find(
+        (column) => column.field === "path",
+      );
+      expect(typeColumn?.valueFormatter).toEqual(expect.any(Function));
+
+      const formatType = typeColumn?.valueFormatter as (params: {
+        value: string;
+      }) => string | undefined;
+      expect(formatType({ value: path })).toBe(expected);
     });
 
     it("calls setQuickFilterText when typing in the search input", () => {


### PR DESCRIPTION
## Summary
- derive file type from the final filename suffix
- preserve correct rendering when filenames or parent paths contain dots
- add regression coverage for MOV, dotted directories, and extensionless files

## Testing
- npm test -- --runInBand --runTestsByPath src/pages/MainPage/pages/filesPage/components/__tests__/FilesTab.test.tsx (16 passed)
- npx @biomejs/biome check src/pages/MainPage/pages/filesPage/components/FilesTab.tsx src/pages/MainPage/pages/filesPage/components/__tests__/FilesTab.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file type and extension display for paths containing directories or multiple dots.
  * Files without extensions no longer show an incorrect extension.

* **Tests**
  * Added coverage for extension formatting across common file path variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->