### PR TITLE
fix(cli): clean up failed serve inputs

### DIFF
--- a/src/lfx/src/lfx/cli/commands.py
+++ b/src/lfx/src/lfx/cli/commands.py
@@ -145,6 +145,8 @@ async def _build_serve_registry(
                 store=flow_store,
             )
         except ValueError as e:
+            with contextlib.suppress(OSError):
+                Path(temp_file_to_cleanup).unlink()
             typer.echo(f"Error: {e}", err=True)
             raise typer.Exit(1) from e
 
@@ -187,6 +189,8 @@ async def _build_serve_registry(
                     store=flow_store,
                 )
             except ValueError as e:
+                with contextlib.suppress(OSError):
+                    Path(temp_file_to_cleanup).unlink()
                 typer.echo(f"Error: {e}", err=True)
                 raise typer.Exit(1) from e
 

--- a/src/lfx/src/lfx/cli/commands.py
+++ b/src/lfx/src/lfx/cli/commands.py
@@ -9,7 +9,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import typer
 import uvicorn
@@ -91,6 +91,43 @@ def _gate_flow_for_serve(
     return merge_flow_envelope(outer_envelope, inner, wrap_bare=True)
 
 
+async def _registry_from_temp_flow_json(
+    json_data: Any,
+    *,
+    verbose_print: Callable[[str], None],
+    check_variables: bool,
+    no_env_fallback: bool,
+    flow_store: FlowStore,
+) -> tuple[FlowRegistry, str]:
+    """Build a registry from *json_data* staged in a temporary ``.json`` file.
+
+    Returns ``(registry, temp_path)``. Ownership of the temp file passes to the caller
+    only on a clean return; every other exit unlinks it here — the ``typer.Exit`` raised
+    for a load error, a Ctrl-C or cancellation mid-load, an unexpected loader failure —
+    because the caller never receives a path for its own ``finally`` to clean up.
+    """
+    fd, temp_path = tempfile.mkstemp(suffix=".json")
+    registry: FlowRegistry | None = None
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            json.dump(json_data, tmp, indent=2)
+        registry = await build_registry_from_paths(
+            [Path(temp_path)],
+            verbose_print,
+            check_variables=check_variables,
+            no_env_fallback=no_env_fallback,
+            store=flow_store,
+        )
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from e
+    finally:
+        if registry is None:
+            with contextlib.suppress(OSError):
+                Path(temp_path).unlink()
+    return registry, temp_path
+
+
 async def _build_serve_registry(
     *,
     script_paths: list[str] | None,
@@ -133,22 +170,13 @@ async def _build_serve_registry(
                 raise typer.Exit(1) from e
         if upgrade_flow:
             json_data = _gate_flow_for_serve(json_data, upgrade_flow, verbose=verbose)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-            json.dump(json_data, tmp, indent=2)
-            temp_file_to_cleanup = tmp.name
-        try:
-            registry = await build_registry_from_paths(
-                [Path(temp_file_to_cleanup)],
-                verbose_print,
-                check_variables=check_variables,
-                no_env_fallback=no_env_fallback,
-                store=flow_store,
-            )
-        except ValueError as e:
-            with contextlib.suppress(OSError):
-                Path(temp_file_to_cleanup).unlink()
-            typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(1) from e
+        registry, temp_file_to_cleanup = await _registry_from_temp_flow_json(
+            json_data,
+            verbose_print=verbose_print,
+            check_variables=check_variables,
+            no_env_fallback=no_env_fallback,
+            flow_store=flow_store,
+        )
 
     elif script_paths:
         resolved = [Path(p).resolve() for p in script_paths]
@@ -177,22 +205,13 @@ async def _build_serve_registry(
                 )
                 raise typer.Exit(1) from e
             gated = _gate_flow_for_serve(payload, upgrade_flow, verbose=verbose)
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-                json.dump(gated, tmp, indent=2)
-                temp_file_to_cleanup = tmp.name
-            try:
-                registry = await build_registry_from_paths(
-                    [Path(temp_file_to_cleanup)],
-                    verbose_print,
-                    check_variables=check_variables,
-                    no_env_fallback=no_env_fallback,
-                    store=flow_store,
-                )
-            except ValueError as e:
-                with contextlib.suppress(OSError):
-                    Path(temp_file_to_cleanup).unlink()
-                typer.echo(f"Error: {e}", err=True)
-                raise typer.Exit(1) from e
+            registry, temp_file_to_cleanup = await _registry_from_temp_flow_json(
+                gated,
+                verbose_print=verbose_print,
+                check_variables=check_variables,
+                no_env_fallback=no_env_fallback,
+                flow_store=flow_store,
+            )
 
         elif len(resolved) == 1 and resolved[0].is_dir():
             dir_path = resolved[0]

--- a/src/lfx/tests/unit/cli/test_serve.py
+++ b/src/lfx/tests/unit/cli/test_serve.py
@@ -369,6 +369,66 @@ class TestBuildRegistryFromPaths:
         assert len(registry) == 2, "both flows must be registered with distinct IDs"
 
 
+class TestBuildServeRegistryTempCleanup:
+    def test_inline_flow_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
+        import asyncio
+
+        import typer
+        from lfx.cli.commands import _build_serve_registry
+
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+        with (
+            patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(side_effect=ValueError("invalid flow"))),
+            pytest.raises(typer.Exit),
+        ):
+            asyncio.run(
+                _build_serve_registry(
+                    script_paths=None,
+                    flow_json="{}",
+                    stdin=False,
+                    check_variables=False,
+                    no_env_fallback=False,
+                    flow_store=MagicMock(),
+                    verbose_print=lambda _: None,
+                )
+            )
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_upgraded_file_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
+        import asyncio
+
+        import typer
+        from lfx.cli.commands import _build_serve_registry
+
+        source_path = tmp_path / "flow.json"
+        source_path.write_text("{}")
+        temp_dir = tmp_path / "temp"
+        temp_dir.mkdir()
+        monkeypatch.setattr(tempfile, "tempdir", str(temp_dir))
+
+        with (
+            patch("lfx.cli.commands._gate_flow_for_serve", return_value={}),
+            patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(side_effect=ValueError("invalid flow"))),
+            pytest.raises(typer.Exit),
+        ):
+            asyncio.run(
+                _build_serve_registry(
+                    script_paths=[str(source_path)],
+                    flow_json=None,
+                    stdin=False,
+                    check_variables=False,
+                    no_env_fallback=False,
+                    flow_store=MagicMock(),
+                    verbose_print=lambda _: None,
+                    upgrade_flow="safe",
+                )
+            )
+
+        assert list(temp_dir.iterdir()) == []
+
+
 class TestServeCommandMultiFlow:
     def test_serve_command_with_directory(self, tmp_path):
         from lfx.cli.commands import serve_command

--- a/src/lfx/tests/unit/cli/test_serve.py
+++ b/src/lfx/tests/unit/cli/test_serve.py
@@ -370,11 +370,33 @@ class TestBuildRegistryFromPaths:
 
 
 class TestBuildServeRegistryTempCleanup:
-    def test_inline_flow_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
+    """``_build_serve_registry`` owns the temp file until it hands the path back.
+
+    ``serve_command`` only learns the path from a successful return, so any exit that
+    skips that return has to unlink the staged flow itself or it is orphaned in the
+    system temp directory.
+    """
+
+    @staticmethod
+    def _build(**overrides):
         import asyncio
 
-        import typer
         from lfx.cli.commands import _build_serve_registry
+
+        kwargs = {
+            "script_paths": None,
+            "flow_json": None,
+            "stdin": False,
+            "check_variables": False,
+            "no_env_fallback": False,
+            "flow_store": MagicMock(),
+            "verbose_print": lambda _: None,
+        }
+        kwargs.update(overrides)
+        return asyncio.run(_build_serve_registry(**kwargs))
+
+    def test_inline_flow_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
+        import typer
 
         monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
 
@@ -382,25 +404,35 @@ class TestBuildServeRegistryTempCleanup:
             patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(side_effect=ValueError("invalid flow"))),
             pytest.raises(typer.Exit),
         ):
-            asyncio.run(
-                _build_serve_registry(
-                    script_paths=None,
-                    flow_json="{}",
-                    stdin=False,
-                    check_variables=False,
-                    no_env_fallback=False,
-                    flow_store=MagicMock(),
-                    verbose_print=lambda _: None,
-                )
-            )
+            self._build(flow_json="{}")
 
         assert list(tmp_path.iterdir()) == []
 
-    def test_upgraded_file_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
-        import asyncio
+    def test_inline_flow_removes_temp_file_when_build_fails_unexpectedly(self, tmp_path, monkeypatch):
+        """Cleanup can't hinge on ValueError — a Ctrl-C mid-load orphans the file too."""
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
 
+        with (
+            patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(side_effect=KeyboardInterrupt)),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            self._build(flow_json="{}")
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_inline_flow_keeps_temp_file_for_caller_on_success(self, tmp_path, monkeypatch):
+        """The success path must still hand the path to ``serve_command``'s finally."""
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+        with patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(return_value=MagicMock())):
+            _registry, temp_file = self._build(flow_json="{}")
+
+        assert temp_file is not None
+        assert Path(temp_file).exists()
+        assert [entry.name for entry in tmp_path.iterdir()] == [Path(temp_file).name]
+
+    def test_upgraded_file_removes_temp_file_when_registry_build_fails(self, tmp_path, monkeypatch):
         import typer
-        from lfx.cli.commands import _build_serve_registry
 
         source_path = tmp_path / "flow.json"
         source_path.write_text("{}")
@@ -413,18 +445,7 @@ class TestBuildServeRegistryTempCleanup:
             patch("lfx.cli.commands.build_registry_from_paths", new=AsyncMock(side_effect=ValueError("invalid flow"))),
             pytest.raises(typer.Exit),
         ):
-            asyncio.run(
-                _build_serve_registry(
-                    script_paths=[str(source_path)],
-                    flow_json=None,
-                    stdin=False,
-                    check_variables=False,
-                    no_env_fallback=False,
-                    flow_store=MagicMock(),
-                    verbose_print=lambda _: None,
-                    upgrade_flow="safe",
-                )
-            )
+            self._build(script_paths=[str(source_path)], upgrade_flow="safe")
 
         assert list(temp_dir.iterdir()) == []
 


### PR DESCRIPTION
## Summary

- delete inline-flow temporary files when registry construction fails
- cover both direct JSON/stdin inputs and upgraded JSON file inputs
- add regression tests for both temporary-file paths

## Root cause

`_build_serve_registry` creates a temporary JSON file and returns its path to the caller for cleanup. When `build_registry_from_paths` raises, the function exits before returning that path, so the caller's `finally` block has nothing to remove.

## Validation

- `uv run --no-sync pytest tests/unit/cli/test_serve.py -q -k "BuildServeRegistryTempCleanup"` from `src/lfx` (2 passed)
- full `test_serve.py` (43 passed; 9 pre-existing Windows failures because the Unix Gunicorn module is unavailable)
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format . --check`
- `git diff --check`

Fixes #14868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files created while preparing serve configurations are now cleaned up when configuration validation fails.
  * Improved cleanup for both inline JSON configurations and upgraded JSON file configurations.

* **Tests**
  * Added coverage to verify temporary files are removed across supported error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->