### PR TITLE
fix(logging): prevent file-mode gunicorn log recursion

### DIFF
--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from gunicorn import glogging
 from gunicorn.app.base import BaseApplication
-from lfx.log.logger import InterceptHandler
+from lfx.log.logger import InterceptHandler, is_file_logging_configured, setup_gunicorn_logger
 from uvicorn.workers import UvicornWorker
 
 
@@ -57,20 +57,21 @@ class LangflowUvicornWorker(UvicornWorker):
 
 
 class Logger(glogging.Logger):
-    """Implements and overrides the gunicorn logging interface.
-
-    This class inherits from the standard gunicorn logger and overrides it by
-    replacing the handlers with `InterceptHandler` in order to route the
-    gunicorn logs to loguru.
-    """
+    """Configure gunicorn logging to use the active Langflow pipeline."""
 
     def __init__(self, cfg) -> None:
         super().__init__(cfg)
-        logging.getLogger("gunicorn.error").setLevel(logging.WARNING)
-        logging.getLogger("gunicorn.access").setLevel(logging.WARNING)
+        gunicorn_loggers = (self.error_log, self.access_log)
+        for gunicorn_logger in gunicorn_loggers:
+            gunicorn_logger.setLevel(logging.WARNING)
 
-        logging.getLogger("gunicorn.error").handlers = [InterceptHandler()]
-        logging.getLogger("gunicorn.access").handlers = [InterceptHandler()]
+        if is_file_logging_configured():
+            # File mode uses structlog.stdlib.LoggerFactory, so routing through
+            # InterceptHandler would cycle back to the same stdlib logger.
+            setup_gunicorn_logger()
+        else:
+            for gunicorn_logger in gunicorn_loggers:
+                gunicorn_logger.handlers = [InterceptHandler()]
 
     def error(self, msg, *args, **kwargs):
         """Override error method to filter out SIGSEGV messages."""

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -934,6 +934,16 @@ def setup_loguru_logger(log_level: str, *, enqueue: bool = False) -> None:
     )
 
 
+def _remove_log_file_handler() -> None:
+    """Remove and close the managed root file handler if present."""
+    global _file_handler  # noqa: PLW0603
+
+    if _file_handler is not None:
+        logging.root.removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None
+
+
 def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatter | None = None) -> None:
     """Set up Langflow's rotating file handler.
 
@@ -944,9 +954,7 @@ def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatt
     """
     global _file_handler  # noqa: PLW0603
 
-    if _file_handler is not None:
-        logging.root.removeHandler(_file_handler)
-        _file_handler.close()
+    _remove_log_file_handler()
 
     _file_handler = logging.handlers.RotatingFileHandler(
         log_file,
@@ -955,6 +963,11 @@ def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatt
     )
     _file_handler.setFormatter(formatter if formatter is not None else logging.Formatter("%(message)s"))
     logging.root.addHandler(_file_handler)
+
+
+def is_file_logging_configured() -> bool:
+    """Return whether the managed file handler is active on the root logger."""
+    return _file_handler is not None and _file_handler in logging.root.handlers
 
 
 class LogConfig(TypedDict):
@@ -1005,6 +1018,17 @@ def configure(
         log_format = os.getenv("LANGFLOW_LOG_FORMAT")
 
     numeric_level = LOG_LEVEL_MAP.get(log_level.upper(), logging.ERROR)
+    json_mode = log_env.lower() in ("container", "container_json") or (
+        not log_env and os.getenv("LANGFLOW_PRETTY_LOGS", "true").lower() != "true"
+    )
+
+    # File mode routes foreign records through the rotating root handler,
+    # so a stale root InterceptHandler from a prior stdout-JSON setup must
+    # not remain installed and re-enter structlog.
+    if not (json_mode and not log_file):
+        _remove_stdlib_intercept()
+    if log_file is None:
+        _remove_log_file_handler()
 
     # Fingerprint of every caller-supplied input that changes the resulting
     # setup. Stored on the wrapper_class (below) so structlog.reset_defaults()
@@ -1355,6 +1379,16 @@ def _install_stdlib_intercept(numeric_level: int) -> None:
         root.addHandler(handler)
     handler.setLevel(numeric_level)
     root.setLevel(numeric_level)
+
+
+def _remove_stdlib_intercept() -> None:
+    """Remove root InterceptHandler when records should not re-enter structlog."""
+    root = logging.root
+    for handler in root.handlers[:]:
+        if isinstance(handler, InterceptHandler):
+            root.removeHandler(handler)
+            with contextlib.suppress(Exception):
+                handler.close()
 
 
 # Initialize logger - will be reconfigured when configure() is called


### PR DESCRIPTION
Fixes #14776

With `LANGFLOW_LOG_FILE` set, a `gunicorn.error` record cycles between stdlib logging and structlog until the container OOMs. In file mode clear any stale root intercept and route gunicorn loggers through the rotating file handler instead of re-entering structlog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server log handling for more consistent warning and access messages.
  * Corrected transitions between file-based, console, and structured logging modes.
  * Prevented stale logging handlers from causing duplicate or incorrectly formatted messages.
* **Improvements**
  * Added a status check for whether file logging is currently configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->