### PR TITLE
fix(logging): prevent file-mode gunicorn recursion

### DIFF
--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from gunicorn import glogging
 from gunicorn.app.base import BaseApplication
-from lfx.log.logger import InterceptHandler
+from lfx.log.logger import InterceptHandler, is_file_logging_configured, setup_gunicorn_logger
 from uvicorn.workers import UvicornWorker
 
 
@@ -57,20 +57,21 @@ class LangflowUvicornWorker(UvicornWorker):
 
 
 class Logger(glogging.Logger):
-    """Implements and overrides the gunicorn logging interface.
-
-    This class inherits from the standard gunicorn logger and overrides it by
-    replacing the handlers with `InterceptHandler` in order to route the
-    gunicorn logs to loguru.
-    """
+    """Configure Gunicorn logging to use Langflow's logging pipeline."""
 
     def __init__(self, cfg) -> None:
         super().__init__(cfg)
-        logging.getLogger("gunicorn.error").setLevel(logging.WARNING)
-        logging.getLogger("gunicorn.access").setLevel(logging.WARNING)
+        gunicorn_loggers = (self.error_log, self.access_log)
+        for gunicorn_logger in gunicorn_loggers:
+            gunicorn_logger.setLevel(logging.WARNING)
 
-        logging.getLogger("gunicorn.error").handlers = [InterceptHandler()]
-        logging.getLogger("gunicorn.access").handlers = [InterceptHandler()]
+        if is_file_logging_configured():
+            # File mode uses structlog's stdlib logger factory. Routing a Gunicorn
+            # record through InterceptHandler would send it back to this same logger.
+            setup_gunicorn_logger()
+        else:
+            for gunicorn_logger in gunicorn_loggers:
+                gunicorn_logger.handlers = [InterceptHandler()]
 
     def error(self, msg, *args, **kwargs):
         """Override error method to filter out SIGSEGV messages."""

--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -60,6 +60,7 @@ class Logger(glogging.Logger):
     """Configure Gunicorn logging to use Langflow's logging pipeline."""
 
     def __init__(self, cfg) -> None:
+        """Route Gunicorn records through the active Langflow output mode."""
         super().__init__(cfg)
         gunicorn_loggers = (self.error_log, self.access_log)
         for gunicorn_logger in gunicorn_loggers:

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -31,6 +31,7 @@ from lfx.log.logger import (
     add_serialized,
     buffer_writer,
     configure,
+    is_file_logging_configured,
     log_buffer,
     setup_gunicorn_logger,
     setup_uvicorn_logger,
@@ -558,9 +559,10 @@ class TestSetupFunctions:
 
 
 class TestGunicornLoggerFileMode:
-    """Gunicorn must not send file-mode records back through structlog."""
+    """Gunicorn must follow logging-mode transitions without stale handlers."""
 
-    def test_file_mode_propagates_gunicorn_logs_to_root_handler(self):
+    def test_file_mode_propagates_gunicorn_logs_to_root_handler(self, capsys):
+        """Write once in file mode, then switch cleanly back to stdout JSON."""
         root = logging.getLogger()
         original_root_handlers = root.handlers[:]
         original_root_level = root.level
@@ -597,6 +599,21 @@ class TestGunicornLoggerFileMode:
                 records = [json.loads(line) for line in log_file_path.read_text().splitlines() if line.strip()]
                 gunicorn_records = [record for record in records if record.get("logger") == "gunicorn.error"]
                 assert [record["event"] for record in gunicorn_records] == ["file mode gunicorn error"]
+
+                configure(log_env="container", log_level="INFO", cache=False)
+                assert not is_file_logging_configured()
+
+                stdout_logger = GunicornLogger(cfg)
+                assert all(
+                    len(logger.handlers) == 1 and isinstance(logger.handlers[0], InterceptHandler)
+                    for logger in (stdout_logger.error_log, stdout_logger.access_log)
+                )
+                stdout_logger.error("stdout gunicorn error")
+                stdout_records = [
+                    json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip().startswith("{")
+                ]
+                assert [record["event"] for record in stdout_records] == ["stdout gunicorn error"]
+                assert "stdout gunicorn error" not in log_file_path.read_text()
         finally:
             for handler in root.handlers[:]:
                 if handler not in original_root_handlers:

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -21,6 +21,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 import structlog
+from gunicorn.config import Config
+from langflow.server import Logger as GunicornLogger
 from lfx.log.logger import (
     LOG_LEVEL_MAP,
     VALID_LOG_LEVELS,
@@ -553,6 +555,63 @@ class TestSetupFunctions:
         assert mock_error_logger.propagate is True
         assert mock_access_logger.handlers == []
         assert mock_access_logger.propagate is True
+
+
+class TestGunicornLoggerFileMode:
+    """Gunicorn must not send file-mode records back through structlog."""
+
+    def test_file_mode_propagates_gunicorn_logs_to_root_handler(self):
+        root = logging.getLogger()
+        original_root_handlers = root.handlers[:]
+        original_root_level = root.level
+        gunicorn_loggers = (logging.getLogger("gunicorn.error"), logging.getLogger("gunicorn.access"))
+        original_gunicorn_state = [
+            (gunicorn_logger.handlers[:], gunicorn_logger.propagate, gunicorn_logger.level)
+            for gunicorn_logger in gunicorn_loggers
+        ]
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                log_file_path = Path(temp_dir) / "langflow.log"
+                configure(log_env="container", log_level="INFO", cache=False)
+                assert any(isinstance(handler, InterceptHandler) for handler in root.handlers)
+
+                configure(log_env="container", log_level="INFO", log_file=log_file_path, cache=False)
+                assert not any(isinstance(handler, InterceptHandler) for handler in root.handlers)
+
+                cfg = Config()
+                cfg.set("loglevel", "warning")
+                cfg.set("errorlog", "-")
+                logger = GunicornLogger(cfg)
+
+                assert logger.error_log.handlers == []
+                assert logger.access_log.handlers == []
+                assert logger.error_log.propagate is True
+                assert logger.access_log.propagate is True
+
+                logger.error("file mode gunicorn error")
+                for handler in root.handlers:
+                    if hasattr(handler, "flush"):
+                        handler.flush()
+
+                records = [json.loads(line) for line in log_file_path.read_text().splitlines() if line.strip()]
+                gunicorn_records = [record for record in records if record.get("logger") == "gunicorn.error"]
+                assert [record["event"] for record in gunicorn_records] == ["file mode gunicorn error"]
+        finally:
+            for handler in root.handlers[:]:
+                if handler not in original_root_handlers:
+                    root.removeHandler(handler)
+                    handler.close()
+            root.handlers[:] = original_root_handlers
+            root.setLevel(original_root_level)
+            for gunicorn_logger, (handlers, propagate, level) in zip(
+                gunicorn_loggers, original_gunicorn_state, strict=True
+            ):
+                gunicorn_logger.handlers = handlers
+                gunicorn_logger.propagate = propagate
+                gunicorn_logger.setLevel(level)
+            structlog.reset_defaults()
+            structlog.configure()
 
 
 class TestLogProcessors:

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -934,6 +934,16 @@ def setup_loguru_logger(log_level: str, *, enqueue: bool = False) -> None:
     )
 
 
+def _remove_log_file_handler() -> None:
+    """Remove and close Langflow's managed root file handler, if present."""
+    global _file_handler  # noqa: PLW0603
+
+    if _file_handler is not None:
+        logging.root.removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None
+
+
 def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatter | None = None) -> None:
     """Set up Langflow's rotating file handler.
 
@@ -944,9 +954,7 @@ def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatt
     """
     global _file_handler  # noqa: PLW0603
 
-    if _file_handler is not None:
-        logging.root.removeHandler(_file_handler)
-        _file_handler.close()
+    _remove_log_file_handler()
 
     _file_handler = logging.handlers.RotatingFileHandler(
         log_file,
@@ -1019,6 +1027,8 @@ def configure(
     # remain installed and send those records back through structlog.
     if not (json_mode and not log_file):
         _remove_stdlib_intercept()
+    if log_file is None:
+        _remove_log_file_handler()
 
     # Fingerprint of every caller-supplied input that changes the resulting
     # setup. Stored on the wrapper_class (below) so structlog.reset_defaults()

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -957,6 +957,11 @@ def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatt
     logging.root.addHandler(_file_handler)
 
 
+def is_file_logging_configured() -> bool:
+    """Return whether Langflow's managed file handler is active on the root logger."""
+    return _file_handler is not None and _file_handler in logging.root.handlers
+
+
 class LogConfig(TypedDict):
     """Configuration for logging."""
 
@@ -1005,6 +1010,15 @@ def configure(
         log_format = os.getenv("LANGFLOW_LOG_FORMAT")
 
     numeric_level = LOG_LEVEL_MAP.get(log_level.upper(), logging.ERROR)
+    json_mode = log_env.lower() in ("container", "container_json") or (
+        not log_env and os.getenv("LANGFLOW_PRETTY_LOGS", "true").lower() != "true"
+    )
+
+    # File mode routes foreign stdlib records through the rotating root handler,
+    # so a root interceptor from an earlier stdout-JSON configuration must not
+    # remain installed and send those records back through structlog.
+    if not (json_mode and not log_file):
+        _remove_stdlib_intercept()
 
     # Fingerprint of every caller-supplied input that changes the resulting
     # setup. Stored on the wrapper_class (below) so structlog.reset_defaults()
@@ -1215,9 +1229,6 @@ def configure(
     # routed into structlog so it comes out as JSON instead of unstructured
     # text. In non-JSON modes leave stdlib alone so dev console output stays
     # readable.
-    json_mode = log_env.lower() in ("container", "container_json") or (
-        not log_env and os.getenv("LANGFLOW_PRETTY_LOGS", "true").lower() != "true"
-    )
     if json_mode and not log_file:
         _install_stdlib_intercept(numeric_level)
 
@@ -1355,6 +1366,15 @@ def _install_stdlib_intercept(numeric_level: int) -> None:
         root.addHandler(handler)
     handler.setLevel(numeric_level)
     root.setLevel(numeric_level)
+
+
+def _remove_stdlib_intercept() -> None:
+    """Remove root intercept handlers when stdlib records should not re-enter structlog."""
+    root = logging.root
+    for handler in root.handlers[:]:
+        if isinstance(handler, InterceptHandler):
+            root.removeHandler(handler)
+            handler.close()
 
 
 # Initialize logger - will be reconfigured when configure() is called


### PR DESCRIPTION
## Summary

- avoid routing Gunicorn records back through `InterceptHandler` when Langflow file logging is active
- remove a stale root stdlib interceptor when logging is reconfigured from stdout JSON to file or pretty mode
- cover the stdout-JSON-to-file transition and verify a Gunicorn error is written exactly once

Fixes #14776

## Root cause

File mode configures structlog with `structlog.stdlib.LoggerFactory` and a rotating root handler. Gunicorn's logger class then replaced its handlers with `InterceptHandler`, so a `gunicorn.error` record was sent to a structlog logger with the same stdlib name and re-entered the same handler. A prior stdout JSON configuration could also leave a root interceptor installed during a later file-mode configuration.

The fix uses the existing Gunicorn propagation setup only when Langflow's managed file handler is active, and removes stale root interceptors whenever stdout JSON interception is not selected.

## Validation

- focused regression: `1 passed`
- `src/backend/tests/unit/test_logger.py`: `100 passed, 2 warnings`
- Ruff format and lint checks passed for all changed files
- `compileall` passed for all changed Python files
- bounded A/B reproduction: the release base reached 13 recursive handler laps and exited via the safety cap; the fixed code exited normally and wrote one matching JSON record

The two pytest warnings are from the lightweight local environment not installing `pytest-timeout`; the test command itself ran inside a 45-second parent-process timeout. A full `langflow-base` dependency sync was not available locally because `litellm==1.93.0` invoked Maturin without a configured Rust toolchain, so the repository's broader CI remains the authoritative integration check.

## AI assistance

OpenAI Codex was used to investigate the issue, implement the patch, and run the validation described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior when writing logs to files, ensuring Gunicorn messages are recorded correctly in JSON format.
  * Prevented stale logging handlers from causing duplicate or incorrectly formatted log entries when switching logging modes.
  * Ensured Gunicorn access and error logs consistently use the configured warning level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->