### PR TITLE
fix(mcp): keep advertising inputs for flows that declared no allowlist

### DIFF
--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -684,8 +684,42 @@ def _is_visible_input_field(field_data: Any) -> bool:
     return isinstance(field_data, dict) and field_data.get("show", False) and not field_data.get("advanced", False)
 
 
-def _is_mcp_input_field(field_data: Any) -> bool:
-    return _is_visible_input_field(field_data) and field_data.get("api_editable") is True
+# ``input_value`` carries the flow's chat message. ``handle_call_tool`` pops it before the tweak
+# filter runs and forwards it as ``SimplifiedAPIRequest.input_value``, so the runtime accepts it
+# whatever the allowlist says. Withholding it from the advertised schema publishes a contract
+# narrower than the one actually served, and a caller obeying that schema sends no message at all.
+_ALWAYS_EXPOSED_INPUT_FIELDS = frozenset({"input_value"})
+
+
+def _input_nodes_declare_api_allowlist(input_nodes: list[Vertex]) -> bool:
+    """Return whether any input node marks a template field ``api_editable``.
+
+    This mirrors ``lfx.utils.flow_validation.flow_declares_api_editable`` and the reasoning
+    recorded there: a flow whose author toggled at least one field has declared an allowlist, so
+    the untoggled fields close. A flow with no toggles has declared nothing and keeps its previous
+    permissive contract. ``api_editable`` defaults to ``False``, is written only by the Inspector's
+    API toggle, and has no backfill, so without this fallback the flag empties the advertised schema
+    of every flow nobody hand-prepared -- including every flow the UI creates from a template.
+
+    Scoped to input nodes because those are the only fields MCP can advertise. A toggle elsewhere in
+    the flow is an API-snippet concern and must not reshape the MCP contract.
+    """
+    for node in input_nodes:
+        template = node.data.get("node", {}).get("template")
+        if not isinstance(template, dict):
+            continue
+        if any(isinstance(field, dict) and field.get("api_editable") is True for field in template.values()):
+            return True
+    return False
+
+
+def _is_exposed_input_field(field_name: str, field_data: Any, *, honor_allowlist: bool) -> bool:
+    """Return whether an input node's field belongs in the advertised input contract."""
+    if not _is_visible_input_field(field_data):
+        return False
+    if not honor_allowlist or field_name in _ALWAYS_EXPOSED_INPUT_FIELDS:
+        return True
+    return field_data.get("api_editable") is True
 
 
 _JSON_SCHEMA_TYPE_BY_FIELD_TYPE = {
@@ -746,12 +780,14 @@ def _json_schema_type_for_field(field_data: dict[str, Any]) -> dict[str, Any]:
 def get_flow_input_tweaks(flow: Flow, inputs: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Map advertised MCP inputs to node-scoped flow tweaks."""
     tweaks: dict[str, dict[str, Any]] = {}
-    for node in _get_flow_input_nodes(flow):
+    input_nodes = _get_flow_input_nodes(flow)
+    honor_allowlist = _input_nodes_declare_api_allowlist(input_nodes)
+    for node in input_nodes:
         template = node.data["node"]["template"]
         node_tweaks = {
             field_name: inputs[field_name]
             for field_name, field_data in template.items()
-            if field_name in inputs and _is_mcp_input_field(field_data)
+            if field_name in inputs and _is_exposed_input_field(field_name, field_data, honor_allowlist=honor_allowlist)
         }
         if node_tweaks:
             tweaks[node.id] = node_tweaks
@@ -762,18 +798,19 @@ def get_flow_input_tweaks(flow: Flow, inputs: dict[str, Any]) -> dict[str, dict[
 def json_schema_from_flow(flow: Flow, *, require_api_editable: bool = True) -> dict:
     """Generate JSON schema from flow input nodes.
 
-    MCP schemas expose only API-editable fields. Other consumers, such as A2A,
-    can include every visible, non-advanced field in their input contract.
+    MCP schemas honor a flow's API exposure allowlist once the flow declares one. Other consumers,
+    such as A2A, include every visible, non-advanced field in their input contract.
     """
     properties = {}
     required = []
-    is_input_field = _is_mcp_input_field if require_api_editable else _is_visible_input_field
-    for node in _get_flow_input_nodes(flow):
+    input_nodes = _get_flow_input_nodes(flow)
+    honor_allowlist = require_api_editable and _input_nodes_declare_api_allowlist(input_nodes)
+    for node in input_nodes:
         node_data = node.data["node"]
         template = node_data["template"]
 
         for field_name, field_data in template.items():
-            if is_input_field(field_data):
+            if _is_exposed_input_field(field_name, field_data, honor_allowlist=honor_allowlist):
                 properties[field_name] = {
                     **_json_schema_type_for_field(field_data),
                     "description": field_data.get("info", f"Input for {field_name}"),

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -885,6 +885,114 @@ def test_json_schema_from_flow_only_advertises_api_exposed_fields(monkeypatch):
     assert schema["required"] == ["exposed"]
 
 
+def _patch_graph_with_input_nodes(monkeypatch, templates):
+    """Stand a fake graph whose input vertices carry ``templates`` (a list of node templates)."""
+
+    class _FakeNode:
+        def __init__(self, node_id, template):
+            self.id = node_id
+            self.is_input = True
+            self.data = {"node": {"template": template}}
+
+    class _FakeGraph:
+        vertices = [_FakeNode(f"input-{index}", template) for index, template in enumerate(templates)]
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+
+def test_json_schema_from_flow_keeps_visible_fields_when_flow_declares_no_allowlist(monkeypatch):
+    """A flow that toggled nothing has declared no allowlist and keeps its previous contract.
+
+    ``api_editable`` defaults to False and has no backfill, so gating on it without this fallback
+    empties the advertised schema of every flow nobody hand-prepared -- templates included.
+    """
+    _patch_graph_with_input_nodes(
+        monkeypatch,
+        [
+            {
+                "input_value": {"show": True, "advanced": False, "type": "str", "required": True},
+                "sender_name": {"show": True, "advanced": False, "type": "str"},
+                "opt_out": {"show": True, "advanced": False, "api_editable": False, "type": "str"},
+                "hidden": {"show": False, "advanced": False, "type": "str"},
+                "off_node": {"show": True, "advanced": True, "type": "str"},
+            }
+        ],
+    )
+
+    schema = flow_helpers.json_schema_from_flow(SimpleNamespace(data={"nodes": [], "edges": []}))
+
+    assert set(schema["properties"]) == {"input_value", "sender_name", "opt_out", "session_id"}
+    assert schema["required"] == ["input_value"]
+
+
+def test_json_schema_from_flow_always_advertises_input_value(monkeypatch):
+    """``input_value`` stays advertised even under an allowlist, because the runtime still takes it.
+
+    ``handle_call_tool`` pops ``input_value`` before the tweak filter and forwards it directly, so
+    dropping it from the schema would publish a contract narrower than the one served -- a caller
+    obeying the schema would run the flow with no message.
+    """
+    _patch_graph_with_input_nodes(
+        monkeypatch,
+        [
+            {
+                "input_value": {"show": True, "advanced": False, "type": "str"},
+                "sender_name": {"show": True, "advanced": False, "api_editable": True, "type": "str"},
+                "session_ttl": {"show": True, "advanced": False, "type": "int"},
+            }
+        ],
+    )
+
+    schema = flow_helpers.json_schema_from_flow(SimpleNamespace(data={"nodes": [], "edges": []}))
+
+    assert set(schema["properties"]) == {"input_value", "sender_name", "session_id"}
+
+
+def test_json_schema_from_flow_allowlist_is_scoped_to_a_single_flow(monkeypatch):
+    """One input node's toggle closes the whole flow, not just that node."""
+    _patch_graph_with_input_nodes(
+        monkeypatch,
+        [
+            {"greeting": {"show": True, "advanced": False, "api_editable": True, "type": "str"}},
+            {"untoggled": {"show": True, "advanced": False, "type": "str"}},
+        ],
+    )
+
+    schema = flow_helpers.json_schema_from_flow(SimpleNamespace(data={"nodes": [], "edges": []}))
+
+    assert set(schema["properties"]) == {"greeting", "session_id"}
+
+
+def test_get_flow_input_tweaks_matches_the_advertised_schema(monkeypatch):
+    """The call-time filter must accept exactly what ``tools/list`` advertised."""
+    template = {
+        "sender_name": {"show": True, "advanced": False, "type": "str"},
+        "hidden": {"show": False, "advanced": False, "type": "str"},
+    }
+    _patch_graph_with_input_nodes(monkeypatch, [template])
+    flow = SimpleNamespace(data={"nodes": [], "edges": []})
+
+    # No toggle anywhere: permissive, so the visible field is forwarded.
+    assert flow_helpers.get_flow_input_tweaks(flow, {"sender_name": "ada", "hidden": "no"}) == {
+        "input-0": {"sender_name": "ada"}
+    }
+
+    # Once the flow declares an allowlist, an untoggled field is refused at both ends.
+    _patch_graph_with_input_nodes(
+        monkeypatch,
+        [{**template, "greeting": {"show": True, "advanced": False, "api_editable": True, "type": "str"}}],
+    )
+    assert flow_helpers.get_flow_input_tweaks(flow, {"sender_name": "ada", "greeting": "hi"}) == {
+        "input-0": {"greeting": "hi"}
+    }
+
+
 def test_json_schema_from_flow_maps_structured_and_list_field_types(monkeypatch):
     """MCP input schemas must describe the JSON values accepted by exposed fields."""
 

--- a/src/backend/tests/unit/initial_setup/test_starter_projects_mcp_schema.py
+++ b/src/backend/tests/unit/initial_setup/test_starter_projects_mcp_schema.py
@@ -1,0 +1,60 @@
+"""Regression guard: shipped starter projects must advertise their inputs over MCP.
+
+A project's flows are published on its MCP server, and the very first flow a new user creates comes
+from this template picker. ``api_editable`` — the Inspector's per-field "API" toggle — defaults to
+False, is written only by the frontend, and has no backfill, so gating the advertised schema on it
+without a per-flow fallback publishes every one of these templates with an input schema containing
+nothing but the optional ``session_id``. The failure is silent at both ends: the tool call returns
+``isError: false`` with empty content and the flow runs on an empty message.
+
+These tests are file-system level on purpose: they read the shipped JSON the same way the seeder
+does at first boot, then run the real ``tools/list`` schema derivation over it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from langflow.helpers.flow import json_schema_from_flow
+from lfx.graph.schema import INPUT_COMPONENTS
+
+STARTER_PROJECTS_DIR = Path(__file__).resolve().parents[3] / "base" / "langflow" / "initial_setup" / "starter_projects"
+
+
+def _starter_project_files() -> list[Path]:
+    if not STARTER_PROJECTS_DIR.is_dir():
+        msg = f"starter_projects directory not found at {STARTER_PROJECTS_DIR}"
+        raise FileNotFoundError(msg)
+    return sorted(STARTER_PROJECTS_DIR.glob("*.json"))
+
+
+def _input_node_types(flow_data: dict) -> list[str]:
+    return [
+        node.get("data", {}).get("type")
+        for node in flow_data.get("nodes", [])
+        if node.get("data", {}).get("type") in INPUT_COMPONENTS
+    ]
+
+
+@pytest.mark.parametrize("starter_path", _starter_project_files(), ids=lambda path: path.stem)
+def test_starter_project_advertises_its_flow_inputs_over_mcp(starter_path: Path):
+    """A shipped template with an input node must advertise more than the injected session_id."""
+    flow_data = json.loads(starter_path.read_text(encoding="utf-8")).get("data") or {}
+    input_types = _input_node_types(flow_data)
+    if not input_types:
+        pytest.skip(f"{starter_path.stem} has no input component; MCP has nothing to advertise")
+
+    schema = json_schema_from_flow(SimpleNamespace(data=flow_data))
+    advertised = set(schema["properties"]) - {"session_id"}
+
+    assert advertised, (
+        f"{starter_path.stem} publishes an MCP tool whose only input is the optional session_id. "
+        f"A caller obeying that schema runs the flow with no message."
+    )
+    if "ChatInput" in input_types:
+        assert "input_value" in advertised, (
+            f"{starter_path.stem} accepts input_value at call time but does not advertise it."
+        )


### PR DESCRIPTION
QA is right — #14837 does not hold up, and the reason is the flag it gates on.

## The defect

`_is_mcp_input_field` was tightened to require `api_editable is True`. That flag defaults to `False` (`src/lfx/src/lfx/inputs/input_mixin.py`, `src/lfx/src/lfx/template/field/base.py`), is written only by two frontend controls, is set by no component and no backend code, and has no backfill migration. A flow nobody hand-toggled therefore advertises an input schema containing nothing but the injected `session_id`.

This is not confined to legacy or upgraded flows. All 23 shipped starter projects that carry an input node store `input_value` with no `api_editable` key at all — the templates hold 161 occurrences of `"api_editable": false` and zero of `true` — so the first flow a new user creates from the template picker is published on the project MCP server with no callable input.

Reproduced on `release-1.12.0` at c5b56f99e6, before this change:

```
Basic Prompting: properties=['session_id']  required=[]
Simple Agent:    properties=['session_id']  required=[]
```

The failure is silent at both ends. `handle_call_tool` pops `input_value` before the tweak filter runs and forwards it as `SimplifiedAPIRequest.input_value`:

```python
input_value = processed_inputs.pop("input_value", "")
tweaks = get_flow_input_tweaks(execution_flow, processed_inputs) if processed_inputs else None
```

So the runtime still accepts the message the schema no longer declares. A caller obeying the advertised schema calls with `{}`, gets `isError: false` with empty content, and the flow runs on `input_value=""`. Nothing is logged.

## The fix

Two changes in `helpers/flow.py`, both applied to `json_schema_from_flow` (the advertised schema) and to `get_flow_input_tweaks` (the call-time filter), so the two cannot drift apart.

**1. The allowlist becomes a per-flow opt-in.** `_input_nodes_declare_api_allowlist` mirrors the reasoning the codebase already recorded for the deployment tweak policy at `src/lfx/src/lfx/utils/flow_validation.py:162-180`: a flow whose author toggled at least one field has declared an allowlist, so the untoggled fields close; a flow with no toggles has declared nothing and keeps its previous permissive contract.

Toggling still narrows the schema, which is what the ticket asked for — it just no longer empties the schema of every flow nobody prepared. Scoped to input nodes, since those are the only fields MCP can advertise; a toggle on an Agent's field is an API-snippet concern (`api_editable` shipped in #14078 as a tweaks / API-snippet feature) and must not silently reshape the MCP contract.

**2. `input_value` stays advertised.** It is exempt from the allowlist the same way the call path already exempts it, so the advertised contract matches the one actually served — including for a flow that *has* declared an allowlist on some other field, which would otherwise lose the chat message.

Unchanged: the type-mapping half of #14837 (non-primitive fields no longer collapsing to `string`), and the A2A agent card, which has read this schema with `require_api_editable=False` since #14843.

## Verification

Behavior across the three cases the QA report enumerates, before and after:

| flow | `release-1.12.0` @ c5b56f99e6 | this PR |
| --- | --- | --- |
| from Basic Prompting template | `[session_id]` | `[input_value, session_id]` |
| ChatInput → ChatOutput, nothing toggled | `[session_id]` | `[input_value, sender_name, session_id]` |
| same, with `sender_name` toggled | `[sender_name, session_id]` | `[input_value, sender_name, session_id]` |

Tests added:

- `test_starter_projects_mcp_schema.py` — file-system level, the same way the seeder reads these templates at first boot. Walks every shipped starter project and asserts each one with an input node advertises more than `session_id`, and that every `ChatInput` flow advertises `input_value`. 23 pass, 4 skip (`Financial Report Parser`, `Portfolio Website Code Generator`, `SEO Keyword Generator`, `Text Sentiment Analysis` have no input component at all — pre-existing, and the architectural constraint the ticket notes as context rather than a defect).
- Four cases in `test_mcp_utils.py` covering the undeclared-flow fallback, the `input_value` exemption under a declared allowlist, allowlist scope across input nodes, and agreement between `get_flow_input_tweaks` and the advertised schema.

Mutation-verified: reverting `_is_exposed_input_field` to the #14837 predicate turns 26 of these red, including 8 starter projects and 3 of the 4 unit cases. With the fix in place:

```
172 passed, 5 skipped in 231.20s
```

covering `test_mcp_utils.py`, `test_a2a.py`, `test_mcp_failure_reporting.py`, and the new starter-project guard.

## Not addressed here

The report's third point — MCP schema derivation only considers vertices flagged `is_input`, so fields on an Agent, Prompt Template or model component can never be advertised — is a scope limit of `INPUT_COMPONENTS`, not a regression from #14837, and is left alone. The same goes for the absence of any UI surface showing a published tool's input schema, which is what let this land unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP flow input schemas for flows without an API-editable field allowlist.
  * Ensured visible, non-advanced inputs are exposed when no allowlist is defined.
  * Always exposes the `input_value` field.
  * Keeps advertised schemas and accepted input tweaks consistent.

* **Tests**
  * Added coverage for legacy flows and starter project templates to verify accurate MCP input schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->