### PR TITLE
fix(ci): address release branch regressions

### DIFF
--- a/src/backend/base/langflow/api/v1/a2a_utils.py
+++ b/src/backend/base/langflow/api/v1/a2a_utils.py
@@ -196,7 +196,7 @@ async def build_agent_card(flow: Flow, *, rpc_url: str, session: AsyncSession) -
     try:
         # json_schema_from_flow does a full, synchronous graph build; offload it
         # so this public endpoint never blocks the event loop.
-        input_schema = await asyncio.to_thread(json_schema_from_flow, flow)
+        input_schema = await asyncio.to_thread(json_schema_from_flow, flow, require_api_editable=False)
     except Exception:  # noqa: BLE001 - any graph build failure degrades, not crashes
         logger.warning("Could not build A2A input schema for flow %s; serving empty input contract", flow.id)
         input_schema = dict(_EMPTY_INPUT_SCHEMA)

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -680,13 +680,12 @@ def _get_flow_input_nodes(flow: Flow) -> list[Vertex]:
     return [vertex for vertex in graph.vertices if vertex.is_input]
 
 
+def _is_visible_input_field(field_data: Any) -> bool:
+    return isinstance(field_data, dict) and field_data.get("show", False) and not field_data.get("advanced", False)
+
+
 def _is_mcp_input_field(field_data: Any) -> bool:
-    return (
-        isinstance(field_data, dict)
-        and field_data.get("show", False)
-        and not field_data.get("advanced", False)
-        and field_data.get("api_editable") is True
-    )
+    return _is_visible_input_field(field_data) and field_data.get("api_editable") is True
 
 
 _JSON_SCHEMA_TYPE_BY_FIELD_TYPE = {
@@ -760,16 +759,21 @@ def get_flow_input_tweaks(flow: Flow, inputs: dict[str, Any]) -> dict[str, dict[
     return tweaks
 
 
-def json_schema_from_flow(flow: Flow) -> dict:
-    """Generate JSON schema from flow input nodes."""
+def json_schema_from_flow(flow: Flow, *, require_api_editable: bool = True) -> dict:
+    """Generate JSON schema from flow input nodes.
+
+    MCP schemas expose only API-editable fields. Other consumers, such as A2A,
+    can include every visible, non-advanced field in their input contract.
+    """
     properties = {}
     required = []
+    is_input_field = _is_mcp_input_field if require_api_editable else _is_visible_input_field
     for node in _get_flow_input_nodes(flow):
         node_data = node.data["node"]
         template = node_data["template"]
 
         for field_name, field_data in template.items():
-            if _is_mcp_input_field(field_data):
+            if is_input_field(field_data):
                 properties[field_name] = {
                     **_json_schema_type_for_field(field_data),
                     "description": field_data.get("info", f"Input for {field_name}"),

--- a/src/backend/tests/unit/api/v1/test_a2a.py
+++ b/src/backend/tests/unit/api/v1/test_a2a.py
@@ -114,12 +114,13 @@ async def test_get_agent_card_returns_valid_card(client: AsyncClient, active_use
 
     input_schema = body["skills"][0]["inputSchema"]
     assert input_schema["type"] == "object"
+    assert input_schema["properties"]["input_value"]["type"] == "string"
     assert input_schema["properties"]["session_id"]["type"] == "string"
 
     # The published schema matches what json_schema_from_flow computes directly.
     async with session_scope() as session:
         flow = await session.get(Flow, flow_id)
-        assert input_schema == json_schema_from_flow(flow)
+        assert input_schema == json_schema_from_flow(flow, require_api_editable=False)
 
 
 @pytest.mark.usefixtures("a2a_flag_on")

--- a/src/backend/tests/unit/utils/test_validate.py
+++ b/src/backend/tests/unit/utils/test_validate.py
@@ -367,7 +367,10 @@ class MyComponent(CustomComponent):
                 mock_extract.return_value = Mock()
                 with patch("lfx.custom.validate.compile_class_code") as mock_compile:
                     mock_compile.return_value = compile("pass", "<string>", "exec")
-                    with patch("lfx.custom.validate.build_class_constructor") as mock_build:
+                    with (
+                        patch("lfx.custom.validate.build_class_constructor") as mock_build,
+                        patch("lfx.custom.validate.register_compiled_class_method_returns"),
+                    ):
                         mock_build.return_value = lambda: None
                         create_class(code, "MyComponent")
 

--- a/src/frontend/src/CustomNodes/GenericNode/__tests__/restore-dismissed-node.test.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/__tests__/restore-dismissed-node.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { OutputFieldType } from "@/types/api";
 import GenericNode from "../index";
 
 const mockUpdateNodeInternals = jest.fn();
@@ -337,6 +338,54 @@ describe("GenericNode dismissed update recovery", () => {
       );
       expect(mockRemoveDismissedNodes).toHaveBeenCalledWith(["node-1"]);
       expect(mockCompleteNodeUpdate).toHaveBeenCalledWith("node-1");
+    });
+  });
+
+  it("selects the first visible output when no output is selected", async () => {
+    const outputs: OutputFieldType[] = [
+      {
+        name: "response",
+        display_name: "Response",
+        types: ["Message"],
+      },
+      {
+        name: "agent",
+        display_name: "Agent",
+        types: ["Agent"],
+      },
+    ];
+    const nodeData = {
+      id: "node-1",
+      type: "Prompt",
+      selected_output: undefined as string | undefined,
+      node: {
+        display_name: "Prompt",
+        description: "Prompt node",
+        documentation: "",
+        template: {},
+        outputs,
+      },
+    };
+    const existingNode = { data: nodeData };
+    let updatedNode = existingNode;
+
+    mockSetEdges.mockImplementation(
+      (updater: (edges: unknown[]) => unknown[]) => updater([]),
+    );
+    mockSetNode.mockImplementation(
+      (
+        _nodeId: string,
+        updater: (node: typeof existingNode) => typeof existingNode,
+      ) => {
+        updatedNode = updater(existingNode);
+      },
+    );
+
+    render(<GenericNode selected={false} data={nodeData} />);
+
+    await waitFor(() => {
+      expect(updatedNode.data.selected_output).toBe("response");
+      expect(updatedNode.data.node.outputs[0].selected).toBe("Message");
     });
   });
 });

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -337,8 +337,8 @@ function GenericNode({
   );
 
   const handleSelectOutput = useCallback(
-    (output) => {
-      if (isReadOnly) return;
+    (output: OutputFieldType | null) => {
+      if (isReadOnly || !output) return;
       setSelectedOutput(output);
 
       setEdges((eds) => {
@@ -404,9 +404,11 @@ function GenericNode({
         0) <= 1
     )
       return;
-    handleSelectOutput(
-      data.node?.outputs?.find((output) => output.selected) || null,
-    );
+    const defaultOutput =
+      data.node?.outputs?.find((output) => output.selected) ??
+      data.node?.outputs?.find((output) => !output.group_outputs) ??
+      null;
+    handleSelectOutput(defaultOutput);
   }, [data.node?.outputs, data?.selected_output, handleSelectOutput]);
 
   // Sync local `selectedOutput` state when `data.selected_output` is mutated

--- a/src/frontend/src/controllers/API/queries/flows/__tests__/use-post-add-flow.test.ts
+++ b/src/frontend/src/controllers/API/queries/flows/__tests__/use-post-add-flow.test.ts
@@ -8,8 +8,14 @@ const mockQueryClient = {
   getQueryCache: jest.fn(() => ({ findAll: jest.fn(() => []) })),
 };
 
+type FolderStoreState = { myCollectionId: string };
+type MockMutationFn = (payload: unknown) => Promise<unknown>;
+type MockMutationOptions = {
+  onSettled?: (result: unknown) => void | Promise<void>;
+};
+
 jest.mock("@/stores/foldersStore", () => ({
-  useFolderStore: jest.fn((selector: any) =>
+  useFolderStore: jest.fn((selector: (state: FolderStoreState) => unknown) =>
     selector({ myCollectionId: "mc" }),
   ),
 }));
@@ -28,13 +34,15 @@ jest.mock("@/controllers/API/helpers/constants", () => ({
 
 jest.mock("@/controllers/API/services/request-processor", () => ({
   UseRequestProcessor: jest.fn(() => ({
-    mutate: jest.fn((_key: any, fn: any, options: any) => ({
-      mutate: async (payload: any) => {
-        const result = await fn(payload);
-        await options?.onSettled?.(result);
-        return result;
-      },
-    })),
+    mutate: jest.fn(
+      (_key: unknown, fn: MockMutationFn, options: MockMutationOptions) => ({
+        mutate: async (payload: unknown) => {
+          const result = await fn(payload);
+          await options?.onSettled?.(result);
+          return result;
+        },
+      }),
+    ),
     queryClient: mockQueryClient,
   })),
 }));

--- a/src/frontend/src/controllers/API/queries/flows/use-post-add-flow.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-post-add-flow.ts
@@ -1,8 +1,10 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { ReactFlowJsonObject } from "@xyflow/react";
+import type { AxiosError } from "axios";
 import { refetchQueriesFresh } from "@/controllers/API/helpers/query-cache";
 import { useFolderStore } from "@/stores/foldersStore";
 import type { useMutationFunctionType } from "@/types/api";
+import type { FlowType } from "@/types/flow";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -21,15 +23,21 @@ interface IPostAddFlow {
   mcp_enabled: boolean | undefined;
 }
 
+interface PostAddFlowErrorResponse {
+  detail?: string | Array<{ type?: string }>;
+}
+
 export const usePostAddFlow: useMutationFunctionType<
   undefined,
-  IPostAddFlow
+  IPostAddFlow,
+  FlowType,
+  AxiosError<PostAddFlowErrorResponse>
 > = (options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
 
-  const postAddFlowFn = async (payload: IPostAddFlow): Promise<any> => {
-    const response = await api.post(`${getURL("FLOWS")}/`, {
+  const postAddFlowFn = async (payload: IPostAddFlow): Promise<FlowType> => {
+    const response = await api.post<FlowType>(`${getURL("FLOWS")}/`, {
       name: payload.name,
       data: payload.data,
       description: payload.description,
@@ -45,31 +53,31 @@ export const usePostAddFlow: useMutationFunctionType<
     return response.data;
   };
 
-  const mutation: UseMutationResult<IPostAddFlow, any, IPostAddFlow> = mutate(
-    ["usePostAddFlow"],
-    postAddFlowFn,
-    {
-      ...options,
-      // Fire-and-forget on purpose: TanStack dispatches the mutation's
-      // "success" only after this callback settles, so awaiting the refetches
-      // would hold up every caller of `addFlow` — including the navigation to
-      // the flow that was just created.
-      onSettled: (response) => {
-        if (response) {
-          void refetchQueriesFresh(queryClient, {
-            queryKey: [
-              "useGetRefreshFlowsQuery",
-              { get_all: true, header_flows: true },
-            ],
-          });
+  const mutation: UseMutationResult<
+    FlowType,
+    AxiosError<PostAddFlowErrorResponse>,
+    IPostAddFlow
+  > = mutate(["usePostAddFlow"], postAddFlowFn, {
+    ...options,
+    // Fire-and-forget on purpose: TanStack dispatches the mutation's
+    // "success" only after this callback settles, so awaiting the refetches
+    // would hold up every caller of `addFlow` — including the navigation to
+    // the flow that was just created.
+    onSettled: (response) => {
+      if (response) {
+        void refetchQueriesFresh(queryClient, {
+          queryKey: [
+            "useGetRefreshFlowsQuery",
+            { get_all: true, header_flows: true },
+          ],
+        });
 
-          void refetchQueriesFresh(queryClient, {
-            queryKey: ["useGetFolder", response.folder_id ?? myCollectionId],
-          });
-        }
-      },
+        void refetchQueriesFresh(queryClient, {
+          queryKey: ["useGetFolder", response.folder_id ?? myCollectionId],
+        });
+      }
     },
-  );
+  });
 
   return mutation;
 };


### PR DESCRIPTION
## Summary

- type the flow-creation mutation so Biome can validate its error path
- initialize multi-output nodes when stored flow data has no selected output
- preserve visible A2A input fields while keeping MCP limited to API-editable fields
- isolate the legacy-import unit test from the newer compiled-class provenance validator

## Validation

- Biome checks for the changed frontend files
- focused Jest tests: 5 passed
- frontend production build
- focused Playwright tests: A2A agent-card publishing and Tool Calling Agent default prompt (2 passed)
- Ruff checks for the changed Python files
- focused backend tests: A2A agent card, MCP schema policy, and Python 3.14 legacy-import case (6 passed)
- pre-commit hooks for all four commits

## CI triage

The deterministic failures from run 33217827991 and the first PR run are covered here. The Docker retry built and started the image successfully before the hosted runner received a shutdown signal, so this PR does not change Docker code for that infrastructure cancellation.
