### PR TITLE
fix(files): decode nested Google credentials

### DIFF
--- a/src/lfx/src/lfx/base/data/cloud_storage_utils.py
+++ b/src/lfx/src/lfx/base/data/cloud_storage_utils.py
@@ -99,15 +99,7 @@ def parse_google_service_account_key(service_account_key: Any) -> dict:
         except json.JSONDecodeError as e:
             parse_errors.append(f"Stripped parse: {e!s}")
 
-    # Strategy 3: Check if it's double-encoded (JSON string of a JSON string)
-    if credentials_dict is None:
-        try:
-            decoded_once = json.loads(service_account_key, strict=False)
-            credentials_dict = json.loads(decoded_once, strict=False) if isinstance(decoded_once, str) else decoded_once
-        except json.JSONDecodeError as e:
-            parse_errors.append(f"Double-encoded parse: {e!s}")
-
-    # Strategy 4: Try to fix common issues with newlines in the private_key field
+    # Strategy 3: Try to fix common issues with newlines in the private_key field
     if credentials_dict is None:
         try:
             # Replace literal \n with actual newlines which is common in pasted JSON
@@ -115,6 +107,18 @@ def parse_google_service_account_key(service_account_key: Any) -> dict:
             credentials_dict = json.loads(fixed_key, strict=False)
         except json.JSONDecodeError as e:
             parse_errors.append(f"Newline-fixed parse: {e!s}")
+
+    # A JSON string containing JSON is valid at the outer layer, so decode its contents separately.
+    if isinstance(credentials_dict, str):
+        try:
+            credentials_dict = json.loads(credentials_dict, strict=False)
+        except json.JSONDecodeError as e:
+            parse_errors.append(f"Double-encoded parse: {e!s}")
+            credentials_dict = None
+
+    if credentials_dict is not None and not isinstance(credentials_dict, dict):
+        parse_errors.append(f"Parsed value must be an object, got {type(credentials_dict).__name__}")
+        credentials_dict = None
 
     if credentials_dict is None:
         error_details = "; ".join(parse_errors)

--- a/src/lfx/tests/unit/base/data/test_cloud_storage_utils.py
+++ b/src/lfx/tests/unit/base/data/test_cloud_storage_utils.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+from lfx.base.data.cloud_storage_utils import parse_google_service_account_key
+
+
+def test_parse_google_service_account_key_accepts_json_object():
+    """A normal JSON object is returned unchanged."""
+    credentials = {"type": "service_account", "project_id": "test-project"}
+
+    assert parse_google_service_account_key(json.dumps(credentials)) == credentials
+
+
+def test_parse_google_service_account_key_decodes_double_encoded_json():
+    """A JSON string containing a credential object is decoded twice."""
+    credentials = {"type": "service_account", "project_id": "test-project"}
+    double_encoded_credentials = json.dumps(json.dumps(credentials))
+
+    assert parse_google_service_account_key(double_encoded_credentials) == credentials
+
+
+@pytest.mark.parametrize("credentials", ["[]", "null", "42"])
+def test_parse_google_service_account_key_rejects_non_object_json(credentials):
+    """Valid JSON values that are not objects are rejected."""
+    with pytest.raises(ValueError, match=r"Unable to parse|Parsed value must be an object"):
+        parse_google_service_account_key(credentials)
+
+
+def test_parse_google_service_account_key_rejects_invalid_inner_json():
+    """A JSON string containing invalid JSON reports the nested parse failure."""
+    invalid_inner_json = json.dumps("not valid JSON")
+
+    with pytest.raises(ValueError, match="Double-encoded parse"):
+        parse_google_service_account_key(invalid_inner_json)


### PR DESCRIPTION
## Summary

- decode a JSON string that contains a serialized Google service-account object
- reject valid JSON values that are not credential objects
- add focused tests for normal, double-encoded, and non-object JSON inputs

## Root cause

The first parsing strategy accepts a double-encoded value as a JSON string. Because the result is non-null, the existing double-decoding fallback is skipped and the string is passed to Google authentication code instead of a dictionary.

## Validation

- `uv run pytest tests/unit/base/data/test_cloud_storage_utils.py -q` from `src/lfx` (6 passed)
- LFX `tests/unit/base/data` regression set (92 passed, 1 skipped; 5 pre-existing Windows-only failures from symlink privileges, newline normalization, and an unrelated storage mock assertion)
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format . --check`
- `git diff --check`

Fixes #14867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Google service account credentials, including double-encoded JSON.
  * Added validation to reject invalid credential formats that are not JSON objects.

* **Tests**
  * Added coverage for standard JSON, double-encoded JSON, and invalid non-object inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->