### PR TITLE
fix(memory): use OpenAI Compatible credentials for memory embeddings

### DIFF
--- a/src/backend/base/langflow/services/database/models/memory_base/model.py
+++ b/src/backend/base/langflow/services/database/models/memory_base/model.py
@@ -41,6 +41,14 @@ class MemoryBase(MemoryBaseBase, table=True):  # type: ignore[call-arg]
 class MemoryBaseCreate(MemoryBaseBase):
     user_id: UUID | None = None  # Derived from auth token in the endpoint; not required in request body
 
+    # Optional explicit provider for the embedding model. When supplied (e.g.
+    # from the UI's selected ModelOption.provider), it is authoritative and
+    # avoids the heuristic inference in ``infer_embedding_provider``. This
+    # makes OpenAI Compatible and other bundle providers with overlapping model
+    # names (like ``text-embedding-3-small``) unambiguous. Falls back to
+    # inference when omitted for backward compatibility with older clients.
+    embedding_provider: str | None = None
+
     # Vector-store selection for the Memory Base's backing KB. Declared on the
     # create payload rather than on ``MemoryBaseBase`` so no column is added to
     # the ``memory_base`` table: the values are persisted on the

--- a/src/backend/base/langflow/services/memory_base/embedding_helpers.py
+++ b/src/backend/base/langflow/services/memory_base/embedding_helpers.py
@@ -35,12 +35,20 @@ _MODEL_TO_PROVIDER: list[tuple[list[str], str]] = [
 ]
 
 
-def infer_embedding_provider(embedding_model: str) -> str:
+def infer_embedding_provider(embedding_model: str, user_id=None) -> str:
     """Derive embedding provider name from a model string.
 
     Looks up the model in the unified models catalog first so the answer
     matches what the UI dropdown shows; falls back to pattern-based
     inference for legacy/edge cases.
+
+    When ``user_id`` is provided, live models discovered for that user's
+    configured providers (e.g. OpenAI Compatible via /v1/models) are also
+    considered, so a model like ``text-embedding-3-small`` served by an
+    OpenAI Compatible endpoint is correctly attributed to ``OpenAI Compatible``
+    instead of ``OpenAI``. Without a user context the static catalog is the
+    only source, preserving the previous behaviour for callers that lack an
+    identity.
 
     Ollama's ``/api/tags`` endpoint returns model names with a tag suffix
     (e.g. ``bge-m3:latest``), but the unified catalog stores them without
@@ -50,6 +58,11 @@ def infer_embedding_provider(embedding_model: str) -> str:
     """
     if not embedding_model:
         return "OpenAI"  # Safe default — matches _resolve_embedding fallback
+
+    if user_id is not None:
+        live_provider = _lookup_provider_in_live_catalog(embedding_model, user_id)
+        if live_provider:
+            return live_provider
 
     catalog_provider = _lookup_provider_in_catalog(embedding_model)
     if catalog_provider:
@@ -92,6 +105,22 @@ def infer_llm_provider(model_name: str) -> str:
         )
         raise ValueError(msg)
     return provider
+
+
+
+def _lookup_provider_in_live_catalog(embedding_model: str, user_id) -> str | None:
+    """Return provider for ``embedding_model`` from the user-scoped live catalog."""
+    with contextlib.suppress(Exception):
+        from lfx.base.models.unified_models.model_catalog import get_embedding_model_options
+
+        options = get_embedding_model_options(user_id)
+        bare_name = embedding_model.split(":")[0]
+        for opt in options:
+            if opt.get("name") in (embedding_model, bare_name):
+                provider = opt.get("provider")
+                if isinstance(provider, str) and provider.strip():
+                    return provider
+    return None
 
 
 def _lookup_provider_in_catalog(embedding_model: str) -> str | None:

--- a/src/backend/base/langflow/services/memory_base/embedding_helpers.py
+++ b/src/backend/base/langflow/services/memory_base/embedding_helpers.py
@@ -107,7 +107,6 @@ def infer_llm_provider(model_name: str) -> str:
     return provider
 
 
-
 def _lookup_provider_in_live_catalog(embedding_model: str, user_id) -> str | None:
     """Return provider for ``embedding_model`` from the user-scoped live catalog."""
     with contextlib.suppress(Exception):

--- a/src/backend/base/langflow/services/memory_base/service.py
+++ b/src/backend/base/langflow/services/memory_base/service.py
@@ -177,7 +177,11 @@ class MemoryBaseService(Service):
         # supplied by the UI (payload.embedding_provider) when present — it is
         # authoritative and avoids heuristic misclassification for overlapping
         # names like text-embedding-3-small across OpenAI / OpenAI Compatible.
-        embedding_provider = payload.embedding_provider.strip() if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip() else infer_embedding_provider(payload.embedding_model, user_id)
+        embedding_provider = (
+            payload.embedding_provider.strip()
+            if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip()
+            else infer_embedding_provider(payload.embedding_model, user_id)
+        )
         require_model_provider(
             user_id=user_id,
             provider=embedding_provider,
@@ -202,7 +206,11 @@ class MemoryBaseService(Service):
                 raise ValueError(msg)
 
         # 3. Auto-generate kb_name: sanitized_name_<8hex>
-        embedding_provider = payload.embedding_provider.strip() if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip() else infer_embedding_provider(payload.embedding_model, user_id)
+        embedding_provider = (
+            payload.embedding_provider.strip()
+            if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip()
+            else infer_embedding_provider(payload.embedding_model, user_id)
+        )
         kb_name = f"{sanitize_kb_name(payload.name)}_{uuid.uuid4().hex[:8]}"
 
         # 4-5. Provision the backing KB (vector-store collection + ``knowledge_base``

--- a/src/backend/base/langflow/services/memory_base/service.py
+++ b/src/backend/base/langflow/services/memory_base/service.py
@@ -173,8 +173,11 @@ class MemoryBaseService(Service):
             _require_preprocessing_model_provider(user_id, payload.preproc_model)
 
         # 1c. Resolve and authorize the embedding provider before filesystem
-        # initialization or any persistence work.
-        embedding_provider = infer_embedding_provider(payload.embedding_model)
+        # initialization or any persistence work. Prefer the explicit provider
+        # supplied by the UI (payload.embedding_provider) when present — it is
+        # authoritative and avoids heuristic misclassification for overlapping
+        # names like text-embedding-3-small across OpenAI / OpenAI Compatible.
+        embedding_provider = payload.embedding_provider.strip() if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip() else infer_embedding_provider(payload.embedding_model, user_id)
         require_model_provider(
             user_id=user_id,
             provider=embedding_provider,
@@ -199,7 +202,7 @@ class MemoryBaseService(Service):
                 raise ValueError(msg)
 
         # 3. Auto-generate kb_name: sanitized_name_<8hex>
-        embedding_provider = infer_embedding_provider(payload.embedding_model)
+        embedding_provider = payload.embedding_provider.strip() if isinstance(payload.embedding_provider, str) and payload.embedding_provider.strip() else infer_embedding_provider(payload.embedding_model, user_id)
         kb_name = f"{sanitize_kb_name(payload.name)}_{uuid.uuid4().hex[:8]}"
 
         # 4-5. Provision the backing KB (vector-store collection + ``knowledge_base``
@@ -345,7 +348,7 @@ class MemoryBaseService(Service):
             if mb is None:
                 return None
 
-            embedding_provider = infer_embedding_provider(mb.embedding_model)
+            embedding_provider = infer_embedding_provider(mb.embedding_model, user_id)
             require_model_provider(
                 user_id=user_id,
                 provider=embedding_provider,

--- a/src/frontend/src/controllers/API/queries/memories/types.ts
+++ b/src/frontend/src/controllers/API/queries/memories/types.ts
@@ -77,6 +77,7 @@ export interface CreateMemoryPayload {
   name: string;
   flow_id: string;
   embedding_model: string;
+  embedding_provider?: string;
   threshold?: number;
   auto_capture?: boolean;
   preprocessing?: boolean;

--- a/src/frontend/src/modals/createMemoryModal/useCreateMemoryModal.ts
+++ b/src/frontend/src/modals/createMemoryModal/useCreateMemoryModal.ts
@@ -243,6 +243,7 @@ export function useCreateMemoryModal({
       name: name.trim(),
       flow_id: flowId,
       embedding_model: embeddingSelection?.name,
+      embedding_provider: embeddingSelection?.provider,
       auto_capture: true,
       threshold: parsedThreshold,
       preprocessing: preprocessingEnabled,


### PR DESCRIPTION
Fixes #14860

**Problem**

When a Memory is created with an embedding model from the OpenAI Compatible provider, flows fail during ingestion with `OpenAI API key is required`. The provider was inferred from the model name (`text-embedding-*` → OpenAI), so the configured `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_API_KEY` were never used.

**Root cause**

`infer_embedding_provider` consulted only the static model catalog, which does not contain live OpenAI Compatible models. Overlapping names like `text-embedding-3-small` therefore defaulted to `OpenAI`. The create endpoint accepted only `embedding_model` (string) and relied entirely on that heuristic.

**Change**

- `embedding_helpers.infer_embedding_provider` now accepts an optional `user_id` and checks the user-scoped live catalog (`get_embedding_model_options`) before the static catalog/pattern fallback. Live discovery is tried first when a user context exists, so a model served by the configured Compatible endpoint is correctly attributed.
- `MemoryBaseCreate` accepts an optional `embedding_provider`. When provided it is authoritative and bypasses inference; otherwise the user-aware inference is used. This preserves backward compatibility while making the assignment unambiguous.
- `MemoryBaseService.create` / `update` thread the user id through the inference and prefer the explicit provider.
- Frontend `useCreateMemoryModal` sends `embedding_provider` from the selected `ModelOption.provider` alongside `embedding_model`.

**Testing**

- `src/backend/tests/unit/test_memory_bases.py` — all 126 tests pass (including `TestInferEmbeddingProvider`).
- `src/bundles/openai-compatible/tests/test_openai_compatible_provider.py` — 32 tests pass.
- Verified that `KBIngestionHelper.build_embeddings` resolves the embedding via `get_embeddings` which picks up `OPENAI_COMPATIBLE_BASE_URL`/`API_KEY` through the registered provider wiring.

**Risk**

Minimal. The new `embedding_provider` field is optional and ignored by old clients. The live-catalog lookup is best-effort (`suppress(Exception)`) and falls back to the previous heuristic, so no new failure modes are introduced for other providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory creation now preserves the embedding provider selected in the interface.
  * Added support for user-configured embedding providers, including providers with overlapping model names.
* **Bug Fixes**
  * Improved embedding provider identification during memory creation and updates.
  * Existing clients remain compatible through automatic provider detection when no provider is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->